### PR TITLE
MSD: Use async validation for the email field of the transfer site

### DIFF
--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -1,3 +1,4 @@
+import { checkSiteOwnerTransferEligibility } from '@automattic/api-core';
 import { siteOwnerTransferEligibilityCheckMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
@@ -5,11 +6,9 @@ import {
 	__experimentalText as Text,
 	Button,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
@@ -20,18 +19,41 @@ export type ConfirmNewOwnerFormData = {
 	email: string;
 };
 
-const fields: Field< ConfirmNewOwnerFormData >[] = [
-	{
-		id: 'email',
-		label: __( 'Email' ),
-		type: 'email' as const,
-	},
-];
-
 const form = {
 	layout: { type: 'regular' as const },
 	fields: [ 'email' ],
 };
+
+const useFields = ( siteId: number ): Field< ConfirmNewOwnerFormData >[] => [
+	{
+		id: 'email',
+		label: __( 'Email' ),
+		type: 'email' as const,
+		isValid: {
+			required: true,
+			custom: async ( data: ConfirmNewOwnerFormData ) => {
+				try {
+					await checkSiteOwnerTransferEligibility( siteId, {
+						new_site_owner: data.email,
+					} );
+					return null;
+				} catch ( error ) {
+					if ( error instanceof Error ) {
+						return error.message;
+					}
+					return (
+						String( error ) ||
+						sprintf(
+							/* translators: %s is the new owner's email */
+							__( 'Sorry, the site cannot be transferred to %s' ),
+							data.email
+						)
+					);
+				}
+			},
+		},
+	},
+];
 
 export function ConfirmNewOwnerForm( {
 	site,
@@ -48,36 +70,15 @@ export function ConfirmNewOwnerForm( {
 
 	const mutation = useMutation( siteOwnerTransferEligibilityCheckMutation( site.ID ) );
 
-	const { createErrorNotice } = useDispatch( noticesStore );
-
-	const { isValid } = useFormValidity( formData, fields, form );
+	const fields = useFields( site.ID );
+	const { validity, isValid } = useFormValidity( formData, fields, form );
 	const isSaveDisabled = ! isValid;
 
 	const handleSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
-
-		mutation.mutate(
-			{ new_site_owner: formData.email },
-			{
-				onSuccess: () => {
-					onSubmit( formData );
-				},
-				onError: ( error ) => {
-					// TODO: Show the error via Data Form when the ValidatedTextControl is ready.
-					createErrorNotice(
-						error.message ??
-							sprintf(
-								/* translators: %s is the new owner's email */
-								__( 'Sorry, the site cannot be transferred to %s' ),
-								formData.email
-							),
-						{
-							type: 'snackbar',
-						}
-					);
-				},
-			}
-		);
+		if ( isValid ) {
+			onSubmit( formData );
+		}
 	};
 
 	return (
@@ -101,6 +102,7 @@ export function ConfirmNewOwnerForm( {
 					data={ formData }
 					fields={ fields }
 					form={ form }
+					validity={ validity }
 					onChange={ ( edits: Partial< ConfirmNewOwnerFormData > ) => {
 						setFormData( ( data ) => ( { ...data, ...edits } ) );
 					} }

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -24,7 +24,7 @@ const form = {
 	fields: [ 'email' ],
 };
 
-const useFields = ( siteId: number ): Field< ConfirmNewOwnerFormData >[] => [
+const getFields = ( siteId: number ): Field< ConfirmNewOwnerFormData >[] => [
 	{
 		id: 'email',
 		label: __( 'Email' ),
@@ -70,7 +70,7 @@ export function ConfirmNewOwnerForm( {
 
 	const mutation = useMutation( siteOwnerTransferEligibilityCheckMutation( site.ID ) );
 
-	const fields = useFields( site.ID );
+	const fields = getFields( site.ID );
 	const { validity, isValid } = useFormValidity( formData, fields, form );
 	const isSaveDisabled = ! isValid;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Use async validation for the email field of the transfer site
* Known issues
  * We'll request the validation check whenever input changes. I tried to use debounce but the result became weird as it always got the previous one instead of the latest
  * The error message is shown once the input field has been blurred. It's the limitation of the `ValidatedInputControl`...

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites
* Select any site that is transferrable
* Navigate to Settings > Transfer site
* Input the owner's email
* Make the input field blur
* Ensure you can see the error message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
