### PR TITLE
Partner Directory: Fix partner dir mobile e2e test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/partner-directory-component.ts
+++ b/packages/calypso-e2e/src/lib/components/partner-directory-component.ts
@@ -1,3 +1,4 @@
+import { envVariables } from '../..';
 import type { Page } from 'playwright';
 
 /**
@@ -22,6 +23,13 @@ export class PartnerDirectoryComponent {
 	 * @param {string} filterName The name of the filter to apply.
 	 */
 	async applyDropdownFilter( dropdownName: string, filterName: string ): Promise< void > {
+		// On mobile, we need to click the filters toggle button first to open the filters panel.
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// TODO: This button has no accessible name, so we have to use a CSS selector.
+			const filtersToggle = this.page.locator( '.a4a-partner-directory-filters-toggle' );
+			await filtersToggle.waitFor( { state: 'visible' } );
+			await filtersToggle.click();
+		}
 		await this.page.getByRole( 'button', { name: dropdownName } ).click();
 		await this.page.getByRole( 'checkbox', { name: filterName } ).click();
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/107268

## Proposed Changes

* Fixes the mobile partner directory e2e test.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The directory filters are hidden on mobile, so we need to open the filter menu to interact with them.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
