### PR TITLE
Revert "MSD: Update mobile styles for site switcher. (#107232)"

### DIFF
--- a/client/dashboard/components/header-bar/index.tsx
+++ b/client/dashboard/components/header-bar/index.tsx
@@ -24,7 +24,11 @@ function Header( { as = 'div', children }: { as?: 'div' | 'header'; children?: R
 
 Header.Title = function HeaderBarTitle( { children }: { children: React.ReactNode } ) {
 	return (
-		<HStack className="dashboard-header-bar-title" spacing={ 3 } expanded={ false }>
+		<HStack
+			style={ { width: 'auto', flexShrink: 0 } }
+			className="dashboard-header-bar-title"
+			spacing={ 3 }
+		>
 			{ children }
 		</HStack>
 	);

--- a/client/dashboard/components/header-bar/style.scss
+++ b/client/dashboard/components/header-bar/style.scss
@@ -28,9 +28,3 @@ $component-icon-padding: 6px;
 .dashboard-header-bar-title > span {
 	padding-inline: $grid-unit-15;
 }
-
-.dashboard-header-bar-title {
-	@include break-medium {
-		flex-shrink: 0;
-	}
-}

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -212,12 +212,12 @@ function ResponsiveMenu( {
 
 	return (
 		<DropdownMenu
-			className="dashboard-responsive-menu"
 			icon={ icon }
 			label={ label }
 			popoverProps={ {
 				placement: dropdownPlacement,
 			} }
+			style={ { justifyContent: 'flex-end' } }
 		>
 			{ ( { onClose } ) => (
 				<>

--- a/client/dashboard/components/responsive-menu/style.scss
+++ b/client/dashboard/components/responsive-menu/style.scss
@@ -1,7 +1,3 @@
-.dashboard-responsive-menu {
-	flex-shrink: 0;
-}
-
 .dashboard-responsive-menu__scrollable-container {
 	overflow-x: scroll;
 	-ms-overflow-style: none;  /* Internet Explorer 10+ */

--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -4,7 +4,6 @@ import {
 	Button,
 	ScrollLock,
 } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { chevronDownSmall } from '@wordpress/icons';
 import SwitcherContent from './switcher-content';
 import { RenderItemTitle, RenderItemMedia, RenderItemDescription } from './types';
@@ -39,7 +38,6 @@ export default function Switcher< T >( {
 	onToggle,
 	defaultOpen,
 }: SwitcherProps< T > ) {
-	const isDesktop = useViewportMatch( 'medium' );
 	return (
 		<Dropdown
 			open={ open }
@@ -59,12 +57,8 @@ export default function Switcher< T >( {
 					} }
 					aria-haspopup="true"
 					aria-expanded={ isOpen }
-					style={ { width: '100%', justifyContent: 'flex-start' } }
 				>
-					<HStack
-						alignment="center"
-						style={ { overflow: 'hidden', maxWidth: isDesktop ? 'calc(30vw)' : '100%' } }
-					>
+					<HStack alignment="center">
 						{ renderItemMedia( { item: value, context: 'dropdown', size: 16 } ) }
 						{ renderItemTitle( { item: value, context: 'dropdown' } ) }
 					</HStack>


### PR DESCRIPTION
Context: p1763946556058379-slack-C02FMH4G8

This reverts commit 50031ba59b886877c8328f18f1d8531e688deef5.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?