### PR TITLE
Global Styles on Personal: A/B/C experiment implementation

### DIFF
--- a/client/state/sites/hooks/use-site-global-styles-on-personal.ts
+++ b/client/state/sites/hooks/use-site-global-styles-on-personal.ts
@@ -1,21 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useEffect } from 'react';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 
 type SiteIdOrSlug = number | string | null;
 
-const loadExperimentVariation = async () => {
-	const assignment = await loadExperimentAssignment(
-		'calypso_plans_global_styles_personal_20251124_v5'
-	);
-
-	// do something with assignment.variationName if you need it
-	( window as any ).globalStylesPersonalVariation = assignment.variationName;
-};
-
 export function useSiteGlobalStylesOnPersonal( siteIdOrSlug: SiteIdOrSlug = null ): boolean {
-	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus( siteIdOrSlug );
+	const { globalStylesInPersonalPlan, variation } = useSiteGlobalStylesStatus( siteIdOrSlug );
 
 	// Return true if global styles are enabled in the Personal Plan through feature flag or experiment.
 	const isGlobalStylesOnPersonalEnabled =
@@ -24,9 +14,9 @@ export function useSiteGlobalStylesOnPersonal( siteIdOrSlug: SiteIdOrSlug = null
 	useEffect( () => {
 		if ( typeof window !== 'undefined' ) {
 			( window as any ).isGlobalStylesOnPersonal = isGlobalStylesOnPersonalEnabled;
-			void loadExperimentVariation();
+			( window as any ).globalStylesPersonalVariation = variation;
 		}
-	}, [ isGlobalStylesOnPersonalEnabled ] );
+	}, [ isGlobalStylesOnPersonalEnabled, variation ] );
 
 	return isGlobalStylesOnPersonalEnabled;
 }

--- a/client/state/sites/hooks/use-site-global-styles-on-personal.ts
+++ b/client/state/sites/hooks/use-site-global-styles-on-personal.ts
@@ -1,8 +1,18 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useEffect } from 'react';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 
 type SiteIdOrSlug = number | string | null;
