### PR TITLE
Domains: Fix issue when transferring domain to site with paid plan

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -189,7 +189,7 @@ const domain: FlowV2< typeof initialize > = {
 						const mappingIsFree = hasPlanFeature( site, DotcomFeatures.DOMAIN_MAPPING );
 						const hasPaidPlan = siteHasPaidPlan( site );
 
-						if ( ( isDomainMapping && mappingIsFree ) || hasPaidPlan ) {
+						if ( isDomainMapping && ( mappingIsFree || hasPaidPlan ) ) {
 							const queryArgs = getQueryArgs( window.location.href );
 							const redirectTo = queryArgs.redirect_to as string | undefined;
 


### PR DESCRIPTION
Part of #

## Proposed Changes

This PR fixes an issue in the "Use a domain I own" flow where, regardless if you were adding a domain transfer or connection to a site with a paid plan, a domain connection was always added.

## Why are these changes being made?

#106819 changed the logic when the "use-my-domain" step was submitted due to a short-circuited conditional with a `hasPaidPlan` boolean. So if a site had a paid plan, a domain connection was added, even if you were trying to add a domain transfer.

### Demo

- Before

https://github.com/user-attachments/assets/5292e0b9-e53b-452d-a005-c3b89ac74231

(the domain list wasn't updated, but a domain connection was added to the site)

- After

https://github.com/user-attachments/assets/4880df79-d165-4d9f-9e9d-339cb33d5620

## Testing Instructions

- Open the live Calypso link or build this branch locally
- In the Multi-Site Dashboard, go to a site you own
- Select "Add domain name > Use a domain name I own"
- Input a domain you can transfer
- Select the transfer option
- Ensure you go to the checkout page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
