### PR TITLE
A4A: Add A4A contact form in the Help center.

### DIFF
--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -8,6 +8,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { onboardingUrl } from 'calypso/lib/paths';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
@@ -38,6 +39,7 @@ export default function HelpCenterLoader( {
 	const locale = useLocale();
 	const hasPurchases = useSelector( hasCancelableUserPurchases );
 	const user = useSelector( getCurrentUser );
+	const agency = useSelector( getActiveAgency );
 	const selectedSite = useSelector( getSelectedSite );
 	const primarySiteSlug = useSelector( getPrimarySiteSlug );
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
@@ -49,6 +51,12 @@ export default function HelpCenterLoader( {
 	const additionalHelpCenterProps = isA8CForAgencies()
 		? {
 				newInteractionsBotSlug: 'automattic-chat-support_a4a',
+				agency: agency
+					? {
+							id: agency.id,
+							pressableId: agency?.third_party?.pressable?.pressable_id,
+					  }
+					: null,
 		  }
 		: {};
 

--- a/packages/help-center/src/components/help-center-a4a-contact-form.scss
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.scss
@@ -1,18 +1,8 @@
 @import "@automattic/typography/styles/variables";
 
-.help-center__container-content .help-center-a4a-contact-form__wrapper {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	gap: 16px;
-	padding: 16px;
+.help-center__container-content .help-center-a4a-contact-form {
 	height: 100%;
-
-	.help-center-a4a-contact-form {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
+	padding: 16px;
 
 	.help-center-a4a-contact-form__title {
 		font-size: $root-font-size;

--- a/packages/help-center/src/components/help-center-a4a-contact-form.scss
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.scss
@@ -1,0 +1,22 @@
+@import "@automattic/typography/styles/variables";
+
+.help-center__container-content .help-center-a4a-contact-form__wrapper {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	gap: 16px;
+	padding: 16px;
+	height: 100%;
+
+	.help-center-a4a-contact-form {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	.help-center-a4a-contact-form__title {
+		font-size: $root-font-size;
+		color: var(--studio-gray-100);
+		margin-top: 20px;
+	}
+}

--- a/packages/help-center/src/components/help-center-a4a-contact-form.scss
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.scss
@@ -3,10 +3,4 @@
 .help-center__container-content .help-center-a4a-contact-form {
 	height: 100%;
 	padding: 16px;
-
-	.help-center-a4a-contact-form__title {
-		font-size: $root-font-size;
-		color: var(--studio-gray-100);
-		margin-top: 20px;
-	}
 }

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -7,6 +7,7 @@ import {
 	Button,
 	TextareaControl,
 	__experimentalVStack as VStack,
+	__experimentalHeading as Heading,
 	Notice,
 } from '@wordpress/components';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
@@ -212,9 +213,7 @@ export const HelpCenterA4AContactForm = () => {
 	return (
 		<form onSubmit={ handleSubmit } className="help-center-a4a-contact-form">
 			<VStack spacing={ 4 } justify="flex-start">
-				<h1 className="help-center-a4a-contact-form__title">
-					{ __( 'Contact sales & support', __i18n_text_domain__ ) }
-				</h1>
+				<Heading level={ 3 }>{ __( 'Contact sales & support', __i18n_text_domain__ ) }</Heading>
 
 				<DataForm< FormData >
 					data={ formData }

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -3,20 +3,21 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { FormInputValidation } from '@automattic/components';
 import { Button, SelectControl, TextareaControl, TextControl } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 /**
  * Internal Dependencies
  */
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import './help-center-a4a-contact-form.scss';
+import { useSubmitA4ATicketMutation } from '../data/use-submit-a4a-support-ticket';
 
 export const HelpCenterA4AContactForm = () => {
-	const dispatch = useDispatch();
-
-	const { currentUser } = useHelpCenterContext();
+	const { currentUser, agency } = useHelpCenterContext();
+	const navigate = useNavigate();
 
 	const [ formData, setFormData ] = useState( {
 		name: currentUser?.display_name ?? '',
@@ -27,19 +28,51 @@ export const HelpCenterA4AContactForm = () => {
 		pressable_contact: 'sales',
 	} );
 
+	const [ hasSubmitError, setHasSubmitError ] = useState( false );
+
+	const { isPending, mutate: submitA4ATicket } = useSubmitA4ATicketMutation();
+
 	const isPressableSelected = formData[ 'product' ] === 'pressable';
 
 	const handleChange = ( key: string, value: string ) => {
 		setFormData( { ...formData, [ key ]: value } );
 	};
 
-	const handleSubmit = () => {
-		dispatch(
-			recordTracksEvent( 'calypso_a4a_user_contact_support_form_submit', {
-				form_data: JSON.stringify( formData ),
-			} )
+	const handleSubmit = useCallback( () => {
+		recordTracksEvent( 'calypso_a4a_user_contact_support_form_submit', {
+			data: formData[ 'message' ],
+		} );
+
+		setHasSubmitError( false );
+
+		submitA4ATicket(
+			{
+				name: formData[ 'name' ],
+				email: formData[ 'email' ],
+				message: formData[ 'message' ],
+				product: formData[ 'product' ],
+				agency_id: agency?.id,
+				pressable_id: agency?.pressableId,
+				site: formData[ 'site' ] ?? undefined,
+				contact_type: isPressableSelected ? formData[ 'pressable_contact' ] : undefined,
+			},
+			{
+				onSuccess: () => {
+					navigate( '/success' );
+				},
+				onError: () => {
+					setHasSubmitError( true );
+				},
+			}
 		);
-	};
+	}, [
+		formData,
+		submitA4ATicket,
+		agency?.id,
+		agency?.pressableId,
+		isPressableSelected,
+		navigate,
+	] );
 
 	useEffect( () => {
 		if ( formData[ 'product' ] === 'pressable' ) {
@@ -160,11 +193,18 @@ export const HelpCenterA4AContactForm = () => {
 			</div>
 
 			<div className="contact-form-submit">
+				{ hasSubmitError && (
+					<FormInputValidation
+						isError
+						text={ __( 'Something went wrong, please try again later.', __i18n_text_domain__ ) }
+					/>
+				) }
+
 				<Button
 					__next40pxDefaultSize
 					variant="primary"
-					onClick={ () => handleSubmit() }
-					disabled={ ! isValidForm }
+					onClick={ handleSubmit }
+					disabled={ ! isValidForm || isPending }
 				>
 					{ __( 'Submit form', __i18n_text_domain__ ) }
 				</Button>

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -3,8 +3,12 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { FormInputValidation } from '@automattic/components';
-import { Button, TextareaControl } from '@wordpress/components';
+import {
+	Button,
+	TextareaControl,
+	__experimentalVStack as VStack,
+	Notice,
+} from '@wordpress/components';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useMemo, useCallback } from 'react';
@@ -206,8 +210,8 @@ export const HelpCenterA4AContactForm = () => {
 	}, [ validity ] );
 
 	return (
-		<form onSubmit={ handleSubmit } className="help-center-a4a-contact-form__wrapper">
-			<div className="help-center-a4a-contact-form">
+		<form onSubmit={ handleSubmit } className="help-center-a4a-contact-form">
+			<VStack spacing={ 4 } justify="flex-start">
 				<h1 className="help-center-a4a-contact-form__title">
 					{ __( 'Contact sales & support', __i18n_text_domain__ ) }
 				</h1>
@@ -221,15 +225,6 @@ export const HelpCenterA4AContactForm = () => {
 						setFormData( ( data ) => ( { ...data, ...edits } ) );
 					} }
 				/>
-			</div>
-
-			<div className="contact-form-submit">
-				{ hasSubmitError && (
-					<FormInputValidation
-						isError
-						text={ __( 'Something went wrong, please try again later.', __i18n_text_domain__ ) }
-					/>
-				) }
 
 				<Button
 					__next40pxDefaultSize
@@ -239,7 +234,13 @@ export const HelpCenterA4AContactForm = () => {
 				>
 					{ __( 'Submit form', __i18n_text_domain__ ) }
 				</Button>
-			</div>
+
+				{ hasSubmitError && (
+					<Notice status="warning" isDismissible={ false }>
+						{ __( 'Something went wrong. Please try again later.', __i18n_text_domain__ ) }
+					</Notice>
+				) }
+			</VStack>
 		</form>
 	);
 };

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -67,11 +67,6 @@ const fields: Field< FormData >[] = [
 		Edit: 'select',
 		elements: [
 			{
-				label: __( 'Select a product', __i18n_text_domain__ ),
-				value: '',
-				disabled: true,
-			},
-			{
 				label: __( 'Automattic for Agencies', __i18n_text_domain__ ),
 				value: 'a4a',
 			},

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/components';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 /**
  * Internal Dependencies
@@ -29,6 +29,11 @@ type FormData = {
 	product: string;
 	message: string;
 	pressable_contact: string;
+};
+
+const FORM_CONFIG = {
+	layout: { type: 'regular' as const },
+	fields: [ 'name', 'email', 'site', 'product', 'pressable_contact', 'message' ],
 };
 
 export const HelpCenterA4AContactForm = () => {
@@ -164,12 +169,7 @@ export const HelpCenterA4AContactForm = () => {
 		[]
 	);
 
-	const form = {
-		layout: { type: 'regular' as const },
-		fields: [ 'name', 'email', 'site', 'product', 'pressable_contact', 'message' ],
-	};
-
-	const { validity } = useFormValidity( formData, fields, form );
+	const { validity } = useFormValidity( formData, fields, FORM_CONFIG );
 
 	const handleSubmit = useCallback(
 		( e: React.FormEvent ) => {
@@ -199,16 +199,7 @@ export const HelpCenterA4AContactForm = () => {
 		[ formData, submitA4ATicket, agency?.id, agency?.pressableId, isPressableSelected, navigate ]
 	);
 
-	useEffect( () => {
-		if ( formData.product === 'pressable' && ! formData.pressable_contact ) {
-			setFormData( ( prev ) => ( { ...prev, pressable_contact: 'sales' } ) );
-		}
-	}, [ formData.product, formData.pressable_contact ] );
-
-	const isValidForm = useMemo( () => {
-		// If validaty is empty, it means we don't have any invalid fields.
-		return ! validity;
-	}, [ validity ] );
+	const isValidForm = ! validity;
 
 	return (
 		<form onSubmit={ handleSubmit } className="help-center-a4a-contact-form">
@@ -218,7 +209,7 @@ export const HelpCenterA4AContactForm = () => {
 				<DataForm< FormData >
 					data={ formData }
 					fields={ fields }
-					form={ form }
+					form={ FORM_CONFIG }
 					validity={ validity }
 					onChange={ ( edits: Partial< FormData > ) => {
 						setFormData( ( data ) => ( { ...data, ...edits } ) );

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-imports */
 /**
  * External Dependencies
  */
@@ -12,7 +11,7 @@ import {
 } from '@wordpress/components';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 /**
  * Internal Dependencies
@@ -36,6 +35,115 @@ const FORM_CONFIG = {
 	fields: [ 'name', 'email', 'site', 'product', 'pressable_contact', 'message' ],
 };
 
+const fields: Field< FormData >[] = [
+	{
+		id: 'name',
+		label: __( 'Name', __i18n_text_domain__ ),
+		type: 'text' as const,
+		placeholder: __( 'Your name', __i18n_text_domain__ ),
+		isValid: {
+			required: true,
+		},
+	},
+	{
+		id: 'email',
+		label: __( 'Email address', __i18n_text_domain__ ),
+		type: 'text' as const,
+		placeholder: __( 'Your email', __i18n_text_domain__ ),
+		isValid: {
+			required: true,
+		},
+	},
+	{
+		id: 'site',
+		label: __( 'Related site', __i18n_text_domain__ ),
+		type: 'text' as const,
+		placeholder: __( 'Add site if necessary', __i18n_text_domain__ ),
+	},
+	{
+		id: 'product',
+		label: __( 'What Automattic product would you like help with?', __i18n_text_domain__ ),
+		type: 'text' as const,
+		Edit: 'select',
+		elements: [
+			{
+				label: __( 'Select a product', __i18n_text_domain__ ),
+				value: '',
+				disabled: true,
+			},
+			{
+				label: __( 'Automattic for Agencies', __i18n_text_domain__ ),
+				value: 'a4a',
+			},
+			{
+				label: __( 'Woo', __i18n_text_domain__ ),
+				value: 'woo',
+			},
+			{
+				label: __( 'WordPress.com', __i18n_text_domain__ ),
+				value: 'wpcom',
+			},
+			{
+				label: __( 'Jetpack', __i18n_text_domain__ ),
+				value: 'jetpack',
+			},
+			{
+				label: __( 'Pressable', __i18n_text_domain__ ),
+				value: 'pressable',
+			},
+		],
+		isValid: {
+			required: true,
+		},
+	},
+	{
+		id: 'pressable_contact',
+		label: __( 'Would you like help with Pressable sales or support?', __i18n_text_domain__ ),
+		type: 'text' as const,
+		Edit: 'select',
+		elements: [
+			{
+				label: __( 'Sales', __i18n_text_domain__ ),
+				value: 'sales',
+			},
+			{
+				label: __( 'Support', __i18n_text_domain__ ),
+				value: 'support',
+			},
+		],
+		isVisible: ( item: FormData ) => item.product === 'pressable',
+	},
+	{
+		id: 'message',
+		label: __( 'How can we help?', __i18n_text_domain__ ),
+		type: 'text' as const,
+		Edit: ( { field, data, onChange } ) => {
+			const { id, getValue } = field;
+			const placeholder =
+				data.product === 'pressable'
+					? __(
+							"Please provide the team with a detailed explanation of the issue you're facing, including steps to reproduce the issue on our end and/or URLs. Providing these details will greatly help us with your support request.",
+							__i18n_text_domain__
+					  )
+					: __( 'Add your message here', __i18n_text_domain__ );
+			return (
+				<TextareaControl
+					__nextHasNoMarginBottom
+					label={ field.label }
+					placeholder={ placeholder }
+					value={ getValue( { item: data } ) }
+					onChange={ ( value ) => {
+						return onChange( { [ id ]: value ?? '' } );
+					} }
+				/>
+			);
+		},
+		isValid: {
+			required: true,
+		},
+	},
+];
+
 export const HelpCenterA4AContactForm = () => {
 	const { currentUser, agency } = useHelpCenterContext();
 	const navigate = useNavigate();
@@ -56,118 +164,6 @@ export const HelpCenterA4AContactForm = () => {
 	} = useSubmitA4ATicketMutation();
 
 	const isPressableSelected = formData.product === 'pressable';
-
-	const fields: Field< FormData >[] = useMemo(
-		() => [
-			{
-				id: 'name',
-				label: __( 'Name', __i18n_text_domain__ ),
-				type: 'text' as const,
-				placeholder: __( 'Your name', __i18n_text_domain__ ),
-				isValid: {
-					required: true,
-				},
-			},
-			{
-				id: 'email',
-				label: __( 'Email address', __i18n_text_domain__ ),
-				type: 'text' as const,
-				placeholder: __( 'Your email', __i18n_text_domain__ ),
-				isValid: {
-					required: true,
-				},
-			},
-			{
-				id: 'site',
-				label: __( 'Related site', __i18n_text_domain__ ),
-				type: 'text' as const,
-				placeholder: __( 'Add site if necessary', __i18n_text_domain__ ),
-			},
-			{
-				id: 'product',
-				label: __( 'What Automattic product would you like help with?', __i18n_text_domain__ ),
-				type: 'text' as const,
-				Edit: 'select',
-				elements: [
-					{
-						label: __( 'Select a product', __i18n_text_domain__ ),
-						value: '',
-						disabled: true,
-					},
-					{
-						label: __( 'Automattic for Agencies', __i18n_text_domain__ ),
-						value: 'a4a',
-					},
-					{
-						label: __( 'Woo', __i18n_text_domain__ ),
-						value: 'woo',
-					},
-					{
-						label: __( 'WordPress.com', __i18n_text_domain__ ),
-						value: 'wpcom',
-					},
-					{
-						label: __( 'Jetpack', __i18n_text_domain__ ),
-						value: 'jetpack',
-					},
-					{
-						label: __( 'Pressable', __i18n_text_domain__ ),
-						value: 'pressable',
-					},
-				],
-				isValid: {
-					required: true,
-				},
-			},
-			{
-				id: 'pressable_contact',
-				label: __( 'Would you like help with Pressable sales or support?', __i18n_text_domain__ ),
-				type: 'text' as const,
-				Edit: 'select',
-				elements: [
-					{
-						label: __( 'Sales', __i18n_text_domain__ ),
-						value: 'sales',
-					},
-					{
-						label: __( 'Support', __i18n_text_domain__ ),
-						value: 'support',
-					},
-				],
-				isVisible: ( item: FormData ) => item.product === 'pressable',
-			},
-			{
-				id: 'message',
-				label: __( 'How can we help?', __i18n_text_domain__ ),
-				type: 'text' as const,
-				Edit: ( { field, data, onChange } ) => {
-					const { id, getValue } = field;
-					const placeholder =
-						data.product === 'pressable'
-							? __(
-									"Please provide the team with a detailed explanation of the issue you're facing, including steps to reproduce the issue on our end and/or URLs. Providing these details will greatly help us with your support request.",
-									__i18n_text_domain__
-							  )
-							: __( 'Add your message here', __i18n_text_domain__ );
-					return (
-						<TextareaControl
-							__nextHasNoMarginBottom
-							label={ field.label }
-							placeholder={ placeholder }
-							value={ getValue( { item: data } ) }
-							onChange={ ( value ) => {
-								return onChange( { [ id ]: value ?? '' } );
-							} }
-						/>
-					);
-				},
-				isValid: {
-					required: true,
-				},
-			},
-		],
-		[]
-	);
 
 	const { validity } = useFormValidity( formData, fields, FORM_CONFIG );
 
@@ -221,6 +217,7 @@ export const HelpCenterA4AContactForm = () => {
 					variant="primary"
 					type="submit"
 					disabled={ ! isValidForm || isPending }
+					isBusy={ isPending }
 				>
 					{ __( 'Submit form', __i18n_text_domain__ ) }
 				</Button>

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -4,7 +4,8 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FormInputValidation } from '@automattic/components';
-import { Button, SelectControl, TextareaControl, TextControl } from '@wordpress/components';
+import { Button, TextareaControl } from '@wordpress/components';
+import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -14,12 +15,22 @@ import { useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import './help-center-a4a-contact-form.scss';
 import { useSubmitA4ATicketMutation } from '../data/use-submit-a4a-support-ticket';
+import type { Field } from '@wordpress/dataviews';
+
+type FormData = {
+	name: string;
+	email: string;
+	site: string;
+	product: string;
+	message: string;
+	pressable_contact: string;
+};
 
 export const HelpCenterA4AContactForm = () => {
 	const { currentUser, agency } = useHelpCenterContext();
 	const navigate = useNavigate();
 
-	const [ formData, setFormData ] = useState( {
+	const [ formData, setFormData ] = useState< FormData >( {
 		name: currentUser?.display_name ?? '',
 		email: currentUser?.email ?? '',
 		site: '',
@@ -34,158 +45,181 @@ export const HelpCenterA4AContactForm = () => {
 		isError: hasSubmitError,
 	} = useSubmitA4ATicketMutation();
 
-	const isPressableSelected = formData[ 'product' ] === 'pressable';
+	const isPressableSelected = formData.product === 'pressable';
 
-	const handleChange = ( key: string, value: string ) => {
-		setFormData( { ...formData, [ key ]: value } );
-	};
-
-	const handleSubmit = useCallback( () => {
-		recordTracksEvent( 'calypso_a4a_user_contact_support_form_submit', {
-			data: formData[ 'message' ],
-		} );
-
-		submitA4ATicket(
+	const fields: Field< FormData >[] = useMemo(
+		() => [
 			{
-				name: formData[ 'name' ],
-				email: formData[ 'email' ],
-				message: formData[ 'message' ],
-				product: formData[ 'product' ],
-				agency_id: agency?.id,
-				pressable_id: agency?.pressableId,
-				site: formData[ 'site' ] ?? undefined,
-				contact_type: isPressableSelected ? formData[ 'pressable_contact' ] : undefined,
+				id: 'name',
+				label: __( 'Name', __i18n_text_domain__ ),
+				type: 'text' as const,
+				placeholder: __( 'Your name', __i18n_text_domain__ ),
+				isValid: {
+					required: true,
+				},
 			},
 			{
-				onSuccess: () => {
-					navigate( '/success' );
+				id: 'email',
+				label: __( 'Email address', __i18n_text_domain__ ),
+				type: 'text' as const,
+				placeholder: __( 'Your email', __i18n_text_domain__ ),
+				isValid: {
+					required: true,
 				},
-			}
-		);
-	}, [
-		formData,
-		submitA4ATicket,
-		agency?.id,
-		agency?.pressableId,
-		isPressableSelected,
-		navigate,
-	] );
+			},
+			{
+				id: 'site',
+				label: __( 'Related site', __i18n_text_domain__ ),
+				type: 'text' as const,
+				placeholder: __( 'Add site if necessary', __i18n_text_domain__ ),
+			},
+			{
+				id: 'product',
+				label: __( 'What Automattic product would you like help with?', __i18n_text_domain__ ),
+				type: 'text' as const,
+				Edit: 'select',
+				elements: [
+					{
+						label: __( 'Select a product', __i18n_text_domain__ ),
+						value: '',
+						disabled: true,
+					},
+					{
+						label: __( 'Automattic for Agencies', __i18n_text_domain__ ),
+						value: 'a4a',
+					},
+					{
+						label: __( 'Woo', __i18n_text_domain__ ),
+						value: 'woo',
+					},
+					{
+						label: __( 'WordPress.com', __i18n_text_domain__ ),
+						value: 'wpcom',
+					},
+					{
+						label: __( 'Jetpack', __i18n_text_domain__ ),
+						value: 'jetpack',
+					},
+					{
+						label: __( 'Pressable', __i18n_text_domain__ ),
+						value: 'pressable',
+					},
+				],
+				isValid: {
+					required: true,
+				},
+			},
+			{
+				id: 'pressable_contact',
+				label: __( 'Would you like help with Pressable sales or support?', __i18n_text_domain__ ),
+				type: 'text' as const,
+				Edit: 'select',
+				elements: [
+					{
+						label: __( 'Sales', __i18n_text_domain__ ),
+						value: 'sales',
+					},
+					{
+						label: __( 'Support', __i18n_text_domain__ ),
+						value: 'support',
+					},
+				],
+				isVisible: ( item: FormData ) => item.product === 'pressable',
+			},
+			{
+				id: 'message',
+				label: __( 'How can we help?', __i18n_text_domain__ ),
+				type: 'text' as const,
+				Edit: ( { field, data, onChange } ) => {
+					const { id, getValue } = field;
+					const placeholder =
+						data.product === 'pressable'
+							? __(
+									"Please provide the team with a detailed explanation of the issue you're facing, including steps to reproduce the issue on our end and/or URLs. Providing these details will greatly help us with your support request.",
+									__i18n_text_domain__
+							  )
+							: __( 'Add your message here', __i18n_text_domain__ );
+					return (
+						<TextareaControl
+							__nextHasNoMarginBottom
+							label={ field.label }
+							placeholder={ placeholder }
+							value={ getValue( { item: data } ) }
+							onChange={ ( value ) => {
+								return onChange( { [ id ]: value ?? '' } );
+							} }
+						/>
+					);
+				},
+				isValid: {
+					required: true,
+				},
+			},
+		],
+		[]
+	);
+
+	const form = {
+		layout: { type: 'regular' as const },
+		fields: [ 'name', 'email', 'site', 'product', 'pressable_contact', 'message' ],
+	};
+
+	const { validity } = useFormValidity( formData, fields, form );
+
+	const handleSubmit = useCallback(
+		( e: React.FormEvent ) => {
+			e.preventDefault();
+			recordTracksEvent( 'calypso_a4a_user_contact_support_form_submit', {
+				data: formData.message,
+			} );
+
+			submitA4ATicket(
+				{
+					name: formData.name,
+					email: formData.email,
+					message: formData.message,
+					product: formData.product,
+					agency_id: agency?.id,
+					pressable_id: agency?.pressableId,
+					site: formData.site || undefined,
+					contact_type: isPressableSelected ? formData.pressable_contact : undefined,
+				},
+				{
+					onSuccess: () => {
+						navigate( '/success' );
+					},
+				}
+			);
+		},
+		[ formData, submitA4ATicket, agency?.id, agency?.pressableId, isPressableSelected, navigate ]
+	);
 
 	useEffect( () => {
-		if ( formData[ 'product' ] === 'pressable' ) {
-			setFormData( { ...formData, pressable_contact: 'sales' } );
+		if ( formData.product === 'pressable' && ! formData.pressable_contact ) {
+			setFormData( ( prev ) => ( { ...prev, pressable_contact: 'sales' } ) );
 		}
-	}, [ formData ] );
+	}, [ formData.product, formData.pressable_contact ] );
 
 	const isValidForm = useMemo( () => {
-		return (
-			formData[ 'name' ] && formData[ 'email' ] && formData[ 'product' ] && formData[ 'message' ]
-		);
-	}, [ formData ] );
+		// If validaty is empty, it means we don't have any invalid fields.
+		return ! validity;
+	}, [ validity ] );
 
 	return (
-		<div className="help-center-a4a-contact-form__wrapper">
+		<form onSubmit={ handleSubmit } className="help-center-a4a-contact-form__wrapper">
 			<div className="help-center-a4a-contact-form">
 				<h1 className="help-center-a4a-contact-form__title">
 					{ __( 'Contact sales & support', __i18n_text_domain__ ) }
 				</h1>
 
-				<TextControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					label={ __( 'Name', __i18n_text_domain__ ) }
-					placeholder={ __( 'Your name', __i18n_text_domain__ ) }
-					value={ formData[ 'name' ] }
-					onChange={ ( value ) => handleChange( 'name', value ) }
-				/>
-
-				<TextControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					label={ __( 'Email address', __i18n_text_domain__ ) }
-					value={ formData[ 'email' ] }
-					placeholder={ __( 'Your email', __i18n_text_domain__ ) }
-					onChange={ ( value ) => handleChange( 'email', value ) }
-				/>
-
-				<TextControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					label={ __( 'Related site', __i18n_text_domain__ ) }
-					value={ formData[ 'site' ] }
-					placeholder={ __( 'Add site if necessary', __i18n_text_domain__ ) }
-					onChange={ ( value ) => handleChange( 'site', value ) }
-				/>
-
-				<SelectControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					label={ __( 'What Automattic product would you like help with?', __i18n_text_domain__ ) }
-					onChange={ ( value ) => handleChange( 'product', value ) }
-					options={ [
-						{
-							label: __( 'Select a product', __i18n_text_domain__ ),
-							value: '',
-							disabled: true,
-						},
-						{
-							label: __( 'Automattic for Agencies', __i18n_text_domain__ ),
-							value: 'a4a',
-						},
-						{
-							label: __( 'Woo', __i18n_text_domain__ ),
-							value: 'woo',
-						},
-						{
-							label: __( 'WordPress.com', __i18n_text_domain__ ),
-							value: 'wpcom',
-						},
-						{
-							label: __( 'Jetpack', __i18n_text_domain__ ),
-							value: 'jetpack',
-						},
-						{
-							label: __( 'Pressable', __i18n_text_domain__ ),
-							value: 'pressable',
-						},
-					] }
-				/>
-
-				{ isPressableSelected && (
-					<SelectControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __(
-							'Would you like help with Pressable sales or support?',
-							__i18n_text_domain__
-						) }
-						onChange={ ( value ) => handleChange( 'pressable_contact', value ) }
-						options={ [
-							{
-								label: __( 'Sales', __i18n_text_domain__ ),
-								value: 'sales',
-							},
-							{
-								label: __( 'Support', __i18n_text_domain__ ),
-								value: 'support',
-							},
-						] }
-					/>
-				) }
-
-				<TextareaControl
-					__nextHasNoMarginBottom
-					label={ __( 'How can we help?', __i18n_text_domain__ ) }
-					value={ formData[ 'message' ] }
-					placeholder={
-						isPressableSelected
-							? __(
-									"Please provide the team with a detailed explanation of the issue you're facing, including steps to reproduce the issue on our end and/or URLs. Providing these details will greatly help us with your support request.",
-									__i18n_text_domain__
-							  )
-							: __( 'Add your message here', __i18n_text_domain__ )
-					}
-					onChange={ ( value ) => handleChange( 'message', value ) }
+				<DataForm< FormData >
+					data={ formData }
+					fields={ fields }
+					form={ form }
+					validity={ validity }
+					onChange={ ( edits: Partial< FormData > ) => {
+						setFormData( ( data ) => ( { ...data, ...edits } ) );
+					} }
 				/>
 			</div>
 
@@ -200,12 +234,12 @@ export const HelpCenterA4AContactForm = () => {
 				<Button
 					__next40pxDefaultSize
 					variant="primary"
-					onClick={ handleSubmit }
+					type="submit"
 					disabled={ ! isValidForm || isPending }
 				>
 					{ __( 'Submit form', __i18n_text_domain__ ) }
 				</Button>
 			</div>
-		</div>
+		</form>
 	);
 };

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -28,9 +28,11 @@ export const HelpCenterA4AContactForm = () => {
 		pressable_contact: 'sales',
 	} );
 
-	const [ hasSubmitError, setHasSubmitError ] = useState( false );
-
-	const { isPending, mutate: submitA4ATicket } = useSubmitA4ATicketMutation();
+	const {
+		isPending,
+		mutate: submitA4ATicket,
+		isError: hasSubmitError,
+	} = useSubmitA4ATicketMutation();
 
 	const isPressableSelected = formData[ 'product' ] === 'pressable';
 
@@ -42,8 +44,6 @@ export const HelpCenterA4AContactForm = () => {
 		recordTracksEvent( 'calypso_a4a_user_contact_support_form_submit', {
 			data: formData[ 'message' ],
 		} );
-
-		setHasSubmitError( false );
 
 		submitA4ATicket(
 			{
@@ -59,9 +59,6 @@ export const HelpCenterA4AContactForm = () => {
 			{
 				onSuccess: () => {
 					navigate( '/success' );
-				},
-				onError: () => {
-					setHasSubmitError( true );
 				},
 			}
 		);

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -1,0 +1,174 @@
+/* eslint-disable no-restricted-imports */
+/**
+ * External Dependencies
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button, SelectControl, TextareaControl, TextControl } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect, useMemo } from 'react';
+/**
+ * Internal Dependencies
+ */
+import { useHelpCenterContext } from '../contexts/HelpCenterContext';
+import './help-center-a4a-contact-form.scss';
+
+export const HelpCenterA4AContactForm = () => {
+	const dispatch = useDispatch();
+
+	const { currentUser } = useHelpCenterContext();
+
+	const [ formData, setFormData ] = useState( {
+		name: currentUser?.display_name ?? '',
+		email: currentUser?.email ?? '',
+		site: '',
+		product: 'a4a',
+		message: '',
+		pressable_contact: 'sales',
+	} );
+
+	const isPressableSelected = formData[ 'product' ] === 'pressable';
+
+	const handleChange = ( key: string, value: string ) => {
+		setFormData( { ...formData, [ key ]: value } );
+	};
+
+	const handleSubmit = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_user_contact_support_form_submit', {
+				form_data: JSON.stringify( formData ),
+			} )
+		);
+	};
+
+	useEffect( () => {
+		if ( formData[ 'product' ] === 'pressable' ) {
+			setFormData( { ...formData, pressable_contact: 'sales' } );
+		}
+	}, [ formData ] );
+
+	const isValidForm = useMemo( () => {
+		return (
+			formData[ 'name' ] && formData[ 'email' ] && formData[ 'product' ] && formData[ 'message' ]
+		);
+	}, [ formData ] );
+
+	return (
+		<div className="help-center-a4a-contact-form__wrapper">
+			<div className="help-center-a4a-contact-form">
+				<h1 className="help-center-a4a-contact-form__title">
+					{ __( 'Contact sales & support', __i18n_text_domain__ ) }
+				</h1>
+
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Name', __i18n_text_domain__ ) }
+					placeholder={ __( 'Your name', __i18n_text_domain__ ) }
+					value={ formData[ 'name' ] }
+					onChange={ ( value ) => handleChange( 'name', value ) }
+				/>
+
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Email address', __i18n_text_domain__ ) }
+					value={ formData[ 'email' ] }
+					placeholder={ __( 'Your email', __i18n_text_domain__ ) }
+					onChange={ ( value ) => handleChange( 'email', value ) }
+				/>
+
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Related site', __i18n_text_domain__ ) }
+					value={ formData[ 'site' ] }
+					placeholder={ __( 'Add site if necessary', __i18n_text_domain__ ) }
+					onChange={ ( value ) => handleChange( 'site', value ) }
+				/>
+
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'What Automattic product would you like help with?', __i18n_text_domain__ ) }
+					onChange={ ( value ) => handleChange( 'product', value ) }
+					options={ [
+						{
+							label: __( 'Select a product', __i18n_text_domain__ ),
+							value: '',
+							disabled: true,
+						},
+						{
+							label: __( 'Automattic for Agencies', __i18n_text_domain__ ),
+							value: 'a4a',
+						},
+						{
+							label: __( 'Woo', __i18n_text_domain__ ),
+							value: 'woo',
+						},
+						{
+							label: __( 'WordPress.com', __i18n_text_domain__ ),
+							value: 'wpcom',
+						},
+						{
+							label: __( 'Jetpack', __i18n_text_domain__ ),
+							value: 'jetpack',
+						},
+						{
+							label: __( 'Pressable', __i18n_text_domain__ ),
+							value: 'pressable',
+						},
+					] }
+				/>
+
+				{ isPressableSelected && (
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __(
+							'Would you like help with Pressable sales or support?',
+							__i18n_text_domain__
+						) }
+						onChange={ ( value ) => handleChange( 'pressable_contact', value ) }
+						options={ [
+							{
+								label: __( 'Sales', __i18n_text_domain__ ),
+								value: 'sales',
+							},
+							{
+								label: __( 'Support', __i18n_text_domain__ ),
+								value: 'support',
+							},
+						] }
+					/>
+				) }
+
+				<TextareaControl
+					__nextHasNoMarginBottom
+					label={ __( 'How can we help?', __i18n_text_domain__ ) }
+					value={ formData[ 'message' ] }
+					placeholder={
+						isPressableSelected
+							? __(
+									"Please provide the team with a detailed explanation of the issue you're facing, including steps to reproduce the issue on our end and/or URLs. Providing these details will greatly help us with your support request.",
+									__i18n_text_domain__
+							  )
+							: __( 'Add your message here', __i18n_text_domain__ )
+					}
+					onChange={ ( value ) => handleChange( 'message', value ) }
+				/>
+			</div>
+
+			<div className="contact-form-submit">
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					onClick={ () => handleSubmit() }
+					disabled={ ! isValidForm }
+				>
+					{ __( 'Submit form', __i18n_text_domain__ ) }
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -14,6 +14,7 @@ import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useSupportStatus } from '../data/use-support-status';
 import { HELP_CENTER_STORE } from '../stores';
+import { HelpCenterA4AContactForm } from './help-center-a4a-contact-form';
 import { HelpCenterArticle } from './help-center-article';
 import { HelpCenterChat } from './help-center-chat';
 import { HelpCenterChatHistory } from './help-center-chat-history';
@@ -122,7 +123,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 					<Route path="/" element={ <HelpCenterSearch currentRoute={ currentRoute } /> } />
 					<Route path="/post" element={ <HelpCenterArticle /> } />
 					<Route path="/contact-form" element={ <HelpCenterContactForm /> } />
-					<Route path="/a4a-contact-form" element={ <HelpCenterContactForm /> } />
+					<Route path="/a4a-contact-form" element={ <HelpCenterA4AContactForm /> } />
 					<Route path="/success" element={ <SuccessScreen /> } />
 					<Route
 						path="/support-guides"

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -122,6 +122,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 					<Route path="/" element={ <HelpCenterSearch currentRoute={ currentRoute } /> } />
 					<Route path="/post" element={ <HelpCenterArticle /> } />
 					<Route path="/contact-form" element={ <HelpCenterContactForm /> } />
+					<Route path="/a4a-contact-form" element={ <HelpCenterContactForm /> } />
 					<Route path="/success" element={ <SuccessScreen /> } />
 					<Route
 						path="/support-guides"

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -43,6 +43,11 @@ export type HelpCenterRequiredInformation = {
 	 */
 	markdownExtensions?: MarkdownExtensions;
 	source: '' | 'wpcom' | 'a4a';
+	// This is specific to A4A
+	agency: {
+		id: number;
+		pressableId?: number;
+	} | null;
 };
 
 const defaultContext: HelpCenterRequiredInformation = {
@@ -92,6 +97,7 @@ const defaultContext: HelpCenterRequiredInformation = {
 	onboardingUrl: '',
 	isCommerceGarden: false,
 	source: 'wpcom',
+	agency: null,
 };
 
 const HelpCenterRequiredContext = createContext< HelpCenterRequiredInformation >( defaultContext );

--- a/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
+++ b/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
@@ -1,0 +1,32 @@
+import { useMutation } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+
+type Ticket = {
+	name: string;
+	email: string;
+	message: string;
+	product: string;
+	agency_id: number | undefined;
+	site?: string;
+	contact_type?: string;
+	pressable_id?: number;
+};
+
+export function useSubmitA4ATicketMutation() {
+	return useMutation( {
+		mutationFn: ( ticket: Ticket ) => {
+			let path = '/agency/help/zendesk/create-ticket';
+
+			if ( ticket.product === 'pressable' && ticket.contact_type === 'support' ) {
+				path = '/agency/help/pressable/support';
+			}
+
+			return wpcomRequest( {
+				path,
+				apiNamespace: 'wpcom/v2',
+				method: 'POST',
+				body: ticket,
+			} );
+		},
+	} );
+}

--- a/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
+++ b/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import { useMutation } from '@tanstack/react-query';
-import wpcom from 'calypso/lib/wp';
+import wpcomRequest from 'wpcom-proxy-request';
 
 type Ticket = {
 	name: string;
@@ -22,9 +22,10 @@ export function useSubmitA4ATicketMutation() {
 				path = '/agency/help/pressable/support';
 			}
 
-			return wpcom.req.post( {
+			return wpcomRequest( {
 				path,
 				apiNamespace: 'wpcom/v2',
+				method: 'POST',
 				body: ticket,
 			} );
 		},

--- a/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
+++ b/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
@@ -1,5 +1,6 @@
+/* eslint-disable no-restricted-imports */
 import { useMutation } from '@tanstack/react-query';
-import wpcomRequest from 'wpcom-proxy-request';
+import wpcom from 'calypso/lib/wp';
 
 type Ticket = {
 	name: string;
@@ -21,10 +22,9 @@ export function useSubmitA4ATicketMutation() {
 				path = '/agency/help/pressable/support';
 			}
 
-			return wpcomRequest( {
+			return wpcom.req.post( {
 				path,
 				apiNamespace: 'wpcom/v2',
-				method: 'POST',
 				body: ticket,
 			} );
 		},

--- a/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
+++ b/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-imports */
 import { useMutation } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -1,10 +1,18 @@
 /* eslint-disable no-restricted-imports */
 
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { useShouldUseWapuu } from './use-should-use-wapuu';
 
 export function useStillNeedHelpURL() {
 	const shouldUseWapuu = useShouldUseWapuu();
 
-	const url = shouldUseWapuu ? '/odie' : '/contact-form';
+	let url = '/contact-form';
+
+	if ( isA8CForAgencies() ) {
+		url = '/a4a-contact-form';
+	} else if ( shouldUseWapuu ) {
+		url = '/odie';
+	}
+
 	return { url, isLoading: false };
 }


### PR DESCRIPTION
In A4A, we are reverting from our initial plan to use the Odie bot. We lack the staffing to support the human chat component, so for now, we will rely on a simple A4A form.

<img width="1032" height="734" alt="Screenshot 2025-11-25 at 9 19 29 PM" src="https://github.com/user-attachments/assets/a126ced4-1691-4a88-842f-02c5f0643049" />




Depends on https://github.com/Automattic/wp-calypso/pull/107097

## Proposed Changes

* We are updating the `HelpCenterContext` to accept new agency-related fields. This information is necessary for us to process the A4A ticket.
* The PR introduces a new `HelpCenterA4AContactForm` component used for submitting an A4A ticket. We are building the form within the Help center package. 
* Additionally, a new route `/a4a-contact-form` has been added to the Help Center to access this form. The route can be reached via the 'Get in touch' button.

## Why are these changes being made?


* This is part of a cohesive support enhancement in the A4A dashboard.

## Testing Instructions

* Use the A4A live link and navigate to `/overview`.
* Click the Help center button located at the Sidebar's footer next to the User profile button.
   <img width="483" height="456" alt="Screenshot 2025-11-25 at 9 15 03 PM" src="https://github.com/user-attachments/assets/97b5e865-73dd-48c3-906f-c35e09816aef" />

* Click the 'Get in touch' button.
* Verify that the A4A contact form is displayed.
* Submit a form and verify that you are redirected to the success message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
