### PR TITLE
Stats: Use site timezone string for more accurate time handling

### DIFF
--- a/client/components/date-control/index.tsx
+++ b/client/components/date-control/index.tsx
@@ -4,7 +4,7 @@ import { Moment } from 'moment';
 import { RefObject } from 'react';
 import DateRange from 'calypso/components/date-range';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import useMomentSiteZone from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
+import { useMomentInSite } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { DateControlProps } from './types';
 import './style.scss';
 
@@ -20,7 +20,8 @@ const DateControl = ( {
 	shortcutList,
 }: DateControlProps ) => {
 	const moment = useLocalizedMoment();
-	const siteToday = useMomentSiteZone();
+	const momentInSite = useMomentInSite();
+	const siteToday = momentInSite();
 
 	const getButtonLabel = () => {
 		const localizedStartDate = moment( dateRange.chartStart );

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -55,7 +55,7 @@ export const getShortcuts = createSelector(
 	) => {
 		const translate = translateFromProps ?? i18nCalypsoTranslate;
 		const siteId = getSelectedSiteId( state );
-		const siteToday = getMomentSiteZone( state, siteId );
+		const siteToday = getMomentSiteZone( state, siteId )();
 		const siteTodayStr = siteToday.format( DATE_FORMAT );
 
 		const supportedShortcutList = [
@@ -129,7 +129,7 @@ export const getShortcuts = createSelector(
 		}
 	) => {
 		const siteId = getSelectedSiteId( state );
-		const siteToday = getMomentSiteZone( state, siteId );
+		const siteToday = getMomentSiteZone( state, siteId )();
 
 		return [
 			siteId,

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -8,7 +8,6 @@ import {
 import { formatNumber } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { Moment } from 'moment';
 import { useCallback, useMemo } from 'react';
 import ChartBarTooltip from 'calypso/components/chart/bar-tooltip';
 import { DATE_FORMAT } from '../../constants';
@@ -42,7 +41,6 @@ function StatsLineChart( {
 	formatTimeTick?: ( value: number ) => string;
 	className?: string;
 	height?: number;
-	moment: Moment;
 	emptyState: JSX.Element;
 	zeroBaseline?: boolean;
 	fixedDomain?: boolean;

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -11,8 +11,8 @@ import { translate } from 'i18n-calypso';
 import { Moment } from 'moment';
 import { useCallback, useMemo } from 'react';
 import ChartBarTooltip from 'calypso/components/chart/bar-tooltip';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { DATE_FORMAT } from '../../constants';
+import { useMomentInSite } from '../../hooks/use-moment-site-zone';
 import StatsEmptyState from '../../stats-empty-state';
 
 import './styles.scss';
@@ -49,7 +49,7 @@ function StatsLineChart( {
 	curveType?: 'smooth' | 'linear' | 'monotone';
 	onClick?: ( item: { data: { period: string } } ) => void;
 } ) {
-	const moment = useLocalizedMoment();
+	const moment = useMomentInSite();
 
 	const formatTime = formatTimeTick
 		? formatTimeTick

--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import Main, { MainProps } from 'calypso/components/main';
 import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
 import StatsUpsellModal from 'calypso/my-sites/stats/stats-upsell-modal';
@@ -23,6 +24,7 @@ export default function StatsMain( { children, className, ...props }: MainProps 
 	return (
 		<Main { ...props } className={ clsx( 'stats-main', 'color-scheme', customTheme, className ) }>
 			{ ! isWPAdminAndNotSimpleSite && <QuerySiteFeatures siteIds={ [ siteId ] } /> }
+			<QuerySiteSettings siteId={ siteId } />
 			{ children }
 			{ upsellModalView && <StatsUpsellModal siteId={ siteId } /> }
 		</Main>

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -6,7 +6,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { getSiteFragment, getStatsDefaultSitePage } from 'calypso/lib/route';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
-import { getSite, getSiteOption } from 'calypso/state/sites/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -192,11 +192,11 @@ export function site( context, next ) {
 
 	// startDate is the date the user clicked on the chart, which is basically the start of the period, i.e. Monday of weeks, 1st of months, or the selected date.
 	const date = isValidStartDate
-		? moment( queryOptions.startDate ).locale( 'en' )
-		: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
+		? momentSiteZone( queryOptions.startDate ).locale( 'en' )
+		: rangeOfPeriod( activeFilter.period, momentSiteZone().locale( 'en' ) ).startOf;
 
 	const parsedPeriod = isValidStartDate
-		? parseInt( getNumPeriodAgo( momentSiteZone, date, activeFilter.period ), 10 )
+		? parseInt( getNumPeriodAgo( momentSiteZone(), date, activeFilter.period ), 10 )
 		: 0;
 
 	// eslint-disable-next-line no-nested-ternary
@@ -262,7 +262,6 @@ export function summary( context, next ) {
 		'utm',
 		'devices',
 	];
-	let momentSiteZone = moment();
 
 	const selectedSite = getSite( context.store.getState(), siteId );
 	siteId = selectedSite ? selectedSite.ID || 0 : 0;
@@ -280,21 +279,18 @@ export function summary( context, next ) {
 		return next();
 	}
 
-	const gmtOffset = getSiteOption( context.store.getState(), siteId, 'gmt_offset' );
-	if ( Number.isFinite( gmtOffset ) ) {
-		momentSiteZone = moment().utcOffset( gmtOffset );
-	}
+	const momentSiteZone = getMomentSiteZone( context.store.getState(), siteId );
 	const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
 	const date = isValidStartDate
-		? moment( queryOptions.startDate ).locale( 'en' )
-		: momentSiteZone.endOf( activeFilter.period ).locale( 'en' );
+		? momentSiteZone( queryOptions.startDate ).locale( 'en' )
+		: momentSiteZone().endOf( activeFilter.period ).locale( 'en' );
 	const period = rangeOfPeriod( activeFilter.period, date );
 
 	// Support for custom date ranges.
 	// Evaluate the endDate param if provided and create a date range object if valid.
 	// Valid means endDate is a valid date and is not before the startDate.
 	const isValidEndDate = queryOptions.endDate && moment( queryOptions.endDate ).isValid();
-	const endDate = isValidEndDate ? moment( queryOptions.endDate ).locale( 'en' ) : null;
+	const endDate = isValidEndDate ? momentSiteZone( queryOptions.endDate ).locale( 'en' ) : null;
 	const isValidRange = isValidEndDate && ! endDate.isBefore( date );
 	const dateRange = isValidRange ? { startDate: date, endDate: endDate } : null;
 
@@ -411,11 +407,11 @@ export function wordAds( context, next ) {
 	const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
 
 	const date = isValidStartDate
-		? moment( queryOptions.startDate ).locale( 'en' )
-		: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
+		? momentSiteZone( queryOptions.startDate ).locale( 'en' )
+		: rangeOfPeriod( activeFilter.period, momentSiteZone().locale( 'en' ) ).startOf;
 
 	const parsedPeriod = isValidStartDate
-		? parseInt( getNumPeriodAgo( momentSiteZone, date, activeFilter.period ), 10 )
+		? parseInt( getNumPeriodAgo( momentSiteZone(), date, activeFilter.period ), 10 )
 		: 0;
 
 	// eslint-disable-next-line no-nested-ternary
@@ -459,8 +455,8 @@ export function emailStats( context, next ) {
 	const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
 
 	const date = isValidStartDate
-		? moment( queryOptions.startDate ).locale( 'en' )
-		: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
+		? momentSiteZone( queryOptions.startDate ).locale( 'en' )
+		: rangeOfPeriod( activeFilter.period, momentSiteZone().locale( 'en' ) ).startOf;
 
 	if ( 0 === siteId ) {
 		window.location = '/stats';
@@ -507,7 +503,8 @@ export function emailSummary( context, next ) {
 		);
 	} );
 
-	const date = moment().locale( 'en' );
+	const momentSiteZone = getMomentSiteZone( context.store.getState(), siteId );
+	const date = momentSiteZone().locale( 'en' );
 
 	context.primary = (
 		<StatsEmailSummary

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -2,6 +2,7 @@ import { createSelector } from '@automattic/state-utils';
 import i18n from 'i18n-calypso';
 import moment from 'moment-timezone';
 import { useSelector } from 'calypso/state';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DATE_FORMAT } from '../constants';
@@ -9,7 +10,7 @@ import { DATE_FORMAT } from '../constants';
 export const getMomentSiteZone = createSelector(
 	( state: object, siteId: number | null, dateFormat = DATE_FORMAT ) => {
 		const localeSlug = i18n.getLocaleSlug() || 'en';
-		const timezoneString = getSiteOption( state, siteId, 'timezone_string' ) as string;
+		const timezoneString = getSiteTimezoneValue( state, siteId );
 		const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' ) as number;
 
 		return ( dateInput?: moment.MomentInput ) => {
@@ -45,7 +46,7 @@ export const getMomentSiteZone = createSelector(
 	},
 	[
 		( state, siteId ) => getSiteOption( state, siteId, 'gmt_offset' ),
-		( state, siteId ) => getSiteOption( state, siteId, 'timezone_string' ),
+		( state, siteId ) => getSiteTimezoneValue( state, siteId ),
 		() => i18n.getLocaleSlug(),
 	]
 );

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -4,14 +4,19 @@ import moment from 'moment-timezone';
 import { useSelector } from 'calypso/state';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DATE_FORMAT } from '../constants';
 
 export const getMomentSiteZone = createSelector(
 	( state: object, siteId: number | null, dateFormat = DATE_FORMAT ) => {
 		const localeSlug = i18n.getLocaleSlug() || 'en';
-		const timezoneString = getSiteTimezoneValue( state, siteId as number );
-		const gmtOffset = getSiteGmtOffset( state, siteId as number );
+		const timezoneString =
+			getSiteTimezoneValue( state, siteId as number ) ||
+			( getSiteOption( state, siteId, 'timezone_string' ) as string );
+		const gmtOffset =
+			getSiteGmtOffset( state, siteId as number ) ||
+			( getSiteOption( state, siteId, 'gmt_offset' ) as number );
 
 		return ( dateInput?: moment.MomentInput ) => {
 			if ( timezoneString ) {
@@ -47,6 +52,8 @@ export const getMomentSiteZone = createSelector(
 	[
 		( state, siteId ) => getSiteGmtOffset( state, siteId ),
 		( state, siteId ) => getSiteTimezoneValue( state, siteId ),
+		( state, siteId ) => getSiteOption( state, siteId, 'gmt_offset' ),
+		( state, siteId ) => getSiteOption( state, siteId, 'timezone_string' ),
 		() => i18n.getLocaleSlug(),
 	]
 );

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@automattic/state-utils';
 import i18n from 'i18n-calypso';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { useSelector } from 'calypso/state';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -8,30 +8,53 @@ import { DATE_FORMAT } from '../constants';
 
 export const getMomentSiteZone = createSelector(
 	( state: object, siteId: number | null, dateFormat = DATE_FORMAT ) => {
-		let localeSlug = i18n.getLocaleSlug();
-		if ( localeSlug === null ) {
-			localeSlug = 'en';
-		}
-
-		const localizedMoment = moment().locale( localeSlug );
-
+		const localeSlug = i18n.getLocaleSlug() || 'en';
+		const timezoneString = getSiteOption( state, siteId, 'timezone_string' ) as string;
 		const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' ) as number;
-		if ( Number.isFinite( gmtOffset ) ) {
-			// In all the components, `moment` is directly used, which defaults to the browser's local timezone.
-			// As a result, we need to convert the moment object to the site's timezone for easier comparison like `isSame`.
-			return moment( localizedMoment.utcOffset( gmtOffset ).format( dateFormat ) );
-		}
 
-		// Falls back to the browser's local timezone if no GMT offset is found
-		return localizedMoment;
+		return ( dateInput?: moment.MomentInput ) => {
+			if ( timezoneString ) {
+				if ( dateInput === undefined ) {
+					return moment.tz( timezoneString ).locale( localeSlug );
+				}
+				return moment.tz( dateInput, timezoneString ).locale( localeSlug );
+			}
+
+			if ( Number.isFinite( gmtOffset ) ) {
+				if ( dateInput === undefined ) {
+					// In all the components, `moment` is directly used, which defaults to the browser's local timezone.
+					// As a result, we need to convert the moment object to the site's timezone for easier comparison like `isSame`.
+					return moment( moment().utcOffset( gmtOffset ).format( dateFormat ) ).locale(
+						localeSlug
+					);
+				}
+				// If dateInput is provided, we assume it's already in the correct timezone or we just want to apply the locale.
+				// However, if we want to simulate the site's timezone with a fake offset, we might need more complex logic.
+				// But for now, let's stick to the previous behavior of useMomentInSite for defined inputs:
+				// return moment( dateInput ).locale( momentSiteZone.locale() );
+				// Wait, the previous logic for defined input in useMomentInSite was:
+				// return moment( dateInput ).locale( momentSiteZone.locale() );
+				// And momentSiteZone was the fake moment object.
+				// So here we should just return moment(dateInput).locale(localeSlug).
+				return moment( dateInput ).locale( localeSlug );
+			}
+
+			// Falls back to the browser's local timezone if no GMT offset is found
+			return moment( dateInput ).locale( localeSlug );
+		};
 	},
-	[ ( state, siteId ) => getSiteOption( state, siteId, 'gmt_offset' ), () => i18n.getLocaleSlug() ]
+	[
+		( state, siteId ) => getSiteOption( state, siteId, 'gmt_offset' ),
+		( state, siteId ) => getSiteOption( state, siteId, 'timezone_string' ),
+		() => i18n.getLocaleSlug(),
+	]
 );
 
 /**
- * Get moment object based on site timezone.
+ * Hook to get a function that creates a moment object in the site's timezone.
  */
-export default function useMomentSiteZone() {
-	const siteId = useSelector( getSelectedSiteId );
+export function useMomentInSite( siteIdInput?: number | null ) {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const siteId = siteIdInput ?? selectedSiteId;
 	return useSelector( ( state ) => getMomentSiteZone( state, siteId ) );
 }

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -34,7 +34,6 @@ export const getMomentSiteZone = createSelector(
 						localeSlug
 					);
 				}
-
 				return moment( dateInput ).locale( localeSlug );
 			}
 

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -34,14 +34,7 @@ export const getMomentSiteZone = createSelector(
 						localeSlug
 					);
 				}
-				// If dateInput is provided, we assume it's already in the correct timezone or we just want to apply the locale.
-				// However, if we want to simulate the site's timezone with a fake offset, we might need more complex logic.
-				// But for now, let's stick to the previous behavior of useMomentInSite for defined inputs:
-				// return moment( dateInput ).locale( momentSiteZone.locale() );
-				// Wait, the previous logic for defined input in useMomentInSite was:
-				// return moment( dateInput ).locale( momentSiteZone.locale() );
-				// And momentSiteZone was the fake moment object.
-				// So here we should just return moment(dateInput).locale(localeSlug).
+
 				return moment( dateInput ).locale( localeSlug );
 			}
 

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -19,7 +19,8 @@ export const getMomentSiteZone = createSelector(
 			( getSiteOption( state, siteId, 'gmt_offset' ) as number );
 
 		return ( dateInput?: moment.MomentInput ) => {
-			if ( timezoneString ) {
+			// Validate timezone string exists and is a valid IANA timezone identifier
+			if ( timezoneString && timezoneString !== '' && moment.tz.zone( timezoneString ) ) {
 				if ( dateInput === undefined ) {
 					return moment.tz( timezoneString ).locale( localeSlug );
 				}
@@ -34,7 +35,7 @@ export const getMomentSiteZone = createSelector(
 						localeSlug
 					);
 				}
-				return moment( dateInput ).locale( localeSlug );
+				return moment( dateInput ).utcOffset( gmtOffset ).locale( localeSlug );
 			}
 
 			// Falls back to the browser's local timezone if no GMT offset is found

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -2,16 +2,16 @@ import { createSelector } from '@automattic/state-utils';
 import i18n from 'i18n-calypso';
 import moment from 'moment-timezone';
 import { useSelector } from 'calypso/state';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
-import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DATE_FORMAT } from '../constants';
 
 export const getMomentSiteZone = createSelector(
 	( state: object, siteId: number | null, dateFormat = DATE_FORMAT ) => {
 		const localeSlug = i18n.getLocaleSlug() || 'en';
-		const timezoneString = getSiteTimezoneValue( state, siteId );
-		const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' ) as number;
+		const timezoneString = getSiteTimezoneValue( state, siteId as number );
+		const gmtOffset = getSiteGmtOffset( state, siteId as number );
 
 		return ( dateInput?: moment.MomentInput ) => {
 			if ( timezoneString ) {
@@ -45,7 +45,7 @@ export const getMomentSiteZone = createSelector(
 		};
 	},
 	[
-		( state, siteId ) => getSiteOption( state, siteId, 'gmt_offset' ),
+		( state, siteId ) => getSiteGmtOffset( state, siteId ),
 		( state, siteId ) => getSiteTimezoneValue( state, siteId ),
 		() => i18n.getLocaleSlug(),
 	]

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -43,8 +43,8 @@ export const getMomentSiteZone = createSelector(
 		};
 	},
 	[
-		( state, siteId ) => getSiteGmtOffset( state, siteId ),
-		( state, siteId ) => getSiteTimezoneValue( state, siteId ),
+		( state, siteId ) => getSiteGmtOffset( state, siteId as number ),
+		( state, siteId ) => getSiteTimezoneValue( state, siteId as number ),
 		( state, siteId ) => getSiteOption( state, siteId, 'gmt_offset' ),
 		( state, siteId ) => getSiteOption( state, siteId, 'timezone_string' ),
 		() => i18n.getLocaleSlug(),

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -110,7 +110,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 			chartData: data,
 			maxViews,
 		};
-	}, [ JSON.stringify( viewsData ) ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ viewsData, momentInSite, initialViewsCount ] );
 
 	// Format the time in minute difference from now.
 	const formatTimeTick = ( value: number ) => {

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -2,10 +2,9 @@ import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
 import clsx from 'clsx';
 import moment from 'moment';
 import { useEffect, useState, useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
-import { getSiteOption } from 'calypso/state/sites/selectors';
 import { parseChartData } from 'calypso/state/stats/lists/utils';
+import { useMomentInSite } from '../../hooks/use-moment-site-zone';
 
 type Unit = 'hour' | 'day' | 'week' | 'month' | 'year';
 
@@ -28,20 +27,16 @@ const UPDATE_INTERVAL_IN_SECONDS = 5;
 const MINUTE_DATA_LENGTH = 30;
 
 const RealtimeChart = ( { siteId }: { siteId: number } ) => {
-	const gmtOffset = useSelector( ( state: object ) =>
-		getSiteOption( state, siteId, 'gmt_offset' )
-	) as number;
+	const momentInSite = useMomentInSite( siteId );
 	const [ viewsData, setViewsData ] = useState( {} as chartMinuteDataTypes );
 	const [ initialViewsCount, setInitialViewsCount ] = useState< number | undefined >( undefined );
 
 	useEffect( () => {
 		const intervalId = setInterval( () => {
-			// Query the chart data by offset YYYY-MM-DD HH:mm:00.
-			const adjustedDatetimeForQuery = moment()
-				.utcOffset( gmtOffset )
-				.format( 'YYYY-MM-DD HH:mm:00' );
+			// Query the chart data by site timezone YYYY-MM-DD HH:mm:00.
+			const adjustedDatetimeForQuery = momentInSite().format( 'YYYY-MM-DD HH:mm:00' );
 			// Index the chart data by local YYYY-MM-DD HH:mm:00 to compare with local time in X-axis tickFormat.
-			const localDatetimeKey = moment().format( 'YYYY-MM-DD HH:mm:00' );
+			const localDatetimeKey = momentInSite().format( 'YYYY-MM-DD HH:mm:00' );
 
 			queryStatsVisits( siteId, {
 				unit: 'hour',
@@ -66,13 +61,13 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 		}, UPDATE_INTERVAL_IN_SECONDS * 1000 );
 
 		return () => clearInterval( intervalId );
-	}, [ siteId, gmtOffset, initialViewsCount ] );
+	}, [ siteId, momentInSite, initialViewsCount ] );
 
 	const { chartData, maxViews } = useMemo( () => {
 		const allDatetimeKeys = [];
 		// Display all the minutes in the last 30 minutes.
 		for ( let i = 0; i <= MINUTE_DATA_LENGTH; i++ ) {
-			const datetime = moment().subtract( i, 'minute' ).format( 'YYYY-MM-DD HH:mm:00' );
+			const datetime = momentInSite().subtract( i, 'minute' ).format( 'YYYY-MM-DD HH:mm:00' );
 			allDatetimeKeys.unshift( datetime );
 		}
 

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -61,7 +61,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 		}, UPDATE_INTERVAL_IN_SECONDS * 1000 );
 
 		return () => clearInterval( intervalId );
-	}, [ siteId, momentInSite, initialViewsCount ] );
+	}, [ siteId, initialViewsCount ] );
 
 	const { chartData, maxViews } = useMemo( () => {
 		const allDatetimeKeys = [];

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -62,7 +62,7 @@ function StatsRealtime( { context } ) {
 	const query = useMemo(
 		() => ( {
 			period: 'day',
-			date: momentSiteZone.format( 'YYYY-MM-DD' ),
+			date: momentSiteZone().format( 'YYYY-MM-DD' ),
 			max: 10,
 			summarize: 1,
 		} ),

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -66,7 +66,7 @@ function StatsRealtime( { context } ) {
 			max: 10,
 			summarize: 1,
 		} ),
-		[ momentSiteZone ]
+		[]
 	);
 
 	useEffect( () => {

--- a/client/my-sites/stats/pages/subscribers/controller.tsx
+++ b/client/my-sites/stats/pages/subscribers/controller.tsx
@@ -1,6 +1,6 @@
 import { find } from 'lodash';
-import moment from 'moment';
 import AsyncLoad from 'calypso/components/async-load';
+import { getMomentSiteZone } from '../../hooks/use-moment-site-zone';
 import { getSiteFilters, rangeOfPeriod, type SiteFilterType } from '../shared/helpers';
 import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
@@ -18,7 +18,8 @@ function subscribers( context: Context, next: () => void ) {
 	} ) as SiteFilterType;
 
 	// moment and rangeOfPeriod format needed for summary page link for email mdule
-	const date = moment().locale( 'en' );
+	const momentSiteZone = getMomentSiteZone( context.store.getState(), givenSiteId );
+	const date = momentSiteZone().locale( 'en' );
 
 	context.primary = (
 		<AsyncLoad

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -305,7 +305,7 @@ const connectComponent = connect(
 		// If not provided we compute the value. (maintains previous behaviour)
 		const date = customRange
 			? customRange.chartEnd
-			: getQueryDate( queryDate, timezoneOffset, period, quantity );
+			: getQueryDate( queryDate, state, siteId, period, quantity );
 		const chartStart = customRange?.chartStart || '';
 
 		const queryKey = `${ date }-${ period }-${ quantity }-${ siteId }`;

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -13,6 +13,7 @@ import { translate } from 'i18n-calypso';
 import { capitalize } from 'lodash';
 import moment from 'moment';
 import memoizeLast from 'calypso/lib/memoize-last';
+import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { rangeOfPeriod } from 'calypso/state/stats/lists/utils';
 import { parseLocalDate } from '../utils';
 
@@ -50,9 +51,9 @@ export function formatDate( date, period, chartStart = null, chartEnd = null ) {
 	}
 }
 
-export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
-	const momentSiteZone = moment().utcOffset( timezoneOffset );
-	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone.locale( 'en' ) ).endOf;
+export function getQueryDate( queryDate, state, siteId, period, quantity ) {
+	const momentSiteZone = getMomentSiteZone( state, siteId );
+	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone().locale( 'en' ) ).endOf;
 	const periodDifference = moment( endOfPeriodDate ).diff( moment( queryDate ), period );
 	if ( periodDifference >= quantity ) {
 		return moment( endOfPeriodDate )

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -40,13 +40,13 @@ class StatsDatePicker extends Component {
 	};
 
 	dateForSummarize() {
-		const { query, moment, translate } = this.props;
+		const { query, momentSiteZone, translate } = this.props;
 
 		if ( query.start_date ) {
 			return this.dateForCustomRange( query.start_date, query.date );
 		}
 
-		const localizedDate = moment();
+		const localizedDate = momentSiteZone();
 
 		switch ( query.num ) {
 			case '-1':
@@ -65,16 +65,16 @@ class StatsDatePicker extends Component {
 	}
 
 	dateForCustomRange( startDate, endDate, selectedShortcut = null ) {
-		const { moment, momentSiteZone } = this.props;
+		const { momentSiteZone } = this.props;
 
 		// Generate a full date range for the label.
-		const localizedStartDate = moment( startDate );
-		const localizedEndDate = moment( endDate );
+		const localizedStartDate = momentSiteZone( startDate );
+		const localizedEndDate = momentSiteZone( endDate );
 
 		// If it's a partial month but ends today.
 		if (
 			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'month' ), 'day' ) &&
-			localizedEndDate.isSame( momentSiteZone, 'day' ) &&
+			localizedEndDate.isSame( momentSiteZone(), 'day' ) &&
 			localizedStartDate.isSame( localizedEndDate, 'month' ) &&
 			( ! selectedShortcut || selectedShortcut.id === 'month_to_date' )
 		) {
@@ -84,7 +84,7 @@ class StatsDatePicker extends Component {
 		// If it's a partial year but ends today.
 		if (
 			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'year' ), 'day' ) &&
-			localizedEndDate.isSame( momentSiteZone, 'day' ) &&
+			localizedEndDate.isSame( momentSiteZone(), 'day' ) &&
 			localizedStartDate.isSame( localizedEndDate, 'year' ) &&
 			( ! selectedShortcut || selectedShortcut.id === 'year_to_date' )
 		) {
@@ -93,7 +93,7 @@ class StatsDatePicker extends Component {
 
 		// If it's the same day, show single date.
 		if ( localizedStartDate.isSame( localizedEndDate, 'day' ) ) {
-			return localizedStartDate.isSame( moment(), 'year' )
+			return localizedStartDate.isSame( momentSiteZone(), 'year' )
 				? localizedStartDate.format( 'MMM D' )
 				: localizedStartDate.format( 'll' );
 		}
@@ -118,7 +118,9 @@ class StatsDatePicker extends Component {
 
 		if ( localizedStartDate.year() === localizedEndDate.year() ) {
 			return `${ localizedStartDate.format( 'MMM D' ) } - ${ localizedEndDate.format( `MMM D` ) }${
-				localizedStartDate.isSame( moment(), 'year' ) ? '' : localizedEndDate.format( ', YYYY' ) // Only append year if it's not the current year.
+				localizedStartDate.isSame( momentSiteZone(), 'year' )
+					? ''
+					: localizedEndDate.format( ', YYYY' ) // Only append year if it's not the current year.
 			}`;
 		}
 
@@ -133,7 +135,7 @@ class StatsDatePicker extends Component {
 			return selectedShortcut.label;
 		}
 
-		const { date, moment, period, translate, isShort, dateRange } = this.props;
+		const { date, moment, period, translate, isShort, dateRange, momentSiteZone } = this.props;
 		const weekPeriodFormat = isShort ? 'll' : 'LL';
 
 		// Respect the dateRange if provided.
@@ -142,8 +144,8 @@ class StatsDatePicker extends Component {
 		}
 
 		// Ensure we have a moment instance here to work with.
-		const momentDate = moment.isMoment( date ) ? date : moment( date );
-		const localizedDate = moment( momentDate.format( 'YYYY-MM-DD' ) );
+		const momentDate = moment.isMoment( date ) ? date : momentSiteZone( date );
+		const localizedDate = momentSiteZone( momentDate.format( 'YYYY-MM-DD' ) );
 		let formattedDate;
 
 		switch ( period ) {
@@ -174,12 +176,12 @@ class StatsDatePicker extends Component {
 	}
 
 	renderQueryDate() {
-		const { query, queryDate, moment, translate } = this.props;
+		const { query, queryDate, momentSiteZone, translate } = this.props;
 
 		let content = '';
 		if ( queryDate && isAutoRefreshAllowedForQuery( query ) ) {
-			const today = moment();
-			const date = moment( queryDate );
+			const today = momentSiteZone();
+			const date = momentSiteZone( queryDate );
 			const isToday = today.isSame( date, 'day' );
 
 			content = translate( '{{b}}Last update: %(time)s{{/b}} (Updates every 30 minutes)', {

--- a/client/my-sites/stats/stats-email-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-email-chart-tabs/index.jsx
@@ -8,7 +8,6 @@ import Chart from 'calypso/components/chart';
 import Legend from 'calypso/components/chart/legend';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { getSiteOption } from 'calypso/state/sites/selectors';
 import { isLoadingTabs, getCountRecords } from 'calypso/state/stats/email-chart-tabs/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StatsModulePlaceholder from '../stats-module/placeholder';
@@ -131,8 +130,7 @@ const connectComponent = connect(
 
 		const quantity = 'hour' === period ? 24 : 30;
 		const counts = getCountRecords( state, siteId, postId, period, statType );
-		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
-		const date = getQueryDate( queryDate, timezoneOffset, period, quantity );
+		const date = getQueryDate( queryDate, state, siteId, period, quantity );
 		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
 		const maxBarsForRequest = 'hour' === period ? quantity : maxBars;
 		const isActiveTabLoading = isLoadingTabs(

--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -4,6 +4,7 @@ import { translate } from 'i18n-calypso';
 import { capitalize } from 'lodash';
 import moment from 'moment';
 import memoizeLast from 'calypso/lib/memoize-last';
+import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { rangeOfPeriod } from 'calypso/state/stats/lists/utils';
 
 export function formatDate( date, period ) {
@@ -19,9 +20,9 @@ export function formatDate( date, period ) {
 	}
 }
 
-export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
-	const momentSiteZone = moment().utcOffset( timezoneOffset );
-	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone.locale( 'en' ) ).endOf;
+export function getQueryDate( queryDate, state, siteId, period, quantity ) {
+	const momentSiteZone = getMomentSiteZone( state, siteId );
+	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone().locale( 'en' ) ).endOf;
 	const periodDifference = moment( endOfPeriodDate ).diff( moment( queryDate ), period );
 	if ( periodDifference >= quantity ) {
 		return moment( endOfPeriodDate )

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -3,7 +3,6 @@ import { Icon, lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { flowRight, find, get } from 'lodash';
-import moment from 'moment';
 import { useMemo } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -18,6 +17,7 @@ import {
 	STATS_FEATURE_SUMMARY_LINKS_QUARTER,
 	STATS_FEATURE_SUMMARY_LINKS_YEAR,
 } from '../constants';
+import { useMomentInSite } from '../hooks/use-moment-site-zone';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import DatePicker from '../stats-date-picker';
 import { trackStatsAnalyticsEvent } from '../utils';
@@ -38,6 +38,7 @@ export const StatsModuleSummaryLinks = ( props ) => {
 	} = props;
 
 	const dispatch = useDispatch();
+	const momentInSite = useMomentInSite( siteId );
 	const getSummaryPeriodLabel = () => {
 		if ( query.start_date ) {
 			return translate( 'Custom Range Summary' );
@@ -85,7 +86,7 @@ export const StatsModuleSummaryLinks = ( props ) => {
 	const getSummaryPathForDaysRange = ( numberDays ) => {
 		const queryParams = new URLSearchParams( context.query );
 
-		queryParams.set( 'startDate', moment().format( 'YYYY-MM-DD' ) );
+		queryParams.set( 'startDate', momentInSite().format( 'YYYY-MM-DD' ) );
 		queryParams.set( 'summarize', 1 );
 		queryParams.set( 'num', numberDays );
 		queryParams.delete( 'endDate' );

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -78,7 +78,7 @@ class StatsPeriodNavigation extends PureComponent {
 	calculatePeriod = ( period ) => ( this.isHoursPeriod( period ) ? 'day' : period );
 
 	queryParamsForNextDate = ( nextDay ) => {
-		const { dateRange, moment } = this.props;
+		const { dateRange, momentSiteZone } = this.props;
 		// Takes a 'YYYY-MM-DD' string.
 		const newParams = { startDate: nextDay };
 		// Maintain previous behaviour if we don't have a date range to work with.
@@ -86,10 +86,12 @@ class StatsPeriodNavigation extends PureComponent {
 			return newParams;
 		}
 		// Test if we need to update the chart start/end dates.
-		const isAfter = moment( nextDay ).isAfter( moment( dateRange.chartEnd ) );
+		const isAfter = momentSiteZone( nextDay ).isAfter( momentSiteZone( dateRange.chartEnd ) );
 		if ( isAfter ) {
-			newParams.chartStart = moment( dateRange.chartEnd ).add( 1, 'days' ).format( 'YYYY-MM-DD' );
-			newParams.chartEnd = moment( dateRange.chartEnd )
+			newParams.chartStart = momentSiteZone( dateRange.chartEnd )
+				.add( 1, 'days' )
+				.format( 'YYYY-MM-DD' );
+			newParams.chartEnd = momentSiteZone( dateRange.chartEnd )
 				.add( dateRange.daysInRange, 'days' )
 				.format( 'YYYY-MM-DD' );
 		}
@@ -97,10 +99,12 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	handleArrowPrevious = () => {
-		const { date, moment, period, url, queryParams, isEmailStats, maxBars } = this.props;
+		const { date, momentSiteZone, period, url, queryParams, isEmailStats, maxBars } = this.props;
 		const numberOfDAys = this.getNumberOfDays( isEmailStats, period, maxBars );
 		const usedPeriod = this.calculatePeriod( period );
-		const previousDay = moment( date ).subtract( numberOfDAys, usedPeriod ).format( 'YYYY-MM-DD' );
+		const previousDay = momentSiteZone( date )
+			.subtract( numberOfDAys, usedPeriod )
+			.format( 'YYYY-MM-DD' );
 		const newQueryParams = this.queryParamsForPreviousDate( previousDay );
 		const previousDayQuery = qs.stringify( Object.assign( {}, queryParams, newQueryParams ), {
 			addQueryPrefix: true,
@@ -115,10 +119,10 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	handleArrowNext = () => {
-		const { date, moment, period, url, queryParams, isEmailStats, maxBars } = this.props;
+		const { date, momentSiteZone, period, url, queryParams, isEmailStats, maxBars } = this.props;
 		const numberOfDAys = this.getNumberOfDays( isEmailStats, period, maxBars );
 		const usedPeriod = this.calculatePeriod( period );
-		const nextDay = moment( date ).add( numberOfDAys, usedPeriod ).format( 'YYYY-MM-DD' );
+		const nextDay = momentSiteZone( date ).add( numberOfDAys, usedPeriod ).format( 'YYYY-MM-DD' );
 		const newQueryParams = this.queryParamsForNextDate( nextDay );
 		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, newQueryParams ), {
 			addQueryPrefix: true,
@@ -142,14 +146,14 @@ class StatsPeriodNavigation extends PureComponent {
 
 	// TODO: refactor to extract logic with `dateForCustomRange` from `client/my-sites/stats/stats-date-picker/index.jsx`.
 	getFullPeriod = () => {
-		const { moment, dateRange, momentSiteZone } = this.props;
-		const localizedStartDate = moment( dateRange.chartStart );
-		const localizedEndDate = moment( dateRange.chartEnd );
+		const { dateRange, momentSiteZone } = this.props;
+		const localizedStartDate = momentSiteZone( dateRange.chartStart );
+		const localizedEndDate = momentSiteZone( dateRange.chartEnd );
 
 		// If it's a partial month but ends today.
 		if (
 			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'month' ), 'day' ) &&
-			localizedEndDate.isSame( momentSiteZone, 'day' ) &&
+			localizedEndDate.isSame( momentSiteZone(), 'day' ) &&
 			localizedStartDate.isSame( localizedEndDate, 'month' ) &&
 			( ! dateRange.shortcutId || dateRange.shortcutId === 'month_to_date' )
 		) {
@@ -159,7 +163,7 @@ class StatsPeriodNavigation extends PureComponent {
 		// If it's a partial year but ends today.
 		if (
 			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'year' ), 'day' ) &&
-			localizedEndDate.isSame( momentSiteZone, 'day' ) &&
+			localizedEndDate.isSame( momentSiteZone(), 'day' ) &&
 			localizedStartDate.isSame( localizedEndDate, 'year' ) &&
 			( ! dateRange.shortcutId || dateRange.shortcutId === 'year_to_date' )
 		) {
@@ -193,7 +197,7 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	handleArrowNavigation = ( previousOrNext = false ) => {
-		const { moment, momentSiteZone, period, slug, dateRange } = this.props;
+		const { momentSiteZone, period, slug, dateRange } = this.props;
 
 		const isWPAdmin = config.isEnabled( 'is_odyssey' );
 		const event_from = isWPAdmin ? 'jetpack_odyssey' : 'calypso';
@@ -202,8 +206,8 @@ class StatsPeriodNavigation extends PureComponent {
 			direction: previousOrNext ? 'previous' : 'next',
 		} );
 
-		const navigationStart = moment( dateRange.chartStart );
-		let navigationEnd = moment( dateRange.chartEnd );
+		const navigationStart = momentSiteZone( dateRange.chartStart );
+		let navigationEnd = momentSiteZone( dateRange.chartEnd );
 
 		// If it's a full month then we need to navigate to the previous/next month.
 		// If it's a full year then we need to navigate to the previous/next year.
@@ -233,8 +237,8 @@ class StatsPeriodNavigation extends PureComponent {
 			}
 			navigationStart.startOf( fullPeriod );
 			navigationEnd.endOf( fullPeriod );
-			if ( navigationEnd.isAfter( momentSiteZone, 'day' ) ) {
-				navigationEnd = momentSiteZone;
+			if ( navigationEnd.isAfter( momentSiteZone(), 'day' ) ) {
+				navigationEnd = momentSiteZone();
 			}
 		}
 
@@ -254,7 +258,7 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	queryParamsForPreviousDate = ( previousDay ) => {
-		const { dateRange, moment } = this.props;
+		const { dateRange, momentSiteZone } = this.props;
 		// Takes a 'YYYY-MM-DD' string.
 		const newParams = { startDate: previousDay };
 		// Maintain previous behaviour if we don't have a date range to work with.
@@ -262,12 +266,14 @@ class StatsPeriodNavigation extends PureComponent {
 			return newParams;
 		}
 		// Test if we need to update the chart start/end dates.
-		const isBefore = moment( previousDay ).isBefore( moment( dateRange.chartStart ) );
+		const isBefore = momentSiteZone( previousDay ).isBefore(
+			momentSiteZone( dateRange.chartStart )
+		);
 		if ( isBefore ) {
-			newParams.chartEnd = moment( dateRange.chartStart )
+			newParams.chartEnd = momentSiteZone( dateRange.chartStart )
 				.subtract( 1, 'days' )
 				.format( 'YYYY-MM-DD' );
-			newParams.chartStart = moment( dateRange.chartStart )
+			newParams.chartStart = momentSiteZone( dateRange.chartStart )
 				.subtract( dateRange.daysInRange, 'days' )
 				.format( 'YYYY-MM-DD' );
 		}
@@ -307,7 +313,6 @@ class StatsPeriodNavigation extends PureComponent {
 		const {
 			children,
 			date,
-			moment,
 			period,
 			showArrows,
 			disablePreviousArrow,
@@ -322,10 +327,10 @@ class StatsPeriodNavigation extends PureComponent {
 			momentSiteZone,
 		} = this.props;
 
-		const isToday = moment( date ).isSame( momentSiteZone, period );
+		const isToday = momentSiteZone( date ).isSame( momentSiteZone(), period );
 
-		const isChartRangeEndSameOrAfterToday = moment( dateRange?.chartEnd ).isSameOrAfter(
-			momentSiteZone,
+		const isChartRangeEndSameOrAfterToday = momentSiteZone( dateRange?.chartEnd ).isSameOrAfter(
+			momentSiteZone(),
 			'day'
 		);
 		// Make sure we only show arrows for date ranges that are less than 3 years for performance reasons.

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -105,7 +105,6 @@ export const parseLocalDate = ( dateString ) => {
  * Process the start date and from period to determine the target chart range parameters.
  * @param {string} startDate The start date of the chart range.
  * @param {string} fromPeriod The period of the chart where the action comes from.
- * @param {function} [momentInSite] Optional moment-like function for site-aware timezone handling.
  * @param {Function} [momentInSite] Optional moment-like function for site-aware timezone handling.
  * @returns {ChartRangeParams} The chart range parameters for navigating the chart.
  */

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -105,6 +105,7 @@ export const parseLocalDate = ( dateString ) => {
  * Process the start date and from period to determine the target chart range parameters.
  * @param {string} startDate The start date of the chart range.
  * @param {string} fromPeriod The period of the chart where the action comes from.
+ * @param {function} [momentInSite] Optional moment-like function for site-aware timezone handling.
  * @param {Function} [momentInSite] Optional moment-like function for site-aware timezone handling.
  * @returns {ChartRangeParams} The chart range parameters for navigating the chart.
  */

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -107,15 +107,15 @@ export const parseLocalDate = ( dateString ) => {
  * @param {string} fromPeriod The period of the chart where the action comes from.
  * @returns {ChartRangeParams} The chart range parameters for navigating the chart.
  */
-export const getChartRangeParams = ( startDate, fromPeriod ) => {
+export const getChartRangeParams = ( startDate, fromPeriod, momentInSite = moment ) => {
 	const chartStart = startDate;
-	let chartEnd = moment( chartStart )
+	let chartEnd = momentInSite( chartStart )
 		.endOf( fromPeriod === 'week' ? 'isoWeek' : fromPeriod )
 		.format( DATE_FORMAT );
 
 	// Do not go beyond the current date.
-	if ( moment().isBefore( chartEnd ) ) {
-		chartEnd = moment().format( DATE_FORMAT );
+	if ( momentInSite().isBefore( chartEnd ) ) {
+		chartEnd = momentInSite().format( DATE_FORMAT );
 	}
 
 	let chartPeriod = 'day';

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -105,6 +105,7 @@ export const parseLocalDate = ( dateString ) => {
  * Process the start date and from period to determine the target chart range parameters.
  * @param {string} startDate The start date of the chart range.
  * @param {string} fromPeriod The period of the chart where the action comes from.
+ * @param {Function} [momentInSite] Optional moment-like function for site-aware timezone handling.
  * @returns {ChartRangeParams} The chart range parameters for navigating the chart.
  */
 export const getChartRangeParams = ( startDate, fromPeriod, momentInSite = moment ) => {

--- a/client/my-sites/stats/wordads-chart-tabs/index.jsx
+++ b/client/my-sites/stats/wordads-chart-tabs/index.jsx
@@ -11,7 +11,6 @@ import Chart from 'calypso/components/chart';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import compareProps from 'calypso/lib/compare-props';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { getSiteOption } from 'calypso/state/sites/selectors';
 import {
 	getSiteStatsNormalizedData,
 	isRequestingSiteStatsForQuery,
@@ -164,8 +163,7 @@ const connectComponent = connect(
 		}
 
 		const quantity = 'year' === period ? 10 : 30;
-		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
-		const date = getQueryDate( queryDate, timezoneOffset, period, quantity );
+		const date = getQueryDate( queryDate, state, siteId, period, quantity );
 
 		const query = { unit: period, date, quantity };
 		const data = getSiteStatsNormalizedData( state, siteId, 'statsAds', query );

--- a/client/state/selectors/test/get-site-stats-view-summary.js
+++ b/client/state/selectors/test/get-site-stats-view-summary.js
@@ -13,6 +13,9 @@ describe( 'getSiteStatsViewSummary()', () => {
 						items: {},
 					},
 				},
+				siteSettings: {
+					items: {},
+				},
 			},
 			2916284
 		);
@@ -37,6 +40,9 @@ describe( 'getSiteStatsViewSummary()', () => {
 							},
 						},
 					},
+				},
+				siteSettings: {
+					items: {},
 				},
 			},
 			2916284
@@ -68,6 +74,9 @@ describe( 'getSiteStatsViewSummary()', () => {
 							},
 						},
 					},
+				},
+				siteSettings: {
+					items: {},
 				},
 			},
 			2916284
@@ -122,6 +131,9 @@ describe( 'getSiteStatsViewSummary()', () => {
 							},
 						},
 					},
+				},
+				siteSettings: {
+					items: {},
 				},
 			},
 			2916284

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -214,7 +214,7 @@ export function getSiteStatsViewSummary( state, siteId ) {
 	}
 
 	const viewSummary = {};
-	const currentDate = getMomentSiteZone( state, siteId ).toDate();
+	const currentDate = getMomentSiteZone( state, siteId )().toDate();
 	const currentYear = currentDate.getFullYear();
 	const currentMonth = currentDate.getMonth();
 


### PR DESCRIPTION
Part of STATS-180

## Proposed Changes

* Refactored timezone handling in Stats to use site timezone string (timezone_string) with moment-timezone instead of relying solely on GMT offset
* Updated `useMomentSiteZone` to return a function that creates timezone-aware moment objects
* Renamed hook to `useMomentInSite` for better clarity and exported `getMomentSiteZone` for controller usage
* Used dedicated selectors (`getSiteTimezoneValue` and `getSiteGmtOffset`) with fallback to `getSiteOption` for better reliability
* Updated all Stats components to use the new timezone-aware moment function
* Added `QuerySiteSettings` to ensure site settings are loaded before timezone selectors access them
* Removed debug console.log statements

## Why are these changes being made?

The previous implementation only used GMT offset for timezone calculations, which doesn't account for daylight saving time (DST) changes and can lead to incorrect date/time calculations. For example, a site in Pacific/Auckland would show incorrect times during DST transitions between NZDT (UTC+13) and NZST (UTC+12).

By using the proper timezone string with moment-timezone, we can:
- Accurately handle DST transitions
- Ensure date/time calculations respect the site's actual timezone rules
- Provide more reliable stats date filtering and navigation
- Fix issues where stats for specific dates might be off by hours during DST periods

The implementation now:
1. Prioritizes timezone string from `getSiteTimezoneValue` (falls back to `getSiteOption`)
2. Falls back to GMT offset from `getSiteGmtOffset` (falls back to `getSiteOption`)
3. Finally falls back to browser's local timezone

This ensures maximum compatibility across different state configurations.

## Testing Instructions

1. Test on a site with a timezone that observes DST (e.g., Pacific/Auckland - in 2025, September 28th has 25 hours while April 6 has 23 hours)
2. Navigate through different date periods in Stats
3. Verify the date picker shows correct dates relative to the site timezone (Pacific/Auckland)
4. Check that the realtime chart updates correctly with site timezone
5. Test date range selection and navigation during both DST and non-DST periods
6. Verify all Stats modules (traffic, insights, subscribers, etc.) display correct dates
7. Test on sites where timezone settings are in `state.siteSettings.items` vs `getSiteOption`
8. Specifically test around DST transition dates (e.g., late September and early April for Pacific/Auckland)
9. **Ensure all functionality works correctly in Odyssey Stats (WP Admin) as well as Calypso Stats**

September 28, 2025 - missing 2am


https://github.com/user-attachments/assets/8cda1fcd-ec3c-4fea-ace4-1e48307023e2

April 6, 2025 - two 2AMs

<img width="543" height="266" alt="Screenshot 2025-11-24 at 3 54 35 PM" src="https://github.com/user-attachments/assets/a17af835-a536-4bf0-9662-9fecb2feafa2" />


https://github.com/user-attachments/assets/8568a145-fb21-4de9-a2b0-55833475b05d





## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Using memoizing selectors and Our Approach to Data
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?