### PR TITLE
E2E: Fix editor Social UI tests

### DIFF
--- a/test/e2e/specs/jetpack/social__editor-smoke.ts
+++ b/test/e2e/specs/jetpack/social__editor-smoke.ts
@@ -52,8 +52,10 @@ skipDescribeIf( isPrivateSite )(
 			const editorParent = await editorPage.getEditorParent();
 
 			const toggle = editorParent.getByLabel( 'Auto-share post' );
+			const connectButton = editorParent.getByLabel( 'Connect your accounts' );
 
-			await toggle.waitFor();
+			// Either "Auto-share post" toggle or "Connect your accounts" button should be visible.
+			expect( ( await toggle.count() ) || ( await connectButton.count() ) ).toBeGreaterThan( 0 );
 		} );
 	}
 );


### PR DESCRIPTION
Following https://github.com/Automattic/jetpack/pull/45970, we updated the logic for Auto-share UI, thus we need to update the E2E test for the same

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
