### PR TITLE
Align Jetpack login CTA with username label

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -382,17 +382,13 @@ export class LoginForm extends Component {
 	};
 
 	getLoginButtonText = () => {
-		const { translate, isWoo, loginButtonText, isJetpack } = this.props;
+		const { translate, loginButtonText } = this.props;
 
 		if ( loginButtonText ) {
 			return loginButtonText;
 		}
 
 		if ( this.isUsernameOrEmailView() ) {
-			if ( isJetpack && ! isWoo ) {
-				return translate( 'Continue with email' );
-			}
-
 			return translate( 'Continue' );
 		}
 

--- a/client/blocks/login/stories/submit-button/jetpack.stories.tsx
+++ b/client/blocks/login/stories/submit-button/jetpack.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta } from '@storybook/react';
 const meta: Meta = {
 	title: 'client/blocks/Login/Submit Button/Brands',
 	component: LoginSubmitButton,
-	args: { ...submitButtonArgs, buttonText: 'Continue with email' },
+	args: { ...submitButtonArgs, buttonText: 'Continue' },
 };
 
 export default meta;

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -156,6 +156,18 @@ describe( 'LoginForm', () => {
 		expect( label ).toBeInTheDocument();
 	} );
 
+	test( 'shows the default "Continue" button text for Jetpack logins', async () => {
+		render( <LoginForm isJetpack />, {
+			initialState: {
+				login: { socialAccountLink: { isLinking: false } },
+				route: { query: { current: {}, initial: {} } },
+			},
+		} );
+
+		const btn = screen.getByRole( 'button', { name: /^Continue$/i } );
+		expect( btn ).toBeInTheDocument();
+	} );
+
 	test( 'shows the username-only label when query flag is set', async () => {
 		render( <LoginForm />, {
 			initialState: {


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/M4R73CH-1282/jetpack-login-fix-inconsistent-text-between-label-username-or-email

## Proposed Changes

* reuse the default Continue button text for Jetpack username/email step
* update the Jetpack Storybook submit button args to the same copy
* add a regression test to lock the Jetpack button label

## Why are these changes being made?

* Jetpack login showed "Continue with email" while the field label already allows usernames, which is confusing for returning users. Reusing the generic copy keeps the CTA in sync with the label.

## Media

| Before | After |
|--------|--------|
| <img width="781" height="666" alt="Screenshot 2025-11-24 at 1 05 02 PM" src="https://github.com/user-attachments/assets/00ce2738-63d2-486a-9010-83982df36777" /> | <img width="826" height="670" alt="Screenshot 2025-11-24 at 1 04 45 PM" src="https://github.com/user-attachments/assets/6a99b822-bba2-4ea2-8252-e11108486d9f" /> |


## Testing Instructions

* `/log-in/jetpack` after rebuilding assets to confirm the CTA copy shows "Continue"

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests? (https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?