### PR TITLE
Dashboard: Fix translations of site statuses

### DIFF
--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -8,7 +8,7 @@ import TimeSince from '../../components/time-since';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
-import { STATUS_LABELS, getSiteStatus } from '../../utils/site-status';
+import { getSiteStatus, getStatusLabels } from '../../utils/site-status';
 import { getSiteDisplayUrl } from '../../utils/site-url';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import {
@@ -28,6 +28,7 @@ import type { Site } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
 
 function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
+	const statusLabels = getStatusLabels();
 	return [
 		{
 			id: 'name',
@@ -94,7 +95,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 			id: 'status',
 			label: __( 'Status' ),
 			getValue: ( { item } ) => getSiteStatus( item ),
-			elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
+			elements: Object.entries( statusLabels ).map( ( [ value, label ] ) => ( { value, label } ) ),
 			filterBy: {
 				operators: [ 'isAny' as Operator ],
 			},

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import type { Site } from '@automattic/api-core';
 
 export interface MigrationStatus {
@@ -9,15 +9,17 @@ export interface MigrationStatus {
 const MIGRATION_STATUSES: MigrationStatus[ 'status' ][] = [ 'pending', 'started', 'completed' ];
 const MIGRATION_TYPES: MigrationStatus[ 'type' ][] = [ 'difm', 'diy' ];
 
-export const STATUS_LABELS = {
-	public: __( 'Public' ),
-	private: __( 'Private' ),
-	coming_soon: __( 'Coming soon' ),
-	deleted: __( 'Deleted' ),
-	difm_lite_in_progress: __( 'Express service' ),
-	migration_pending: __( 'Migration pending' ),
-	migration_started: __( 'Migration started' ),
-};
+export function getStatusLabels() {
+	return {
+		public: _x( 'Public', 'site' ),
+		private: _x( 'Private', 'site' ),
+		coming_soon: _x( 'Coming soon', 'site' ),
+		deleted: _x( 'Deleted', 'site' ),
+		difm_lite_in_progress: _x( 'Express service', 'site' ),
+		migration_pending: _x( 'Migration pending', 'site' ),
+		migration_started: _x( 'Migration started', 'site' ),
+	};
+}
 
 export function getSiteStatus( item: Site ) {
 	if ( item.is_deleted ) {
@@ -82,5 +84,6 @@ export function isSiteMigrationInProgress( item: Site ) {
 }
 
 export function getSiteStatusLabel( item: Site ) {
-	return STATUS_LABELS[ getSiteStatus( item ) ];
+	const statusLabels = getStatusLabels();
+	return statusLabels[ getSiteStatus( item ) ];
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of I18N-280

## Proposed Changes

* Change the array of site statuses labels to be dynamic.

| Before | After |
|-----|-----|
| <img width="1405" height="577" alt="Screenshot 2025-11-21 at 23 40 45" src="https://github.com/user-attachments/assets/ea0735c4-724b-46d2-a211-df9574b9cf2d" /> | <img width="1405" height="577" alt="Screenshot 2025-11-21 at 23 41 08" src="https://github.com/user-attachments/assets/3a206983-2612-43f4-82a6-aa9124f1a757" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The site status labels often appear untranslated in non-English locales.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set your locale to a popular one, like Spanish, German or Japanese.
* Go to /sites and confirm that the labels are translated.
* Check with /v2/sites as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
