### PR TITLE
MSD: Display URL without scheme on SitesWithPlugins DataViews

### DIFF
--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -62,8 +62,9 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 				id: 'domain',
 				label: __( 'Site' ),
 				type: 'text',
-				getValue: ( { item }: { item: SiteWithPluginData } ) => item.URL,
-				render: ( { item }: { item: SiteWithPluginData } ) => item.URL,
+				getValue: ( { item }: { item: SiteWithPluginData } ) =>
+					item.URL.replace( 'https://', '' ).replace( 'http://', '' ),
+				render: ( { field, item } ) => field.getValue( { item } ),
 				enableHiding: false,
 				enableSorting: true,
 				enableGlobalSearch: true,

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -13,6 +13,7 @@ import { DataViews, filterSortAndPaginate, View, type Field } from '@wordpress/d
 import { __, sprintf } from '@wordpress/i18n';
 import { link, linkOff, trash } from '@wordpress/icons';
 import { useMemo, useState } from 'react';
+import { getSiteDisplayUrl } from '../../utils/site-url';
 import ActionRenderModal, { getModalHeader } from '../manage/components/action-render-modal';
 import { buildBulkSitesPluginAction } from '../manage/utils';
 import { ActionRenderModalWrapper } from './components/action-render-modal-wrapper';
@@ -62,8 +63,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 				id: 'domain',
 				label: __( 'Site' ),
 				type: 'text',
-				getValue: ( { item }: { item: SiteWithPluginData } ) =>
-					item.URL.replace( 'https://', '' ).replace( 'http://', '' ),
+				getValue: ( { item }: { item: SiteWithPluginData } ) => getSiteDisplayUrl( item ),
 				render: ( { field, item } ) => field.getValue( { item } ),
 				enableHiding: false,
 				enableSorting: true,

--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -4,6 +4,7 @@ import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { usePlugin } from './use-plugin';
+import type { Field } from '@wordpress/dataviews';
 
 const defaultView: View = {
 	type: 'table',
@@ -21,13 +22,14 @@ export const SitesWithoutThisPlugin = ( { pluginSlug }: { pluginSlug: string } )
 	const [ view, setView ] = useState< View >( defaultView );
 	const { isLoading, sitesWithoutThisPlugin } = usePlugin( pluginSlug );
 
-	const fields = useMemo(
+	const fields: Field< Site >[] = useMemo(
 		() => [
 			{
 				id: 'domain',
 				label: __( 'Site' ),
-				getValue: ( { item }: { item: Site } ) => item.URL,
-				render: ( { item }: { item: Site } ) => item.URL,
+				getValue: ( { item }: { item: Site } ) =>
+					item.URL.replace( 'https://', '' ).replace( 'http://', '' ),
+				render: ( { field, item } ) => field.getValue( { item } ),
 				enableHiding: false,
 				enableSorting: true,
 				enableGlobalSearch: true,

--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -3,6 +3,7 @@ import { ExternalLink } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
+import { getSiteDisplayUrl } from '../../utils/site-url';
 import { usePlugin } from './use-plugin';
 import type { Field } from '@wordpress/dataviews';
 
@@ -27,8 +28,7 @@ export const SitesWithoutThisPlugin = ( { pluginSlug }: { pluginSlug: string } )
 			{
 				id: 'domain',
 				label: __( 'Site' ),
-				getValue: ( { item }: { item: Site } ) =>
-					item.URL.replace( 'https://', '' ).replace( 'http://', '' ),
+				getValue: ( { item }: { item: Site } ) => getSiteDisplayUrl( item ),
 				render: ( { field, item } ) => field.getValue( { item } ),
 				enableHiding: false,
 				enableSorting: true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* We always display site slug (or domain) instead of full URL, so this PR removes `https://` from the URL. Or should we use `getSiteDisplayUrl` here as well?

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It would be better to display the slug instead of the full URL to align with other places

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/plugins/manage/akismet
* Ensure the site displays without `https://`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
