### PR TITLE
Reader: Lazy load quickpost component

### DIFF
--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -1,12 +1,12 @@
 import config from '@automattic/calypso-config';
 import { FoldableCard } from '@automattic/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import clsx from 'clsx';
 import { fixMe, translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
-import QuickPost from 'calypso/reader/components/quick-post';
 import { focusEditor } from 'calypso/reader/components/quick-post/utils';
 import ReaderOnboarding from 'calypso/reader/onboarding';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
@@ -15,11 +15,23 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
+import Skeleton from '../components/skeleton';
 import Recent from '../recent';
 import { useSiteSubscriptions } from './use-site-subscriptions';
 import { useFollowingView } from './view-preference';
 import ViewToggle from './view-toggle';
 import './style.scss';
+
+function QuickPostPlaceholder() {
+	return (
+		<div className="quick-post-placeholder">
+			<VStack spacing="4">
+				<Skeleton height="52px" width="264px" />
+				<Skeleton height="136px" width="100%" />
+			</VStack>
+		</div>
+	);
+}
 
 function FollowingStream( { ...props } ) {
 	const { currentView } = useFollowingView();
@@ -90,7 +102,10 @@ function FollowingStream( { ...props } ) {
 								recordReaderTracksEvent( 'calypso_reader_editor_card_closed' );
 							} }
 						>
-							<QuickPost />
+							<AsyncLoad
+								fallback={ <QuickPostPlaceholder /> }
+								require="calypso/reader/components/quick-post"
+							/>
 						</FoldableCard>
 					) }
 					<ReaderOnboarding />

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -99,3 +99,7 @@
 		font-weight: 600;
 	}
 }
+
+.quick-post-placeholder {
+	padding: 20px;
+}


### PR DESCRIPTION
## Proposed Changes

* Lazy load quick post component

## Why are these changes being made?
* I noticed the QuickPost is not a frequently used feature; it is only opened about 150 times a day, and 100% of our users are paying for the resource loading cost. This PR aims to lazy-load this component and save around 1MB of download assets, as shown in the video below. You can see the large number of assets we are currently lazy loading and which are loaded on every single /reader access. 


https://github.com/user-attachments/assets/88e57882-2cd5-4c57-a678-e9985b9ccf73



## Testing Instructions
* Go to `/reader`
* Click on "Write a quick post"
* Check it works fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
