### PR TITLE
Theme Experience: Update upsell plans

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -1,9 +1,7 @@
 import {
 	FEATURE_UPLOAD_THEMES,
-	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
-	getPlan,
 } from '@automattic/calypso-products';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -33,56 +31,26 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	} = props;
 
 	const isWooExpressTrial = PLAN_ECOMMERCE_TRIAL_MONTHLY === currentPlan?.productSlug;
+	const displayUpsellBanner = isAtomic && ! requestingSitePlans && isWooExpressTrial;
 
 	const upsellBanner = () => {
-		if ( isWooExpressTrial ) {
-			return (
-				<UpsellNudge
-					className="themes__showcase-banner"
-					event="calypso_themes_list_install_themes"
-					feature={ FEATURE_UPLOAD_THEMES }
-					title={ translate( 'Upgrade to a plan to upload your own themes!' ) }
-					callToAction={ translate( 'Upgrade now' ) }
-					showIcon
-				/>
-			);
-		}
-
-		return (
+		return displayUpsellBanner ? (
 			<UpsellNudge
 				className="themes__showcase-banner"
 				event="calypso_themes_list_install_themes"
 				feature={ FEATURE_UPLOAD_THEMES }
-				plan={ PLAN_BUSINESS }
-				title={
-					/* translators: %(planName1)s and %(planName2)s are the short-hand version of the Business and Commerce plan names */
-					translate(
-						'Unlock ALL premium themes and upload your own themes with our %(planName1)s and %(planName2)s plans!',
-						{
-							args: {
-								planName1: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-								planName2: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
-							},
-						}
-					)
-				}
+				title={ translate( 'Upgrade to a plan to upload your own themes!' ) }
 				callToAction={ translate( 'Upgrade now' ) }
 				showIcon
 			/>
-		);
+		) : null;
 	};
 
 	const upsellUrl = () => {
-		if ( isWooExpressTrial ) {
-			return `/plans/${ siteId }?feature=${ FEATURE_UPLOAD_THEMES }&plan=${ PLAN_ECOMMERCE }`;
-		}
-
-		return (
-			isAtomic && `/plans/${ siteId }?feature=${ FEATURE_UPLOAD_THEMES }&plan=${ PLAN_BUSINESS }`
-		);
+		return isWooExpressTrial
+			? `/plans/${ siteId }?feature=${ FEATURE_UPLOAD_THEMES }&plan=${ PLAN_ECOMMERCE }`
+			: null;
 	};
-
-	const displayUpsellBanner = isAtomic && ! requestingSitePlans && currentPlan;
 
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.THEMES_BROWSED );
 
@@ -98,7 +66,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 				upsellUrl={ upsellUrl() }
 				siteId={ siteId }
 				isJetpackSite
-				upsellBanner={ displayUpsellBanner ? upsellBanner() : null }
+				upsellBanner={ upsellBanner() }
 			/>
 		</Main>
 	);

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,51 +1,16 @@
-import {
-	FEATURE_UPLOAD_THEMES,
-	WPCOM_PREMIUM_PLANS,
-	PLAN_BUSINESS,
-	PLAN_ECOMMERCE,
-	getPlan,
-} from '@automattic/calypso-products';
-import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import Main from 'calypso/components/main';
 import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { getCurrentPlan, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getActiveTheme } from 'calypso/state/themes/selectors';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
-const getUpgradeBannerForPlan = ( planSlug ) => {
-	if ( WPCOM_PREMIUM_PLANS.includes( planSlug ) ) {
-		return (
-			<UpsellNudge
-				className="themes__showcase-banner"
-				event="calypso_themes_list_install_themes"
-				feature={ FEATURE_UPLOAD_THEMES }
-				plan={ PLAN_BUSINESS }
-				title={
-					/* translators: %(planName1)s and %(planName2)s the short-hand version of the Business and Commerce plan names */
-					translate( 'Upload your own themes with our %(planName1)s and %(planName2)s plans!', {
-						args: {
-							planName1: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-							planName2: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
-						},
-					} )
-				}
-				callToAction={ translate( 'Upgrade now' ) }
-				showIcon
-			/>
-		);
-	}
-};
-
 const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
-	const { currentPlan, currentThemeId, siteId, siteSlug } = props;
+	const { currentThemeId, siteId } = props;
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.THEMES_BROWSED );
 
 	return (
@@ -55,20 +20,12 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 				<QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } />
 			) }
 
