### PR TITLE
Add explicit Site Spec URL Param for Big Sky onboarded

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -237,7 +237,7 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 							}
 
 							window.location.replace(
-								`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }${ sourceParam }${ specIdParam }`
+								`${ siteURL }/wp-admin/site-editor.php?canvas=edit&ai-step=spec&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }${ sourceParam }${ specIdParam }`
 							);
 						} else if ( providedDependencies.isLaunched ) {
 							const site = await resolveSelect( SITE_STORE ).getSite(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -121,7 +121,7 @@ const LaunchBigSky: Step = function ( props ) {
 				}
 
 				window.location.replace(
-					`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ flow }${ promptParam }&source=${ flow }${ specIdParam }`
+					`${ siteURL }/wp-admin/site-editor.php?canvas=edit&ai-step=spec&referrer=${ flow }${ promptParam }&source=${ flow }${ specIdParam }`
 				);
 			} catch ( error ) {
 				// eslint-disable-next-line no-console


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15297

## Proposed Changes

For the flows that redirect to the site-editor version of Site Spec, pass an explicit `&ai-step=spec` param. 
This is to prepare for Big Sky PR 5074, which removes isOnboarded and makes spec step stateless. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently this has no actual effect until big-sky-plugin/pull/5074 is merged. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

wordpress.com/ai-website-builder: 
1. http://calypso.localhost:3000/setup/ai-site-builder?prompt=howdy (mimic a flow start from the LP)
2. watch the URL. It should land on the editor with the `&ai-step=spec` param. 

CIAB: 
1. http://calypso.localhost:3000/ciab
2. Add a new store
3. watch the URL. It should land on the editor with the `&ai-step=spec` param

Note that the param will get overwritten by the `ai-step=onboarding` param. This is expected until 5074 is deployed. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
