### PR TITLE
Reader: Fix wrong spacing between related-meta and related-content

### DIFF
--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -96,7 +96,6 @@
 	.reader-related-card__meta {
 		display: grid;
 		grid-template-columns: auto 1fr auto;
-		height: 38px;
 		margin-bottom: 13px;
 		z-index: z-index(".reader-related-card.card", ".reader-related-card__meta");
 		width: 100%;


### PR DESCRIPTION


## Proposed Changes

| Before | After |
|--------|--------|
| <img width="1854" height="1870" alt="CleanShot 2025-11-23 at 11 37 39@2x" src="https://github.com/user-attachments/assets/71e37267-9926-434d-95dc-b06c5ba27436" /> | <img width="1856" height="1870" alt="CleanShot 2025-11-23 at 11 39 52@2x" src="https://github.com/user-attachments/assets/5f9f9fd0-0856-4017-a697-eca3ba565f46" /> |



## Testing Instructions
* Go to any feed page (E.g /reader/feeds/158416280/posts/5876736854)
* Check if the space is equal to the screenshot (After)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
