### PR TITLE
Always show Domain Connection Setup link in domain overview

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/summary.tsx
+++ b/client/dashboard/domains/domain-connection-setup/summary.tsx
@@ -4,10 +4,6 @@ import RouterLinkSummaryButton from '../../components/router-link-summary-button
 import type { Domain } from '@automattic/api-core';
 
 export default function DomainConnectionSetupSummary( { domain }: { domain: Domain } ) {
-	if ( domain.points_to_wpcom ) {
-		return null;
-	}
-
 	return (
 		<RouterLinkSummaryButton
 			to={ domainConnectionSetupRoute.fullPath }

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -14,7 +14,7 @@ import NameServersSettingsSummary from '../name-servers/summary';
 export default function DomainOverviewSettings( { domain }: { domain: Domain } ) {
 	const buttonListItems = [];
 
-	if ( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION && ! domain.points_to_wpcom ) {
+	if ( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {
 		buttonListItems.push(
 			<DomainConnectionSetupSummary key="connection-setup" domain={ domain } />
 		);

--- a/client/dashboard/domains/domain-overview/test/settings.test.tsx
+++ b/client/dashboard/domains/domain-overview/test/settings.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { DomainSubtype, DomainTransferStatus, type Domain } from '@automattic/api-core';
+import { DomainSubtype, type Domain } from '@automattic/api-core';
 import { screen, waitFor } from '@testing-library/react';
 import { render } from '../../../test-utils';
 import DomainOverviewSettings from '../settings';
@@ -261,40 +261,9 @@ describe( 'DomainOverviewSettings', () => {
 			expect( screen.queryByText( 'Contact details & privacy' ) ).not.toBeInTheDocument();
 			expect( screen.queryByText( 'Glue records' ) ).not.toBeInTheDocument();
 		} );
-
-		test( 'hides settings when transfer is pending async', async () => {
-			const { container } = renderDomainSettings( {
-				subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
-				can_manage_dns_records: true,
-				transfer_status: DomainTransferStatus.PENDING_ASYNC,
-				points_to_wpcom: true, // This makes DomainConnectionSetupSummary return null
-			} );
-
-			// Should not show any settings
-			expect( screen.queryByText( 'Settings' ) ).not.toBeInTheDocument();
-			expect( container.firstChild ).toBeNull();
-		} );
 	} );
 
 	describe( 'Edge Cases', () => {
-		test( 'renders nothing when no settings should be shown', async () => {
-			// Domain with no permissions or capabilities
-			const { container } = render(
-				<DomainOverviewSettings
-					domain={ getMockedDomainData( {
-						subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Domain Connection' },
-						can_manage_dns_records: false,
-						transfer_status: DomainTransferStatus.PENDING_ASYNC,
-						points_to_wpcom: true, // This makes DomainConnectionSetupSummary return null
-					} ) }
-				/>
-			);
-
-			// Component should return null and render nothing
-			expect( container.firstChild ).toBeNull();
-			expect( screen.queryByText( 'Settings' ) ).not.toBeInTheDocument();
-		} );
-
 		test( 'shows correct number of settings for partially restricted registered domain', async () => {
 			renderDomainSettings( {
 				subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },


### PR DESCRIPTION
Closes [DOMAINS-1853](https://linear.app/a8c/issue/DOMAINS-1853/always-show-the-domain-connection-setup-link-in-the-domain-overview)

## Proposed Changes
For connected domains, always show the `Domain connection setup` link in the domain overview page.

## Why are these changes being made?
The connection and verification page should always be accessible, even when the domain is already pointing to WordPress.com. Users should be able to change the connection mode and restart the setup at any time.


## Testing Instructions
Open the overview page for a connected domain and verify that the `Domain connection setup` link is visible even when the domain is pointing to WordPress.com.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
