### PR TITLE
A4A: Add A4A Express Checkout section and initial route controller.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -63,6 +63,7 @@ export const A4A_CLIENT_PAYMENT_METHODS_LINK = '/client/payment-methods';
 export const A4A_CLIENT_INVOICES_LINK = '/client/invoices';
 export const A4A_CLIENT_PAYMENT_METHODS_ADD_LINK = `${ A4A_CLIENT_PAYMENT_METHODS_LINK }/add`;
 export const A4A_CLIENT_CHECKOUT = '/client/checkout';
+export const A4A_CLIENT_EXPRESS_CHECKOUT = '/client/express-checkout';
 export const EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE =
 	'https://agencieshelp.automattic.com/knowledge-base/client-billing/';
 

--- a/client/a8c-for-agencies/sections/express-checkout/controller.tsx
+++ b/client/a8c-for-agencies/sections/express-checkout/controller.tsx
@@ -1,8 +1,10 @@
 import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { hideMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
 import ClientCheckoutV2 from '../client/primary/checkout-v2';
 
 export const clientExpressCheckout: Callback = ( context, next ) => {
+	context.store.dispatch( hideMasterbar() );
 	context.primary = (
 		<>
 			<PageViewTracker title="Client > Express Checkout" path="/client/express-checkout" />

--- a/client/a8c-for-agencies/sections/express-checkout/controller.tsx
+++ b/client/a8c-for-agencies/sections/express-checkout/controller.tsx
@@ -1,0 +1,13 @@
+import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import ClientCheckoutV2 from '../client/primary/checkout-v2';
+
+export const clientExpressCheckout: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker title="Client > Express Checkout" path="/client/express-checkout" />
+			<ClientCheckoutV2 />
+		</>
+	);
+	next();
+};

--- a/client/a8c-for-agencies/sections/express-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/express-checkout/index.tsx
@@ -1,0 +1,7 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import * as controller from './controller';
+
+export default function () {
+	page( '/express-checkout', controller.clientExpressCheckout, makeLayout, clientRender );
+}

--- a/client/a8c-for-agencies/sections/express-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/express-checkout/index.tsx
@@ -1,7 +1,8 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { A4A_CLIENT_EXPRESS_CHECKOUT } from '../../components/sidebar-menu/lib/constants';
 import * as controller from './controller';
 
 export default function () {
-	page( '/express-checkout', controller.clientExpressCheckout, makeLayout, clientRender );
+	page( A4A_CLIENT_EXPRESS_CHECKOUT, controller.clientExpressCheckout, makeLayout, clientRender );
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -874,6 +874,13 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
+		name: 'a8c-for-agencies-express-checkout',
+		paths: [ '/express-checkout' ],
+		module: 'calypso/a8c-for-agencies/sections/express-checkout',
+		group: 'a8c-for-agencies',
+		enableLoggedOut: true,
+	},
+	{
 		name: 'a8c-for-agencies-client',
 		paths: [
 			'/client/landing',

--- a/client/sections.js
+++ b/client/sections.js
@@ -874,13 +874,6 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
-		name: 'a8c-for-agencies-express-checkout',
-		paths: [ '/express-checkout' ],
-		module: 'calypso/a8c-for-agencies/sections/express-checkout',
-		group: 'a8c-for-agencies',
-		enableLoggedOut: true,
-	},
-	{
 		name: 'a8c-for-agencies-client',
 		paths: [
 			'/client/landing',
@@ -892,6 +885,13 @@ const sections = [
 		],
 		module: 'calypso/a8c-for-agencies/sections/client',
 		group: 'a8c-for-agencies',
+	},
+	{
+		name: 'a8c-for-agencies-express-checkout',
+		paths: [ '/client/express-checkout' ],
+		module: 'calypso/a8c-for-agencies/sections/express-checkout',
+		group: 'a8c-for-agencies',
+		enableLoggedOut: true,
 	},
 	{
 		name: 'a8c-for-agencies-agency-tier',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -177,6 +177,7 @@
 		"a8c-for-agencies-team": false,
 		"a8c-for-agencies-agency-tier": false,
 		"a8c-for-agencies-woopayments": false,
+		"a8c-for-agencies-express-checkout": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -72,7 +72,8 @@
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a8c-for-agencies-woopayments": true
+		"a8c-for-agencies-woopayments": true,
+		"a8c-for-agencies-express-checkout": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -65,7 +65,8 @@
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a8c-for-agencies-woopayments": true
+		"a8c-for-agencies-woopayments": true,
+		"a8c-for-agencies-express-checkout": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -65,7 +65,8 @@
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a8c-for-agencies-woopayments": true
+		"a8c-for-agencies-woopayments": true,
+		"a8c-for-agencies-express-checkout": false
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -67,7 +67,8 @@
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a8c-for-agencies-woopayments": true
+		"a8c-for-agencies-woopayments": true,
+		"a8c-for-agencies-express-checkout": false
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
This PR adds a new Client express checkout section and route that enable access for logged-out users.

**Note that the checkout will show an empty cart at the moment. We will address those issues bit by bit until we have a working express checkout. For now, this is the first step.**

## Proposed Changes

* This PR introduces a new checkout section accessible to logged-out users. We created a separate version to avoid disrupting the existing client checkout flow. 
* The final goal is to have two checkout pages: the existing one and a new one. The new express checkout page will be used for all new clients in the new BD system, while older clients still on the previous system will continue to use the old checkout page. We will have this setup until we migrate all clients to the new BD system.

## Why are these changes being made?

* This is part of a new project aimed at enhancing referral flow and minimizing friction.

## Testing Instructions

* Obtain a referral order link from https://agencies.automattic.com/referrals/dashboard. You can copy a link.
* Use the live link below and replace the base path with `/client/express-checkout` with your referral link.
* Verify that you see the checkout page without being redirected to the login page.

<img width="2544" height="699" alt="Screenshot 2025-11-20 at 9 15 49 PM" src="https://github.com/user-attachments/assets/46a7f9f8-cace-4793-aa53-ef376402b7aa" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
