### PR TITLE
Use isCommerceGarden instead of checking for feature availability

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -45,15 +45,11 @@ import {
 	canViewSiteVisibilitySettings,
 	canViewWordPressSettings,
 } from '../../sites/features';
-import {
-	hasHostingFeature,
-	hasPlanFeature,
-	isPlanFeatureAvailable,
-} from '../../utils/site-features';
+import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSiteMigrationInProgress, getSiteMigrationState } from '../../utils/site-status';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { isCommerceGarden, isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
 import type { DifmWebsiteContentResponse, Site } from '@automattic/api-core';
@@ -190,7 +186,7 @@ export const siteDeploymentsRoute = createRoute( {
 	path: 'deployments',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( ! isPlanFeatureAvailable( site, HostingFeatures.DEPLOYMENT ) ) {
+		if ( isCommerceGarden( site ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
@@ -229,7 +225,7 @@ export const siteMonitoringRoute = createRoute( {
 	path: 'monitoring',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( ! isPlanFeatureAvailable( site, HostingFeatures.MONITOR ) ) {
+		if ( isCommerceGarden( site ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
@@ -253,7 +249,7 @@ export const siteLogsRoute = createRoute( {
 	path: 'logs',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( ! isPlanFeatureAvailable( site, HostingFeatures.LOGS ) ) {
+		if ( isCommerceGarden( site ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
@@ -345,7 +341,7 @@ export const siteScanRoute = createRoute( {
 	path: 'scan',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( ! isPlanFeatureAvailable( site, HostingFeatures.SCAN ) ) {
+		if ( isCommerceGarden( site ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
@@ -419,7 +415,7 @@ export const siteBackupsRoute = createRoute( {
 	path: 'backups',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( ! isPlanFeatureAvailable( site, HostingFeatures.BACKUPS ) ) {
+		if ( isCommerceGarden( site ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
@@ -545,7 +541,7 @@ export const sitePerformanceRoute = createRoute( {
 	path: 'performance',
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( ! isPlanFeatureAvailable( site, HostingFeatures.PERFORMANCE ) ) {
+		if ( isCommerceGarden( site ) ) {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -19,14 +19,6 @@ export function hasPlanFeature(
 	return site.plan.features.active.includes( feature );
 }
 
-export function isPlanFeatureAvailable( site: Site, feature: HostingFeatureSlug ) {
-	if ( ! site.plan ) {
-		return false;
-	}
-
-	return !! site.plan.features.available?.[ feature ];
-}
-
 // Returns whether the plan supports a specific "hosting feature",
 // which is a feature that requires Atomic or self-hosted infrastructure.
 export function hasHostingFeature( site: Site, feature: HostingFeatureSlug ) {

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -9,7 +9,6 @@ export interface SitePlan {
 	billing_period: 'Yearly' | 'Monthly';
 	features: {
 		active: string[];
-		available?: Record< string, string[] >;
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

In order to block some routes for CIAB sites, we used a plan feature availability check that didn't work out so well in practice due to that data not always being available. As an alternative, this PR checks for the site type instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /v2
* Ensure that CIAB sites are not able to access routes such as Deployments or Performance
* Ensure that WP.com sites are able to access those routes 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
