### PR TITLE
MSD: Add async validation to the bulk domain info editing form

### DIFF
--- a/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form-fields.tsx
@@ -9,7 +9,6 @@ import {
 import { type Field } from '@wordpress/dataviews';
 import { createInterpolateElement, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { validatePhone } from '../../utils/phone-number';
 import InlineSupportLink from '../inline-support-link';
 import PhoneNumberInput from '../phone-number-input';
 import { createFieldAsyncValidator, type AsyncValidator } from './contact-validation-utils';
@@ -21,7 +20,7 @@ export const getContactFormFields = (
 	countryList: CountryListItem[] | undefined,
 	statesList: StatesListItem[] | undefined,
 	countryCode: string,
-	asyncValidator?: AsyncValidator
+	asyncValidator: AsyncValidator
 ): Field< DomainContactDetails >[] => {
 	return [
 		{
@@ -30,9 +29,7 @@ export const getContactFormFields = (
 			type: 'text',
 			isValid: {
 				required: true,
-				...( asyncValidator && {
-					custom: createFieldAsyncValidator( 'firstName', asyncValidator ),
-				} ),
+				custom: createFieldAsyncValidator( 'firstName', asyncValidator ),
 			},
 		},
 		{
@@ -41,20 +38,16 @@ export const getContactFormFields = (
 			type: 'text',
 			isValid: {
 				required: true,
-				...( asyncValidator && {
-					custom: createFieldAsyncValidator( 'lastName', asyncValidator ),
-				} ),
+				custom: createFieldAsyncValidator( 'lastName', asyncValidator ),
 			},
 		},
 		{
 			id: 'organization',
 			label: __( 'Organization' ),
 			type: 'text',
-			...( asyncValidator && {
-				isValid: {
-					custom: createFieldAsyncValidator( 'organization', asyncValidator ),
-				},
-			} ),
+			isValid: {
+				custom: createFieldAsyncValidator( 'organization', asyncValidator ),
+			},
 		},
 		{
 			id: 'email',
@@ -62,9 +55,7 @@ export const getContactFormFields = (
 			type: 'email',
 			isValid: {
 				required: true,
-				...( asyncValidator && {
-					custom: createFieldAsyncValidator( 'email', asyncValidator ),
-				} ),
+				custom: createFieldAsyncValidator( 'email', asyncValidator ),
 			},
 		},
 		{
@@ -124,54 +115,7 @@ export const getContactFormFields = (
 			},
 			isValid: {
 				required: true,
-				custom: asyncValidator
-					? // Async validation (includes sync validation check first)
-					  async ( item, field ) => {
-							// First run sync validation
-							const raw = field.getValue ? field.getValue( { item } ) : '';
-							if ( ! raw ) {
-								return null;
-							}
-							const fullPhoneNumber = String( raw ).split( '.' ).join( '' );
-							const [ , phoneNumberOnly ] = String( raw ).split( '.' ) ?? [ '', '' ];
-							const result = validatePhone( fullPhoneNumber );
-
-							if ( 'error' in result && result.error === 'phone_number_too_short' ) {
-								const resultWithoutCountryCode = validatePhone( phoneNumberOnly );
-								const syncError =
-									'error' in resultWithoutCountryCode ? resultWithoutCountryCode.message : null;
-								if ( syncError ) {
-									return syncError;
-								}
-							}
-
-							const syncError = 'error' in result ? result.message : null;
-							if ( syncError ) {
-								return syncError;
-							}
-
-							// Then run async validation
-							return createFieldAsyncValidator( 'phone', asyncValidator )( item, field );
-					  }
-					: // Sync validation only (original behavior)
-					  ( item, field ) => {
-							const raw = field.getValue ? field.getValue( { item } ) : '';
-							if ( ! raw ) {
-								return null;
-							}
-							const fullPhoneNumber = String( raw ).split( '.' ).join( '' );
-							const [ , phoneNumberOnly ] = String( raw ).split( '.' ) ?? [ '', '' ];
-							const result = validatePhone( fullPhoneNumber );
-
-							if ( 'error' in result && result.error === 'phone_number_too_short' ) {
-								const resultWithoutCountryCode = validatePhone( phoneNumberOnly );
-								return 'error' in resultWithoutCountryCode
-									? resultWithoutCountryCode.message
-									: null;
-							}
-
-							return 'error' in result ? result.message : null;
-					  },
+				custom: createFieldAsyncValidator( 'phone', asyncValidator ),
 			},
 		},
 		{
@@ -185,9 +129,7 @@ export const getContactFormFields = (
 				} ) ) ?? [],
 			isValid: {
 				required: true,
-				...( asyncValidator && {
-					custom: createFieldAsyncValidator( 'countryCode', asyncValidator ),
-				} ),
+				custom: createFieldAsyncValidator( 'countryCode', asyncValidator ),
 			},
 		},
 		...RegionAddressFieldsets( statesList, countryCode, asyncValidator ),

--- a/client/dashboard/components/domain-contact-details-form/custom-form-fieldsets/test/region-address-fieldsets.js
+++ b/client/dashboard/components/domain-contact-details-form/custom-form-fieldsets/test/region-address-fieldsets.js
@@ -112,7 +112,7 @@ describe( 'Region Address Fieldsets', () => {
 			expect( fields.find( ( f ) => f.id === 'address1' ).isValid.required ).toBe( true );
 			expect( fields.find( ( f ) => f.id === 'city' ).isValid.required ).toBe( true );
 			expect( fields.find( ( f ) => f.id === 'postalCode' ).isValid.required ).toBe( true );
-			expect( fields.find( ( f ) => f.id === 'address2' ).isValid ).toBeUndefined();
+			expect( fields.find( ( f ) => f.id === 'address2' ).isValid.required ).toBeUndefined();
 		} );
 	} );
 

--- a/client/dashboard/components/domain-contact-details-form/region-address-fieldsets.tsx
+++ b/client/dashboard/components/domain-contact-details-form/region-address-fieldsets.tsx
@@ -81,7 +81,7 @@ const createStateFieldEdit = ( statesList: StatesListItem[] | undefined, country
 export function RegionAddressFieldsets(
 	statesList: StatesListItem[] | undefined,
 	countryCode: string,
-	asyncValidator?: AsyncValidator
+	asyncValidator: AsyncValidator
 ): Field< DomainContactDetails >[] {
 	const StateFieldEdit = createStateFieldEdit( statesList, countryCode );
 
@@ -92,20 +92,16 @@ export function RegionAddressFieldsets(
 			type: 'text',
 			isValid: {
 				required: true,
-				...( asyncValidator && {
-					custom: createFieldAsyncValidator( 'address1', asyncValidator ),
-				} ),
+				custom: createFieldAsyncValidator( 'address1', asyncValidator ),
 			},
 		},
 		{
 			id: 'address2',
 			label: __( 'Address line 2' ),
 			type: 'text',
-			...( asyncValidator && {
-				isValid: {
-					custom: createFieldAsyncValidator( 'address2', asyncValidator ),
-				},
-			} ),
+			isValid: {
+				custom: createFieldAsyncValidator( 'address2', asyncValidator ),
+			},
 		},
 		{
 			id: 'city',
@@ -113,9 +109,7 @@ export function RegionAddressFieldsets(
 			type: 'text',
 			isValid: {
 				required: true,
-				...( asyncValidator && {
-					custom: createFieldAsyncValidator( 'city', asyncValidator ),
-				} ),
+				custom: createFieldAsyncValidator( 'city', asyncValidator ),
 			},
 		},
 		{
@@ -123,11 +117,9 @@ export function RegionAddressFieldsets(
 			type: 'text',
 			getValue: ( { item }: { item: DomainContactDetails } ) => item.state ?? '',
 			Edit: StateFieldEdit,
-			...( asyncValidator && {
-				isValid: {
-					custom: createFieldAsyncValidator( 'state', asyncValidator ),
-				},
-			} ),
+			isValid: {
+				custom: createFieldAsyncValidator( 'state', asyncValidator ),
+			},
 		},
 		{
 			id: 'postalCode',
@@ -135,9 +127,7 @@ export function RegionAddressFieldsets(
 			type: 'text',
 			isValid: {
 				required: true,
-				...( asyncValidator && {
-					custom: createFieldAsyncValidator( 'postalCode', asyncValidator ),
-				} ),
+				custom: createFieldAsyncValidator( 'postalCode', asyncValidator ),
 			},
 		},
 	];

--- a/client/dashboard/domains/domains-contact-details/index.tsx
+++ b/client/dashboard/domains/domains-contact-details/index.tsx
@@ -94,9 +94,11 @@ export default function DomainsContactInfo() {
 			.filter( ( domain ) => domain.whois_update_unmodifiable_fields.length > 0 );
 	}, [ domainDetails ] );
 
-	const { mutate: validateBulkDomains, isPending: isValidatePending } = useMutation(
-		domainWhoisValidateMutation( selectedDomains )
-	);
+	const {
+		mutate: validateBulkDomains,
+		mutateAsync: validateBulkDomainsAsync,
+		isPending: isValidatePending,
+	} = useMutation( domainWhoisValidateMutation( selectedDomains ) );
 
 	const { mutate: bulkDomainsAction, isPending: isUpdatePending } = useMutation(
 		bulkDomainsActionMutation()
@@ -196,6 +198,7 @@ export default function DomainsContactInfo() {
 				initialData={ initialData }
 				isSubmitting={ isValidatePending || isUpdatePending }
 				onSubmit={ handleSubmit }
+				validate={ validateBulkDomainsAsync }
 			/>
 		</PageLayout>
 	);


### PR DESCRIPTION
Part of [DOMAINS-1793: Create async validation for Contact Info](https://linear.app/a8c/issue/DOMAINS-1793/create-async-validation-for-contact-info).

## Proposed Changes

In #107212, we added async validation to the single domain editing form. This PR enables validating the information from the back-end for all involved domains selected for bulk editing.

## Testing Instructions

Enter `/v2/domains/contact-info?selected=%s,%s` where `%s` are domain names you own and verify that the async validation is working just like in #107212, but for multiple domains in this specific page.