### PR TITLE
MSD Cancel flow: Fix downgrade

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -165,6 +165,7 @@ export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
 			return (
 				<UpsellStep
 					cancelBundledDomain={ props.cancelBundledDomain }
+					cancellationInProgress={ props.cancellationInProgress }
 					cancellationReason={ questionOneText }
 					closeDialog={ closeDialog }
 					currencyCode={ purchase.currency_code }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -7,7 +7,6 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from 'react';
 import * as React from 'react';
 import imgBuiltBy from 'calypso/assets/images/cancellation/built-by.png';
 import imgBusinessPlan from 'calypso/assets/images/cancellation/business-plan.png';
@@ -27,11 +26,11 @@ type UpsellProps = {
 	acceptButtonUrl?: string;
 	onAccept?: () => void;
 	onDecline?: () => void;
+	isBusy?: boolean;
 };
 
 function Upsell( { image, ...props }: UpsellProps ) {
 	const declineButtonText = __( 'Cancel my current plan' );
-	const [ busyButton, setBusyButton ] = useState( '' );
 
 	return (
 		<VStack>
@@ -43,23 +42,12 @@ function Upsell( { image, ...props }: UpsellProps ) {
 					<Button
 						variant="primary"
 						href={ props.acceptButtonUrl }
-						onClick={ () => {
-							setBusyButton( 'accept' );
-							props.onAccept?.();
-						} }
-						isBusy={ busyButton === 'accept' }
+						onClick={ props.onAccept }
+						isBusy={ props.isBusy }
 					>
 						{ props.acceptButtonText }
 					</Button>
-					<Button
-						variant="secondary"
-						onClick={ () => {
-							setBusyButton( 'decline' );
-							props.onDecline?.();
-						} }
-						isBusy={ busyButton === 'decline' }
-						disabled={ Boolean( busyButton && busyButton !== 'decline' ) }
-					>
+					<Button variant="secondary" onClick={ props.onDecline } disabled={ props.isBusy }>
 						{ declineButtonText }
 					</Button>
 				</div>
@@ -89,6 +77,7 @@ function getLiveChatUrl( type: string, purchase: Purchase ) {
 type StepProps = {
 	cancelBundledDomain?: boolean;
 	cancellationReason?: string;
+	cancellationInProgress?: boolean;
 	closeDialog?: () => void;
 	currencyCode: string;
 	downgradePlanPrice?: number | null;
@@ -106,6 +95,7 @@ export default function UpsellStep( {
 	upsell,
 	purchase,
 	currencyCode,
+	cancellationInProgress,
 	plans,
 	...props
 }: StepProps ) {
@@ -156,6 +146,7 @@ export default function UpsellStep( {
 						props.closeDialog && props.closeDialog();
 					} }
 					onDecline={ props.onDeclineUpsell }
+					isBusy={ cancellationInProgress }
 					image={ imgLiveChat }
 				>
 					{ hasEnTranslation(
@@ -192,6 +183,7 @@ export default function UpsellStep( {
 						window.location.replace( builtByURL );
 					} }
 					onDecline={ props.onDeclineUpsell }
+					isBusy={ cancellationInProgress }
 					image={ imgBuiltBy }
 				>
 					{ __(
@@ -217,6 +209,7 @@ export default function UpsellStep( {
 						recordTracksEvent( 'calypso_cancellation_upgrade_at_step_upgrade_click' );
 					} }
 					onDecline={ props.onDeclineUpsell }
+					isBusy={ cancellationInProgress }
 					image={ imgBusinessPlan }
 				>
 					{ createInterpolateElement(
@@ -245,6 +238,7 @@ export default function UpsellStep( {
 					acceptButtonText={ __( 'Switch to monthly payments' ) }
 					onAccept={ () => props.onClickDowngrade?.( upsell ) }
 					onDecline={ props.onDeclineUpsell }
+					isBusy={ cancellationInProgress }
 					image={ imgMonthlyPayments }
 				>
 					<>
@@ -289,6 +283,7 @@ export default function UpsellStep( {
 					} ) }
 					onAccept={ () => props.onClickDowngrade?.( upsell ) }
 					onDecline={ props.onDeclineUpsell }
+					isBusy={ cancellationInProgress }
 					image={ imgSwitchPlan }
 				>
 					<>
@@ -320,6 +315,7 @@ export default function UpsellStep( {
 					acceptButtonText={ __( 'Get a free month' ) }
 					onAccept={ () => props.onClickFreeMonthOffer?.() }
 					onDecline={ props.onDeclineUpsell }
+					isBusy={ cancellationInProgress }
 					image={ imgFreeMonth }
 				>
 					{ sprintf(

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -258,7 +258,7 @@ export default function UpsellStep( {
 							__(
 								'You will lose your free domain registration since that feature is only included in annual/biannual plans.'
 							) }
-						{ refundAmount && <br /> }
+						{ refundAmount ? <br /> : null }
 						{ refundAmount
 							? sprintf(
 									/* translators: %(refundAmount)s is a monetary amount in the form of a refund */
@@ -294,17 +294,18 @@ export default function UpsellStep( {
 							),
 							{ plan: personalPlanName }
 						) }{ ' ' }
-						{ refundAmount &&
-							sprintf(
-								/* translators: %(amount)s is a monetary amount in the form of a refund */
-								__(
-									'You can downgrade and get a partial refund of %(amount)s or ' +
-										'continue to the next step and cancel the plan.'
-								),
-								{
-									amount: formatCurrency( refundAmount, currencyCode ),
-								}
-							) }
+						{ refundAmount
+							? sprintf(
+									/* translators: %(amount)s is a monetary amount in the form of a refund */
+									__(
+										'You can downgrade and get a partial refund of %(amount)s or ' +
+											'continue to the next step and cancel the plan.'
+									),
+									{
+										amount: formatCurrency( refundAmount, currencyCode ),
+									}
+							  )
+							: null }
 					</>
 				</Upsell>
 			);

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -548,12 +548,12 @@ export default function CancelPurchase() {
 		switch ( downgradeType ) {
 			case PurchaseDowngradeType.TermDowngrade:
 				downgradePlanInfo = plan.downgrade_paths.find( ( path ) => {
-					path.bill_period !== plan.bill_period;
+					return path.bill_period !== plan.bill_period;
 				} );
 				break;
 			case PurchaseDowngradeType.PlanDowngrade:
 				downgradePlanInfo = plan.downgrade_paths.find( ( path ) => {
-					path.bill_period === plan.bill_period;
+					return path.bill_period === plan.bill_period;
 				} );
 				break;
 		}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -323,6 +323,7 @@ export default function CancelPurchase() {
 
 		return steps;
 	}, [
+		userHasCompletedCancelSurveyForPurchase,
 		purchase,
 		availableJetpackSurveySteps,
 		flowType,
@@ -579,10 +580,12 @@ export default function CancelPurchase() {
 				);
 			}
 
-			setState( ( state ) => ( { ...state, isLoading: true } ) );
 			if ( ! downgradePlan ) {
-				throw new Error( 'Cannot find a plan to downgrade to' );
+				createErrorNotice( 'Cannot find a plan to downgrade to', { type: 'snackbar' } );
+				return;
 			}
+
+			setState( ( state ) => ( { ...state, isLoading: true } ) );
 
 			cancelAndRefundPurchaseMutate.mutate(
 				{
@@ -599,6 +602,7 @@ export default function CancelPurchase() {
 						navigate( { to: purchasesRoute.to } );
 					},
 					onError: ( error ) => {
+						setState( ( state ) => ( { ...state, isLoading: false, isSubmitting: false } ) );
 						createErrorNotice( error.message, { type: 'snackbar' } );
 					},
 				}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1367/hosting-dashboard-cancellation-flow-unable-to-downgrade-from-premium
Fixes https://linear.app/a8c/issue/SHILL-1368/hosting-dashboard-cancellation-flow-unable-to-downgrade-from-yearly-to

## Proposed Changes

This PR refactors some parts of the cancel flow in the Multi Site Dashboard to fix the downgrade behavior. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The "downgrade" flow of the cancel page does not work. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit http://calypso.localhost:3000/v2/me/billing/purchases 
- Select an annual  Premium plan.
- On the purchase settings page, add `/cancel` to the URL (the buttons are not yet hooked up).
- In the following survey, choose "Too expensive", then "The plan is too expensive for the features offered", and then click "Switch to the WordPress.com Personal Plan".
- Verify that the downgrade completes successfully.