### PR TITLE
MSD: Send unknown error to logstash

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -16,12 +16,14 @@ module.exports = {
 							// Allowed: calypso/lib/explat
 							// Allowed: calypso/lib/interval/use-interval (temporary)
 							// Allowed: calypso/lib/load-dev-helpers
+							// Allowed: calypso/lib/logstash
 							// Allowed: calypso/lib/wp
 							'!calypso/lib',
 							'calypso/lib/*',
 							'!calypso/lib/explat',
 							'!calypso/lib/interval',
 							'!calypso/lib/load-dev-helpers',
+							'!calypso/lib/logstash',
 							'!calypso/lib/wp',
 							// Allowed: calypso/assets/icons
 							// Allowed: calypso/assets/images

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,26 +1,10 @@
-import config from '@automattic/calypso-config';
-import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from 'react';
-import { logToLogstash } from 'calypso/lib/logstash';
+import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 
 function UnknownError( { error }: { error: Error } ) {
-	useEffect( () => {
-		logToLogstash( {
-			feature: 'calypso_client',
-			message: 'Unknown error',
-			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-			tags: [ 'dashboard' ],
-			extra: {
-				env: config( 'env_id' ),
-				message: error.message,
-			},
-		} );
-	}, [ error.message ] );
-
 	return (
 		<PageLayout
 			header={
@@ -34,11 +18,7 @@ function UnknownError( { error }: { error: Error } ) {
 					}
 				/>
 			}
-			notices={
-				<Notice status="error" isDismissible={ false }>
-					{ error.message }
-				</Notice>
-			}
+			notices={ <Notice variant="error">{ error.message }</Notice> }
 		></PageLayout>
 	);
 }

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,10 +1,26 @@
+import config from '@automattic/calypso-config';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 
 function UnknownError( { error }: { error: Error } ) {
+	useEffect( () => {
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: 'Unknown error',
+			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+			tags: [ 'dashboard' ],
+			extra: {
+				env: config( 'env_id' ),
+				message: error.message,
+			},
+		} );
+	}, [ error ] );
+
 	return (
 		<PageLayout
 			header={

--- a/client/sites/v2/components/500.tsx
+++ b/client/sites/v2/components/500.tsx
@@ -2,16 +2,15 @@ import config from '@automattic/calypso-config';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
+import { PageHeader } from 'calypso/dashboard/components/page-header';
+import PageLayout from 'calypso/dashboard/components/page-layout';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { PageHeader } from '../../components/page-header';
-import PageLayout from '../../components/page-layout';
-import RouterLinkButton from '../../components/router-link-button';
 
 function UnknownError( { error }: { error: Error } ) {
 	useEffect( () => {
 		logToLogstash( {
 			feature: 'calypso_client',
-			message: 'Unknown error',
+			message: 'Unknown error (backport)',
 			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
 			tags: [ 'dashboard' ],
 			extra: {
@@ -24,15 +23,7 @@ function UnknownError( { error }: { error: Error } ) {
 	return (
 		<PageLayout
 			header={
-				<PageHeader
-					title={ __( '500 Error' ) }
-					description={ __( 'Something wrong happened.' ) }
-					actions={
-						<RouterLinkButton to="/sites" variant="primary" __next40pxDefaultSize>
-							{ __( 'Go to Sites' ) }
-						</RouterLinkButton>
-					}
-				/>
+				<PageHeader title={ __( '500 Error' ) } description={ __( 'Something wrong happened.' ) } />
 			}
 			notices={
 				<Notice status="error" isDismissible={ false }>

--- a/client/sites/v2/components/500.tsx
+++ b/client/sites/v2/components/500.tsx
@@ -1,35 +1,15 @@
-import config from '@automattic/calypso-config';
-import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from 'react';
+import Notice from 'calypso/dashboard/components/notice';
 import { PageHeader } from 'calypso/dashboard/components/page-header';
 import PageLayout from 'calypso/dashboard/components/page-layout';
-import { logToLogstash } from 'calypso/lib/logstash';
 
 function UnknownError( { error }: { error: Error } ) {
-	useEffect( () => {
-		logToLogstash( {
-			feature: 'calypso_client',
-			message: 'Unknown error (backport)',
-			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-			tags: [ 'dashboard' ],
-			extra: {
-				env: config( 'env_id' ),
-				message: error.message,
-			},
-		} );
-	}, [ error.message ] );
-
 	return (
 		<PageLayout
 			header={
 				<PageHeader title={ __( '500 Error' ) } description={ __( 'Something wrong happened.' ) } />
 			}
-			notices={
-				<Notice status="error" isDismissible={ false }>
-					{ error.message }
-				</Notice>
-			}
+			notices={ <Notice variant="error">{ error.message }</Notice> }
 		></PageLayout>
 	);
 }

--- a/client/sites/v2/utils/router.ts
+++ b/client/sites/v2/utils/router.ts
@@ -1,14 +1,30 @@
+import calypsoConfig from '@automattic/calypso-config';
 import pagejs from '@automattic/calypso-router';
 import { createMemoryHistory } from '@tanstack/react-router';
+import { logToLogstash } from 'calypso/lib/logstash';
 import UnknownError from '../components/500';
 import type { AnyRoute, AnyRouter } from '@tanstack/react-router';
 import type { AppConfig } from 'calypso/dashboard/app/context';
+import type { ErrorInfo } from 'react';
 
 export function getRouterOptions( config: AppConfig ) {
 	return {
 		basepath: config.basePath,
 		context: {
 			config,
+		},
+		defaultOnCatch: ( error: Error, errorInfo: ErrorInfo ) => {
+			logToLogstash( {
+				feature: 'calypso_client',
+				message: 'Unknown error (backport)',
+				severity: calypsoConfig( 'env_id' ) === 'production' ? 'error' : 'debug',
+				tags: [ 'dashboard' ],
+				properties: {
+					env: calypsoConfig( 'env_id' ),
+					message: error.message,
+					stack: errorInfo.componentStack,
+				},
+			} );
 		},
 		defaultPreload: 'intent' as const,
 		defaultPreloadStaleTime: 0,

--- a/client/sites/v2/utils/router.ts
+++ b/client/sites/v2/utils/router.ts
@@ -1,5 +1,6 @@
 import pagejs from '@automattic/calypso-router';
 import { createMemoryHistory } from '@tanstack/react-router';
+import UnknownError from '../components/500';
 import type { AnyRoute, AnyRouter } from '@tanstack/react-router';
 import type { AppConfig } from 'calypso/dashboard/app/context';
 
@@ -11,6 +12,7 @@ export function getRouterOptions( config: AppConfig ) {
 		},
 		defaultPreload: 'intent' as const,
 		defaultPreloadStaleTime: 0,
+		defaultErrorComponent: UnknownError,
 		defaultNotFoundComponent: () => null,
 		defaultViewTransition: true,
 


### PR DESCRIPTION
## Proposed Changes

Send unknown errors to logstash. Follow ups include setting up monitoring for these errors.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
