### PR TITLE
Domain Transfer Redesign: Route domain transfers to the `domain-transfer-setup` page instead of the domain overview page

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -103,6 +103,8 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 
 					const targetRoute =
 						domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER &&
+						// TODO: When DOMAINS-1802 is completed, we should check if the domain has the `pending_registry` status
+						// and send the user to the `/v2/domains/<domain_name>/transfer` URL instead of the `domain-transfer-setup` URL
 						config.isEnabled( 'domain-transfer-redesign' )
 							? domainTransferSetupRoute
 							: domainOverviewRoute;

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,5 +1,6 @@
 import { DomainSubtype } from '@automattic/api-core';
 import { userPurchasesQuery, siteSetPrimaryDomainMutation } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
@@ -12,6 +13,7 @@ import {
 	domainDnsRoute,
 	domainContactInfoRoute,
 	domainConnectionSetupRoute,
+	domainTransferSetupRoute,
 	domainTransferToAnyUserRoute,
 	domainTransferToOtherSiteRoute,
 	domainsContactInfoRoute,
@@ -99,8 +101,14 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
 
+					const targetRoute =
+						domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER &&
+						config.isEnabled( 'domain-transfer-redesign' )
+							? domainTransferSetupRoute
+							: domainOverviewRoute;
+
 					router.navigate( {
-						to: domainOverviewRoute.fullPath,
+						to: targetRoute.fullPath,
 						params: {
 							domainName: domain.domain,
 						},

--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -1,8 +1,9 @@
 import { DomainSubtype } from '@automattic/api-core';
+import config from '@automattic/calypso-config';
 import { Link } from '@tanstack/react-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { domainOverviewRoute } from '../../app/router/domains';
+import { domainOverviewRoute, domainTransferSetupRoute } from '../../app/router/domains';
 import { Text } from '../../components/text';
 import { textOverflowStyles } from './utils';
 import type { DomainSummary, Site } from '@automattic/api-core';
@@ -20,9 +21,15 @@ export const DomainNameField = ( {
 } ) => {
 	const siteSlug = site?.slug ?? domain.site_slug;
 
+	const href =
+		domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER &&
+		config.isEnabled( 'domain-transfer-redesign' )
+			? domainTransferSetupRoute.fullPath
+			: domainOverviewRoute.fullPath;
+
 	return (
 		<Link
-			to={ domainOverviewRoute.fullPath }
+			to={ href }
 			params={ { siteSlug, domainName: domain.domain } }
 			disabled={ ! domain.subscription_id }
 		>

--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -23,6 +23,8 @@ export const DomainNameField = ( {
 
 	const href =
 		domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER &&
+		// TODO: When DOMAINS-1802 is completed, we should check if the domain has the `pending_registry` status
+		// and send the user to the `/v2/domains/<domain_name>/transfer` URL instead of the `domain-transfer-setup` URL
 		config.isEnabled( 'domain-transfer-redesign' )
 			? domainTransferSetupRoute.fullPath
 			: domainOverviewRoute.fullPath;


### PR DESCRIPTION
Part of [DOMAINS-1801](https://linear.app/a8c/issue/DOMAINS-1801)

## Proposed Changes

This PR updates the destination of domain transfer rows' links in the domains overview page to be the `domain-transfer-setup` page instead of the domain overview page.

### Screenshots

- Links that were updated

<img width="1121" height="907" alt="Screenshot 2025-11-20 at 19 09 34" src="https://github.com/user-attachments/assets/9993a916-030c-41a3-a0e7-eacfbf6f00f1" />

| Link destination before | Link destination after |
| --- | --- |
|  <img width="1121" height="907" alt="Screenshot 2025-11-20 at 19 14 59" src="https://github.com/user-attachments/assets/a1e3ad6e-865c-459c-8402-b93e326ab30f" /> | <img width="1121" height="907" alt="Screenshot 2025-11-20 at 19 12 04" src="https://github.com/user-attachments/assets/eda31210-4a90-40a7-aa84-ab94666747cf" /> |

## Why are these changes being made?

These changes should make transferring domains simpler and easier for customers.
 
This is part of the [Domain Transfer Redesign](https://linear.app/a8c/project/implement-new-domain-transfer-designs-e7cf391f6e4a/overview) project.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Enable the `domain-transfer-redesign` feature flag
- You must have a domain transfer in one of your sites
- Go to the site domains list or to the global domains list and find your domain transfer
- Ensure that clicking both the domain name and the "View transfer" link will take you to the `domain-transfer-setup` page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
