### PR TITLE
MSD Backups: Fix the weird animation during the navigation on mobile

### DIFF
--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -122,26 +122,22 @@ export function BackupsListPage() {
 		if ( ! rewindId && ! backup ) {
 			setSelectedBackupInState( null );
 		}
-	}, [ rewindId, activityLog, setSelectedBackup, isSmallViewport ] );
+	}, [ rewindId, activityLog, setSelectedBackupInState, isSmallViewport ] );
 
 	const handleDateRangeChangeWrapper = ( next: { start: Date; end: Date } ) => {
 		handleDateRangeChange( next );
 		setSelectedBackup( null, false );
 	};
-	const [ showDetails, setShowDetails ] = useState( Boolean( rewindId ) );
 	const columns = isSmallViewport ? 1 : 2;
 
 	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS );
 
 	const handleBackupSelection = ( backup: ActivityLogEntry | null ) => {
 		setSelectedBackup( backup );
-		if ( isSmallViewport && backup ) {
-			setShowDetails( true );
-		}
 	};
 
 	const renderMobileView = () => {
-		if ( showDetails && selectedBackup ) {
+		if ( selectedBackup ) {
 			return (
 				<BackupDetails
 					backup={ selectedBackup }
@@ -165,7 +161,7 @@ export function BackupsListPage() {
 		);
 	};
 
-	const isMobileDetailsView = isSmallViewport && showDetails;
+	const isMobileDetailsView = isSmallViewport && selectedBackup;
 	const shouldShowActions = hasBackups && ! isMobileDetailsView;
 	const shouldShowNotices = ! isMobileDetailsView;
 
@@ -195,7 +191,7 @@ export function BackupsListPage() {
 					description={ __(
 						'Access and restore your site backups, powered by Jetpack VaultPress Backup.'
 					) }
-					prefix={ isMobileDetailsView && rewindId ? <Breadcrumbs length={ 2 } /> : undefined }
+					prefix={ isMobileDetailsView ? <Breadcrumbs length={ 2 } /> : undefined }
 					actions={ shouldShowActions ? actions : undefined }
 				/>
 			}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* The transition between backups and its detail view is not smooth as the `Breadcrumbs` is shown and the actions are gone immediately. As a result, this PR changes to use the `selectedBackup` to determine whether it's in the detail view or not to above the issue

**Before**

https://github.com/user-attachments/assets/935576a8-cff5-44ad-9cc6-df11abc16e3c

**After**

https://github.com/user-attachments/assets/84ec5ea7-2197-48fc-aacd-250e2459cd82


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The transition is important to users. It should look smooth without any weird state.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select any atomic site
* Navigate to Backups on mobile
* Select any backup
* Ensure the transition is smooth

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
