### PR TITLE
MSD Billing: Fix checkbox misalignment on domain options page

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
@@ -323,43 +323,37 @@ const CancelPurchaseDomainOptions = ( {
 				/>
 			</p>
 			{ cancelBundledDomain && (
-				<p>
-					{ createInterpolateElement(
-						__(
-							"When you cancel a domain, it becomes unavailable for a while. Anyone may register it once it's " +
-								"available again, so it's possible you won't have another chance to register it in the future. " +
-								"If you'd like to use your domain on a site hosted elsewhere, consider <a>updating your name " +
-								'servers</a> instead.'
-						),
-						{
-							a: (
-								<a
-									href={ localizeUrl( UPDATE_NAMESERVERS ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
+				<>
+					<p>
+						{ createInterpolateElement(
+							__(
+								"When you cancel a domain, it becomes unavailable for a while. Anyone may register it once it's " +
+									"available again, so it's possible you won't have another chance to register it in the future. " +
+									"If you'd like to use your domain on a site hosted elsewhere, consider <a>updating your name " +
+									'servers</a> instead.'
 							),
-						}
-					) }
-					<label>
+							{
+								a: (
+									<a
+										href={ localizeUrl( UPDATE_NAMESERVERS ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							}
+						) }
+					</p>
+					<p>
 						<CheckboxControl
 							checked={ confirmCancel }
 							onChange={ onConfirmCancelBundledDomainChange }
 							disabled={ isLoading }
-						/>
-						<span className="cancel-purchase__domain-confirm">
-							{ createInterpolateElement(
-								__(
-									'I understand that canceling my domain means I might <strong>never be able to register it ' +
-										'again</strong>.'
-								),
-								{
-									strong: <strong />,
-								}
+							label={ __(
+								'I understand that canceling my domain means I might never be able to register it again.'
 							) }
-						</span>
-					</label>
-				</p>
+						/>
+					</p>
+				</>
 			) }
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [SHILL-1358](https://linear.app/a8c/issue/SHILL-1358/hosting-dashboard-cancellation-flow-misaligned-checkbox-when-choosing)

## Proposed Changes

* Remove `<strong>` HTML from confirmation text so that it can be used as a label property (`string`)
* Use confirmation text as label property so that it is aligned properly.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The checkbox was on a separate line from the text asking for confirmation, which was hard to read.

Before:

<img width="712" height="743" alt="Screenshot 2025-11-21 at 12 03 42 PM" src="https://github.com/user-attachments/assets/602e4521-7d5e-445b-8708-4e0ae4c987ed" />

After:

<img width="690" height="725" alt="Screenshot 2025-11-21 at 12 06 39 PM" src="https://github.com/user-attachments/assets/2930c095-1394-486a-8e70-c55972316efb" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/v2/me/billing/purchases` and select a purchase which has a domain name that has been registered at checkout for an expiration date of over 2 years along with a plan that is at least yearly, bi yearly or tri yearly plan. Select "Manage purchase" and append `/cancel` to the end of the URL.
* Click the checkbox on the first page and continue to the second page. Choose the "Cancel the plan and the domain" option and observe that the text is on the same line as the checkbox. You should be able to click the checkbox or the confirmation text and both the checkbox should check and you should be able to continue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