+
+const loadExperimentVariation = async () => {
+	const assignment = await loadExperimentAssignment(
+		'calypso_plans_global_styles_personal_20251124_v5'
+	);
+
+	// do something with assignment.variationName if you need it
+	( window as any ).globalStylesPersonalVariation = assignment.variationName;
+};
 
 export function useSiteGlobalStylesOnPersonal( siteIdOrSlug: SiteIdOrSlug = null ): boolean {
 	const { globalStylesInPersonalPlan } = useSiteGlobalStylesStatus( siteIdOrSlug );
@@ -14,6 +24,7 @@ export function useSiteGlobalStylesOnPersonal( siteIdOrSlug: SiteIdOrSlug = null
 	useEffect( () => {
 		if ( typeof window !== 'undefined' ) {
 			( window as any ).isGlobalStylesOnPersonal = isGlobalStylesOnPersonalEnabled;
+			void loadExperimentVariation();
 		}
 	}, [ isGlobalStylesOnPersonalEnabled ] );
 

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -10,6 +10,7 @@ export type GlobalStylesStatus = {
 	shouldLimitGlobalStyles: boolean;
 	globalStylesInUse: boolean;
 	globalStylesInPersonalPlan?: boolean;
+	variation?: string | null;
 };
 
 // While we are loading the Global Styles Info we can't assume that we should limit global styles, or we would be
@@ -18,6 +19,7 @@ const DEFAULT_GLOBAL_STYLES_INFO: GlobalStylesStatus = {
 	shouldLimitGlobalStyles: false,
 	globalStylesInUse: false,
 	globalStylesInPersonalPlan: false,
+	variation: null,
 };
 
 /*
@@ -71,6 +73,7 @@ const getGlobalStylesInfoForSite = (
 			shouldLimitGlobalStyles: true,
 			globalStylesInUse: false,
 			globalStylesInPersonalPlan: false,
+			variation: null,
 		} );
 	}
 
@@ -81,6 +84,7 @@ const getGlobalStylesInfoForSite = (
 					shouldLimitGlobalStyles: true,
 					globalStylesInUse: false,
 					globalStylesInPersonalPlan: !! experimentAssignment?.variationName,
+					variation: experimentAssignment?.variationName,
 				} )
 		);
 	}

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -75,7 +75,7 @@ const getGlobalStylesInfoForSite = (
 	}
 
 	if ( siteId === null ) {
-		return loadExperimentAssignment( 'calypso_plans_global_styles_personal_20251108_v4' ).then(
+		return loadExperimentAssignment( 'calypso_plans_global_styles_personal_20251124_v5' ).then(
 			( experimentAssignment ) =>
 				Promise.resolve( {
 					shouldLimitGlobalStyles: true,

--- a/packages/calypso-products/src/constants/feature-group.ts
+++ b/packages/calypso-products/src/constants/feature-group.ts
@@ -33,6 +33,7 @@ export const FEATURE_GROUP_ADS = 'feature-group-ads';
 export const FEATURE_GROUP_ANALYTICS = 'feature-group-analytics';
 export const FEATURE_GROUP_CUSTOM_PLUGINS = 'feature-group-custom-plugins';
 export const FEATURE_GROUP_CUSTOMIZE_STYLE = 'feature-group-customize-style';
+export const FEATURE_GROUP_WORDADS = 'feature-group-wordads';
 export const FEATURE_GROUP_DEV_TOOLS = 'feature-group-dev-tools';
 export const FEATURE_GROUP_DOMAIN = 'feature-group-domain';
 export const FEATURE_GROUP_ENTITIES = 'feature-group-entities';

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -168,6 +168,7 @@ import {
 	FEATURE_PAYMENT_TRANSACTION_FEES_4,
 	FEATURE_PAYMENT_TRANSACTION_FEES_2,
 	FEATURE_PAYMENT_TRANSACTION_FEES_0,
+	FEATURE_GROUP_WORDADS,
 } from './constants';
 import { FeatureGroupMap } from './types';
 
@@ -537,6 +538,11 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 			FEATURE_PAYMENT_TRANSACTION_FEES_0,
 		],
 	},
+	[ FEATURE_GROUP_WORDADS ]: {
+		slug: FEATURE_GROUP_WORDADS,
+		getTitle: () => i18n.translate( 'WordAds' ),
+		getFeatures: () => [ FEATURE_WORDADS ],
+	},
 	[ FEATURE_GROUP_WP_HOSTING_COMMERCE ]: {
 		slug: FEATURE_GROUP_WP_HOSTING_COMMERCE,
 		getTitle: () => i18n.translate( 'Commerce specific capabilities' ),
@@ -575,6 +581,7 @@ export function resolveFeatureGroupsForFeaturesGrid( {
 			[ FEATURE_GROUP_CUSTOMIZE_STYLE ]: featureGroups[ FEATURE_GROUP_CUSTOMIZE_STYLE ],
 			[ FEATURE_GROUP_PAYMENT_TRANSACTION_FEES ]:
 				featureGroups[ FEATURE_GROUP_PAYMENT_TRANSACTION_FEES ],
+			[ FEATURE_GROUP_WORDADS ]: featureGroups[ FEATURE_GROUP_WORDADS ],
 			[ FEATURE_GROUP_ANALYTICS ]: featureGroups[ FEATURE_GROUP_ANALYTICS ],
 			...( isUploadVideosTranslated() && {
 				[ FEATURE_GROUP_UPLOAD_VIDEOS ]: featureGroups[ FEATURE_GROUP_UPLOAD_VIDEOS ],

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -529,7 +529,7 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 		getFeatures: () => [ FEATURE_PRIORITY_24_7_SUPPORT ],
 	},
 	[ FEATURE_GROUP_PAYMENT_TRANSACTION_FEES ]: {
-		slug: FEATURE_GROUP_WP_HOSTING_COMMERCE,
+		slug: FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 		getTitle: () => i18n.translate( 'Payment transaction fees' ),
 		getFeatures: () => [
 			FEATURE_PAYMENT_TRANSACTION_FEES_8,

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -163,6 +163,11 @@ import {
 	FEATURE_WOO_AUTOMATE,
 	FEATURE_WOO_SHIPPING_TRACKING,
 	FEATURE_GOOGLE_LISTING_ADS,
+	FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
+	FEATURE_PAYMENT_TRANSACTION_FEES_8,
+	FEATURE_PAYMENT_TRANSACTION_FEES_4,
+	FEATURE_PAYMENT_TRANSACTION_FEES_2,
+	FEATURE_PAYMENT_TRANSACTION_FEES_0,
 } from './constants';
 import { FeatureGroupMap } from './types';
 
@@ -522,6 +527,16 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 		getTitle: () => i18n.translate( 'Support' ),
 		getFeatures: () => [ FEATURE_PRIORITY_24_7_SUPPORT ],
 	},
+	[ FEATURE_GROUP_PAYMENT_TRANSACTION_FEES ]: {
+		slug: FEATURE_GROUP_WP_HOSTING_COMMERCE,
+		getTitle: () => i18n.translate( 'Payment transaction fees' ),
+		getFeatures: () => [
+			FEATURE_PAYMENT_TRANSACTION_FEES_8,
+			FEATURE_PAYMENT_TRANSACTION_FEES_4,
+			FEATURE_PAYMENT_TRANSACTION_FEES_2,
+			FEATURE_PAYMENT_TRANSACTION_FEES_0,
+		],
+	},
 	[ FEATURE_GROUP_WP_HOSTING_COMMERCE ]: {
 		slug: FEATURE_GROUP_WP_HOSTING_COMMERCE,
 		getTitle: () => i18n.translate( 'Commerce specific capabilities' ),
@@ -558,6 +573,8 @@ export function resolveFeatureGroupsForFeaturesGrid( {
 				[ FEATURE_GROUP_CUSTOM_PLUGINS ]: featureGroups[ FEATURE_GROUP_CUSTOM_PLUGINS ],
 			} ),
 			[ FEATURE_GROUP_CUSTOMIZE_STYLE ]: featureGroups[ FEATURE_GROUP_CUSTOMIZE_STYLE ],
+			[ FEATURE_GROUP_PAYMENT_TRANSACTION_FEES ]:
+				featureGroups[ FEATURE_GROUP_PAYMENT_TRANSACTION_FEES ],
 			[ FEATURE_GROUP_ANALYTICS ]: featureGroups[ FEATURE_GROUP_ANALYTICS ],
 			...( isUploadVideosTranslated() && {
 				[ FEATURE_GROUP_UPLOAD_VIDEOS ]: featureGroups[ FEATURE_GROUP_UPLOAD_VIDEOS ],

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -341,6 +341,7 @@ import {
 	FEATURE_SUPPORT_FROM_EXPERTS,
 	FEATURE_AI_ASSISTANT,
 	FEATURE_ADVANCED_FORM_FEATURES_JP,
+	FEATURE_GROUP_WORDADS,
 } from './constants';
 import type { FeatureList } from './types';
 
@@ -1862,6 +1863,7 @@ const FEATURES_LIST: FeatureList = {
 		getTitle: () => i18n.translate( 'Earn with WordAds' ),
 		getDescription: () =>
 			i18n.translate( 'Display ads and earn from premium networks via the WordAds program.' ),
+		getFeatureGroup: () => FEATURE_GROUP_WORDADS,
 	},
 	[ FEATURE_PLUGINS_THEMES ]: {
 		getSlug: () => FEATURE_PLUGINS_THEMES,

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -374,13 +374,10 @@ const getTransactionFeeCopy = ( commission = 0, variation = '' ) => {
 			);
 
 		default:
-			return i18n.translate(
-				'%(commission)d%% transaction fee for payments {{br}}{{/br}}(+ standard processing fee)',
-				{
-					components: { br: <br /> },
-					args: { commission },
-				}
-			);
+			return i18n.translate( 'Collect payments (%(commission)d%% fee + standard processing fee)', {
+				components: { br: <br /> },
+				args: { commission },
+			} );
 	}
 };
 
@@ -1705,20 +1702,14 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_2 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_2,
-		getTitle: () =>
-			i18n.translate( '%(commission)d%% transaction fee for payments', {
-				args: { commission: 2 },
-			} ),
-		getAlternativeTitle: () => '2%',
+		getTitle: () => getTransactionFeeCopy( 2 ),
+		getAlternativeTitle: () => getTransactionFeeCopy( 2 ),
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_0 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_0,
-		getTitle: () =>
-			i18n.translate( '%(commission)d%% transaction fee for payments', {
-				args: { commission: 0 },
-			} ),
-		getAlternativeTitle: () => '0%',
+		getTitle: () => getTransactionFeeCopy( 0 ),
+		getAlternativeTitle: () => getTransactionFeeCopy( 0 ),
 		getFeatureGroup: () => FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_0_WOO ]: {

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -376,7 +376,6 @@ const getTransactionFeeCopy = ( commission = 0, variation = '' ) => {
 
 		default:
 			return i18n.translate( 'Collect payments (%(commission)d%% fee + standard processing fee)', {
-				components: { br: <br /> },
 				args: { commission },
 			} );
 	}

--- a/packages/calypso-products/src/is-global-styles-on-personal-enabled.ts
+++ b/packages/calypso-products/src/is-global-styles-on-personal-enabled.ts
@@ -3,6 +3,7 @@ import { isEnabled } from '@automattic/calypso-config';
 declare global {
 	interface Window {
 		isGlobalStylesOnPersonal?: boolean;
+		globalStylesPersonalVariation?: string;
 	}
 }
 export function isGlobalStylesOnPersonalEnabled(): boolean {
@@ -17,4 +18,12 @@ export function isGlobalStylesOnPersonalEnabled(): boolean {
 	window.isGlobalStylesOnPersonal = isEnabled( 'global-styles/on-personal-plan' );
 
 	return !! window.isGlobalStylesOnPersonal;
+}
+
+export function isGlobalStylesGridChangesVariation(): boolean {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+
+	return window.globalStylesPersonalVariation === 'treatment2';
 }

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -473,7 +473,10 @@ import {
 	WPCOM_FEATURES_PERFORMANCE,
 } from './constants';
 import { isBigSkyOnboarding } from './is-big-sky-onboarding';
-import { isGlobalStylesOnPersonalEnabled } from './is-global-styles-on-personal-enabled';
+import {
+	isGlobalStylesOnPersonalEnabled,
+	isGlobalStylesGridChangesVariation,
+} from './is-global-styles-on-personal-enabled';
 import {
 	getPlanBusinessTitle,
 	getPlanEcommerceTitle,
@@ -847,6 +850,10 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 			features = [ FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL, ...features ];
 		}
 
+		if ( isGlobalStylesGridChangesVariation() ) {
+			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_8 ];
+		}
+
 		if ( isGlobalStylesOnPersonalEnabled() ) {
 			features = [ ...features, FEATURE_STYLE_CUSTOMIZATION ];
 		}
@@ -867,6 +874,10 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		];
 
 		let features = baseFeatures;
+
+		if ( isGlobalStylesGridChangesVariation() ) {
+			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_8 ];
+		}
 
 		if ( isGlobalStylesOnPersonalEnabled() ) {
 			features = [ ...features, FEATURE_STYLE_CUSTOMIZATION ];
@@ -1034,8 +1045,8 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SHIPPING_CARRIERS,
 		FEATURE_ALL_BUSINESS_FEATURES,
 	],
-	getSignupCompareAvailableFeatures: () =>
-		[
+	getSignupCompareAvailableFeatures: () => {
+		const baseFeatures = [
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_HOSTING,
 			FEATURE_NO_ADS,
@@ -1052,9 +1063,14 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_ACCEPT_PAYMENTS,
 			FEATURE_SHIPPING_CARRIERS,
 			PREMIUM_DESIGN_FOR_STORES,
-		].filter( isValueTruthy ),
+		].filter( isValueTruthy );
+
+		return isGlobalStylesGridChangesVariation()
+			? [ ...baseFeatures, FEATURE_PAYMENT_TRANSACTION_FEES_0 ]
+			: baseFeatures;
+	},
 	get2023PricingGridSignupWpcomFeatures: () => {
-		return [
+		let features = [
 			FEATURE_UNLIMITED_ENTITIES,
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_AD_FREE_EXPERIENCE,
@@ -1068,6 +1084,13 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_DEV_TOOLS,
 			FEATURE_WOOCOMMERCE_HOSTING,
 		];
+
+		// When the global styles grid variation is active, surface the payments fee for Commerce
+		if ( isGlobalStylesGridChangesVariation() ) {
+			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_0 ];
+		}
+
+		return features;
 	},
 	get2023PlanComparisonFeatureOverride: () => {
 		return [
@@ -1480,8 +1503,8 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			isEnabled( 'themes/premium' ) ? WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED : null,
 			FEATURE_ALL_PERSONAL_FEATURES,
 		].filter( isValueTruthy ),
-	getSignupCompareAvailableFeatures: () =>
-		[
+	getSignupCompareAvailableFeatures: () => {
+		const baseFeatures = [
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_HOSTING,
 			FEATURE_NO_ADS,
@@ -1491,7 +1514,12 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_EARN_AD,
 			isEnabled( 'themes/premium' ) ? WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED : null,
 			FEATURE_GOOGLE_ANALYTICS,
-		].filter( isValueTruthy ),
+		].filter( isValueTruthy );
+
+		return isGlobalStylesGridChangesVariation()
+			? [ ...baseFeatures, FEATURE_PAYMENT_TRANSACTION_FEES_4 ]
+			: baseFeatures;
+	},
 	get2023PricingGridSignupWpcomFeatures: ( props?: { isSummerSpecial?: boolean } ) => {
 		const baseFeatures = [
 			...( isBigSkyOnboarding() ? [ FEATURE_BIG_SKY_WEBSITE_BUILDER ] : [] ),
@@ -1510,6 +1538,11 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 
 		if ( props?.isSummerSpecial ) {
 			features = [ FEATURE_UPLOAD_PLUGINS_SUMMER_SPECIAL, ...features ];
+		}
+
+		// When the global styles grid variation is active, surface the payments fee for Premium
+		if ( isGlobalStylesGridChangesVariation() ) {
+			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_4 ];
 		}
 
 		return features;
@@ -1680,8 +1713,8 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_200GB_STORAGE,
 		FEATURE_ALL_PREMIUM_FEATURES,
 	],
-	getSignupCompareAvailableFeatures: () =>
-		[
+	getSignupCompareAvailableFeatures: () => {
+		const baseFeatures = [
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_HOSTING,
 			FEATURE_NO_ADS,
@@ -1695,9 +1728,14 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_ADVANCED_SEO_EXPANDED_ABBR,
 			FEATURE_SITE_BACKUPS_AND_RESTORE,
 			FEATURE_SFTP_DATABASE,
-		].filter( isValueTruthy ),
+		].filter( isValueTruthy );
+
+		return isGlobalStylesGridChangesVariation()
+			? [ ...baseFeatures, FEATURE_PAYMENT_TRANSACTION_FEES_2 ]
+			: baseFeatures;
+	},
 	get2023PricingGridSignupWpcomFeatures: () => {
-		return [
+		let features = [
 			...( isBigSkyOnboarding() ? [ FEATURE_BIG_SKY_WEBSITE_BUILDER ] : [] ),
 			FEATURE_UNLIMITED_ENTITIES,
 			FEATURE_CUSTOM_DOMAIN,
@@ -1711,6 +1749,13 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			FEATURE_UPLOAD_PLUGINS,
 			FEATURE_DEV_TOOLS,
 		];
+
+		// When the global styles grid variation is active, surface the payments fee for Business
+		if ( isGlobalStylesGridChangesVariation() ) {
+			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_2 ];
+		}
+
+		return features;
 	},
 	get2023PlanComparisonFeatureOverride: () => {
 		return [

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -851,7 +851,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		}
 
 		if ( isGlobalStylesGridChangesVariation() ) {
-			features = [ ...features, FEATURE_WORDADS, FEATURE_PAYMENT_TRANSACTION_FEES_8 ];
+			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_8 ];
 		}
 
 		if ( isGlobalStylesOnPersonalEnabled() ) {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -851,7 +851,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		}
 
 		if ( isGlobalStylesGridChangesVariation() ) {
-			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_8 ];
+			features = [ ...features, FEATURE_WORDADS, FEATURE_PAYMENT_TRANSACTION_FEES_8 ];
 		}
 
 		if ( isGlobalStylesOnPersonalEnabled() ) {
@@ -876,7 +876,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		let features = baseFeatures;
 
 		if ( isGlobalStylesGridChangesVariation() ) {
-			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_8 ];
+			features = [ ...features, FEATURE_WORDADS, FEATURE_PAYMENT_TRANSACTION_FEES_8 ];
 		}
 
 		if ( isGlobalStylesOnPersonalEnabled() ) {
@@ -1066,7 +1066,7 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		].filter( isValueTruthy );
 
 		return isGlobalStylesGridChangesVariation()
-			? [ ...baseFeatures, FEATURE_PAYMENT_TRANSACTION_FEES_0 ]
+			? [ ...baseFeatures, FEATURE_WORDADS, FEATURE_PAYMENT_TRANSACTION_FEES_0 ]
 			: baseFeatures;
 	},
 	get2023PricingGridSignupWpcomFeatures: () => {
@@ -1087,7 +1087,7 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 
 		// When the global styles grid variation is active, surface the payments fee for Commerce
 		if ( isGlobalStylesGridChangesVariation() ) {
-			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_0 ];
+			features = [ ...features, FEATURE_WORDADS, FEATURE_PAYMENT_TRANSACTION_FEES_0 ];
 		}
 
 		return features;
@@ -1517,7 +1517,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		].filter( isValueTruthy );
 
 		return isGlobalStylesGridChangesVariation()
-			? [ ...baseFeatures, FEATURE_PAYMENT_TRANSACTION_FEES_4 ]
+			? [ ...baseFeatures, FEATURE_WORDADS, FEATURE_PAYMENT_TRANSACTION_FEES_4 ]
 			: baseFeatures;
 	},
 	get2023PricingGridSignupWpcomFeatures: ( props?: { isSummerSpecial?: boolean } ) => {
@@ -1542,7 +1542,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 
 		// When the global styles grid variation is active, surface the payments fee for Premium
 		if ( isGlobalStylesGridChangesVariation() ) {
-			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_4 ];
+			features = [ ...features, FEATURE_WORDADS, FEATURE_PAYMENT_TRANSACTION_FEES_4 ];
 		}
 
 		return features;
@@ -1731,7 +1731,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		].filter( isValueTruthy );
 
 		return isGlobalStylesGridChangesVariation()
-			? [ ...baseFeatures, FEATURE_PAYMENT_TRANSACTION_FEES_2 ]
+			? [ ...baseFeatures, FEATURE_WORDADS, FEATURE_PAYMENT_TRANSACTION_FEES_2 ]
 			: baseFeatures;
 	},
 	get2023PricingGridSignupWpcomFeatures: () => {
@@ -1752,7 +1752,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 
 		// When the global styles grid variation is active, surface the payments fee for Business
 		if ( isGlobalStylesGridChangesVariation() ) {
-			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_2 ];
+			features = [ ...features, FEATURE_WORDADS, FEATURE_PAYMENT_TRANSACTION_FEES_2 ];
 		}
 
 		return features;

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -876,7 +876,7 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		let features = baseFeatures;
 
 		if ( isGlobalStylesGridChangesVariation() ) {
-			features = [ ...features, FEATURE_WORDADS, FEATURE_PAYMENT_TRANSACTION_FEES_8 ];
+			features = [ ...features, FEATURE_PAYMENT_TRANSACTION_FEES_8 ];
 		}
 
 		if ( isGlobalStylesOnPersonalEnabled() ) {

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -63,6 +63,7 @@ import {
 	FEATURE_GROUP_WP_HOSTING_DEVELOPER,
 	FEATURE_GROUP_WP_HOSTING_SUPPORT,
 	FEATURE_GROUP_WP_HOSTING_COMMERCE,
+	FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 } from './constants';
 import { PriceTierEntry } from './get-price-tier-for-units';
 import type { TranslateResult } from 'i18n-calypso';
@@ -283,6 +284,7 @@ export type FeatureGroupSlug =
 	| typeof FEATURE_GROUP_WP_HOSTING_MANAGED
 	| typeof FEATURE_GROUP_WP_HOSTING_DEVELOPER
 	| typeof FEATURE_GROUP_WP_HOSTING_SUPPORT
+	| typeof FEATURE_GROUP_PAYMENT_TRANSACTION_FEES
 	| typeof FEATURE_GROUP_WP_HOSTING_COMMERCE;
 
 export interface FeatureFootnotes {

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -64,6 +64,7 @@ import {
 	FEATURE_GROUP_WP_HOSTING_SUPPORT,
 	FEATURE_GROUP_WP_HOSTING_COMMERCE,
 	FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
+	FEATURE_GROUP_WORDADS,
 } from './constants';
 import { PriceTierEntry } from './get-price-tier-for-units';
 import type { TranslateResult } from 'i18n-calypso';
@@ -285,6 +286,7 @@ export type FeatureGroupSlug =
 	| typeof FEATURE_GROUP_WP_HOSTING_DEVELOPER
 	| typeof FEATURE_GROUP_WP_HOSTING_SUPPORT
 	| typeof FEATURE_GROUP_PAYMENT_TRANSACTION_FEES
+	| typeof FEATURE_GROUP_WORDADS
 	| typeof FEATURE_GROUP_WP_HOSTING_COMMERCE;
 
 export interface FeatureFootnotes {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTCOM-15271/global-styles-on-personal-abc-experiment-calypso-changes

## Proposed Changes

* Added a new feature group so that we can display payment features on the grid.
* Implemented A/B/C experiment logic and variations.

| Control | Treatment 1 | Treatment 2 |
|--------|--------|--------|
|<img width="1517" height="1289" alt="Screenshot 2025-11-20 at 15 29 36" src="https://github.com/user-attachments/assets/1fa8afe1-8611-4f0a-a800-e663d4f663b0" />|<img width="1518" height="1287" alt="Screenshot 2025-11-20 at 15 29 12" src="https://github.com/user-attachments/assets/9f7eeee4-ee9c-4f58-b932-54af3a64fb92" />|<img width="1514" height="1288" alt="Screenshot 2025-11-20 at 15 30 29" src="https://github.com/user-attachments/assets/6bfc43e5-265c-48cf-a30d-d5ac3887bca5" />| 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to determine if we can provide Global Styles to all our users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link and go to: `/setup/onboarding/plans`
* Sandbox your API and apply this PR to it: https://github.com/Automattic/jetpack/pull/46025
* Use the explat experiment change to alternate between the different experiment groups: pbxNRc-5wW-p2
* You should see the expected variations. (you might need to clear the local storage key for the experiment to avoid hitting the cache)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?