### PR TITLE
Add restart connection option in domain connection verification page

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -2,6 +2,7 @@ import { Domain, DomainConnectionSetupMode } from '@automattic/api-core';
 import { Badge } from '@automattic/ui';
 import {
 	Icon,
+	Button,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -28,6 +29,8 @@ interface DomainConnectionVerificationProps {
 	siteSlug: string;
 	domainConnectionSetupInfo: DomainMappingSetupInfo;
 	domainMappingStatus: DomainMappingStatus;
+	onRestartConnection: () => void;
+	isRestartingConnection: boolean;
 }
 
 export default function DomainConnectionVerification( {
@@ -36,6 +39,8 @@ export default function DomainConnectionVerification( {
 	siteSlug,
 	domainMappingStatus,
 	domainConnectionSetupInfo,
+	onRestartConnection,
+	isRestartingConnection,
 }: DomainConnectionVerificationProps ) {
 	const status: DomainConnectionStatus = isMappingVerificationSuccess(
 		domainMappingStatus.mode,
@@ -122,6 +127,16 @@ export default function DomainConnectionVerification( {
 						{ __( 'Need help?' ) }
 					</Text>
 					<VStack spacing={ 2 }>
+						<HStack>
+							<Button
+								variant="link"
+								onClick={ onRestartConnection }
+								isBusy={ isRestartingConnection }
+								disabled={ isRestartingConnection }
+							>
+								{ __( 'Restart connection' ) }
+							</Button>
+						</HStack>
 						<InlineSupportLink supportContext="map-domain-setup-instructions">
 							{ __( 'Domain connection guide' ) }
 						</InlineSupportLink>

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -123,29 +123,32 @@ export default function DomainConnectionVerification( {
 					</VStack>
 					{ status === 'verifying' && <VerificationInProgressNextSteps /> }
 
-					<Text size="medium" weight={ 500 }>
-						{ __( 'Need help?' ) }
-					</Text>
-					<VStack spacing={ 2 }>
-						<HStack>
-							<Button
-								variant="link"
-								onClick={ onRestartConnection }
-								isBusy={ isRestartingConnection }
-								disabled={ isRestartingConnection }
-							>
-								{ __( 'Restart connection' ) }
-							</Button>
-						</HStack>
-						<InlineSupportLink supportContext="map-domain-setup-instructions">
-							{ __( 'Domain connection guide' ) }
-						</InlineSupportLink>
-						<InlineSupportLink supportContext="general-support-options">
-							{ __( 'Contact support' ) }
-						</InlineSupportLink>
-						<InlineSupportLink supportContext="transfer-domain-registrar-login">
-							{ __( 'Registrar instructions' ) }
-						</InlineSupportLink>
+					<VStack spacing={ 4 }>
+						<Text size="medium" weight={ 500 }>
+							{ __( 'Need help?' ) }
+						</Text>
+						<VStack spacing={ 2 }>
+							<HStack>
+								<Button
+									variant="link"
+									onClick={ onRestartConnection }
+									isBusy={ isRestartingConnection }
+									disabled={ isRestartingConnection }
+									style={ { lineHeight: '20px' } }
+								>
+									{ __( 'Restart connection' ) }
+								</Button>
+							</HStack>
+							<InlineSupportLink supportContext="map-domain-setup-instructions">
+								{ __( 'Domain connection guide' ) }
+							</InlineSupportLink>
+							<InlineSupportLink supportContext="general-support-options">
+								{ __( 'Contact support' ) }
+							</InlineSupportLink>
+							<InlineSupportLink supportContext="transfer-domain-registrar-login">
+								{ __( 'Registrar instructions' ) }
+							</InlineSupportLink>
+						</VStack>
 					</VStack>
 				</VStack>
 			</CardBody>

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -108,6 +108,33 @@ export default function DomainConnection() {
 		} );
 	};
 
+	const onRestartConnection = () => {
+		// Reset connection mode to null to restart the flow
+		updateConnectionMode( null, {
+			onSuccess: () => {
+				recordTracksEvent( 'calypso_dashboard_domain_connection_restart', {
+					domain: domainName,
+				} );
+
+				// Set local state to null to show setup step
+				setConnectionMode( null );
+
+				// Navigate to the setup route
+				router.navigate( {
+					to: domainConnectionSetupRoute.fullPath,
+					params: { domainName },
+					search: {},
+					replace: true,
+				} );
+			},
+			onError: () => {
+				createErrorNotice( __( 'We could not restart your domain connection. Please try again.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
+
 	// If returning from successful Domain Connect, update the server
 	useEffect( () => {
 		if ( step === 'dc_return' && ! queryError && ! isUpdatingConnectionMode ) {
@@ -174,6 +201,8 @@ export default function DomainConnection() {
 					siteSlug={ siteSlug }
 					domainConnectionSetupInfo={ domainConnectionSetupInfo }
 					domainMappingStatus={ domainMappingStatus }
+					onRestartConnection={ onRestartConnection }
+					isRestartingConnection={ isUpdatingConnectionMode }
 				/>
 			) : (
 				<DomainConnectionSetup

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
@@ -158,6 +158,8 @@ describe( 'DomainConnectionVerification', () => {
 		siteSlug: 'example.wordpress.com',
 		domainMappingStatus: createMockDomainMappingStatus(),
 		domainConnectionSetupInfo: createMockDomainConnectionSetupInfo(),
+		onRestartConnection: jest.fn(),
+		isRestartingConnection: false,
 	};
 
 	describe( 'Basic Rendering', () => {

--- a/packages/api-core/src/domain-connection-setup/mutators.ts
+++ b/packages/api-core/src/domain-connection-setup/mutators.ts
@@ -3,7 +3,7 @@ import type { DomainMappingStatus } from './types';
 
 export function updateConnectionModeAndGetMappingStatus(
 	domainName: string,
-	connectionMode: string
+	connectionMode: string | null
 ): Promise< DomainMappingStatus > {
 	return wpcom.req.post( `/domains/${ domainName }/mapping-status`, {
 		mode: connectionMode,

--- a/packages/api-queries/src/domain-connection-setup.ts
+++ b/packages/api-queries/src/domain-connection-setup.ts
@@ -24,7 +24,7 @@ export const domainMappingStatusQuery = ( domainName: string ) =>
 
 export const updateConnectionModeMutation = ( domainName: string, siteId: number ) =>
 	mutationOptions( {
-		mutationFn: ( connectionMode: string ) =>
+		mutationFn: ( connectionMode: string | null ) =>
 			updateConnectionModeAndGetMappingStatus( domainName, connectionMode ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( domainConnectionSetupInfoQuery( domainName, siteId ) );


### PR DESCRIPTION
## Proposed Changes
Added a "Restart connection" button to the domain connection verification page

<img width="1436" height="604" alt="restart connection" src="https://github.com/user-attachments/assets/47b2d684-04ab-4328-9fad-a6fea706d284" />

## Why are these changes being made?
Users sometimes need to restart the domain connection setup process, whether due to choosing the wrong connection method, encountering configuration issues, or wanting to try a different approach. Previously, there was no straightforward way for users to reset the connection flow once they had entered the verification stage.
This feature provides users with a clear, accessible way to start over without having to navigate away from the page or manually reset their configuration.

## Testing Instructions
### Prerequisites
* Depends on 196430-ghe-Automattic/wpcom
* You'll need access to a domain that can be connected to a WordPress.com site
* The domain should be in the verification stage

### Steps to Test

1. Navigate to the domain connection setup page for a domain that's in the verification stage
2. You should see the domain connection verification UI with DNS records and propagation status
3. Scroll down to the "Need help?" section at the bottom of the page
4. Verify that the "Restart connection" button appears above the support links (Domain connection guide, Contact support, Registrar instructions)
5. Click the "Restart connection" button
6. Observe that:
   - The button shows a loading state (becomes disabled and shows busy indicator)
   - Upon successful API call, you're navigated back to the domain connection setup page
   - The page shows the initial connection method selection (Domain Connect, Suggested mode, Advanced mode)
   - No error notices appear
7. Test error handling by simulating a network failure (use browser DevTools to block the API request)
8. Verify that an error notice appears: "We could not restart your domain connection. Please try again."
9. Check browser console for the analytics event: `calypso_dashboard_domain_connection_restart` with the domain name

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?