### PR TITLE
Login: Fix incorrect input field when returning from magic login

### DIFF
--- a/client/login/magic-login/test/build-enter-password-login-parameters.test.js
+++ b/client/login/magic-login/test/build-enter-password-login-parameters.test.js
@@ -1,0 +1,41 @@
+import { buildEnterPasswordLoginParameters } from '../index.jsx';
+
+const baseProps = {
+	isJetpackLogin: false,
+	locale: 'en',
+	userEmail: 'user@example.com',
+	query: {},
+	twoFactorNotificationSent: 'none',
+	redirectToOriginal: '/log-in',
+	oauth2Client: { id: 123 },
+};
+
+describe( 'buildEnterPasswordLoginParameters', () => {
+	it( 'omits usernameOnly when not forced and query lacks flag', () => {
+		const result = buildEnterPasswordLoginParameters( baseProps );
+
+		expect( result ).not.toHaveProperty( 'usernameOnly' );
+		expect( result ).toMatchObject( {
+			isJetpack: baseProps.isJetpackLogin,
+			locale: baseProps.locale,
+			emailAddress: baseProps.userEmail,
+			redirectTo: baseProps.redirectToOriginal,
+			oauth2ClientId: baseProps.oauth2Client.id,
+		} );
+	} );
+
+	it( 'adds usernameOnly when query contains username_only flag', () => {
+		const result = buildEnterPasswordLoginParameters( {
+			...baseProps,
+			query: { username_only: 'true' },
+		} );
+
+		expect( result.usernameOnly ).toBe( true );
+	} );
+
+	it( 'forces usernameOnly when option is provided', () => {
+		const result = buildEnterPasswordLoginParameters( baseProps, { forceUsernameOnly: true } );
+
+		expect( result.usernameOnly ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/M4R73CH-1276/login-label-flips-between-email-address-or-username-and-your-username

## Proposed Changes

* Only append the `username_only` flag when the flow requires it, and share the URL-building logic in a helper.
* Keep the auto-trigger fallback forcing username-only while letting manual clicks return to the default label.
* Add focused unit coverage for `buildEnterPasswordLoginParameters`.

## Why are these changes being made?

* Returning from the magic login form always added `username_only`, which made the primary login label switch to "Your username" even for email-friendly flows. The helper makes the behavior explicit and prevents accidental regressions.

## Testing Instructions

* `yarn test-client client/login/magic-login/test/build-enter-password-login-parameters.test.js`
* `/log-in` → Email me a login link → Enter a password instead. Confirm the field label still reads "Email address or username".

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?