### PR TITLE
Disable transfer card if the domain cannot be transferred

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/option-content-v2.tsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/option-content-v2.tsx
@@ -56,7 +56,7 @@ export default function OptionContentV2( {
 				}
 				decoration={ illustration }
 				onClick={ onSelect }
-				disabled={ disabled || isPlaceholder }
+				disabled={ disabled || isPlaceholder || ! onSelect }
 				badges={ recommended ? [ { text: __( 'Recommended' ), intent: 'success' } ] : undefined }
 			/>
 			{ benefits && (


### PR DESCRIPTION
Closes [DOMAINS-1852](https://linear.app/a8c/issue/DOMAINS-1852/disable-transfer-card-if-the-domain-cannot-be-transferred)

## Proposed Changes
* Disable transfer option card when `onSelect` handler is not provided

![Screenshot 2025-11-20 alle 11 02 09](https://github.com/user-attachments/assets/cca3be38-317e-4892-b6cb-e534040ec16e)

## Why are these changes being made?
* The transfer card should be disabled when the domain cannot be transferred
* When `onSelect` is not provided (likely because the domain is not transferable), the card was still appearing clickable/enabled
* This change ensures the UI accurately reflects when the transfer option is not available by checking for the presence of the `onSelect` handler

## Testing Instructions
* Navigate to the domain transfer or connect flow with a domain that cannot be transferred
* Verify that the transfer option card appears disabled (visually and functionally)
* Test with a transferable domain to ensure the card still works correctly when `onSelect` is provided

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
