### PR TITLE
Akismet: Show correct request limit/month in Purchases view

### DIFF
--- a/client/dashboard/utils/akismet.ts
+++ b/client/dashboard/utils/akismet.ts
@@ -1,0 +1,16 @@
+import { AkismetPlans } from '@automattic/api-core';
+
+/**
+ * Determines whether the specified product slug is for an Akismet Pro 500 plan.
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to any Akismeret Pro 500 plan, false otherwise
+ */
+export function isAkismetPro500Plan( productSlug: string ): boolean {
+	return (
+		[
+			AkismetPlans.PRODUCT_AKISMET_PRO_500_MONTHLY,
+			AkismetPlans.PRODUCT_AKISMET_PRO_500_YEARLY,
+			AkismetPlans.PRODUCT_AKISMET_PRO_500_BI_YEARLY,
+		] as readonly string[]
+	 ).includes( productSlug );
+}

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -10,6 +10,7 @@ import {
 } from '@automattic/api-core';
 import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
+import { isAkismetPro500Plan } from './akismet';
 import { isWithinLast, isWithinNext, getDateFromCreditCardExpiry } from './datetime';
 import { isGSuiteProductSlug } from './gsuite';
 import { wpcomLink } from './link';
@@ -263,6 +264,19 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 	if ( purchase.meta && ( purchase.is_domain_registration || purchase.is_domain ) ) {
 		return purchase.meta;
 	}
