### PR TITLE
Fix Calypso unified agents sidebar

### DIFF
--- a/packages/agents-manager/src/components/chat-layout-manager/style.scss
+++ b/packages/agents-manager/src/components/chat-layout-manager/style.scss
@@ -131,45 +131,68 @@ body.wp-admin:has( .agents-manager-sidebar-container--sidebar-open ) {
 }
 
 /* Calypso */
-body:has( #wpcom.agents-manager-sidebar-container--sidebar-open ) {
+// When the sidebar is open, adjust the Calypso layout to create bordered surfaces
+// The masterbar and sidebar are both fixed positioned elements
+body:has( .help-center.agents-manager-sidebar-container--sidebar-open ) {
 	background-color: $gray-900;
-}
 
-#wpcom.agents-manager-sidebar-container {
-	@include sidebar-base( '#content' );
-
-	#content {
-		background-color: #fcfcfc !important;
-	}
-
-	&.agents-manager-sidebar-container--sidebar-open {
-		@include sidebar-open-base( '#content' );
-
-		#header {
+	#wpcom {
+		// Adjust the masterbar (fixed positioned)
+		.layout__header-section .masterbar {
+			position: fixed !important;
 			top: $layout-spacing;
 			left: $layout-spacing;
-			right: $sidebar-width;
-			width: auto;
-			overflow: hidden;
-			border-top-left-radius: $main-border-radius;
-			border-top-right-radius: $main-border-radius;
+			right: calc( $sidebar-width + $layout-spacing );
+			width: auto !important;
+			border-radius: $main-border-radius $main-border-radius 0 0;
+			border: 1px solid $border-color;
+			border-bottom: none;
+			will-change: right, width, left;
+			transition:
+				right $transition-timing,
+				width $transition-timing,
+				left $transition-timing,
+				border $transition-timing;
 		}
 
-		#content {
-			top: $layout-spacing;
-			left: $layout-spacing;
-			height: calc( 100vh - ( $layout-spacing * 2 ) );
-			min-height: unset;
-			margin: 0 !important;
-		}
-
+		// Adjust the sidebar (fixed positioned)
 		#secondary {
-			top: calc( $layout-spacing + $admin-bar-height );
+			position: fixed !important;
+			top: calc( var(--masterbar-height) + $layout-spacing );
 			left: $layout-spacing;
 			bottom: $layout-spacing;
-			overflow: hidden;
-			border-top-left-radius: $main-border-radius;
-			border-bottom-left-radius: $main-border-radius;
+			border-left: 1px solid $border-color;
+			border-right: 1px solid $border-color;
+			border-bottom: 1px solid $border-color;
+			border-radius: 0 0 0 $main-border-radius;
+			will-change: border;
+			transition: border $transition-timing;
+		}
+
+		// Adjust the content area
+		#content {
+			position: fixed !important;
+			top: calc( var(--masterbar-height) + $layout-spacing );
+			left: calc( var(--sidebar-width-max) + $layout-spacing );
+			right: calc( $sidebar-width + $layout-spacing );
+			bottom: $layout-spacing;
+			height: calc( 100vh - var(--masterbar-height) - ( $layout-spacing * 2 ) );
+			margin: 0 !important;
+			box-sizing: border-box;
+			overflow-y: auto;
+			overflow-x: hidden;
+			will-change: left, right;
+			transition:
+				left $transition-timing,
+				right $transition-timing,
+				border $transition-timing;
+
+			// Use box-shadow for the border to ensure it's always visible
+			box-shadow:
+				0 0 0 1px $border-color,
+				inset 0 0 0 1px #fcfcfc;
+			border-radius: 0 0 $main-border-radius 0;
+			background-color: #fcfcfc !important;
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Updates styles for Calypso with the new container based on the help center parent portal.
* Not perfect, but gets us back to a somewhat working state.
* Sidebar length is still too long, getting rid of the border.

### Testing Instructions
- In Calypso, add `?flags=unified-agent` to a page.
- Open the chat and switch to the docked view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
