### PR TITLE
MSD: Improve billing-purchases DataViews persistence

### DIFF
--- a/client/dashboard/app/dataviews/use-persistent-view.ts
+++ b/client/dashboard/app/dataviews/use-persistent-view.ts
@@ -74,7 +74,7 @@ export function usePersistentView( {
 					( {
 						field,
 						operator: 'isAny',
-						value: [ queryParams[ field ] ],
+						value: [ queryParams[ field ].toString() ],
 					} ) as Filter
 			)
 		);

--- a/client/dashboard/app/dataviews/use-persistent-view.ts
+++ b/client/dashboard/app/dataviews/use-persistent-view.ts
@@ -89,8 +89,8 @@ export function usePersistentView( {
 		}
 
 		let transientQueryParams: Record< string, unknown > = {};
-		transientFilters.forEach( ( { field, value } ) => {
-			transientQueryParams[ field ] = value;
+		transientFilters.forEach( ( { field } ) => {
+			transientQueryParams[ field ] = queryParams[ field ];
 		} );
 		transientQueryParams = mergeQueryParamsWithTransientProperties(
 			transientQueryParams,
@@ -100,7 +100,7 @@ export function usePersistentView( {
 			matches[ matches.length - 1 ].pathname.replace( /\/$/, '' ),
 			transientQueryParams
 		);
-	}, [ matches, transientProperties, transientFilters ] );
+	}, [ matches, transientProperties, transientFilters, queryParams ] );
 
 	// Merge transient properties and filters from query params into the view.
 	const view: View = useMemo(

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -185,11 +185,11 @@ export const purchasesRoute = createRoute( {
 			queryClient.ensureQueryData( context.config.queries.sitesQuery() ),
 		] );
 	},
-	validateSearch: ( search ): { page?: number; search?: string; site?: string } => {
+	validateSearch: ( search ): { page?: number; search?: string; site?: number } => {
 		return {
 			page: typeof search.page === 'number' ? search.page : undefined,
 			search: typeof search.search === 'string' ? search.search : undefined,
-			site: typeof search.site === 'string' ? search.site : undefined,
+			site: typeof search.site === 'number' ? search.site : undefined,
 		};
 	},
 	path: '/purchases',

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -27,28 +27,28 @@ import type { ReactNode, ComponentProps } from 'react';
 
 import './style.scss';
 
-export const purchasesWideFields = [ 'status', 'payment-method' ];
-export const purchasesDesktopFields = [ 'status' ];
-export const purchasesMobileFields: string[] = [];
-const defaultPerPage = 10;
-const defaultSort = {
-	field: 'site',
-	direction: 'desc' as SortDirection,
-};
-export const purchasesDataView: View = {
+export const WIDE_FIELDS = [ 'status', 'payment-method' ];
+export const DESKTOP_FIELDS = [ 'status' ];
+export const MOBILE_FIELDS: string[] = [];
+
+export const DEFAULT_VIEW: View = {
 	type: 'table',
-	page: 1,
-	search: '',
-	perPage: defaultPerPage,
+	perPage: 10,
 	titleField: 'product',
 	showTitle: true,
 	mediaField: 'site',
 	showMedia: true,
 	descriptionField: 'description',
 	showDescription: true,
-	fields: purchasesDesktopFields,
-	sort: defaultSort,
-	layout: {},
+	showLevels: false,
+	fields: DESKTOP_FIELDS,
+	sort: {
+		field: 'site',
+		direction: 'desc' as SortDirection,
+	},
+	layout: {
+		density: 'balanced',
+	},
 };
 
 export function BillingPurchaseInfoPopover( { children }: { children: ReactNode } ) {
@@ -208,12 +208,12 @@ export function getFields( {
 	sites,
 	paymentMethods,
 	transferredPurchases,
-	filterViewBySite,
+	siteFilter,
 }: {
 	sites: Site[];
 	paymentMethods: Array< StoredPaymentMethod >;
 	transferredPurchases: Array< Purchase >;
-	filterViewBySite: ( site: Site ) => void;
+	siteFilter?: number;
 } ): Fields< Purchase > {
 	const backupPaymentMethods = paymentMethods.filter(
 		( paymentMethod ) => paymentMethod.is_backup === true
@@ -234,7 +234,7 @@ export function getFields( {
 						elements: sites.map( ( site ) => {
 							return { value: String( site.ID ), label: `${ site.name } (${ site.slug })` };
 						} ),
-						filterBy: { operators: [ 'isAny' ] },
+						filterBy: { operators: [ 'isAny' ], ...( siteFilter && { isPrimary: true } ) },
 				  }
 				: { filterBy: false } ),
 			getValue: ( { item }: { item: Purchase } ) => {
@@ -300,9 +300,7 @@ export function getFields( {
 			},
 			render: ( { item }: { item: Purchase } ) => {
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
-				return (
-					<PurchaseProduct purchase={ item } site={ site } filterViewBySite={ filterViewBySite } />
-				);
+				return <PurchaseProduct purchase={ item } site={ site } />;
 			},
 		},
 		{

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -5,28 +5,26 @@ import {
 } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useResizeObserver } from '@wordpress/compose';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useAppContext } from '../../app/context';
-import { usePersistentView } from '../../app/dataviews';
+import { DataViews, usePersistentView } from '../../app/dataviews';
 import { purchasesRoute } from '../../app/router/me';
 import { DataViewsCard } from '../../components/dataviews-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { adjustDataViewFieldsForWidth } from '../../utils/dataviews-width';
 import {
-	purchasesWideFields,
-	purchasesDesktopFields,
-	purchasesMobileFields,
-	purchasesDataView,
+	WIDE_FIELDS,
+	DESKTOP_FIELDS,
+	MOBILE_FIELDS,
+	DEFAULT_VIEW,
 	getFields,
 	getItemId,
 	usePurchasesListActions,
 } from './dataviews';
-import type { Site } from '@automattic/api-core';
-import type { View } from '@wordpress/dataviews';
 
 export default function PurchasesList() {
 	const { queries } = useAppContext();
@@ -37,40 +35,23 @@ export default function PurchasesList() {
 	);
 	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
 
-	const { view: currentView, updateView } = usePersistentView( {
-		slug: 'purchases',
-		defaultView: purchasesDataView,
+	const [ defaultView, setDefaultView ] = useState( DEFAULT_VIEW );
+	const { view, updateView, resetView } = usePersistentView( {
+		slug: 'me-billing-purchases',
+		defaultView,
 		queryParams: currentSearchParams,
+		queryParamFilterFields: [ 'site' ],
 	} );
-
-	// Ensure fields are always present (fallback if persisted view is corrupted)
-	const viewWithFields = useMemo( () => {
-		if ( ! currentView.fields || currentView.fields.length === 0 ) {
-			return {
-				...currentView,
-				fields: purchasesDesktopFields,
-			};
-		}
-		return currentView;
-	}, [ currentView ] );
-
-	const wrappedSetView = useCallback(
-		( setter: View | ( ( view: View ) => View ) ) => {
-			const newView = typeof setter === 'function' ? setter( viewWithFields ) : setter;
-			updateView( newView );
-		},
-		[ viewWithFields, updateView ]
-	);
 
 	const ref = useResizeObserver( ( entries ) => {
 		const firstEntry = entries[ 0 ];
 		if ( firstEntry ) {
 			adjustDataViewFieldsForWidth( {
 				width: firstEntry.contentRect.width,
-				setView: wrappedSetView,
-				wideFields: purchasesWideFields,
-				desktopFields: purchasesDesktopFields,
-				mobileFields: purchasesMobileFields,
+				setView: setDefaultView,
+				wideFields: WIDE_FIELDS,
+				desktopFields: DESKTOP_FIELDS,
+				mobileFields: MOBILE_FIELDS,
 			} );
 		}
 	} );
@@ -80,17 +61,7 @@ export default function PurchasesList() {
 		sites: sites ?? [],
 		paymentMethods: paymentMethods ?? [],
 		transferredPurchases: transferredPurchases ?? [],
-		filterViewBySite: ( site: Site ) => {
-			const newView: View = {
-				...viewWithFields,
-				filters: [
-					...( viewWithFields.filters?.filter( ( f ) => f.field !== 'site' ) ?? [] ),
-					{ field: 'site', operator: 'is' as const, value: String( site.ID ) },
-				],
-				page: 1,
-			};
-			updateView( newView );
-		},
+		siteFilter: currentSearchParams.site,
 	} );
 
 	const allSubscriptions = useMemo( () => {
@@ -98,8 +69,8 @@ export default function PurchasesList() {
 	}, [ purchases, transferredPurchases ] );
 
 	const { data: filteredSubscriptions, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( allSubscriptions, viewWithFields, purchasesDataFields );
-	}, [ allSubscriptions, viewWithFields, purchasesDataFields ] );
+		return filterSortAndPaginate( allSubscriptions, view, purchasesDataFields );
+	}, [ allSubscriptions, view, purchasesDataFields ] );
 
 	const actions = usePurchasesListActions( {
 		transferredPurchases: transferredPurchases ?? [],
@@ -118,8 +89,9 @@ export default function PurchasesList() {
 						isLoading={ isLoadingPurchases || isLoadingTransferredPurchases || isLoadingSites }
 						data={ filteredSubscriptions ?? [] }
 						fields={ purchasesDataFields }
-						view={ viewWithFields }
+						view={ view }
 						onChangeView={ updateView }
+						onResetView={ resetView }
 						defaultLayouts={ { table: {} } }
 						actions={ actions }
 						getItemId={ getItemId }

--- a/client/dashboard/me/billing-purchases/purchase-product.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-product.tsx
@@ -1,18 +1,12 @@
-import { ExternalLink, Button } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { purchasesRoute } from '../../app/router/me';
+import RouterLinkButton from '../../components/router-link-button';
 import { isTemporarySitePurchase, getSubtitleForDisplay } from '../../utils/purchase';
 import type { Purchase, Site } from '@automattic/api-core';
 
-export function PurchaseProduct( {
-	purchase,
-	site,
-	filterViewBySite,
-}: {
-	purchase: Purchase;
-	site?: Site;
-	filterViewBySite: ( site: Site ) => void;
-} ) {
+export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?: Site } ) {
 	if ( isTemporarySitePurchase( purchase ) ) {
 		return null;
 	}
@@ -39,9 +33,10 @@ export function PurchaseProduct( {
 						),
 						{
 							siteName: (
-								<Button
+								<RouterLinkButton
 									variant="link"
-									onClick={ () => filterViewBySite( site ) }
+									to={ purchasesRoute.fullPath }
+									search={ { site: site.ID } }
 									title={
 										// translators: the siteName is the name of the site
 										sprintf( __( 'View active upgrades for %(siteName)s' ), {
@@ -50,7 +45,7 @@ export function PurchaseProduct( {
 									}
 								>
 									{ site.name }
-								</Button>
+								</RouterLinkButton>
 							),
 							siteDomain: (
 								<ExternalLink href={ 'https://' + site.slug } rel="noreferrer" title={ linkTitle }>
@@ -73,9 +68,10 @@ export function PurchaseProduct( {
 						} ),
 						{
 							siteDomain: (
-								<Button
+								<RouterLinkButton
 									variant="link"
-									onClick={ () => filterViewBySite( site ) }
+									to={ purchasesRoute.fullPath }
+									search={ { site: site.ID } }
 									title={
 										// translators: the siteDomain is the domain of the site
 										sprintf( __( 'View active upgrades for %(siteDomain)s' ), {
@@ -84,7 +80,7 @@ export function PurchaseProduct( {
 									}
 								>
 									{ site.slug }
-								</Button>
+								</RouterLinkButton>
 							),
 							viewSite: (
 								<ExternalLink
@@ -115,9 +111,10 @@ export function PurchaseProduct( {
 						__( 'for <siteName /> (<viewSite />)' ),
 						{
 							siteName: (
-								<Button
+								<RouterLinkButton
 									variant="link"
-									onClick={ () => filterViewBySite( site ) }
+									to={ purchasesRoute.fullPath }
+									search={ { site: site.ID } }
 									title={
 										// translators: the siteName is the name of the site
 										sprintf( __( 'View active upgrades for %(siteName)s' ), {
@@ -126,7 +123,7 @@ export function PurchaseProduct( {
 									}
 								>
 									{ site.name }
-								</Button>
+								</RouterLinkButton>
 							),
 							viewSite: (
 								<ExternalLink href={ 'https://' + site.slug } rel="noreferrer" title={ linkTitle }>


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/107047

## Proposed Changes

- Updated the persistence key from `purchases` to `me-billing-purchases` (for consistency).
- Add the `Reset view` functionality.
- Use built-in `queryParamFilterFields: [ 'site' ]` to enable filtering by site, instead of doing that manually.
- Apply the responsive fields to `defaultView` instead of the current view (similar to https://github.com/Automattic/wp-calypso/pull/107121)

## Why are these changes being made?

Implementation consistency

## Testing Instructions

See instructions from https://github.com/Automattic/wp-calypso/pull/107047.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
