### PR TITLE
MSD: Don't refresh "Hosted on {Platform}" on window focus.

### DIFF
--- a/client/dashboard/sites/overview-site-fields/index.tsx
+++ b/client/dashboard/sites/overview-site-fields/index.tsx
@@ -17,7 +17,6 @@ const HostingProvider = ( { site }: { site: Site } ) => {
 	const { data: agencyBlog, isLoading: isLoadingAgencyBlog } = useQuery( {
 		...siteAgencyBlogQuery( site.ID ),
 		enabled: site.is_wpcom_atomic,
-		refetchOnWindowFocus: false,
 	} );
 
 	if ( isLoadingAgencyBlog ) {

--- a/client/dashboard/sites/overview-site-fields/index.tsx
+++ b/client/dashboard/sites/overview-site-fields/index.tsx
@@ -17,6 +17,7 @@ const HostingProvider = ( { site }: { site: Site } ) => {
 	const { data: agencyBlog, isLoading: isLoadingAgencyBlog } = useQuery( {
 		...siteAgencyBlogQuery( site.ID ),
 		enabled: site.is_wpcom_atomic,
+		refetchOnWindowFocus: false,
 	} );
 
 	if ( isLoadingAgencyBlog ) {

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -57,7 +57,7 @@ function getAgencyBillingMessage( agency: AgencyBlog | undefined, isAgencyQueryE
 export function LaunchAgencyDevelopmentSiteForm( { site }: { site: Site } ) {
 	const { data, isError } = useQuery( siteAgencyBlogQuery( site.ID ) );
 
-	const billingMessage = getAgencyBillingMessage( data, isError );
+	const billingMessage = getAgencyBillingMessage( data ?? undefined, isError );
 	const isReferralStatusActive = data?.referral_status === 'active';
 	const shouldShowBillingMessage = ! isReferralStatusActive && !! billingMessage;
 	const shouldShowReferClientButton = ! isReferralStatusActive;

--- a/packages/api-queries/src/site-agency.ts
+++ b/packages/api-queries/src/site-agency.ts
@@ -4,13 +4,16 @@ import { queryOptions } from '@tanstack/react-query';
 export const siteAgencyBlogQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'agency-blog' ],
-		queryFn: () => fetchAgencyBlog( siteId ),
-		retry: ( failureCount, error ) => {
-			// Stop retrying if we already know the blog is not an agency blog.
-			if ( isWpError( error ) && error.code === 'partner_for_blog_not_found' ) {
-				return false;
-			}
+		queryFn: async () => {
+			try {
+				return await fetchAgencyBlog( siteId );
+			} catch ( error ) {
+				// Return null if the blog is not an agency blog.
+				if ( isWpError( error ) && error.code === 'partner_for_blog_not_found' ) {
+					return null;
+				}
 
-			return failureCount < 3;
+				throw error;
+			}
 		},
 	} );


### PR DESCRIPTION
## Proposed Changes

This has been driving me nuts for a while. Everytime you restore focus to your site overview, the "Hosted on {Platform", re-renders. 

I can't think of a case where we need this to refresh on window focus.

## Why are these changes being made?

It's distracting.

### GIF

<img width="400" src="https://github.com/user-attachments/assets/f8b69013-a58a-46e9-bd1e-1bb4743c724b" />


## Testing Instructions

Load your site overview. Change tabs, come back. It should not re-render.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
