### PR TITLE
CIAB ARC-1212: Pass spec_id, if available, when creating a new site

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -233,7 +233,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			undefined, // siteGoals
 			gardenName,
 			gardenPartnerName,
-			urlQueryParams.get( 'spec_id' ) || ''
+			urlQueryParams.get( 'spec_id' )
 		);
 
 		// Poll for garden provisioning status if this is a garden site

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -232,7 +232,8 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			siteIntent,
 			undefined, // siteGoals
 			gardenName,
-			gardenPartnerName
+			gardenPartnerName,
+			urlQueryParams.get( 'spec_id' ) || ''
 		);
 
 		// Poll for garden provisioning status if this is a garden site

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -151,7 +151,8 @@ export const createSiteWithCart = async (
 	siteIntent?: string,
 	siteGoals?: SiteGoal[],
 	gardenName?: string | null,
-	gardenPartnerName?: string | null
+	gardenPartnerName?: string | null,
+	specId?: string | null
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
@@ -200,6 +201,9 @@ export const createSiteWithCart = async (
 					garden_name: gardenName,
 					garden_partner_name: gardenPartnerName,
 				} ),
+			...( specId && {
+				spec_id: specId,
+			} ),
 			options: {
 				...newSiteParams.options,
 				has_segmentation_survey: hasSegmentationSurvey,


### PR DESCRIPTION
ARC-1212

## Proposed Changes

* CIAB: Pass spec_id, if available, when creating a new site so that it can be stored for future reference. This way we can avoid the fragility of spec_id only being present in the current session's URL when building a site using AI.

## Testing Instructions

* Follow the instructions in 196540-ghe-Automattic/wpcom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
