### PR TITLE
Remove padding when sale banner is visible

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -193,6 +193,10 @@ $delay: 0.055s;
 		color: #101517;
 		font-size: 18px;
 		transition: background 0.1s;
+
+		&:has( .sale-banner ) {
+			padding-top: 0;
+		}
 	}
 	@media ( max-width: 900px ) {
 		.header {
@@ -483,9 +487,6 @@ $delay: 0.055s;
 	.header.force-opaque,
 	.header.is-opaque {
 		background-color: #fff;
-	}
-	.header:has( .sale-banner ) {
-		padding-top: 0;
 	}
 	html.with-admin-bar .header {
 		top: 32px;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -484,6 +484,9 @@ $delay: 0.055s;
 	.header.is-opaque {
 		background-color: #fff;
 	}
+	.header:has( .sale-banner ) {
+		padding-top: 0;
+	}
 	html.with-admin-bar .header {
 		top: 32px;
 	}


### PR DESCRIPTION
Fixes MYJP-276
Part of 196824-ghe-Automattic/wpcom

## Proposed Changes

<img width="3020" height="664" alt="CleanShot 2025-11-25 at 14 03 38@2x" src="https://github.com/user-attachments/assets/1f54ecc7-d1ba-4420-9649-7aab8a46826e" />

Remove top padding from the Jetpack pricing page header when the sale banner is active using the CSS :has() selector

## Why are these changes being made?

When the sale banner is displayed on the Jetpack pricing page, the default 2rem top padding on .header.js-header.force-opaque creates unnecessary whitespace above the banner. This change conditionally removes the top padding when the .sale-banner element is present, improving the visual layout. The padding is automatically restored when the user closes the banner since the element is removed from the DOM.

## Testing Instructions

* Checkout 196824-ghe-Automattic/wpcom on your sandbox (time sensitive based on active coupon), and point public-api.wordpress.com to your sandbox
* Go to <live url>/pricing and verify there is no padding on top of sale banner when it's active. the padding appears as you close the sale banner