### PR TITLE
Fix issue where checkout styles broke the email plan screen

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -3,9 +3,6 @@
 @import "@wordpress/base-styles/variables";
 
 
-.layout__content {
-	overflow: visible;
-}
 .checkout-thank-you {
 	box-sizing: border-box;
 	position: static;
@@ -599,6 +596,7 @@
 
 .is-section-checkout-thank-you {
 	.layout__content {
+		overflow: visible;
 		padding-right: 0;
 		padding-left: 0;
 	}

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -5,6 +5,9 @@
 
 .promo-card.checkout-sidebar-plan-upsell {
 	padding: 24px;
+	max-width: 384px;
+	width: 100%;
+	border-radius: 3px;
 }
 
 .promo-card.checkout-sidebar-plan-upsell .action-panel__title {
@@ -14,13 +17,7 @@
 	font-size: $font-title-small;
 	line-height: 1.3;
 }
-
-.promo-card {
-	max-width: 384px;
-	width: 100%;
-	border-radius: 3px;
-}
-.promo-card .action-panel__body {
+.promo-card.checkout-sidebar-plan-upsell .action-panel__body {
 	overflow: visible;
 	color: var(--studio-gray-100);
 }

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -5,9 +5,6 @@
 
 .promo-card.checkout-sidebar-plan-upsell {
 	padding: 24px;
-	max-width: 384px;
-	width: 100%;
-	border-radius: 3px;
 }
 
 .promo-card.checkout-sidebar-plan-upsell .action-panel__title {

--- a/packages/composite-checkout/src/components/use-custom-property-for-height.tsx
+++ b/packages/composite-checkout/src/components/use-custom-property-for-height.tsx
@@ -13,6 +13,13 @@ function setCustomPropertyForElement< T extends HTMLElement >(
 	root.style.setProperty( customProperty, `${ height }px` );
 }
 
+function removeCustomProperty( customProperty: `--${ string }` ) {
+	const root = document.documentElement;
+	if ( root.style ) {
+		root.style.removeProperty( customProperty );
+	}
+}
+
 export function useCustomPropertyForHeight< T extends HTMLElement >(
 	customProperty: `--${ string }`
 ): RefObject< T > {
@@ -20,6 +27,9 @@ export function useCustomPropertyForHeight< T extends HTMLElement >(
 
 	useEffect( () => {
 		setCustomPropertyForElement( customProperty, elementRef.current );
+		return () => {
+			removeCustomProperty( customProperty );
+		};
 	}, [ customProperty ] );
 
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTEMP-45

## Proposed Changes

When skipping the email plan screen, going to checkout, and going back, the email screen still had some checkout styles loaded which breaks the layout.

We've made some of the checkout styles more specific and also unload the checkout styles when navigating away.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can verify the issue by doing the following on WordPress.com:
* Create a new site with a paid plan that allows domains and email.
* Add a domain, then click "Skip" on the email plan page.
* Once you reach checkout, click the Back button on your browser. 
* The layout will look like this:
<img width="1269" height="716" alt="image" src="https://github.com/user-attachments/assets/796eeaf9-b92d-4f7d-beb5-4e9506b7ccb0" />

Now run this locally or use the calypso.live url. Repeat the above steps and the layout shouldn't be broken.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
