### PR TITLE
MSD Billing: Improve language while inside removal flow

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -426,7 +426,7 @@ export default function CancelPurchase() {
 			customerConfirmedUnderstanding: false,
 			domainConfirmationConfirmed: false,
 			initialized: true,
-			isLoading: REMOVE_PLAN_STEP !== firstStep,
+			isLoading: REMOVE_PLAN_STEP !== firstStep && CANCEL_FLOW_TYPE.REMOVE !== flowType,
 			isNextAdventureValid: false,
 			isSubmitting: false,
 			questionOneOrder,
@@ -440,7 +440,7 @@ export default function CancelPurchase() {
 			showDomainOptionsStep: false,
 			siteId: undefined,
 			solution: '',
-			surveyShown: REMOVE_PLAN_STEP === firstStep,
+			surveyShown: REMOVE_PLAN_STEP === firstStep || CANCEL_FLOW_TYPE.REMOVE === flowType,
 			surveyStep: firstStep,
 			upsell: '',
 		};

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -429,8 +429,7 @@ export default function CancelPurchase() {
 			customerConfirmedUnderstanding: false,
 			domainConfirmationConfirmed: false,
 			initialized: true,
-			isLoading:
-				REMOVE_PLAN_STEP !== firstStep && ! hasExpired && CANCEL_FLOW_TYPE.REMOVE !== flowType,
+			isLoading: REMOVE_PLAN_STEP !== firstStep && ! hasExpired,
 			isNextAdventureValid: false,
 			isSubmitting: false,
 			questionOneOrder,
@@ -444,8 +443,7 @@ export default function CancelPurchase() {
 			showDomainOptionsStep: false,
 			siteId: undefined,
 			solution: '',
-			surveyShown:
-				REMOVE_PLAN_STEP === firstStep || hasExpired || CANCEL_FLOW_TYPE.REMOVE === flowType,
+			surveyShown: REMOVE_PLAN_STEP === firstStep || hasExpired,
 			surveyStep: firstStep,
 			upsell: '',
 		};

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -199,6 +199,7 @@ function getBasicSurveySteps( {
 	const isJetpack = purchase.is_jetpack_plan_or_product;
 	const downgradePlan = getDowngradePlanForPurchase( plans, purchase, upsell );
 	const isDowngradePlan = [ 'downgrade-monthly', 'downgrade-personal' ].includes( upsell ?? '' );
+	const hasExpired = purchase.expiry_status === 'expired';
 
 	if (
 		isPartnerPurchase( purchase ) &&
@@ -216,11 +217,11 @@ function getBasicSurveySteps( {
 	if ( ! isGSuiteOrGoogleWorkspaceProductSlug( purchase.product_slug ) && ! purchase.is_plan ) {
 		return [ NEXT_ADVENTURE_STEP ];
 	}
-	if ( upsell && ! isDowngradePlan ) {
+	if ( upsell && ! hasExpired && ! isDowngradePlan ) {
 		return [ FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP ];
 	}
 	// NOTE: downgradePlan only ever exists if upsell is true (see getDowngradePlanForPurchase).
-	if ( upsell && downgradePlan ) {
+	if ( upsell && ! hasExpired && downgradePlan ) {
 		return [ FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP ];
 	}
 	if ( hasQuestionTwo ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -416,6 +416,8 @@ export default function CancelPurchase() {
 
 		const [ firstStep ] = allSteps;
 
+		const hasExpired = purchase.expiry_status === 'expired';
+
 		const newState: CancelPurchaseState = {
 			...initialSurveyState(),
 			atomicRevertCheckOne: false,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -426,7 +426,8 @@ export default function CancelPurchase() {
 			customerConfirmedUnderstanding: false,
 			domainConfirmationConfirmed: false,
 			initialized: true,
-			isLoading: REMOVE_PLAN_STEP !== firstStep && CANCEL_FLOW_TYPE.REMOVE !== flowType,
+			isLoading:
+				REMOVE_PLAN_STEP !== firstStep && ! hasExpired && CANCEL_FLOW_TYPE.REMOVE !== flowType,
 			isNextAdventureValid: false,
 			isSubmitting: false,
 			questionOneOrder,
@@ -440,7 +441,8 @@ export default function CancelPurchase() {
 			showDomainOptionsStep: false,
 			siteId: undefined,
 			solution: '',
-			surveyShown: REMOVE_PLAN_STEP === firstStep || CANCEL_FLOW_TYPE.REMOVE === flowType,
+			surveyShown:
+				REMOVE_PLAN_STEP === firstStep || hasExpired || CANCEL_FLOW_TYPE.REMOVE === flowType,
 			surveyStep: firstStep,
 			upsell: '',
 		};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [SHILL-1350](https://linear.app/a8c/issue/SHILL-1350/hosting-dashboard-cancellation-flow-prevent-cancel-langauge-from)
Fixes [SHILL-1477](https://linear.app/a8c/issue/SHILL-1477/when-i-remove-an-expired-plan-the-removal-dates-are-in-the-past)

## Proposed Changes

* Show the remove plan step if the plan has already expired.
* Hide the upsell pages if the plan has already expired.
* Prevent the "features lost" page from being shown when the purchase has expired (SHILL-1477)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Removing a plan includes language about cancelling, and the features being available until a certain date which exists in the past. There's a remove plan step that exists already which can be used and although it is intended to be used in place of the survey, we can also use it to begin the survey if a survey hasn't been taken.
* The survey includes upsell pages that would let the person keep the current (expired) plan or downgrade to a new plan, which doesn't make sense if it's expired.
* There is still existing language from the remove plan step that implies the features will be available until a certain time which can be updated to new language if that date is in the past.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test changes made in this PR
To begin, login to the multi-site dashboard with an account that has expired purchases that have not been removed. Ideally your account will have an expired plan purchase as well so that you can test that it is not "upsold".

Confirm removing expired subscriptions skips directly to the survey (SHILL-1477):
* From the active upgrades page under billing, choose "Manage purchase" for an expired purchase.
* Click the "Remove" button and you should be given the survey. You should not see any mention of the old expiration date.

Confirm removing expired plans don't have the "Upsell" step.
* Choose manage purchase for an expired WordPress.com plan.
* Click the "Remove" button.
* Fill out the survey using a path that would lead you to an upsell. For instance: "Too expensive" / "Budget constraints" which would normally ask if you would like to switch to monthly payments but in this case should not ask you this question.

### Test against regressions
* Login to the multi-site dashboard with an account that has active purchases, ideally one that also has a WordPress.com plan (or, add one from SA if you are an a11n).
* Choose manage purchase for the active purchase.
* Click the "Remove" button. (Note: the purchase needs to not be refundable in this case. Using SA might help in this case if you are an a11n).
* Ensure you see the page showing what features would be lost.
* When going through the removal process, if this is a plan choose "Too expensive" / "Budget constraints" and make sure you are offered to switch to monthly payments.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
