### PR TITLE
Help Center: Enable workflow in development and `wpcalypso` environments

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -73,7 +73,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help/gpt-response": true,
-		"help-center/workflow": false,
+		"help-center/workflow": true,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
 		"hosting/datacenter-picker": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -51,7 +51,7 @@
 		"cookie-banner": true,
 		"google-my-business": true,
 		"global-styles/on-personal-plan": false,
-		"help-center/workflow": false,
+		"help-center/workflow": true,
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/106148, and updates the Help Center to use the `wpcom-workflow-support_chat` workflow in development and `wpcalypso` environments.

#### Testing instructions

1. Run `git checkout enable/help-center-workflow-in-development` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/107216#issuecomment-3553679894)
2. Open any administration page
3. Bring up the Help Center
4. Click the `Need help? Get in touch` button to start a new discussion
5. Submit a query
6. Locate that discussion in the `Chats` page in Mission Control
7. Assert it was handled by `WP.com Workflow (Support chat)`