### PR TITLE
CIAB DOTMSD-881: Update auth flows in preparation for CIAB

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -12,6 +12,7 @@ import {
 	QrCodeLoginButton,
 	UsernameOrEmailButton,
 } from 'calypso/components/social-buttons';
+import { isCIAB } from 'calypso/utils';
 
 import './social.scss';
 
@@ -69,7 +70,7 @@ class SocialLoginForm extends Component {
 		},
 		{
 			service: 'paypal',
-			enabled: config.isEnabled( 'sign-in-with-paypal' ),
+			enabled: () => config.isEnabled( 'sign-in-with-paypal' ) && isCIAB( 'paypal' ),
 			button: (
 				<PayPalSocialButton
 					responseHandler={ this.props.handleLogin }
@@ -102,8 +103,9 @@ class SocialLoginForm extends Component {
 
 	renderSocialButton( { service, enabled, button } ) {
 		const { isSocialFirst, lastUsedAuthenticationMethod } = this.props;
+		const isEnabled = typeof enabled === 'function' ? enabled() : enabled;
 
-		if ( ! enabled ) {
+		if ( ! isEnabled ) {
 			return null;
 		}
 
@@ -122,13 +124,27 @@ class SocialLoginForm extends Component {
 	render() {
 		const { isSocialFirst } = this.props;
 
+		let buttons = this.socialLoginButtons;
+
+		if ( isCIAB( 'paypal' ) ) {
+			buttons = buttons.toSorted( ( a, b ) => {
+				if ( a.service === 'paypal' ) {
+					return -1;
+				}
+				if ( b.service === 'paypal' ) {
+					return 1;
+				}
+				return 0;
+			} );
+		}
+
 		return (
 			<Card
 				className={ clsx( 'auth-form__social', 'is-login', { 'is-social-first': isSocialFirst } ) }
 			>
 				<div className="auth-form__social-buttons">
 					<div className="auth-form__social-buttons-container">
-						{ this.socialLoginButtons.map( this.renderSocialButton.bind( this ) ) }
+						{ buttons.map( this.renderSocialButton.bind( this ) ) }
 					</div>
 				</div>
 			</Card>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -12,7 +12,7 @@ import {
 	QrCodeLoginButton,
 	UsernameOrEmailButton,
 } from 'calypso/components/social-buttons';
-import { isCIAB } from 'calypso/utils';
+import { isCIAB, sortLoginButtons } from 'calypso/utils';
 
 import './social.scss';
 
@@ -29,114 +29,85 @@ class SocialLoginForm extends Component {
 		isJetpack: PropTypes.bool,
 	};
 
-	socialLoginButtons = [
-		{
-			service: 'google',
-			enabled: true,
-			button: (
-				<GoogleSocialButton
-					responseHandler={ this.props.handleLogin }
-					onClick={ this.props.trackLoginAndRememberRedirect }
-					key="social-login-button-google"
-					isLogin
-				/>
-			),
-		},
-		{
-			service: 'apple',
-			enabled: true,
-			button: (
-				<AppleLoginButton
-					responseHandler={ this.props.handleLogin }
-					onClick={ this.props.trackLoginAndRememberRedirect }
-					socialServiceResponse={ this.props.socialServiceResponse }
-					key="social-login-button-apple"
-					isLogin
-				/>
-			),
-		},
-		{
-			service: 'github',
-			enabled: true,
-			button: (
-				<GithubSocialButton
-					responseHandler={ this.props.handleLogin }
-					onClick={ this.props.trackLoginAndRememberRedirect }
-					socialServiceResponse={ this.props.socialServiceResponse }
-					key="social-login-button-github"
-					isLogin
-				/>
-			),
-		},
-		{
-			service: 'paypal',
-			enabled: () => config.isEnabled( 'sign-in-with-paypal' ) && isCIAB( 'paypal' ),
-			button: (
-				<PayPalSocialButton
-					responseHandler={ this.props.handleLogin }
-					onClick={ this.props.trackLoginAndRememberRedirect }
-					socialServiceResponse={ this.props.socialServiceResponse }
-					key="social-login-button-paypal"
-					isLogin
-				/>
-			),
-		},
-		{
-			service: 'magic-login',
-			enabled: true,
-			button: this.props.isSocialFirst && this.props.magicLoginLink && (
-				<MagicLoginButton
-					loginUrl={ this.props.magicLoginLink }
-					key="social-login-button-magic-login"
-					isJetpack={ this.props.isJetpack }
-				/>
-			),
-		},
-		{
-			service: 'qr-code',
-			enabled: true,
-			button: this.props.isSocialFirst && this.props.qrLoginLink && (
-				<QrCodeLoginButton loginUrl={ this.props.qrLoginLink } key="social-login-button-qr-code" />
-			),
-		},
-	];
-
-	renderSocialButton( { service, enabled, button } ) {
-		const { isSocialFirst, lastUsedAuthenticationMethod } = this.props;
-		const isEnabled = typeof enabled === 'function' ? enabled() : enabled;
-
-		if ( ! isEnabled ) {
-			return null;
-		}
-
-		if ( isSocialFirst && service === lastUsedAuthenticationMethod ) {
-			return (
-				<UsernameOrEmailButton
-					key="social-login-button-username-or-email"
-					onClick={ this.props.resetLastUsedAuthenticationMethod }
-				/>
-			);
-		}
-
-		return button;
-	}
-
 	render() {
-		const { isSocialFirst } = this.props;
+		const { isSocialFirst, lastUsedAuthenticationMethod } = this.props;
 
-		let buttons = this.socialLoginButtons;
+		let buttons = [
+			{
+				service: 'google',
+				enabled: true,
+				button: (
+					<GoogleSocialButton
+						responseHandler={ this.props.handleLogin }
+						onClick={ this.props.trackLoginAndRememberRedirect }
+						key="social-login-button-google"
+						isLogin
+					/>
+				),
+			},
+			{
+				service: 'apple',
+				enabled: true,
+				button: (
+					<AppleLoginButton
+						responseHandler={ this.props.handleLogin }
+						onClick={ this.props.trackLoginAndRememberRedirect }
+						socialServiceResponse={ this.props.socialServiceResponse }
+						key="social-login-button-apple"
+						isLogin
+					/>
+				),
+			},
+			{
+				service: 'github',
+				enabled: true,
+				button: (
+					<GithubSocialButton
+						responseHandler={ this.props.handleLogin }
+						onClick={ this.props.trackLoginAndRememberRedirect }
+						socialServiceResponse={ this.props.socialServiceResponse }
+						key="social-login-button-github"
+						isLogin
+					/>
+				),
+			},
+			{
+				service: 'paypal',
+				enabled: config.isEnabled( 'sign-in-with-paypal' ) && isCIAB( 'paypal' ),
+				button: (
+					<PayPalSocialButton
+						responseHandler={ this.props.handleLogin }
+						onClick={ this.props.trackLoginAndRememberRedirect }
+						socialServiceResponse={ this.props.socialServiceResponse }
+						key="social-login-button-paypal"
+						isLogin
+					/>
+				),
+			},
+			{
+				service: 'magic-login',
+				enabled: this.props.isSocialFirst && this.props.magicLoginLink,
+				button: (
+					<MagicLoginButton
+						loginUrl={ this.props.magicLoginLink }
+						key="social-login-button-magic-login"
+						isJetpack={ this.props.isJetpack }
+					/>
+				),
+			},
+			{
+				service: 'qr-code',
+				enabled: this.props.isSocialFirst && this.props.qrLoginLink,
+				button: (
+					<QrCodeLoginButton
+						loginUrl={ this.props.qrLoginLink }
+						key="social-login-button-qr-code"
+					/>
+				),
+			},
+		];
 
-		if ( isCIAB( 'paypal' ) ) {
-			buttons = buttons.toSorted( ( a, b ) => {
-				if ( a.service === 'paypal' ) {
-					return -1;
-				}
-				if ( b.service === 'paypal' ) {
-					return 1;
-				}
-				return 0;
-			} );
-		}
+		buttons = sortLoginButtons( buttons.filter( ( button ) => button.enabled ) );
 
 		return (
 			<Card
@@ -144,7 +115,18 @@ class SocialLoginForm extends Component {
 			>
 				<div className="auth-form__social-buttons">
 					<div className="auth-form__social-buttons-container">
-						{ buttons.map( this.renderSocialButton.bind( this ) ) }
+						{ buttons.map( ( item ) => {
+							if ( isSocialFirst && item.service === lastUsedAuthenticationMethod ) {
+								return (
+									<UsernameOrEmailButton
+										key="social-login-button-username-or-email"
+										onClick={ this.props.resetLastUsedAuthenticationMethod }
+									/>
+								);
+							}
+
+							return item.button;
+						} ) }
 					</div>
 				</div>
 			</Card>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -107,7 +107,33 @@ class SocialLoginForm extends Component {
 			},
 		];
 
+		const usernameOrEmailButton = {
+			service: 'username-or-email',
+			enabled: true,
+			button: (
+				<UsernameOrEmailButton
+					key="social-login-button-username-or-email"
+					onClick={ this.props.resetLastUsedAuthenticationMethod }
+				/>
+			),
+		};
+
 		buttons = sortLoginButtons( buttons.filter( ( button ) => button.enabled ) );
+
+		// Some login options may be present only in certain flows (e.g. PayPal), so if the last used
+		// one is only shown conditionally, the username option will need to be appended as it
+		// cannot replace the last used one.
+		if ( lastUsedAuthenticationMethod ) {
+			const lastUsedButtonIndex = buttons.findIndex(
+				( button ) => button.service === lastUsedAuthenticationMethod
+			);
+
+			if ( lastUsedButtonIndex > -1 ) {
+				buttons[ lastUsedButtonIndex ] = usernameOrEmailButton;
+			} else {
+				buttons.push( usernameOrEmailButton );
+			}
+		}
 
 		return (
 			<Card
@@ -115,18 +141,7 @@ class SocialLoginForm extends Component {
 			>
 				<div className="auth-form__social-buttons">
 					<div className="auth-form__social-buttons-container">
-						{ buttons.map( ( item ) => {
-							if ( isSocialFirst && item.service === lastUsedAuthenticationMethod ) {
-								return (
-									<UsernameOrEmailButton
-										key="social-login-button-username-or-email"
-										onClick={ this.props.resetLastUsedAuthenticationMethod }
-									/>
-								);
-							}
-
-							return item.button;
-						} ) }
+						{ buttons.map( ( item ) => item.button ) }
 					</div>
 				</div>
 			</Card>

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -150,7 +150,7 @@ class SocialSignupForm extends Component {
 			{
 				service: 'username-or-email',
 				enabled: isSocialFirst,
-				button: () => (
+				button: (
 					<UsernameOrEmailButton
 						key="username-or-email"
 						onClick={ () => setCurrentStep( 'email' ) }

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -20,6 +20,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { isCIAB } from 'calypso/utils';
 
 class SocialSignupForm extends Component {
 	static propTypes = {
@@ -96,6 +97,82 @@ class SocialSignupForm extends Component {
 			flowName,
 			setCurrentStep,
 		} = this.props;
+
+		let buttons = [
+			{
+				service: 'google',
+				enabled: true,
+				button: (
+					<GoogleSocialButton
+						key="google"
+						responseHandler={ this.handleSignup }
+						onClick={ this.trackSignupAndRememberRedirect }
+					/>
+				),
+			},
+			{
+				service: 'apple',
+				enabled: true,
+				button: (
+					<AppleLoginButton
+						key="apple"
+						responseHandler={ this.handleSignup }
+						onClick={ this.trackSignupAndRememberRedirect }
+						socialServiceResponse={ socialServiceResponse }
+						queryString={ isWpccFlow( flowName ) ? window?.location?.search?.slice( 1 ) : '' }
+					/>
+				),
+			},
+			{
+				service: 'github',
+				enabled: true,
+				button: (
+					<GithubSocialButton
+						key="github"
+						responseHandler={ this.handleSignup }
+						onClick={ this.trackSignupAndRememberRedirect }
+						socialServiceResponse={ socialServiceResponse }
+					/>
+				),
+			},
+			{
+				service: 'paypal',
+				enabled: config.isEnabled( 'sign-in-with-paypal' ) && isCIAB( 'paypal' ),
+				button: (
+					<PayPalSocialButton
+						key="paypal"
+						responseHandler={ this.handleSignup }
+						onClick={ this.trackSignupAndRememberRedirect }
+						socialServiceResponse={ socialServiceResponse }
+					/>
+				),
+			},
+			{
+				service: 'username-or-email',
+				enabled: isSocialFirst,
+				button: () => (
+					<UsernameOrEmailButton
+						key="username-or-email"
+						onClick={ () => setCurrentStep( 'email' ) }
+					/>
+				),
+			},
+		];
+
+		if ( isCIAB( 'paypal' ) ) {
+			buttons = buttons.toSorted( ( a, b ) => {
+				if ( a.service === 'paypal' ) {
+					return -1;
+				}
+				if ( b.service === 'paypal' ) {
+					return 1;
+				}
+				return 0;
+			} );
+		}
+
+		buttons = buttons.filter( ( button ) => button.enabled );
+
 		return (
 			<Card
 				className={ clsx( 'auth-form__social', 'is-signup', {
@@ -108,35 +185,7 @@ class SocialSignupForm extends Component {
 
 				<div className="auth-form__social-buttons">
 					<div className="auth-form__social-buttons-container">
-						<GoogleSocialButton
-							responseHandler={ this.handleSignup }
-							onClick={ this.trackSignupAndRememberRedirect }
-						/>
-
-						<AppleLoginButton
-							responseHandler={ this.handleSignup }
-							onClick={ this.trackSignupAndRememberRedirect }
-							socialServiceResponse={ socialServiceResponse }
-							queryString={ isWpccFlow( flowName ) ? window?.location?.search?.slice( 1 ) : '' }
-						/>
-
-						<GithubSocialButton
-							responseHandler={ this.handleSignup }
-							onClick={ this.trackSignupAndRememberRedirect }
-							socialServiceResponse={ socialServiceResponse }
-						/>
-
-						{ config.isEnabled( 'sign-in-with-paypal' ) && (
-							<PayPalSocialButton
-								responseHandler={ this.handleSignup }
-								onClick={ this.trackSignupAndRememberRedirect }
-								socialServiceResponse={ socialServiceResponse }
-							/>
-						) }
-
-						{ isSocialFirst && (
-							<UsernameOrEmailButton onClick={ () => setCurrentStep( 'email' ) } />
-						) }
+						{ buttons.map( ( item ) => item.button ) }
 					</div>
 					{ ! disableTosText && <SocialToS /> }
 				</div>

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -20,7 +20,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { isCIAB } from 'calypso/utils';
+import { isCIAB, sortLoginButtons } from 'calypso/utils';
 
 class SocialSignupForm extends Component {
 	static propTypes = {
@@ -159,19 +159,7 @@ class SocialSignupForm extends Component {
 			},
 		];
 
-		if ( isCIAB( 'paypal' ) ) {
-			buttons = buttons.toSorted( ( a, b ) => {
-				if ( a.service === 'paypal' ) {
-					return -1;
-				}
-				if ( b.service === 'paypal' ) {
-					return 1;
-				}
-				return 0;
-			} );
-		}
-
-		buttons = buttons.filter( ( button ) => button.enabled );
+		buttons = sortLoginButtons( buttons.filter( ( button ) => button.enabled ) );
 
 		return (
 			<Card

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -20,6 +20,7 @@ import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
 import { useSelector } from 'calypso/state';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isCIAB } from 'calypso/utils';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { Step as StepType } from '../../types';
 import { useHandleSocialResponse } from './handle-social-response';
@@ -113,12 +114,16 @@ const UserStepComponent: StepType = function UserStep( {
 		</>
 	);
 
+	const headingText = isCIAB( 'paypal' )
+		? translate( 'Create an account for PayPal Stores' )
+		: translate( 'Create your account' );
+
 	if ( isStepContainerV2 ) {
 		const heading = (
 			// The locale suggestions are going to be reworked. Don't worry about it now.
 			<>
 				{ localeSuggestions }
-				<Step.Heading text={ translate( 'Create your account' ) } />
+				<Step.Heading text={ headingText } />
 			</>
 		);
 
@@ -159,11 +164,7 @@ const UserStepComponent: StepType = function UserStep( {
 				goBack={ navigation.goBack }
 				stepContent={
 					<>
-						<FormattedHeader
-							align="center"
-							headerText={ translate( 'Create your account' ) }
-							brandFont
-						/>
+						<FormattedHeader align="center" headerText={ headingText } brandFont />
 						{ stepContent }
 					</>
 				}

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -9,6 +9,7 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import { isCIAB } from 'calypso/utils';
 
 interface Props {
 	twoFactorAuthType: string | null;
@@ -125,6 +126,10 @@ export function getHeaderText( {
 					oldCopy: translate( 'Log in to WordPress.com' ),
 			  } ) as TranslateResult )
 			: translate( 'Log in to WordPress.com' );
+	}
+
+	if ( isCIAB( 'paypal' ) ) {
+		headerText = translate( 'Log in to PayPal Stores' );
 	}
 
 	if ( twoFactorAuthType === 'authenticator' || twoFactorAuthType === 'email' ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -53,6 +53,7 @@ import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import { isCIAB } from 'calypso/utils';
 import './style.scss';
 
 // Wrapper component to set headers in login context
@@ -438,6 +439,10 @@ export class UserStep extends Component {
 			isStudioApp,
 			isBlazePro,
 		} = this.props;
+
+		if ( isCIAB( 'paypal' ) ) {
+			return translate( 'Create an account for PayPal Stores' );
+		}
 
 		/**
 		 * BEGIN: Unified create account

--- a/client/utils.ts
+++ b/client/utils.ts
@@ -112,6 +112,11 @@ export function isCIAB( partner: string ): boolean {
 	return /\/ciab/.test( redirectTo ) || ( isAuth && service === partner );
 }
 
+/**
+ * Sort social login buttons based on the current context.
+ *
+ * This is a quick and dirty solution to put PayPal first for CIAB when trying to log in/sign up.
+ */
 export function sortLoginButtons< T extends { service: string } >( buttons: T[] ): T[] {
 	if ( ! isCIAB( 'paypal' ) ) {
 		return buttons;

--- a/client/utils.ts
+++ b/client/utils.ts
@@ -92,3 +92,13 @@ export function setupRedirectRoutes( redirectRouteList: RedirectRouteList[] ): v
 		} );
 	} );
 }
+
+/**
+ * Janky placeholder for future behavior that determines whether we are in a CIAB partner flow.
+ *
+ * @todo this needs to be reimplemented once CIAB is stabilized.
+ */
+export function isCIAB( partner: string ): boolean {
+	const redirectTo = new URLSearchParams( window.location.search ).get( 'redirect_to' ) || '';
+	return partner === 'paypal' && /\/ciab/.test( redirectTo );
+}

--- a/client/utils.ts
+++ b/client/utils.ts
@@ -96,9 +96,18 @@ export function setupRedirectRoutes( redirectRouteList: RedirectRouteList[] ): v
 /**
  * Janky placeholder for future behavior that determines whether we are in a CIAB partner flow.
  *
- * @todo this needs to be reimplemented once CIAB is stabilized.
+ * @todo this needs to be reimplemented once CIAB is stabilized - this should NOT be shipped to end users as-is.
  */
 export function isCIAB( partner: string ): boolean {
 	const redirectTo = new URLSearchParams( window.location.search ).get( 'redirect_to' ) || '';
-	return partner === 'paypal' && /\/ciab/.test( redirectTo );
+	const service = new URLSearchParams( window.location.search ).get( 'service' ) || '';
+	const isAuth =
+		/\/log-in\/paypal/.test( window.location.pathname ) ||
+		/\/setup\/onboarding/.test( window.location.pathname );
+
+	if ( partner !== 'paypal' ) {
+		return false;
+	}
+
+	return /\/ciab/.test( redirectTo ) || ( isAuth && service === partner );
 }

--- a/client/utils.ts
+++ b/client/utils.ts
@@ -111,3 +111,19 @@ export function isCIAB( partner: string ): boolean {
 
 	return /\/ciab/.test( redirectTo ) || ( isAuth && service === partner );
 }
+
+export function sortLoginButtons< T extends { service: string } >( buttons: T[] ): T[] {
+	if ( ! isCIAB( 'paypal' ) ) {
+		return buttons;
+	}
+
+	return buttons.toSorted( ( a, b ) => {
+		if ( a.service === 'paypal' ) {
+			return -1;
+		}
+		if ( b.service === 'paypal' ) {
+			return 1;
+		}
+		return 0;
+	} );
+}


### PR DESCRIPTION
DOTMSD-881

## Proposed Changes

* When trying to access a CIAB-specific route, adjust login/register headings to be CIAB-specific and put the PayPal login option at the top.

## Testing Instructions

* Follow the steps in #106969
* Visit /ciab when logged out and switch between logging in and creating a user to confirm the titles are CIAB-specific and the PayPal login option is at the top of the list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
