### PR TITLE
Purchases: Force break and width for purchase status

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/style.scss
+++ b/client/me/purchases/purchases-list-in-dataviews/style.scss
@@ -96,7 +96,8 @@
 
 	.dataviews-view-table__cell-content-wrapper .purchase-item__status {
 		margin-right: 16px;
-		max-width: 250px;
+		width: 250px;
+		white-space: break-spaces;
 	}
 
 	.dataviews-view-table__cell-content-wrapper .purchase-item__payment-method {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-291/regression-expiresrenews-and-payment-method-columns-on-purchase

## Proposed Changes

This forces a line break and width for the purchase status element in the legacy purchases list. It seems to have been caused by a change to Core's DataViews, mixed with the overrides from the purchase list.

| Before | After |
| ----------- | ----------- |
| <img width="1578" height="1060" alt="Screenshot 2025-11-19 at 14 26 46" src="https://github.com/user-attachments/assets/b7edf3fe-eeb2-4d8f-acc2-303f24a42301" /> | <img width="1578" height="1060" alt="Screenshot 2025-11-19 at 14 26 52" src="https://github.com/user-attachments/assets/4fe65fd2-b67c-4da4-8037-b5bc2799786f" /> |

## Testing Instructions

- visit me/purchases for a user with purchases in various states of expiration
- verify that the status column has a line-break and forced width
