### PR TITLE
HC: escalation improvements

### DIFF
--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -55,8 +55,8 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		mostRecentSupportInteractionId || null
 	);
 
-	// Early return if user is already talking to a human
-	if ( chat.provider !== 'odie' ) {
+	// Early return if user is already talking to a human or transferring to Zendesk
+	if ( chat.provider !== 'odie' || chat.status === 'transfer' ) {
 		return null;
 	}
 
@@ -102,7 +102,9 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 					} );
 				} else if ( canConnectToZendesk || contextCanConnectToZendesk ) {
 					buttons.push( {
-						text: __( 'No thanks, let’s keep it here', __i18n_text_domain__ ),
+						text: ! supportInteraction
+							? __( 'Get support', __i18n_text_domain__ )
+							: __( 'No thanks, let’s keep it here', __i18n_text_domain__ ),
 						action: async () => {
 							onClickAdditionalEvent?.( 'chat' );
 							if ( isChatLoaded ) {

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -102,9 +102,9 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 					} );
 				} else if ( canConnectToZendesk || contextCanConnectToZendesk ) {
 					buttons.push( {
-						text: ! supportInteraction
-							? __( 'Get support', __i18n_text_domain__ )
-							: __( 'No thanks, let’s keep it here', __i18n_text_domain__ ),
+						text: supportInteraction
+							? __( 'No thanks, let’s keep it here', __i18n_text_domain__ )
+							: __( 'Get support', __i18n_text_domain__ ),
 						action: async () => {
 							onClickAdditionalEvent?.( 'chat' );
 							if ( isChatLoaded ) {

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -13,6 +13,7 @@ import {
 	getIsRequestingHumanSupport,
 	getIsLastBotMessage,
 } from '../../utils';
+import getMostRecentOpenLiveInteraction from '../notices/get-most-recent-open-live-interaction';
 import BotMessageActions from './bot-message-actions';
 import CustomALink from './custom-a-link';
 import { GetSupport } from './get-support';
@@ -21,6 +22,7 @@ import Sources from './sources';
 import type { Message } from '../../types';
 
 const getDisplayMessage = (
+	userHasRecentOpenConversation: boolean,
 	isUserEligibleForPaidSupport: boolean,
 	canConnectToZendesk: boolean,
 	forceEmailSupport?: boolean,
@@ -40,7 +42,7 @@ const getDisplayMessage = (
 	}
 
 	const forwardMessage = isUserEligibleForPaidSupport
-		? getOdieForwardToZendeskMessage()
+		? getOdieForwardToZendeskMessage( userHasRecentOpenConversation )
 		: getOdieForwardToForumsMessage();
 
 	return isErrorMessage ? getOdieErrorMessage() : forwardMessage;
@@ -65,12 +67,14 @@ export const UserMessage = ( {
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 	const isRequestingHumanSupport = getIsRequestingHumanSupport( message );
 	const isLastBotMessage = getIsLastBotMessage( chat, message );
+	const hasRecentOpenConversation = getMostRecentOpenLiveInteraction();
 
 	const isMessageShowingDisclaimer =
 		message.context?.question_tags?.inquiry_type !== 'request-for-human-support';
 
 	const messageContent = isRequestingHumanSupport
 		? getDisplayMessage(
+				!! hasRecentOpenConversation,
 				isUserEligibleForPaidSupport,
 				canConnectToZendesk,
 				forceEmailSupport,

--- a/packages/odie-client/src/components/notices/get-most-recent-open-live-interaction.tsx
+++ b/packages/odie-client/src/components/notices/get-most-recent-open-live-interaction.tsx
@@ -17,6 +17,7 @@ export default function getMostRecentOpenLiveInteraction() {
 			// having a csat message means the conversation is closed
 			conversation.messages.every(
 				( message ) =>
+					message.type !== 'form' &&
 					message.metadata?.type !== 'csat' &&
 					message.metadata?.type !== 'form' &&
 					! message.metadata?.rated &&

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -37,11 +37,16 @@ export const getOdieForwardToForumsMessage = (): string =>
 		__i18n_text_domain__
 	);
 
-export const getOdieForwardToZendeskMessage = (): string =>
-	__(
-		'We noticed you have an ongoing conversation. Would you like to continue it?',
-		__i18n_text_domain__
-	);
+export const getOdieForwardToZendeskMessage = ( userHasRecentOpenConversation: boolean ): string =>
+	! userHasRecentOpenConversation
+		? __(
+				'Would you like to continue your conversation with a support agent?',
+				__i18n_text_domain__
+		  )
+		: __(
+				'We noticed you have an ongoing conversation. Would you like to continue it?',
+				__i18n_text_domain__
+		  );
 
 export function getFlowFromBotSlug( botSlug?: OdieAllBotSlugs ): string {
 	if ( botSlug === 'ciab-workflow-support_chat' ) {

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -38,13 +38,13 @@ export const getOdieForwardToForumsMessage = (): string =>
 	);
 
 export const getOdieForwardToZendeskMessage = ( userHasRecentOpenConversation: boolean ): string =>
-	! userHasRecentOpenConversation
+	userHasRecentOpenConversation
 		? __(
-				'Would you like to continue your conversation with a support agent?',
+				'We noticed you have an ongoing conversation. Would you like to continue it?',
 				__i18n_text_domain__
 		  )
 		: __(
-				'We noticed you have an ongoing conversation. Would you like to continue it?',
+				'Would you like to continue your conversation with a support agent?',
 				__i18n_text_domain__
 		  );
 

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -296,7 +296,6 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 			}
 		},
 		onSettled: () => {
-			setChatStatus( 'loaded' );
 			queryClient.invalidateQueries( {
 				queryKey: [ 'odie-chat', currentSupportInteraction?.bot_slug, odieId ],
 			} );

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -177,7 +177,6 @@ export const useGetCombinedChat = (
 		refreshingAfterReconnect,
 		isUploadingUnsentMessages,
 		isChatLoaded,
-		odieChat,
 		conversationId,
 		odieId,
 		currentSupportInteraction,

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -96,12 +96,26 @@ export const useGetCombinedChat = (
 
 		// We don't have a conversation id, so our chat is simply the odie chat
 		if ( ! conversationId ) {
-			setMainChatState( {
-				...( odieChat ? odieChat : emptyChat ),
-				conversationId: null,
-				status: 'loaded',
-				provider: 'odie',
-			} );
+			if ( ! currentSupportInteraction?.uuid ) {
+				setMainChatState( {
+					...emptyChat,
+					conversationId: null,
+					status: 'loaded',
+					provider: 'odie',
+				} );
+			}
+
+			// only load odie chat when we have the data, and status is either loading or the chat was empty
+			const shouldLoadOdieChat =
+				odieChat && ( chatStatus === 'loading' || ! mainChatState.messages.length );
+			if ( shouldLoadOdieChat ) {
+				setMainChatState( {
+					...odieChat,
+					conversationId: null,
+					status: 'loaded',
+					provider: 'odie',
+				} );
+			}
 			return;
 		}
 

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -96,21 +96,14 @@ export const useGetCombinedChat = (
 
 		// We don't have a conversation id, so our chat is simply the odie chat
 		if ( ! conversationId ) {
-			if ( ! currentSupportInteraction?.uuid ) {
-				setMainChatState( {
-					...emptyChat,
-					conversationId: null,
-					status: 'loaded',
-					provider: 'odie',
-				} );
-			}
-
 			// only load odie chat when we have the data, and status is either loading or the chat was empty
 			const shouldLoadOdieChat =
 				odieChat && ( chatStatus === 'loading' || ! mainChatState.messages.length );
-			if ( shouldLoadOdieChat ) {
+
+			// set chat empty state or with messages
+			if ( ! currentSupportInteraction?.uuid || shouldLoadOdieChat ) {
 				setMainChatState( {
-					...odieChat,
+					...( shouldLoadOdieChat ? odieChat : emptyChat ),
 					conversationId: null,
 					status: 'loaded',
 					provider: 'odie',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTCOM-15254

| Before  | After |
| ------------- | ------------- |
| https://github.com/user-attachments/assets/52700ad6-2dba-4e5b-b0b5-5458f9eed34a  | https://github.com/user-attachments/assets/189422b1-4313-459f-9fba-0cc7d3a4dd3c  |

**Image for translators** 
<img width="214" height="373" alt="image" src="https://github.com/user-attachments/assets/4b4a7a96-71ad-432d-9940-1940ff118828" />


## Proposed Changes

* Hide escalation buttons while transferring
* Avoid 'No thanks, let’s keep it here' message and show 'Get Support' if there is no recent chat

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix ui Inconsitencies

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Create user via [e-commerce flow](https://wordpress.com/setup/entrepreneur/start/?ref=ecommerce-lp) 
* Verify email
* Go to /sites
* Open the help-center and escalate to support

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
