### PR TITLE
Restore correct redirect url for domain connections

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -191,13 +191,17 @@ const domain: FlowV2< typeof initialize > = {
 
 						if ( ( isDomainMapping && mappingIsFree ) || hasPaidPlan ) {
 							const queryArgs = getQueryArgs( window.location.href );
-							const redirectTo = queryArgs.redirect_to as string | undefined;
+							let redirectTo = queryArgs.redirect_to as string | undefined;
+
+							const isGardenSite = ( site as { is_garden?: boolean } ).is_garden;
+							const domain = providedDependencies.domainCartItem.meta;
+							if ( ! isGardenSite ) {
+								redirectTo = `/v2/domains/${ domain }/domain-connection-setup`;
+							}
 
 							// Use pending action for domain mapping
 							// Note: Verification (if required) is handled in the step before submission
 							setPendingAction( async () => {
-								const domain = providedDependencies.domainCartItem.meta;
-
 								await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
 
 								/// Redirect to appropriate domains page based on redirect_to parameter


### PR DESCRIPTION
## Proposed Changes
Restore the correct domain setup connection redirect after a user adds a new domain connection on a site with a paid plan. This behavior was changed in #106819.

## Why are these changes being made?
After creating a new domain connection on a paid site, the user should be redirected to the setup flow.

## Testing Instructions
- Navigate to `v2/sites/[SITE]/domains` (where SITE is a site with a paid plan)
- Click **Add domain button** and select **Use I domain name I own**
- Complete the connection steps and confirm that you are redirected to the connection setup pag (`v2/domains/[DOMAIN]/domain-connection-setup`)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
