### PR TITLE
MSD Billing: Wire new cancel flow to v2 purchase page, remove unused v1 components

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -310,6 +310,13 @@ export const addPaymentMethodRoute = createRoute( {
 );
 
 export const cancelPurchaseRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Cancel' ),
+			},
+		],
+	} ),
 	getParentRoute: () => purchaseSettingsRoute,
 	path: 'cancel',
 } ).lazy( () =>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1665,7 +1665,7 @@ export default function CancelPurchase() {
 				header={
 					<PageHeader
 						title={ getHeaderTitle() }
-						prefix={ <Breadcrumbs length={ 2 } /> }
+						prefix={ <Breadcrumbs length={ 4 } /> }
 						description={ __(
 							'Before you go, please answer a few quick questions to help us improve.'
 						) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -303,8 +303,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 						size="compact"
 						onClick={ () =>
 							// FIXME: add refund, cancel, and downgrade action
-							// This is a stopgap solution to allow customers to cancel until the cancellation flow is migrated to the dashboard.
-							( window.location.href = `/me/purchases/${ purchase.site_slug }/${ purchase.ID }/cancel` )
+							( window.location.href = `/v2/me/billing/purchases/${ purchase.ID }/cancel` )
 						}
 					>
 						{ __( 'Downgrade or cancel' ) }
@@ -324,8 +323,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 						size="compact"
 						onClick={ () =>
 							// FIXME: add remove action
-							// This is a stopgap solution to allow customers to cancel until the cancellation flow is migrated to the dashboard.
-							( window.location.href = `/me/purchases/${ purchase.site_slug }/${ purchase.ID }/remove` )
+							( window.location.href = `/v2/me/billing/purchases/${ purchase.ID }/cancel` )
 						}
 					>
 						{ __( 'Remove subscription' ) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -21,7 +21,7 @@ import { domainManagementEdit, domainUseMyDomain } from '@automattic/domains-tab
 import { formatCurrency } from '@automattic/number-formatters';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS } from '@automattic/urls';
 import { useQuery, useMutation, useSuspenseQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalGrid as Grid,
 	__experimentalText as Text,
@@ -47,7 +47,7 @@ import Breadcrumbs from '../../../app/breadcrumbs';
 import { useLocale } from '../../../app/locale';
 import { domainRoute } from '../../../app/router/domains';
 import { emailsRoute } from '../../../app/router/emails';
-import { purchaseSettingsRoute } from '../../../app/router/me';
+import { cancelPurchaseRoute, purchaseSettingsRoute } from '../../../app/router/me';
 import { ActionList } from '../../../components/action-list';
 import { Card, CardBody } from '../../../components/card';
 import ClipboardInputControl from '../../../components/clipboard-input-control';
@@ -289,6 +289,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 }
 
 function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
+	const navigate = useNavigate();
 	// FIXME: render renderWordAdsEligibilityWarningDialog for refund/cancel
 	// FIXME: render renderNonPrimaryDomainWarningDialog for refund/cancel
 	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete." next to cancel button (see domainTransferDuration)
@@ -302,8 +303,10 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 						variant="secondary"
 						size="compact"
 						onClick={ () =>
-							// FIXME: add refund, cancel, and downgrade action
-							( window.location.href = `/v2/me/billing/purchases/${ purchase.ID }/cancel` )
+							navigate( {
+								to: cancelPurchaseRoute.fullPath,
+								params: { purchaseId: purchase.ID },
+							} )
 						}
 					>
 						{ __( 'Downgrade or cancel' ) }
@@ -322,8 +325,10 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 						variant="secondary"
 						size="compact"
 						onClick={ () =>
-							// FIXME: add remove action
-							( window.location.href = `/v2/me/billing/purchases/${ purchase.ID }/cancel` )
+							navigate( {
+								to: cancelPurchaseRoute.fullPath,
+								params: { purchaseId: purchase.ID },
+							} )
 						}
 					>
 						{ __( 'Remove subscription' ) }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -91,34 +91,6 @@ export function addCreditCard( context, next ) {
 	next();
 }
 
-export function removePurchase( context, next ) {
-	const ManagePurchasesWrapper = localize( () => {
-		const classes = 'manage-purchase';
-		const purchaseListUrl = usePreviousUrlIfPurchasesList();
-
-		return (
-			<PurchasesWrapper title={ titles.managePurchase }>
-				<Main wideLayout className={ classes }>
-					<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
-					<PageViewTracker
-						path="/me/purchases/:site/:purchaseId"
-						title="Purchases > Manage Purchase"
-					/>
-					<ManagePurchase
-						showRemovePurchaseDialog
-						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-						siteSlug={ context.params.site }
-						purchaseListUrl={ purchaseListUrl }
-					/>
-				</Main>
-			</PurchasesWrapper>
-		);
-	} );
-
-	context.primary = <ManagePurchasesWrapper />;
-	next();
-}
-
 export function cancelPurchase( context, next ) {
 	const CancelPurchaseWrapper = localize( () => {
 		return (

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -123,14 +123,6 @@ export default ( router ) => {
 	);
 
 	router(
-		paths.removePurchase( ':site', ':purchaseId' ),
-		sidebar,
-		controller.removePurchase,
-		makeLayout,
-		clientRender
-	);
-
-	router(
 		paths.downgradePurchase( ':site', ':purchaseId' ),
 		sidebar,
 		controller.downgradePurchase,

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -198,7 +198,6 @@ export interface ManagePurchaseProps {
 	purchaseId: number;
 	redirectTo?: string;
 	siteSlug: string;
-	showRemovePurchaseDialog?: boolean | undefined;
 
 	/**
 	 * Note: this defaults to true.
@@ -746,7 +745,6 @@ class ManagePurchase extends Component<
 
 		return (
 			<RemovePurchase
-				showDialog={ this.props.showRemovePurchaseDialog }
 				hasLoadedSites={ hasLoadedSites }
 				hasLoadedUserPurchasesFromServer={ this.props.hasLoadedPurchasesFromServer }
 				hasNonPrimaryDomainsFlag={ hasNonPrimaryDomainsFlag }

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -38,15 +38,6 @@ export function managePurchaseByOwnership( ownershipId ) {
 	return '/me/purchases-by-owner/' + ownershipId;
 }
 
-export function removePurchase( siteName, purchaseId ) {
-	if ( process.env.NODE_ENV !== 'production' ) {
-		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
-			throw new Error( 'siteName and purchaseId must be provided' );
-		}
-	}
-	return managePurchase( siteName, purchaseId ) + '/remove';
-}
-
 export function cancelPurchase( siteName, purchaseId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -65,7 +65,6 @@ class RemovePurchase extends Component {
 		linkIcon: PropTypes.string,
 		primaryDomain: PropTypes.object,
 		skipRemovePlanSurvey: PropTypes.bool,
-		showDialog: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -101,7 +100,11 @@ class RemovePurchase extends Component {
 		} );
 	};
 
-	actuallyOpenDialog = () => {
+	openDialog = () => {
+		event.preventDefault();
+		if ( this.props.onClickTracks ) {
+			this.props.onClickTracks( event );
+		}
 		if (
 			this.shouldShowNonPrimaryDomainWarning() &&
 			! this.state.isShowingNonPrimaryDomainWarning
@@ -140,14 +143,6 @@ class RemovePurchase extends Component {
 				isDialogVisible: true,
 			} );
 		}
-	};
-
-	openDialog = ( event ) => {
-		event.preventDefault();
-		if ( this.props.onClickTracks ) {
-			this.props.onClickTracks( event );
-		}
-		this.actuallyOpenDialog();
 	};
 
 	componentDidMount = () => {
@@ -424,15 +419,6 @@ class RemovePurchase extends Component {
 
 			return null;
 		};
-
-		if ( this.props.showDialog ) {
-			return (
-				<>
-					{ getWarningDialog() }
-					{ this.renderDialog() }
-				</>
-			);
-		}
 
 		return (
 			<>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes [SHILL-1278](https://linear.app/a8c/issue/SHILL-1278/hosting-dashboard-cancellation-flow-wire-v2-cancellation-flow-up-to)

## Proposed Changes

* Connect v2 cancel flow to v2 settings page
* Remove old code needed to redirect to v1 cancel flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The cancellation flow in the dashboard is working well enough that we can let customers who have opted in to the dashboard use it.
* The code created to facilitate redirection to the v1 cancel flow is no longer needed and can be removed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/v2/me/billing/purchases` and select a purchase that you'd like to cancel, choosing "Manage purchase" for that row.
* Click "downgrade or cancel" or click "Remove plan" and you should be redirected to the v2 cancellation flow.
* Visit `/me/purchases` and select a purchase that you'd like to cancel, choosing "Manage purchase" for that row.
* Clicking "Cancel" or "remove" buttons should work as normal with no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
