### PR TITLE
Reader: Fix wrong related posts padding

### DIFF
--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -88,10 +88,10 @@
 	}
 }
 
-.reader-related-card.card {
+:root .reader-related-card.card {
 	z-index: z-index("root", ".reader-related-card.card");
-	padding: 16px;
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
+	padding: 0;
 
 	.reader-related-card__meta {
 		display: grid;


### PR DESCRIPTION
Closes CML-1091

| BEFORE | AFTER |
|--------|--------|
| <img width="2284" height="1920" alt="CleanShot 2025-11-23 at 11 32 05@2x" src="https://github.com/user-attachments/assets/45b3ab82-7bf3-4cb3-9e0e-817fdc28290c" /> | <img width="2284" height="1920" alt="CleanShot 2025-11-23 at 11 33 09@2x" src="https://github.com/user-attachments/assets/6aed8fba-9824-4f13-9e2c-2f18b1eff250" /> |




## Proposed Changes

* Go to /reader/blogs/234374527/posts/679
* Check the padding spacing is correct

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
