### PR TITLE
MSD: Add persistence to site logs (PHP/web server) DataViews

### DIFF
--- a/client/dashboard/app/dataviews/dataviews.tsx
+++ b/client/dashboard/app/dataviews/dataviews.tsx
@@ -10,7 +10,12 @@ export type DataViewsProps< Item > = WPDataViewsProps< Item > & {
 	onResetView?: () => void;
 };
 
-export function DataViews< Item >( { view, onResetView, ...props }: DataViewsProps< Item > ) {
+export function DataViews< Item >( {
+	view,
+	onResetView,
+	header,
+	...props
+}: DataViewsProps< Item > ) {
 	const sanitizedView = sanitizeView( view, props.fields );
 
 	// TODO: apply local styles if necessary.
@@ -18,10 +23,20 @@ export function DataViews< Item >( { view, onResetView, ...props }: DataViewsPro
 		<WPDataViews< Item >
 			view={ sanitizedView }
 			header={
-				onResetView && (
-					<Button variant="tertiary" size="compact" style={ { order: -1 } } onClick={ onResetView }>
-						{ __( 'Reset view' ) }
-					</Button>
+				( header || onResetView ) && (
+					<>
+						{ header }
+						{ onResetView && (
+							<Button
+								variant="tertiary"
+								size="compact"
+								style={ { order: -1 } }
+								onClick={ onResetView }
+							>
+								{ __( 'Reset view' ) }
+							</Button>
+						) }
+					</>
 				)
 			}
 			{ ...( props as any ) }

--- a/client/dashboard/sites/logs/dataviews/filters.ts
+++ b/client/dashboard/sites/logs/dataviews/filters.ts
@@ -1,5 +1,4 @@
 import { LogType } from '@automattic/api-core';
-import { decodeSearchParam } from './url-sync';
 import type { Filter } from '@wordpress/dataviews';
 
 export function filtersSignature(
@@ -17,56 +16,8 @@ export function filtersSignature(
 		.join( '|' );
 }
 
-const SEVERITY_LABELS: Readonly< Record< string, string > > = {
-	user: 'User',
-	warning: 'Warning',
-	deprecated: 'Deprecated',
-	fatal: 'Fatal error',
-	'fatal error': 'Fatal error',
-	fatal_error: 'Fatal error',
-};
-
-type SimpleFilter = {
-	field: string;
-	operator: 'isAny';
-	value: string[];
-};
-
 export function getAllowedFields( logType: LogType ): ReadonlyArray< string > {
 	return logType === LogType.PHP
 		? [ 'severity' ]
 		: [ 'cached', 'renderer', 'request_type', 'status' ];
-}
-
-export function getInitialFiltersFromSearch( logType: LogType, search: string ): Filter[] {
-	const allowed = getAllowedFields( logType );
-	const params = new URLSearchParams( search );
-
-	const normalizeSeverity = ( values: string[] ): string[] =>
-		Array.from(
-			new Set(
-				values
-					.map( ( v ) => SEVERITY_LABELS[ v.trim().toLowerCase() ] )
-					.filter( Boolean ) as string[]
-			)
-		);
-
-	const out: Filter[] = [];
-	for ( const field of allowed ) {
-		const raw = params.get( field );
-		if ( ! raw ) {
-			continue;
-		}
-		let values = raw
-			.split( ',' )
-			.map( ( rawToken ) => decodeSearchParam( rawToken ).trim() )
-			.filter( Boolean );
-		if ( field === 'severity' ) {
-			values = normalizeSeverity( values );
-		}
-		if ( values.length ) {
-			out.push( { field, operator: 'isAny', value: values } satisfies SimpleFilter );
-		}
-	}
-	return out;
 }

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -110,7 +110,7 @@ function SiteLogsDataViews( {
 		url.searchParams.set( 'from', String( startSec ) );
 		url.searchParams.set( 'to', String( endSec ) );
 		window.history.replaceState( null, '', url.toString() );
-	}, [ startSec, endSec ] );
+	}, [ startSec, endSec, logType ] );
 
 	const filter = useMemo( () => toFilterParams( { view, logType } ), [ view, logType ] );
 

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -5,12 +5,13 @@ import { useRouter } from '@tanstack/react-router';
 import { ToggleControl, Button } from '@wordpress/components';
 import { throttle } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
-import { DataViews, View, Filter, Field } from '@wordpress/dataviews';
+import { View, Filter, Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { arrowUp } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useEffect, useCallback, useRef, useLayoutEffect, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
+import { DataViews, usePersistentView } from '../../../app/dataviews';
 import { LogsDownloader } from '../downloader';
 import {
 	buildTimeRangeInSeconds,
@@ -21,9 +22,13 @@ import {
 } from '../utils';
 import { useActions } from './actions';
 import { useFields } from './fields';
-import { getInitialFiltersFromSearch, getAllowedFields, filtersSignature } from './filters';
-import { syncFiltersSearchParams } from './url-sync';
-import { useView, toFilterParams } from './views';
+import { getAllowedFields, filtersSignature } from './filters';
+import {
+	DEFAULT_PER_PAGE,
+	DEFAULT_PHP_LOGS_VIEW,
+	DEFAULT_SERVER_LOGS_VIEW,
+	toFilterParams,
+} from './views';
 import type { Site } from '@automattic/api-core';
 import type { Action } from '@wordpress/dataviews';
 import './style.scss';
@@ -40,8 +45,6 @@ export type SiteLogsDataViewsProps = {
 	timezoneString: string | undefined;
 	site: Site;
 };
-
-const DEFAULT_PER_PAGE = 50;
 
 function SiteLogsDataViews( {
 	logType,
@@ -64,9 +67,10 @@ function SiteLogsDataViews( {
 	const dataviewsRef = useRef< HTMLDivElement | null >( null );
 	const [ showScrollTop, setShowScrollTop ] = useState( false );
 
-	const [ view, setView ] = useView( {
-		logType,
-		initialFilters: getInitialFiltersFromSearch( logType, search ),
+	const { view, updateView, resetView } = usePersistentView( {
+		slug: `site-logs-${ logType }`,
+		defaultView: logType === LogType.PHP ? DEFAULT_PHP_LOGS_VIEW : DEFAULT_SERVER_LOGS_VIEW,
+		queryParams: search,
 	} );
 
 	// We want to parse 'from' and 'to' from the URL.
@@ -99,21 +103,14 @@ function SiteLogsDataViews( {
 	const startSec = parseUrlSeconds ? parseUrlSeconds.from : computed.startSec;
 	const endSec = parseUrlSeconds ? parseUrlSeconds.to : computed.endSec;
 
-	// Sync URL when time or filters change. Guard against first render before filters hydrate.
+	// Sync URL when time change.
 	useEffect( () => {
-		if ( typeof view.filters === 'undefined' ) {
-			return;
-		}
 		const url = new URL( window.location.href );
-		// Re-apply filters currently in view to the URL
-		const allowed = getAllowedFields( logType );
-		const sourceFilters = ( view.filters ?? [] ) as Filter[];
-		syncFiltersSearchParams( url.searchParams, allowed, sourceFilters );
 		// Always set canonical time params (seconds)
 		url.searchParams.set( 'from', String( startSec ) );
 		url.searchParams.set( 'to', String( endSec ) );
 		window.history.replaceState( null, '', url.toString() );
-	}, [ startSec, endSec, view.filters, logType, search ] );
+	}, [ startSec, endSec ] );
 
 	const filter = useMemo( () => toFilterParams( { view, logType } ), [ view, logType ] );
 
@@ -151,8 +148,8 @@ function SiteLogsDataViews( {
 	}, [] );
 
 	useEffect( () => {
-		setView( ( value ) => ( { ...value, page: 1 } ) );
-	}, [ dateRangeVersion, setView ] );
+		updateView( { ...view, page: 1 } );
+	}, [ dateRangeVersion, view, updateView ] );
 
 	useLayoutEffect( () => {
 		dataviewsRef.current = document.querySelector< HTMLDivElement >( '.dataviews-wrapper' );
@@ -231,9 +228,7 @@ function SiteLogsDataViews( {
 			next.sort?.direction !== view.sort?.direction ||
 			filtersSignature( sourceFilters, allowed ) !== filtersSignature( view.filters, allowed );
 
-		// Sync allowed filters to URL using sourceFilters and preserve from/to params
 		const url = new URL( window.location.href );
-		syncFiltersSearchParams( url.searchParams, allowed, sourceFilters );
 		// Always keep canonical time range params
 		url.searchParams.set( 'from', String( startSec ) );
 		url.searchParams.set( 'to', String( endSec ) );
@@ -246,13 +241,13 @@ function SiteLogsDataViews( {
 				queryKey: [ 'site', site.ID, 'logs', 'infinite' ],
 				exact: false,
 			} );
-			setView( {
+			updateView( {
 				...next,
 				page: 1,
 				filters: sourceFilters.filter( ( filter: Filter ) => allowed.includes( filter.field ) ),
 			} );
 		} else {
-			setView( {
+			updateView( {
 				...next,
 				filters: sourceFilters.filter( ( filter: Filter ) => allowed.includes( filter.field ) ),
 			} );
@@ -327,13 +322,6 @@ function SiteLogsDataViews( {
 		totalPages: 1,
 	};
 
-	useEffect( () => {
-		setView( ( currentView ) => ( {
-			...currentView,
-			perPage: Math.max( logs.length, currentView.perPage ?? DEFAULT_PER_PAGE ),
-		} ) );
-	}, [ logs.length, setView ] );
-
 	return (
 		<>
 			{ logType === LogType.PHP ? (
@@ -348,6 +336,7 @@ function SiteLogsDataViews( {
 					search={ false }
 					defaultLayouts={ { table: {} } }
 					onChangeView={ onChangeView }
+					onResetView={ resetView }
 					header={ LogsHeader }
 				/>
 			) : (
@@ -362,6 +351,7 @@ function SiteLogsDataViews( {
 					search={ false }
 					defaultLayouts={ { table: {} } }
 					onChangeView={ onChangeView }
+					onResetView={ resetView }
 					header={ LogsHeader }
 				/>
 			) }

--- a/client/dashboard/sites/logs/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs/dataviews/test/index.test.tsx
@@ -54,7 +54,11 @@ const mockSite: DeepPartial< Site > = {
 };
 
 function mockPhpLogsOnce() {
-	return nock( API_BASE )
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/preferences' )
+		.reply( 200, { calypso_preferences: {} } );
+
+	nock( API_BASE )
 		.get( `/wpcom/v2/sites/${ mockSiteId }/hosting/error-logs` )
 		.query( true )
 		.reply( 200, {
@@ -79,7 +83,11 @@ function mockPhpLogsOnce() {
 }
 
 function mockServerLogsOnce() {
-	return nock( API_BASE )
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/preferences' )
+		.reply( 200, { calypso_preferences: {} } );
+
+	nock( API_BASE )
 		.get( `/wpcom/v2/sites/${ mockSiteId }/hosting/logs` )
 		.query( true )
 		.reply( 200, {

--- a/client/dashboard/sites/logs/dataviews/views.ts
+++ b/client/dashboard/sites/logs/dataviews/views.ts
@@ -1,14 +1,24 @@
 import { LogType, FilterType } from '@automattic/api-core';
-import { useState } from '@wordpress/element';
 import type { View } from '@wordpress/dataviews';
 
-const phpLogsViewConfig = {
-	sortField: 'timestamp',
-	titleField: 'severity',
-	primaryField: 'severity',
-	visibleFields: [ 'timestamp', 'message' ],
-	allowedFilters: [ 'severity' ],
+export const DEFAULT_PER_PAGE = 50;
+
+const DEFAULT_VIEW = {
+	type: 'table',
+	perPage: DEFAULT_PER_PAGE,
+	infiniteScrollEnabled: true,
+	showLevels: false,
+} satisfies Partial< View >;
+
+export const DEFAULT_PHP_LOGS_VIEW: View = {
+	...DEFAULT_VIEW,
+	sort: {
+		field: 'timestamp',
+		direction: 'desc',
+	},
+	fields: [ 'timestamp', 'severity', 'message' ],
 	layout: {
+		density: 'balanced',
 		styles: {
 			timestamp: { maxWidth: '300px', minWidth: '140px' },
 			name: { maxWidth: '200px', minWidth: '75px' },
@@ -18,13 +28,15 @@ const phpLogsViewConfig = {
 	},
 };
 
-const serverLogsViewConfig = {
-	sortField: 'date',
-	titleField: 'status',
-	primaryField: 'severity',
-	visibleFields: [ 'date', 'request_type', 'request_url' ],
-	allowedFilters: [ 'cached', 'request_type', 'status', 'renderer' ],
+export const DEFAULT_SERVER_LOGS_VIEW: View = {
+	...DEFAULT_VIEW,
+	fields: [ 'date', 'request_type', 'status', 'request_url' ],
+	sort: {
+		field: 'date',
+		direction: 'desc',
+	},
 	layout: {
+		density: 'balanced',
 		styles: {
 			date: { maxWidth: '300px', minWidth: '140px' },
 			request_url: { minWidth: '300px' },
@@ -62,29 +74,4 @@ export function toFilterParams( { view, logType }: { view: View; logType: LogTyp
 	}
 
 	return getFilterParamsFromView( view, [ 'cached', 'request_type', 'status', 'renderer' ] );
-}
-
-export function useView( {
-	logType,
-	initialFilters,
-}: {
-	logType: Omit< LogType, 'activity' >;
-	initialFilters?: View[ 'filters' ];
-} ) {
-	const config = logType === LogType.PHP ? phpLogsViewConfig : serverLogsViewConfig;
-	return useState< View >( () => ( {
-		type: 'table',
-		page: 1,
-		perPage: 50,
-		sort: {
-			field: config.sortField,
-			direction: 'desc',
-		},
-		filters: initialFilters ?? [],
-		titleField: config.titleField,
-		primaryField: config.primaryField,
-		fields: config.visibleFields,
-		layout: config.layout,
-		infiniteScrollEnabled: true,
-	} ) );
 }

--- a/client/dashboard/sites/logs/dataviews/views.ts
+++ b/client/dashboard/sites/logs/dataviews/views.ts
@@ -16,7 +16,7 @@ export const DEFAULT_PHP_LOGS_VIEW: View = {
 		field: 'timestamp',
 		direction: 'desc',
 	},
-	fields: [ 'timestamp', 'severity', 'message' ],
+	fields: [ 'severity', 'timestamp', 'message' ],
 	layout: {
 		density: 'balanced',
 		styles: {
@@ -30,7 +30,7 @@ export const DEFAULT_PHP_LOGS_VIEW: View = {
 
 export const DEFAULT_SERVER_LOGS_VIEW: View = {
 	...DEFAULT_VIEW,
-	fields: [ 'date', 'request_type', 'status', 'request_url' ],
+	fields: [ 'status', 'date', 'request_type', 'request_url' ],
 	sort: {
 		field: 'date',
 		direction: 'desc',

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -116,6 +116,10 @@ function SiteLogs( { logType }: { logType: LogType } ) {
 	};
 
 	const handleTabChange = ( tab: LogType ) => {
+		if ( logType === tab ) {
+			return;
+		}
+
 		if ( tab === LogType.PHP ) {
 			router.navigate( { to: `/sites/${ siteSlug }/logs/php` } );
 		} else if ( tab === LogType.ACTIVITY ) {

--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -190,25 +190,28 @@ afterAll( () => {
 } );
 
 describe( 'SiteLogs page', () => {
-	test( 'navigates on tab select for PHP errors/Web server/Activity', async () => {
-		render( <SiteLogs logType={ LogType.PHP } /> );
+	test.each( Object.entries( LogType ) )(
+		'on selecting tab %s, navigates to /%s',
+		async ( logType, logTypeName ) => {
+			// Different initial log type that the one under test
+			const initialLogType = logTypeName !== LogType.PHP ? LogType.PHP : LogType.SERVER;
+			render( <SiteLogs logType={ initialLogType } /> );
 
-		// Wait for data and TabPanel to render
-		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+			// Wait for data and TabPanel to render
+			await waitFor( () => expect( nock.isDone() ).toBe( true ) );
 
-		// Click web server and activity tabs
-		await userEvent.click( await screen.findByRole( 'button', { name: 'Web server' } ) );
-		const { __mocks: routerMocks } = jest.requireMock( '@tanstack/react-router' ) as {
-			__mocks: { navigate: jest.Mock };
-		};
-		expect( routerMocks.navigate ).toHaveBeenCalledWith( { to: '/sites/test-site/logs/server' } );
-
-		await userEvent.click( await screen.findByRole( 'button', { name: 'Activity' } ) );
-		expect( routerMocks.navigate ).toHaveBeenCalledWith( { to: '/sites/test-site/logs/activity' } );
-
-		await userEvent.click( await screen.findByRole( 'button', { name: 'PHP errors' } ) );
-		expect( routerMocks.navigate ).toHaveBeenCalledWith( { to: '/sites/test-site/logs/php' } );
-	} );
+			// Click another tab
+			await userEvent.click(
+				await screen.findByRole( 'button', { name: new RegExp( logTypeName, 'i' ) } )
+			);
+			const { __mocks: routerMocks } = jest.requireMock( '@tanstack/react-router' ) as {
+				__mocks: { navigate: jest.Mock };
+			};
+			expect( routerMocks.navigate ).toHaveBeenCalledWith( {
+				to: `/sites/test-site/logs/${ logTypeName }`,
+			} );
+		}
+	);
 
 	test( 'URL from/to params are normalized from ms to seconds', async () => {
 		const replaceSpy = jest.spyOn( window.history, 'replaceState' );


### PR DESCRIPTION
Fixes DOTMSD-886

## Proposed Changes

This PR implements DataViews persistence for Site -> Logs -> {PHP, Web Server} tabs.

This means we are not syncing the filters to the query params anymore. Instead, we're persisting them to the Calypso preferences instead, aligning the behavior with the rest of the MSD.

---

This PR also updates the DataViews to not use `titleField` anymore. I'm not sure why the existing fields are set as `titleField` in the first place. ~~With those removed, the fields are now aligned with v1.~~ Also, after https://github.com/WordPress/gutenberg/pull/72969, those fields have been way too long and feels broken.



|Before|After|
|-|-|
|<img width="1359" height="256" alt="image" src="https://github.com/user-attachments/assets/2ffb5578-5f82-49ab-ba32-6694fa19a6f1" />|<img width="1358" height="256" alt="image" src="https://github.com/user-attachments/assets/d29699ac-9871-4cf3-8f36-cfe31a763765" />
|<img width="1356" height="254" alt="image" src="https://github.com/user-attachments/assets/3e079f57-5757-4488-9a90-6da2a7cc4868" />|<img width="1356" height="256" alt="image" src="https://github.com/user-attachments/assets/afbd0129-463d-4636-9a7f-c3ee8507013e" />



## Why are these changes being made?

We want to persist DataViews config across MSD.

## Testing Instructions

1. Go to `/v2/sites/:siteSlug` of an Atomic site.
2. Go to Logs.
3. Go the Web server tabs.
4. Try to modify the filters and/or appearance options. Refresh the page.
    - Verify the config persist.
    - Verify you can see the `Reset view` button link and it works to reset the config.
5. Also check the PHP errors tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
