### PR TITLE
Jetpack Login: Show email/username label above input field

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -434,8 +434,6 @@ export class LoginForm extends Component {
 			return this.renderChangeUsername();
 		}
 
-		const showLabel = ! this.props.isJetpack || this.props.isWoo;
-
 		return (
 			// Since the input receives focus on page load, screen reader users don't have any context
 			// for what credentials to use. Unlike other users, they won't have seen the informative
@@ -444,9 +442,7 @@ export class LoginForm extends Component {
 				<span className="screen-reader-text">
 					{ this.props.translate( 'WordPress.com email address or username' ) }
 				</span>
-				{ showLabel && (
-					<span aria-hidden="true">{ this.props.translate( 'Email address or username' ) }</span>
-				) }
+				<span aria-hidden="true">{ this.props.translate( 'Email address or username' ) }</span>
 			</>
 		);
 	}

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -141,4 +141,33 @@ describe( 'LoginForm', () => {
 		const btn = screen.getByRole( 'button', { name: /Log In/i } );
 		expect( btn ).toBeInTheDocument();
 	} );
+
+	test( 'shows the visual email-or-username label for Jetpack logins', async () => {
+		render( <LoginForm isJetpack />, {
+			initialState: {
+				login: { socialAccountLink: { isLinking: false } },
+				route: { query: { current: {}, initial: {} } },
+			},
+		} );
+
+		const label = screen.getByText( 'Email address or username', {
+			selector: 'span[aria-hidden="true"]',
+		} );
+		expect( label ).toBeInTheDocument();
+	} );
+
+	test( 'shows the username-only label when query flag is set', async () => {
+		render( <LoginForm />, {
+			initialState: {
+				route: {
+					query: {
+						current: { username_only: 'true' },
+						initial: {},
+					},
+				},
+			},
+		} );
+
+		expect( screen.getByText( 'Your username' ) ).toBeInTheDocument();
+	} );
 } );


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/M4R73CH-1281/jetpack-login-no-username-or-email-label-above-the-input-field

## Proposed Changes

* Always render the visual “Email address or username” label so the Jetpack form matches the main login experience.
* Keep the  override so forced flows still show “Your username”.
* Add regression tests for both scenarios.

| Before | Before (returning from magic) | After |
|--------|--------|--------|
| <img width="843" height="669" alt="Screenshot 2025-11-20 at 2 31 02 PM" src="https://github.com/user-attachments/assets/94ecbb90-544f-417d-bd32-a962d15bf012" /> | <img width="784" height="661" alt="Screenshot 2025-11-20 at 2 31 11 PM" src="https://github.com/user-attachments/assets/369cc419-6f7e-4e91-bc97-89a0a50295af" /> | <img width="768" height="657" alt="Screenshot 2025-11-20 at 2 31 24 PM" src="https://github.com/user-attachments/assets/6e2fd885-5709-4e14-9592-8be34de14f0b" /> |


## Why are these changes being made?

The Jetpack login screen relied on the screen-reader-only span, so the field looked unlabeled until you visited the magic-login page and returned. The inconsistency was confusing, especially because Jetpack still accepts emails. Displaying the same text as the default login resolves the UX bug tracked in M4R73CH-1281.

## Testing Instructions

* yarn test-client client/blocks/login/test/login-form.jsx
* `/log-in/jetpack` — label should read “Email address or username”.
* `/log-in/jetpack/link` → Enter a password instead — label remains “Email address or username”.
* `/log-in/jetpack?username_only=true` — label switches to “Your username”.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?