### PR TITLE
Help Center: Search - Use the updated endpoint and add A4A

### DIFF
--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -19,9 +19,15 @@ type Props = {
 	sectionName: string;
 	loadHelpCenter: boolean;
 	currentRoute: string;
+	source: string;
 };
 
-export default function HelpCenterLoader( { sectionName, loadHelpCenter, currentRoute }: Props ) {
+export default function HelpCenterLoader( {
+	sectionName,
+	loadHelpCenter,
+	currentRoute,
+	source,
+}: Props ) {
 	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 	const isDesktop = useBreakpoint( '>782px' );
 	const handleClose = useCallback( () => {
@@ -54,6 +60,7 @@ export default function HelpCenterLoader( { sectionName, loadHelpCenter, current
 			hidden={ sectionName === 'gutenberg-editor' && isDesktop }
 			onboardingUrl={ onboardingUrl() }
 			googleMailServiceFamily={ getGoogleMailServiceFamily() }
+			source={ source }
 		/>
 	);
 }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -264,6 +264,7 @@ class Layout extends Component {
 					sectionName={ this.props.sectionName }
 					loadHelpCenter={ loadHelpCenter }
 					currentRoute={ this.props.currentRoute }
+					source={ isA8CForAgencies() ? 'a4a' : 'wpcom' }
 				/>
 				{ ! shouldDisableSidebarScrollSynchronizer && (
 					<SidebarScrollSynchronizer layoutFocus={ this.props.currentLayoutFocus } />

--- a/packages/calypso-e2e/src/lib/components/help-center.ts
+++ b/packages/calypso-e2e/src/lib/components/help-center.ts
@@ -170,7 +170,7 @@ export class HelpCenterComponent {
 			this.page.waitForResponse(
 				( response ) => {
 					return (
-						response.request().url().includes( '/help/search/wpcom' ) &&
+						response.request().url().includes( '/help/search' ) &&
 						response
 							.request()
 							.url()

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -197,7 +197,7 @@ function HelpSearchResults( {
 	location = 'inline-help-popover',
 	currentRoute,
 }: HelpSearchResultsProps ) {
-	const { hasPurchases, sectionName, site } = useHelpCenterContext();
+	const { hasPurchases, sectionName, site, source } = useHelpCenterContext();
 	const { setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
 	const contextTerm = useSelect(
 		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getContextTerm(),
@@ -223,7 +223,8 @@ function HelpSearchResults( {
 	const { data: searchData, isLoading: isSearching } = useHelpSearchQuery(
 		searchQuery || contextTerm || contextSearch, // If there's a query, we don't context search
 		locale,
-		currentRoute
+		currentRoute,
+		source
 	);
 
 	const searchResults = searchData ?? [];

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -42,6 +42,7 @@ export type HelpCenterRequiredInformation = {
 	 * Custom markdown extensions (optional)
 	 */
 	markdownExtensions?: MarkdownExtensions;
+	source: string;
 };
 
 const defaultContext: HelpCenterRequiredInformation = {
@@ -90,6 +91,7 @@ const defaultContext: HelpCenterRequiredInformation = {
 	googleMailServiceFamily: '',
 	onboardingUrl: '',
 	isCommerceGarden: false,
+	source: 'wpcom',
 };
 
 const HelpCenterRequiredContext = createContext< HelpCenterRequiredInformation >( defaultContext );

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -42,7 +42,7 @@ export type HelpCenterRequiredInformation = {
 	 * Custom markdown extensions (optional)
 	 */
 	markdownExtensions?: MarkdownExtensions;
-	source: string;
+	source: '' | 'wpcom' | 'a4a';
 };
 
 const defaultContext: HelpCenterRequiredInformation = {

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -13,14 +13,15 @@ interface APIFetchOptions {
 const fetchArticlesAPI = async (
 	search: string,
 	locale: string,
-	sectionName: string
+	sectionName: string,
+	source: string
 ): Promise< SearchResult[] > => {
 	let searchResultResponse: SearchResult[] = [];
 
-	const queryString = buildQueryString( { query: search, locale, section: sectionName } );
+	const queryString = buildQueryString( { query: search, locale, section: sectionName, source } );
 	if ( canAccessWpcomApis() ) {
 		searchResultResponse = ( await wpcomRequest( {
-			path: `/help/search/wpcom?${ queryString }`,
+			path: `/help/search?${ queryString }`,
 			apiNamespace: 'wpcom/v2',
 		} ) ) as SearchResult[];
 	} else {
@@ -49,11 +50,12 @@ export const useHelpSearchQuery = (
 	search: string,
 	locale = 'en',
 	sectionName = '',
+	source = 'wpcom',
 	queryOptions: Record< string, unknown > = {}
 ) => {
 	return useQuery< any >( {
-		queryKey: [ 'help-center-search', search, locale, sectionName ],
-		queryFn: () => fetchArticlesAPI( search, locale, sectionName ),
+		queryKey: [ 'help-center-search', search, locale, sectionName, source ],
+		queryFn: () => fetchArticlesAPI( search, locale, sectionName, source ),
 		refetchOnWindowFocus: false,
 		...queryOptions,
 	} );

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -51,7 +51,7 @@ export const useHelpSearchQuery = (
 	search: string,
 	locale = 'en',
 	sectionName = '',
-	source = '',
+	source: HelpCenterRequiredInformation[ 'source' ] = '',
 	queryOptions: Record< string, unknown > = {}
 ) => {
 	return useQuery< any >( {

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -3,7 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { buildQueryString } from '@wordpress/url';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
-import { SearchResult } from '../types';
+import type { HelpCenterRequiredInformation } from '../contexts/HelpCenterContext';
+import type { SearchResult } from '../types';
 
 interface APIFetchOptions {
 	global: boolean;
@@ -14,7 +15,7 @@ const fetchArticlesAPI = async (
 	search: string,
 	locale: string,
 	sectionName: string,
-	source: string
+	source: HelpCenterRequiredInformation[ 'source' ]
 ): Promise< SearchResult[] > => {
 	let searchResultResponse: SearchResult[] = [];
 

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -50,7 +50,7 @@ export const useHelpSearchQuery = (
 	search: string,
 	locale = 'en',
 	sectionName = '',
-	source = 'wpcom',
+	source = '',
 	queryOptions: Record< string, unknown > = {}
 ) => {
 	return useQuery< any >( {


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/HAPD-2967/refactor-help-center-search-api-to-support-a4a

- Use the correct search endpoint as the wpcom PR.
- A4A now searches on the A4A blog.

## Testing steps

1. Visit /sites, Help Center search should work fine.
2. Run `yarn  start-a8c-for-agencies`, and check that Help Center search works on A4A.
3. Run `yarn dev --sync` from `apps/help-center`.
4. Sandbox widgets and a simple site, check wp-admin. Search should work fine.
5. Test Atomic with https://github.com/Automattic/jetpack/pull/46046