### PR TITLE
Partner Directory: Add smoke test

### DIFF
--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -21,6 +21,7 @@ class EnvVariables implements SupportedEnvVariables {
 		GUTENBERG_NIGHTLY: false,
 		HEADLESS: false,
 		JETPACK_TARGET: 'wpcom-production',
+		PARTNER_DIRECTORY_BASE_URL: 'https://wordpress.com/development-services',
 		RETRY_COUNT: 0,
 		RUN_ID: '',
 		SLOW_MO: 0,
@@ -184,6 +185,10 @@ class EnvVariables implements SupportedEnvVariables {
 			);
 		}
 		return value as JetpackTarget;
+	}
+
+	get PARTNER_DIRECTORY_BASE_URL(): string {
+		return this.getValidatedUrlEnvVar( 'PARTNER_DIRECTORY_BASE_URL' );
 	}
 	/**
 	 * Helper to get and validate a URL environment variable.

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -6,6 +6,7 @@ export * from './sidebar-component';
 export * from './help-center';
 export * from './preview-component';
 export * from './notifications-component';
+export * from './partner-directory-component';
 export * from './site-select-component';
 export * from './cookie-banner-component';
 export * from './editor-settings-sidebar-component';

--- a/packages/calypso-e2e/src/lib/components/partner-directory-component.ts
+++ b/packages/calypso-e2e/src/lib/components/partner-directory-component.ts
@@ -1,0 +1,46 @@
+import type { Page } from 'playwright';
+
+/**
+ * Component representing the a partner directory block.
+ */
+export class PartnerDirectoryComponent {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Apply a dropdown filter to the partner directory.
+	 *
+	 * @param {string} dropdownName The name of the dropdown to apply the filter to.
+	 * @param {string} filterName The name of the filter to apply.
+	 */
+	async applyDropdownFilter( dropdownName: string, filterName: string ): Promise< void > {
+		await this.page.getByRole( 'button', { name: dropdownName } ).click();
+		await this.page.getByRole( 'checkbox', { name: filterName } ).click();
+	}
+
+	/**
+	 * Wait for the filter to be applied.
+	 */
+	async waitForFilterToBeApplied(): Promise< void > {
+		await this.page.waitForSelector( 'text=/\\d+ partners found for filters/', {
+			timeout: 10000,
+		} );
+	}
+
+	/**
+	 * Click the first partner in the partner directory.
+	 */
+	async clickFirstPartner(): Promise< void > {
+		const partner = this.page.getByRole( 'link', { name: 'Accepting new clients' } ).first();
+
+		await partner.click();
+	}
+}

