### PR TITLE
Adapter for yjs that uses pinghub for all websockets connections

### DIFF
--- a/client/server/index.js
+++ b/client/server/index.js
@@ -5,6 +5,7 @@ import fs from 'fs';
 import config from '@automattic/calypso-config';
 import boot from './boot';
 import { getLogger } from './lib/logger';
+import { startRTCWebSocketServer } from './websocket/rtc-websocket-server';
 const logger = getLogger();
 const start = Date.now();
 
@@ -83,4 +84,9 @@ process.on( 'uncaughtExceptionMonitor', ( err ) => {
 server.listen( { port, host: process.env.CALYPSO_IS_FORK ? host : null }, function () {
 	// Tell the parent process that Calypso has booted.
 	sendBootStatus( 'ready' );
+
+	// Start RTC WebSocket server if enabled
+	startRTCWebSocketServer().catch( ( error ) => {
+		logger.error( 'Failed to start RTC WebSocket server:', error );
+	} );
 } );

--- a/client/server/websocket/rtc-websocket-server.js
+++ b/client/server/websocket/rtc-websocket-server.js
@@ -1,0 +1,284 @@
+/**
+ * Real-Time Collaboration WebSocket Server
+ *
+ * This module implements a WebSocket server for real-time collaborative editing
+ * based on the VIP RTC implementation. It uses YJS for operational transforms
+ * and JWT tokens for authentication.
+ */
+
+import http from 'http';
+import config from '@automattic/calypso-config';
+import { setPersistence, setupWSConnection } from '@y/websocket-server/utils';
+import jwt from 'jsonwebtoken';
+import { WebSocketServer } from 'ws';
+import { getLogger } from '../lib/logger';
+
+const logger = getLogger();
+
+// Use a dummy shared secret for development - replace with real secret in production
+const JWT_SECRET = process.env.RTC_WEBSOCKET_SECRET || 'dummy-dev-secret-replace-in-production';
+const WEBSOCKET_PORT = 3001; // Default port, can be overridden
+const CONNECTION_TIMEOUT = 4 * 60 * 60 * 1000; // 4 hours in ms
+
+/**
+ * Types for TypeScript-style JSDoc
+ * @typedef {Object} AuthSuccessResult
+ * @property {true} authenticated
+ *
+ * @typedef {Object} AuthFailureResult
+ * @property {false} authenticated
+ * @property {'missing_token'|'invalid_token'|'invalid_payload'} reason
+ *
+ * @typedef {AuthSuccessResult|AuthFailureResult} AuthResult
+ *
+ * @typedef {Object} SyncTokenPayload
+ * @property {number} user_id
+ * @property {string} username
+ * @property {string} room_name
+ * @property {string} connection_id
+ * @property {number} iat - issued at
+ * @property {number} exp - expires at
+ */
+
+/**
+ * WebSocket close codes and their meanings
+ */
+const WEBSOCKET_CLOSE_CODES = new Map( [ [ 4001, 'Connection timed out. Reconnect.' ] ] );
+
+/**
+ * Simple in-memory persistence provider that doesn't actually persist.
+ * In WP's RTC implementation, yjs doc state is managed on the clients with
+ * the server just serving as a stateless data transport.
+ */
+class NoopPersistenceProvider {
+	constructor() {
+		this.docs = new Map();
+	}
+
+	bindState( docName, ydoc ) {
+		// Store in memory but don't persist to disk
+		this.docs.set( docName, ydoc );
+	}
+
+	writeState( /* docName, ydoc */ ) {
+		// Noop - we're not persisting anything
+		return Promise.resolve();
+	}
+}
+
+/**
+ * Validates if an object is a valid sync token payload
+ * @param {unknown} payload
+ * @returns {payload is SyncTokenPayload}
+ */
+function isSyncTokenPayload( payload ) {
+	return (
+		typeof payload === 'object' &&
+		payload !== null &&
+		'user_id' in payload &&
+		'username' in payload &&
+		'room_name' in payload &&
+		'connection_id' in payload
+	);
+}
+
+/**
+ * Verifies and decodes JWT token
+ * @param {string} token
+ * @returns {SyncTokenPayload}
+ * @throws {Error} If token is invalid
+ */
+function verifyToken( token ) {
+	const jwtPayload = jwt.verify( token, JWT_SECRET );
+	if ( ! isSyncTokenPayload( jwtPayload ) ) {
+		throw new Error( 'Invalid JWT payload' );
+	}
+	return jwtPayload;
+}
+
+/**
+ * Extracts connection ID from request
+ * @param {http.IncomingMessage} request
+ * @returns {string|null}
+ */
+function getConnectionId( request ) {
+	const searchParams = new URLSearchParams( request.url?.split( '?' )[ 1 ] || '' );
+	const authToken = searchParams.get( 'auth' );
+	if ( ! authToken ) {
+		return null;
+	}
+
+	try {
+		const jwtPayload = verifyToken( authToken );
+		return jwtPayload.connection_id;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Gets the pathname from a request URL
+ * @param {http.IncomingMessage} request
+ * @returns {string}
+ */
+function getRequestPathname( request ) {
+	const pathname = request.url?.split( '?' )[ 0 ] || '/';
+	// Remove trailing slashes (except for root path)
+	return pathname === '/' ? pathname : pathname.replace( /\/+$/, '' );
+}
+
+/**
+ * Validates that the room_name in the JWT payload matches the request URL
+ * @param {http.IncomingMessage} request
+ * @param {SyncTokenPayload} jwtPayload
+ * @returns {boolean}
+ */
+function validateTokenPayload( request, jwtPayload ) {
+	const { room_name: roomNameFromToken } = jwtPayload;
+	const pathname = getRequestPathname( request );
+	const roomNameFromUrl = pathname.replace( /^\/(_ws\/)?/, '' );
+
+	const isValid = roomNameFromToken === roomNameFromUrl;
+	if ( ! isValid ) {
+		logger.warn( 'JWT decoded but payload invalid:', {
+			roomNameFromToken,
+			roomNameFromUrl,
+			pathname,
+		} );
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Authenticates a WebSocket request
+ * @param {http.IncomingMessage} request
+ * @returns {AuthResult}
+ */
+function isRequestAuthenticated( request ) {
+	const searchParams = new URLSearchParams( request.url?.split( '?' )[ 1 ] || '' );
+	const authToken = searchParams.get( 'auth' );
+
+	if ( ! authToken ) {
+		return { authenticated: false, reason: 'missing_token' };
+	}
+
+	try {
+		const jwtPayload = verifyToken( authToken );
+		const isValid = validateTokenPayload( request, jwtPayload );
+		if ( ! isValid ) {
+			return { authenticated: false, reason: 'invalid_payload' };
+		}
+		return { authenticated: true };
+	} catch ( error ) {
+		logger.warn( 'Token verification failed:', error.message );
+		return { authenticated: false, reason: 'invalid_token' };
+	}
+}
+
+/**
+ * Creates and starts the WebSocket server
+ * @returns {Promise<{server: http.Server, wss: WebSocketServer}>}
+ */
+async function createRTCWebSocketServer() {
+	// Initialize YJS persistence provider
+	setPersistence( new NoopPersistenceProvider() );
+
+	// Create WebSocket server
+	const wss = new WebSocketServer( { noServer: true } );
+
+	// Create HTTP server for WebSocket upgrades and health checks
+	const server = http.createServer( ( request, response ) => {
+		const pathname = getRequestPathname( request );
+
+		if ( [ '/cache-healthcheck', '/health', '/ready' ].includes( pathname ) ) {
+			response.writeHead( 200, { 'Content-Type': 'text/plain' } );
+			response.end( 'OK' );
+			return;
+		}
+
+		response.writeHead( 404, { 'Content-Type': 'text/plain' } );
+		response.end( 'Not Found' );
+	} );
+
+	// Handle WebSocket connections
+	wss.on( 'connection', ( ws, request ) => {
+		const connectionStartTime = Date.now();
+		const connectionId = getConnectionId( request );
+
+		logger.info( 'WebSocket connection established', { connectionId } );
+
+		// Set up YJS WebSocket connection
+		setupWSConnection( ws, request );
+
+		// Set connection timeout
+		const timeout = setTimeout( () => {
+			logger.info( 'WebSocket connection timeout', { connectionId } );
+			ws.close( 4001, WEBSOCKET_CLOSE_CODES.get( 4001 ) );
+		}, CONNECTION_TIMEOUT );
+
+		// Handle connection close
+		ws.on( 'close', ( code ) => {
+			clearTimeout( timeout );
+			const duration = Date.now() - connectionStartTime;
+			logger.info( 'WebSocket connection closed', {
+				connectionId,
+				code,
+				duration: `${ duration }ms`,
+			} );
+		} );
+
+		// Handle errors
+		ws.on( 'error', ( error ) => {
+			logger.error( 'WebSocket error:', error, { connectionId } );
+		} );
+	} );
+
+	// Handle WebSocket upgrade requests
+	server.on( 'upgrade', ( request, socket, head ) => {
+		const authResult = isRequestAuthenticated( request );
+		if ( ! authResult.authenticated ) {
+			logger.warn( 'WebSocket authentication failed', { reason: authResult.reason } );
+			socket.write( 'HTTP/1.1 401 Unauthorized\r\n\r\n' );
+			socket.destroy();
+			return;
+		}
+
+		wss.handleUpgrade( request, socket, head, ( ws ) => {
+			wss.emit( 'connection', ws, request );
+		} );
+	} );
+
+	return { server, wss };
+}
+
+/**
+ * Starts the RTC WebSocket server if the feature is enabled
+ * @returns {Promise<void>}
+ */
+async function startRTCWebSocketServer() {
+	if ( ! config.isEnabled( 'rtc-websocket' ) ) {
+		logger.info( 'RTC WebSocket server disabled via feature flag' );
+		return;
+	}
+
+	try {
+		const { server } = await createRTCWebSocketServer();
+
+		const port = process.env.RTC_WEBSOCKET_PORT || WEBSOCKET_PORT;
+		const host = process.env.RTC_WEBSOCKET_HOST || 'localhost';
+
+		server.listen( port, host, () => {
+			logger.info( `RTC WebSocket server running at ws://${ host }:${ port }` );
+		} );
+
+		// Handle server errors
+		server.on( 'error', ( error ) => {
+			logger.error( 'RTC WebSocket server error:', error );
+		} );
+	} catch ( error ) {
+		logger.error( 'Failed to start RTC WebSocket server:', error );
+	}
+}
+
+export { startRTCWebSocketServer, createRTCWebSocketServer };

--- a/client/server/websocket/test-token-generator.js
+++ b/client/server/websocket/test-token-generator.js
@@ -1,0 +1,66 @@
+/**
+ * Test Token Generator for RTC WebSocket Server
+ *
+ * This utility generates JWT tokens for testing the RTC WebSocket server.
+ * Usage: node test-token-generator.js [room_name] [user_id] [username]
+ */
+
+import jwt from 'jsonwebtoken';
+
+// Use the same dummy secret as the server
+const JWT_SECRET = process.env.RTC_WEBSOCKET_SECRET || 'dummy-dev-secret-replace-in-production';
+
+/**
+ * Generates a test JWT token for WebSocket authentication
+ * @param {string} roomName - The room/document name
+ * @param {number} userId - User ID
+ * @param {string} username - Username
+ * @returns {string} JWT token
+ */
+function generateTestToken( roomName = 'test-document', userId = 1, username = 'testuser' ) {
+	const payload = {
+		user_id: userId,
+		username: username,
+		room_name: roomName,
+		connection_id: `conn_${ Date.now() }_${ Math.random().toString( 36 ).substr( 2, 9 ) }`,
+		iat: Math.floor( Date.now() / 1000 ),
+		exp: Math.floor( Date.now() / 1000 ) + 4 * 60 * 60, // 4 hours
+	};
+
+	const token = jwt.sign( payload, JWT_SECRET );
+	return token;
+}
+
+/**
+ * Main function for CLI usage
+ */
+function main() {
+	const args = process.argv.slice( 2 );
+	const roomName = args[ 0 ] || 'test-document';
+	const userId = parseInt( args[ 1 ] ) || 1;
+	const username = args[ 2 ] || 'testuser';
+
+	const token = generateTestToken( roomName, userId, username );
+
+	console.log( 'Generated JWT token for WebSocket testing:' );
+	console.log( '' );
+	console.log( 'Room Name:', roomName );
+	console.log( 'User ID:', userId );
+	console.log( 'Username:', username );
+	console.log( '' );
+	console.log( 'Token:' );
+	console.log( token );
+	console.log( '' );
+	console.log( 'WebSocket URL example:' );
+	console.log( `ws://localhost:3001/${ roomName }?auth=${ token }` );
+	console.log( '' );
+	console.log( 'Test with wscat:' );
+	console.log( `wscat -c "ws://localhost:3001/${ roomName }?auth=${ token }"` );
+}
+
+// Run main function if this script is executed directly
+if ( import.meta.url === `file://${ process.argv[ 1 ] }` ) {
+	main();
+}
+
+export { generateTestToken };

--- a/config/development.json
+++ b/config/development.json
@@ -158,6 +158,7 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
+		"rtc-websocket": true,
 		"reader": true,
 		"reader/comment-polling": false,
 		"reader/full-errors": true,

--- a/package.json
+++ b/package.json
@@ -235,7 +235,9 @@
 		"react-modal": "^3.16.3",
 		"redux": "^5.0.1",
 		"swiper": "^10.3.1",
-		"wpcom": "workspace:^"
+		"wpcom": "workspace:^",
+		"ws": "^8.18.2",
+		"yjs": "^13.6.27"
 	},
 	"optionalDependencies": {
 		"fsevents": "^2.3.3"
@@ -260,13 +262,16 @@
 		"@types/ga-gtag": "^1.2.0",
 		"@types/gtag.js": "^0.0.20",
 		"@types/jest-when": "^3.5.5",
+		"@types/jsonwebtoken": "^9.0.10",
 		"@types/superagent": "^4.1.24",
 		"@types/wordpress__blocks": "^12.5.17",
+		"@types/ws": "^8.5.0",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"@typescript-eslint/parser": "^6.21.0",
 		"@wordpress/eslint-plugin": "^22.9.0",
 		"@wordpress/prettier-config": "^4.23.0",
 		"@wordpress/stylelint-config": "^23.15.0",
+		"@y/websocket-server": "^0.1.1",
 		"babel-loader": "^8.2.3",
 		"bunyan": "^1.8.15",
 		"chalk": "^4.1.2",
@@ -296,6 +301,7 @@
 		"jest-canvas-mock": "^2.5.2",
 		"jest-environment-jsdom": "^29.7.0",
 		"jest-teamcity": "^1.12.0",
+		"jsonwebtoken": "^9.0.2",
 		"loader-utils": "^1.4.2",
 		"lunr": "^2.3.9",
 		"mixedindentlint": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10361,6 +10361,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jsonwebtoken@npm:^9.0.10":
+  version: 9.0.10
+  resolution: "@types/jsonwebtoken@npm:9.0.10"
+  dependencies:
+    "@types/ms": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 0688ac8fb75f809201cb7e18a12b9d80ce539cb9dd27e1b01e11807cb1a337059e899b8ee3abc3f2c9417f02e363a3069d9eab9ef9724b1da1f0e10713514f94
+  languageName: node
+  linkType: hard
+
 "@types/keyv@npm:*, @types/keyv@npm:^3.1.1":
   version: 3.1.1
   resolution: "@types/keyv@npm:3.1.1"
@@ -10928,6 +10938,15 @@ __metadata:
   version: 3.0.0
   resolution: "@types/wrap-ansi@npm:3.0.0"
   checksum: 8d8f53363f360f38135301a06b596c295433ad01debd082078c33c6ed98b05a5c8fe8853a88265432126096084f4a135ec1564e3daad631b83296905509f90b3
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.5.0":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 
@@ -13353,6 +13372,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@y/websocket-server@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@y/websocket-server@npm:0.1.1"
+  dependencies:
+    lib0: "npm:^0.2.102"
+    ws: "npm:^6.2.1"
+    y-leveldb: "npm:^0.1.0"
+    y-protocols: "npm:^1.0.5"
+  peerDependencies:
+    yjs: ^13.5.6
+  dependenciesMeta:
+    ws:
+      optional: true
+    y-leveldb:
+      optional: true
+  bin:
+    y-websocket: src/server.js
+    y-websocket-server: src/server.js
+  checksum: 3623519e43fdf8dabd93a49c28fd95a0a2a09c515d9dff3f87a460e6583ab6ad1d2678ae9cb78b8e00c131c3f1f4a277d2028e1b0ed4eab5a56169b087759cef
+  languageName: node
+  linkType: hard
+
 "@zip.js/zip.js@npm:2.7.57":
   version: 2.7.57
   resolution: "@zip.js/zip.js@npm:2.7.57"
@@ -13414,6 +13455,32 @@ __metadata:
   dependencies:
     event-target-shim: "npm:^5.0.0"
   checksum: 90ccc50f010250152509a344eb2e71977fbf8db0ab8f1061197e3275ddf6c61a41a6edfd7b9409c664513131dd96e962065415325ef23efa5db931b382d24ca5
+  languageName: node
+  linkType: hard
+
+"abstract-leveldown@npm:^6.2.1":
+  version: 6.3.0
+  resolution: "abstract-leveldown@npm:6.3.0"
+  dependencies:
+    buffer: "npm:^5.5.0"
+    immediate: "npm:^3.2.3"
+    level-concat-iterator: "npm:~2.0.0"
+    level-supports: "npm:~1.0.0"
+    xtend: "npm:~4.0.0"
+  checksum: 441c7e6765b6c2e9a36999e2bda3f4421d09348c0e925e284d873bcbf5ecad809788c9eda416aed37fe5b6e6a9e75af6e27142d1fcba460b8757d70028e307b1
+  languageName: node
+  linkType: hard
+
+"abstract-leveldown@npm:~6.2.1, abstract-leveldown@npm:~6.2.3":
+  version: 6.2.3
+  resolution: "abstract-leveldown@npm:6.2.3"
+  dependencies:
+    buffer: "npm:^5.5.0"
+    immediate: "npm:^3.2.3"
+    level-concat-iterator: "npm:~2.0.0"
+    level-supports: "npm:~1.0.0"
+    xtend: "npm:~4.0.0"
+  checksum: a7994531a4618a409ee016dabf132014be9a2d07a3438f835c1eb5607f77f6cf12abc437e8f5bff353b1d8dcb31628c8ae65b41e7533bf606c6f7213ab61c1d1
   languageName: node
   linkType: hard
 
@@ -14256,6 +14323,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-limiter@npm:~1.0.0":
+  version: 1.0.1
+  resolution: "async-limiter@npm:1.0.1"
+  checksum: 0693d378cfe86842a70d4c849595a0bb50dc44c11649640ca982fa90cbfc74e3cc4753b5a0847e51933f2e9c65ce8e05576e75e5e1fd963a086e673735b35969
+  languageName: node
+  linkType: hard
+
 "async-lock@npm:1.4.1, async-lock@npm:^1.4.1":
   version: 1.4.1
   resolution: "async-lock@npm:1.4.1"
@@ -14923,7 +14997,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.1.0, buffer@npm:^5.5.0":
+"buffer@npm:^5.1.0, buffer@npm:^5.5.0, buffer@npm:^5.6.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
@@ -18070,6 +18144,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deferred-leveldown@npm:~5.3.0":
+  version: 5.3.0
+  resolution: "deferred-leveldown@npm:5.3.0"
+  dependencies:
+    abstract-leveldown: "npm:~6.2.1"
+    inherits: "npm:^2.0.3"
+  checksum: b1021314bfd5875b10e4c8c69429a69d37affc79df53aedf3c18a4bcd7460619220fa6b1bc309bcd85851c2c9c2b4da6cb03127abc08b715ff56da8aeae6b74f
+  languageName: node
+  linkType: hard
+
 "define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.4":
   version: 1.1.4
   resolution: "define-data-property@npm:1.1.4"
@@ -18981,6 +19065,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encoding-down@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "encoding-down@npm:6.3.0"
+  dependencies:
+    abstract-leveldown: "npm:^6.2.1"
+    inherits: "npm:^2.0.3"
+    level-codec: "npm:^9.0.0"
+    level-errors: "npm:^2.0.0"
+  checksum: f7e92149863863c11e04d71ceb71baa1772270dc9ef15cbdbb155fed0a7d31c823682e043af3100f96ce8ab2e0a70a2464c1fa4902d4dce9a0584498f40d07bf
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.12, encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -19105,6 +19201,17 @@ __metadata:
   bin:
     errno: ./cli.js
   checksum: 184fac1d706e074cb88d8e7ff62617a91c9839e9edf9e9c1ba0a315820c7e05c2299fd71c20c8f20017872debd86f7a2d4c48f72a5d33c4f0f9d9d9892d222da
+  languageName: node
+  linkType: hard
+
+"errno@npm:~0.1.1":
+  version: 0.1.8
+  resolution: "errno@npm:0.1.8"
+  dependencies:
+    prr: "npm:~1.0.1"
+  bin:
+    errno: cli.js
+  checksum: 83758951967ec57bf00b5f5b7dc797e6d65a6171e57ea57adcf1bd1a0b477fd9b5b35fae5be1ff18f4090ed156bce1db749fe7e317aac19d485a5d150f6a4936
   languageName: node
   linkType: hard
 
@@ -22785,6 +22892,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immediate@npm:^3.2.3":
+  version: 3.3.0
+  resolution: "immediate@npm:3.3.0"
+  checksum: 40eab095d5944ad79af054700beee97000271fde8743720932d8eb41ccbf2cb8c855ff95b128cf9a7fec523a4f11ee2e392b9f2fa6456b055b1160f1b4ad3e3b
+  languageName: node
+  linkType: hard
+
 "immer@npm:^9.0.7":
   version: 9.0.21
   resolution: "immer@npm:9.0.21"
@@ -25057,6 +25171,109 @@ __metadata:
   languageName: node
   linkType: hard
 
+"level-codec@npm:^9.0.0":
+  version: 9.0.2
+  resolution: "level-codec@npm:9.0.2"
+  dependencies:
+    buffer: "npm:^5.6.0"
+  checksum: 38a7eb8beed37969ad93160251d5be8e667d4ea0ee199d5e72e61739e552987a71acaa2daa1d2dbc7541f0cfb64e2bd8b50c3d8757cfa41468d8631aa45cc0eb
+  languageName: node
+  linkType: hard
+
+"level-concat-iterator@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "level-concat-iterator@npm:2.0.1"
+  checksum: b0a55ec63137b159fdb69204fbac02f33fbfbaa61563db21121300f6da6a35dd4654dc872df6ca1067c0ca4f98074ccbb59c28044d0043600a940a506c3d4a71
+  languageName: node
+  linkType: hard
+
+"level-errors@npm:^2.0.0, level-errors@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "level-errors@npm:2.0.1"
+  dependencies:
+    errno: "npm:~0.1.1"
+  checksum: 9e664afb98febe22e6ccde063be85e2b6e472414325bea87f0b2288bec589ef97658028f8654dc4716a06cda15c205e910b6cf5eb3906ed3ca06ea84d370002f
+  languageName: node
+  linkType: hard
+
+"level-iterator-stream@npm:~4.0.0":
+  version: 4.0.2
+  resolution: "level-iterator-stream@npm:4.0.2"
+  dependencies:
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:^3.4.0"
+    xtend: "npm:^4.0.2"
+  checksum: 29994d5449428c246dc7d983220ca333ddaaa9e0fe9a664bb23750693db6cff4be62e8e31b6e8a0e1057c09a94580b965206c048701f96c3e8e97720a3c1e7c8
+  languageName: node
+  linkType: hard
+
+"level-js@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "level-js@npm:5.0.2"
+  dependencies:
+    abstract-leveldown: "npm:~6.2.3"
+    buffer: "npm:^5.5.0"
+    inherits: "npm:^2.0.3"
+    ltgt: "npm:^2.1.2"
+  checksum: 2f5ccc96541ee9191bb9f8fd970918ade426d3dbb68e0414267a3c204d04952ef72651be241d40579dcb178948c14be5c36758da99df76a04a31d6227949f8a6
+  languageName: node
+  linkType: hard
+
+"level-packager@npm:^5.1.0":
+  version: 5.1.1
+  resolution: "level-packager@npm:5.1.1"
+  dependencies:
+    encoding-down: "npm:^6.3.0"
+    levelup: "npm:^4.3.2"
+  checksum: dc3ad1d3bc1fc85154ab85ac8220ffc7ff4da7b2be725c53ea8716780a2ef37d392c7dffae769a0419341f19febe78d86da998981b4ba3be673db1cb95051e95
+  languageName: node
+  linkType: hard
+
+"level-supports@npm:~1.0.0":
+  version: 1.0.1
+  resolution: "level-supports@npm:1.0.1"
+  dependencies:
+    xtend: "npm:^4.0.2"
+  checksum: 6e8eb2be4c2c55e04e71dff831421a81d95df571e0004b6e6e0cee8421e792e22b3ab94ecaa925dc626164f442185b2e2bfb5d52b257d1639f8f9da8714c8335
+  languageName: node
+  linkType: hard
+
+"level@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "level@npm:6.0.1"
+  dependencies:
+    level-js: "npm:^5.0.0"
+    level-packager: "npm:^5.1.0"
+    leveldown: "npm:^5.4.0"
+  checksum: 275068a7c58e6fd3eb53be2eeaf90d6ba6d566904591b68fe10022affc16b28575a2ccf580f384d38ea64c116b2c8046e517a34a0c3b5da12c635a4732eccf6d
+  languageName: node
+  linkType: hard
+
+"leveldown@npm:^5.4.0":
+  version: 5.6.0
+  resolution: "leveldown@npm:5.6.0"
+  dependencies:
+    abstract-leveldown: "npm:~6.2.1"
+    napi-macros: "npm:~2.0.0"
+    node-gyp: "npm:latest"
+    node-gyp-build: "npm:~4.1.0"
+  checksum: d5c4569aca5a856da4012ecaf507a7ba3e28ef18bde000a1826bf7a485357ddd18ea9ea335e94b9f12274d19b9b7d28d3268ac330f2e96d0067115edf8dc3396
+  languageName: node
+  linkType: hard
+
+"levelup@npm:^4.3.2":
+  version: 4.4.0
+  resolution: "levelup@npm:4.4.0"
+  dependencies:
+    deferred-leveldown: "npm:~5.3.0"
+    level-errors: "npm:~2.0.0"
+    level-iterator-stream: "npm:~4.0.0"
+    level-supports: "npm:~1.0.0"
+    xtend: "npm:~4.0.0"
+  checksum: e67eeb72cf10face92f73527b63ea0754bc3ab7ced76f8bf909fb51db1a2e687e2206415807c2de6862902eb00046e5bf34d64d587e3892d4cb89db687c2a957
+  languageName: node
+  linkType: hard
+
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -25081,6 +25298,19 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:~0.4.0"
   checksum: effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
+  languageName: node
+  linkType: hard
+
+"lib0@npm:^0.2.102, lib0@npm:^0.2.31, lib0@npm:^0.2.99":
+  version: 0.2.114
+  resolution: "lib0@npm:0.2.114"
+  dependencies:
+    isomorphic.js: "npm:^0.2.4"
+  bin:
+    0ecdsa-generate-keypair: bin/0ecdsa-generate-keypair.js
+    0gentesthtml: bin/gentesthtml.js
+    0serve: bin/0serve.js
+  checksum: 3edaebb4ac80da164dfc097720a610bba4d08f44dc60ecb186aa42924d8e67679c12a6b7415eaffc07c47f1fbddccb15fd925bee7745c7aef16ab1a1e0a3cdc0
   languageName: node
   linkType: hard
 
@@ -25694,6 +25924,13 @@ __metadata:
   dependencies:
     inherits: "npm:^2.0.1"
   checksum: b05d4bece5eca2251252034932dfb660a52efe9bd512951c52623f4e3b8f05ae91b7776c559dfe36946b81dc0d8c35245d258cd82d2fdef5b9dd9d9616c7ea19
+  languageName: node
+  linkType: hard
+
+"ltgt@npm:^2.1.2":
+  version: 2.2.1
+  resolution: "ltgt@npm:2.2.1"
+  checksum: 60fdad732c3aa6acf37e927a5ef58c0d1776192321d55faa1f8775c134c27fbf20ef8ec542fb7f7f33033f79c2a2df75cac39b43e274b32e9d95400154cd41f3
   languageName: node
   linkType: hard
 
@@ -27712,6 +27949,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"napi-macros@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "napi-macros@npm:2.0.0"
+  checksum: 583ef5084b43e49a12488cdcd4c5142f11e114e249b359161579b64f06776ed523c209d96e4ee2689e2e824c92445d0f529d817cc153f7cec549210296ec4be6
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -27895,6 +28139,17 @@ __metadata:
     node-gyp-build-optional: optional.js
     node-gyp-build-test: build-test.js
   checksum: 4ca30ae1f7ba570cd33ae6b71c7e3eb249c3901c0b8a02014cfe2ce18f7f23df621c8d087868973e4f32c90b1c4ad753b4dff1d8bf54666a3f848f414828c14f
+  languageName: node
+  linkType: hard
+
+"node-gyp-build@npm:~4.1.0":
+  version: 4.1.1
+  resolution: "node-gyp-build@npm:4.1.1"
+  bin:
+    node-gyp-build: ./bin.js
+    node-gyp-build-optional: ./optional.js
+    node-gyp-build-test: ./build-test.js
+  checksum: 8c652daa855612c9ed8aa95dca5e7dc34d72f3849ef415412aef261e44956c0d73ba197401be5c605a709e47fbaa80c76bb31ce29c6bba4f829efbaf457b4698
   languageName: node
   linkType: hard
 
@@ -38436,6 +38691,7 @@ __metadata:
     "@types/gtag.js": "npm:^0.0.20"
     "@types/jest": "npm:^29.5.14"
     "@types/jest-when": "npm:^3.5.5"
+    "@types/jsonwebtoken": "npm:^9.0.10"
     "@types/lodash": "npm:^4.17.17"
     "@types/node": "npm:^22.15.3"
     "@types/page": "npm:^1.11.9"
@@ -38449,6 +38705,7 @@ __metadata:
     "@types/webpack-env": "npm:^1.18.8"
     "@types/wordpress__block-editor": "npm:^11.5.16"
     "@types/wordpress__blocks": "npm:^12.5.17"
+    "@types/ws": "npm:^8.5.0"
     "@typescript-eslint/eslint-plugin": "npm:^6.21.0"
     "@typescript-eslint/parser": "npm:^6.21.0"
     "@vgs/collect-js": "npm:^0.7.2"
@@ -38477,6 +38734,7 @@ __metadata:
     "@wordpress/url": "npm:^4.23.0"
     "@wordpress/viewport": "npm:^6.23.0"
     "@wp-playground/client": "npm:^1.1.0"
+    "@y/websocket-server": "npm:^0.1.1"
     animate.css: "npm:^4.1.1"
     babel-loader: "npm:^8.2.3"
     browserslist: "npm:^4.24.5"
@@ -38518,6 +38776,7 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     jest-teamcity: "npm:^1.12.0"
     jsdom: "npm:^20.0.3"
+    jsonwebtoken: "npm:^9.0.2"
     loader-utils: "npm:^1.4.2"
     lodash: "npm:^4.17.21"
     lottie-web: "npm:^5.9.6"
@@ -38559,7 +38818,9 @@ __metadata:
     webpack-dev-middleware: "npm:^5.3.4"
     whybundled: "npm:^2.0.0"
     wpcom: "workspace:^"
+    ws: "npm:^8.18.2"
     yargs: "npm:^17.0.1"
+    yjs: "npm:^13.6.27"
   dependenciesMeta:
     "@react-spring/core@9.3.0":
       built: false
@@ -38793,6 +39054,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:^6.2.1":
+  version: 6.2.3
+  resolution: "ws@npm:6.2.3"
+  dependencies:
+    async-limiter: "npm:~1.0.0"
+  checksum: 56a35b9799993cea7ce2260197e7879f21bbbb194a967f31acbbda6f7f46ecda4365951966fb062044c95197e19fb2f053be6f65c172435455186835f494de41
+  languageName: node
+  linkType: hard
+
 "ws@npm:^7.2.0, ws@npm:^7.3.1, ws@npm:^7.5.10":
   version: 7.5.10
   resolution: "ws@npm:7.5.10"
@@ -38805,6 +39075,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.2":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
   languageName: node
   linkType: hard
 
@@ -38865,7 +39150,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:^4.0.0, xtend@npm:^4.0.1, xtend@npm:~4.0.0, xtend@npm:~4.0.1":
+"xtend@npm:^4.0.0, xtend@npm:^4.0.1, xtend@npm:^4.0.2, xtend@npm:~4.0.0, xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 366ae4783eec6100f8a02dff02ac907bf29f9a00b82ac0264b4d8b832ead18306797e283cf19de776538babfdcb2101375ec5646b59f08c52128ac4ab812ed0e
@@ -38880,6 +39165,18 @@ __metadata:
   peerDependencies:
     yjs: ^13.0.0
   checksum: 2968254276535daa476048a51056942019a92746507146b7322cf577a02aaca047aa81a54121832a2233c48c8c0bd53bdb28050ef60dc8164e54160190f2b22c
+  languageName: node
+  linkType: hard
+
+"y-leveldb@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "y-leveldb@npm:0.1.2"
+  dependencies:
+    level: "npm:^6.0.1"
+    lib0: "npm:^0.2.31"
+  peerDependencies:
+    yjs: ^13.0.0
+  checksum: c1bc82a7ac31406c36b41dcb7a01273323f8b353dec289512c1116cc4df54673ee112c0546b49b6431be4918c8267a3aeb891ba727a7adef8638eb4baa83fa57
   languageName: node
   linkType: hard
 
@@ -39033,6 +39330,15 @@ __metadata:
     buffer-crc32: "npm:~0.2.3"
     fd-slicer: "npm:~1.1.0"
   checksum: f265002af7541b9ec3589a27f5fb8f11cf348b53cc15e2751272e3c062cd73f3e715bc72d43257de71bbaecae446c3f1b14af7559e8ab0261625375541816422
+  languageName: node
+  linkType: hard
+
+"yjs@npm:^13.6.27":
+  version: 13.6.27
+  resolution: "yjs@npm:13.6.27"
+  dependencies:
+    lib0: "npm:^0.2.99"
+  checksum: f89520fed12816f9e56db0626189e39c9b913e51d24233c3190ceadee9913fc013f438b7cd0a945f2c151ab76e7474eca9d95631e32fdbe581b151ad14afeaae
   languageName: node
   linkType: hard
 

--- a/yjs-pinghub-adapter.js
+++ b/yjs-pinghub-adapter.js
@@ -1,0 +1,436 @@
+/**
+ * YJS-Pinghub Adapter
+ *
+ * This adapter allows YJS documents to use Pinghub as the WebSocket transport
+ * instead of the standard y-websocket implementation. It translates between
+ * YJS binary operational transform messages and Pinghub's JSON message format.
+ */
+
+import * as Y from 'yjs';
+
+/**
+ * YJS-Pinghub Adapter Class
+ *
+ * Bridges YJS collaborative editing with Pinghub's proven WebSocket infrastructure
+ */
+export class YjsPinghubAdapter {
+	/**
+	 * @param {string} pinghubChannel - Channel path like "/rtc/site-123/doc-456"
+	 * @param {Y.Doc} ydoc - YJS document instance
+	 * @param {Object} options - Configuration options
+	 */
+	constructor( pinghubChannel, ydoc, options = {} ) {
+		this.channel = pinghubChannel;
+		this.doc = ydoc;
+		this.options = {
+			pinghubUrl: options.pinghubUrl || '/pinghub',
+			reconnectDelay: options.reconnectDelay || 1000,
+			maxReconnectAttempts: options.maxReconnectAttempts || 10,
+			...options,
+		};
+
+		// Connection state
+		this.ws = null;
+		this.isConnected = false;
+		this.reconnectAttempts = 0;
+		this.reconnectTimer = null;
+
+		// YJS awareness for cursor/selection tracking
+		this.awareness = new Y.YAwareness( this.doc );
+
+		// Message queues
+		this.pendingMessages = [];
+		this.isInitialSyncComplete = false;
+
+		// Bind methods
+		this.handlePinghubMessage = this.handlePinghubMessage.bind( this );
+		this.handleYjsUpdate = this.handleYjsUpdate.bind( this );
+		this.handleAwarenessUpdate = this.handleAwarenessUpdate.bind( this );
+		this.handleConnectionOpen = this.handleConnectionOpen.bind( this );
+		this.handleConnectionClose = this.handleConnectionClose.bind( this );
+		this.handleConnectionError = this.handleConnectionError.bind( this );
+
+		// Set up YJS event listeners
+		this.setupYjsListeners();
+
+		// Start connection
+		this.connect();
+	}
+
+	/**
+	 * Set up YJS document and awareness event listeners
+	 */
+	setupYjsListeners() {
+		// Listen for document updates (actual content changes)
+		this.doc.on( 'update', this.handleYjsUpdate );
+
+		// Listen for awareness updates (cursors, selections, user presence)
+		this.awareness.on( 'update', this.handleAwarenessUpdate );
+
+		// Set local awareness state (user info, cursor color, etc.)
+		this.awareness.setLocalStateField( 'user', {
+			name: this.options.userName || 'Anonymous',
+			color: this.options.userColor || this.generateUserColor(),
+			colorLight: this.options.userColorLight || this.generateUserColor( true ),
+		} );
+	}
+
+	/**
+	 * Generate a random color for user cursors/selections
+	 * @param {boolean} light - Whether to generate a light variant
+	 * @returns {string} Hex color
+	 */
+	generateUserColor( light = false ) {
+		const hue = Math.floor( Math.random() * 360 );
+		const saturation = light ? 30 : 70;
+		const lightness = light ? 90 : 50;
+		return `hsl(${ hue }, ${ saturation }%, ${ lightness }%)`;
+	}
+
+	/**
+	 * Establish WebSocket connection to Pinghub
+	 */
+	connect() {
+		if ( this.ws ) {
+			return; // Already connected or connecting
+		}
+
+		const pinghubUrl = `${ this.options.pinghubUrl }${ this.channel }`;
+
+		console.log( `[YJS-Pinghub] Connecting to: ${ pinghubUrl }` );
+
+		try {
+			// For WordPress.com domains, cookies are automatically included
+			this.ws = new WebSocket(
+				pinghubUrl.startsWith( 'ws' ) ? pinghubUrl : `ws://${ window.location.host }${ pinghubUrl }`
+			);
+
+			// Set up event listeners
+			this.ws.addEventListener( 'open', this.handleConnectionOpen );
+			this.ws.addEventListener( 'message', this.handlePinghubMessage );
+			this.ws.addEventListener( 'close', this.handleConnectionClose );
+			this.ws.addEventListener( 'error', this.handleConnectionError );
+		} catch ( error ) {
+			console.error( '[YJS-Pinghub] Connection failed:', error );
+			this.scheduleReconnect();
+		}
+	}
+
+	/**
+	 * Handle WebSocket connection open
+	 */
+	handleConnectionOpen() {
+		console.log( '[YJS-Pinghub] Connected successfully' );
+		this.isConnected = true;
+		this.reconnectAttempts = 0;
+
+		// Send any pending messages
+		this.flushPendingMessages();
+
+		// Perform initial sync - send our current document state
+		this.sendInitialSync();
+
+		// Emit connection event for external listeners
+		this.emit( 'connected' );
+	}
+
+	/**
+	 * Handle WebSocket connection close
+	 * @param {CloseEvent} event
+	 */
+	handleConnectionClose( event ) {
+		console.log( `[YJS-Pinghub] Connection closed: ${ event.code } - ${ event.reason }` );
+		this.isConnected = false;
+		this.ws = null;
+
+		// Clear awareness state when disconnected
+		this.awareness.setLocalState( null );
+
+		// Schedule reconnection unless it was a clean close
+		if ( event.code !== 1000 ) {
+			this.scheduleReconnect();
+		}
+
+		this.emit( 'disconnected', event );
+	}
+
+	/**
+	 * Handle WebSocket connection error
+	 * @param {Event} error
+	 */
+	handleConnectionError( error ) {
+		console.error( '[YJS-Pinghub] Connection error:', error );
+		this.emit( 'error', error );
+	}
+
+	/**
+	 * Handle incoming messages from Pinghub
+	 * @param {MessageEvent} event
+	 */
+	handlePinghubMessage( event ) {
+		try {
+			const message = JSON.parse( event.data );
+
+			// Route different message types
+			switch ( message.type ) {
+				case 'yjs-update':
+					this.handleYjsUpdateMessage( message );
+					break;
+				case 'yjs-awareness':
+					this.handleYjsAwarenessMessage( message );
+					break;
+				case 'yjs-sync-request':
+					this.handleYjsSyncRequest( message );
+					break;
+				case 'yjs-sync-response':
+					this.handleYjsSyncResponse( message );
+					break;
+				default:
+					console.warn( '[YJS-Pinghub] Unknown message type:', message.type );
+			}
+		} catch ( error ) {
+			console.error( '[YJS-Pinghub] Failed to parse message:', error, event.data );
+		}
+	}
+
+	/**
+	 * Handle YJS document update from remote peer
+	 * @param {Object} message
+	 */
+	handleYjsUpdateMessage( message ) {
+		if ( message.clientId === this.doc.clientID ) {
+			return; // Ignore our own messages
+		}
+
+		try {
+			const update = new Uint8Array( message.update );
+			Y.applyUpdate( this.doc, update );
+		} catch ( error ) {
+			console.error( '[YJS-Pinghub] Failed to apply update:', error );
+		}
+	}
+
+	/**
+	 * Handle YJS awareness update from remote peer
+	 * @param {Object} message
+	 */
+	handleYjsAwarenessMessage( message ) {
+		if ( message.clientId === this.doc.clientID ) {
+			return; // Ignore our own messages
+		}
+
+		try {
+			const update = new Uint8Array( message.awarenessUpdate );
+			Y.YAwareness.applyAwarenessUpdate( this.awareness, update, message.clientId );
+		} catch ( error ) {
+			console.error( '[YJS-Pinghub] Failed to apply awareness update:', error );
+		}
+	}
+
+	/**
+	 * Handle sync request from remote peer
+	 * @param {Object} message
+	 */
+	handleYjsSyncRequest( message ) {
+		// Send our current document state to the requesting peer
+		const stateVector = Y.encodeStateVector( this.doc );
+		this.sendToPinghub( {
+			type: 'yjs-sync-response',
+			stateVector: Array.from( stateVector ),
+			clientId: this.doc.clientID,
+			requestId: message.requestId,
+		} );
+	}
+
+	/**
+	 * Handle sync response from remote peer
+	 * @param {Object} message
+	 */
+	handleYjsSyncResponse( message ) {
+		try {
+			const stateVector = new Uint8Array( message.stateVector );
+			const diff = Y.encodeStateAsUpdate( this.doc, stateVector );
+
+			if ( diff.length > 0 ) {
+				// Send missing updates to the peer
+				this.sendToPinghub( {
+					type: 'yjs-update',
+					update: Array.from( diff ),
+					clientId: this.doc.clientID,
+				} );
+			}
+		} catch ( error ) {
+			console.error( '[YJS-Pinghub] Failed to handle sync response:', error );
+		}
+	}
+
+	/**
+	 * Handle YJS document updates (outgoing)
+	 * @param {Uint8Array} update
+	 * @param {Object} origin
+	 */
+	handleYjsUpdate( update, origin ) {
+		// Don't send updates that originated from network
+		if ( origin === this ) {
+			return;
+		}
+
+		this.sendToPinghub( {
+			type: 'yjs-update',
+			update: Array.from( update ),
+			clientId: this.doc.clientID,
+		} );
+	}
+
+	/**
+	 * Handle YJS awareness updates (outgoing)
+	 * @param {Object} param0
+	 */
+	handleAwarenessUpdate( { added, updated, removed } ) {
+		const changedClients = added.concat( updated ).concat( removed );
+
+		if ( changedClients.includes( this.doc.clientID ) ) {
+			const update = Y.YAwareness.encodeAwarenessUpdate( this.awareness, changedClients );
+
+			this.sendToPinghub( {
+				type: 'yjs-awareness',
+				awarenessUpdate: Array.from( update ),
+				clientId: this.doc.clientID,
+			} );
+		}
+	}
+
+	/**
+	 * Send initial sync request to get current document state from peers
+	 */
+	sendInitialSync() {
+		this.sendToPinghub( {
+			type: 'yjs-sync-request',
+			requestId: `sync-${ Date.now() }-${ Math.random() }`,
+			clientId: this.doc.clientID,
+		} );
+	}
+
+	/**
+	 * Send a message to Pinghub
+	 * @param {Object} message
+	 */
+	sendToPinghub( message ) {
+		const jsonMessage = JSON.stringify( message );
+
+		if ( this.isConnected && this.ws ) {
+			this.ws.send( jsonMessage );
+		} else {
+			// Queue message for when connection is restored
+			this.pendingMessages.push( jsonMessage );
+		}
+	}
+
+	/**
+	 * Flush any pending messages after connection is restored
+	 */
+	flushPendingMessages() {
+		while ( this.pendingMessages.length > 0 ) {
+			const message = this.pendingMessages.shift();
+			this.ws.send( message );
+		}
+	}
+
+	/**
+	 * Schedule reconnection attempt
+	 */
+	scheduleReconnect() {
+		if ( this.reconnectAttempts >= this.options.maxReconnectAttempts ) {
+			console.error( '[YJS-Pinghub] Max reconnection attempts reached' );
+			this.emit( 'max-reconnects-reached' );
+			return;
+		}
+
+		const delay = this.options.reconnectDelay * Math.pow( 2, this.reconnectAttempts );
+		this.reconnectAttempts++;
+
+		console.log(
+			`[YJS-Pinghub] Scheduling reconnect attempt ${ this.reconnectAttempts } in ${ delay }ms`
+		);
+
+		this.reconnectTimer = setTimeout( () => {
+			this.reconnectTimer = null;
+			this.connect();
+		}, delay );
+	}
+
+	/**
+	 * Clean disconnect
+	 */
+	disconnect() {
+		if ( this.reconnectTimer ) {
+			clearTimeout( this.reconnectTimer );
+			this.reconnectTimer = null;
+		}
+
+		if ( this.ws ) {
+			this.ws.close( 1000, 'User disconnected' );
+		}
+
+		// Clean up YJS listeners
+		this.doc.off( 'update', this.handleYjsUpdate );
+		this.awareness.off( 'update', this.handleAwarenessUpdate );
+
+		// Clear awareness
+		this.awareness.destroy();
+	}
+
+	/**
+	 * Simple event emitter for external listeners
+	 * @param {string} event
+	 * @param {...any} args
+	 */
+	emit( event, ...args ) {
+		if ( this.options[ `on${ event }` ] ) {
+			this.options[ `on${ event }` ]( ...args );
+		}
+	}
+}
+
+/**
+ * Convenience function to create a collaborative YJS document with Pinghub
+ * @param {string} siteId - WordPress site ID
+ * @param {string} docId - Document identifier (post ID, page ID, etc.)
+ * @param {Object} options - Configuration options
+ * @returns {Object} { doc, awareness, adapter }
+ */
+export function createCollaborativeDocument( siteId, docId, options = {} ) {
+	const doc = new Y.Doc();
+	const channel = `/rtc/site-${ siteId }/doc-${ docId }`;
+
+	const adapter = new YjsPinghubAdapter( channel, doc, options );
+
+	return {
+		doc,
+		awareness: adapter.awareness,
+		adapter,
+		disconnect: () => adapter.disconnect(),
+	};
+}
+
+/**
+ * Example usage:
+ *
+ * import { createCollaborativeDocument } from './yjs-pinghub-adapter.js';
+ *
+ * // Create a collaborative document
+ * const { doc, awareness, adapter } = createCollaborativeDocument('123', '456', {
+ *     userName: 'John Doe',
+ *     userColor: '#ff6b6b',
+ *     onconnected: () => console.log('Connected to collaboration!'),
+ *     ondisconnected: () => console.log('Disconnected from collaboration'),
+ *     onerror: (error) => console.error('Collaboration error:', error)
+ * });
+ *
+ * // Use YJS normally
+ * const text = doc.getText('content');
+ * text.insert(0, 'Hello collaborative world!');
+ *
+ * // Clean up when done
+ * adapter.disconnect();
+ */

--- a/yjs-pinghub-test.html
+++ b/yjs-pinghub-test.html
@@ -1,0 +1,533 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YJS-Pinghub Adapter Test</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 40px auto;
+            padding: 20px;
+            background: #f8f9fa;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .status {
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            font-weight: 500;
+        }
+        .status.connected {
+            background: #d4edda;
+            color: #155724;
+            border: 1px solid #c3e6cb;
+        }
+        .status.disconnected {
+            background: #f8d7da;
+            color: #721c24;
+            border: 1px solid #f5c6cb;
+        }
+        .status.connecting {
+            background: #fff3cd;
+            color: #856404;
+            border: 1px solid #ffeaa7;
+        }
+        #editor {
+            width: 100%;
+            min-height: 200px;
+            padding: 15px;
+            border: 2px solid #e9ecef;
+            border-radius: 6px;
+            font-family: 'Monaco', 'Courier New', monospace;
+            font-size: 14px;
+            line-height: 1.5;
+            resize: vertical;
+            background: #fafafa;
+        }
+        #editor:focus {
+            outline: none;
+            border-color: #0073aa;
+            background: white;
+        }
+        .info {
+            margin-top: 20px;
+            padding: 15px;
+            background: #e7f3ff;
+            border-left: 4px solid #0073aa;
+            border-radius: 4px;
+        }
+        .info h3 {
+            margin-top: 0;
+            color: #0073aa;
+        }
+        .collaborators {
+            margin-top: 20px;
+        }
+        .collaborator {
+            display: inline-block;
+            padding: 5px 10px;
+            margin: 5px;
+            border-radius: 15px;
+            background: #e9ecef;
+            font-size: 12px;
+            font-weight: 500;
+        }
+        .debug {
+            margin-top: 20px;
+            padding: 15px;
+            background: #f8f9fa;
+            border-radius: 6px;
+            border: 1px solid #dee2e6;
+            font-family: monospace;
+            font-size: 12px;
+            max-height: 200px;
+            overflow-y: auto;
+        }
+        button {
+            background: #0073aa;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 6px;
+            cursor: pointer;
+            margin: 5px;
+            font-weight: 500;
+        }
+        button:hover {
+            background: #005a87;
+        }
+        button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🚀 YJS-Pinghub Adapter Test</h1>
+        
+        <div id="status" class="status connecting">
+            Connecting to Pinghub...
+        </div>
+
+        <div>
+            <label for="editor"><strong>Collaborative Text Editor:</strong></label>
+            <textarea 
+                id="editor" 
+                placeholder="Start typing... Changes will sync in real-time with other collaborators via Pinghub!"
+            ></textarea>
+        </div>
+
+        <div class="collaborators">
+            <h3>👥 Active Collaborators:</h3>
+            <div id="collaborator-list">
+                <span class="collaborator">Loading...</span>
+            </div>
+        </div>
+
+        <div>
+            <button onclick="testConnection()">Test Connection</button>
+            <button onclick="clearEditor()">Clear Editor</button>
+            <button onclick="simulateUpdate()">Simulate Remote Update</button>
+            <button onclick="toggleDebug()">Toggle Debug Log</button>
+        </div>
+
+        <div class="info">
+            <h3>🧪 How This Test Works</h3>
+            <ul>
+                <li><strong>YJS Document:</strong> Creates a collaborative text document</li>
+                <li><strong>Pinghub Transport:</strong> Uses existing Pinghub WebSocket infrastructure</li>
+                <li><strong>Message Translation:</strong> Converts YJS binary updates to/from JSON for Pinghub</li>
+                <li><strong>Multi-User:</strong> Open this page in multiple tabs to see real-time collaboration</li>
+                <li><strong>Authentication:</strong> Uses WordPress.com cookies (wp_api_sec) automatically</li>
+            </ul>
+        </div>
+
+        <div id="debug" class="debug" style="display: none;">
+            <h4>Debug Log:</h4>
+            <div id="debug-log"></div>
+        </div>
+    </div>
+
+    <!-- YJS Dependencies -->
+    <script src="https://unpkg.com/yjs@13.6.10/dist/yjs.js"></script>
+    
+    <script>
+        // Global state
+        let collaborativeDoc = null;
+        let adapter = null;
+        let debugVisible = false;
+
+        // Simple YJS-Pinghub Adapter (inline for testing)
+        class YjsPinghubAdapter {
+            constructor(channel, doc, options = {}) {
+                this.channel = channel;
+                this.doc = doc;
+                this.options = {
+                    pinghubUrl: options.pinghubUrl || '/pinghub',
+                    reconnectDelay: options.reconnectDelay || 1000,
+                    maxReconnectAttempts: options.maxReconnectAttempts || 5,
+                    ...options
+                };
+
+                this.ws = null;
+                this.isConnected = false;
+                this.reconnectAttempts = 0;
+                this.pendingMessages = [];
+
+                // Create awareness
+                this.awareness = new Y.YAwareness(this.doc);
+                
+                this.setupYjsListeners();
+                this.connect();
+            }
+
+            setupYjsListeners() {
+                this.doc.on('update', (update, origin) => {
+                    if (origin === this) return;
+                    
+                    this.sendToPinghub({
+                        type: 'yjs-update',
+                        update: Array.from(update),
+                        clientId: this.doc.clientID
+                    });
+                });
+
+                this.awareness.on('update', ({ added, updated, removed }) => {
+                    const changedClients = added.concat(updated).concat(removed);
+                    if (changedClients.includes(this.doc.clientID)) {
+                        const update = Y.YAwareness.encodeAwarenessUpdate(this.awareness, changedClients);
+                        this.sendToPinghub({
+                            type: 'yjs-awareness',
+                            awarenessUpdate: Array.from(update),
+                            clientId: this.doc.clientID
+                        });
+                    }
+                });
+
+                // Set user info
+                this.awareness.setLocalStateField('user', {
+                    name: this.options.userName || `User-${this.doc.clientID}`,
+                    color: this.generateUserColor()
+                });
+            }
+
+            generateUserColor() {
+                const hue = Math.floor(Math.random() * 360);
+                return `hsl(${hue}, 70%, 50%)`;
+            }
+
+            connect() {
+                if (this.ws) return;
+
+                const pinghubUrl = `ws://${window.location.host}${this.options.pinghubUrl}${this.channel}`;
+                debugLog(`Connecting to: ${pinghubUrl}`);
+                
+                try {
+                    this.ws = new WebSocket(pinghubUrl);
+                    
+                    this.ws.onopen = () => {
+                        debugLog('✅ Connected to Pinghub');
+                        this.isConnected = true;
+                        this.reconnectAttempts = 0;
+                        updateStatus('connected', 'Connected to Pinghub');
+                        this.flushPendingMessages();
+                        this.sendInitialSync();
+                    };
+
+                    this.ws.onmessage = (event) => {
+                        this.handlePinghubMessage(event);
+                    };
+
+                    this.ws.onclose = (event) => {
+                        debugLog(`❌ Connection closed: ${event.code} - ${event.reason}`);
+                        this.isConnected = false;
+                        this.ws = null;
+                        updateStatus('disconnected', `Disconnected: ${event.reason || 'Connection closed'}`);
+                        
+                        if (event.code !== 1000) {
+                            this.scheduleReconnect();
+                        }
+                    };
+
+                    this.ws.onerror = (error) => {
+                        debugLog(`💥 WebSocket error: ${error}`);
+                        updateStatus('disconnected', 'Connection error');
+                    };
+
+                } catch (error) {
+                    debugLog(`💥 Failed to connect: ${error}`);
+                    updateStatus('disconnected', `Failed to connect: ${error.message}`);
+                    this.scheduleReconnect();
+                }
+            }
+
+            handlePinghubMessage(event) {
+                try {
+                    const message = JSON.parse(event.data);
+                    debugLog(`📨 Received: ${message.type} from client ${message.clientId}`);
+                    
+                    if (message.clientId === this.doc.clientID) {
+                        return; // Ignore our own messages
+                    }
+
+                    switch (message.type) {
+                        case 'yjs-update':
+                            const update = new Uint8Array(message.update);
+                            Y.applyUpdate(this.doc, update, this);
+                            break;
+                        case 'yjs-awareness':
+                            const awarenessUpdate = new Uint8Array(message.awarenessUpdate);
+                            Y.YAwareness.applyAwarenessUpdate(this.awareness, awarenessUpdate, message.clientId);
+                            updateCollaborators();
+                            break;
+                        case 'yjs-sync-request':
+                            this.handleSyncRequest(message);
+                            break;
+                        case 'yjs-sync-response':
+                            this.handleSyncResponse(message);
+                            break;
+                    }
+                } catch (error) {
+                    debugLog(`💥 Failed to parse message: ${error}`);
+                }
+            }
+
+            handleSyncRequest(message) {
+                const stateVector = Y.encodeStateVector(this.doc);
+                this.sendToPinghub({
+                    type: 'yjs-sync-response',
+                    stateVector: Array.from(stateVector),
+                    clientId: this.doc.clientID,
+                    requestId: message.requestId
+                });
+            }
+
+            handleSyncResponse(message) {
+                try {
+                    const stateVector = new Uint8Array(message.stateVector);
+                    const diff = Y.encodeStateAsUpdate(this.doc, stateVector);
+                    
+                    if (diff.length > 0) {
+                        this.sendToPinghub({
+                            type: 'yjs-update',
+                            update: Array.from(diff),
+                            clientId: this.doc.clientID
+                        });
+                    }
+                } catch (error) {
+                    debugLog(`💥 Failed to handle sync response: ${error}`);
+                }
+            }
+
+            sendInitialSync() {
+                this.sendToPinghub({
+                    type: 'yjs-sync-request',
+                    requestId: `sync-${Date.now()}-${Math.random()}`,
+                    clientId: this.doc.clientID
+                });
+            }
+
+            sendToPinghub(message) {
+                const jsonMessage = JSON.stringify(message);
+
+                if (this.isConnected && this.ws) {
+                    this.ws.send(jsonMessage);
+                    debugLog(`📤 Sent: ${message.type}`);
+                } else {
+                    this.pendingMessages.push(jsonMessage);
+                    debugLog(`📦 Queued: ${message.type} (not connected)`);
+                }
+            }
+
+            flushPendingMessages() {
+                while (this.pendingMessages.length > 0) {
+                    const message = this.pendingMessages.shift();
+                    this.ws.send(message);
+                }
+                if (this.pendingMessages.length > 0) {
+                    debugLog(`📤 Sent ${this.pendingMessages.length} pending messages`);
+                }
+            }
+
+            scheduleReconnect() {
+                if (this.reconnectAttempts >= this.options.maxReconnectAttempts) {
+                    updateStatus('disconnected', 'Max reconnection attempts reached');
+                    return;
+                }
+
+                const delay = this.options.reconnectDelay * Math.pow(2, this.reconnectAttempts);
+                this.reconnectAttempts++;
+
+                updateStatus('connecting', `Reconnecting in ${delay}ms... (attempt ${this.reconnectAttempts})`);
+                debugLog(`🔄 Reconnect attempt ${this.reconnectAttempts} in ${delay}ms`);
+
+                setTimeout(() => {
+                    this.connect();
+                }, delay);
+            }
+
+            disconnect() {
+                if (this.ws) {
+                    this.ws.close(1000, 'User disconnected');
+                }
+            }
+        }
+
+        // Utility functions
+        function debugLog(message) {
+            console.log(`[YJS-Pinghub] ${message}`);
+            const debugLog = document.getElementById('debug-log');
+            if (debugLog) {
+                const timestamp = new Date().toLocaleTimeString();
+                debugLog.innerHTML += `<div>[${timestamp}] ${message}</div>`;
+                debugLog.scrollTop = debugLog.scrollHeight;
+            }
+        }
+
+        function updateStatus(type, message) {
+            const statusEl = document.getElementById('status');
+            statusEl.className = `status ${type}`;
+            statusEl.textContent = message;
+        }
+
+        function updateCollaborators() {
+            const collaboratorList = document.getElementById('collaborator-list');
+            const states = adapter.awareness.getStates();
+            
+            const collaborators = [];
+            states.forEach((state, clientId) => {
+                if (state.user && clientId !== adapter.doc.clientID) {
+                    collaborators.push(`
+                        <span class="collaborator" style="background-color: ${state.user.color}20; border-left: 3px solid ${state.user.color};">
+                            ${state.user.name}
+                        </span>
+                    `);
+                }
+            });
+
+            if (collaborators.length === 0) {
+                collaboratorList.innerHTML = '<span class="collaborator">No other collaborators</span>';
+            } else {
+                collaboratorList.innerHTML = collaborators.join('');
+            }
+        }
+
+        // Initialize the collaborative document
+        function initializeCollaboration() {
+            const doc = new Y.Doc();
+            const text = doc.getText('content');
+            
+            // Create adapter
+            adapter = new YjsPinghubAdapter('/rtc/site-123/doc-test', doc, {
+                userName: `User-${Math.floor(Math.random() * 1000)}`,
+            });
+
+            // Sync textarea with YJS document
+            const editor = document.getElementById('editor');
+            
+            // YJS -> Textarea
+            text.observe(() => {
+                const currentText = text.toString();
+                if (editor.value !== currentText) {
+                    const cursorPos = editor.selectionStart;
+                    editor.value = currentText;
+                    editor.setSelectionRange(cursorPos, cursorPos);
+                }
+                updateCollaborators();
+            });
+
+            // Textarea -> YJS
+            editor.addEventListener('input', () => {
+                const currentText = text.toString();
+                const editorText = editor.value;
+                
+                if (currentText !== editorText) {
+                    // Calculate diff and apply changes
+                    let i = 0;
+                    while (i < Math.min(currentText.length, editorText.length) && currentText[i] === editorText[i]) {
+                        i++;
+                    }
+                    
+                    let deleteLength = currentText.length - i;
+                    let j = 0;
+                    while (j < Math.min(deleteLength, editorText.length - i) && 
+                           currentText[currentText.length - 1 - j] === editorText[editorText.length - 1 - j]) {
+                        j++;
+                    }
+                    deleteLength -= j;
+                    
+                    const insertText = editorText.slice(i, editorText.length - j);
+                    
+                    if (deleteLength > 0) {
+                        text.delete(i, deleteLength);
+                    }
+                    if (insertText.length > 0) {
+                        text.insert(i, insertText);
+                    }
+                }
+            });
+
+            collaborativeDoc = { doc, text, adapter };
+            updateCollaborators();
+        }
+
+        // Test functions
+        function testConnection() {
+            if (adapter && adapter.isConnected) {
+                debugLog('✅ Connection test: Already connected!');
+                updateStatus('connected', 'Connection test passed!');
+            } else {
+                debugLog('❌ Connection test: Not connected');
+                updateStatus('disconnected', 'Connection test failed - not connected');
+            }
+        }
+
+        function clearEditor() {
+            if (collaborativeDoc) {
+                collaborativeDoc.text.delete(0, collaborativeDoc.text.length);
+                debugLog('🗑️ Editor cleared');
+            }
+        }
+
+        function simulateUpdate() {
+            if (collaborativeDoc) {
+                const messages = [
+                    '🤖 This is a simulated remote update!\n',
+                    '✨ Multiple users can edit simultaneously.\n',
+                    '🚀 All changes sync via Pinghub in real-time.\n'
+                ];
+                const message = messages[Math.floor(Math.random() * messages.length)];
+                collaborativeDoc.text.insert(0, message);
+                debugLog('🤖 Simulated remote update');
+            }
+        }
+
+        function toggleDebug() {
+            debugVisible = !debugVisible;
+            const debugEl = document.getElementById('debug');
+            debugEl.style.display = debugVisible ? 'block' : 'none';
+        }
+
+        // Initialize when page loads
+        document.addEventListener('DOMContentLoaded', () => {
+            debugLog('🚀 Initializing YJS-Pinghub test...');
+            initializeCollaboration();
+        });
+
+        // Cleanup on page unload
+        window.addEventListener('beforeunload', () => {
+            if (adapter) {
+                adapter.disconnect();
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
*Do not merge*

This is a demonstration of an alternative approach to providing websockets for realtime collaboration, not intended to be merged. Mostly just parking this here for discussion. Basically, this moves all the yjs integration client-side, converting messages to be suitable for Pinghub. This way, we don't have to host and scale a Node application for many websockets connections and can instead rely on existing infrastructure and auth approaches. So far, this is only tested locally with a local Pinghub install.

Ultimately, this would likely be distributed via Jetpack, allowing it to use the existing cookies and JWTs for Pinghub auth. 

From an operations perspective, the only change this approach "requires" is a new /rtc route prefix to group all these collaboration connections together. RTC sockets become just chatty notification connections.