### PR TITLE
A4A: Client express checkout initial implementation.

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -158,6 +158,7 @@ function ClientCheckoutContent( { expressMode }: CheckoutProps ) {
 				redirectTo={ window.location.origin + '/client/subscriptions' }
 				customizedPreviousPath="/client/subscriptions"
 				siteSlug=""
+				isLoggedOutCart={ expressMode }
 				siteId={ 0 }
 			/>
 		</div>

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -2,6 +2,7 @@ import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
+import { useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -11,6 +12,7 @@ import { getClientReferralQueryArgs } from 'calypso/a8c-for-agencies/sections/ma
 import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
+import { CHECKOUT_STORE } from 'calypso/my-sites/checkout/src/lib/wpcom-store';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import ClientCheckoutV2Error from '../../checkout-v2-error';
@@ -45,6 +47,9 @@ function ClientCheckoutContent( { expressMode }: CheckoutProps ) {
 	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
 
 	const emailMismatchWithReferralClient = referral?.client?.email !== userEmail;
+
+	// Access checkout store to set email for express checkout
+	const checkoutStoreDispatch = useDispatch( CHECKOUT_STORE );
 
 	// Add products to cart when referral data is loaded
 	useEffect( () => {
@@ -103,6 +108,17 @@ function ClientCheckoutContent( { expressMode }: CheckoutProps ) {
 		queryArgs.referralId,
 		queryArgs.agencyId,
 	] );
+
+	// Set referral client email in checkout store for express checkout
+	useEffect( () => {
+		if ( expressMode && referral?.client?.email && checkoutStoreDispatch ) {
+			debug(
+				'[A4A Checkout] Setting referral client email in checkout store:',
+				referral.client.email
+			);
+			checkoutStoreDispatch.updateEmail( referral.client.email );
+		}
+	}, [ expressMode, referral?.client?.email, checkoutStoreDispatch ] );
 
 	// Debugging: Set a timeout to force showing the checkout after 10 seconds
 	useEffect( () => {

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -21,10 +21,14 @@ import './style.scss';
 
 const debug = debugFactory( 'client:checkout-v2' );
 
+type CheckoutProps = {
+	expressMode?: boolean;
+};
+
 /**
  * Client Checkout Component using the WordPress.com checkout
  */
-function ClientCheckoutContent() {
+function ClientCheckoutContent( { expressMode }: CheckoutProps ) {
 	const translate = useTranslate();
 	const [ isReady, setIsReady ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
@@ -34,7 +38,9 @@ function ClientCheckoutContent() {
 	const { referredProducts } = useProductsById( referral?.products ?? [] );
 
 	// Access the shopping cart API
-	const { replaceProductsInCart, responseCart } = useShoppingCart( 'no-site' );
+	const { replaceProductsInCart, responseCart } = useShoppingCart(
+		expressMode ? 'no-user' : 'no-site'
+	);
 
 	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
 
@@ -116,7 +122,7 @@ function ClientCheckoutContent() {
 		return <ClientCheckoutV2Placeholder />;
 	}
 
-	if ( emailMismatchWithReferralClient ) {
+	if ( ! expressMode && emailMismatchWithReferralClient ) {
 		return (
 			<ClientCheckoutV2Error
 				title={ translate( 'Permission denied' ) }
@@ -161,6 +167,9 @@ function ClientCheckoutContent() {
 export default function ClientCheckoutV2() {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
+	const currentUser = useSelector( getCurrentUser );
+
+	const expressMode = ! currentUser; // If no user is logged in, we are in express mode
 
 	return (
 		<CheckoutErrorBoundary
@@ -169,7 +178,7 @@ export default function ClientCheckoutV2() {
 			<CalypsoShoppingCartProvider shouldShowPersistentErrors>
 				<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
 					<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
-						<ClientCheckoutContent />
+						<ClientCheckoutContent expressMode={ expressMode } />
 					</RazorpayHookProvider>
 				</StripeHookProvider>
 			</CalypsoShoppingCartProvider>

--- a/client/a8c-for-agencies/sections/express-checkout/controller.tsx
+++ b/client/a8c-for-agencies/sections/express-checkout/controller.tsx
@@ -1,9 +1,21 @@
+import page from '@automattic/calypso-router';
 import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hideMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
+import { A4A_CLIENT_CHECKOUT } from '../../components/sidebar-menu/lib/constants';
 import ClientCheckoutV2 from '../client/primary/checkout-v2';
 
 export const clientExpressCheckout: Callback = ( context, next ) => {
+	const state = context.store.getState();
+	const isLoggedIn = isUserLoggedIn( state );
+
+	// If user has a current session (logged in), redirect to regular checkout
+	if ( isLoggedIn ) {
+		const queryParams = context.querystring ? `?${ context.querystring }` : '';
+		return page.redirect( `${ A4A_CLIENT_CHECKOUT }${ queryParams }` );
+	}
+
 	context.store.dispatch( hideMasterbar() );
 	context.primary = (
 		<>

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -157,7 +157,7 @@ function authorizePath() {
 }
 
 const JP_CLOUD_PUBLIC_ROUTES = [ '/pricing', '/plans', '/features/comparison', '/manage/pricing' ];
-const A4A_PUBLIC_ROUTES = [ '/signup' ];
+const A4A_PUBLIC_ROUTES = [ '/signup', '/client/express-checkout' ];
 
 const oauthTokenMiddleware = () => {
 	if ( config.isEnabled( 'oauth' ) ) {

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -149,11 +149,12 @@ export default function CheckoutMain( {
 		sitelessCheckoutType === 'a4a';
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const { razorpayConfiguration, isRazorpayLoading, razorpayLoadingError } = useRazorpay();
-	// Allow account creation for A4A siteless checkout when user is logged out (express mode)
-	const isA4AExpressMode =
-		sitelessCheckoutType === 'a4a' && Boolean( isLoggedOutCart || isNoSiteCart );
+
 	const createUserAndSiteBeforeTransaction =
-		Boolean( isLoggedOutCart || isNoSiteCart ) && ( ! isSiteless || isA4AExpressMode );
+		Boolean( isLoggedOutCart || isNoSiteCart ) &&
+		( ! isSiteless ||
+			// Allow account creation for A4A siteless checkout when user is logged out (express mode)
+			sitelessCheckoutType === 'a4a' );
 	const reduxDispatch = useDispatch();
 
 	const updatedSiteSlug = useMemo( () => {

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -149,8 +149,11 @@ export default function CheckoutMain( {
 		sitelessCheckoutType === 'a4a';
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const { razorpayConfiguration, isRazorpayLoading, razorpayLoadingError } = useRazorpay();
+	// Allow account creation for A4A siteless checkout when user is logged out (express mode)
+	const isA4AExpressMode =
+		sitelessCheckoutType === 'a4a' && Boolean( isLoggedOutCart || isNoSiteCart );
 	const createUserAndSiteBeforeTransaction =
-		Boolean( isLoggedOutCart || isNoSiteCart ) && ! isSiteless;
+		Boolean( isLoggedOutCart || isNoSiteCart ) && ( ! isSiteless || isA4AExpressMode );
 	const reduxDispatch = useDispatch();
 
 	const updatedSiteSlug = useMemo( () => {

--- a/client/my-sites/checkout/src/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/src/components/contact-details-container.tsx
@@ -91,6 +91,15 @@ export default function ContactDetailsContainer( {
 		updateDomainContactFields( details );
 	};
 
+	// Check if we're in A4A express checkout (siteless checkout with logged out cart)
+	const isA4AExpressCheckout =
+		isLoggedOutCart &&
+		responseCart.products.some( ( product ) => product.extra?.isA4ASitelessCheckout );
+
+	// Disable email field if we're in A4A express checkout and email is already set (from referral)
+	const isEmailDisabledForA4A =
+		isA4AExpressCheckout && contactDetails.email && contactDetails.email.trim() !== '';
+
 	switch ( contactDetailsType ) {
 		case 'domain':
 			return (
@@ -132,10 +141,13 @@ export default function ContactDetailsContainer( {
 							id="email"
 							type="email"
 							label={ String( translate( 'Email' ) ) }
-							disabled={ isDisabled }
+							disabled={ isDisabled || isEmailDisabledForA4A }
 							value={ contactDetails.email ?? '' }
 							onChange={ ( value ) => {
-								updateEmail( value );
+								// Prevent updating email if it's disabled for A4A express checkout
+								if ( ! isEmailDisabledForA4A ) {
+									updateEmail( value );
+								}
 							} }
 							autoComplete="email"
 							isError={ email?.isTouched && ! isValid( email ) }

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -234,6 +234,12 @@ function chooseAddHandler( {
 		return 'addProductFromBillingIntent';
 	}
 
+	// A4A checkout handles products directly via replaceProductsInCart in the checkout component
+	// so we should not try to add products from localStorage or other sources
+	if ( sitelessCheckoutType === 'a4a' ) {
+		return 'doNotAdd';
+	}
+
 	if ( ! isLoading ) {
 		return 'doNotAdd';
 	}

--- a/client/my-sites/checkout/src/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/src/lib/contact-validation.tsx
@@ -109,11 +109,53 @@ async function runContactValidationCheck(
 async function runLoggedOutEmailValidationCheck(
 	contactInfo: ManagedContactDetails,
 	reduxDispatch: CalypsoDispatch,
-	translate: ReturnType< typeof useTranslate >
+	translate: ReturnType< typeof useTranslate >,
+	shouldCheckForEmailTaken?: boolean
 ): Promise< unknown > {
 	const email = contactInfo.email?.value ?? '';
-	return getSignupEmailValidationResult( email, ( newEmail: string ) =>
-		getEmailTakenLoginRedirectMessage( newEmail, reduxDispatch, translate )
+	const originalResponse = await wpcomValidateSignupEmail( {
+		email,
+		is_from_registrationless_checkout: true,
+	} );
+
+	// Check if we're in A4A express checkout and email already exists
+	if ( shouldCheckForEmailTaken && isSignupValidationResponse( originalResponse ) ) {
+		const emailResponse: Record< string, string > = originalResponse.messages?.email ?? {};
+		const emailExists = emailResponse.hasOwnProperty( 'taken' );
+
+		if ( emailExists ) {
+			const { href, pathname } = window.location;
+			const currentURLQueryParameters = Object.fromEntries(
+				new URL( href ).searchParams.entries()
+			);
+			// Redirect back to express checkout after login with query params preserved
+			const redirectTo = addQueryArgs(
+				{ ...currentURLQueryParameters, flow: 'coming_from_login' },
+				pathname
+			);
+			const loginUrl = login( { redirectTo, emailAddress: email } );
+
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_wpcom_email_exists', {
+					email,
+				} )
+			);
+
+			// Immediately redirect to login page
+			window.location.href = loginUrl;
+			// Return a failed validation response to stop further processing
+			return {
+				success: false,
+				messages: {},
+			};
+		}
+	}
+
+	// Transform the response using the existing logic, passing the cached response
+	return getSignupEmailValidationResult(
+		email,
+		( newEmail: string ) => getEmailTakenLoginRedirectMessage( newEmail, reduxDispatch, translate ),
+		originalResponse
 	);
 }
 
@@ -152,11 +194,18 @@ export async function validateContactDetails(
 	};
 
 	if ( isLoggedOutCart ) {
+		// Check if this is an A4A siteless checkout by examining cart products
+		const isA4AExpressCheckout = responseCart.products.some(
+			( product ) => product.extra?.isA4ASitelessCheckout
+		);
+
 		const loggedOutValidationResult = await runLoggedOutEmailValidationCheck(
 			contactInfo,
 			reduxDispatch,
-			translate
+			translate,
+			isA4AExpressCheckout
 		);
+
 		if ( shouldDisplayErrors ) {
 			handleContactValidationResult( {
 				translate,
@@ -411,12 +460,15 @@ function handleContactValidationResult( {
 
 async function getSignupEmailValidationResult(
 	email: string,
-	emailTakenLoginRedirect: ( email: string ) => TranslateResult
+	emailTakenLoginRedirect: ( email: string ) => TranslateResult,
+	cachedResponse?: SignupValidationResponse
 ) {
-	const response = await wpcomValidateSignupEmail( {
-		email,
-		is_from_registrationless_checkout: true,
-	} );
+	const response =
+		cachedResponse ??
+		( await wpcomValidateSignupEmail( {
+			email,
+			is_from_registrationless_checkout: true,
+		} ) );
 	const signupValidationErrorResponse = getSignupValidationErrorResponse(
 		response,
 		email,

--- a/client/my-sites/checkout/src/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/src/lib/contact-validation.tsx
@@ -110,52 +110,15 @@ async function runLoggedOutEmailValidationCheck(
 	contactInfo: ManagedContactDetails,
 	reduxDispatch: CalypsoDispatch,
 	translate: ReturnType< typeof useTranslate >,
-	shouldCheckForEmailTaken?: boolean
+	isA4AExpressCheckout?: boolean
 ): Promise< unknown > {
 	const email = contactInfo.email?.value ?? '';
-	const originalResponse = await wpcomValidateSignupEmail( {
-		email,
-		is_from_registrationless_checkout: true,
-	} );
 
-	// Check if we're in A4A express checkout and email already exists
-	if ( shouldCheckForEmailTaken && isSignupValidationResponse( originalResponse ) ) {
-		const emailResponse: Record< string, string > = originalResponse.messages?.email ?? {};
-		const emailExists = emailResponse.hasOwnProperty( 'taken' );
-
-		if ( emailExists ) {
-			const { href, pathname } = window.location;
-			const currentURLQueryParameters = Object.fromEntries(
-				new URL( href ).searchParams.entries()
-			);
-			// Redirect back to express checkout after login with query params preserved
-			const redirectTo = addQueryArgs(
-				{ ...currentURLQueryParameters, flow: 'coming_from_login' },
-				pathname
-			);
-			const loginUrl = login( { redirectTo, emailAddress: email } );
-
-			reduxDispatch(
-				recordTracksEvent( 'calypso_checkout_wpcom_email_exists', {
-					email,
-				} )
-			);
-
-			// Immediately redirect to login page
-			window.location.href = loginUrl;
-			// Return a failed validation response to stop further processing
-			return {
-				success: false,
-				messages: {},
-			};
-		}
-	}
-
-	// Transform the response using the existing logic, passing the cached response
 	return getSignupEmailValidationResult(
 		email,
 		( newEmail: string ) => getEmailTakenLoginRedirectMessage( newEmail, reduxDispatch, translate ),
-		originalResponse
+		reduxDispatch,
+		isA4AExpressCheckout
 	);
 }
 
@@ -461,14 +424,47 @@ function handleContactValidationResult( {
 async function getSignupEmailValidationResult(
 	email: string,
 	emailTakenLoginRedirect: ( email: string ) => TranslateResult,
-	cachedResponse?: SignupValidationResponse
+	reduxDispatch: CalypsoDispatch,
+	isA4AExpressCheckout?: boolean
 ) {
-	const response =
-		cachedResponse ??
-		( await wpcomValidateSignupEmail( {
-			email,
-			is_from_registrationless_checkout: true,
-		} ) );
+	const response = await wpcomValidateSignupEmail( {
+		email,
+		is_from_registrationless_checkout: true,
+	} );
+
+	// Check if we're in A4A express checkout and email already exists - redirect immediately
+	if ( isA4AExpressCheckout && isSignupValidationResponse( response ) ) {
+		const emailResponse: Record< string, string > = response.messages?.email ?? {};
+		const emailExists = emailResponse.hasOwnProperty( 'taken' );
+
+		if ( emailExists ) {
+			const { href, pathname } = window.location;
+			const currentURLQueryParameters = Object.fromEntries(
+				new URL( href ).searchParams.entries()
+			);
+			// Redirect back to express checkout after login with query params preserved
+			const redirectTo = addQueryArgs(
+				{ ...currentURLQueryParameters, flow: 'coming_from_login' },
+				pathname
+			);
+			const loginUrl = login( { redirectTo, emailAddress: email } );
+
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_wpcom_email_exists', {
+					email,
+				} )
+			);
+
+			// Immediately redirect to login page
+			window.location.href = loginUrl;
+			// Return a failed validation response to stop further processing
+			return {
+				success: false,
+				messages: {},
+			};
+		}
+	}
+
 	const signupValidationErrorResponse = getSignupValidationErrorResponse(
 		response,
 		email,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -27,6 +27,8 @@
 		}
 	],
 	"oauth_client_id": 95928,
+	"wpcom_signup_id": "39911",
+	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"features": {
 		"a4a-help-center": true,
 		"ad-tracking": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -24,6 +24,8 @@
 			"content": "https://agencies.automattic.com/calypso/images/a8c-for-agencies/a8c-logo.jpeg"
 		}
 	],
+	"wpcom_signup_id": "39911",
+	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"features": {
 		"a4a-help-center": true,
 		"ad-tracking": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -26,6 +26,8 @@
 		}
 	],
 	"oauth_client_id": 95932,
+	"wpcom_signup_id": "39911",
+	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"features": {
 		"a4a-help-center": false,
 		"ad-tracking": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -26,6 +26,8 @@
 		}
 	],
 	"oauth_client_id": 95931,
+	"wpcom_signup_id": "39911",
+	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"features": {
 		"a4a-help-center": true,
 		"ad-tracking": false,


### PR DESCRIPTION

Depends on 196798-ghe-Automattic/wpcom


## Proposed changes

This pull request introduces "express checkout" support for A8C for Agencies, allowing agency clients to complete a checkout flow without logging in. The main changes include enabling a siteless, registrationless checkout mode, handling referral client emails, ensuring proper validation and redirection, and updating UI logic for this new flow. Several configuration updates and logic changes across multiple files support this feature.

**Express Checkout Flow Implementation:**

* Added express checkout mode to `ClientCheckoutV2` and its content component, toggling based on user login status and updating cart logic accordingly (`client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx`). [[1]](diffhunk://#diff-bd33d4b133108bec614a1fa23fd82a1772f2e2cd3a98f16bcbbd38c136c88adfR26-R33) [[2]](diffhunk://#diff-bd33d4b133108bec614a1fa23fd82a1772f2e2cd3a98f16bcbbd38c136c88adfL37-R53) [[3]](diffhunk://#diff-bd33d4b133108bec614a1fa23fd82a1772f2e2cd3a98f16bcbbd38c136c88adfR112-R122) [[4]](diffhunk://#diff-bd33d4b133108bec614a1fa23fd82a1772f2e2cd3a98f16bcbbd38c136c88adfL119-R141) [[5]](diffhunk://#diff-bd33d4b133108bec614a1fa23fd82a1772f2e2cd3a98f16bcbbd38c136c88adfR177) [[6]](diffhunk://#diff-bd33d4b133108bec614a1fa23fd82a1772f2e2cd3a98f16bcbbd38c136c88adfR187-R189) [[7]](diffhunk://#diff-bd33d4b133108bec614a1fa23fd82a1772f2e2cd3a98f16bcbbd38c136c88adfL172-R198)
* Created controller logic to redirect logged-in users to regular checkout and hide masterbar for express checkout (`client/a8c-for-agencies/sections/express-checkout/controller.tsx`).
* Marked `/client/express-checkout` as a public route to allow access without authentication (`client/boot/common.js`).

**Checkout and Cart Logic Updates:**

* Modified checkout logic to allow account creation for A4A siteless checkout in express mode and updated product handling to avoid adding products from local storage (`client/my-sites/checkout/src/components/checkout-main.tsx`, `client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts`). [[1]](diffhunk://#diff-33c8d352d35e0d07fda17c3814413f15f6cb77f956bffe9ac0ed24e2474cfc0eR152-R156) [[2]](diffhunk://#diff-57153c78ecd3852961953a97b49d6aab1169f06d5d490dc32b3068cc8b4cfd2eR237-R242)
* Updated contact details UI to disable the email field if it is already set by a referral in express checkout, preventing user edits (`client/my-sites/checkout/src/components/contact-details-container.tsx`). [[1]](diffhunk://#diff-b7eef0e4d3cfac8f5742ed77c49af3d31b4548bd91a8fff8089f5d65cd689a28R94-R102) [[2]](diffhunk://#diff-b7eef0e4d3cfac8f5742ed77c49af3d31b4548bd91a8fff8089f5d65cd689a28L135-R150)

**Validation and Redirection Enhancements:**

* Improved email validation logic for express checkout: if a referred email already exists, the user is redirected to login and tracking is recorded (`client/my-sites/checkout/src/lib/contact-validation.tsx`). [[1]](diffhunk://#diff-f01fb420612523fdb18f941fcb2fc42f2e900545f70a96025dbbae9cfca29d96L112-R158) [[2]](diffhunk://#diff-f01fb420612523fdb18f941fcb2fc42f2e900545f70a96025dbbae9cfca29d96R197-R208) [[3]](diffhunk://#diff-f01fb420612523fdb18f941fcb2fc42f2e900545f70a96025dbbae9cfca29d96L414-R471)

**Configuration Updates:**

* Added `wpcom_signup_id` and `wpcom_signup_key` to all A8C for Agencies environment configs to support registrationless checkout (`config/a8c-for-agencies-development.json`, `config/a8c-for-agencies-horizon.json`, `config/a8c-for-agencies-production.json`, `config/a8c-for-agencies-stage.json`). [[1]](diffhunk://#diff-b7fdfbca27fe9c8150a2cb73e811d96b030fad1f6072494c8291f188cef9779aR30-R31) [[2]](diffhunk://#diff-1c75c03fadc6b49d3df97ba7dd9ba5ad3304c19beebef3584ffad47314e4ac5fR27-R28) [[3]](diffhunk://#diff-6cae595596e0ea2cf4edffd0083ea7fb071702d10e058839990765fb49f4aa36R29-R30) [[4]](diffhunk://#diff-75d25521c97285a60bd86cedb61e8660ece2a553e9e420e2bba8c2aee89f3cb1R29-R30)
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?