### PR TITLE
MSD: Debounce the validation on the email field of the transfer site

### DIFF
--- a/client/dashboard/app/hooks/use-debounced-state.ts
+++ b/client/dashboard/app/hooks/use-debounced-state.ts
@@ -1,0 +1,20 @@
+import { useDebounce } from '@wordpress/compose';
+import { useState, useEffect } from 'react';
+
+const useDebouncedState = < T >(
+	defaultValue: T,
+	wait: number = 250
+): [ T, React.Dispatch< React.SetStateAction< T > >, T ] => {
+	const [ state, setState ] = useState( defaultValue );
+	const [ debouncedState, setDebouncedState ] = useState( defaultValue );
+
+	const debouncedSetDebouncedState = useDebounce( setDebouncedState, wait );
+
+	useEffect( () => {
+		debouncedSetDebouncedState( state );
+	}, [ state, debouncedSetDebouncedState ] );
+
+	return [ state, setState, debouncedState ];
+};
+
+export default useDebouncedState;

--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -10,6 +10,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
+import useDebouncedState from '../../app/hooks/use-debounced-state';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import FlashMessage, { reloadWithFlashMessage } from '../../components/flash-message';
@@ -53,11 +54,12 @@ export default function SecurityPassword() {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const [ isReloading, setIsReloading ] = useState( false );
 
-	const [ formData, setFormData ] = useState< SecurityPasswordFormData >( {
-		password: '',
-	} );
+	const [ formData, setFormData, debouncedFormData ] =
+		useDebouncedState< SecurityPasswordFormData >( {
+			password: '',
+		} );
 
-	const { validity, isValid } = useFormValidity( formData, fields, form );
+	const { validity, isValid } = useFormValidity( debouncedFormData, fields, form );
 	const isLoading = mutation.isPending || isReloading;
 
 	const handleSubmit = ( e: React.FormEvent ) => {

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -9,7 +9,7 @@ import {
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import useDebouncedState from '../../app/hooks/use-debounced-state';
 import { ButtonStack } from '../../components/button-stack';
 import { SectionHeader } from '../../components/section-header';
 import type { Site } from '@automattic/api-core';
@@ -64,14 +64,14 @@ export function ConfirmNewOwnerForm( {
 	newOwnerEmail: string;
 	onSubmit: ( data: ConfirmNewOwnerFormData ) => void;
 } ) {
-	const [ formData, setFormData ] = useState( {
+	const [ formData, setFormData, debouncedFormData ] = useDebouncedState( {
 		email: newOwnerEmail,
 	} );
 
 	const mutation = useMutation( siteOwnerTransferEligibilityCheckMutation( site.ID ) );
 
 	const fields = getFields( site.ID );
-	const { validity, isValid } = useFormValidity( formData, fields, form );
+	const { validity, isValid } = useFormValidity( debouncedFormData, fields, form );
 	const isSaveDisabled = ! isValid;
 
 	const handleSubmit = ( event: React.FormEvent ) => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/107230

## Proposed Changes

* Debounce the validation as suggested by p1763629517741109/1763612966.060929-slack-C05QAFZSFTL

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It would be better to debounce the api call when the user is still typing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites
* Select any site that is transferrable
* Navigate to Settings > Transfer site
* Input the owner's email
* Check your network request
* Ensure the validation endpoint won't be called immediately

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?