### PR TITLE
Align lost-password help link copy and styling

### DIFF
--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -202,7 +202,7 @@ const LostPasswordForm = ( {
 					) }
 					className="login__lostpassword-form-external-link"
 				>
-					{ translate( 'Need More Help?' ) }
+					{ translate( 'Need more help?' ) }
 				</ExternalLink>
 			</div>
 			<div className="login__form-action">

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -200,7 +200,6 @@ const LostPasswordForm = ( {
 						'https://wordpress.com/support/account-recovery/#verify-your-account-ownership',
 						locale
 					) }
-					className="login__lostpassword-form-external-link"
 				>
 					{ translate( 'Need more help?' ) }
 				</ExternalLink>

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -181,6 +181,8 @@ $breakpoint-mobile: 782px; //Mobile size.
 
 }
 
+// Ensure inline support links beside the form inputs inherit the subheader styling
+// without needing bespoke classes on the JSX.
 .login__form-userdata .components-external-link {
 	color: var(--studio-gray-50, #646970);
 	font-weight: 400;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -314,5 +314,16 @@ $breakpoint-mobile: 782px; //Mobile size.
 }
 
 .login__lostpassword-form-external-link {
-	font-size: 0.875em;
+	font-size: $font-body-small;
+	color: var(--studio-gray-90, #1d2327);
+	font-weight: 500;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.1em;
+
+	&:visited,
+	&:hover,
+	&:focus {
+		color: var(--studio-gray-90, #1d2327);
+	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -316,10 +316,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 .login__lostpassword-form-external-link {
 	font-size: $font-body-small;
 	color: var(--studio-gray-50, #646970);
-	font-weight: 500;
-	display: inline-flex;
-	align-items: center;
-	gap: 0.1em;
+	font-weight: 400;
 
 	&:visited,
 	&:hover,

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -315,7 +315,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 
 .login__lostpassword-form-external-link {
 	font-size: $font-body-small;
-	color: var(--studio-gray-90, #1d2327);
+	color: var(--color-neutral-70);
 	font-weight: 500;
 	display: inline-flex;
 	align-items: center;
@@ -324,6 +324,6 @@ $breakpoint-mobile: 782px; //Mobile size.
 	&:visited,
 	&:hover,
 	&:focus {
-		color: var(--studio-gray-90, #1d2327);
+		color: var(--color-neutral-70);
 	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -314,9 +314,10 @@ $breakpoint-mobile: 782px; //Mobile size.
 }
 
 .login__lostpassword-form-external-link {
-	font-size: $font-body-small;
-	color: var(--studio-gray-90, #1d2327);
-	font-weight: 500;
+	font-size: $font-body;
+	color: var(--studio-gray-50, #646970);
+	font-weight: 400;
+	text-decoration: underline;
 	display: inline-flex;
 	align-items: center;
 	gap: 0.1em;
@@ -324,6 +325,6 @@ $breakpoint-mobile: 782px; //Mobile size.
 	&:visited,
 	&:hover,
 	&:focus {
-		color: var(--studio-gray-90, #1d2327);
+		color: var(--studio-gray-50, #646970);
 	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -315,7 +315,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 
 .login__lostpassword-form-external-link {
 	font-size: $font-body-small;
-	color: var(--color-neutral-70);
+	color: var(--studio-gray-50, #646970);
 	font-weight: 500;
 	display: inline-flex;
 	align-items: center;
@@ -324,6 +324,6 @@ $breakpoint-mobile: 782px; //Mobile size.
 	&:visited,
 	&:hover,
 	&:focus {
-		color: var(--color-neutral-70);
+		color: var(--studio-gray-50, #646970);
 	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -314,10 +314,9 @@ $breakpoint-mobile: 782px; //Mobile size.
 }
 
 .login__lostpassword-form-external-link {
-	font-size: $font-body;
-	color: var(--studio-gray-50, #646970);
-	font-weight: 400;
-	text-decoration: underline;
+	font-size: $font-body-small;
+	color: var(--studio-gray-90, #1d2327);
+	font-weight: 500;
 	display: inline-flex;
 	align-items: center;
 	gap: 0.1em;
@@ -325,6 +324,6 @@ $breakpoint-mobile: 782px; //Mobile size.
 	&:visited,
 	&:hover,
 	&:focus {
-		color: var(--studio-gray-50, #646970);
+		color: var(--studio-gray-90, #1d2327);
 	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -184,6 +184,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 .login__form-userdata .components-external-link {
 	color: var(--studio-gray-50, #646970);
 	font-weight: 400;
+	font-size: $font-body-small;
 
 	&:visited,
 	&:hover,

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -178,6 +178,18 @@ $breakpoint-mobile: 782px; //Mobile size.
 			color: var(--color-link-dark);
 		}
 	}
+
+}
+
+.login__form-userdata .components-external-link {
+	color: var(--studio-gray-50, #646970);
+	font-weight: 400;
+
+	&:visited,
+	&:hover,
+	&:focus {
+		color: var(--studio-gray-50, #646970);
+	}
 }
 
 .login__form-change-username {
@@ -310,17 +322,5 @@ $breakpoint-mobile: 782px; //Mobile size.
 		.login__lostpassword-form  {
 			padding: 16px 16px 0;
 		}
-	}
-}
-
-.login__lostpassword-form-external-link {
-	font-size: $font-body-small;
-	color: var(--studio-gray-50, #646970);
-	font-weight: 400;
-
-	&:visited,
-	&:hover,
-	&:focus {
-		color: var(--studio-gray-50, #646970);
 	}
 }


### PR DESCRIPTION
Part of #N/A

## Proposed Changes

* Switch the lost-password help link text to sentence case so it matches the rest of the form copy.
* Restyle to reuse the subheader link color token, keeping typography consistent but avoiding the previous bright blue emphasis.

| Before | After |
|--------|--------|
| <img width="570" height="424" alt="Screenshot 2025-11-21 at 12 58 51 PM" src="https://github.com/user-attachments/assets/b473ff1a-5303-407c-8b6c-3ae15cf3f7ad" /> | <img width="553" height="445" alt="Screenshot 2025-11-21 at 1 44 00 PM" src="https://github.com/user-attachments/assets/74108201-bec8-42b1-81f7-0a3ad18ae961" /> |

## Why are these changes being made?

* The “Need more help?” link stood out awkwardly against the rest of the UI; sentence case matches the tone of surrounding labels.
* Matching the link color to the subheader links harmonizes the form’s visual hierarchy while still distinguishing it as an actionable link.

## Testing Instructions

* Visit `/log-in/lostpassword`.
* Verify the help link reads “Need more help?” and renders in the same gray tone as the header/subheader links.
* Confirm clicking the link still opens the support article in a new tab.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this PR changes tracked data/activity?
