### PR TITLE
MSD Billing: Make custom response optional on Jetpack cancel purchase form

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -304,7 +304,10 @@ export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
 				return false;
 			}
 
-			return Boolean( questionOneRadio && ( ! purchase.is_plan || questionOneText ) );
+			return Boolean(
+				questionOneRadio &&
+					( purchase.is_jetpack_plan_or_product || ! purchase.is_plan || questionOneText )
+			);
 		}
 
 		if ( surveyStep === ATOMIC_REVERT_STEP ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [SHILL-1307](https://linear.app/a8c/issue/SHILL-1307/hosting-dashboard-cancellation-flow-jetpack-akismet-purchases-should)

## Proposed Changes

* Don't require the custom response when cancelling Jetpack purchases.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To maintain parity with how the existing Jetpack cancellation form operates.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/v2/me/billing/purchases` and pick a Jetpack product to cancel - choose "Manage purchase" and then append `/cancel` to the url.
* Check the box to confirm you want to proceed, and click on to the next page. Observe that the Submit button is disabled until you click a radio button. Once you click a radio button, do not enter any text in the text area and instead Submit the survey / complete cancellation.
* Confirm the purchase was refunded correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
