### PR TITLE
Update Windows and macOS architecture detection for desktop app downloads

### DIFF
--- a/client/blocks/get-apps/apps-config.tsx
+++ b/client/blocks/get-apps/apps-config.tsx
@@ -48,14 +48,14 @@ const basePlatformConfigs: Record<
 		name: 'Mac (Intel)',
 		icon: Apple,
 		iconName: 'apple-logo',
-		buttonText: translate( 'Download for Mac' ),
+		buttonText: translate( 'Download for Mac (Intel)' ),
 		group: 'mac',
 	} ),
 	[ PlatformType.MacSilicon ]: ( translate ) => ( {
 		name: 'Mac (Apple Silicon)',
 		icon: Apple,
 		iconName: 'apple-logo',
-		buttonText: translate( 'Download for Mac' ),
+		buttonText: translate( 'Download for Mac (Apple Silicon)' ),
 		group: 'mac',
 	} ),
 	[ PlatformType.WindowsX64 ]: ( translate ) => ( {

--- a/client/blocks/get-apps/apps-config.tsx
+++ b/client/blocks/get-apps/apps-config.tsx
@@ -10,7 +10,8 @@ import Windows from 'calypso/assets/images/icons/windows-logo.svg';
 export enum PlatformType {
 	MacIntel = 'MacIntel',
 	MacSilicon = 'MacSilicon',
-	Windows = 'Windows',
+	WindowsARM64 = 'WindowsARM64',
+	WindowsX64 = 'WindowsX64',
 	Linux = 'Linux',
 	LinuxDeb = 'LinuxDeb',
 }
@@ -57,11 +58,18 @@ const basePlatformConfigs: Record<
 		buttonText: translate( 'Download for Mac' ),
 		group: 'mac',
 	} ),
