### PR TITLE
MSD Emails: minor tweaks for perceived performance improvement

### DIFF
--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -7,6 +7,7 @@ import {
 	queryClient,
 	rawUserPreferencesQuery,
 	siteByIdQuery,
+	userMailboxesQuery,
 } from '@automattic/api-queries';
 import { createLazyRoute, createRoute, redirect } from '@tanstack/react-router';
 import { __, _n } from '@wordpress/i18n';
@@ -25,6 +26,7 @@ export const emailsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'emails',
 	loader: async () => {
+		queryClient.prefetchQuery( userMailboxesQuery() );
 		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 	},
 	validateSearch: ( search ): { domainName: string | undefined } => {

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -27,6 +27,7 @@ export const emailsRoute = createRoute( {
 	path: 'emails',
 	loader: async () => {
 		queryClient.prefetchQuery( userMailboxesQuery() );
+		queryClient.prefetchQuery( domainsQuery() );
 		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 	},
 	validateSearch: ( search ): { domainName: string | undefined } => {

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -7,7 +7,6 @@ import {
 	queryClient,
 	rawUserPreferencesQuery,
 	siteByIdQuery,
-	userMailboxesQuery,
 } from '@automattic/api-queries';
 import { createLazyRoute, createRoute, redirect } from '@tanstack/react-router';
 import { __, _n } from '@wordpress/i18n';
@@ -26,7 +25,6 @@ export const emailsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'emails',
 	loader: async () => {
-		queryClient.prefetchQuery( userMailboxesQuery() );
 		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 	},
 	validateSearch: ( search ): { domainName: string | undefined } => {

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -7,7 +7,6 @@ import {
 	queryClient,
 	rawUserPreferencesQuery,
 	siteByIdQuery,
-	userMailboxesQuery,
 } from '@automattic/api-queries';
 import { createLazyRoute, createRoute, redirect } from '@tanstack/react-router';
 import { __, _n } from '@wordpress/i18n';
@@ -27,7 +26,6 @@ export const emailsRoute = createRoute( {
 	path: 'emails',
 	loader: async () => {
 		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
-		queryClient.ensureQueryData( userMailboxesQuery() );
 	},
 	validateSearch: ( search ): { domainName: string | undefined } => {
 		return {

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -108,7 +108,7 @@ function Emails() {
 			<DataViewsCard>
 				<DataViews
 					data={ filteredData }
-					isLoading={ isLoadingDomains || isLoadingEmailAccounts }
+					isLoading={ isLoadingEmailAccounts }
 					fields={ emailFields }
 					view={ view }
 					onChangeView={ updateView }

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -17,14 +17,13 @@ import type { Email } from './types';
 import './style.scss';
 
 function Emails() {
+	const { data: allEmailAccounts, isLoading: isLoadingEmailAccounts } = useQuery(
+		userMailboxesQuery()
+	);
 	const { domainName: domainNameFilter }: { domainName?: string } = emailsRoute.useSearch();
 	const { data: allDomains, isLoading: isLoadingDomains } = useQuery( domainsQuery() );
 	const domains = ( allDomains ?? [] ).filter(
 		( d ) => d.current_user_is_owner && d.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
-	);
-
-	const { data: allEmailAccounts, isLoading: isLoadingEmailAccounts } = useQuery(
-		userMailboxesQuery()
 	);
 
 	// Aggregate all domains into a single array


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
 - dotmsd-867-multisite-dashboard-slow-loading-on-emails

## Proposed Changes

Applied some minor tweaks so that perceived performance is increased.


https://github.com/user-attachments/assets/58e44ef6-03e5-4912-b89f-25eb45c396bb



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
The email list's perceived performance isn't satisfactory since we're showing a spinner while we load results when refetching.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link and go to `/v2/emails`
* Perceived performance should be more pleasing than on wpcalypso.
* For better results, also apply the API changes made here: 196637-ghe-Automattic/wpcom
* Considerations: If you sandbox your API, the response times are greater than in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?