+
+	if (
+		isAkismetPro500Plan( purchase.product_slug ) &&
+		purchase.renewal_price_tier_usage_quantity &&
+		purchase.renewal_price_tier_usage_quantity > 1
+	) {
+		/* translators: %s is the product name "Akismet Pro", %d is a number of requests/month */
+		return sprintf( __( '%(productName)s (%(requests)d requests/month)' ), {
+			productName: purchase.product_name.replace( /\s*\(.*$/, '' ).trim(),
+			requests: 500 * purchase.renewal_price_tier_usage_quantity,
+		} );
+	}
+
 	return purchase.product_name;
 }
 

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -25,6 +25,8 @@ import {
 	is100Year,
 	isJetpackAISlug,
 	isJetpackStatsPaidProductSlug,
+	isAkismetPro5h,
+	getAkismetPro5hProductDisplayName,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { formatCurrency, formatNumber } from '@automattic/number-formatters';
@@ -303,6 +305,10 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 
 	if ( isTieredVolumeSpaceAddon( purchase ) ) {
 		return getStorageAddOnDisplayName( productName, purchaseRenewalQuantity );
+	}
+
+	if ( isAkismetPro5h( purchase ) ) {
+		return getAkismetPro5hProductDisplayName( productName, purchaseRenewalQuantity );
 	}
 
 	return getName( purchase );

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -25,8 +25,8 @@ import {
 	is100Year,
 	isJetpackAISlug,
 	isJetpackStatsPaidProductSlug,
-	isAkismetPro5h,
-	getAkismetPro5hProductDisplayName,
+	isAkismetPro500,
+	getAkismetPro500ProductDisplayName,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { formatCurrency, formatNumber } from '@automattic/number-formatters';
@@ -307,8 +307,8 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 		return getStorageAddOnDisplayName( productName, purchaseRenewalQuantity );
 	}
 
-	if ( isAkismetPro5h( purchase ) ) {
-		return getAkismetPro5hProductDisplayName( productName, purchaseRenewalQuantity );
+	if ( isAkismetPro500( purchase ) ) {
+		return getAkismetPro500ProductDisplayName( productName, purchaseRenewalQuantity );
 	}
 
 	return getName( purchase );

--- a/client/my-sites/checkout/src/lib/get-akismet-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-akismet-product-features.ts
@@ -3,7 +3,7 @@ import {
 	isAkismetBusiness5k,
 	isAkismetPersonal,
 	isAkismetPro,
-	isAkismetPro5h,
+	isAkismetPro500,
 	isAkismetFree,
 	isAkismetEnterprise,
 	isAkismetPlus10k,
@@ -106,7 +106,7 @@ export default function getAkismetProductFeatures(
 		if ( isAkismetPlus40k( product ) ) {
 			return getFeatureStrings( 'pro_40k', translate );
 		}
-		if ( isAkismetPro5h( product ) ) {
+		if ( isAkismetPro500( product ) ) {
 			return getFeatureStrings( 'pro_5h', translate );
 		}
 	}

--- a/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
@@ -1,6 +1,6 @@
 import { translate } from 'i18n-calypso';
 
-export function getAkismetPro500ProductDisplayName(productName: string, quantity: number | null ) {
+export function getAkismetPro500ProductDisplayName( productName: string, quantity: number | null ) {
 	if ( quantity && quantity > 1 ) {
 		/* translators: %s is the product name "Akismet Pro", %d is a number of requests/month */
 		return translate( '%(productName)s (%(requests)d requests/month)', {

--- a/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
@@ -1,6 +1,6 @@
 import { translate } from 'i18n-calypso';
 
-export function getAkismetPro5hProductDisplayName( productName: string, quantity: number | null ) {
+export function getAkismetPro500ProductDisplayName(productName: string, quantity: number | null ) {
 	if ( quantity && quantity > 1 ) {
 		/* translators: %s is the product name "Akismet Pro", %d is a number of requests/month */
 		return translate( '%(productName)s (%(requests)d requests/month)', {

--- a/packages/calypso-products/src/get-akismet-pro-5h-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-pro-5h-product-display-name.ts
@@ -1,0 +1,16 @@
+import { translate } from 'i18n-calypso';
+
+export function getAkismetPro5hProductDisplayName( productName: string, quantity: number | null ) {
+	if ( quantity && quantity > 1 ) {
+		/* translators: %s is the product name "Akismet Pro", %d is a number of requests/month */
+		return translate( '%(productName)s (%(requests)d requests/month)', {
+			args: {
+				productName: productName.replace( /\s*\(.*$/, '' ).trim(),
+				requests: 500 * quantity,
+			},
+			textOnly: true,
+		} );
+	}
+
+	return productName;
+}

--- a/packages/calypso-products/src/index.ts
+++ b/packages/calypso-products/src/index.ts
@@ -11,4 +11,4 @@ export * from './is-tiered-volume-space-addon';
 export * from './is-multi-year-domain-product';
 export * from './get-storage-addon-display-name';
 export * from './is-summer-special-enabled';
-export * from './get-akismet-pro-5h-product-display-name';
+export * from './get-akismet-pro-500-product-display-name';

--- a/packages/calypso-products/src/index.ts
+++ b/packages/calypso-products/src/index.ts
@@ -11,3 +11,4 @@ export * from './is-tiered-volume-space-addon';
 export * from './is-multi-year-domain-product';
 export * from './get-storage-addon-display-name';
 export * from './is-summer-special-enabled';
+export * from './get-akismet-pro-5h-product-display-name';

--- a/packages/calypso-products/src/is-akismet-pro-500.ts
+++ b/packages/calypso-products/src/is-akismet-pro-500.ts
@@ -2,7 +2,7 @@ import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { AKISMET_PRO_500_PRODUCTS } from './constants/akismet';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
-export function isAkismetPro5h( product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
+export function isAkismetPro500(product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
 	return ( AKISMET_PRO_500_PRODUCTS as ReadonlyArray< string > ).includes(
 		camelOrSnakeSlug( product )
 	);

--- a/packages/calypso-products/src/is-akismet-pro-500.ts
+++ b/packages/calypso-products/src/is-akismet-pro-500.ts
@@ -2,7 +2,7 @@ import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { AKISMET_PRO_500_PRODUCTS } from './constants/akismet';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
-export function isAkismetPro500(product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
+export function isAkismetPro500( product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
 	return ( AKISMET_PRO_500_PRODUCTS as ReadonlyArray< string > ).includes(
 		camelOrSnakeSlug( product )
 	);

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -29,7 +29,7 @@ export { isAkismetBusiness5k } from './is-akismet-business-5k';
 export { isAkismetFree } from './is-akismet-free';
 export { isAkismetPersonal } from './is-akismet-personal';
 export { isAkismetPro } from './is-akismet-pro';
-export { isAkismetPro5h } from './is-akismet-pro-5h';
+export { isAkismetPro500 } from './is-akismet-pro-500';
 export { isAkismetPlus10k } from './is-akismet-plus-10k';
 export { isAkismetPlus20k } from './is-akismet-plus-20k';
 export { isAkismetPlus30k } from './is-akismet-plus-30k';

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -15,8 +15,8 @@ import {
 	isTriennially,
 	isJetpackAISlug,
 	isJetpackStatsPaidTieredProductSlug,
-	isAkismetPro5h,
-	getAkismetPro5hProductDisplayName,
+	isAkismetPro500,
+	getAkismetPro500ProductDisplayName,
 } from '@automattic/calypso-products';
 import { formatNumber } from '@automattic/number-formatters';
 import { translate } from 'i18n-calypso';
@@ -122,8 +122,8 @@ export function getLabel( product: ResponseCartProduct ): string {
 		} );
 	}
 
-	if ( isAkismetPro5h( product ) ) {
-		return getAkismetPro5hProductDisplayName( product.product_name, quantity );
+	if ( isAkismetPro500( product ) ) {
+		return getAkismetPro500ProductDisplayName( product.product_name, quantity );
 	}
 
 	return product.product_name || '';

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -16,6 +16,7 @@ import {
 	isJetpackAISlug,
 	isJetpackStatsPaidTieredProductSlug,
 	isAkismetPro5h,
+	getAkismetPro5hProductDisplayName,
 } from '@automattic/calypso-products';
 import { formatNumber } from '@automattic/number-formatters';
 import { translate } from 'i18n-calypso';
@@ -122,16 +123,7 @@ export function getLabel( product: ResponseCartProduct ): string {
 	}
 
 	if ( isAkismetPro5h( product ) ) {
-		if ( quantity > 1 ) {
-			/* translators: %s is the product name "Akismet Pro", %d is a number of requests/month */
-			return translate( '%(productName)s (%(requests)d requests/month)', {
-				args: {
-					productName: product.product_name.replace( /\s*\(.*$/, '' ).trim(),
-					requests: 500 * quantity,
-				},
-				textOnly: true,
-			} );
-		}
+		return getAkismetPro5hProductDisplayName( product.product_name, quantity );
 	}
 
 	return product.product_name || '';


### PR DESCRIPTION
Resolves NOSPAM-133

## Proposed Changes

* This PR nudges copy for Akismet Pro product titles in the purchases view, such that it will render out the appropriate number of requests available per month for a subscription that was created with more than one quantity.
  * See: https://github.com/Automattic/wp-calypso/pull/103849 for original changes relating to the checkout.

## Why are these changes being made?

* These changes are being made to clarify a subscription's actual request limit when composed of stacked / multiple pro plans.

### Example - Purchases View

* Note the change in the `Akismet Pro` subscription.

BEFORE | AFTER
--- | ---
![before](https://github.com/user-attachments/assets/a50872e4-b095-4aae-9915-c4f53d0f6fd6) | ![after](https://github.com/user-attachments/assets/f3a39b08-ce83-4f4f-b95d-5ba72354b02f)

### Example - Purchase View

BEFORE | AFTER
--- | ---
![before](https://github.com/user-attachments/assets/b09908bb-4044-49d9-bd7c-7f2188f15aa1) | ![after](https://github.com/user-attachments/assets/06731504-2147-4c5e-af86-6e835039e1ad)

## Testing Instructions

* Open the calypso.live link in the comments below
* Ensure as a tester you are logged in with an account that has an Akismet Pro subscription with more than one quantity checked out.
* Navigate to `/me/purchases` and:
   * Note that the request limit is rendered as it should be.
   * Select the subscription from the list.
* Note that the product title changes are reflected for the subscription in the product name.

Additionally, a quick regression test on the checkout should be run, as this will unify how those product names are displayed for both views.

* See: Testing Instructions in https://github.com/Automattic/wp-calypso/pull/103849

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
