### PR TITLE
MSD: Remove 'any' from usePersistentView

### DIFF
--- a/client/dashboard/app/dataviews/use-persistent-view.ts
+++ b/client/dashboard/app/dataviews/use-persistent-view.ts
@@ -6,6 +6,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { setTransientQueryParamsAtPathname } from '../transient-query-params';
 import type { Filter, View } from '@wordpress/dataviews';
 
+export type QueryParams = { page?: string | number; search?: string } | Record< string, string >;
+
 interface UseViewOptions {
 	/**
 	 * Unique slug to identify the view.
@@ -22,7 +24,7 @@ interface UseViewOptions {
 	 * The URL query params in the current page.
 	 * If passed, transient properties (`page` and `search`) are synced to the URL query params.
 	 */
-	queryParams?: any;
+	queryParams?: QueryParams;
 
 	/**
 	 * Fields that should become transient filters when present in the URL query params.
@@ -56,13 +58,13 @@ export function usePersistentView( {
 
 	const baseView = persistedView ?? defaultView;
 
-	const page = parseInt( queryParams?.page ) || baseView.page || 1;
+	const page = parseInt( String( queryParams?.page ) ) || baseView.page || 1;
 	const search = queryParams?.search || baseView.search || '';
 
 	const transientProperties = useMemo( () => ( { page, search } ), [ page, search ] );
 
 	const transientFilterFields = queryParamFilterFields.filter(
-		( field ) => queryParams && queryParams[ field ] !== undefined
+		( field ) => queryParams && queryParams[ field as keyof typeof queryParams ] !== undefined
 	);
 
 	const [ transientFilters, setTransientFilters ] = useState< Filter[] >( [] );
@@ -74,7 +76,10 @@ export function usePersistentView( {
 					( {
 						field,
 						operator: 'isAny',
-						value: [ queryParams[ field ].toString() ],
+						value:
+							queryParams && queryParams[ field as keyof typeof queryParams ]
+								? [ queryParams[ field as keyof typeof queryParams ].toString() ]
+								: [],
 					} ) as Filter
 			)
 		);
@@ -125,7 +130,10 @@ export function usePersistentView( {
 				( field ) =>
 					newView.filters?.some(
 						( filter ) =>
-							filter.field === field && fastDeepEqual( filter.value, [ queryParams[ field ] ] )
+							filter.field === field &&
+							fastDeepEqual( filter.value, [
+								queryParams ? queryParams[ field as keyof typeof queryParams ] : undefined,
+							] )
 					)
 			);
 
@@ -205,20 +213,23 @@ function removeEmptyFiltersFromView( view: View ): View {
 	return view;
 }
 
-function clearQueryParamsFromTransientFilters( queryParams: any, transientFilterFields: string[] ) {
+function clearQueryParamsFromTransientFilters(
+	queryParams: QueryParams,
+	transientFilterFields: string[]
+) {
 	const newQueryParams = { ...queryParams };
 
 	transientFilterFields.forEach( ( field ) => {
-		delete newQueryParams[ field ];
+		delete newQueryParams[ field as keyof typeof queryParams ];
 	} );
 
 	return newQueryParams;
 }
 
 function mergeQueryParamsWithTransientProperties(
-	queryParams: any,
+	queryParams: QueryParams,
 	{ page, search }: { page?: number; search?: string }
-): any {
+): QueryParams {
 	const newQueryParams = { ...queryParams };
 
 	if ( page === 1 ) {

--- a/client/dashboard/app/dataviews/use-persistent-view.ts
+++ b/client/dashboard/app/dataviews/use-persistent-view.ts
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { setTransientQueryParamsAtPathname } from '../transient-query-params';
 import type { Filter, View } from '@wordpress/dataviews';
 
-export type QueryParams = { page?: string | number; search?: string } | Record< string, string >;
+export type QueryParams = Record< string, string | number | undefined >;
 
 interface UseViewOptions {
 	/**
@@ -59,7 +59,7 @@ export function usePersistentView( {
 	const baseView = persistedView ?? defaultView;
 
 	const page = parseInt( String( queryParams?.page ) ) || baseView.page || 1;
-	const search = queryParams?.search || baseView.search || '';
+	const search = String( queryParams?.search || baseView.search || '' );
 
 	const transientProperties = useMemo( () => ( { page, search } ), [ page, search ] );
 
@@ -78,7 +78,7 @@ export function usePersistentView( {
 						operator: 'isAny',
 						value:
 							queryParams && queryParams[ field as keyof typeof queryParams ]
-								? [ queryParams[ field as keyof typeof queryParams ].toString() ]
+								? [ queryParams[ field as keyof typeof queryParams ]?.toString() ]
 								: [],
 					} ) as Filter
 			)
@@ -93,9 +93,9 @@ export function usePersistentView( {
 			return;
 		}
 
-		let transientQueryParams: Record< string, unknown > = {};
-		transientFilters.forEach( ( { field } ) => {
-			transientQueryParams[ field ] = queryParams[ field ];
+		let transientQueryParams: QueryParams = {};
+		transientFilters.forEach( ( { field, value } ) => {
+			transientQueryParams[ field ] = value as string | number | undefined;
 		} );
 		transientQueryParams = mergeQueryParamsWithTransientProperties(
 			transientQueryParams,
@@ -146,12 +146,29 @@ export function usePersistentView( {
 				if ( ! fastDeepEqual( newTransientFilterFields, transientFilterFields ) ) {
 					setTransientFilters( [] );
 					navigate( {
-						search: clearQueryParamsFromTransientFilters( queryParams, transientFilterFields ),
+						// This hook is used across multiple routes with
+						// different search param types. Each route defines its
+						// own validateSearch to ensure runtime type safety,
+						// but TypeScript can't infer the correct union type at
+						// the hook level so we have to use `as any`.
+						search: ( () =>
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							clearQueryParamsFromTransientFilters( queryParams, transientFilterFields ) ) as any,
 						replace: true,
 					} );
 				} else if ( ! fastDeepEqual( newTransientProperties, transientProperties ) ) {
 					navigate( {
-						search: mergeQueryParamsWithTransientProperties( queryParams, newTransientProperties ),
+						// This hook is used across multiple routes with
+						// different search param types. Each route defines its
+						// own validateSearch to ensure runtime type safety,
+						// but TypeScript can't infer the correct union type at
+						// the hook level so we have to use `as any`.
+						search: ( () =>
+							mergeQueryParamsWithTransientProperties(
+								queryParams,
+								newTransientProperties
+								// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							) ) as any,
 					} );
 				}
 			}


### PR DESCRIPTION
Fixes SHILL-1379

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

This PR refactors the types of `usePersistentView()` – part of the Multi Site Dashboard which allows persisting the `DataViews` state (a `View`) – so that its `queryParams` option does not use TypeScript `any`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

`usePersistentView` makes use of TypeScript's `any` for the `queryParams` option. This is bad for several reasons. One: it goes against our philosophy for the calypso monorepo (hence why we have a `no-explicit-any` linter rule). Two: it opts out of any type checking whatsoever, which would allow fatal errors to easily occur if this property is misused (eg: if you pass in a number). Three: it prevents us from making sure that the property is used correctly within the component.

Fixing this should be fairly easy because we know exactly what type of data it should contain: I believe it's just a Record of key value pairs where the values are primitive types like number, string, or undefined.

The only difficulty is passing it to `navigate()` because that includes type checking for each route's allowed query parameters and we don't know which route we're in inside the hook. Still, we could at least reduce the any surface area to that one place.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit http://calypso.localhost:3000/v2/me/billing/purchases
- Change the view by, for example, changing the page of results or filtering by a single site.
- Click back to the purchases list using either the browser back button or using the breadcrumbs.
- Verify that the view changes remain unchanged.