### PR TITLE
Cancel flow: Only display partial refund text if there is a partial refund

### DIFF
--- a/client/me/purchases/cancel-purchase/domain-options.tsx
+++ b/client/me/purchases/cancel-purchase/domain-options.tsx
@@ -137,7 +137,7 @@ const CancelPlanWithoutCancellingDomainMessage = ( {
 							}
 					  ) }
 			</p>
-			{ isRefundable( planPurchase ) && (
+			{ isRefundable( planPurchase ) && includedDomainPurchase.costToUnbundleText && (
 				<p>
 					{ translate(
 						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -86,7 +86,7 @@ describe( 'selectors', () => {
 				canExplicitRenew: false,
 				canDisableAutoRenew: false,
 				canReenableAutoRenewal: false,
-				costToUnbundleText: undefined,
+				costToUnbundleText: '',
 				currencyCode: undefined,
 				currencySymbol: undefined,
 				description: undefined,

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -126,10 +126,10 @@ export interface Purchase {
 	can_explicit_renew: boolean;
 
 	/**
-	 * If this upgrade is a plan and its domain credit was used to purchase a
-	 * domain registration, and the plan is within its refund period, then
-	 * `cost_to_unbundle_display` will be the formatted amount of the amount that
-	 * would be withheld to keep the domain if the plan is cancelled.
+	 * If this upgrade is a domain and a domain credit was used to purchase it,
+	 * and the plan is within its refund period, then `cost_to_unbundle_display`
+	 * will be the formatted amount of the amount that would be withheld to keep
+	 * the domain if the plan is cancelled.
 	 *
 	 * If there is nothing that would be withheld, this will be null.
 	 */

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -153,7 +153,14 @@ export interface Purchase {
 		| 'expired'
 		| 'one-time-purchase';
 	iap_purchase_management_link: string | null;
+
+	/**
+	 * If this subscription is for a plan with a bundled domain, this will
+	 * contain the domain name for that domain subscription. Otherwise this will
+	 * be an empty string.
+	 */
 	included_domain: string;
+
 	included_domain_purchase_amount: number;
 	introductory_offer: RawPurchaseIntroductoryOffer | null;
 

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -15,9 +15,7 @@ export function createPurchaseObject( purchase: RawPurchase ): Purchase {
 		canDisableAutoRenew: Boolean( purchase.can_disable_auto_renew ),
 		canReenableAutoRenewal: Boolean( purchase.can_reenable_auto_renewal ),
 		canExplicitRenew: Boolean( purchase.can_explicit_renew ),
-		costToUnbundleText: purchase.cost_to_unbundle_display
-			? purchase.cost_to_unbundle_display
-			: purchase.price_text,
+		costToUnbundleText: purchase.cost_to_unbundle_display ?? '',
 		currencyCode: purchase.currency_code,
 		currencySymbol: purchase.currency_symbol,
 		description: purchase.description,

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -12,10 +12,10 @@ export interface Purchase {
 	canReenableAutoRenewal: boolean;
 
 	/**
-	 * If this upgrade is a plan and its domain credit was used to purchase a
-	 * domain registration, and the plan is within its refund period, then
-	 * `costToUnbundleText` will be the formatted amount of the amount that
-	 * would be withheld to keep the domain if the plan is cancelled.
+	 * If this upgrade is a domain and a domain credit was used to purchase it,
+	 * and the plan is within its refund period, then `cost_to_unbundle_display`
+	 * will be the formatted amount of the amount that would be withheld to keep
+	 * the domain if the plan is cancelled.
 	 *
 	 * If there is nothing that would be withheld, this will be null.
 	 */

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -10,7 +10,17 @@ export interface Purchase {
 	asyncPendingPaymentBlockIsSet: boolean;
 	canExplicitRenew: boolean;
 	canReenableAutoRenewal: boolean;
+
+	/**
+	 * If this upgrade is a plan and its domain credit was used to purchase a
+	 * domain registration, and the plan is within its refund period, then
+	 * `costToUnbundleText` will be the formatted amount of the amount that
+	 * would be withheld to keep the domain if the plan is cancelled.
+	 *
+	 * If there is nothing that would be withheld, this will be null.
+	 */
 	costToUnbundleText: string;
+
 	currencyCode: string;
 	currencySymbol: string;
 	description: string;
@@ -31,7 +41,14 @@ export interface Purchase {
 	expiryStatus: string;
 	iapPurchaseManagementLink: string | null;
 	id: number;
+
+	/**
+	 * If this subscription is for a plan with a bundled domain, this will
+	 * contain the domain name for that domain subscription. Otherwise this will
+	 * be an empty string.
+	 */
 	includedDomain: string;
+
 	includedDomainPurchaseAmount: number;
 	introductoryOffer: PurchaseIntroductoryOffer | null;
 	isAutoRenewEnabled: boolean;


### PR DESCRIPTION
Fixes SHILL-1356

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR modifies how we generate `costToUnbundleText` in the legacy Purchase object -- which is still used by the cancel purchase flow outside of the Multi Site Dashboard -- so that it no longer uses the product's `price_text` as a fallback when `cost_to_unbundle_display` is not set. Then it prevents showing the `costToUnbundleText` value unless it's set.

(The Multi Site Dashboard cancel flow does not suffer from this same issue.)

Before             |  After
:-------------------------:|:-------------------------:
<img width="1076" height="588" alt="Screenshot 2025-11-20 at 4 36 23 PM" src="https://github.com/user-attachments/assets/faec1cba-cbb4-48d7-aceb-a404367afa1e" /> | <img width="1076" height="513" alt="Screenshot 2025-11-20 at 4 45 10 PM" src="https://github.com/user-attachments/assets/66b6ce53-27ac-4eda-a662-210807bcc169" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When canceling a plan with a bundled domain (the domain was free due to the domain credit from the plan) when both are still within their refund period and when the user wishes to keep the domain, we withhold money from the plan refund to cover the cost of the domain being kept. This amount is returned from the upgrades endpoint as `cost_to_unbundle_display` on the domain purchase (which can be found via the `included_domain` property of the plan purchase).

At one point, there may have been cases where `cost_to_unbundle_display` was inaccurate and so calypso's cancelation process was set up to use the domain product's price as a fallback, but this is no longer needed. In fact, it is a bug because it will claim there will be a withholding amount when there will not be.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Purchase a plan and domain together (or otherwise use the domain credit).
- Start the process to cancel the plan from calypso. Verify that you see text that reads "You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan minus %(domainCost)s for the domain."
- Modify the plan subscription so that it's no longer within its refund period. (**NOTE** I'm not sure actually how to do this because it uses the _receipt_ dates to determine the refund period. I had to use `Store_Time` to move the current time forward on the backend.)
- Start the cancel process again. This time, verify that you do not see the text at all.