-			<ThemeShowcase
-				{ ...props }
-				upsellUrl={ `/plans/${ siteSlug }` }
-				upsellBanner={ getUpgradeBannerForPlan( currentPlan?.productSlug ) }
-				siteId={ siteId }
-			/>
+			<ThemeShowcase { ...props } siteId={ siteId } />
 		</Main>
 	);
 } );
 
 export default connect( ( state, { siteId } ) => ( {
 	isVip: isVipSite( state, siteId ),
-	siteSlug: getSiteSlug( state, siteId ),
-	requestingSitePlans: isRequestingSitePlans( state, siteId ),
-	currentPlan: getCurrentPlan( state, siteId ),
 	currentThemeId: getActiveTheme( state, siteId ),
 } ) )( ConnectedSingleSiteWpcom );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -12,7 +12,7 @@ import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
 const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
-	const { currentThemeId, siteId } = props;
+	const { currentThemeId, siteId, siteSlug } = props;
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.THEMES_BROWSED );
 
 	return (
@@ -22,7 +22,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 				<QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } />
 			) }
 
-			<ThemeShowcase { ...props } siteId={ siteId } />
+			<ThemeShowcase { ...props } upsellUrl={ `/plans/${ siteSlug }` } siteId={ siteId } />
 		</Main>
 	);
 } );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -5,6 +5,8 @@ import Main from 'calypso/components/main';
 import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import { getCurrentPlan, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getActiveTheme } from 'calypso/state/themes/selectors';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
@@ -27,5 +29,8 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 
 export default connect( ( state, { siteId } ) => ( {
 	isVip: isVipSite( state, siteId ),
+	siteSlug: getSiteSlug( state, siteId ),
+	requestingSitePlans: isRequestingSitePlans( state, siteId ),
+	currentPlan: getCurrentPlan( state, siteId ),
 	currentThemeId: getActiveTheme( state, siteId ),
 } ) )( ConnectedSingleSiteWpcom );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -1,5 +1,5 @@
 import {
-	PLAN_BUSINESS,
+	PLAN_PERSONAL,
 	FEATURE_UPLOAD_THEMES,
 	FEATURE_UPLOAD_PLUGINS,
 	PLAN_ECOMMERCE,
@@ -198,13 +198,13 @@ class Upload extends Component {
 		const { siteSlug, isCommerceTrial, translate } = this.props;
 		const redirectTo = encodeURIComponent( `/themes/upload/${ siteSlug }` );
 
-		let upsellPlan = PLAN_BUSINESS;
+		let upsellPlan = PLAN_PERSONAL;
 		let title =
-			/* translators: %(planName)s the short-hand version of the Business plan name */
+			/* translators: %(planName)s the short-hand version of the Personal plan name */
 			translate( 'Upgrade to the %(planName)s plan to access the theme install features', {
-				args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+				args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
 			} );
-		let upgradeUrl = `/checkout/${ siteSlug }/business?redirect_to=${ redirectTo }`;
+		let upgradeUrl = `/checkout/${ siteSlug }/personal?redirect_to=${ redirectTo }`;
 
 		if ( isCommerceTrial ) {
 			upsellPlan = PLAN_ECOMMERCE;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-122

## Proposed Changes

* Update the theme upload banner to upsell the Personal plan instead of Business.
* Remove a theme upload banner for Premium plans that never showed up because overridden by the JITM feature.
* Remove a theme upload banner for Atomic and Jetpack sites that never showed up because overridden by the JITM feature.

Note: I've left the Woo Trial equivalents because I'm not familiar enough with the program.

| Location | Before | After |
|--------|--------|--------|
| `/themes/upload/SITE` | <img width="750" height="455" alt="Screenshot 2025-11-19 at 16 22 40" src="https://github.com/user-attachments/assets/26f83de8-d59e-47e4-ae54-9f569ed4956f" /> | <img width="750" height="455" alt="Screenshot 2025-11-19 at 16 22 17" src="https://github.com/user-attachments/assets/087f1586-6b16-49eb-9b34-cbd3d2ab28a8" /> |
| `/themes/SITE?flags=-jitms` | <img width="970" height="480" alt="Screenshot 2025-11-19 at 16 29 20" src="https://github.com/user-attachments/assets/1026a25a-48fa-4361-881f-f4a615e83a45" /> | <img width="970" height="480" alt="Screenshot 2025-11-19 at 16 39 11" src="https://github.com/user-attachments/assets/e84d34eb-4b2b-4642-9eb9-60d11bdcc326" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Summer Special gave every paid plan the ability to upload themes. These banners were leftovers from a previous cleanup effort.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Case 1: `/themes/upload/SITE`**

* Select a free site.
* Navigate to the Calypso Theme Showcase.
* Click on "Install new theme" in the top-right corner.
* 👀 Ensure that the banner upsells the Personal plan.

**Case 2: `/themes/SITE?flags=-jitms`**

Note: turning off the `jitms` feature (note the plural!) is needed to prevent overriding the Theme Showcase's `upsellBanner` feature.

* Select a Premium site.
* Navigate to the Calypso Theme Showcase.
* 👀 Ensure the "upload themes" banner doesn't show anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
