### PR TITLE
e2e tests: Fix Slack report for failed tests

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -979,9 +979,6 @@ object PlaywrightTestPRMatrix : BuildType({
 				REPORT_URL="https://automattic.github.io/wp-calypso-test-results/r"
 				echo "##teamcity[notification notifier='slack' message='Report available: ${'$'}{REPORT_URL}/${'$'}{ARCHIVE_NAME}.tgz.enc|nBranch: %teamcity.build.branch%' sendTo='calypso-e2e-reports-ext' connectionId='PROJECT_EXT_11']"
 			""".trimIndent()
-			conditions {
-				matches("teamcity.build.branch", ".*e2e.*")
-			}
 			dockerImage = "%docker_image_e2e%"
 		}
 	}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -958,10 +958,9 @@ object PlaywrightTestPRMatrix : BuildType({
 	steps {
 		bashNodeScript {
 			name = "Upload report and send Slack notification"
-			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			executionMode = BuildStep.ExecutionMode.RUN_ONLY_ON_FAILURE
 			conditions {
 				matches("teamcity.build.branch", ".*e2e.*")
-				moreThan("FailedTestCount", "0")
 			}
 			scriptContent = """
 				ARCHIVE_NAME="%build.counter%-%build.vcs.number%-%PROJECT%"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -961,12 +961,12 @@ object PlaywrightTestPRMatrix : BuildType({
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			conditions {
 				matches("teamcity.build.branch", ".*e2e.*")
-				equals("teamcity.build.step.status.run_tests", "failure")
+				moreThan("FailedTestCount", "0")
 			}
 			scriptContent = """
 				ARCHIVE_NAME="%build.counter%-%build.vcs.number%-%PROJECT%"
 				export E2E_SECRETS_KEY="%E2E_SECRETS_ENCRYPTION_KEY_CURRENT%"
-				
+
 				# Need to use -C to avoid creation of an unnecessary top level directory.
 				tar cvfz - -C test/e2e/output/html . | openssl enc -aes-256-cbc -salt -out ${'$'}{ARCHIVE_NAME}.tgz.enc -pass env:E2E_SECRETS_KEY
 


### PR DESCRIPTION
Fix [QAO-162](https://linear.app/a8c/issue/QAO-162/slack-report-for-failed-tests-is-not-working)

## Proposed Changes

The Slack notification with a link to a full report is not longer working, probably since #106126.
Fixed the condition.

Tested with a failure on this PR. Alert was sent: p1763558729492969-slack-C09DMP444T0