### PR TITLE
Reader: Fix wrong action bar position and vertical alignment 

### DIFF
--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -196,7 +196,7 @@ body.is-reader-full-post {
 
 		&-engagement-bar {
 			position: fixed;
-			bottom: var( --content-padding-bottom );
+			bottom: calc(var( --content-padding-bottom ) - 1px);
 			height: 60px;
 			background: var( --color-surface );
 			border-radius: 0 0 $feed-card-border-radius $feed-card-border-radius;

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -226,6 +226,7 @@ body.is-reader-full-post {
 			}
 
 			.reader-post-actions {
+				padding-top: 0;
 				margin: 0;
 				justify-content: space-evenly;
 


### PR DESCRIPTION

Closes CML-1088

## Proposed Changes
* Fix actions toolbar position
* Fix wrong actions toolbar vertical alignment

## Why are these changes being made?

| Before | After |
|--------|--------|
| <img width="2312" height="1916" alt="CleanShot 2025-11-23 at 12 55 57@2x" src="https://github.com/user-attachments/assets/e64d7245-7ca2-4737-a7e4-21d8b6784016" /> | <img width="2312" height="1916" alt="CleanShot 2025-11-23 at 12 56 32@2x" src="https://github.com/user-attachments/assets/7400438f-d96c-457d-afbe-eb7829bd0ff3" /> |



## Testing Instructions
* Go to /reader/recent/143967848 using the full post view
* Check if the position and vertical alignment are correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
