### PR TITLE
Expand CSP for all calypso pages

### DIFF
--- a/client/document/domains-landing.jsx
+++ b/client/document/domains-landing.jsx
@@ -57,13 +57,15 @@ function DomainsLanding( {
 						} }
 					/>
 				) }
-				{ i18nLocaleScript && <script src={ i18nLocaleScript } /> }
+				{ i18nLocaleScript && <script nonce={ inlineScriptNonce } src={ i18nLocaleScript } /> }
 				{ /*
 				 * inline manifest in production, but reference by url for development.
 				 * this lets us have the performance benefit in prod, without breaking HMR in dev
 				 * since the manifest needs to be updated on each save
 				 */ }
-				{ env === 'development' && <script src="/calypso/evergreen/runtime.js" /> }
+				{ env === 'development' && (
+					<script nonce={ inlineScriptNonce } src="/calypso/evergreen/runtime.js" />
+				) }
 				{ env !== 'development' &&
 					manifests.map( ( manifest ) => (
 						<script
@@ -74,7 +76,7 @@ function DomainsLanding( {
 						/>
 					) ) }
 				{ entrypoint.js.map( ( asset ) => (
-					<script key={ asset } src={ asset } />
+					<script key={ asset } nonce={ inlineScriptNonce } src={ asset } />
 				) ) }
 				<script
 					nonce={ inlineScriptNonce }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -212,13 +212,17 @@ class Document extends Component {
 							__html: inlineScript,
 						} }
 					/>
-					{ i18nLocaleScript && ! useTranslationChunks && <script src={ i18nLocaleScript } /> }
+					{ i18nLocaleScript && ! useTranslationChunks && (
+						<script nonce={ inlineScriptNonce } src={ i18nLocaleScript } />
+					) }
 					{ /*
 					 * inline manifest in production, but reference by url for development.
 					 * this lets us have the performance benefit in prod, without breaking HMR in dev
 					 * since the manifest needs to be updated on each save
 					 */ }
-					{ env === 'development' && <script src={ `/calypso/${ target }/runtime.js` } /> }
+					{ env === 'development' && (
+						<script nonce={ inlineScriptNonce } src={ `/calypso/${ target }/runtime.js` } />
+					) }
 					{ env !== 'development' &&
 						manifests.map( ( manifest ) => (
 							<script
@@ -231,6 +235,7 @@ class Document extends Component {
 
 					{ isBilmurEnabled() && (
 						<script
+							nonce={ inlineScriptNonce }
 							defer
 							id="bilmur"
 							src={ getBilmurUrl() }
@@ -241,14 +246,16 @@ class Document extends Component {
 						/>
 					) }
 
-					{ entrypoint?.language?.manifest && <script src={ entrypoint.language.manifest } /> }
+					{ entrypoint?.language?.manifest && (
+						<script nonce={ inlineScriptNonce } src={ entrypoint.language.manifest } />
+					) }
 
 					{ ( entrypoint?.language?.translations || [] ).map( ( translationChunk ) => (
-						<script key={ translationChunk } src={ translationChunk } />
+						<script key={ translationChunk } nonce={ inlineScriptNonce } src={ translationChunk } />
 					) ) }
 
 					{ entrypoint.js.map( ( asset ) => (
-						<script key={ asset } src={ asset } />
+						<script key={ asset } nonce={ inlineScriptNonce } src={ asset } />
 					) ) }
 					<script
 						nonce={ inlineScriptNonce }

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -553,6 +553,8 @@ function setUpCSP( req, res, next ) {
 			'https://amplifypixel.outbrain.com',
 			'https://hexagon-analytics.com', // Hexagon analytics tracking pixels
 			'https://img.youtube.com',
+			'https://ps.w.org', // WordPress.org plugin directory (plugin icons)
+			'https://woocommerce.com', // WooCommerce marketplace
 			'localhost:8888',
 			'p.typekit.net',
 		],

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -484,6 +484,7 @@ function setUpLoggedInRoute( req, res, next ) {
  * Security approach:
  * - Uses cryptographic nonces for inline scripts (generated per request)
  * - Allows specific trusted third-party domains (payment providers, analytics, fonts)
+ * - Environment-aware: allows 'unsafe-eval' only in dev (for webpack eval source maps)
  * - Reports violations to /cspreport endpoint for monitoring
  *
  * Required for compliance on pages handling credit card information.
@@ -502,18 +503,31 @@ function setUpCSP( req, res, next ) {
 	// and calculating SHA256 hash on it, encoded in base64, example:
 	// `sha256-${ base64( sha256( 'window.AppBoot();' ) ) }` === sha256-3yiQswl88knA3EhjrG5tj5gmV6EUdLYFvn2dygc0xUQ
 	// you can also just run it in Chrome, chrome will give you the hash of the violating scripts
-	const inlineScripts = [ 'sha256-ZKTuGaoyrLu2lwYpcyzib+xE4/2mCN8PKv31uXS3Eg4=' ];
+	const inlineScripts = [
+		'sha256-ZKTuGaoyrLu2lwYpcyzib+xE4/2mCN8PKv31uXS3Eg4=',
+		'sha256-Ab4XY87C+5uFAaNDtQ+4UTgs8t6MTnQmMtSsZCvmoiw=', // Additional inline script
+		'sha256-ehBD9wGNfnN0flaZIjbVClW1//FJFsATigcdVB4VdMQ=', // Additional inline script
+	];
 
 	req.context.inlineScriptNonce = crypto.randomBytes( 48 ).toString( 'hex' );
+
+	// Development environments that need webpack eval-based source maps
+	const isDevelopmentEnv = [
+		'development',
+		'wpcalypso',
+		'jetpack-cloud-development',
+		'a8c-for-agencies-development',
+	].includes( calypsoEnv );
 
 	const policy = {
 		'default-src': [ "'self'" ],
 		'script-src': [
 			"'self'",
 			"'report-sample'",
-			// Note: 'unsafe-eval' has been removed to improve security. Calypso's codebase
-			// doesn't use eval() or new Function() directly. If violations are reported,
-			// they may indicate webpack config issues or third-party libraries that need review.
+			// Allow eval only in development for webpack's eval-based source maps (devtool: 'eval')
+			// which enable fast rebuilds and hot module reloading. Production uses 'hidden-source-map'
+			// which doesn't require eval, maintaining strict CSP in production environments.
+			...( isDevelopmentEnv ? [ "'unsafe-eval'" ] : [] ),
 			'stats.wp.com',
 			'https://widgets.wp.com',
 			'*.wordpress.com',
@@ -527,6 +541,10 @@ function setUpCSP( req, res, next ) {
 			'js.verygoodvault.com', // VGS for EBANX credit card tokenization
 			'www.paypal.com', // PayPal SDK
 			'www.paypalobjects.com', // PayPal assets
+			'cdn.siftscience.com', // Sift Science fraud detection for checkout
+			// User feedback and support tools
+			'survey.survicate.com', // Survicate survey tool
+			'surveys-static-prd.survicate-cdn.com', // Survicate CDN
 			...inlineScripts.map( ( hash ) => `'${ hash }'` ),
 		],
 		'base-uri': [ "'none'" ],
@@ -535,6 +553,7 @@ function setUpCSP( req, res, next ) {
 			'*.wp.com',
 			'https://fonts.googleapis.com',
 			'use.typekit.net',
+			'surveys-static-prd.survicate-cdn.com', // Survicate survey styles
 			// per https://helpx.adobe.com/ca/fonts/using/content-security-policy.html
 			"'unsafe-inline'",
 		],
@@ -542,12 +561,14 @@ function setUpCSP( req, res, next ) {
 		'object-src': [ "'none'" ],
 		'img-src': [
 			"'self'",
-			'data',
+			'data:', // data: URI scheme (e.g., data:image/svg+xml;base64,...)
 			'*.wp.com',
+			'https://wordpress.com', // WordPress.com assets (mu-plugins, etc.)
 			'*.files.wordpress.com',
 			'*.gravatar.com',
 			'https://www.google-analytics.com',
 			'https://amplifypixel.outbrain.com',
+			'https://hexagon-analytics.com', // Hexagon analytics tracking pixels
 			'https://img.youtube.com',
 			'localhost:8888',
 			'p.typekit.net',
@@ -557,6 +578,7 @@ function setUpCSP( req, res, next ) {
 			'https://public-api.wordpress.com',
 			'https://accounts.google.com/',
 			'https://jetpack.com',
+			'*.wordpress.com', // User WordPress.com sites (site previews, embeds)
 			// Payment provider iframes (secure card input elements)
 			'js.stripe.com', // Stripe Elements iframes
 			'*.stripe.com', // Stripe 3D Secure and other payment flows
@@ -570,12 +592,14 @@ function setUpCSP( req, res, next ) {
 			'https://fonts.gstatic.com',
 			'use.typekit.net',
 			'https://woocommerce.com',
+			'surveys-static-prd.survicate-cdn.com', // Survicate fonts
 			'data:', // should remove 'data:' ASAP
 		],
 		'media-src': [ "'self'" ],
 		'connect-src': [
 			"'self'",
 			'https://*.wordpress.com/',
+			'wss://*.wordpress.com', // WebSocket connections (realtime API, notifications)
 			'https://*.wp.com',
 			'https://wordpress.com',
 			// Payment provider APIs (for tokenization and payment processing)
@@ -583,6 +607,8 @@ function setUpCSP( req, res, next ) {
 			'api.stripe.com', // Stripe API endpoint
 			'*.verygoodsecurity.com', // VGS API calls
 			'*.paypal.com', // PayPal API calls
+			// Support and feedback tools
+			'*.zendesk.com', // Zendesk support chat
 		],
 		'report-uri': [ '/cspreport' ],
 	};

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -214,6 +214,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		clientIp: request.ip ? request.ip.replace( '::ffff:', '' ) : request.ip,
 		isWpMobileApp: isWpMobileApp( request.useragent.source ),
 		isWcMobileApp: isWcMobileApp( request.useragent.source ),
+		isDevelopmentEnv: devEnvironments.includes( calypsoEnv ),
 		isDebug,
 	};
 
@@ -495,13 +496,6 @@ function setUpCSP( req, res, next ) {
 
 	req.context.inlineScriptNonce = crypto.randomBytes( 48 ).toString( 'hex' );
 
-	// Development environments that need webpack eval-based source maps
-	const isDevelopmentEnv = [
-		'development',
-		'jetpack-cloud-development',
-		'a8c-for-agencies-development',
-	].includes( calypsoEnv );
-
 	const policy = {
 		'default-src': [ "'self'" ],
 		'script-src': [
@@ -510,7 +504,7 @@ function setUpCSP( req, res, next ) {
 			// Allow eval only in development for webpack's eval-based source maps (devtool: 'eval')
 			// which enable fast rebuilds and hot module reloading. Production uses 'hidden-source-map'
 			// which doesn't require eval, maintaining strict CSP in production environments.
-			...( isDevelopmentEnv ? [ "'unsafe-eval'" ] : [] ),
+			...( req.context.app.isDevelopmentEnv ? [ "'unsafe-eval'" ] : [] ),
 			`'nonce-${ req.context.inlineScriptNonce }'`,
 			'stats.wp.com',
 			'https://widgets.wp.com',

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -511,7 +511,9 @@ function setUpCSP( req, res, next ) {
 		'script-src': [
 			"'self'",
 			"'report-sample'",
-			"'unsafe-eval'",
+			// Note: 'unsafe-eval' has been removed to improve security. Calypso's codebase
+			// doesn't use eval() or new Function() directly. If violations are reported,
+			// they may indicate webpack config issues or third-party libraries that need review.
 			'stats.wp.com',
 			'https://widgets.wp.com',
 			'*.wordpress.com',

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -498,7 +498,6 @@ function setUpCSP( req, res, next ) {
 	// Development environments that need webpack eval-based source maps
 	const isDevelopmentEnv = [
 		'development',
-		'wpcalypso',
 		'jetpack-cloud-development',
 		'a8c-for-agencies-development',
 	].includes( calypsoEnv );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -476,20 +476,27 @@ function setUpLoggedInRoute( req, res, next ) {
 }
 
 /**
- * Sets up a Content Security Policy header
+ * Sets up a Content Security Policy header for all Calypso routes
+ *
+ * This CSP is currently in REPORT-ONLY mode, which means violations are logged but not blocked.
+ * This allows us to identify issues before enforcing the policy.
+ *
+ * Security approach:
+ * - Uses cryptographic nonces for inline scripts (generated per request)
+ * - Allows specific trusted third-party domains (payment providers, analytics, fonts)
+ * - Reports violations to /cspreport endpoint for monitoring
+ *
+ * Required for compliance on pages handling credit card information.
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
  * @param {Object} req Express request object
  * @param {Object} res Express response object
  * @param {Function} next a callback to call when done
  */
 function setUpCSP( req, res, next ) {
-	const originalUrlPathname = req.originalUrl.split( '?' )[ 0 ];
-
-	// We only setup CSP for /log-in* for now
-	if ( ! /^\/log-in/.test( originalUrlPathname ) ) {
-		next();
-		return;
-	}
+	// CSP is now applied to all routes for security compliance (previously only /log-in*).
+	// This is necessary because Calypso is an SPA - the initial page load's CSP applies
+	// to the entire session, so we need CSP protection on all entry points, especially
+	// pages that handle credit card information (checkout, payment methods, billing).
 
 	// This is calculated by taking the contents of the script text from between the tags,
 	// and calculating SHA256 hash on it, encoded in base64, example:
@@ -513,6 +520,11 @@ function setUpCSP( req, res, next ) {
 			`'nonce-${ req.context.inlineScriptNonce }'`,
 			'www.google-analytics.com',
 			'use.typekit.net',
+			// Payment provider scripts (required for credit card processing)
+			'js.stripe.com', // Stripe payment processing
+			'js.verygoodvault.com', // VGS for EBANX credit card tokenization
+			'www.paypal.com', // PayPal SDK
+			'www.paypalobjects.com', // PayPal assets
 			...inlineScripts.map( ( hash ) => `'${ hash }'` ),
 		],
 		'base-uri': [ "'none'" ],
@@ -543,6 +555,12 @@ function setUpCSP( req, res, next ) {
 			'https://public-api.wordpress.com',
 			'https://accounts.google.com/',
 			'https://jetpack.com',
+			// Payment provider iframes (secure card input elements)
+			'js.stripe.com', // Stripe Elements iframes
+			'*.stripe.com', // Stripe 3D Secure and other payment flows
+			'*.verygoodsecurity.com', // VGS Collect secure iframes
+			'www.paypal.com', // PayPal checkout flow
+			'*.paypal.com', // PayPal additional flows
 		],
 		'font-src': [
 			"'self'",
@@ -558,6 +576,11 @@ function setUpCSP( req, res, next ) {
 			'https://*.wordpress.com/',
 			'https://*.wp.com',
 			'https://wordpress.com',
+			// Payment provider APIs (for tokenization and payment processing)
+			'*.stripe.com', // Stripe API calls
+			'api.stripe.com', // Stripe API endpoint
+			'*.verygoodsecurity.com', // VGS API calls
+			'*.paypal.com', // PayPal API calls
 		],
 		'report-uri': [ '/cspreport' ],
 	};

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -481,12 +481,6 @@ function setUpLoggedInRoute( req, res, next ) {
  * This CSP is currently in REPORT-ONLY mode, which means violations are logged but not blocked.
  * This allows us to identify issues before enforcing the policy.
  *
- * Security approach:
- * - Uses cryptographic nonces for inline scripts (generated per request)
- * - Allows specific trusted third-party domains (payment providers, analytics, fonts)
- * - Environment-aware: allows 'unsafe-eval' only in dev (for webpack eval source maps)
- * - Reports violations to /cspreport endpoint for monitoring
- *
  * Required for compliance on pages handling credit card information.
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
  * @param {Object} req Express request object
@@ -498,16 +492,6 @@ function setUpCSP( req, res, next ) {
 	// This is necessary because Calypso is an SPA - the initial page load's CSP applies
 	// to the entire session, so we need CSP protection on all entry points, especially
 	// pages that handle credit card information (checkout, payment methods, billing).
-
-	// This is calculated by taking the contents of the script text from between the tags,
-	// and calculating SHA256 hash on it, encoded in base64, example:
-	// `sha256-${ base64( sha256( 'window.AppBoot();' ) ) }` === sha256-3yiQswl88knA3EhjrG5tj5gmV6EUdLYFvn2dygc0xUQ
-	// you can also just run it in Chrome, chrome will give you the hash of the violating scripts
-	const inlineScripts = [
-		'sha256-ZKTuGaoyrLu2lwYpcyzib+xE4/2mCN8PKv31uXS3Eg4=',
-		'sha256-Ab4XY87C+5uFAaNDtQ+4UTgs8t6MTnQmMtSsZCvmoiw=', // Additional inline script
-		'sha256-ehBD9wGNfnN0flaZIjbVClW1//FJFsATigcdVB4VdMQ=', // Additional inline script
-	];
 
 	req.context.inlineScriptNonce = crypto.randomBytes( 48 ).toString( 'hex' );
 
@@ -528,12 +512,12 @@ function setUpCSP( req, res, next ) {
 			// which enable fast rebuilds and hot module reloading. Production uses 'hidden-source-map'
 			// which doesn't require eval, maintaining strict CSP in production environments.
 			...( isDevelopmentEnv ? [ "'unsafe-eval'" ] : [] ),
+			`'nonce-${ req.context.inlineScriptNonce }'`,
 			'stats.wp.com',
 			'https://widgets.wp.com',
 			'*.wordpress.com',
 			'https://apis.google.com',
 			'https://appleid.cdn-apple.com',
-			`'nonce-${ req.context.inlineScriptNonce }'`,
 			'www.google-analytics.com',
 			'use.typekit.net',
 			// Payment provider scripts (required for credit card processing)
@@ -545,7 +529,6 @@ function setUpCSP( req, res, next ) {
 			// User feedback and support tools
 			'survey.survicate.com', // Survicate survey tool
 			'surveys-static-prd.survicate-cdn.com', // Survicate CDN
-			...inlineScripts.map( ( hash ) => `'${ hash }'` ),
 		],
 		'base-uri': [ "'none'" ],
 		'style-src': [


### PR DESCRIPTION
Fixes SHILL-1351

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://linear.app/a8c/issue/SHILL-1347

## Proposed Changes

This PR expands the Content Security Policy (CSP) in calypso so that it will be applied to all routes and not just `/log-in`. It also adds exceptions for some known scripts from certain hosts we use for payment processing (eg: Stripe, PayPal). 

**The CSP remains report-only, which means that its findings will be sent to a logging endpoint and will not block any scripts.**

Most critically, this removes the `'unsafe-eval'` directive from the CSP. That directive allows inline scripts to be used which is a major source of XSS attacks.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

For legal/compliance reasons we need to have a fairly restrictive CSP for pages which allow entering credit card information. We have several such pages in calypso (eg: checkout and the "add payment method" page). However, we can't just have a CSP for those routes because calypso is a Single Page Application (SPA) and therefore whatever headers are sent when calypso first loads are the ones which will apply to any page visited after that point.

Calypso already has a CSP set up in https://github.com/Automattic/wp-calypso/pull/22345 for the `/log-in` route, but due to the SPA, this is not sufficient for our purposes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I believe the only way to test this is to visit various pages in calypso and see if there are any CSP errors reported in the console. This is tricky, of course, given the number of pages (and their variations) that exist, but since this header is report-only the worst case scenario is creating a lot of logs.

Try visiting all sorts of pages like the Reader, plans page, My Home, checkout, etc.

> [!NOTE]
> If you change the CSP settings during development you have to stop and re-start the development server to get them to apply.

Violations look something like this in the console:

```
Loading the script 'https://cdn.siftscience.com/s.js' violates the following Content Security Policy directive
```