--- a/packages/calypso-e2e/src/types/env-variables.types.ts
+++ b/packages/calypso-e2e/src/types/env-variables.types.ts
@@ -27,6 +27,7 @@ export interface SupportedEnvVariables {
 	readonly GUTENBERG_NIGHTLY: boolean;
 	readonly HEADLESS: boolean;
 	readonly JETPACK_TARGET: JetpackTarget;
+	readonly PARTNER_DIRECTORY_BASE_URL: string;
 	readonly RETRY_COUNT: number;
 	readonly RUN_ID: string;
 	readonly SLOW_MO: number;

--- a/test/e2e/specs/a8c-for-agencies/partner-directory__smoke.ts
+++ b/test/e2e/specs/a8c-for-agencies/partner-directory__smoke.ts
@@ -2,22 +2,22 @@
  * @group gutenberg
  */
 
+import { envVariables } from '@automattic/calypso-e2e';
 import type { Browser, Page } from 'playwright';
-
 declare const browser: Browser;
 
 /**
- * Verify the WordPress.com Partner Directory page loads and is interactive.
+ * Verify the Partner Directory page loads and is interactive.
  */
-describe( 'Automattic For Agencies: WordPress.com Partner Directory', () => {
+describe( 'Automattic For Agencies: Partner Directory', () => {
 	let page: Page;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
 	} );
 
-	test( 'Navigate to the WordPress.com Partner Directory', async () => {
-		await page.goto( 'https://wordpress.com/development-services/' );
+	test( 'Navigate to the Partner Directory', async () => {
+		await page.goto( envVariables.PARTNER_DIRECTORY_BASE_URL );
 	} );
 
 	test( 'Click the Industries dropdown', async () => {
@@ -35,7 +35,7 @@ describe( 'Automattic For Agencies: WordPress.com Partner Directory', () => {
 	test( "Visit the first partner's details page", async () => {
 		await Promise.all( [
 			page.getByText( 'Accepting new clients' ).first().click(),
-			page.waitForURL( /https:\/\/wordpress\.com\/development-services\/[^/]+\/[^/]+\//, {
+			page.waitForURL( new RegExp( `^${ envVariables.PARTNER_DIRECTORY_BASE_URL }/[^/]+/[^/]+/` ), {
 				timeout: 10_000,
 			} ),
 		] );

--- a/test/e2e/specs/a8c-for-agencies/partner-directory__smoke.ts
+++ b/test/e2e/specs/a8c-for-agencies/partner-directory__smoke.ts
@@ -2,7 +2,7 @@
  * @group gutenberg
  */
 
-import { envVariables } from '@automattic/calypso-e2e';
+import { envVariables, PartnerDirectoryComponent } from '@automattic/calypso-e2e';
 import type { Browser, Page } from 'playwright';
 declare const browser: Browser;
 
@@ -11,33 +11,31 @@ declare const browser: Browser;
  */
 describe( 'Automattic For Agencies: Partner Directory', () => {
 	let page: Page;
+	let partnerDirectory: PartnerDirectoryComponent;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
+		partnerDirectory = new PartnerDirectoryComponent( page );
 	} );
 
 	test( 'Navigate to the Partner Directory', async () => {
 		await page.goto( envVariables.PARTNER_DIRECTORY_BASE_URL );
 	} );
 
-	test( 'Click the Industries dropdown', async () => {
-		await page.getByRole( 'button', { name: 'Industries' } ).click();
-	} );
-
-	test( 'Select the Legal & Professional Services industry', async () => {
-		await page.getByRole( 'checkbox', { name: 'Legal & Professional Services' } ).click();
+	test( 'Apply the Legal & Professional Services industry filter', async () => {
+		await partnerDirectory.applyDropdownFilter( 'Industries', 'Legal & Professional Services' );
 	} );
 
 	test( 'Wait for the filter to be applied', async () => {
-		await page.waitForSelector( 'text=/\\d+ partners found for filters/', { timeout: 10000 } );
+		await partnerDirectory.waitForFilterToBeApplied();
 	} );
 
 	test( "Visit the first partner's details page", async () => {
 		await Promise.all( [
-			page.getByText( 'Accepting new clients' ).first().click(),
 			page.waitForURL( new RegExp( `^${ envVariables.PARTNER_DIRECTORY_BASE_URL }/[^/]+/[^/]+/` ), {
 				timeout: 10_000,
 			} ),
+			partnerDirectory.clickFirstPartner(),
 		] );
 	} );
 } );

--- a/test/e2e/specs/a8c-for-agencies/wpcom-partner-directory__smoke.ts
+++ b/test/e2e/specs/a8c-for-agencies/wpcom-partner-directory__smoke.ts
@@ -1,0 +1,43 @@
+/**
+ * @group gutenberg
+ */
+
+import type { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+/**
+ * Verify the WordPress.com Partner Directory page loads and is interactive.
+ */
+describe( 'Automattic For Agencies: WordPress.com Partner Directory', () => {
+	let page: Page;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+	} );
+
+	test( 'Navigate to the WordPress.com Partner Directory', async () => {
+		await page.goto( 'https://wordpress.com/development-services/' );
+	} );
+
+	test( 'Click the Industries dropdown', async () => {
+		await page.getByRole( 'button', { name: 'Industries' } ).click();
+	} );
+
+	test( 'Select the Legal & Professional Services industry', async () => {
+		await page.getByRole( 'checkbox', { name: 'Legal & Professional Services' } ).click();
+	} );
+
+	test( 'Wait for the filter to be applied', async () => {
+		await page.waitForSelector( 'text=/\\d+ partners found for filters/', { timeout: 10000 } );
+	} );
+
+	test( "Visit the first partner's details page", async () => {
+		await Promise.all( [
+			page.getByText( 'Accepting new clients' ).first().click(),
+			page.waitForURL( /https:\/\/wordpress\.com\/development-services\/[^/]+\/[^/]+\//, {
+				timeout: 10_000,
+			} ),
+		] );
+	} );
+} );


### PR DESCRIPTION
Prevents p1763722757972479-slack-C05GY7MD3ST.

## Proposed Changes

It's useful to have a test that checks for regressions in the Partner Directory whenever Gutenberg is upgraded. This PR ensures we won't see this escalation again.

## Testing Instructions

No manual testing needed. Wait for [the tests](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_simple_edge_desktop/16175786?buildTab=overview) to pass:

<img width="990" height="395" alt="image" src="https://github.com/user-attachments/assets/7baa55bd-42c7-4315-97b9-aa3ddb2c8723" />
