### PR TITLE
Reader: update link text to indicate this is not a public link

### DIFF
--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -164,7 +164,7 @@ class Profile extends Component {
 						</FormFieldset>
 
 						<p className="profile__public-url">
-							{ this.props.translate( 'View your public profile at {{a}}{{url/}}{{/a}}.', {
+							{ this.props.translate( 'View your Reader profile at {{a}}{{url/}}{{/a}}.', {
 								components: {
 									a: <ExternalLink href={ relativeProfileUrl } />,
 									url: <>{ absoluteProfileUrl }</>,


### PR DESCRIPTION
Fixes READ-209

## Proposed Changes

Small change since the Reader profile is only acceptable when logged in.

<img width="1265" height="412" alt="image" src="https://github.com/user-attachments/assets/7af6cbad-9407-43fb-a35d-5cd41544c167" />


## Testing Instructions

* Check out this branch
* Load http://calypso.localhost:3000/me
* Check the link towards the button of the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
