### PR TITLE
E2E: Fix editor related E2E tests for Social

### DIFF
--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -115,10 +115,10 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			}
 		);
 
-		skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )( 'Social Previews', function () {
+		skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )( 'Link Preview', function () {
 			it( 'Open social preview', async function () {
-				await editorPage.expandSection( 'Social Previews' );
-				await editorPage.clickSidebarButton( 'Open Social Previews' );
+				await editorPage.expandSection( 'Link Preview' );
+				await editorPage.clickSidebarButton( 'Open Link Preview' );
 			} );
 
 			it( 'Show social preview for Tumblr', async function () {

--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -274,10 +274,13 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				// Open the Jetpack sidebar.
 				await editorPage.openSettings( 'Jetpack' );
 
-				const section = await editorPage.getSettingsSection( 'Social Image Generator' );
+				// Expand the Publicize panel.
+				const section = await editorPage.expandSection( 'Share to Social Media' );
 
-				// Verify whether the Social Image Generator panel exists.
-				expect( await section.isVisible() ).toBe( features.socialImageGenerator );
+				const toggle = section.getByLabel( 'Enable Social Image' );
+
+				// Verify whether the Social Image Generator exists.
+				expect( await toggle.isVisible() ).toBe( features.socialImageGenerator );
 			} );
 		} );
 	}

--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -115,7 +115,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				] );
 
 				// Expand the Publicize panel.
-				const section = await editorPage.expandSection( 'Share this post' );
+				const section = await editorPage.expandSection( 'Share to Social Media' );
 
 				// Verify that the toggle is enabled.
 				const toggle = section.getByLabel( 'Auto-share post' );
@@ -144,7 +144,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await connectionTestPromise;
 
 				// Expand the Publicize panel.
-				let section = await editorPage.expandSection( 'Share this post' );
+				let section = await editorPage.expandSection( 'Share to Social Media' );
 
 				// Verify that resharing button is not visible on new posts in the share modal
 				let sharePostModalButton = section.getByRole( 'button', {
@@ -178,7 +178,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await connectionTestPromise;
 
 				// Expand the Publicize panel.
-				section = await editorPage.expandSection( 'Share this post' );
+				section = await editorPage.expandSection( 'Share to Social Media' );
 
 				// Verify whether the auto-share toggle is no longer visible.
 				const toggle = section.getByLabel( 'Auto-share post' );
@@ -234,7 +234,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await editorPage.openSettings( 'Jetpack' );
 
 				// Expand the Publicize panel.
-				let section = await editorPage.expandSection( 'Share this post' );
+				let section = await editorPage.expandSection( 'Share to Social Media' );
 
 				// Verify that manual sharing is NOT available before publishing.
 				let manualSharing = section.getByRole( 'paragraph', { name: 'Manual sharing' } );
@@ -261,7 +261,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await editorPage.openSettings( 'Jetpack' );
 
 				// Expand the Publicize panel.
-				section = await editorPage.expandSection( 'Share this post' );
+				section = await editorPage.expandSection( 'Share to Social Media' );
 
 				// Verify whether manual sharing is available in the Jetpack sidebar.
 				manualSharing = section.getByText( 'Manual sharing' );

--- a/test/e2e/specs/jetpack/social__editor-smoke.ts
+++ b/test/e2e/specs/jetpack/social__editor-smoke.ts
@@ -47,7 +47,7 @@ skipDescribeIf( isPrivateSite )(
 			await editorPage.openSettings( 'Jetpack' );
 
 			// Expand the Publicize panel.
-			await editorPage.expandSection( 'Share this post' );
+			await editorPage.expandSection( 'Share to Social Media' );
 
 			const editorParent = await editorPage.getEditorParent();
 


### PR DESCRIPTION
Following https://github.com/Automattic/jetpack/pull/46007, we need to update the E2E tests

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
