### PR TITLE
Add a field to capture the customer name for the UPI method.

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -14,6 +14,7 @@ import {
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,
 	createRazorpayMethod,
+	createRazorpayPaymentMethodStore,
 	isValueTruthy,
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	type StoredPaymentMethod,
@@ -368,15 +369,18 @@ function useCreateRazorpay( {
 		razorpayConfiguration &&
 		isEnabled( 'checkout/razorpay' );
 
+	const paymentMethodStore = useMemo( () => createRazorpayPaymentMethodStore(), [] );
+
 	return useMemo( () => {
 		return isRazorpayReady && razorpayConfiguration && cartKey
 			? createRazorpayMethod( {
 					razorpayConfiguration,
 					cartKey,
 					submitButtonContent: <CheckoutSubmitButtonContent />,
+					store: paymentMethodStore,
 			  } )
 			: null;
-	}, [ razorpayConfiguration, isRazorpayReady, cartKey ] );
+	}, [ razorpayConfiguration, isRazorpayReady, cartKey, paymentMethodStore ] );
 }
 
 /**

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -37,7 +37,6 @@ import { createPayPalMethod, createPayPalStore } from '../../payment-methods/pay
 import { createPayPal } from '../../payment-methods/paypal-js';
 import { createPixPaymentMethod } from '../../payment-methods/pix';
 import { createWeChatMethod, createWeChatPaymentMethodStore } from '../../payment-methods/wechat';
-import { useCachedContactDetails } from '../use-cached-contact-details';
 import useCreateExistingCards from './use-create-existing-cards';
 import type { RazorpayConfiguration, RazorpayLoadingError } from '@automattic/calypso-razorpay';
 import type { StripeConfiguration, StripeLoadingError } from '@automattic/calypso-stripe';
@@ -372,9 +371,6 @@ function useCreateRazorpay( {
 
 	const paymentMethodStore = useMemo( () => createRazorpayPaymentMethodStore(), [] );
 
-	// Fetch cached contact details for prefilling address fields
-	const { contactDetails } = useCachedContactDetails( { isLoggedOut: false } );
-
 	return useMemo( () => {
 		return isRazorpayReady && razorpayConfiguration && cartKey
 			? createRazorpayMethod( {
@@ -382,10 +378,9 @@ function useCreateRazorpay( {
 					cartKey,
 					submitButtonContent: <CheckoutSubmitButtonContent />,
 					store: paymentMethodStore,
-					contactDetails: contactDetails ?? undefined,
 			  } )
 			: null;
-	}, [ razorpayConfiguration, isRazorpayReady, cartKey, paymentMethodStore, contactDetails ] );
+	}, [ razorpayConfiguration, isRazorpayReady, cartKey, paymentMethodStore ] );
 }
 
 /**

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -14,7 +14,6 @@ import {
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,
 	createRazorpayMethod,
-	createRazorpayPaymentMethodStore,
 	isValueTruthy,
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	type StoredPaymentMethod,
@@ -369,18 +368,15 @@ function useCreateRazorpay( {
 		razorpayConfiguration &&
 		isEnabled( 'checkout/razorpay' );
 
-	const paymentMethodStore = useMemo( () => createRazorpayPaymentMethodStore(), [] );
-
 	return useMemo( () => {
 		return isRazorpayReady && razorpayConfiguration && cartKey
 			? createRazorpayMethod( {
 					razorpayConfiguration,
 					cartKey,
 					submitButtonContent: <CheckoutSubmitButtonContent />,
-					store: paymentMethodStore,
 			  } )
 			: null;
-	}, [ razorpayConfiguration, isRazorpayReady, cartKey, paymentMethodStore ] );
+	}, [ razorpayConfiguration, isRazorpayReady, cartKey ] );
 }
 
 /**

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -37,6 +37,7 @@ import { createPayPalMethod, createPayPalStore } from '../../payment-methods/pay
 import { createPayPal } from '../../payment-methods/paypal-js';
 import { createPixPaymentMethod } from '../../payment-methods/pix';
 import { createWeChatMethod, createWeChatPaymentMethodStore } from '../../payment-methods/wechat';
+import { useCachedContactDetails } from '../use-cached-contact-details';
 import useCreateExistingCards from './use-create-existing-cards';
 import type { RazorpayConfiguration, RazorpayLoadingError } from '@automattic/calypso-razorpay';
 import type { StripeConfiguration, StripeLoadingError } from '@automattic/calypso-stripe';
@@ -371,6 +372,9 @@ function useCreateRazorpay( {
 
 	const paymentMethodStore = useMemo( () => createRazorpayPaymentMethodStore(), [] );
 
+	// Fetch cached contact details for prefilling address fields
+	const { contactDetails } = useCachedContactDetails( { isLoggedOut: false } );
+
 	return useMemo( () => {
 		return isRazorpayReady && razorpayConfiguration && cartKey
 			? createRazorpayMethod( {
@@ -378,9 +382,10 @@ function useCreateRazorpay( {
 					cartKey,
 					submitButtonContent: <CheckoutSubmitButtonContent />,
 					store: paymentMethodStore,
+					contactDetails: contactDetails ?? undefined,
 			  } )
 			: null;
-	}, [ razorpayConfiguration, isRazorpayReady, cartKey, paymentMethodStore ] );
+	}, [ razorpayConfiguration, isRazorpayReady, cartKey, paymentMethodStore, contactDetails ] );
 }
 
 /**

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -37,6 +37,8 @@ type RazorpayTransactionRequest = {
 	razorpay: Razorpay;
 	razorpayConfiguration: RazorpayConfiguration;
 	name: string | undefined;
+	address1: string | undefined;
+	address2: string | undefined;
 };
 
 export default async function razorpayProcessor(

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -225,6 +225,11 @@ function combineRazorpayOptions(
 	prefill.email = prefill.email ?? ( contactDetails ? contactDetails.email?.value : '' );
 	options.prefill = prefill;
 
+	// Add notes with invoice number for tracking
+	const notes = options.notes ?? {};
+	notes.invoice_number = txnResponse.order_id?.toString() ?? '';
+	options.notes = notes;
+
 	return options;
 }
 

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -113,16 +113,6 @@ export default async function razorpayProcessor(
 							)
 						);
 						return resolve( {} );
-					},
-					( error ) => {
-						debug( 'Razorpay modal error', error );
-						transactionOptions.reduxDispatch(
-							recordTracksEvent(
-								'calypso_checkout_razorpay_modal_error',
-								constructTracksProps( formattedTransactionData, { error } )
-							)
-						);
-						return resolve( {} );
 					}
 				);
 				debug( 'Opening Razorpay modal with options', razorpayOptions );
@@ -204,8 +194,7 @@ function combineRazorpayOptions(
 	contactDetails: ManagedContactDetails | undefined,
 	txnResponse: WPCOMTransactionEndpointResponseRedirect,
 	handler: ( response: RazorpayModalResponse ) => void,
-	ondismiss: () => void,
-	onerror: ( error: unknown ) => void
+	ondismiss: () => void
 ): RazorpayOptions {
 	debug( 'Transaction response in combineRazorpayOptions', txnResponse );
 	if ( ! txnResponse.razorpay_order_id ) {
@@ -223,7 +212,6 @@ function combineRazorpayOptions(
 	options.handler = handler;
 	const modal = options.modal ?? {};
 	modal.ondismiss = ondismiss;
-	modal.onerror = onerror;
 	options.modal = modal;
 
 	debug( 'Constructing Razorpay prefill object using contact details', contactDetails );

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -61,6 +61,8 @@ export default async function razorpayProcessor(
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...submitData,
 		name: submitData.name ?? '',
+		address: submitData.address1 ?? '',
+		streetNumber: submitData.address2 ?? '',
 		country: contactDetails?.countryCode?.value ?? '',
 		postalCode: getPostalCode( contactDetails ),
 		domainDetails: getDomainDetails( contactDetails, {

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -219,7 +219,6 @@ function combineRazorpayOptions(
 	prefill.contact =
 		prefill.contact ?? ( contactDetails ? contactDetails.phone?.value.replace( '.', '' ) : '' );
 	prefill.email = prefill.email ?? ( contactDetails ? contactDetails.email?.value : '' );
-	prefill.name = prefill.name ?? ( contactDetails ? contactDetails.name?.value : '' );
 	options.prefill = prefill;
 
 	return options;

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -113,6 +113,16 @@ export default async function razorpayProcessor(
 							)
 						);
 						return resolve( {} );
+					},
+					( error ) => {
+						debug( 'Razorpay modal error', error );
+						transactionOptions.reduxDispatch(
+							recordTracksEvent(
+								'calypso_checkout_razorpay_modal_error',
+								constructTracksProps( formattedTransactionData, { error } )
+							)
+						);
+						return resolve( {} );
 					}
 				);
 				debug( 'Opening Razorpay modal with options', razorpayOptions );
@@ -194,13 +204,16 @@ function combineRazorpayOptions(
 	contactDetails: ManagedContactDetails | undefined,
 	txnResponse: WPCOMTransactionEndpointResponseRedirect,
 	handler: ( response: RazorpayModalResponse ) => void,
-	ondismiss: () => void
+	ondismiss: () => void,
+	onerror: ( error: unknown ) => void
 ): RazorpayOptions {
+	debug( 'Transaction response in combineRazorpayOptions', txnResponse );
 	if ( ! txnResponse.razorpay_order_id ) {
 		throw new Error( 'Missing order_id for razorpay transaction' );
 	}
 
 	const options = razorpayConfiguration.options;
+	debug( 'Initial razorpayConfiguration.options', options );
 	options.order_id = txnResponse.razorpay_order_id;
 	options.customer_id = txnResponse.razorpay_customer_id;
 	if ( txnResponse.razorpay_option_recurring ) {
@@ -210,6 +223,7 @@ function combineRazorpayOptions(
 	options.handler = handler;
 	const modal = options.modal ?? {};
 	modal.ondismiss = ondismiss;
+	modal.onerror = onerror;
 	options.modal = modal;
 
 	debug( 'Constructing Razorpay prefill object using contact details', contactDetails );
@@ -217,6 +231,7 @@ function combineRazorpayOptions(
 	prefill.contact =
 		prefill.contact ?? ( contactDetails ? contactDetails.phone?.value.replace( '.', '' ) : '' );
 	prefill.email = prefill.email ?? ( contactDetails ? contactDetails.email?.value : '' );
+	prefill.name = prefill.name ?? ( contactDetails ? contactDetails.name?.value : '' );
 	options.prefill = prefill;
 
 	return options;

--- a/packages/api-core/src/me-razorpay-configuration.ts
+++ b/packages/api-core/src/me-razorpay-configuration.ts
@@ -19,6 +19,7 @@ export interface RazorpayOptions {
 	prefill?: {
 		contact?: string;
 		email?: string;
+		name?: string;
 	};
 	modal?: {
 		ondismiss?: ( response: RazorpayModalResponse ) => void;

--- a/packages/api-core/src/me-razorpay-configuration.ts
+++ b/packages/api-core/src/me-razorpay-configuration.ts
@@ -25,6 +25,9 @@ export interface RazorpayOptions {
 		ondismiss?: ( response: RazorpayModalResponse ) => void;
 	};
 	recurring?: string;
+	notes?: {
+		[ key: string ]: string;
+	};
 }
 
 /**

--- a/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
@@ -14,7 +14,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
-import type { AnyAction, PossiblyCompleteDomainContactDetails } from '../types';
+import type { AnyAction, ManagedContactDetails } from '../types';
 import type { RazorpayConfiguration } from '@automattic/calypso-razorpay';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -166,11 +166,7 @@ const RazorpayField = styled( Field )`
 	}
 `;
 
-function RazorpayFields( {
-	contactDetails,
-}: {
-	contactDetails?: PossiblyCompleteDomainContactDetails;
-} ) {
+function RazorpayFields() {
 	const { __ } = useI18n();
 
 	const { customerName, address1, address2, city, state, postalCode, country } = useRazorpayData();
@@ -186,28 +182,29 @@ function RazorpayFields( {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
-	// Prefill state, postalCode, and country from cached contact details
+	// Get live contact details from checkout store
+	const checkoutContactDetails = useSelect( ( select ) => {
+		const store = select( 'wpcom-checkout' );
+		return store && typeof store === 'object' && 'getContactInfo' in store
+			? ( store as { getContactInfo: () => ManagedContactDetails } ).getContactInfo()
+			: null;
+	}, [] ) as ManagedContactDetails | null;
+
+	// Keep state, postalCode, and country synced with live checkout contact details
+	// These fields are disabled/readonly, so they should always reflect billing info
 	useEffect( () => {
-		if ( contactDetails ) {
-			if ( contactDetails.state && ! state.isTouched ) {
-				changeState( contactDetails.state );
+		if ( checkoutContactDetails ) {
+			if ( checkoutContactDetails.state?.value ) {
+				changeState( checkoutContactDetails.state.value );
 			}
-			if ( contactDetails.postalCode && ! postalCode.isTouched ) {
-				changePostalCode( contactDetails.postalCode );
+			if ( checkoutContactDetails.postalCode?.value ) {
+				changePostalCode( checkoutContactDetails.postalCode.value );
 			}
-			if ( contactDetails.countryCode && ! country.isTouched ) {
-				changeCountry( contactDetails.countryCode );
+			if ( checkoutContactDetails.countryCode?.value ) {
+				changeCountry( checkoutContactDetails.countryCode.value );
 			}
 		}
-	}, [
-		contactDetails,
-		changeState,
-		changePostalCode,
-		changeCountry,
-		state.isTouched,
-		postalCode.isTouched,
-		country.isTouched,
-	] );
+	}, [ checkoutContactDetails, changeState, changePostalCode, changeCountry ] );
 
 	return (
 		<RazorpayFormWrapper>
@@ -297,20 +294,18 @@ export function createRazorpayMethod( {
 	cartKey,
 	submitButtonContent,
 	store,
-	contactDetails,
 }: {
 	razorpayConfiguration: RazorpayConfiguration;
 	cartKey: CartKey;
 	submitButtonContent: ReactNode;
 	store: RazorpayStore;
-	contactDetails?: PossiblyCompleteDomainContactDetails;
 } ): PaymentMethod {
 	return {
 		id: 'razorpay',
 		hasRequiredFields: true,
 		paymentProcessorId: 'razorpay',
 		label: <RazorpayLabel />,
-		activeContent: <RazorpayFields contactDetails={ contactDetails } />,
+		activeContent: <RazorpayFields />,
 		submitButton: (
 			<RazorpaySubmitButton
 				razorpayConfiguration={ razorpayConfiguration }

--- a/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment, ReactNode } from 'react';
+import { Fragment, ReactNode, useEffect } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
@@ -13,6 +13,7 @@ import type {
 	StoreSelectorsWithState,
 	StoreActions,
 	StoreState,
+	PossiblyCompleteDomainContactDetails,
 } from '../payment-method-store';
 import type { AnyAction } from '../types';
 import type { RazorpayConfiguration } from '@automattic/calypso-razorpay';
@@ -166,7 +167,11 @@ const RazorpayField = styled( Field )`
 	}
 `;
 
-function RazorpayFields() {
+function RazorpayFields( {
+	contactDetails,
+}: {
+	contactDetails?: PossiblyCompleteDomainContactDetails;
+} ) {
 	const { __ } = useI18n();
 
 	const { customerName, address1, address2, city, state, postalCode, country } = useRazorpayData();
@@ -182,13 +187,36 @@ function RazorpayFields() {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
+	// Prefill state, postalCode, and country from cached contact details
+	useEffect( () => {
+		if ( contactDetails ) {
+			if ( contactDetails.state && ! state.isTouched ) {
+				changeState( contactDetails.state );
+			}
+			if ( contactDetails.postalCode && ! postalCode.isTouched ) {
+				changePostalCode( contactDetails.postalCode );
+			}
+			if ( contactDetails.countryCode && ! country.isTouched ) {
+				changeCountry( contactDetails.countryCode );
+			}
+		}
+	}, [
+		contactDetails,
+		changeState,
+		changePostalCode,
+		changeCountry,
+		state.isTouched,
+		postalCode.isTouched,
+		country.isTouched,
+	] );
+
 	return (
 		<RazorpayFormWrapper>
 			<RazorpayField
 				id="razorpay-cardholder-name"
 				type="Text"
 				autoComplete="name"
-				label={ __( 'Cardholder name' ) }
+				label={ __( 'Your name' ) }
 				value={ customerName.value }
 				onChange={ changeCustomerName }
 				isError={ customerName.isTouched && customerName.value.length === 0 }
@@ -237,7 +265,7 @@ function RazorpayFields() {
 				onChange={ changeState }
 				isError={ state.isTouched && state.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
-				disabled={ isDisabled }
+				disabled
 			/>
 			<RazorpayField
 				id="razorpay-postal-code"
@@ -248,7 +276,7 @@ function RazorpayFields() {
 				onChange={ changePostalCode }
 				isError={ postalCode.isTouched && postalCode.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
-				disabled={ isDisabled }
+				disabled
 			/>
 			<RazorpayField
 				id="razorpay-country"
@@ -259,7 +287,7 @@ function RazorpayFields() {
 				onChange={ changeCountry }
 				isError={ country.isTouched && country.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
-				disabled={ isDisabled }
+				disabled
 			/>
 		</RazorpayFormWrapper>
 	);
@@ -270,18 +298,20 @@ export function createRazorpayMethod( {
 	cartKey,
 	submitButtonContent,
 	store,
+	contactDetails,
 }: {
 	razorpayConfiguration: RazorpayConfiguration;
 	cartKey: CartKey;
 	submitButtonContent: ReactNode;
 	store: RazorpayStore;
+	contactDetails?: PossiblyCompleteDomainContactDetails;
 } ): PaymentMethod {
 	return {
 		id: 'razorpay',
 		hasRequiredFields: true,
 		paymentProcessorId: 'razorpay',
 		label: <RazorpayLabel />,
-		activeContent: <RazorpayFields />,
+		activeContent: <RazorpayFields contactDetails={ contactDetails } />,
 		submitButton: (
 			<RazorpaySubmitButton
 				razorpayConfiguration={ razorpayConfiguration }

--- a/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
@@ -13,9 +13,8 @@ import type {
 	StoreSelectorsWithState,
 	StoreActions,
 	StoreState,
-	PossiblyCompleteDomainContactDetails,
 } from '../payment-method-store';
-import type { AnyAction } from '../types';
+import type { AnyAction, PossiblyCompleteDomainContactDetails } from '../types';
 import type { RazorpayConfiguration } from '@automattic/calypso-razorpay';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { CartKey } from '@automattic/shopping-cart';

--- a/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
@@ -1,140 +1,115 @@
 import { Button, useFormStatus, FormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch, registerStore } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment, ReactNode, useEffect } from 'react';
+import { Fragment, ReactNode, useEffect, useState } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
-import type {
-	PaymentMethodStore,
-	StoreSelectors,
-	StoreSelectorsWithState,
-	StoreActions,
-	StoreState,
-} from '../payment-method-store';
-import type { AnyAction, ManagedContactDetails } from '../types';
+import type { ManagedContactDetails } from '../types';
 import type { RazorpayConfiguration } from '@automattic/calypso-razorpay';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
 
 const debug = debugFactory( 'wpcom-checkout:razorpay-payment-method' );
 
-type NounsInStore =
-	| 'customerName'
-	| 'address1'
-	| 'address2'
-	| 'city'
-	| 'state'
-	| 'postalCode'
-	| 'country';
-
-type RazorpayStore = PaymentMethodStore< NounsInStore >;
-
-const actions: StoreActions< NounsInStore > = {
-	changeCustomerName( payload ) {
-		return { type: 'CUSTOMER_NAME_SET', payload };
-	},
-	changeAddress1( payload ) {
-		return { type: 'ADDRESS_1_SET', payload };
-	},
-	changeAddress2( payload ) {
-		return { type: 'ADDRESS_2_SET', payload };
-	},
-	changeCity( payload ) {
-		return { type: 'CITY_SET', payload };
-	},
-	changeState( payload ) {
-		return { type: 'STATE_SET', payload };
-	},
-	changePostalCode( payload ) {
-		return { type: 'POSTAL_CODE_SET', payload };
-	},
-	changeCountry( payload ) {
-		return { type: 'COUNTRY_SET', payload };
-	},
-};
-
-const selectors: StoreSelectorsWithState< NounsInStore > = {
-	getCustomerName( state ) {
-		return state.customerName;
-	},
-	getAddress1( state ) {
-		return state.address1;
-	},
-	getAddress2( state ) {
-		return state.address2;
-	},
-	getCity( state ) {
-		return state.city;
-	},
-	getState( state ) {
-		return state.state;
-	},
-	getPostalCode( state ) {
-		return state.postalCode;
-	},
-	getCountry( state ) {
-		return state.country;
-	},
-};
-
-export function createRazorpayPaymentMethodStore(): RazorpayStore {
-	debug( 'creating a new razorpay payment method store' );
-	const store = registerStore( 'razorpay', {
-		reducer(
-			state: StoreState< NounsInStore > = {
-				customerName: { value: '', isTouched: false },
-				address1: { value: '', isTouched: false },
-				address2: { value: '', isTouched: false },
-				city: { value: '', isTouched: false },
-				state: { value: '', isTouched: false },
-				postalCode: { value: '', isTouched: false },
-				country: { value: '', isTouched: false },
-			},
-			action: AnyAction
-		): StoreState< NounsInStore > {
-			switch ( action.type ) {
-				case 'CUSTOMER_NAME_SET':
-					return { ...state, customerName: { value: action.payload, isTouched: true } };
-				case 'ADDRESS_1_SET':
-					return { ...state, address1: { value: action.payload, isTouched: true } };
-				case 'ADDRESS_2_SET':
-					return { ...state, address2: { value: action.payload, isTouched: true } };
-				case 'CITY_SET':
-					return { ...state, city: { value: action.payload, isTouched: true } };
-				case 'STATE_SET':
-					return { ...state, state: { value: action.payload, isTouched: true } };
-				case 'POSTAL_CODE_SET':
-					return { ...state, postalCode: { value: action.payload, isTouched: true } };
-				case 'COUNTRY_SET':
-					return { ...state, country: { value: action.payload, isTouched: true } };
-			}
-			return state;
-		},
-		actions,
-		selectors,
-	} );
-
-	return store;
+interface RazorpayPaymentMethodStateShape {
+	customerName: string;
+	address1: string;
+	address2: string;
+	city: string;
+	state: string;
+	postalCode: string;
+	country: string;
 }
 
-function useRazorpayData() {
-	const data = useSelect( ( select ) => {
-		const store = select( 'razorpay' ) as StoreSelectors< NounsInStore >;
-		return {
-			customerName: store.getCustomerName(),
-			address1: store.getAddress1(),
-			address2: store.getAddress2(),
-			city: store.getCity(),
-			state: store.getState(),
-			postalCode: store.getPostalCode(),
-			country: store.getCountry(),
-		};
-	}, [] );
+type RazorpayPaymentMethodKey = keyof RazorpayPaymentMethodStateShape;
 
-	return data;
+interface RazorpayFieldState {
+	value: string;
+	isTouched: boolean;
+}
+
+type StateSubscriber = () => void;
+
+class RazorpayPaymentMethodState {
+	data: RazorpayPaymentMethodStateShape = {
+		customerName: '',
+		address1: '',
+		address2: '',
+		city: '',
+		state: '',
+		postalCode: '',
+		country: '',
+	};
+
+	touched: Record< RazorpayPaymentMethodKey, boolean > = {
+		customerName: false,
+		address1: false,
+		address2: false,
+		city: false,
+		state: false,
+		postalCode: false,
+		country: false,
+	};
+
+	subscribers: StateSubscriber[] = [];
+
+	change = ( field: RazorpayPaymentMethodKey, newValue: string ): void => {
+		this.data[ field ] = newValue;
+		this.touched[ field ] = true;
+		this.notifySubscribers();
+	};
+
+	getFieldState = ( field: RazorpayPaymentMethodKey ): RazorpayFieldState => {
+		return {
+			value: this.data[ field ],
+			isTouched: this.touched[ field ],
+		};
+	};
+
+	subscribe = ( callback: () => void ): ( () => void ) => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( subscriber ) => subscriber !== callback );
+		};
+	};
+
+	notifySubscribers = (): void => {
+		this.subscribers.forEach( ( subscriber ) => subscriber() );
+	};
+
+	isValid = (): boolean => {
+		// Touch all fields that are empty so they display validation errors
+		const fields: RazorpayPaymentMethodKey[] = [
+			'customerName',
+			'address1',
+			'address2',
+			'city',
+			'state',
+			'postalCode',
+			'country',
+		];
+
+		fields.forEach( ( field ) => {
+			if ( ! this.data[ field ].length ) {
+				this.change( field, '' );
+			}
+		} );
+
+		// Check if all required fields have values
+		return fields.every( ( field ) => this.data[ field ].length > 0 );
+	};
+}
+
+function useSubscribeToEventEmitter( state: RazorpayPaymentMethodState ) {
+	const [ , forceReload ] = useState( 0 );
+	useEffect( () => {
+		return state.subscribe( () => {
+			forceReload( ( val: number ) => val + 1 );
+		} );
+	}, [ state ] );
 }
 
 const RazorpayFormWrapper = styled.div`
@@ -166,19 +141,9 @@ const RazorpayField = styled( Field )`
 	}
 `;
 
-function RazorpayFields() {
+function RazorpayFields( { state }: { state: RazorpayPaymentMethodState } ) {
 	const { __ } = useI18n();
-
-	const { customerName, address1, address2, city, state, postalCode, country } = useRazorpayData();
-	const {
-		changeCustomerName,
-		changeAddress1,
-		changeAddress2,
-		changeCity,
-		changeState,
-		changePostalCode,
-		changeCountry,
-	} = useDispatch( 'razorpay' );
+	useSubscribeToEventEmitter( state );
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
@@ -195,16 +160,24 @@ function RazorpayFields() {
 	useEffect( () => {
 		if ( checkoutContactDetails ) {
 			if ( checkoutContactDetails.state?.value ) {
-				changeState( checkoutContactDetails.state.value );
+				state.change( 'state', checkoutContactDetails.state.value );
 			}
 			if ( checkoutContactDetails.postalCode?.value ) {
-				changePostalCode( checkoutContactDetails.postalCode.value );
+				state.change( 'postalCode', checkoutContactDetails.postalCode.value );
 			}
 			if ( checkoutContactDetails.countryCode?.value ) {
-				changeCountry( checkoutContactDetails.countryCode.value );
+				state.change( 'country', checkoutContactDetails.countryCode.value );
 			}
 		}
-	}, [ checkoutContactDetails, changeState, changePostalCode, changeCountry ] );
+	}, [ checkoutContactDetails, state ] );
+
+	const customerName = state.getFieldState( 'customerName' );
+	const address1 = state.getFieldState( 'address1' );
+	const address2 = state.getFieldState( 'address2' );
+	const city = state.getFieldState( 'city' );
+	const stateField = state.getFieldState( 'state' );
+	const postalCode = state.getFieldState( 'postalCode' );
+	const country = state.getFieldState( 'country' );
 
 	return (
 		<RazorpayFormWrapper>
@@ -214,7 +187,7 @@ function RazorpayFields() {
 				autoComplete="name"
 				label={ __( 'Your name' ) }
 				value={ customerName.value }
-				onChange={ changeCustomerName }
+				onChange={ ( value: string ) => state.change( 'customerName', value ) }
 				isError={ customerName.isTouched && customerName.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
 				disabled={ isDisabled }
@@ -225,7 +198,7 @@ function RazorpayFields() {
 				autoComplete="address-line1"
 				label={ __( 'Address line 1' ) }
 				value={ address1.value }
-				onChange={ changeAddress1 }
+				onChange={ ( value: string ) => state.change( 'address1', value ) }
 				isError={ address1.isTouched && address1.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
 				disabled={ isDisabled }
@@ -236,7 +209,7 @@ function RazorpayFields() {
 				autoComplete="address-line2"
 				label={ __( 'Address line 2' ) }
 				value={ address2.value }
-				onChange={ changeAddress2 }
+				onChange={ ( value: string ) => state.change( 'address2', value ) }
 				isError={ address2.isTouched && address2.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
 				disabled={ isDisabled }
@@ -247,7 +220,7 @@ function RazorpayFields() {
 				autoComplete="address-level2"
 				label={ __( 'City' ) }
 				value={ city.value }
-				onChange={ changeCity }
+				onChange={ ( value: string ) => state.change( 'city', value ) }
 				isError={ city.isTouched && city.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
 				disabled={ isDisabled }
@@ -257,9 +230,9 @@ function RazorpayFields() {
 				type="Text"
 				autoComplete="address-level1"
 				label={ __( 'State' ) }
-				value={ state.value }
-				onChange={ changeState }
-				isError={ state.isTouched && state.value.length === 0 }
+				value={ stateField.value }
+				onChange={ ( value: string ) => state.change( 'state', value ) }
+				isError={ stateField.isTouched && stateField.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
 				disabled
 			/>
@@ -269,7 +242,7 @@ function RazorpayFields() {
 				autoComplete="postal-code"
 				label={ __( 'Postcode' ) }
 				value={ postalCode.value }
-				onChange={ changePostalCode }
+				onChange={ ( value: string ) => state.change( 'postalCode', value ) }
 				isError={ postalCode.isTouched && postalCode.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
 				disabled
@@ -280,7 +253,7 @@ function RazorpayFields() {
 				autoComplete="country"
 				label={ __( 'Country' ) }
 				value={ country.value }
-				onChange={ changeCountry }
+				onChange={ ( value: string ) => state.change( 'country', value ) }
 				isError={ country.isTouched && country.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
 				disabled
@@ -293,28 +266,28 @@ export function createRazorpayMethod( {
 	razorpayConfiguration,
 	cartKey,
 	submitButtonContent,
-	store,
 }: {
 	razorpayConfiguration: RazorpayConfiguration;
 	cartKey: CartKey;
 	submitButtonContent: ReactNode;
-	store: RazorpayStore;
 } ): PaymentMethod {
+	const state = new RazorpayPaymentMethodState();
+
 	return {
 		id: 'razorpay',
 		hasRequiredFields: true,
 		paymentProcessorId: 'razorpay',
 		label: <RazorpayLabel />,
-		activeContent: <RazorpayFields />,
+		activeContent: <RazorpayFields state={ state } />,
 		submitButton: (
 			<RazorpaySubmitButton
 				razorpayConfiguration={ razorpayConfiguration }
 				cartKey={ cartKey }
 				submitButtonContent={ submitButtonContent }
-				store={ store }
+				state={ state }
 			/>
 		),
-		inactiveContent: <RazorpaySummary />,
+		inactiveContent: <RazorpaySummary state={ state } />,
 		// translators: UPI stands for Unified Payments Interface and may not need to be transalted.
 		getAriaLabel: ( __ ) => __( 'UPI' ),
 	};
@@ -333,8 +306,16 @@ export function RazorpayLabel() {
 	);
 }
 
-export function RazorpaySummary() {
-	const { customerName, address1, address2, city, state, postalCode, country } = useRazorpayData();
+export function RazorpaySummary( { state }: { state: RazorpayPaymentMethodState } ) {
+	useSubscribeToEventEmitter( state );
+
+	const customerName = state.getFieldState( 'customerName' );
+	const address1 = state.getFieldState( 'address1' );
+	const address2 = state.getFieldState( 'address2' );
+	const city = state.getFieldState( 'city' );
+	const stateField = state.getFieldState( 'state' );
+	const postalCode = state.getFieldState( 'postalCode' );
+	const country = state.getFieldState( 'country' );
 
 	return (
 		<SummaryDetails>
@@ -343,8 +324,8 @@ export function RazorpaySummary() {
 			{ address2.value && <SummaryLine>{ address2.value }</SummaryLine> }
 			<SummaryLine>
 				{ city.value }
-				{ city.value && state.value ? ', ' : '' }
-				{ state.value } { postalCode.value }
+				{ city.value && stateField.value ? ', ' : '' }
+				{ stateField.value } { postalCode.value }
 			</SummaryLine>
 			<SummaryLine>{ country.value }</SummaryLine>
 		</SummaryDetails>
@@ -357,17 +338,17 @@ export function RazorpaySubmitButton( {
 	razorpayConfiguration,
 	cartKey,
 	submitButtonContent,
-	store,
+	state,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	razorpayConfiguration: RazorpayConfiguration;
 	cartKey: CartKey;
 	submitButtonContent: ReactNode;
-	store: RazorpayStore;
+	state: RazorpayPaymentMethodState;
 } ) {
 	const { formStatus } = useFormStatus();
-	const { customerName, address1, address2, city, state, postalCode, country } = useRazorpayData();
+	useSubscribeToEventEmitter( state );
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -383,18 +364,18 @@ export function RazorpaySubmitButton( {
 			disabled={ disabled }
 			onClick={ ( ev ) => {
 				ev.preventDefault();
-				if ( isFormValid( store ) ) {
+				if ( state.isValid() ) {
 					debug( 'Initiate razorpay payment' );
 					onClick( {
 						razorpayConfiguration,
 						cartKey,
-						name: customerName.value,
-						address1: address1.value,
-						address2: address2.value,
-						city: city.value,
-						state: state.value,
-						postalCode: postalCode.value,
-						country: country.value,
+						name: state.data.customerName,
+						address1: state.data.address1,
+						address2: state.data.address2,
+						city: state.data.city,
+						state: state.data.state,
+						postalCode: state.data.postalCode,
+						country: state.data.country,
 					} );
 				}
 			} }
@@ -405,55 +386,6 @@ export function RazorpaySubmitButton( {
 			{ submitButtonContent }
 		</Button>
 	);
-}
-
-function isFormValid( store: RazorpayStore ): boolean {
-	const storeState = store.getState();
-	const customerName = selectors.getCustomerName( storeState );
-	const address1 = selectors.getAddress1( storeState );
-	const address2 = selectors.getAddress2( storeState );
-	const city = selectors.getCity( storeState );
-	const state = selectors.getState( storeState );
-	const postalCode = selectors.getPostalCode( storeState );
-	const country = selectors.getCountry( storeState );
-
-	// Touch all fields that are empty so they display validation errors
-	if ( ! customerName.value.length ) {
-		store.dispatch( actions.changeCustomerName( '' ) );
-	}
-	if ( ! address1.value.length ) {
-		store.dispatch( actions.changeAddress1( '' ) );
-	}
-	if ( ! address2.value.length ) {
-		store.dispatch( actions.changeAddress2( '' ) );
-	}
-	if ( ! city.value.length ) {
-		store.dispatch( actions.changeCity( '' ) );
-	}
-	if ( ! state.value.length ) {
-		store.dispatch( actions.changeState( '' ) );
-	}
-	if ( ! postalCode.value.length ) {
-		store.dispatch( actions.changePostalCode( '' ) );
-	}
-	if ( ! country.value.length ) {
-		store.dispatch( actions.changeCountry( '' ) );
-	}
-
-	// Check if all required fields have values
-	if (
-		! customerName.value.length ||
-		! address1.value.length ||
-		! address2.value.length ||
-		! city.value.length ||
-		! state.value.length ||
-		! postalCode.value.length ||
-		! country.value.length
-	) {
-		return false;
-	}
-
-	return true;
 }
 
 // Adapted from https://en.wikipedia.org/wiki/File:Razorpay_logo.svg

--- a/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
@@ -21,7 +21,14 @@ import type { CartKey } from '@automattic/shopping-cart';
 
 const debug = debugFactory( 'wpcom-checkout:razorpay-payment-method' );
 
-type NounsInStore = 'customerName';
+type NounsInStore =
+	| 'customerName'
+	| 'address1'
+	| 'address2'
+	| 'city'
+	| 'state'
+	| 'postalCode'
+	| 'country';
 
 type RazorpayStore = PaymentMethodStore< NounsInStore >;
 
@@ -29,11 +36,47 @@ const actions: StoreActions< NounsInStore > = {
 	changeCustomerName( payload ) {
 		return { type: 'CUSTOMER_NAME_SET', payload };
 	},
+	changeAddress1( payload ) {
+		return { type: 'ADDRESS_1_SET', payload };
+	},
+	changeAddress2( payload ) {
+		return { type: 'ADDRESS_2_SET', payload };
+	},
+	changeCity( payload ) {
+		return { type: 'CITY_SET', payload };
+	},
+	changeState( payload ) {
+		return { type: 'STATE_SET', payload };
+	},
+	changePostalCode( payload ) {
+		return { type: 'POSTAL_CODE_SET', payload };
+	},
+	changeCountry( payload ) {
+		return { type: 'COUNTRY_SET', payload };
+	},
 };
 
 const selectors: StoreSelectorsWithState< NounsInStore > = {
 	getCustomerName( state ) {
 		return state.customerName;
+	},
+	getAddress1( state ) {
+		return state.address1;
+	},
+	getAddress2( state ) {
+		return state.address2;
+	},
+	getCity( state ) {
+		return state.city;
+	},
+	getState( state ) {
+		return state.state;
+	},
+	getPostalCode( state ) {
+		return state.postalCode;
+	},
+	getCountry( state ) {
+		return state.country;
 	},
 };
 
@@ -43,12 +86,30 @@ export function createRazorpayPaymentMethodStore(): RazorpayStore {
 		reducer(
 			state: StoreState< NounsInStore > = {
 				customerName: { value: '', isTouched: false },
+				address1: { value: '', isTouched: false },
+				address2: { value: '', isTouched: false },
+				city: { value: '', isTouched: false },
+				state: { value: '', isTouched: false },
+				postalCode: { value: '', isTouched: false },
+				country: { value: '', isTouched: false },
 			},
 			action: AnyAction
 		): StoreState< NounsInStore > {
 			switch ( action.type ) {
 				case 'CUSTOMER_NAME_SET':
 					return { ...state, customerName: { value: action.payload, isTouched: true } };
+				case 'ADDRESS_1_SET':
+					return { ...state, address1: { value: action.payload, isTouched: true } };
+				case 'ADDRESS_2_SET':
+					return { ...state, address2: { value: action.payload, isTouched: true } };
+				case 'CITY_SET':
+					return { ...state, city: { value: action.payload, isTouched: true } };
+				case 'STATE_SET':
+					return { ...state, state: { value: action.payload, isTouched: true } };
+				case 'POSTAL_CODE_SET':
+					return { ...state, postalCode: { value: action.payload, isTouched: true } };
+				case 'COUNTRY_SET':
+					return { ...state, country: { value: action.payload, isTouched: true } };
 			}
 			return state;
 		},
@@ -59,17 +120,21 @@ export function createRazorpayPaymentMethodStore(): RazorpayStore {
 	return store;
 }
 
-function useCustomerData() {
-	const { customerName } = useSelect( ( select ) => {
+function useRazorpayData() {
+	const data = useSelect( ( select ) => {
 		const store = select( 'razorpay' ) as StoreSelectors< NounsInStore >;
 		return {
 			customerName: store.getCustomerName(),
+			address1: store.getAddress1(),
+			address2: store.getAddress2(),
+			city: store.getCity(),
+			state: store.getState(),
+			postalCode: store.getPostalCode(),
+			country: store.getCountry(),
 		};
 	}, [] );
 
-	return {
-		customerName,
-	};
+	return data;
 }
 
 const RazorpayFormWrapper = styled.div`
@@ -104,8 +169,16 @@ const RazorpayField = styled( Field )`
 function RazorpayFields() {
 	const { __ } = useI18n();
 
-	const { customerName } = useCustomerData();
-	const { changeCustomerName } = useDispatch( 'razorpay' );
+	const { customerName, address1, address2, city, state, postalCode, country } = useRazorpayData();
+	const {
+		changeCustomerName,
+		changeAddress1,
+		changeAddress2,
+		changeCity,
+		changeState,
+		changePostalCode,
+		changeCountry,
+	} = useDispatch( 'razorpay' );
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
@@ -115,10 +188,76 @@ function RazorpayFields() {
 				id="razorpay-cardholder-name"
 				type="Text"
 				autoComplete="name"
-				label={ __( 'Your name' ) }
+				label={ __( 'Cardholder name' ) }
 				value={ customerName.value }
 				onChange={ changeCustomerName }
 				isError={ customerName.isTouched && customerName.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<RazorpayField
+				id="razorpay-address-1"
+				type="Text"
+				autoComplete="address-line1"
+				label={ __( 'Address line 1' ) }
+				value={ address1.value }
+				onChange={ changeAddress1 }
+				isError={ address1.isTouched && address1.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<RazorpayField
+				id="razorpay-address-2"
+				type="Text"
+				autoComplete="address-line2"
+				label={ __( 'Address line 2' ) }
+				value={ address2.value }
+				onChange={ changeAddress2 }
+				isError={ address2.isTouched && address2.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<RazorpayField
+				id="razorpay-city"
+				type="Text"
+				autoComplete="address-level2"
+				label={ __( 'City' ) }
+				value={ city.value }
+				onChange={ changeCity }
+				isError={ city.isTouched && city.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<RazorpayField
+				id="razorpay-state"
+				type="Text"
+				autoComplete="address-level1"
+				label={ __( 'State' ) }
+				value={ state.value }
+				onChange={ changeState }
+				isError={ state.isTouched && state.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<RazorpayField
+				id="razorpay-postal-code"
+				type="Text"
+				autoComplete="postal-code"
+				label={ __( 'Postcode' ) }
+				value={ postalCode.value }
+				onChange={ changePostalCode }
+				isError={ postalCode.isTouched && postalCode.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<RazorpayField
+				id="razorpay-country"
+				type="Text"
+				autoComplete="country"
+				label={ __( 'Country' ) }
+				value={ country.value }
+				onChange={ changeCountry }
+				isError={ country.isTouched && country.value.length === 0 }
 				errorMessage={ __( 'This field is required' ) }
 				disabled={ isDisabled }
 			/>
@@ -171,11 +310,19 @@ export function RazorpayLabel() {
 }
 
 export function RazorpaySummary() {
-	const { customerName } = useCustomerData();
+	const { customerName, address1, address2, city, state, postalCode, country } = useRazorpayData();
 
 	return (
 		<SummaryDetails>
 			<SummaryLine>{ customerName.value }</SummaryLine>
+			<SummaryLine>{ address1.value }</SummaryLine>
+			{ address2.value && <SummaryLine>{ address2.value }</SummaryLine> }
+			<SummaryLine>
+				{ city.value }
+				{ city.value && state.value ? ', ' : '' }
+				{ state.value } { postalCode.value }
+			</SummaryLine>
+			<SummaryLine>{ country.value }</SummaryLine>
 		</SummaryDetails>
 	);
 }
@@ -196,7 +343,7 @@ export function RazorpaySubmitButton( {
 	store: RazorpayStore;
 } ) {
 	const { formStatus } = useFormStatus();
-	const { customerName } = useCustomerData();
+	const { customerName, address1, address2, city, state, postalCode, country } = useRazorpayData();
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -218,6 +365,12 @@ export function RazorpaySubmitButton( {
 						razorpayConfiguration,
 						cartKey,
 						name: customerName.value,
+						address1: address1.value,
+						address2: address2.value,
+						city: city.value,
+						state: state.value,
+						postalCode: postalCode.value,
+						country: country.value,
 					} );
 				}
 			} }
@@ -231,15 +384,51 @@ export function RazorpaySubmitButton( {
 }
 
 function isFormValid( store: RazorpayStore ): boolean {
-	const customerName = selectors.getCustomerName( store.getState() );
+	const storeState = store.getState();
+	const customerName = selectors.getCustomerName( storeState );
+	const address1 = selectors.getAddress1( storeState );
+	const address2 = selectors.getAddress2( storeState );
+	const city = selectors.getCity( storeState );
+	const state = selectors.getState( storeState );
+	const postalCode = selectors.getPostalCode( storeState );
+	const country = selectors.getCountry( storeState );
 
+	// Touch all fields that are empty so they display validation errors
 	if ( ! customerName.value.length ) {
-		// Touch the field so it displays a validation error
 		store.dispatch( actions.changeCustomerName( '' ) );
 	}
-	if ( ! customerName.value.length ) {
+	if ( ! address1.value.length ) {
+		store.dispatch( actions.changeAddress1( '' ) );
+	}
+	if ( ! address2.value.length ) {
+		store.dispatch( actions.changeAddress2( '' ) );
+	}
+	if ( ! city.value.length ) {
+		store.dispatch( actions.changeCity( '' ) );
+	}
+	if ( ! state.value.length ) {
+		store.dispatch( actions.changeState( '' ) );
+	}
+	if ( ! postalCode.value.length ) {
+		store.dispatch( actions.changePostalCode( '' ) );
+	}
+	if ( ! country.value.length ) {
+		store.dispatch( actions.changeCountry( '' ) );
+	}
+
+	// Check if all required fields have values
+	if (
+		! customerName.value.length ||
+		! address1.value.length ||
+		! address2.value.length ||
+		! city.value.length ||
+		! state.value.length ||
+		! postalCode.value.length ||
+		! country.value.length
+	) {
 		return false;
 	}
+
 	return true;
 }
 

--- a/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
@@ -1,32 +1,154 @@
 import { Button, useFormStatus, FormStatus } from '@automattic/composite-checkout';
+import styled from '@emotion/styled';
+import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import { Fragment, ReactNode } from 'react';
+import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
+import { SummaryLine, SummaryDetails } from '../summary-details';
+import type {
+	PaymentMethodStore,
+	StoreSelectors,
+	StoreSelectorsWithState,
+	StoreActions,
+	StoreState,
+} from '../payment-method-store';
+import type { AnyAction } from '../types';
 import type { RazorpayConfiguration } from '@automattic/calypso-razorpay';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
 
 const debug = debugFactory( 'wpcom-checkout:razorpay-payment-method' );
 
+type NounsInStore = 'customerName';
+
+type RazorpayStore = PaymentMethodStore< NounsInStore >;
+
+const actions: StoreActions< NounsInStore > = {
+	changeCustomerName( payload ) {
+		return { type: 'CUSTOMER_NAME_SET', payload };
+	},
+};
+
+const selectors: StoreSelectorsWithState< NounsInStore > = {
+	getCustomerName( state ) {
+		return state.customerName;
+	},
+};
+
+export function createRazorpayPaymentMethodStore(): RazorpayStore {
+	debug( 'creating a new razorpay payment method store' );
+	const store = registerStore( 'razorpay', {
+		reducer(
+			state: StoreState< NounsInStore > = {
+				customerName: { value: '', isTouched: false },
+			},
+			action: AnyAction
+		): StoreState< NounsInStore > {
+			switch ( action.type ) {
+				case 'CUSTOMER_NAME_SET':
+					return { ...state, customerName: { value: action.payload, isTouched: true } };
+			}
+			return state;
+		},
+		actions,
+		selectors,
+	} );
+
+	return store;
+}
+
+function useCustomerData() {
+	const { customerName } = useSelect( ( select ) => {
+		const store = select( 'razorpay' ) as StoreSelectors< NounsInStore >;
+		return {
+			customerName: store.getCustomerName(),
+		};
+	}, [] );
+
+	return {
+		customerName,
+	};
+}
+
+const RazorpayFormWrapper = styled.div`
+	padding: 16px;
+	position: relative;
+
+	::after {
+		display: block;
+		width: calc( 100% - 6px );
+		height: 1px;
+		content: '';
+		background: ${ ( props ) => props.theme.colors.borderColorLight };
+		position: absolute;
+		top: 0;
+		left: 3px;
+
+		.rtl & {
+			right: 3px;
+			left: auto;
+		}
+	}
+`;
+
+const RazorpayField = styled( Field )`
+	margin-top: 16px;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+function RazorpayFields() {
+	const { __ } = useI18n();
+
+	const { customerName } = useCustomerData();
+	const { changeCustomerName } = useDispatch( 'razorpay' );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+
+	return (
+		<RazorpayFormWrapper>
+			<RazorpayField
+				id="razorpay-cardholder-name"
+				type="Text"
+				autoComplete="name"
+				label={ __( 'Your name' ) }
+				value={ customerName.value }
+				onChange={ changeCustomerName }
+				isError={ customerName.isTouched && customerName.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+		</RazorpayFormWrapper>
+	);
+}
+
 export function createRazorpayMethod( {
 	razorpayConfiguration,
 	cartKey,
 	submitButtonContent,
+	store,
 }: {
 	razorpayConfiguration: RazorpayConfiguration;
 	cartKey: CartKey;
 	submitButtonContent: ReactNode;
+	store: RazorpayStore;
 } ): PaymentMethod {
 	return {
 		id: 'razorpay',
+		hasRequiredFields: true,
 		paymentProcessorId: 'razorpay',
 		label: <RazorpayLabel />,
+		activeContent: <RazorpayFields />,
 		submitButton: (
 			<RazorpaySubmitButton
 				razorpayConfiguration={ razorpayConfiguration }
 				cartKey={ cartKey }
 				submitButtonContent={ submitButtonContent }
+				store={ store }
 			/>
 		),
 		inactiveContent: <RazorpaySummary />,
@@ -49,8 +171,13 @@ export function RazorpayLabel() {
 }
 
 export function RazorpaySummary() {
-	const { __ } = useI18n();
-	return <Fragment>{ __( 'UPI' ) }</Fragment>;
+	const { customerName } = useCustomerData();
+
+	return (
+		<SummaryDetails>
+			<SummaryLine>{ customerName.value }</SummaryLine>
+		</SummaryDetails>
+	);
 }
 
 export function RazorpaySubmitButton( {
@@ -59,14 +186,17 @@ export function RazorpaySubmitButton( {
 	razorpayConfiguration,
 	cartKey,
 	submitButtonContent,
+	store,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	razorpayConfiguration: RazorpayConfiguration;
 	cartKey: CartKey;
 	submitButtonContent: ReactNode;
+	store: RazorpayStore;
 } ) {
 	const { formStatus } = useFormStatus();
+	const { customerName } = useCustomerData();
 
 	// This must be typed as optional because it's injected by cloning the
 	// element in CheckoutSubmitButton, but the uncloned element does not have
@@ -82,8 +212,14 @@ export function RazorpaySubmitButton( {
 			disabled={ disabled }
 			onClick={ ( ev ) => {
 				ev.preventDefault();
-				debug( 'Initiate razorpay payment' );
-				onClick( { razorpayConfiguration, cartKey } );
+				if ( isFormValid( store ) ) {
+					debug( 'Initiate razorpay payment' );
+					onClick( {
+						razorpayConfiguration,
+						cartKey,
+						name: customerName.value,
+					} );
+				}
 			} }
 			buttonType="primary"
 			isBusy={ FormStatus.SUBMITTING === formStatus }
@@ -92,6 +228,19 @@ export function RazorpaySubmitButton( {
 			{ submitButtonContent }
 		</Button>
 	);
+}
+
+function isFormValid( store: RazorpayStore ): boolean {
+	const customerName = selectors.getCustomerName( store.getState() );
+
+	if ( ! customerName.value.length ) {
+		// Touch the field so it displays a validation error
+		store.dispatch( actions.changeCustomerName( '' ) );
+	}
+	if ( ! customerName.value.length ) {
+		return false;
+	}
+	return true;
 }
 
 // Adapted from https://en.wikipedia.org/wiki/File:Razorpay_logo.svg


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of Shill-1327

## Proposed Changes

* Adding extra required fields for the UPI integration.
* These new fields include the name and full address of the customer. The fields that we collect for tax reasons (state, postal code, and country) should be pre-filled and readonly. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Razorpay added some extra validation for some mandatory fields that caused our purchases to start failing. We need to collect extra data to complete those fields. This seems like the least painful way to do that. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Screenshot of new fields prefilled: 
<img width="619" height="715" alt="Screenshot 2025-11-19 at 17 53 47" src="https://github.com/user-attachments/assets/57550032-b486-4931-8743-2e412cc1d80d" />

Needs testing with the backend diff from 196205-ghe-Automattic/wpcom
