### PR TITLE
Paragraph: Fix the justify text functionality by using the new attribute

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -46,6 +46,7 @@
 		"@wordpress/rich-text": "^7.23.0",
 		"@wordpress/router": "^1.23.0",
 		"@wordpress/url": "^4.23.0",
+		"clsx": "^2.1.1",
 		"debug": "^4.4.1",
 		"lodash": "^4.17.21",
 		"react": "^18.3.1",

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -7,7 +7,9 @@ import { get } from 'lodash';
 
 const RichTextJustifyButton = ( { blockId, isBlockJustified, updateBlockAttributes } ) => {
 	const onToggle = () =>
-		updateBlockAttributes( blockId, { align: isBlockJustified ? null : 'justify' } );
+		updateBlockAttributes( blockId, {
+			style: { typography: { textAlign: isBlockJustified ? null : 'justify' } },
+		} );
 
 	return (
 		<RichTextToolbarButton
@@ -28,7 +30,7 @@ const ConnectedRichTextJustifyButton = compose(
 		return {
 			blockId: selectedBlock.clientId,
 			blockName: selectedBlock.name,
-			isBlockJustified: 'justify' === get( selectedBlock, 'attributes.align' ),
+			isBlockJustified: 'justify' === get( selectedBlock, 'attributes.style.typography.textAlign' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -29,6 +29,8 @@ const RichTextJustifyButton = ( { blockId, styleAttributes, updateBlockAttribute
 	);
 };
 
+const EMPTY_STYLES = {};
+
 const ConnectedRichTextJustifyButton = compose(
 	withSelect( ( wpSelect ) => {
 		const selectedBlock = wpSelect( 'core/block-editor' ).getSelectedBlock();
@@ -38,7 +40,7 @@ const ConnectedRichTextJustifyButton = compose(
 		return {
 			blockId: selectedBlock.clientId,
 			blockName: selectedBlock.name,
-			styleAttributes: get( selectedBlock.attributes, 'style', {} ),
+			styleAttributes: get( selectedBlock.attributes, 'style', EMPTY_STYLES ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -5,10 +5,21 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { registerFormatType } from '@wordpress/rich-text';
 import { get } from 'lodash';
 
-const RichTextJustifyButton = ( { blockId, isBlockJustified, updateBlockAttributes } ) => {
+const RichTextJustifyButton = ( { blockId, attributes, updateBlockAttributes } ) => {
+	const isBlockJustified = 'justify' === get( attributes, 'style.typography.textAlign' );
+
+	const style = attributes.style || {};
+
 	const onToggle = () =>
 		updateBlockAttributes( blockId, {
-			style: { typography: { textAlign: isBlockJustified ? null : 'justify' } },
+			...attributes,
+			style: {
+				...style,
+				typography: {
+					...style.typography,
+					textAlign: isBlockJustified ? null : 'justify',
+				},
+			},
 		} );
 
 	return (
@@ -30,7 +41,7 @@ const ConnectedRichTextJustifyButton = compose(
 		return {
 			blockId: selectedBlock.clientId,
 			blockName: selectedBlock.name,
-			isBlockJustified: 'justify' === get( selectedBlock, 'attributes.style.typography.textAlign' ),
+			attributes: selectedBlock.attributes,
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -1,14 +1,28 @@
 /* global wpcomGutenberg */
 import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { getBlockType } from '@wordpress/blocks';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { registerFormatType } from '@wordpress/rich-text';
 import { get } from 'lodash';
 
-const RichTextJustifyButton = ( { blockId, styleAttributes, updateBlockAttributes } ) => {
+const RichTextJustifyButton = ( {
+	blockId,
+	isDeprecatedAlignAttribute,
+	deprecatedIsBlockJustified,
+	styleAttributes,
+	updateBlockAttributes,
+} ) => {
 	const isBlockJustified = 'justify' === get( styleAttributes, 'typography.textAlign' );
 
-	const onToggle = () =>
+	const onToggle = () => {
+		// TODO: Remove this once we know all Atomic sites are on Gutenberg 22.1 or higher
+		if ( isDeprecatedAlignAttribute ) {
+			return updateBlockAttributes( blockId, {
+				align: deprecatedIsBlockJustified ? null : 'justify',
+			} );
+		}
+
 		updateBlockAttributes( blockId, {
 			style: {
 				...styleAttributes,
@@ -18,13 +32,14 @@ const RichTextJustifyButton = ( { blockId, styleAttributes, updateBlockAttribute
 				},
 			},
 		} );
+	};
 
 	return (
 		<RichTextToolbarButton
 			icon="editor-justify"
 			title={ wpcomGutenberg.richTextToolbar.justify }
 			onClick={ onToggle }
-			isActive={ isBlockJustified }
+			isActive={ deprecatedIsBlockJustified || isBlockJustified }
 		/>
 	);
 };
@@ -40,6 +55,8 @@ const ConnectedRichTextJustifyButton = compose(
 		return {
 			blockId: selectedBlock.clientId,
 			blockName: selectedBlock.name,
+			isDeprecatedAlignAttribute: getBlockType( 'core/paragraph' ).attributes.align !== undefined,
+			deprecatedIsBlockJustified: 'justify' === get( selectedBlock, 'attributes.align' ),
 			styleAttributes: get( selectedBlock.attributes, 'style', EMPTY_STYLES ),
 		};
 	} ),

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -4,34 +4,63 @@ import { getBlockType } from '@wordpress/blocks';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { registerFormatType } from '@wordpress/rich-text';
+import clsx from 'clsx';
+import { objectHasValues } from '../../utils';
 
 const RichTextJustifyButton = ( {
 	blockId,
 	deprecatedIsBlockJustified,
 	styleAttributes,
 	updateBlockAttributes,
+	className,
 } ) => {
 	const isBlockJustified = 'justify' === styleAttributes.typography?.textAlign;
 
 	const onToggle = () => {
+		/**
+		 * The functionality introduced in Gutenberg 22.1 does not yet support text-align justify,
+		 * so we need to introduce the has-text-align-justify class name ourselves.
+		 */
+		const baseClassName = className.replace( 'has-text-align-justify', '' );
+
 		// TODO: Remove this once we know all Atomic sites are on Gutenberg 22.1 or higher
 		const isDeprecatedAlignAttribute =
 			getBlockType( 'core/paragraph' ).attributes.align !== undefined;
 
 		if ( isDeprecatedAlignAttribute ) {
+			const newAlignValue = deprecatedIsBlockJustified ? undefined : 'justify';
+
+			const newClassName = clsx(
+				baseClassName,
+				newAlignValue === 'justify' && 'has-text-align-justify'
+			);
+
 			return updateBlockAttributes( blockId, {
-				align: deprecatedIsBlockJustified ? null : 'justify',
+				align: newAlignValue,
+				className: newClassName || undefined,
 			} );
 		}
 
+		const newTextAlignValue = isBlockJustified ? undefined : 'justify';
+
+		const newClassName = clsx(
+			baseClassName,
+			newTextAlignValue === 'justify' && 'has-text-align-justify'
+		);
+
+		const typographyAttributes = {
+			...styleAttributes.typography,
+			textAlign: newTextAlignValue,
+		};
+
+		const newStyleAttributes = {
+			...styleAttributes,
+			typography: objectHasValues( typographyAttributes ) ? typographyAttributes : undefined,
+		};
+
 		updateBlockAttributes( blockId, {
-			style: {
-				...styleAttributes,
-				typography: {
-					...styleAttributes.typography,
-					textAlign: isBlockJustified ? null : 'justify',
-				},
-			},
+			style: objectHasValues( newStyleAttributes ) ? newStyleAttributes : undefined,
+			className: newClassName || undefined,
 		} );
 	};
 
@@ -58,6 +87,7 @@ const ConnectedRichTextJustifyButton = compose(
 			blockName: selectedBlock.name,
 			deprecatedIsBlockJustified: 'justify' === selectedBlock.attributes.align,
 			styleAttributes: selectedBlock.attributes.style || EMPTY_STYLES,
+			className: selectedBlock.attributes.className || '',
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -5,18 +5,15 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { registerFormatType } from '@wordpress/rich-text';
 import { get } from 'lodash';
 
-const RichTextJustifyButton = ( { blockId, attributes, updateBlockAttributes } ) => {
-	const isBlockJustified = 'justify' === get( attributes, 'style.typography.textAlign' );
-
-	const style = attributes.style || {};
+const RichTextJustifyButton = ( { blockId, styleAttributes, updateBlockAttributes } ) => {
+	const isBlockJustified = 'justify' === get( styleAttributes, 'typography.textAlign' );
 
 	const onToggle = () =>
 		updateBlockAttributes( blockId, {
-			...attributes,
 			style: {
-				...style,
+				...styleAttributes,
 				typography: {
-					...style.typography,
+					...styleAttributes.typography,
 					textAlign: isBlockJustified ? null : 'justify',
 				},
 			},
@@ -41,7 +38,7 @@ const ConnectedRichTextJustifyButton = compose(
 		return {
 			blockId: selectedBlock.clientId,
 			blockName: selectedBlock.name,
-			attributes: selectedBlock.attributes,
+			styleAttributes: get( selectedBlock.attributes, 'style', {} ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -4,7 +4,6 @@ import { getBlockType } from '@wordpress/blocks';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { registerFormatType } from '@wordpress/rich-text';
-import { get } from 'lodash';
 
 const RichTextJustifyButton = ( {
 	blockId,
@@ -13,7 +12,7 @@ const RichTextJustifyButton = ( {
 	styleAttributes,
 	updateBlockAttributes,
 } ) => {
-	const isBlockJustified = 'justify' === get( styleAttributes, 'typography.textAlign' );
+	const isBlockJustified = 'justify' === styleAttributes.typography?.textAlign;
 
 	const onToggle = () => {
 		// TODO: Remove this once we know all Atomic sites are on Gutenberg 22.1 or higher
@@ -56,8 +55,8 @@ const ConnectedRichTextJustifyButton = compose(
 			blockId: selectedBlock.clientId,
 			blockName: selectedBlock.name,
 			isDeprecatedAlignAttribute: getBlockType( 'core/paragraph' ).attributes.align !== undefined,
-			deprecatedIsBlockJustified: 'justify' === get( selectedBlock, 'attributes.align' ),
-			styleAttributes: get( selectedBlock.attributes, 'style', EMPTY_STYLES ),
+			deprecatedIsBlockJustified: 'justify' === selectedBlock.attributes.align,
+			styleAttributes: selectedBlock.attributes.style || EMPTY_STYLES,
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -7,7 +7,6 @@ import { registerFormatType } from '@wordpress/rich-text';
 
 const RichTextJustifyButton = ( {
 	blockId,
-	isDeprecatedAlignAttribute,
 	deprecatedIsBlockJustified,
 	styleAttributes,
 	updateBlockAttributes,
@@ -16,6 +15,9 @@ const RichTextJustifyButton = ( {
 
 	const onToggle = () => {
 		// TODO: Remove this once we know all Atomic sites are on Gutenberg 22.1 or higher
+		const isDeprecatedAlignAttribute =
+			getBlockType( 'core/paragraph' ).attributes.align !== undefined;
+
 		if ( isDeprecatedAlignAttribute ) {
 			return updateBlockAttributes( blockId, {
 				align: deprecatedIsBlockJustified ? null : 'justify',
@@ -54,7 +56,6 @@ const ConnectedRichTextJustifyButton = compose(
 		return {
 			blockId: selectedBlock.clientId,
 			blockName: selectedBlock.name,
-			isDeprecatedAlignAttribute: getBlockType( 'core/paragraph' ).attributes.align !== undefined,
 			deprecatedIsBlockJustified: 'justify' === selectedBlock.attributes.align,
 			styleAttributes: selectedBlock.attributes.style || EMPTY_STYLES,
 		};

--- a/apps/wpcom-block-editor/src/utils.js
+++ b/apps/wpcom-block-editor/src/utils.js
@@ -1,5 +1,8 @@
 import { select, subscribe } from '@wordpress/data';
 
+export const objectHasValues = ( object ) =>
+	Object.values( object ).some( ( value ) => value !== undefined );
+
 /**
  * Checks self and top to determine if we are being loaded in an iframe.
  * Can't use window.frameElement because we are being embedded from a different origin.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2501,6 +2501,7 @@ __metadata:
     "@wordpress/rich-text": "npm:^7.23.0"
     "@wordpress/router": "npm:^1.23.0"
     "@wordpress/url": "npm:^4.23.0"
+    clsx: "npm:^2.1.1"
     debug: "npm:^4.4.1"
     lodash: "npm:^4.17.21"
     npm-run-all: "npm:^4.1.5"


### PR DESCRIPTION
Closes EDI-136.

## Proposed Changes

In https://github.com/WordPress/gutenberg/pull/73111, Gutenberg moved away from the `align` block attribute in favor of using the native block styling attribute, which is the correct decision.

Unfortunately, this block was still relying on the removed attribute, which broke the functionality. This PR updates the plugin so it uses the correct attribute, restoring the behavior.

## Testing Instructions

Point `widgets.wp.com` to your sandbox's IP address and make sure you have an active connection to it. 

Go to the `apps/wpcom-block-editor` folder and run `yarn dev --sync`. Wait until the plugin builds and you see the "Sync to sandbox completed." message appear on the screen.

Open the editor on the test site. Open the dev tools, go to the network tab and make sure "Disable cache" is checked, then reload.

Now select a paragraph block and click the "justify" button in the block toolbar. The text should stretch to the container's width, which is the expected behavior. Toggle it, and it should align to the left again. Justify the text and save the changes. Check the post in the front-end and verify that the text is indeed justified.

Also test Atomic sites running Gutenberg <22.1. Do the same steps: sync the code to your sandbox, and sandboxing `widgets.wp.com` should do the trick.