### PR TITLE
MSD Billing: Show correct billing information for downgrades

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -45,6 +45,7 @@ interface CancelPurchaseFormProps {
 	closeDialog?: () => void;
 	disableButtons?: boolean;
 	downgradeClick?: ( upsell: string ) => void;
+	downgradePlan?: PlanProduct;
 	downgradePlanToMonthlyPrice?: number;
 	downgradePlanToPersonalPrice?: number;
 	flowType?: string;
@@ -108,6 +109,7 @@ export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
 			clickNext,
 			closeDialog,
 			downgradeClick,
+			downgradePlan,
 			flowType,
 			freeMonthOfferClick,
 			getAllSurveySteps,
@@ -169,11 +171,7 @@ export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
 					cancellationReason={ questionOneText }
 					closeDialog={ closeDialog }
 					currencyCode={ purchase.currency_code }
-					downgradePlanPrice={
-						'downgrade-personal' === upsell
-							? props.downgradePlanToPersonalPrice
-							: props.downgradePlanToMonthlyPrice
-					}
+					downgradePlan={ downgradePlan }
 					includedDomainPurchase={ props.includedDomainPurchase }
 					onClickDowngrade={ downgradeClick }
 					onClickFreeMonthOffer={ freeMonthOfferClick }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -80,7 +80,7 @@ type StepProps = {
 	cancellationInProgress?: boolean;
 	closeDialog?: () => void;
 	currencyCode: string;
-	downgradePlanPrice?: number | null;
+	downgradePlan?: PlanProduct | null;
 	includedDomainPurchase?: object;
 	onClickDowngrade?: ( upsell: string ) => void;
 	onClickFreeMonthOffer?: () => void;
@@ -248,9 +248,13 @@ export default function UpsellStep( {
 								'By switching to monthly payments, you will keep most of the features for %(planCost)s per month.'
 							),
 							{
-								planCost: formatCurrency( props.downgradePlanPrice ?? 0, currencyCode, {
-									isSmallestUnit: true,
-								} ),
+								planCost: formatCurrency(
+									props.downgradePlan?.raw_price_integer ?? 0,
+									currencyCode,
+									{
+										isSmallestUnit: true,
+									}
+								),
 							}
 						) }{ ' ' }
 						{ props.cancelBundledDomain &&

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -317,6 +317,7 @@ export default function CancelPurchase() {
 		let steps = [ FEEDBACK_STEP ];
 		const isJetpack = purchase.is_jetpack_plan_or_product;
 		const skipRemovePlanSurvey = purchase.is_plan && userHasCompletedCancelSurveyForPurchase;
+		const isDowngradePlan = [ 'downgrade-monthly', 'downgrade-personal' ].includes( state.upsell );
 
 		if (
 			isPartnerPurchase( purchase ) &&
@@ -333,7 +334,7 @@ export default function CancelPurchase() {
 			! purchase.is_plan
 		) {
 			steps = [ NEXT_ADVENTURE_STEP ];
-		} else if ( state.upsell && downgradePlan ) {
+		} else if ( state.upsell && ( ! isDowngradePlan || ( isDowngradePlan && downgradePlan ) ) ) {
 			steps = [ FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP ];
 		} else if ( questionTwoOrder?.length ) {
 			steps = [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -281,6 +281,38 @@ export default function CancelPurchase() {
 	let questionOneOrder = [];
 	let questionTwoOrder = [];
 
+	const getDowngradePlanForPurchase = (
+		plans: PlanProduct[],
+		purchase: Purchase
+	): PlanProduct | undefined => {
+		if ( ! plans ) {
+			return;
+		}
+		const plan = plans.find( ( plan ) => plan.product_id === purchase.product_id );
+		if ( ! plan ) {
+			return;
+		}
+
+		let downgradePlanInfo;
+		switch ( state.upsell ) {
+			case 'downgrade-monthly':
+				downgradePlanInfo = plan.downgrade_paths.find( ( path ) => {
+					return path.bill_period !== plan.bill_period;
+				} );
+				break;
+			case 'downgrade-personal':
+				downgradePlanInfo = plan.downgrade_paths.find( ( path ) => {
+					return path.bill_period === plan.bill_period;
+				} );
+				break;
+		}
+		if ( downgradePlanInfo ) {
+			return plans.find( ( plan ) => plan.product_id === downgradePlanInfo.product_id );
+		}
+	};
+
+	const downgradePlan = getDowngradePlanForPurchase( plans, purchase );
+
 	const getAllSurveySteps = useCallback( () => {
 		let steps = [ FEEDBACK_STEP ];
 		const isJetpack = purchase.is_jetpack_plan_or_product;
@@ -301,7 +333,7 @@ export default function CancelPurchase() {
 			! purchase.is_plan
 		) {
 			steps = [ NEXT_ADVENTURE_STEP ];
-		} else if ( state.upsell ) {
+		} else if ( state.upsell && downgradePlan ) {
 			steps = [ FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP ];
 		} else if ( questionTwoOrder?.length ) {
 			steps = [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
@@ -323,6 +355,7 @@ export default function CancelPurchase() {
 
 		return steps;
 	}, [
+		downgradePlan,
 		userHasCompletedCancelSurveyForPurchase,
 		purchase,
 		availableJetpackSurveySteps,
@@ -527,59 +560,8 @@ export default function CancelPurchase() {
 		} ) );
 	};
 
-	enum PurchaseDowngradeType {
-		TermDowngrade = 'downgrade-term', // downgrade-monthly
-		PlanDowngrade = 'downgrade-plan', // downgrade-personal
-	}
-
-	const getDowngradePlanForPurchase = (
-		plans: PlanProduct[],
-		purchase: Purchase,
-		downgradeType: PurchaseDowngradeType
-	): PlanProduct | undefined => {
-		if ( ! plans ) {
-			return;
-		}
-		const plan = plans.find( ( plan ) => plan.product_id === purchase.product_id );
-		if ( ! plan ) {
-			return;
-		}
-
-		let downgradePlanInfo;
-		switch ( downgradeType ) {
-			case PurchaseDowngradeType.TermDowngrade:
-				downgradePlanInfo = plan.downgrade_paths.find( ( path ) => {
-					return path.bill_period !== plan.bill_period;
-				} );
-				break;
-			case PurchaseDowngradeType.PlanDowngrade:
-				downgradePlanInfo = plan.downgrade_paths.find( ( path ) => {
-					return path.bill_period === plan.bill_period;
-				} );
-				break;
-		}
-		if ( downgradePlanInfo ) {
-			return plans.find( ( plan ) => plan.product_id === downgradePlanInfo.product_id );
-		}
-	};
-
-	const downgradeClick = ( upsell: string ) => {
+	const downgradeClick = () => {
 		if ( ! state.isSubmitting ) {
-			let downgradePlan = undefined;
-			if ( 'downgrade-monthly' === upsell ) {
-				downgradePlan = getDowngradePlanForPurchase(
-					plans,
-					purchase,
-					PurchaseDowngradeType.TermDowngrade
-				);
-			} else if ( 'downgrade-personal' === upsell ) {
-				downgradePlan = getDowngradePlanForPurchase(
-					plans,
-					purchase,
-					PurchaseDowngradeType.PlanDowngrade
-				);
-			}
-
 			if ( ! downgradePlan ) {
 				createErrorNotice( 'Cannot find a plan to downgrade to', { type: 'snackbar' } );
 				return;
@@ -1640,28 +1622,6 @@ export default function CancelPurchase() {
 	};
 
 	const planName = purchase.is_domain_registration ? purchase.meta : purchase.product_name;
-	let downgradePlan;
-	let downgradePlanToPersonalPrice;
-	let downgradePlanToMonthlyPrice;
-	if ( 'downgrade-monthly' === state.upsell ) {
-		downgradePlan = getDowngradePlanForPurchase(
-			plans,
-			purchase,
-			PurchaseDowngradeType.TermDowngrade
-		);
-		if ( downgradePlan ) {
-			downgradePlanToMonthlyPrice = parseFloat( downgradePlan.price );
-		}
-	} else if ( 'downgrade-personal' === state.upsell ) {
-		downgradePlan = getDowngradePlanForPurchase(
-			plans,
-			purchase,
-			PurchaseDowngradeType.PlanDowngrade
-		);
-		if ( downgradePlan ) {
-			downgradePlanToPersonalPrice = parseFloat( downgradePlan.price );
-		}
-	}
 	return (
 		<>
 			<PageLayout
@@ -1693,8 +1653,7 @@ export default function CancelPurchase() {
 							closeDialog={ closeDialog }
 							disableButtons={ state.isLoading }
 							downgradeClick={ downgradeClick }
-							downgradePlanToMonthlyPrice={ downgradePlanToMonthlyPrice }
-							downgradePlanToPersonalPrice={ downgradePlanToPersonalPrice }
+							downgradePlan={ downgradePlan }
 							flowType={ flowType }
 							freeMonthOfferClick={ freeMonthOfferClick }
 							getAllSurveySteps={ getAllSurveySteps }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -317,7 +317,9 @@ export default function CancelPurchase() {
 		let steps = [ FEEDBACK_STEP ];
 		const isJetpack = purchase.is_jetpack_plan_or_product;
 		const skipRemovePlanSurvey = purchase.is_plan && userHasCompletedCancelSurveyForPurchase;
-		const isDowngradePlan = [ 'downgrade-monthly', 'downgrade-personal' ].includes( state.upsell );
+		const isDowngradePlan = [ 'downgrade-monthly', 'downgrade-personal' ].includes(
+			state.upsell ?? ''
+		);
 
 		if (
 			isPartnerPurchase( purchase ) &&


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [SHILL-1359](https://linear.app/a8c/issue/SHILL-1359/hosting-dashboard-cancellation-flow-monthly-downgrade-may-be-offered)

## Proposed Changes

* Use the `raw_price_integer` property with `isSmallUnit: true` for `formatCurrency`
* Only allow a downgrade if the backend provides it as a downgrade path option (and if `getUpsellType` allows).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This fixes a bug where the price was always `$0` because the string (e.g., `$70`) could not be parsed into a float.
* This makes use of the downgrade paths that are being sent from the backend instead of relying specifically on the frontend logic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test downgrade from Premium to personal
* Visit the `/v2/me/billing/purchases` page and select a premium plan's "manage purchase" link.
* Click "downgrade or cancel"
* Confirm you want to cancel and click to the next page.
* Select "Too expensive" and "The plan is too expensive for the features offered" or "Budget constraints / Can no longer afford it".
* You should see an offer to downgrade to the personal plan. Take that option and your plan should be downgraded to personal.

### Test downgrade from yearly to monthly
* Visit the `/v2/me/billing/purchases` page and select a yearly (non-premium) plan's "manage purchase" link.
* Click "downgrade or cancel"
* Confirm you want to cancel and click to the next page.
* Select "Too expensive" and "The plan is too expensive for the features offered" or "Budget constraints / Can no longer afford it".
* You should see an offer to downgrade to the monthly version of that plan. You should see the new monthly price of the plan in the text on this page. Take that option and your plan should be downgraded to monthly.

### Test backend removal of downgrade option
* On the backend (sandbox), modify `get_downgrade_paths` and comment out the paths for the plan you want to test (e.g., so that `<plan_name> => []`).
* Make sure you are sending traffic for the public api to the sandbox.
* Visit the `/v2/me/billing/purchases` page and select a plan's "manage purchase" link.
* Click "downgrade or cancel"
* Confirm you want to cancel and click to the next page.
* Select "Too expensive" and "The plan is too expensive for the features offered" or "Budget constraints / Can no longer afford it".
* The button should not say "Continue" but instead say "Submit" clicking this button should not downgrade the plan but instead allow you to cancel the plan while submitting the survey stating why you are cancelling.

### Test other upsells work correctly
The only case where we should expect to have the upsell step omitted is when the backend has no downgrade paths for the plan and where normally the customer would be able to `downgrade-monthly` or `downgrade-personal`. There are lots of other cases (defined in the `getUpsellType` function) where we still would want to show the `UpsellStep` component which are unrelated to `downgrade-monthly` or `downgrade-personal`.
* Keep the backend as it was from the last test or do the following: on the backend (sandbox), modify `get_downgrade_paths` and comment out the paths for the plan you want to test (e.g., so that `<plan_name> => []`).
* Make sure you are sending traffic for the public api to the sandbox.
* Visit the `/v2/me/billing/purchases` page and select a plan's "manage purchase" link.
* Click "downgrade or cancel"
* Confirm you want to cancel and click to the next page.
* Select an option that would trigger a separate upsell step as defined in the `getUpsellType` function (something other than "Too expensive" and "The plan is too expensive for the features offered" or "Budget constraints / Can no longer afford it" ). For instance (if cancelling a premium plan): "Missing features", "Cannot upload custom themes" should offer to upgrade to the Business plan. Alternatively, you could try "Problems with domain" and "Trouble connecting or transferring my existing domain" which will bring up the "Connect a domain guidelines".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