-	[ PlatformType.Windows ]: ( translate ) => ( {
-		name: 'Windows',
+	[ PlatformType.WindowsX64 ]: ( translate ) => ( {
+		name: 'Windows (x64)',
 		icon: Windows,
 		iconName: 'windows-logo',
-		buttonText: translate( 'Download for Windows' ),
+		buttonText: translate( 'Download for Windows (x64)' ),
+		group: 'windows',
+	} ),
+	[ PlatformType.WindowsARM64 ]: ( translate ) => ( {
+		name: 'Windows on ARM',
+		icon: Windows,
+		iconName: 'windows-logo',
+		buttonText: translate( 'Download for Windows on ARM' ),
 		group: 'windows',
 	} ),
 	[ PlatformType.Linux ]: ( translate ) => ( {
@@ -120,9 +128,14 @@ export const createWordPressDesktopConfig = (
 				onClick: () => recordTracksEvent( 'calypso_app_download_mac_silicon_click' ),
 				link: localizeUrl( 'https://apps.wordpress.com/d/osx-silicon?ref=getapps' ),
 			},
-			[ PlatformType.Windows ]: {
-				...platformConfigs[ PlatformType.Windows ],
-				onClick: () => recordTracksEvent( 'calypso_app_download_windows_click' ),
+			[ PlatformType.WindowsX64 ]: {
+				...platformConfigs[ PlatformType.WindowsX64 ],
+				onClick: () => recordTracksEvent( 'calypso_app_download_windows_x64_click' ),
+				link: localizeUrl( 'https://apps.wordpress.com/d/windows?ref=getapps' ),
+			},
+			[ PlatformType.WindowsARM64 ]: {
+				...platformConfigs[ PlatformType.WindowsARM64 ],
+				onClick: () => recordTracksEvent( 'calypso_app_download_windows_arm64_click' ),
 				link: localizeUrl( 'https://apps.wordpress.com/d/windows?ref=getapps' ),
 			},
 			[ PlatformType.Linux ]: {
@@ -167,10 +180,15 @@ export const createWordPressStudioConfig = (
 				onClick: () => recordTracksEvent( 'calypso_studio_download_mac_silicon_click' ),
 				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/mac-silicon/latest',
 			},
-			[ PlatformType.Windows ]: {
-				...platformConfigs[ PlatformType.Windows ],
-				onClick: () => recordTracksEvent( 'calypso_studio_download_windows_click' ),
+			[ PlatformType.WindowsX64 ]: {
+				...platformConfigs[ PlatformType.WindowsX64 ],
+				onClick: () => recordTracksEvent( 'calypso_studio_download_windows_x64_click' ),
 				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/windows-x64/latest',
+			},
+			[ PlatformType.WindowsARM64 ]: {
+				...platformConfigs[ PlatformType.WindowsARM64 ],
+				onClick: () => recordTracksEvent( 'calypso_studio_download_windows_arm64_click' ),
+				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/windows-arm64/latest',
 			},
 		},
 	};

--- a/client/blocks/get-apps/apps-config.tsx
+++ b/client/blocks/get-apps/apps-config.tsx
@@ -8,8 +8,8 @@ import StudioAppLogo from 'calypso/assets/images/icons/studio-app-logo.svg';
 import Windows from 'calypso/assets/images/icons/windows-logo.svg';
 
 export enum PlatformType {
-	MacIntel = 'MacIntel',
 	MacSilicon = 'MacSilicon',
+	MacIntel = 'MacIntel',
 	WindowsARM64 = 'WindowsARM64',
 	WindowsX64 = 'WindowsX64',
 	Linux = 'Linux',
@@ -44,18 +44,18 @@ const basePlatformConfigs: Record<
 	PlatformType,
 	( t: ReturnType< typeof useTranslate > ) => BasePlatformConfig
 > = {
-	[ PlatformType.MacIntel ]: ( translate ) => ( {
-		name: 'Mac (Intel)',
-		icon: Apple,
-		iconName: 'apple-logo',
-		buttonText: translate( 'Download for Mac (Intel)' ),
-		group: 'mac',
-	} ),
 	[ PlatformType.MacSilicon ]: ( translate ) => ( {
 		name: 'Mac (Apple Silicon)',
 		icon: Apple,
 		iconName: 'apple-logo',
 		buttonText: translate( 'Download for Mac (Apple Silicon)' ),
+		group: 'mac',
+	} ),
+	[ PlatformType.MacIntel ]: ( translate ) => ( {
+		name: 'Mac (Intel)',
+		icon: Apple,
+		iconName: 'apple-logo',
+		buttonText: translate( 'Download for Mac (Intel)' ),
 		group: 'mac',
 	} ),
 	[ PlatformType.WindowsX64 ]: ( translate ) => ( {
@@ -118,15 +118,15 @@ export const createWordPressDesktopConfig = (
 			},
 		} ),
 		platforms: {
-			[ PlatformType.MacIntel ]: {
-				...platformConfigs[ PlatformType.MacIntel ],
-				onClick: () => recordTracksEvent( 'calypso_app_download_mac_click' ),
-				link: localizeUrl( 'https://apps.wordpress.com/d/osx?ref=getapps' ),
-			},
 			[ PlatformType.MacSilicon ]: {
 				...platformConfigs[ PlatformType.MacSilicon ],
 				onClick: () => recordTracksEvent( 'calypso_app_download_mac_silicon_click' ),
 				link: localizeUrl( 'https://apps.wordpress.com/d/osx-silicon?ref=getapps' ),
+			},
+			[ PlatformType.MacIntel ]: {
+				...platformConfigs[ PlatformType.MacIntel ],
+				onClick: () => recordTracksEvent( 'calypso_app_download_mac_click' ),
+				link: localizeUrl( 'https://apps.wordpress.com/d/osx?ref=getapps' ),
 			},
 			[ PlatformType.WindowsX64 ]: {
 				...platformConfigs[ PlatformType.WindowsX64 ],
@@ -170,15 +170,15 @@ export const createWordPressStudioConfig = (
 		} ),
 		isPrimary: true,
 		platforms: {
-			[ PlatformType.MacIntel ]: {
-				...platformConfigs[ PlatformType.MacIntel ],
-				onClick: () => recordTracksEvent( 'calypso_studio_download_mac_click' ),
-				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/mac-intel/latest',
-			},
 			[ PlatformType.MacSilicon ]: {
 				...platformConfigs[ PlatformType.MacSilicon ],
 				onClick: () => recordTracksEvent( 'calypso_studio_download_mac_silicon_click' ),
 				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/mac-silicon/latest',
+			},
+			[ PlatformType.MacIntel ]: {
+				...platformConfigs[ PlatformType.MacIntel ],
+				onClick: () => recordTracksEvent( 'calypso_studio_download_mac_click' ),
+				link: 'https://appscdn.wordpress.com/downloads/wordpress-com-studio/mac-intel/latest',
 			},
 			[ PlatformType.WindowsX64 ]: {
 				...platformConfigs[ PlatformType.WindowsX64 ],

--- a/client/blocks/get-apps/desktop-download-card.tsx
+++ b/client/blocks/get-apps/desktop-download-card.tsx
@@ -19,7 +19,6 @@ const getCurrentPlatform = async (): Promise< {
 	if ( detection && detection.detectionMethod === 'client-hints' ) {
 		const { platform, architecture } = detection;
 
-		// macOS
 		if ( platform === 'macos' ) {
 			if ( architecture === 'arm64' ) {
 				return { platform: PlatformType.MacSilicon, detectionFailed: false };
@@ -30,7 +29,6 @@ const getCurrentPlatform = async (): Promise< {
 			return { platform: PlatformType.MacIntel, detectionFailed: true };
 		}
 
-		// Windows
 		if ( platform === 'windows' ) {
 			if ( architecture === 'arm64' ) {
 				return { platform: PlatformType.WindowsARM64, detectionFailed: false };
@@ -41,7 +39,6 @@ const getCurrentPlatform = async (): Promise< {
 			return { platform: PlatformType.WindowsX64, detectionFailed: true };
 		}
 
-		// Linux
 		if ( platform === 'linux' ) {
 			return { platform: PlatformType.Linux, detectionFailed: false };
 		}

--- a/client/blocks/get-apps/desktop-download-card.tsx
+++ b/client/blocks/get-apps/desktop-download-card.tsx
@@ -25,8 +25,8 @@ const getCurrentPlatform = async (): Promise< {
 			} else if ( architecture === 'x64' ) {
 				return { platform: PlatformType.MacIntel, detectionFailed: false };
 			}
-			// Client Hints available but no architecture - fallback to MacIntel
-			return { platform: PlatformType.MacIntel, detectionFailed: true };
+			// Client Hints available but no architecture - fallback to MacSilicon
+			return { platform: PlatformType.MacSilicon, detectionFailed: true };
 		}
 
 		if ( platform === 'windows' ) {

--- a/client/blocks/get-apps/desktop-download-card.tsx
+++ b/client/blocks/get-apps/desktop-download-card.tsx
@@ -1,37 +1,82 @@
-import { useMemo } from 'react';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import userAgent from 'calypso/lib/user-agent';
 import { AppsCard } from './apps-card';
 import { PlatformType, type DesktopAppConfig } from './apps-config';
 import { DesktopDownloadOptions } from './desktop-download-options';
+import { getWindowsArchitecture } from './platform-detection';
 
 type DesktopDownloadCardProps = {
 	appConfig: DesktopAppConfig;
 };
 
-const getCurrentPlatform = (): PlatformType => {
+const getCurrentPlatform = async (): Promise< {
+	platform: PlatformType;
+	detectionFailed: boolean;
+} > => {
 	const platformName = navigator.platform;
 
+	// Non-Windows platforms (existing logic)
 	switch ( platformName ) {
 		case 'MacIntel':
-			return PlatformType.MacIntel;
+			return { platform: PlatformType.MacIntel, detectionFailed: false };
 		case 'MacSilicon':
-			return PlatformType.MacSilicon;
+			return { platform: PlatformType.MacSilicon, detectionFailed: false };
 		case 'Linux i686':
 		case 'Linux i686 on x86_64':
-			return PlatformType.Linux;
-		default:
-			return PlatformType.Windows;
+			return { platform: PlatformType.Linux, detectionFailed: false };
 	}
+
+	// Windows platform - attempt architecture detection
+	const arch = await getWindowsArchitecture();
+
+	if ( arch === 'arm64' ) {
+		return { platform: PlatformType.WindowsARM64, detectionFailed: false };
+	} else if ( arch === 'x64' ) {
+		return { platform: PlatformType.WindowsX64, detectionFailed: false };
+	}
+
+	// Fallback: unknown Windows architecture
+	return { platform: PlatformType.WindowsX64, detectionFailed: true };
 };
 
 const DesktopDownloadCard: React.FC< DesktopDownloadCardProps > = ( { appConfig } ) => {
 	const { isMobile } = userAgent;
-	const platform = useMemo( () => getCurrentPlatform(), [] );
+	const [ platform, setPlatform ] = useState< PlatformType | null >( null );
+	const [ detectionFailed, setDetectionFailed ] = useState( false );
+	const [ isLoading, setIsLoading ] = useState( true );
+
+	useEffect( () => {
+		getCurrentPlatform()
+			.then( ( result ) => {
+				setPlatform( result.platform );
+				setDetectionFailed( result.detectionFailed );
+			} )
+			.catch( () => {
+				setDetectionFailed( true );
+				setPlatform( PlatformType.WindowsX64 );
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
+	}, [] );
 
 	const currentPlatformConfig = useMemo(
-		() => appConfig.platforms[ platform ],
+		() => ( platform ? appConfig.platforms[ platform ] : undefined ),
 		[ appConfig.platforms, platform ]
 	);
+
+	if ( isLoading ) {
+		return (
+			<AppsCard
+				logo={ appConfig.logo }
+				logoName={ appConfig.logoName }
+				title={ appConfig.title }
+				subtitle={ appConfig.subtitle }
+			>
+				<div className="get-apps__loading">Loading...</div>
+			</AppsCard>
+		);
+	}
 
 	return (
 		<AppsCard
@@ -44,6 +89,7 @@ const DesktopDownloadCard: React.FC< DesktopDownloadCardProps > = ( { appConfig 
 				appConfig={ appConfig }
 				currentPlatformConfig={ currentPlatformConfig }
 				isMobile={ isMobile }
+				platformDetectionFailed={ detectionFailed }
 			/>
 		</AppsCard>
 	);

--- a/client/blocks/get-apps/desktop-download-card.tsx
+++ b/client/blocks/get-apps/desktop-download-card.tsx
@@ -3,7 +3,7 @@ import userAgent from 'calypso/lib/user-agent';
 import { AppsCard } from './apps-card';
 import { PlatformType, type DesktopAppConfig } from './apps-config';
 import { DesktopDownloadOptions } from './desktop-download-options';
-import { getWindowsArchitecture } from './platform-detection';
+import { detectPlatformAndArchitecture } from './platform-detection';
 
 type DesktopDownloadCardProps = {
 	appConfig: DesktopAppConfig;
@@ -13,29 +13,61 @@ const getCurrentPlatform = async (): Promise< {
 	platform: PlatformType;
 	detectionFailed: boolean;
 } > => {
-	const platformName = navigator.platform;
+	// Try User-Agent Client Hints API first (works across all platforms)
+	const detection = await detectPlatformAndArchitecture();
 
-	// Non-Windows platforms (existing logic)
-	switch ( platformName ) {
-		case 'MacIntel':
-			return { platform: PlatformType.MacIntel, detectionFailed: false };
-		case 'MacSilicon':
-			return { platform: PlatformType.MacSilicon, detectionFailed: false };
-		case 'Linux i686':
-		case 'Linux i686 on x86_64':
+	if ( detection && detection.detectionMethod === 'client-hints' ) {
+		const { platform, architecture } = detection;
+
+		// macOS
+		if ( platform === 'macos' ) {
+			if ( architecture === 'arm64' ) {
+				return { platform: PlatformType.MacSilicon, detectionFailed: false };
+			} else if ( architecture === 'x64' ) {
+				return { platform: PlatformType.MacIntel, detectionFailed: false };
+			}
+			// Client Hints available but no architecture - fallback to MacIntel
+			return { platform: PlatformType.MacIntel, detectionFailed: true };
+		}
+
+		// Windows
+		if ( platform === 'windows' ) {
+			if ( architecture === 'arm64' ) {
+				return { platform: PlatformType.WindowsARM64, detectionFailed: false };
+			} else if ( architecture === 'x64' ) {
+				return { platform: PlatformType.WindowsX64, detectionFailed: false };
+			}
+			// Client Hints available but no architecture - fallback
+			return { platform: PlatformType.WindowsX64, detectionFailed: true };
+		}
+
+		// Linux
+		if ( platform === 'linux' ) {
 			return { platform: PlatformType.Linux, detectionFailed: false };
+		}
 	}
 
-	// Windows platform - attempt architecture detection
-	const arch = await getWindowsArchitecture();
+	// Fallback to navigator.platform (Client Hints API not available)
+	// Cannot trust architecture detection here
+	if ( detection && detection.detectionMethod === 'navigator-platform' ) {
+		const { platform } = detection;
 
-	if ( arch === 'arm64' ) {
-		return { platform: PlatformType.WindowsARM64, detectionFailed: false };
-	} else if ( arch === 'x64' ) {
-		return { platform: PlatformType.WindowsX64, detectionFailed: false };
+		if ( platform === 'macos' ) {
+			// Cannot detect Mac architecture reliably - show both options
+			return { platform: PlatformType.MacIntel, detectionFailed: true };
+		}
+
+		if ( platform === 'windows' ) {
+			// Cannot detect Windows architecture - show both options
+			return { platform: PlatformType.WindowsX64, detectionFailed: true };
+		}
+
+		if ( platform === 'linux' ) {
+			return { platform: PlatformType.Linux, detectionFailed: false };
+		}
 	}
 
-	// Fallback: unknown Windows architecture
+	// Ultimate fallback - couldn't detect anything
 	return { platform: PlatformType.WindowsX64, detectionFailed: true };
 };
 

--- a/client/blocks/get-apps/desktop-download-options.tsx
+++ b/client/blocks/get-apps/desktop-download-options.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
@@ -8,6 +9,7 @@ type Props = {
 	appConfig: DesktopAppConfig;
 	currentPlatformConfig?: PlatformConfig;
 	isMobile: boolean;
+	platformDetectionFailed?: boolean;
 };
 
 interface AlsoAvailableConfig {
@@ -35,6 +37,7 @@ export const DesktopDownloadOptions: React.FC< Props > = ( {
 	appConfig,
 	currentPlatformConfig,
 	isMobile,
+	platformDetectionFailed = false,
 } ) => {
 	const translate = useTranslate();
 
@@ -42,6 +45,46 @@ export const DesktopDownloadOptions: React.FC< Props > = ( {
 		return <div className="get-apps__desktop-link">{ appConfig.link }</div>;
 	}
 
+	// Architecture detected successfully - show single button
+	if ( currentPlatformConfig && ! platformDetectionFailed ) {
+		return (
+			<>
+				<div className="get-apps__desktop-button">
+					<Button
+						variant={ appConfig.isPrimary ? 'primary' : 'secondary' }
+						disabled={ false }
+						onClick={ currentPlatformConfig.onClick }
+						href={ currentPlatformConfig.link }
+					>
+						<SVGIcon
+							classes="get-apps__desktop-button-icon"
+							aria-hidden="true"
+							name={ currentPlatformConfig.iconName }
+							size={ 16 }
+							icon={ currentPlatformConfig.icon }
+						/>
+						{ currentPlatformConfig.buttonText }
+					</Button>
+				</div>
+
+				<div className="get-apps__also-available">
+					<div className="get-apps__also-available-title">
+						{ translate( 'Also available for:' ) }
+					</div>
+
+					<div className="get-apps__also-available-list">
+						{ Object.entries( appConfig.platforms )
+							.filter( ( [ , config ] ) => config !== currentPlatformConfig )
+							.map( ( [ key, config ] ) => (
+								<AlsoAvailable key={ key } config={ config } />
+							) ) }
+					</div>
+				</div>
+			</>
+		);
+	}
+
+	// Fallback - show SplitButton with dropdown (existing logic)
 	return (
 		<>
 			<div className="get-apps__desktop-button">

--- a/client/blocks/get-apps/desktop-download-options.tsx
+++ b/client/blocks/get-apps/desktop-download-options.tsx
@@ -51,6 +51,7 @@ export const DesktopDownloadOptions: React.FC< Props > = ( {
 			<>
 				<div className="get-apps__desktop-button">
 					<Button
+						className="button"
 						variant={ appConfig.isPrimary ? 'primary' : 'secondary' }
 						disabled={ false }
 						onClick={ currentPlatformConfig.onClick }

--- a/client/blocks/get-apps/desktop-download-options.tsx
+++ b/client/blocks/get-apps/desktop-download-options.tsx
@@ -12,15 +12,7 @@ type Props = {
 	platformDetectionFailed?: boolean;
 };
 
-interface AlsoAvailableConfig {
-	name: string;
-	icon: string;
-	iconName: string;
-	link: string;
-	onClick: () => void;
-}
-
-const AlsoAvailable: React.FC< { config: AlsoAvailableConfig } > = ( { config } ) => (
+const AlsoAvailable: React.FC< { config: PlatformConfig } > = ( { config } ) => (
 	<a href={ config.link } onClick={ config.onClick } className="get-apps__desktop-link">
 		<SVGIcon
 			classes=""

--- a/client/blocks/get-apps/desktop-download-options.tsx
+++ b/client/blocks/get-apps/desktop-download-options.tsx
@@ -13,7 +13,12 @@ type Props = {
 };
 
 const AlsoAvailable: React.FC< { config: PlatformConfig } > = ( { config } ) => (
-	<a href={ config.link } onClick={ config.onClick } className="get-apps__desktop-link">
+	<a
+		href={ config.link }
+		onClick={ config.onClick }
+		className="get-apps__desktop-link"
+		aria-label={ config.buttonText }
+	>
 		<SVGIcon
 			classes=""
 			aria-hidden="true"
@@ -104,7 +109,12 @@ export const DesktopDownloadOptions: React.FC< Props > = ( {
 					{ Object.entries( appConfig.platforms )
 						.filter( ( [ , config ] ) => config.group === currentPlatformConfig?.group )
 						.map( ( [ key, config ] ) => (
-							<PopoverMenuItem key={ key } href={ config.link } onClick={ config.onClick }>
+							<PopoverMenuItem
+								key={ key }
+								href={ config.link }
+								onClick={ config.onClick }
+								aria-label={ config.buttonText }
+							>
 								{ config.name }
 							</PopoverMenuItem>
 						) ) }

--- a/client/blocks/get-apps/desktop-download-options.tsx
+++ b/client/blocks/get-apps/desktop-download-options.tsx
@@ -45,7 +45,6 @@ export const DesktopDownloadOptions: React.FC< Props > = ( {
 					<Button
 						className="button"
 						variant={ appConfig.isPrimary ? 'primary' : 'secondary' }
-						disabled={ false }
 						onClick={ currentPlatformConfig.onClick }
 						href={ currentPlatformConfig.link }
 					>

--- a/client/blocks/get-apps/platform-detection.test.ts
+++ b/client/blocks/get-apps/platform-detection.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getWindowsArchitecture } from './platform-detection';
+
+describe( 'getWindowsArchitecture', () => {
+	const originalNavigator = global.navigator;
+
+	afterEach( () => {
+		// Restore original navigator
+		Object.defineProperty( global, 'navigator', {
+			value: originalNavigator,
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	it( 'should return "arm64" when architecture is "arm"', async () => {
+		const mockUserAgentData = {
+			brands: [],
+			mobile: false,
+			platform: 'Windows',
+			getHighEntropyValues: jest.fn().mockResolvedValue( {
+				platform: 'Windows',
+				architecture: 'arm',
+				bitness: '64',
+			} ),
+		};
+
+		Object.defineProperty( global.navigator, 'userAgentData', {
+			value: mockUserAgentData,
+			writable: true,
+			configurable: true,
+		} );
+
+		const result = await getWindowsArchitecture();
+		expect( result ).toBe( 'arm64' );
+		expect( mockUserAgentData.getHighEntropyValues ).toHaveBeenCalledWith( [
+			'architecture',
+			'bitness',
+			'platform',
+		] );
+	} );
+
+	it( 'should return "arm64" when architecture is "arm64"', async () => {
+		const mockUserAgentData = {
+			brands: [],
+			mobile: false,
+			platform: 'Windows',
+			getHighEntropyValues: jest.fn().mockResolvedValue( {
+				platform: 'Windows',
+				architecture: 'arm64',
+				bitness: '64',
+			} ),
+		};
+
+		Object.defineProperty( global.navigator, 'userAgentData', {
+			value: mockUserAgentData,
+			writable: true,
+			configurable: true,
+		} );
+
+		const result = await getWindowsArchitecture();
+		expect( result ).toBe( 'arm64' );
+	} );
+
+	it( 'should return "x64" when architecture is "x86" and bitness is "64"', async () => {
+		const mockUserAgentData = {
+			brands: [],
+			mobile: false,
+			platform: 'Windows',
+			getHighEntropyValues: jest.fn().mockResolvedValue( {
+				platform: 'Windows',
+				architecture: 'x86',
+				bitness: '64',
+			} ),
+		};
+
+		Object.defineProperty( global.navigator, 'userAgentData', {
+			value: mockUserAgentData,
+			writable: true,
+			configurable: true,
+		} );
+
+		const result = await getWindowsArchitecture();
+		expect( result ).toBe( 'x64' );
+	} );
+
+	it( 'should return "x64" as default when architecture is present but does not match ARM', async () => {
+		const mockUserAgentData = {
+			brands: [],
+			mobile: false,
+			platform: 'Windows',
+			getHighEntropyValues: jest.fn().mockResolvedValue( {
+				platform: 'Windows',
+				architecture: 'unknown',
+				bitness: '64',
+			} ),
+		};
+
+		Object.defineProperty( global.navigator, 'userAgentData', {
+			value: mockUserAgentData,
+			writable: true,
+			configurable: true,
+		} );
+
+		const result = await getWindowsArchitecture();
+		expect( result ).toBe( 'x64' );
+	} );
+
+	it( 'should return null when architecture is not present', async () => {
+		const mockUserAgentData = {
+			brands: [],
+			mobile: false,
+			platform: 'Windows',
+			getHighEntropyValues: jest.fn().mockResolvedValue( {
+				platform: 'Windows',
+				bitness: '64',
+			} ),
+		};
+
+		Object.defineProperty( global.navigator, 'userAgentData', {
+			value: mockUserAgentData,
+			writable: true,
+			configurable: true,
+		} );
+
+		const result = await getWindowsArchitecture();
+		expect( result ).toBeNull();
+	} );
+
+	it( 'should return null when userAgentData is not available', async () => {
+		Object.defineProperty( global.navigator, 'userAgentData', {
+			value: undefined,
+			writable: true,
+			configurable: true,
+		} );
+
+		const result = await getWindowsArchitecture();
+		expect( result ).toBeNull();
+	} );
+
+	it( 'should return null and log warning when getHighEntropyValues throws an error', async () => {
+		const consoleWarnSpy = jest.spyOn( console, 'warn' ).mockImplementation();
+		const mockError = new Error( 'Permission denied' );
+
+		const mockUserAgentData = {
+			brands: [],
+			mobile: false,
+			platform: 'Windows',
+			getHighEntropyValues: jest.fn().mockRejectedValue( mockError ),
+		};
+
+		Object.defineProperty( global.navigator, 'userAgentData', {
+			value: mockUserAgentData,
+			writable: true,
+			configurable: true,
+		} );
+
+		const result = await getWindowsArchitecture();
+		expect( result ).toBeNull();
+		expect( consoleWarnSpy ).toHaveBeenCalledWith(
+			'Failed to get high entropy values:',
+			mockError
+		);
+
+		consoleWarnSpy.mockRestore();
+	} );
+} );

--- a/client/blocks/get-apps/platform-detection.test.ts
+++ b/client/blocks/get-apps/platform-detection.test.ts
@@ -1,9 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { getWindowsArchitecture } from './platform-detection';
+import { detectPlatformAndArchitecture } from './platform-detection';
 
-describe( 'getWindowsArchitecture', () => {
+describe( 'detectPlatformAndArchitecture', () => {
 	const originalNavigator = global.navigator;
 
 	afterEach( () => {
@@ -15,155 +15,256 @@ describe( 'getWindowsArchitecture', () => {
 		} );
 	} );
 
-	it( 'should return "arm64" when architecture is "arm"', async () => {
-		const mockUserAgentData = {
-			brands: [],
-			mobile: false,
-			platform: 'Windows',
-			getHighEntropyValues: jest.fn().mockResolvedValue( {
+	describe( 'Client Hints API detection', () => {
+		it( 'should detect Windows ARM64 via Client Hints', async () => {
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
 				platform: 'Windows',
-				architecture: 'arm',
-				bitness: '64',
-			} ),
-		};
+				getHighEntropyValues: jest.fn().mockResolvedValue( {
+					platform: 'Windows',
+					architecture: 'arm64',
+					bitness: '64',
+				} ),
+			};
 
-		Object.defineProperty( global.navigator, 'userAgentData', {
-			value: mockUserAgentData,
-			writable: true,
-			configurable: true,
-		} );
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
 
-		const result = await getWindowsArchitecture();
-		expect( result ).toBe( 'arm64' );
-		expect( mockUserAgentData.getHighEntropyValues ).toHaveBeenCalledWith( [
-			'architecture',
-			'bitness',
-			'platform',
-		] );
-	} );
-
-	it( 'should return "arm64" when architecture is "arm64"', async () => {
-		const mockUserAgentData = {
-			brands: [],
-			mobile: false,
-			platform: 'Windows',
-			getHighEntropyValues: jest.fn().mockResolvedValue( {
-				platform: 'Windows',
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'windows',
 				architecture: 'arm64',
-				bitness: '64',
-			} ),
-		};
-
-		Object.defineProperty( global.navigator, 'userAgentData', {
-			value: mockUserAgentData,
-			writable: true,
-			configurable: true,
+				detectionMethod: 'client-hints',
+			} );
 		} );
 
-		const result = await getWindowsArchitecture();
-		expect( result ).toBe( 'arm64' );
-	} );
-
-	it( 'should return "x64" when architecture is "x86" and bitness is "64"', async () => {
-		const mockUserAgentData = {
-			brands: [],
-			mobile: false,
-			platform: 'Windows',
-			getHighEntropyValues: jest.fn().mockResolvedValue( {
+		it( 'should detect Windows x64 via Client Hints', async () => {
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
 				platform: 'Windows',
-				architecture: 'x86',
-				bitness: '64',
-			} ),
-		};
+				getHighEntropyValues: jest.fn().mockResolvedValue( {
+					platform: 'Windows',
+					architecture: 'x86',
+					bitness: '64',
+				} ),
+			};
 
-		Object.defineProperty( global.navigator, 'userAgentData', {
-			value: mockUserAgentData,
-			writable: true,
-			configurable: true,
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'windows',
+				architecture: 'x64',
+				detectionMethod: 'client-hints',
+			} );
 		} );
 
-		const result = await getWindowsArchitecture();
-		expect( result ).toBe( 'x64' );
+		it( 'should detect macOS ARM64 via Client Hints', async () => {
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
+				platform: 'macOS',
+				getHighEntropyValues: jest.fn().mockResolvedValue( {
+					platform: 'macOS',
+					architecture: 'arm64',
+					bitness: '64',
+				} ),
+			};
+
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'macos',
+				architecture: 'arm64',
+				detectionMethod: 'client-hints',
+			} );
+		} );
+
+		it( 'should detect macOS x64 via Client Hints', async () => {
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
+				platform: 'macOS',
+				getHighEntropyValues: jest.fn().mockResolvedValue( {
+					platform: 'macOS',
+					architecture: 'x86',
+					bitness: '64',
+				} ),
+			};
+
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'macos',
+				architecture: 'x64',
+				detectionMethod: 'client-hints',
+			} );
+		} );
+
+		it( 'should detect Linux via Client Hints', async () => {
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
+				platform: 'Linux',
+				getHighEntropyValues: jest.fn().mockResolvedValue( {
+					platform: 'Linux',
+					architecture: 'x86',
+					bitness: '64',
+				} ),
+			};
+
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'linux',
+				architecture: 'x64',
+				detectionMethod: 'client-hints',
+			} );
+		} );
 	} );
 
-	it( 'should return "x64" as default when architecture is present but does not match ARM', async () => {
-		const mockUserAgentData = {
-			brands: [],
-			mobile: false,
-			platform: 'Windows',
-			getHighEntropyValues: jest.fn().mockResolvedValue( {
+	describe( 'navigator.platform fallback', () => {
+		it( 'should fallback to navigator.platform for macOS', async () => {
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			} );
+
+			Object.defineProperty( global.navigator, 'platform', {
+				value: 'MacIntel',
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'macos',
+				architecture: undefined,
+				detectionMethod: 'navigator-platform',
+			} );
+		} );
+
+		it( 'should fallback to navigator.platform for Windows', async () => {
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			} );
+
+			Object.defineProperty( global.navigator, 'platform', {
+				value: 'Win32',
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'windows',
+				architecture: undefined,
+				detectionMethod: 'navigator-platform',
+			} );
+		} );
+
+		it( 'should fallback to navigator.platform for Linux', async () => {
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			} );
+
+			Object.defineProperty( global.navigator, 'platform', {
+				value: 'Linux x86_64',
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'linux',
+				architecture: undefined,
+				detectionMethod: 'navigator-platform',
+			} );
+		} );
+	} );
+
+	describe( 'Error handling', () => {
+		it( 'should fallback to navigator.platform when Client Hints throws error', async () => {
+			const consoleWarnSpy = jest.spyOn( console, 'warn' ).mockImplementation();
+			const mockError = new Error( 'Permission denied' );
+
+			const mockUserAgentData = {
+				brands: [],
+				mobile: false,
 				platform: 'Windows',
-				architecture: 'unknown',
-				bitness: '64',
-			} ),
-		};
+				getHighEntropyValues: jest.fn().mockRejectedValue( mockError ),
+			};
 
-		Object.defineProperty( global.navigator, 'userAgentData', {
-			value: mockUserAgentData,
-			writable: true,
-			configurable: true,
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: mockUserAgentData,
+				writable: true,
+				configurable: true,
+			} );
+
+			Object.defineProperty( global.navigator, 'platform', {
+				value: 'Win32',
+				writable: true,
+				configurable: true,
+			} );
+
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toEqual( {
+				platform: 'windows',
+				architecture: undefined,
+				detectionMethod: 'navigator-platform',
+			} );
+			expect( consoleWarnSpy ).toHaveBeenCalledWith(
+				'Failed to get high entropy values:',
+				mockError
+			);
+
+			consoleWarnSpy.mockRestore();
 		} );
 
-		const result = await getWindowsArchitecture();
-		expect( result ).toBe( 'x64' );
-	} );
+		it( 'should return null when no detection method works', async () => {
+			Object.defineProperty( global.navigator, 'userAgentData', {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			} );
 
-	it( 'should return null when architecture is not present', async () => {
-		const mockUserAgentData = {
-			brands: [],
-			mobile: false,
-			platform: 'Windows',
-			getHighEntropyValues: jest.fn().mockResolvedValue( {
-				platform: 'Windows',
-				bitness: '64',
-			} ),
-		};
+			Object.defineProperty( global.navigator, 'platform', {
+				value: 'Unknown Platform',
+				writable: true,
+				configurable: true,
+			} );
 
-		Object.defineProperty( global.navigator, 'userAgentData', {
-			value: mockUserAgentData,
-			writable: true,
-			configurable: true,
+			const result = await detectPlatformAndArchitecture();
+			expect( result ).toBeNull();
 		} );
-
-		const result = await getWindowsArchitecture();
-		expect( result ).toBeNull();
-	} );
-
-	it( 'should return null when userAgentData is not available', async () => {
-		Object.defineProperty( global.navigator, 'userAgentData', {
-			value: undefined,
-			writable: true,
-			configurable: true,
-		} );
-
-		const result = await getWindowsArchitecture();
-		expect( result ).toBeNull();
-	} );
-
-	it( 'should return null and log warning when getHighEntropyValues throws an error', async () => {
-		const consoleWarnSpy = jest.spyOn( console, 'warn' ).mockImplementation();
-		const mockError = new Error( 'Permission denied' );
-
-		const mockUserAgentData = {
-			brands: [],
-			mobile: false,
-			platform: 'Windows',
-			getHighEntropyValues: jest.fn().mockRejectedValue( mockError ),
-		};
-
-		Object.defineProperty( global.navigator, 'userAgentData', {
-			value: mockUserAgentData,
-			writable: true,
-			configurable: true,
-		} );
-
-		const result = await getWindowsArchitecture();
-		expect( result ).toBeNull();
-		expect( consoleWarnSpy ).toHaveBeenCalledWith(
-			'Failed to get high entropy values:',
-			mockError
-		);
-
-		consoleWarnSpy.mockRestore();
 	} );
 } );

--- a/client/blocks/get-apps/platform-detection.ts
+++ b/client/blocks/get-apps/platform-detection.ts
@@ -21,42 +21,77 @@ declare global {
 	}
 }
 
+export interface PlatformDetectionResult {
+	platform: string;
+	architecture?: 'arm64' | 'x64';
+	detectionMethod: 'client-hints' | 'navigator-platform';
+}
+
 /**
- * Detects Windows architecture using User-Agent Client Hints API
- * Returns 'arm64', 'x64', or null if detection fails
+ * Detects platform and architecture using User-Agent Client Hints API
+ * Returns platform info with architecture if detected, or null if detection fails
  */
-export const getWindowsArchitecture = async (): Promise< 'arm64' | 'x64' | null > => {
-	// Check if User-Agent Client Hints API is available
-	if ( 'userAgentData' in navigator && navigator.userAgentData ) {
-		try {
-			const uaData = await navigator.userAgentData.getHighEntropyValues( [
-				'architecture',
-				'bitness',
-				'platform',
-			] );
+export const detectPlatformAndArchitecture =
+	async (): Promise< PlatformDetectionResult | null > => {
+		// Try User-Agent Client Hints API first (most reliable)
+		if ( 'userAgentData' in navigator && navigator.userAgentData ) {
+			try {
+				const uaData = await navigator.userAgentData.getHighEntropyValues( [
+					'architecture',
+					'bitness',
+					'platform',
+				] );
 
-			// ARM64 detection
-			if ( uaData.architecture === 'arm' || uaData.architecture === 'arm64' ) {
-				return 'arm64';
+				const platform = uaData.platform?.toLowerCase() || '';
+
+				let architecture: 'arm64' | 'x64' | undefined;
+
+				// Detect architecture for all platforms
+				if ( uaData.architecture === 'arm' || uaData.architecture === 'arm64' ) {
+					architecture = 'arm64';
+				} else if ( uaData.architecture === 'x86' && uaData.bitness === '64' ) {
+					architecture = 'x64';
+				} else if ( uaData.architecture === 'x86' ) {
+					architecture = 'x64'; // Assume x64 for x86 architecture
+				}
+
+				return {
+					platform,
+					architecture,
+					detectionMethod: 'client-hints',
+				};
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.warn( 'Failed to get high entropy values:', error );
 			}
-
-			// x64/x86 detection
-			if ( uaData.architecture === 'x86' && uaData.bitness === '64' ) {
-				return 'x64';
-			}
-
-			// Default to x64 for Windows if architecture is detected but doesn't match above
-			if ( uaData.architecture ) {
-				return 'x64';
-			}
-
-			return null;
-		} catch ( error ) {
-			// eslint-disable-next-line no-console
-			console.warn( 'Failed to get high entropy values:', error );
-			return null;
 		}
-	}
 
-	return null; // API not available
-};
+		// Fallback to navigator.platform (unreliable, frozen in modern browsers)
+		const platformName = navigator.platform.toLowerCase();
+
+		if ( platformName.includes( 'mac' ) ) {
+			return {
+				platform: 'macos',
+				architecture: undefined, // Cannot reliably detect Mac architecture
+				detectionMethod: 'navigator-platform',
+			};
+		}
+
+		if ( platformName.includes( 'linux' ) ) {
+			return {
+				platform: 'linux',
+				architecture: undefined,
+				detectionMethod: 'navigator-platform',
+			};
+		}
+
+		if ( platformName.includes( 'win' ) ) {
+			return {
+				platform: 'windows',
+				architecture: undefined, // Cannot detect Windows architecture without Client Hints
+				detectionMethod: 'navigator-platform',
+			};
+		}
+
+		return null; // Unable to detect platform
+	};

--- a/client/blocks/get-apps/platform-detection.ts
+++ b/client/blocks/get-apps/platform-detection.ts
@@ -1,0 +1,62 @@
+/**
+ * Type definitions for User-Agent Client Hints API
+ */
+interface UADataValues {
+	platform: string;
+	architecture?: string;
+	bitness?: string;
+	platformVersion?: string;
+}
+
+interface NavigatorUAData {
+	brands: ReadonlyArray< { brand: string; version: string } >;
+	mobile: boolean;
+	platform: string;
+	getHighEntropyValues( hints: string[] ): Promise< UADataValues >;
+}
+
+declare global {
+	interface Navigator {
+		userAgentData?: NavigatorUAData;
+	}
+}
+
+/**
+ * Detects Windows architecture using User-Agent Client Hints API
+ * Returns 'arm64', 'x64', or null if detection fails
+ */
+export const getWindowsArchitecture = async (): Promise< 'arm64' | 'x64' | null > => {
+	// Check if User-Agent Client Hints API is available
+	if ( 'userAgentData' in navigator && navigator.userAgentData ) {
+		try {
+			const uaData = await navigator.userAgentData.getHighEntropyValues( [
+				'architecture',
+				'bitness',
+				'platform',
+			] );
+
+			// ARM64 detection
+			if ( uaData.architecture === 'arm' || uaData.architecture === 'arm64' ) {
+				return 'arm64';
+			}
+
+			// x64/x86 detection
+			if ( uaData.architecture === 'x86' && uaData.bitness === '64' ) {
+				return 'x64';
+			}
+
+			// Default to x64 for Windows if architecture is detected but doesn't match above
+			if ( uaData.architecture ) {
+				return 'x64';
+			}
+
+			return null;
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'Failed to get high entropy values:', error );
+			return null;
+		}
+	}
+
+	return null; // API not available
+};

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -121,6 +121,15 @@ main.get-apps {
 	.get-apps__desktop-button {
 		margin-right: 8px;
 
+		.components-button {
+			display: inline-flex;
+			align-items: center;
+			gap: 8px;
+			white-space: nowrap;
+			height: auto;
+			padding: 8px 14px;
+		}
+
 		.split-button__main {
 			display: inline-flex;
 			align-items: center;

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -128,6 +128,7 @@ main.get-apps {
 			white-space: nowrap;
 			height: auto;
 			padding: 8px 14px;
+			border: 0;
 		}
 
 		.split-button__main {

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -98,22 +98,22 @@ main.get-apps {
 	.get-apps__also-available {
 		margin-top: 16px;
 		display: flex;
-		flex-direction: column;
+		flex-wrap: wrap;
+		align-items: center;
 		gap: 16px;
 		font-size: $font-body-extra-small;
+	}
 
-		@include break-medium {
-			flex-direction: row;
-		}
+	.get-apps__also-available-title {
+		flex-shrink: 0;
 	}
 
 	.get-apps__also-available-list {
-		display: flex;
-		flex-direction: row;
-		gap: 16px;
+		display: contents;
 
 		> a {
 			display: inline-flex;
+			align-items: center;
 			gap: 2px;
 		}
 	}

--- a/client/blocks/get-apps/test/platform-detection.test.ts
+++ b/client/blocks/get-apps/test/platform-detection.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { detectPlatformAndArchitecture } from './platform-detection';
+import { detectPlatformAndArchitecture } from '../platform-detection';
 
 describe( 'detectPlatformAndArchitecture', () => {
 	const originalNavigator = global.navigator;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STU-982

## Proposed Changes

- Add User-Agent Client Hints API detection for Windows ARM64/x64 and macOS Intel/Apple Silicon architectures
- Replace generic Windows platform types with architecture-specific variants (WindowsARM64, WindowsX64)
- Implement async platform detection with graceful fallback to `navigator.platform`
- Add conditional UI rendering: single button for successful detection, split button dropdown for detection failures
- Update platform configurations with architecture-specific download links and analytics events for WordPress Studio and WordPress.com Desktop apps
- Add unit tests for platform detection logic
- Update styles for consistent button sizing and flex-wrap behavior for platform links

|**Chrome**|**Safari**|**Edge (Windows on Parallels)**|
|---|---|---|
|<img width="1069" height="646" alt="chrome-arm" src="https://github.com/user-attachments/assets/af3812a6-7b56-488f-95fd-cc362bcf106e" />|<img width="1094" height="614" alt="safari-arm" src="https://github.com/user-attachments/assets/0d4bf2c7-2317-44d5-a18f-a3f2ca987cd3" />|<img width="1248" height="707" alt="windows-arm" src="https://github.com/user-attachments/assets/58cd1389-59a1-4345-99cc-423fc4eee71d" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Modern Windows and Mac devices come in different CPU architectures (ARM64 vs x64, Apple Silicon vs Intel), and users need the correct binary for optimal performance. The deprecated `navigator.platform` API returns frozen values (e.g., "Win32" for all Windows, "MacIntel" for all Macs), making architecture detection impossible.

This change uses the User-Agent Client Hints API to accurately detect device architecture in Chrome/Edge browsers, enabling:
- Correct architecture-specific downloads for WordPress Studio (which has separate ARM64/x64 builds)
- Better analytics tracking to understand architecture distribution in our user base
- Improved user experience with the right download shown immediately

For browsers without Client Hints support (Firefox, Safari), users see a dropdown to select their architecture manually.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Quick Rendering Tests (Force Scenarios)

Test different platform/architecture combinations by temporarily replacing the `getCurrentPlatform` function in `client/blocks/get-apps/desktop-download-card.tsx` (around line 12-72) with these one-liners:

1. Windows ARM64 (single button):
```
const getCurrentPlatform = async () => ({ platform: PlatformType.WindowsARM64, detectionFailed: false });
```
Expected: Single "Download for Windows on ARM" button

3. Windows x64 (single button):
```
const getCurrentPlatform = async () => ({ platform: PlatformType.WindowsX64, detectionFailed: false });
```
Expected: Single "Download for Windows (x64)" button

4. Mac Apple Silicon (single button):
```
const getCurrentPlatform = async () => ({ platform: PlatformType.MacSilicon, detectionFailed: false });
```
Expected: Single "Download for Mac (Apple Silicon)" button

5. Mac Intel (single button):
```
const getCurrentPlatform = async () => ({ platform: PlatformType.MacIntel, detectionFailed: false });
```
Expected: Single "Download for Mac (Intel)" button

6. Windows detection failed (split button dropdown):
```
const getCurrentPlatform = async () => ({ platform: PlatformType.WindowsX64, detectionFailed: true });
```
Expected: Split button with dropdown showing "Windows (x64)" and "Windows on ARM" options

8. Mac detection failed (split button dropdown):
```
const getCurrentPlatform = async () => ({ platform: PlatformType.MacIntel, detectionFailed: true });
```
Expected: Split button with dropdown showing "Mac (Intel)" and "Mac (Apple Silicon)" options

### Full Workflow Tests

Chrome/Edge on Windows x64:

1. Navigate to the get-apps page
2. Verify single "Download for Windows (x64)" button appears
3. Verify "Also available for:" shows Windows on ARM, Mac options, Linux options
4. Click download button and verify correct x64 link is used
5. Check browser console for calypso_studio_download_windows_x64_click analytics event

Chrome/Edge on Windows ARM64 (e.g., Surface Pro X):
1. Navigate to the get-apps page
2. Verify single "Download for Windows on ARM" button appears
3. Click download and verify ARM64 link for Studio app
4. Check analytics event: calypso_studio_download_windows_arm64_click

Chrome/Edge on Mac with Apple Silicon:
1. Navigate to the get-apps page
2. Verify single "Download for Mac (Apple Silicon)" button appears
3. Verify correct download links for both apps

Chrome/Edge on Mac with Intel:
1. Navigate to the get-apps page
2. Verify single "Download for Mac (Intel)" button appears
3. Verify correct download links

Firefox or Safari (any platform):
1. Navigate to the get-apps page
2. Verify split button dropdown appears (detection fallback)
3. Verify dropdown contains both architecture options for the detected platform
4. Test manual architecture selection works correctly

Mobile devices:
  1. Verify mobile view still displays correctly with app store links

Visual checks:
 - Button sizes match between single button and split button
 - Platform links wrap naturally when line width is exceeded
 - Icons display correctly for all platforms
 - Spacing and alignment are consistent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
