### PR TITLE
Invalidate domain-details data after a Nameserver update

### DIFF
--- a/packages/api-queries/src/domain-name-servers.ts
+++ b/packages/api-queries/src/domain-name-servers.ts
@@ -3,9 +3,9 @@ import {
 	updateDomainNameServers,
 	DomainNameServersResponse,
 } from '@automattic/api-core';
-import { domainQuery } from '@automattic/api-queries';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
+import { domainQuery } from '.';
 
 export const domainNameServersQuery = ( domainName: string ) =>
 	queryOptions( {

--- a/packages/api-queries/src/domain-name-servers.ts
+++ b/packages/api-queries/src/domain-name-servers.ts
@@ -3,6 +3,7 @@ import {
 	updateDomainNameServers,
 	DomainNameServersResponse,
 } from '@automattic/api-core';
+import { domainQuery } from '@automattic/api-queries';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 
@@ -25,5 +26,6 @@ export const domainNameServersMutation = ( domainName: string ) =>
 				nameServers: data,
 			} );
 			queryClient.invalidateQueries( domainNameServersQuery( domainName ) );
+			queryClient.invalidateQueries( domainQuery( domainName ) );
 		},
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMAINS-1761](https://linear.app/a8c/issue/DOMAINS-1761/after-you-edit-the-name-servers-settings-it-doesnt-show-in-the)

## Proposed Changes

* We're making sure we get new domain details data after saving a Name servers change

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* That's important to properly render the Nameserver information in the main Domain screen, DNS records, and Domain forwarding screens.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* make sure we do a /domain-details/{domain} request after saving a new Nameserver information:

<img width="1179" height="1099" alt="image" src="https://github.com/user-attachments/assets/0f85de00-1bf4-4350-88b4-e28c35a91307" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
