### PR TITLE
MSD: Add domain specific removal flow

### DIFF
--- a/.rules/calypso-client-rules.mdc
+++ b/.rules/calypso-client-rules.mdc
@@ -47,6 +47,7 @@ Before responding to any request, follow these steps:
 - Implement proper WordPress hooks system.
 - Structure components using WordPress conventions.
 - Carrefully follow [.eslintrc.js](mdc:.eslintrc.js) coding standarts.
+- **CRITICAL: After creating or modifying ANY JavaScript/TypeScript file, you MUST run `yarn eslint --fix` on that specific file individually. This is mandatory for every single file change.**
 
 ### Naming Conventions
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
@@ -72,20 +72,20 @@ export default function DomainRemovalConfirmationStep( {
 			<ButtonStack>
 				<Button
 					__next40pxDefaultSize
+					variant="tertiary"
+					onClick={ onCancel }
+					disabled={ isLoading }
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
 					variant="primary"
 					isDestructive
 					onClick={ onConfirm }
 					disabled={ ! domainConfirmed || isLoading }
 				>
 					{ __( 'Delete this domain' ) }
-				</Button>
-				<Button
-					__next40pxDefaultSize
-					variant="tertiary"
-					onClick={ onCancel }
-					disabled={ isLoading }
-				>
-					{ __( 'Cancel' ) }
 				</Button>
 			</ButtonStack>
 		</VStack>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
@@ -66,7 +66,7 @@ export default function DomainRemovalConfirmationStep( {
 				/>
 			</VStack>
 
-			<ButtonStack>
+			<ButtonStack justify="flex-end">
 				<Button
 					__next40pxDefaultSize
 					variant="tertiary"

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
@@ -5,7 +5,7 @@ import {
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from 'react';
 import { ButtonStack } from '../../../components/button-stack';
 import { Text } from '../../../components/text';
@@ -46,15 +46,12 @@ export default function DomainRemovalConfirmationStep( {
 
 				<Text>
 					{ createInterpolateElement(
-						sprintf(
-							/* translators: %s is the domain name */
-							__(
-								'<strong>%s</strong> will be deleted. Any services related to it will stop working. Are you sure you want to proceed?'
-							),
-							domainName
+						/* translators: <domainName /> is the domain name */
+						__(
+							'<domainName /> will be deleted. Any services related to it will stop working. Are you sure you want to proceed?'
 						),
 						{
-							strong: <strong />,
+							domainName: <strong>{ domainName }</strong>,
 						}
 					) }
 				</Text>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
@@ -1,0 +1,93 @@
+import {
+	Button,
+	__experimentalInputControl as InputControl,
+	__experimentalVStack as VStack,
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState, useCallback } from 'react';
+import { ButtonStack } from '../../../components/button-stack';
+import { Text } from '../../../components/text';
+import type { Purchase } from '@automattic/api-core';
+
+import './style.scss';
+
+interface DomainRemovalConfirmationStepProps {
+	purchase: Purchase;
+	onConfirm: () => void;
+	onCancel: () => void;
+	isLoading?: boolean;
+}
+
+export default function DomainRemovalConfirmationStep( {
+	purchase,
+	onConfirm,
+	onCancel,
+	isLoading = false,
+}: DomainRemovalConfirmationStepProps ) {
+	const domainName = purchase.meta || purchase.product_name;
+	const [ inputValue, setInputValue ] = useState( '' );
+	const [ domainConfirmed, setDomainConfirmed ] = useState( false );
+
+	const handleInputChange = useCallback(
+		( value: string | undefined ) => {
+			const newValue = value || '';
+			setInputValue( newValue );
+			setDomainConfirmed( newValue === domainName );
+		},
+		[ domainName ]
+	);
+
+	return (
+		<VStack spacing={ 8 }>
+			<VStack spacing={ 3 }>
+				<Heading level={ 2 }>{ __( 'Confirm your decision' ) }</Heading>
+
+				<Text as="p">
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: %s is the domain name */
+							__(
+								'<strong>%s</strong> will be deleted. Any services related to it will stop working. Are you sure you want to proceed?'
+							),
+							domainName
+						),
+						{
+							strong: <strong />,
+						}
+					) }
+				</Text>
+
+				<InputControl
+					__next40pxDefaultSize
+					label={ __( 'Type your domain name to proceed' ) }
+					value={ inputValue }
+					onChange={ handleInputChange }
+					disabled={ isLoading }
+					placeholder={ domainName }
+				/>
+			</VStack>
+
+			<ButtonStack>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					isDestructive
+					onClick={ onConfirm }
+					disabled={ ! domainConfirmed || isLoading }
+				>
+					{ __( 'Delete this domain' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					variant="tertiary"
+					onClick={ onCancel }
+					disabled={ isLoading }
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+			</ButtonStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
@@ -42,9 +42,9 @@ export default function DomainRemovalConfirmationStep( {
 	return (
 		<VStack spacing={ 8 }>
 			<VStack spacing={ 3 }>
-				<Heading level={ 2 }>{ __( 'Confirm your decision' ) }</Heading>
+				<Heading level={ 3 }>{ __( 'Confirm your decision' ) }</Heading>
 
-				<Text as="p">
+				<Text>
 					{ createInterpolateElement(
 						sprintf(
 							/* translators: %s is the domain name */

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-flow.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-flow.tsx
@@ -1,0 +1,89 @@
+import { removePurchaseMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState, useCallback } from 'react';
+import { purchaseSettingsRoute } from '../../../app/router/me';
+import DomainRemovalConfirmationStep from './domain-removal-confirmation-step';
+import DomainRemovalWarningStep from './domain-removal-warning-step';
+import type { Purchase } from '@automattic/api-core';
+
+import './style.scss';
+
+interface DomainRemovalFlowProps {
+	purchase: Purchase;
+	onCancel: () => void;
+}
+
+type RemovalStep = 'warning' | 'confirmation';
+
+export default function DomainRemovalFlow( { purchase, onCancel }: DomainRemovalFlowProps ) {
+	const [ currentStep, setCurrentStep ] = useState< RemovalStep >( 'warning' );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const navigate = useNavigate();
+	const removePurchaseMutator = useMutation( removePurchaseMutation() );
+
+	const handleContinue = useCallback( () => {
+		setCurrentStep( 'confirmation' );
+	}, [] );
+
+	const handleConfirm = useCallback( () => {
+		removePurchaseMutator.mutate( purchase.ID, {
+			onSuccess: () => {
+				const domainName = purchase.meta || purchase.product_name;
+				createSuccessNotice(
+					sprintf(
+						/* translators: %(domain)s is a domain name */
+						__( 'The domain %(domain)s was removed from your account.' ),
+						{
+							domain: domainName,
+						}
+					),
+					{ type: 'snackbar' }
+				);
+				navigate( {
+					to: purchaseSettingsRoute.fullPath,
+					params: { purchaseId: purchase.ID },
+				} );
+			},
+			onError: () => {
+				const domainName = purchase.meta || purchase.product_name;
+				createErrorNotice(
+					sprintf(
+						/* translators: %(domainName)s is the name of the domain. */
+						__(
+							'There was a problem removing %(domainName)s. Please try again later or contact support.'
+						),
+						{ domainName }
+					),
+					{ type: 'snackbar' }
+				);
+			},
+		} );
+	}, [ purchase, removePurchaseMutator, createSuccessNotice, createErrorNotice, navigate ] );
+
+	const isLoading = removePurchaseMutator.isPending;
+
+	return (
+		<div>
+			{ currentStep === 'warning' && (
+				<DomainRemovalWarningStep
+					purchase={ purchase }
+					onContinue={ handleContinue }
+					onCancel={ onCancel }
+					isLoading={ isLoading }
+				/>
+			) }
+			{ currentStep === 'confirmation' && (
+				<DomainRemovalConfirmationStep
+					purchase={ purchase }
+					onConfirm={ handleConfirm }
+					onCancel={ onCancel }
+					isLoading={ isLoading }
+				/>
+			) }
+		</div>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
@@ -89,7 +89,7 @@ export default function DomainRemovalWarningStep( {
 				<Text>{ __( 'Do you still want to continue with deleting your domain?' ) }</Text>
 			</VStack>
 
-			<ButtonStack>
+			<ButtonStack justify="flex-end">
 				<Button
 					__next40pxDefaultSize
 					variant="tertiary"

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
@@ -87,20 +87,10 @@ export default function DomainRemovalWarningStep( {
 					) }
 				</Text>
 
-				<Text>
-					<strong>{ __( 'Do you still want to continue with deleting your domain?' ) }</strong>
-				</Text>
+				<Text>{ __( 'Do you still want to continue with deleting your domain?' ) }</Text>
 			</VStack>
 
 			<ButtonStack>
-				<Button
-					__next40pxDefaultSize
-					variant="primary"
-					onClick={ onContinue }
-					disabled={ isLoading }
-				>
-					{ __( 'Continue' ) }
-				</Button>
 				<Button
 					__next40pxDefaultSize
 					variant="tertiary"
@@ -108,6 +98,14 @@ export default function DomainRemovalWarningStep( {
 					disabled={ isLoading }
 				>
 					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					onClick={ onContinue }
+					disabled={ isLoading }
+				>
+					{ __( 'Continue' ) }
 				</Button>
 			</ButtonStack>
 		</VStack>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
@@ -40,7 +40,9 @@ export default function DomainRemovalWarningStep( {
 					{ sprintf(
 						/* translators: %(domainName)s is the domain name */
 						__( 'Delete %(domainName)s' ),
-						domainName
+						{
+							domainName,
+						}
 					) }
 				</Heading>
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
@@ -36,16 +36,11 @@ export default function DomainRemovalWarningStep( {
 	return (
 		<VStack spacing={ 8 }>
 			<VStack spacing={ 3 }>
-				<Heading level={ 2 }>
-					{ createInterpolateElement(
-						sprintf(
-							/* translators: %s is the domain name */
-							__( 'Delete <strong>%s</strong>' ),
-							domainName
-						),
-						{
-							strong: <strong />,
-						}
+				<Heading level={ 3 }>
+					{ sprintf(
+						/* translators: %s is the domain name */
+						__( 'Delete %s' ),
+						domainName
 					) }
 				</Heading>
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
@@ -38,8 +38,8 @@ export default function DomainRemovalWarningStep( {
 			<VStack spacing={ 3 }>
 				<Heading level={ 3 }>
 					{ sprintf(
-						/* translators: %s is the domain name */
-						__( 'Delete %s' ),
+						/* translators: %(domainName)s is the domain name */
+						__( 'Delete %(domainName)s' ),
 						domainName
 					) }
 				</Heading>
@@ -60,15 +60,12 @@ export default function DomainRemovalWarningStep( {
 
 				<Text>
 					{ createInterpolateElement(
-						sprintf(
-							/* translators: %s is the domain name */
-							__(
-								'If you want to use <strong>%s</strong> with another provider you can <moveLink>move it to another service</moveLink> or <transferLink>transfer it to another provider</transferLink>.'
-							),
-							domainName
+						/* translators: <domainName /> is the domain name */
+						__(
+							'If you want to use <domainName /> with another provider you can <moveLink>move it to another service</moveLink> or <transferLink>transfer it to another provider</transferLink>.'
 						),
 						{
-							strong: <strong />,
+							domainName: <strong>{ domainName }</strong>,
 							moveLink: (
 								<RouterLinkButton
 									variant="link"

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
@@ -1,0 +1,120 @@
+import { domainQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	Button,
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { ButtonStack } from '../../../components/button-stack';
+import RouterLinkButton from '../../../components/router-link-button';
+import { Text } from '../../../components/text';
+import type { Purchase } from '@automattic/api-core';
+
+import './style.scss';
+
+interface DomainRemovalWarningStepProps {
+	purchase: Purchase;
+	onContinue: () => void;
+	onCancel: () => void;
+	isLoading?: boolean;
+}
+
+export default function DomainRemovalWarningStep( {
+	purchase,
+	onContinue,
+	onCancel,
+	isLoading = false,
+}: DomainRemovalWarningStepProps ) {
+	const domainName = purchase.meta || purchase.product_name;
+	const { data: domain } = useQuery( {
+		...domainQuery( domainName ),
+		enabled: Boolean( domainName ),
+	} );
+
+	return (
+		<VStack spacing={ 8 }>
+			<VStack spacing={ 3 }>
+				<Heading level={ 2 }>
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: %s is the domain name */
+							__( 'Delete <strong>%s</strong>' ),
+							domainName
+						),
+						{
+							strong: <strong />,
+						}
+					) }
+				</Heading>
+
+				<Text>
+					{ __(
+						'Deleting a domain will make all services connected to it unreachable, including your email and website. It will also make the domain available for someone else to register.'
+					) }
+				</Text>
+
+				{ domain?.is_gravatar_domain && (
+					<Text>
+						{ __(
+							'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
+						) }
+					</Text>
+				) }
+
+				<Text>
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: %s is the domain name */
+							__(
+								'If you want to use <strong>%s</strong> with another provider you can <moveLink>move it to another service</moveLink> or <transferLink>transfer it to another provider</transferLink>.'
+							),
+							domainName
+						),
+						{
+							strong: <strong />,
+							moveLink: (
+								<RouterLinkButton
+									variant="link"
+									to="/domains/$domainName"
+									params={ { domainName } }
+								/>
+							),
+							transferLink: (
+								<RouterLinkButton
+									variant="link"
+									to="/domains/$domainName/transfer"
+									params={ { domainName } }
+								/>
+							),
+						}
+					) }
+				</Text>
+
+				<Text>
+					<strong>{ __( 'Do you still want to continue with deleting your domain?' ) }</strong>
+				</Text>
+			</VStack>
+
+			<ButtonStack>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					onClick={ onContinue }
+					disabled={ isLoading }
+				>
+					{ __( 'Continue' ) }
+				</Button>
+				<Button
+					__next40pxDefaultSize
+					variant="tertiary"
+					onClick={ onCancel }
+					disabled={ isLoading }
+				>
+					{ __( 'Cancel' ) }
+				</Button>
+			</ButtonStack>
+		</VStack>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1144,135 +1144,131 @@ export default function CancelPurchase() {
 
 	if ( isDomainRemoval ) {
 		return (
-			<>
-				<PageLayout
-					size="small"
-					header={
-						<PageHeader
-							title={ <CancelHeaderTitle flowType={ flowType } purchase={ purchase } /> }
-							prefix={ <Breadcrumbs length={ 4 } /> }
-							description={ __( 'Please confirm that you want to remove this domain.' ) }
-						/>
-					}
-				>
-					<Card className="cancel-purchase__wrapper-card">
-						<DomainRemovalFlow purchase={ purchase } onCancel={ redirectBack } />
-					</Card>
-				</PageLayout>
-			</>
-		);
-	}
-
-	return (
-		<>
 			<PageLayout
 				size="small"
 				header={
 					<PageHeader
 						title={ <CancelHeaderTitle flowType={ flowType } purchase={ purchase } /> }
 						prefix={ <Breadcrumbs length={ 4 } /> }
-						description={ __(
-							'Before you go, please answer a few quick questions to help us improve.'
-						) }
+						description={ __( 'Please confirm that you want to remove this domain.' ) }
 					/>
 				}
 			>
-				<VStack>
-					{ ! state.surveyShown && <TimeRemainingNotice purchase={ purchase } /> }
-
-					<Card className="cancel-purchase__wrapper-card">
-						<CancelPurchaseForm
-							atomicRevertCheckOne={ state.atomicRevertCheckOne }
-							atomicRevertCheckTwo={ state.atomicRevertCheckTwo }
-							atomicRevertOnClickCheckOne={ atomicRevertOnClickCheckOne }
-							atomicRevertOnClickCheckTwo={ atomicRevertOnClickCheckTwo }
-							atomicTransfer={ atomicTransfer }
-							cancelBundledDomain={ state.cancelBundledDomain }
-							cancellationInProgress={ state.isLoading }
-							cancellationOffer={ cancellationOffer }
-							clickNext={ clickNext }
-							closeDialog={ closeDialog }
-							disableButtons={ state.isLoading }
-							downgradeClick={ downgradeClick }
-							downgradePlan={ downgradePlan }
-							flowType={ flowType }
-							freeMonthOfferClick={ freeMonthOfferClick }
-							getAllSurveySteps={ getAllSurveySteps }
-							hasBackupsFeature={ hasBackupsFeature }
-							importQuestionRadio={ state.importQuestionRadio }
-							includedDomainPurchase={ includedDomainPurchase }
-							isAkismet={ isAkismet }
-							isApplyingOffer={ isApplyingOffer }
-							isImport={ isImport }
-							isNextAdventureValid={ state.isNextAdventureValid }
-							isShowing={ state.isShowingMarketplaceSubscriptionsDialog }
-							isSubmitting={ state.isSubmitting }
-							isVisible={ state.surveyShown }
-							offerDiscountBasedFromPurchasePrice={ offerDiscountBasedFromPurchasePrice }
-							onClickAcceptForCancellationOffer={ onClickAcceptForCancellationOffer }
-							onGetCancellationOffer={ onGetCancellationOffer }
-							onImportRadioChange={ onImportRadioChange }
-							onNextAdventureValidationChange={ onNextAdventureValidationChange }
-							onRadioOneChange={ onRadioOneChange }
-							onRadioTwoChange={ onRadioTwoChange }
-							onSubmit={ onSubmit }
-							onSurveyComplete={ onSurveyComplete }
-							onTextOneChange={ onTextOneChange }
-							onTextThreeChange={ onTextThreeChange }
-							onTextTwoChange={ onTextTwoChange }
-							plans={ plans }
-							purchase={ purchase }
-							questionOneOrder={ state.questionOneOrder }
-							questionOneRadio={ state.questionOneRadio }
-							questionOneText={ state.questionOneText }
-							questionTwoOrder={ state.questionTwoOrder }
-							questionTwoRadio={ state.questionTwoRadio }
-							questionTwoText={ state.questionTwoText }
-							refundAmount={ purchase.total_refund_amount }
-							siteSlug={ siteSlug }
-							solution={ state.solution }
-							surveyStep={ state.surveyStep }
-							upsell={ state.upsell }
-						/>
-						{ ! state.surveyShown && (
-							<CancellationPreSurveyContent
-								purchase={ purchase }
-								includedDomainPurchase={ includedDomainPurchase }
-								atomicTransfer={ atomicTransfer }
-								selectedDomain={ selectedDomain }
-								state={ state }
-								purchaseCancelFeatures={ purchaseCancelFeatures }
-								onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
-								onDomainConfirmationChange={ onDomainConfirmationChange }
-								onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
-								onKeepSubscriptionClick={ onKeepSubscriptionClick }
-								onCancellationComplete={ onCancellationComplete }
-								onCancellationStart={ onCancellationStart }
-								shouldHandleMarketplaceSubscriptions={ shouldHandleMarketplaceSubscriptions }
-								showMarketplaceDialog={ showMarketplaceDialog }
-							/>
-						) }
-						{ shouldHandleMarketplaceSubscriptions() && (
-							<MarketPlaceSubscriptionsDialog
-								activeSubscriptions={ activeSubscriptions }
-								bodyParagraphText={ _n(
-									'This subscription will be cancelled. It will be removed when it expires.',
-									'These subscriptions will be cancelled. They will be removed when they expire.',
-									activeSubscriptions.length
-								) }
-								closeDialog={ closeMarketplaceSubscriptionsDialog }
-								isDialogVisible
-								planName={ planName ?? '' }
-								/* Translators: This button cancels the active plan and all active Marketplace subscriptions on the site */
-								primaryButtonText={ __( 'Continue' ) }
-								removePlan={ handleMarketplaceDialogContinue }
-								/* Translators: %(plan)s is the name of the plan being cancelled */
-								sectionHeadingText={ sprintf( __( 'Cancel %(plan)s' ), { plan: planName } ) }
-							/>
-						) }
-					</Card>
-				</VStack>
+				<Card className="cancel-purchase__wrapper-card">
+					<DomainRemovalFlow purchase={ purchase } onCancel={ redirectBack } />
+				</Card>
 			</PageLayout>
-		</>
+		);
+	}
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ <CancelHeaderTitle flowType={ flowType } purchase={ purchase } /> }
+					prefix={ <Breadcrumbs length={ 4 } /> }
+					description={ __(
+						'Before you go, please answer a few quick questions to help us improve.'
+					) }
+				/>
+			}
+		>
+			<VStack>
+				{ ! state.surveyShown && <TimeRemainingNotice purchase={ purchase } /> }
+
+				<Card className="cancel-purchase__wrapper-card">
+					<CancelPurchaseForm
+						atomicRevertCheckOne={ state.atomicRevertCheckOne }
+						atomicRevertCheckTwo={ state.atomicRevertCheckTwo }
+						atomicRevertOnClickCheckOne={ atomicRevertOnClickCheckOne }
+						atomicRevertOnClickCheckTwo={ atomicRevertOnClickCheckTwo }
+						atomicTransfer={ atomicTransfer }
+						cancelBundledDomain={ state.cancelBundledDomain }
+						cancellationInProgress={ state.isLoading }
+						cancellationOffer={ cancellationOffer }
+						clickNext={ clickNext }
+						closeDialog={ closeDialog }
+						disableButtons={ state.isLoading }
+						downgradeClick={ downgradeClick }
+						downgradePlan={ downgradePlan }
+						flowType={ flowType }
+						freeMonthOfferClick={ freeMonthOfferClick }
+						getAllSurveySteps={ getAllSurveySteps }
+						hasBackupsFeature={ hasBackupsFeature }
+						importQuestionRadio={ state.importQuestionRadio }
+						includedDomainPurchase={ includedDomainPurchase }
+						isAkismet={ isAkismet }
+						isApplyingOffer={ isApplyingOffer }
+						isImport={ isImport }
+						isNextAdventureValid={ state.isNextAdventureValid }
+						isShowing={ state.isShowingMarketplaceSubscriptionsDialog }
+						isSubmitting={ state.isSubmitting }
+						isVisible={ state.surveyShown }
+						offerDiscountBasedFromPurchasePrice={ offerDiscountBasedFromPurchasePrice }
+						onClickAcceptForCancellationOffer={ onClickAcceptForCancellationOffer }
+						onGetCancellationOffer={ onGetCancellationOffer }
+						onImportRadioChange={ onImportRadioChange }
+						onNextAdventureValidationChange={ onNextAdventureValidationChange }
+						onRadioOneChange={ onRadioOneChange }
+						onRadioTwoChange={ onRadioTwoChange }
+						onSubmit={ onSubmit }
+						onSurveyComplete={ onSurveyComplete }
+						onTextOneChange={ onTextOneChange }
+						onTextThreeChange={ onTextThreeChange }
+						onTextTwoChange={ onTextTwoChange }
+						plans={ plans }
+						purchase={ purchase }
+						questionOneOrder={ state.questionOneOrder }
+						questionOneRadio={ state.questionOneRadio }
+						questionOneText={ state.questionOneText }
+						questionTwoOrder={ state.questionTwoOrder }
+						questionTwoRadio={ state.questionTwoRadio }
+						questionTwoText={ state.questionTwoText }
+						refundAmount={ purchase.total_refund_amount }
+						siteSlug={ siteSlug }
+						solution={ state.solution }
+						surveyStep={ state.surveyStep }
+						upsell={ state.upsell }
+					/>
+					{ ! state.surveyShown && (
+						<CancellationPreSurveyContent
+							purchase={ purchase }
+							includedDomainPurchase={ includedDomainPurchase }
+							atomicTransfer={ atomicTransfer }
+							selectedDomain={ selectedDomain }
+							state={ state }
+							purchaseCancelFeatures={ purchaseCancelFeatures }
+							onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
+							onDomainConfirmationChange={ onDomainConfirmationChange }
+							onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+							onKeepSubscriptionClick={ onKeepSubscriptionClick }
+							onCancellationComplete={ onCancellationComplete }
+							onCancellationStart={ onCancellationStart }
+							shouldHandleMarketplaceSubscriptions={ shouldHandleMarketplaceSubscriptions }
+							showMarketplaceDialog={ showMarketplaceDialog }
+						/>
+					) }
+					{ shouldHandleMarketplaceSubscriptions() && (
+						<MarketPlaceSubscriptionsDialog
+							activeSubscriptions={ activeSubscriptions }
+							bodyParagraphText={ _n(
+								'This subscription will be cancelled. It will be removed when it expires.',
+								'These subscriptions will be cancelled. They will be removed when they expire.',
+								activeSubscriptions.length
+							) }
+							closeDialog={ closeMarketplaceSubscriptionsDialog }
+							isDialogVisible
+							planName={ planName ?? '' }
+							/* Translators: This button cancels the active plan and all active Marketplace subscriptions on the site */
+							primaryButtonText={ __( 'Continue' ) }
+							removePlan={ handleMarketplaceDialogContinue }
+							/* Translators: %(plan)s is the name of the plan being cancelled */
+							sectionHeadingText={ sprintf( __( 'Cancel %(plan)s' ), { plan: planName } ) }
+						/>
+					) }
+				</Card>
+			</VStack>
+		</PageLayout>
 	);
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -69,6 +69,7 @@ import {
 	UPSELL_STEP,
 } from './cancel-purchase-form/steps';
 import CancellationPreSurveyContent from './cancellation-pre-survey-content';
+import DomainRemovalFlow from './domain-removal-flow';
 import enrichedSurveyData from './enriched-survey-data';
 import { getUpsellType } from './get-upsell-type';
 import initialSurveyState from './initial-survey-state';
@@ -1139,6 +1140,29 @@ export default function CancelPurchase() {
 
 	const isAkismet = isAkismetProduct( purchase );
 	const planName = purchase.is_domain_registration ? purchase.meta : purchase.product_name;
+	const isDomainRemoval = flowType === CANCEL_FLOW_TYPE.REMOVE && purchase.is_domain_registration;
+
+	if ( isDomainRemoval ) {
+		return (
+			<>
+				<PageLayout
+					size="small"
+					header={
+						<PageHeader
+							title={ <CancelHeaderTitle flowType={ flowType } purchase={ purchase } /> }
+							prefix={ <Breadcrumbs length={ 4 } /> }
+							description={ __( 'Please confirm that you want to remove this domain.' ) }
+						/>
+					}
+				>
+					<Card className="cancel-purchase__wrapper-card">
+						<DomainRemovalFlow purchase={ purchase } onCancel={ redirectBack } />
+					</Card>
+				</PageLayout>
+			</>
+		);
+	}
+
 	return (
 		<>
 			<PageLayout

--- a/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
@@ -1,5 +1,5 @@
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/mixins';
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .cancel-purchase__wrapper-card {
 	padding: 32px;
@@ -12,7 +12,7 @@
 	}
 
 	.cancel-purchase__refund-domain-info {
-		color: var( --color-text-subtle );
+		color: var(--color-text-subtle);
 		display: inline-block;
 		font-size: $font-body-extra-small;
 		line-height: 1.4;
@@ -62,19 +62,19 @@
 				flex-shrink: 0;
 				margin-inline-end: 8px;
 				margin-top: 2px;
-				color: var( --color-error-40 );
+				color: var(--color-error-40);
 			}
 		}
 	}
 }
 
 .cancel-purchase__refund-string {
-	color: var( --color-success );
+	color: var(--color-success);
 	font-weight: 600;
 }
 
 .cancel-purchase__warning-string {
-	color: var( --color-error );
+	color: var(--color-error);
 	font-weight: 600;
 }
 
@@ -86,7 +86,7 @@
 	}
 
 	button.cancel-purchase__button {
-		background-color: #f00;
+		background-color: #F00;
 	}
 }
 
@@ -95,7 +95,7 @@
 }
 
 .cancel-purchase__button {
-	@include breakpoint-deprecated( '<660px' ) {
+	@include breakpoint-deprecated( "<660px" ) {
 		width: 100%;
 	}
 }
@@ -120,7 +120,7 @@
 				flex-shrink: 0;
 				margin-inline-end: 8px;
 				margin-top: 2px;
-				color: var( --color-warning );
+				color: var(--color-warning);
 			}
 		}
 	}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
@@ -1,5 +1,5 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .cancel-purchase__wrapper-card {
 	padding: 32px;
@@ -12,7 +12,7 @@
 	}
 
 	.cancel-purchase__refund-domain-info {
-		color: var(--color-text-subtle);
+		color: var( --color-text-subtle );
 		display: inline-block;
 		font-size: $font-body-extra-small;
 		line-height: 1.4;
@@ -62,19 +62,19 @@
 				flex-shrink: 0;
 				margin-inline-end: 8px;
 				margin-top: 2px;
-				color: var(--color-error-40);
+				color: var( --color-error-40 );
 			}
 		}
 	}
 }
 
 .cancel-purchase__refund-string {
-	color: var(--color-success);
+	color: var( --color-success );
 	font-weight: 600;
 }
 
 .cancel-purchase__warning-string {
-	color: var(--color-error);
+	color: var( --color-error );
 	font-weight: 600;
 }
 
@@ -86,7 +86,7 @@
 	}
 
 	button.cancel-purchase__button {
-		background-color: #F00;
+		background-color: #f00;
 	}
 }
 
@@ -95,7 +95,7 @@
 }
 
 .cancel-purchase__button {
-	@include breakpoint-deprecated( "<660px" ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 	}
 }
@@ -120,7 +120,7 @@
 				flex-shrink: 0;
 				margin-inline-end: 8px;
 				margin-top: 2px;
-				color: var(--color-warning);
+				color: var( --color-warning );
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1373

## Proposed Changes

This PR refactors the product removal flow for domain registrations in the Multi Site Dashboard to use a text field confirmation step and to remove the language about feature removal and expiration date. This will make more sense, be safer (for a very destructive action), and more closely match the calypso version.

Before             |  After
:-------------------------:|:-------------------------:
<img width="678" height="596" alt="Screenshot 2025-11-24 at 4 37 23 PM" src="https://github.com/user-attachments/assets/ce54b73f-ca9b-431c-9170-eeefdff834ed" /> | <img width="693" height="445" alt="Screenshot 2025-11-26 at 6 18 53 PM" src="https://github.com/user-attachments/assets/df725a8b-cf70-4766-831c-636f623f1e32" />
<img width="692" height="465" alt="Screenshot 2025-11-26 at 4 33 38 PM" src="https://github.com/user-attachments/assets/624a92e3-3c28-4636-89be-27a4d380c9f3" /> | <img width="685" height="438" alt="Screenshot 2025-11-26 at 6 19 01 PM" src="https://github.com/user-attachments/assets/f838a941-ebe6-4abe-b947-f5119e27beb7" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The calypso removal flow uses a very different flow for domain registrations, using a modal dialog instead of a series of steps. We did not preserve that flow when migrating to the Multi Site Dashboard. We should refactor the MSD flow to use a similar set of steps.

Here's how it appears in calypso:

Step 1             |  Step 2
:-------------------------:|:-------------------------:
<img width="487" height="335" alt="Screenshot 2025-11-26 at 4 38 53 PM" src="https://github.com/user-attachments/assets/d8ee3615-51e5-4d73-9e99-039bde73d340" /> | <img width="455" height="282" alt="Screenshot 2025-11-26 at 4 38 57 PM" src="https://github.com/user-attachments/assets/ba60edab-be16-4a81-9b21-0772f159dcdb" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- View the MSD purchases list at http://calypso.localhost:3000/v2/me/billing/purchases
- Select a domain that's already expired or one which has auto-renew disabled.
- On the purchase settings page click "Remove subscription" (if it says "Cancel" anywhere, then this will not be the right flow).
- Verify that you are shown a domain-specific two-step removal flow and that to complete it you must enter the domain name in a text field.
- Complete the removal and verify that the domain is removed.