### PR TITLE
Help Center Menu Panel: No event if undefined

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -34,6 +34,9 @@ function HelpCenterContent() {
 	const canvasMode = useCanvasMode();
 
 	const trackIconInteraction = useCallback( () => {
+		if ( isMenuPanelExperimentEnabled === undefined ) {
+			return;
+		}
 		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
 			is_help_center_visible: isShown ?? false,
 			section: helpCenterData.sectionName || 'wp-admin',

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -82,6 +82,9 @@ function AdminHelpCenterContent() {
 	);
 
 	const trackIconInteraction = useCallback( () => {
+		if ( isMenuPanelExperimentEnabled === undefined ) {
+			return;
+		}
 		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
 			is_help_center_visible: isShown ?? false,
 			section: helpCenterData.sectionName || 'wp-admin',

--- a/apps/help-center/hooks/use-menu-panel-experiment.js
+++ b/apps/help-center/hooks/use-menu-panel-experiment.js
@@ -45,9 +45,9 @@ const useMenuPanelExperiment = ( experimentName, treatmentVariation ) => {
 		initialData: () => {
 			try {
 				const cached = window.localStorage.getItem( cacheKey );
-				return cached ? JSON.parse( cached ) : false;
+				return cached ? JSON.parse( cached ) : undefined;
 			} catch ( e ) {
-				return false;
+				return undefined;
 			}
 		},
 	} );

--- a/apps/help-center/hooks/use-menu-panel-experiment.js
+++ b/apps/help-center/hooks/use-menu-panel-experiment.js
@@ -25,7 +25,7 @@ const fetchExperimentAssignment = async ( experimentName ) => {
 };
 
 const useMenuPanelExperiment = ( experimentName, treatmentVariation ) => {
-	const cacheKey = `experiment-assignment-${ experimentName }-${ treatmentVariation }`;
+	const cacheKey = `menu-panel-experiment-assignment-${ experimentName }-${ treatmentVariation }`;
 
 	const { data: isInTreatment } = useQuery( {
 		queryKey: [ 'experiment-assignment', experimentName, treatmentVariation ],

--- a/apps/help-center/hooks/use-menu-panel-experiment.js
+++ b/apps/help-center/hooks/use-menu-panel-experiment.js
@@ -33,7 +33,10 @@ const useMenuPanelExperiment = ( experimentName, treatmentVariation ) => {
 			const result = await fetchExperimentAssignment( experimentName );
 			const isMatch = result?.variations?.[ experimentName ] === treatmentVariation;
 			try {
-				window.localStorage.setItem( cacheKey, JSON.stringify( isMatch ) );
+				window.localStorage.setItem(
+					cacheKey,
+					JSON.stringify( { value: isMatch, timestamp: Date.now() } )
+				);
 			} catch ( e ) {
 				// Silent fail if localStorage is unavailable
 			}
@@ -45,7 +48,13 @@ const useMenuPanelExperiment = ( experimentName, treatmentVariation ) => {
 		initialData: () => {
 			try {
 				const cached = window.localStorage.getItem( cacheKey );
-				return cached ? JSON.parse( cached ) : undefined;
+				if ( ! cached ) {
+					return undefined;
+				}
+				const { value, timestamp } = JSON.parse( cached );
+				const age = Date.now() - timestamp;
+				const maxAge = 10 * 60 * 1000; // 10 minutes
+				return age < maxAge ? value : undefined;
 			} catch ( e ) {
 				return undefined;
 			}


### PR DESCRIPTION
For the experiment for the new menu panel, we should not fire the icon interaction event if the experiment variation is null, as it means the experiment is still loading.