### PR TITLE
MSD Cancel flow: Split CancelPurchase into sub-components

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
@@ -7,12 +7,12 @@ import {
 } from '../../../utils/purchase';
 import { ATOMIC_REVERT_STEP } from './cancel-purchase-form/steps';
 import type { CancelPurchaseState } from './types';
-import type { Purchase, SiteLatestAtomicTransfer } from '@automattic/api-core';
+import type { Purchase, AtomicTransfer } from '@automattic/api-core';
 
 interface CancelButtonProps {
 	purchase: Purchase;
 	includedDomainPurchase?: Purchase;
-	atomicTransfer?: SiteLatestAtomicTransfer;
+	atomicTransfer?: AtomicTransfer;
 	state: CancelPurchaseState;
 	disabled?: boolean;
 	isBusy?: boolean;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
@@ -1,0 +1,83 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	hasAmountAvailableToRefund,
+	isNonDomainSubscription,
+	isOneTimePurchase,
+} from '../../../utils/purchase';
+import { ATOMIC_REVERT_STEP } from './cancel-purchase-form/steps';
+import type { CancelPurchaseState } from './types';
+import type { Purchase, SiteLatestAtomicTransfer } from '@automattic/api-core';
+
+interface CancelButtonProps {
+	purchase: Purchase;
+	includedDomainPurchase?: Purchase;
+	atomicTransfer?: SiteLatestAtomicTransfer;
+	state: CancelPurchaseState;
+	disabled?: boolean;
+	isBusy?: boolean;
+	onClick?: () => void;
+}
+
+export default function CancelButton( {
+	purchase,
+	includedDomainPurchase,
+	atomicTransfer,
+	state,
+	disabled,
+	isBusy,
+	onClick,
+}: CancelButtonProps ) {
+	const isDomainRegistrationPurchase = purchase && purchase.is_domain_registration;
+
+	// Check if we need atomic revert confirmation
+	const needsAtomicRevertConfirmation = atomicTransfer?.created_at;
+
+	const isDisabled =
+		disabled ||
+		( state.cancelBundledDomain && ! state.confirmCancelBundledDomain ) ||
+		( state.surveyStep === ATOMIC_REVERT_STEP &&
+			needsAtomicRevertConfirmation &&
+			! state.atomicRevertConfirmed &&
+			purchase.is_plan ) ||
+		( isDomainRegistrationPurchase && ! state.domainConfirmationConfirmed ) ||
+		! ( state?.customerConfirmedUnderstanding || false );
+
+	const cancelButtonText = ( () => {
+		if ( includedDomainPurchase ) {
+			return __( 'Continue with cancellation' );
+		}
+
+		if ( hasAmountAvailableToRefund( purchase ) ) {
+			if ( purchase.is_domain_registration ) {
+				return __( 'Cancel domain and refund' );
+			}
+			if ( isNonDomainSubscription( purchase ) ) {
+				return __( 'Cancel plan' );
+			}
+			if ( isOneTimePurchase( purchase ) ) {
+				return __( 'Cancel and refund' );
+			}
+		}
+
+		if ( purchase.is_domain_registration ) {
+			return __( 'Cancel domain' );
+		}
+
+		if ( isNonDomainSubscription( purchase ) ) {
+			return __( 'Cancel plan' );
+		}
+	} )();
+
+	return (
+		<Button
+			className="cancel-purchase__button"
+			disabled={ isDisabled }
+			isBusy={ isBusy ?? state.isLoading ?? false }
+			onClick={ onClick }
+			variant="primary"
+		>
+			{ cancelButtonText }
+		</Button>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-header-title.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-header-title.tsx
@@ -1,0 +1,22 @@
+import { __ } from '@wordpress/i18n';
+import { CANCEL_FLOW_TYPE } from '../../../utils/purchase';
+import type { Purchase } from '@automattic/api-core';
+
+interface CancelHeaderTitleProps {
+	flowType: string;
+	purchase: Purchase;
+}
+
+export default function CancelHeaderTitle( { flowType, purchase }: CancelHeaderTitleProps ) {
+	if ( flowType === CANCEL_FLOW_TYPE.REMOVE ) {
+		if ( purchase.is_plan ) {
+			return __( 'Remove plan' );
+		}
+		return __( 'Remove product' );
+	}
+
+	if ( purchase.is_plan ) {
+		return __( 'Cancel plan' );
+	}
+	return __( 'Cancel product' );
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-full-text.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-full-text.tsx
@@ -1,0 +1,58 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { intlFormat } from 'date-fns';
+import RefundAmountString from './refund-amount-string';
+import type { Purchase } from '@automattic/api-core';
+
+interface CancellationFullTextProps {
+	purchase: Purchase;
+	cancelBundledDomain: boolean;
+	includedDomainPurchase?: Purchase;
+}
+
+export default function CancellationFullText( {
+	purchase,
+	cancelBundledDomain,
+	includedDomainPurchase,
+}: CancellationFullTextProps ) {
+	const { expiry_date: expiryDate } = purchase;
+	const expirationDate = intlFormat( expiryDate, { dateStyle: 'medium' }, { locale: 'en-US' } );
+
+	const refundAmountString = RefundAmountString( {
+		purchase,
+		cancelBundledDomain,
+		includedDomainPurchase,
+	} );
+
+	if ( refundAmountString ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: $(refundText)s is of the form "[currency-symbol][amount]" i.e. "$20" */
+				__(
+					'If you confirm this cancellation, you will receive a <span>refund of %(refundText)s</span>, and your subscription will be removed immediately.'
+				),
+				{
+					refundText: refundAmountString,
+				}
+			),
+			{
+				span: <span className="cancel-purchase__refund-string" />,
+			}
+		);
+	}
+
+	return createInterpolateElement(
+		sprintf(
+			/* translators: %(expirationDate)s is the date when the subscription will be removed */
+			__(
+				'If you complete this cancellation, your subscription will be removed on <span>%(expirationDate)s</span>.'
+			),
+			{
+				expirationDate,
+			}
+		),
+		{
+			span: <span className="cancel-purchase__warning-string" />,
+		}
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -1,0 +1,154 @@
+import { __ } from '@wordpress/i18n';
+import { isAkismetProduct, isGSuiteOrGoogleWorkspaceProductSlug } from '../../../utils/purchase';
+import BackupRetentionOptionOnCancelPurchase from './backup-retention-management/retention-option-on-cancel-purchase';
+import CancelPurchaseDomainOptions from './domain-options';
+import CancelPurchaseFeatureList from './feature-list';
+import GSuiteAccessMessage from './gsuite-access-message';
+import PlanProductRevertContent from './plan-product-revert-content';
+import CancelPurchaseRefundInformation from './refund-information';
+import type { CancelPurchaseState } from './types';
+import type {
+	Purchase,
+	DomainData,
+	SiteLatestAtomicTransfer,
+	PurchaseCancelFeaturesResult,
+} from '@automattic/api-core';
+
+interface CancellationMainContentProps {
+	purchase: Purchase;
+	includedDomainPurchase?: Purchase;
+	atomicTransfer?: SiteLatestAtomicTransfer;
+	selectedDomain?: DomainData;
+	state: CancelPurchaseState;
+	purchaseCancelFeatures?: PurchaseCancelFeaturesResult;
+	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
+	onDomainConfirmationChange: ( checked: boolean ) => void;
+	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
+	onKeepSubscriptionClick: () => void;
+	onCancelClick?: () => void;
+}
+
+// Helper function to determine if radio buttons will be shown
+const willShowDomainOptionsRadioButtons = (
+	includedDomainPurchase: Purchase,
+	purchase: Purchase
+) => {
+	return (
+		includedDomainPurchase.is_domain_registration &&
+		purchase.is_refundable &&
+		includedDomainPurchase.is_refundable
+	);
+};
+
+export default function CancellationMainContent( {
+	purchase,
+	includedDomainPurchase,
+	atomicTransfer,
+	selectedDomain,
+	state,
+	purchaseCancelFeatures,
+	onCancelConfirmationStateChange,
+	onDomainConfirmationChange,
+	onCustomerConfirmedUnderstandingChange,
+	onKeepSubscriptionClick,
+	onCancelClick,
+}: CancellationMainContentProps ) {
+	const isJetpack = purchase.is_jetpack_plan_or_product;
+	const isAkismet = isAkismetProduct( purchase );
+	const isDomainRegistrationPurchase = purchase && purchase.is_domain_registration;
+	const isGSuite = isGSuiteOrGoogleWorkspaceProductSlug( purchase.product_slug );
+
+	const atomicRevertChanges = [
+		{
+			getSlug: () => 'primarySite',
+			getTitle: () => __( 'Set your site to private.' ),
+		},
+		{
+			getSlug: () => 'primaryDomain',
+			/* translators: %(domainName)s is a domain name */
+			getTitle: () => __( 'Use %(domainName)s as your primary domain' ),
+		},
+		{
+			getSlug: () => 'removeThemesPluginsData',
+			getTitle: () => __( 'Remove your installed themes, plugins, and their data.' ),
+		},
+		{
+			getSlug: () => 'revertThemesAndSettings',
+			getTitle: () => __( 'Switch to the settings and theme you had before you upgraded.' ),
+		},
+	];
+
+	const defaultChanges = [];
+	if (
+		! isJetpack &&
+		! isAkismet &&
+		! isDomainRegistrationPurchase &&
+		Boolean( atomicTransfer?.created_at )
+	) {
+		defaultChanges.push( ...atomicRevertChanges );
+	}
+
+	// Get features from the API endpoint for this product
+	const cancellationFeatures = purchaseCancelFeatures?.features ?? [];
+
+	let showDefaultChanges = false;
+	if ( ! isJetpack && ! isAkismet && ! isGSuite && ! isDomainRegistrationPurchase ) {
+		showDefaultChanges = true;
+	}
+
+	const cancellationChanges = showDefaultChanges ? defaultChanges : [];
+
+	// Check if we should show domain options inline (when they don't need radio buttons)
+	const shouldShowDomainOptionsInline =
+		includedDomainPurchase &&
+		! willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase );
+
+	return (
+		<>
+			{ shouldShowDomainOptionsInline && (
+				<CancelPurchaseDomainOptions
+					includedDomainPurchase={ includedDomainPurchase }
+					cancelBundledDomain={ false }
+					purchase={ purchase }
+					onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
+					isLoading={ false }
+				/>
+			) }
+
+			{ includedDomainPurchase && atomicTransfer?.created_at && ! purchase.is_refundable && (
+				<h2 className="formatted-header__title formatted-header__title--cancellation-flow">
+					{ __( 'What happens when you cancel' ) }
+				</h2>
+			) }
+
+			<BackupRetentionOptionOnCancelPurchase siteId={ purchase.blog_id } purchase={ purchase } />
+
+			{ isGSuite && (
+				<GSuiteAccessMessage purchase={ purchase } selectedDomain={ selectedDomain } />
+			) }
+
+			<CancelPurchaseFeatureList
+				purchase={ purchase }
+				cancellationFeatures={ cancellationFeatures }
+				cancellationChanges={ cancellationChanges }
+			/>
+
+			<CancelPurchaseRefundInformation
+				purchase={ purchase }
+				isJetpackPurchase={ isJetpack }
+				selectedDomain={ selectedDomain }
+			/>
+
+			<PlanProductRevertContent
+				purchase={ purchase }
+				includedDomainPurchase={ includedDomainPurchase }
+				atomicTransfer={ atomicTransfer }
+				state={ state }
+				onDomainConfirmationChange={ onDomainConfirmationChange }
+				onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+				onKeepSubscriptionClick={ onKeepSubscriptionClick }
+				onCancelClick={ onCancelClick }
+			/>
+		</>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -9,18 +9,18 @@ import CancelPurchaseRefundInformation from './refund-information';
 import type { CancelPurchaseState } from './types';
 import type {
 	Purchase,
-	DomainData,
-	SiteLatestAtomicTransfer,
-	PurchaseCancelFeaturesResult,
+	Domain,
+	AtomicTransfer,
+	UpgradesCancelFeaturesResponse,
 } from '@automattic/api-core';
 
 interface CancellationMainContentProps {
 	purchase: Purchase;
 	includedDomainPurchase?: Purchase;
-	atomicTransfer?: SiteLatestAtomicTransfer;
-	selectedDomain?: DomainData;
+	atomicTransfer?: AtomicTransfer;
+	selectedDomain?: Domain;
 	state: CancelPurchaseState;
-	purchaseCancelFeatures?: PurchaseCancelFeaturesResult;
+	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
 	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -1,0 +1,88 @@
+import { __experimentalHeading as Heading } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import CancellationMainContent from './cancellation-main-content';
+import DomainOptionsContent from './domain-options-content';
+import type { CancelPurchaseState } from './types';
+import type {
+	Purchase,
+	DomainData,
+	SiteLatestAtomicTransfer,
+	PurchaseCancelFeaturesResult,
+} from '@automattic/api-core';
+
+interface CancellationPreSurveyContentProps {
+	purchase: Purchase;
+	includedDomainPurchase?: Purchase;
+	atomicTransfer?: SiteLatestAtomicTransfer;
+	selectedDomain?: DomainData;
+	state: CancelPurchaseState;
+	purchaseCancelFeatures?: PurchaseCancelFeaturesResult;
+	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
+	onDomainConfirmationChange: ( checked: boolean ) => void;
+	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
+	onKeepSubscriptionClick: () => void;
+	onCancellationComplete: () => void;
+	onCancellationStart: () => void;
+	shouldHandleMarketplaceSubscriptions: () => boolean;
+	showMarketplaceDialog: () => void;
+}
+
+export default function CancellationPreSurveyContent( {
+	purchase,
+	includedDomainPurchase,
+	atomicTransfer,
+	selectedDomain,
+	state,
+	purchaseCancelFeatures,
+	onCancelConfirmationStateChange,
+	onDomainConfirmationChange,
+	onCustomerConfirmedUnderstandingChange,
+	onKeepSubscriptionClick,
+	onCancellationComplete,
+	onCancellationStart,
+	shouldHandleMarketplaceSubscriptions,
+	showMarketplaceDialog,
+}: CancellationPreSurveyContentProps ) {
+	return (
+		<>
+			<Heading level={ 4 }>
+				{
+					/* translators: %(purchaseName)s is the name of the product which was purchased */
+					sprintf( __( 'Manage %(purchaseName)s' ), {
+						purchaseName: purchase.is_domain ? purchase.meta : purchase.product_name,
+					} )
+				}
+			</Heading>
+
+			<p className="cancel-purchase__left">
+				{ state.showDomainOptionsStep ? (
+					<DomainOptionsContent
+						purchase={ purchase }
+						includedDomainPurchase={ includedDomainPurchase }
+						atomicTransfer={ atomicTransfer }
+						state={ state }
+						onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
+						onKeepSubscriptionClick={ onKeepSubscriptionClick }
+						onCancellationComplete={ onCancellationComplete }
+					/>
+				) : (
+					<CancellationMainContent
+						purchase={ purchase }
+						includedDomainPurchase={ includedDomainPurchase }
+						atomicTransfer={ atomicTransfer }
+						selectedDomain={ selectedDomain }
+						state={ state }
+						purchaseCancelFeatures={ purchaseCancelFeatures }
+						onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
+						onDomainConfirmationChange={ onDomainConfirmationChange }
+						onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+						onKeepSubscriptionClick={ onKeepSubscriptionClick }
+						onCancelClick={
+							shouldHandleMarketplaceSubscriptions() ? showMarketplaceDialog : onCancellationStart
+						}
+					/>
+				) }
+			</p>
+		</>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -5,18 +5,18 @@ import DomainOptionsContent from './domain-options-content';
 import type { CancelPurchaseState } from './types';
 import type {
 	Purchase,
-	DomainData,
-	SiteLatestAtomicTransfer,
-	PurchaseCancelFeaturesResult,
+	Domain,
+	AtomicTransfer,
+	UpgradesCancelFeaturesResponse,
 } from '@automattic/api-core';
 
 interface CancellationPreSurveyContentProps {
 	purchase: Purchase;
 	includedDomainPurchase?: Purchase;
-	atomicTransfer?: SiteLatestAtomicTransfer;
-	selectedDomain?: DomainData;
+	atomicTransfer?: AtomicTransfer;
+	selectedDomain?: Domain;
 	state: CancelPurchaseState;
-	purchaseCancelFeatures?: PurchaseCancelFeaturesResult;
+	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
 	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
@@ -3,11 +3,11 @@ import { CheckboxControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import type { CancelPurchaseState } from './types';
-import type { Purchase, SiteLatestAtomicTransfer } from '@automattic/api-core';
+import type { Purchase, AtomicTransfer } from '@automattic/api-core';
 
 interface ConfirmCheckboxProps {
 	purchase: Purchase;
-	atomicTransfer?: SiteLatestAtomicTransfer;
+	atomicTransfer?: AtomicTransfer;
 	state: CancelPurchaseState;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
@@ -1,0 +1,65 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { CheckboxControl } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { CancelPurchaseState } from './types';
+import type { Purchase, SiteLatestAtomicTransfer } from '@automattic/api-core';
+
+interface ConfirmCheckboxProps {
+	purchase: Purchase;
+	atomicTransfer?: SiteLatestAtomicTransfer;
+	state: CancelPurchaseState;
+	onDomainConfirmationChange: ( checked: boolean ) => void;
+	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
+}
+
+export default function ConfirmCheckbox( {
+	purchase,
+	atomicTransfer,
+	state,
+	onDomainConfirmationChange,
+	onCustomerConfirmedUnderstandingChange,
+}: ConfirmCheckboxProps ) {
+	const isDomainRegistrationPurchase = purchase && purchase.is_domain_registration;
+
+	return (
+		<>
+			<b>{ __( 'Have a question before cancelling?' ) }</b>
+			<p>
+				{ createInterpolateElement(
+					__( 'Our support team is here for you. <contactLink>Contact us</contactLink>' ),
+					{
+						contactLink: <a href={ localizeUrl( 'https://wordpress.com/support' ) } />,
+					}
+				) }
+			</p>
+
+			<hr />
+
+			{ isDomainRegistrationPurchase && ! state.surveyShown && (
+				<div>
+					<CheckboxControl
+						label={ __( 'I understand that canceling means that I may lose this domain forever.' ) }
+						checked={ state.domainConfirmationConfirmed }
+						onChange={ onDomainConfirmationChange }
+					/>
+				</div>
+			) }
+
+			<div>
+				<CheckboxControl
+					label={ __( 'I understand my site will change when my plan expires.' ) }
+					checked={ state.customerConfirmedUnderstanding }
+					onChange={ ( checked ) => {
+						if ( atomicTransfer?.created_at ) {
+							onCustomerConfirmedUnderstandingChange( checked );
+							return;
+						}
+
+						onCustomerConfirmedUnderstandingChange( checked );
+					} }
+				/>
+			</div>
+		</>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-options-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-options-content.tsx
@@ -4,12 +4,12 @@ import CancelButton from './cancel-button';
 import CancelPurchaseDomainOptions from './domain-options';
 import KeepSubscriptionButton from './keep-subscription-button';
 import type { CancelPurchaseState } from './types';
-import type { Purchase, SiteLatestAtomicTransfer } from '@automattic/api-core';
+import type { Purchase, AtomicTransfer } from '@automattic/api-core';
 
 interface DomainOptionsContentProps {
 	purchase: Purchase;
 	includedDomainPurchase?: Purchase;
-	atomicTransfer?: SiteLatestAtomicTransfer;
+	atomicTransfer?: AtomicTransfer;
 	state: CancelPurchaseState;
 	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
 	onKeepSubscriptionClick: () => void;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-options-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-options-content.tsx
@@ -1,0 +1,68 @@
+import { ButtonStack } from '../../../components/button-stack';
+import { isNonDomainSubscription } from '../../../utils/purchase';
+import CancelButton from './cancel-button';
+import CancelPurchaseDomainOptions from './domain-options';
+import KeepSubscriptionButton from './keep-subscription-button';
+import type { CancelPurchaseState } from './types';
+import type { Purchase, SiteLatestAtomicTransfer } from '@automattic/api-core';
+
+interface DomainOptionsContentProps {
+	purchase: Purchase;
+	includedDomainPurchase?: Purchase;
+	atomicTransfer?: SiteLatestAtomicTransfer;
+	state: CancelPurchaseState;
+	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
+	onKeepSubscriptionClick: () => void;
+	onCancellationComplete: () => void;
+}
+
+export default function DomainOptionsContent( {
+	purchase,
+	includedDomainPurchase,
+	atomicTransfer,
+	state,
+	onCancelConfirmationStateChange,
+	onKeepSubscriptionClick,
+	onCancellationComplete,
+}: DomainOptionsContentProps ) {
+	const { cancelBundledDomain, confirmCancelBundledDomain } = state;
+
+	if ( ! includedDomainPurchase || ! isNonDomainSubscription( purchase ) ) {
+		return null;
+	}
+
+	const canContinue = () => {
+		if ( ! cancelBundledDomain ) {
+			return true;
+		}
+		return confirmCancelBundledDomain;
+	};
+
+	return (
+		<>
+			<CancelPurchaseDomainOptions
+				includedDomainPurchase={ includedDomainPurchase }
+				cancelBundledDomain={ cancelBundledDomain ?? false }
+				purchase={ purchase }
+				onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
+				isLoading={ false }
+			/>
+			<ButtonStack>
+				<CancelButton
+					purchase={ purchase }
+					includedDomainPurchase={ includedDomainPurchase }
+					atomicTransfer={ atomicTransfer }
+					state={ state }
+					disabled={ ! canContinue() }
+					onClick={ () => {
+						onCancellationComplete();
+					} }
+				/>
+				<KeepSubscriptionButton
+					purchase={ purchase }
+					onKeepSubscriptionClick={ onKeepSubscriptionClick }
+				/>
+			</ButtonStack>
+		</>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
@@ -1,11 +1,11 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getGSuiteSubscriptionStatus, getGoogleMailServiceFamily } from '../../../utils/gsuite';
-import type { Purchase, DomainData } from '@automattic/api-core';
+import type { Purchase, Domain } from '@automattic/api-core';
 
 interface GSuiteAccessMessageProps {
 	purchase: Purchase;
-	selectedDomain?: DomainData;
+	selectedDomain?: Domain;
 }
 
 export default function GSuiteAccessMessage( {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
@@ -1,0 +1,68 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { getGSuiteSubscriptionStatus, getGoogleMailServiceFamily } from '../../../utils/gsuite';
+import type { Purchase, DomainData } from '@automattic/api-core';
+
+interface GSuiteAccessMessageProps {
+	purchase: Purchase;
+	selectedDomain?: DomainData;
+}
+
+export default function GSuiteAccessMessage( {
+	purchase,
+	selectedDomain,
+}: GSuiteAccessMessageProps ) {
+	const { meta: domainName, product_slug: productSlug } = purchase;
+	if ( ! productSlug || ! selectedDomain ) {
+		return null;
+	}
+	const googleMailService = getGoogleMailServiceFamily( productSlug );
+	const googleSubscriptionStatus = getGSuiteSubscriptionStatus( selectedDomain );
+
+	if ( [ 'suspended', '' ].includes( googleSubscriptionStatus ) ) {
+		return (
+			<p>
+				{ createInterpolateElement(
+					sprintf(
+						// Translators: %(domainName) is the name of the domain (e.g. example.com) and %(googleMailService)s can be either "G Suite" or "Google Workspace"
+						__(
+							'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of ' +
+								'your %(googleMailService)s features immediately</strong>, and you will ' +
+								'need to purchase a new subscription with Google if you wish to regain access to them.'
+						),
+						{
+							domainName,
+							googleMailService,
+						}
+					),
+					{
+						strong: <strong />,
+					}
+				) }
+			</p>
+		);
+	}
+
+	return (
+		<p>
+			{ createInterpolateElement(
+				sprintf(
+					// Translators: %(domainName) is the name of the domain (e.g. example.com), %(googleMailService)s can be either "G Suite" or "Google Workspace", and %(days)d is a number of days (usually '30')
+					__(
+						'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of ' +
+							'your %(googleMailService)s features in %(days)d days</strong>. After that time, ' +
+							'you will need to purchase a new subscription with Google if you wish to regain access to them.'
+					),
+					{
+						domainName,
+						googleMailService,
+						days: 30,
+					}
+				),
+				{
+					strong: <strong />,
+				}
+			) }
+		</p>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -23,12 +23,9 @@ import {
 import config from '@automattic/calypso-config';
 import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import {
-	__experimentalHeading as Heading,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { _n, __, sprintf } from '@wordpress/i18n';
+import { _n, sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { intlFormat } from 'date-fns';
 import { useCallback, useEffect, useRef, useMemo, useState } from 'react';
@@ -70,8 +67,7 @@ import {
 	REMOVE_PLAN_STEP,
 	UPSELL_STEP,
 } from './cancel-purchase-form/steps';
-import CancellationMainContent from './cancellation-main-content';
-import DomainOptionsContent from './domain-options-content';
+import CancellationPreSurveyContent from './cancellation-pre-survey-content';
 import enrichedSurveyData from './enriched-survey-data';
 import { getUpsellType } from './get-upsell-type';
 import initialSurveyState from './initial-survey-state';
@@ -1227,50 +1223,22 @@ export default function CancelPurchase() {
 							upsell={ state.upsell }
 						/>
 						{ ! state.surveyShown && (
-							<>
-								<Heading level={ 4 }>
-									{
-										/* translators: %(purchaseName)s is the name of the product which was purchased */
-										sprintf( __( 'Manage %(purchaseName)s' ), {
-											purchaseName: purchase.is_domain ? purchase.meta : purchase.product_name,
-										} )
-									}
-								</Heading>
-
-								<p className="cancel-purchase__left">
-									{ state.showDomainOptionsStep ? (
-										<DomainOptionsContent
-											purchase={ purchase }
-											includedDomainPurchase={ includedDomainPurchase }
-											atomicTransfer={ atomicTransfer }
-											state={ state }
-											onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
-											onKeepSubscriptionClick={ onKeepSubscriptionClick }
-											onCancellationComplete={ onCancellationComplete }
-										/>
-									) : (
-										<CancellationMainContent
-											purchase={ purchase }
-											includedDomainPurchase={ includedDomainPurchase }
-											atomicTransfer={ atomicTransfer }
-											selectedDomain={ selectedDomain }
-											state={ state }
-											purchaseCancelFeatures={ purchaseCancelFeatures }
-											onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
-											onDomainConfirmationChange={ onDomainConfirmationChange }
-											onCustomerConfirmedUnderstandingChange={
-												onCustomerConfirmedUnderstandingChange
-											}
-											onKeepSubscriptionClick={ onKeepSubscriptionClick }
-											onCancelClick={
-												shouldHandleMarketplaceSubscriptions()
-													? showMarketplaceDialog
-													: onCancellationStart
-											}
-										/>
-									) }
-								</p>
-							</>
+							<CancellationPreSurveyContent
+								purchase={ purchase }
+								includedDomainPurchase={ includedDomainPurchase }
+								atomicTransfer={ atomicTransfer }
+								selectedDomain={ selectedDomain }
+								state={ state }
+								purchaseCancelFeatures={ purchaseCancelFeatures }
+								onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
+								onDomainConfirmationChange={ onDomainConfirmationChange }
+								onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+								onKeepSubscriptionClick={ onKeepSubscriptionClick }
+								onCancellationComplete={ onCancellationComplete }
+								onCancellationStart={ onCancellationStart }
+								shouldHandleMarketplaceSubscriptions={ shouldHandleMarketplaceSubscriptions }
+								showMarketplaceDialog={ showMarketplaceDialog }
+							/>
 						) }
 						{ shouldHandleMarketplaceSubscriptions() && (
 							<MarketPlaceSubscriptionsDialog

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -51,9 +51,7 @@ import {
 	isExpired,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 	isJetpackTemporarySitePurchase,
-	isNonDomainSubscription,
 	isAkismetProduct,
-	isOneTimePurchase,
 	isPartnerPurchase,
 	willAtomicSiteRevertAfterPurchaseDeactivation,
 } from '../../../utils/purchase';
@@ -1141,22 +1139,6 @@ export default function CancelPurchase() {
 		return null;
 	}
 
-	const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
-
-	let heading;
-
-	const isDomainRegistrationPurchase = purchase && purchase.is_domain_registration;
-	if ( isDomainRegistrationPurchase || isOneTimePurchase( purchase ) ) {
-		/* translators: %(purchaseName)s is the name of the product which was purchased */
-		heading = sprintf( __( 'Manage %(purchaseName)s' ), {
-			purchaseName,
-		} );
-	}
-
-	if ( isNonDomainSubscription( purchase ) ) {
-		heading = __( 'Manage plan' );
-	}
-
 	const getHeaderTitle = () => {
 		if ( flowType === CANCEL_FLOW_TYPE.REMOVE ) {
 			if ( purchase.is_plan ) {
@@ -1246,7 +1228,14 @@ export default function CancelPurchase() {
 						/>
 						{ ! state.surveyShown && (
 							<>
-								<Heading level={ 4 }>{ heading }</Heading>
+								<Heading level={ 4 }>
+									{
+										/* translators: %(purchaseName)s is the name of the product which was purchased */
+										sprintf( __( 'Manage %(purchaseName)s' ), {
+											purchaseName: purchase.is_domain ? purchase.meta : purchase.product_name,
+										} )
+									}
+								</Heading>
 
 								<p className="cancel-purchase__left">
 									{ state.showDomainOptionsStep ? (

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -21,33 +21,25 @@ import {
 	userPreferenceQuery,
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { localizeUrl } from '@automattic/i18n-utils';
-import { formatCurrency } from '@automattic/number-formatters';
 import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHeading as Heading,
 	__experimentalVStack as VStack,
-	Button,
-	CheckboxControl,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 import { _n, __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { formatDistanceToNow, intervalToDuration, intlFormat } from 'date-fns';
+import { intlFormat } from 'date-fns';
 import { useCallback, useEffect, useRef, useMemo, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { useLocale } from '../../../app/locale';
 import { cancelPurchaseRoute, purchaseSettingsRoute, purchasesRoute } from '../../../app/router/me';
-import { ButtonStack } from '../../../components/button-stack';
 import { Card } from '../../../components/card';
-import Notice from '../../../components/notice';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { shuffleArray } from '../../../utils/collection';
-import { getGSuiteSubscriptionStatus, getGoogleMailServiceFamily } from '../../../utils/gsuite';
 import {
 	CANCEL_FLOW_TYPE,
 	getIncludedDomainPurchase,
@@ -55,17 +47,16 @@ import {
 	hasAmountAvailableToRefund,
 	hasMarketplaceProduct,
 	isAgencyPartnerType,
-	isAkismetProduct,
 	isAkismetTemporarySitePurchase,
 	isExpired,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 	isJetpackTemporarySitePurchase,
 	isNonDomainSubscription,
+	isAkismetProduct,
 	isOneTimePurchase,
 	isPartnerPurchase,
 	willAtomicSiteRevertAfterPurchaseDeactivation,
 } from '../../../utils/purchase';
-import BackupRetentionOptionOnCancelPurchase from './backup-retention-management/retention-option-on-cancel-purchase';
 import CancelPurchaseForm from './cancel-purchase-form';
 import {
 	cancellationOptionsForPurchase,
@@ -81,14 +72,14 @@ import {
 	REMOVE_PLAN_STEP,
 	UPSELL_STEP,
 } from './cancel-purchase-form/steps';
-import CancelPurchaseDomainOptions from './domain-options';
+import CancellationMainContent from './cancellation-main-content';
+import DomainOptionsContent from './domain-options-content';
 import enrichedSurveyData from './enriched-survey-data';
-import CancelPurchaseFeatureList from './feature-list';
 import { getUpsellType } from './get-upsell-type';
 import initialSurveyState from './initial-survey-state';
 import MarketPlaceSubscriptionsDialog from './marketplace-subscriptions-dialog';
 import nextStep from './next-step';
-import CancelPurchaseRefundInformation from './refund-information';
+import TimeRemainingNotice from './time-remaining-notice';
 import type { CancelPurchaseState } from './types';
 import type {
 	Purchase,
@@ -99,7 +90,6 @@ import type {
 import type { ChangeEvent } from 'react';
 import './style.scss';
 
-// Helper function to determine if radio buttons will be shown
 const willShowDomainOptionsRadioButtons = (
 	includedDomainPurchase: Purchase,
 	purchase: Purchase
@@ -367,10 +357,6 @@ export default function CancelPurchase() {
 		state.upsell,
 		state.willAtomicSiteRevert,
 	] );
-
-	const getFeaturesFromApiForProduct = () => {
-		return purchaseCancelFeatures?.features ?? [];
-	};
 
 	const getActiveMarketplaceSubscriptions = (): Purchase[] => {
 		if ( ! purchase.is_plan || ! productsList ) {
@@ -1144,450 +1130,10 @@ export default function CancelPurchase() {
 		return <PageLayout size="small" />;
 	}
 
-	const isJetpack = purchase.is_jetpack_plan_or_product;
-	const isAkismet = isAkismetProduct( purchase );
-	const isDomainRegistrationPurchase = purchase && purchase.is_domain_registration;
-	const isGSuite = isGSuiteOrGoogleWorkspaceProductSlug( purchase.product_slug );
 	const isHundredYearDomain = selectedDomain?.is_hundred_year_domain ?? false;
 
-	const renderRefundAmountString = (
-		purchase: Purchase,
-		cancelBundledDomain: boolean,
-		includedDomainPurchase?: Purchase
-	) => {
-		const {
-			refund_integer: refundInteger,
-			total_refund_integer: totalRefundInteger,
-			total_refund_currency: totalRefundCurrency,
-		} = purchase;
-
-		if ( hasAmountAvailableToRefund( purchase ) ) {
-			if ( cancelBundledDomain && includedDomainPurchase ) {
-				return formatCurrency( totalRefundInteger, totalRefundCurrency, {
-					isSmallestUnit: true,
-				} );
-			}
-			return formatCurrency( refundInteger, totalRefundCurrency, {
-				isSmallestUnit: true,
-			} );
-		}
-
-		return null;
-	};
-
-	const renderFullText = () => {
-		const { expiry_date: expiryDate } = purchase;
-		const expirationDate = intlFormat( expiryDate, { dateStyle: 'medium' }, { locale: 'en-US' } );
-
-		const refundAmountString = renderRefundAmountString(
-			purchase,
-			state.cancelBundledDomain ?? false,
-			includedDomainPurchase
-		);
-
-		if ( refundAmountString ) {
-			return createInterpolateElement(
-				sprintf(
-					/* translators: $(refundText)s is of the form "[currency-symbol][amount]" i.e. "$20" */
-					__(
-						'If you confirm this cancellation, you will receive a <span>refund of %(refundText)s</span>, and your subscription will be removed immediately.'
-					),
-					{
-						refundText: refundAmountString,
-					}
-				),
-				{
-					span: <span className="cancel-purchase__refund-string" />,
-				}
-			);
-		}
-
-		return createInterpolateElement(
-			sprintf(
-				/* translators: %(expirationDate)s is the date when the subscription will be removed */
-				__(
-					'If you complete this cancellation, your subscription will be removed on <span>%(expirationDate)s</span>.'
-				),
-				{
-					expirationDate,
-				}
-			),
-			{
-				span: <span className="cancel-purchase__warning-string" />,
-			}
-		);
-	};
-
-	type RenderCancelButtonPropOverrides = {
-		disabled?: boolean;
-		isBusy?: boolean;
-		onClick?: () => void;
-	};
-	const renderCancelButton = ( propOverrides: RenderCancelButtonPropOverrides = {} ) => {
-		// Check if we need atomic revert confirmation
-		const needsAtomicRevertConfirmation = atomicTransfer?.created_at;
-
-		const isDisabled =
-			propOverrides?.disabled ||
-			( state.cancelBundledDomain && ! state.confirmCancelBundledDomain ) ||
-			( state.surveyStep === ATOMIC_REVERT_STEP &&
-				needsAtomicRevertConfirmation &&
-				! state.atomicRevertConfirmed &&
-				purchase.is_plan ) ||
-			( isDomainRegistrationPurchase && ! state.domainConfirmationConfirmed ) ||
-			! ( state?.customerConfirmedUnderstanding || false );
-
-		const cancelButtonText = ( () => {
-			if ( includedDomainPurchase ) {
-				return __( 'Continue with cancellation' );
-			}
-
-			if ( hasAmountAvailableToRefund( purchase ) ) {
-				if ( purchase.is_domain_registration ) {
-					return __( 'Cancel domain and refund' );
-				}
-				if ( isNonDomainSubscription( purchase ) ) {
-					return __( 'Cancel plan' );
-				}
-				if ( isOneTimePurchase( purchase ) ) {
-					return __( 'Cancel and refund' );
-				}
-			}
-
-			if ( purchase.is_domain_registration ) {
-				return __( 'Cancel domain' );
-			}
-
-			if ( isNonDomainSubscription( purchase ) ) {
-				return __( 'Cancel plan' );
-			}
-		} )();
-
-		return (
-			<Button
-				className="cancel-purchase__button"
-				disabled={ isDisabled }
-				isBusy={ propOverrides?.isBusy ?? state.isLoading ?? false }
-				onClick={
-					propOverrides?.onClick ??
-					( shouldHandleMarketplaceSubscriptions() ? showMarketplaceDialog : onCancellationStart )
-				}
-				variant="primary"
-			>
-				{ cancelButtonText }
-			</Button>
-		);
-	};
-
-	const renderKeepSubscriptionButton = () => {
-		return (
-			<Button
-				variant="secondary"
-				onClick={ () => {
-					navigate( { to: purchaseSettingsRoute.fullPath, params: { purchaseId: purchase.ID } } );
-					onKeepSubscriptionClick();
-				} }
-			>
-				{ __( 'Keep plan' ) }
-			</Button>
-		);
-	};
-
-	const renderConfirmCheckbox = () => {
-		return (
-			<>
-				<b>{ __( 'Have a question before cancelling?' ) }</b>
-				<p>
-					{ createInterpolateElement(
-						__( 'Our support team is here for you. <contactLink>Contact us</contactLink>' ),
-						{
-							contactLink: <a href={ localizeUrl( 'https://wordpress.com/support' ) } />,
-						}
-					) }
-				</p>
-
-				<hr />
-
-				{ isDomainRegistrationPurchase && ! state.surveyShown && (
-					<div>
-						<CheckboxControl
-							label={ __(
-								'I understand that canceling means that I may lose this domain forever.'
-							) }
-							checked={ state.domainConfirmationConfirmed }
-							onChange={ onDomainConfirmationChange }
-						/>
-					</div>
-				) }
-
-				<div>
-					<CheckboxControl
-						label={ __( 'I understand my site will change when my plan expires.' ) }
-						checked={ state.customerConfirmedUnderstanding }
-						onChange={ ( checked ) => {
-							if ( atomicTransfer?.created_at ) {
-								setState( ( state ) => ( {
-									...state,
-									customerConfirmedUnderstanding: checked,
-								} ) );
-								return;
-							}
-
-							setState( ( state ) => ( { ...state, customerConfirmedUnderstanding: checked } ) );
-						} }
-					/>
-				</div>
-			</>
-		);
-	};
-
-	const renderPlanProductRevertContent = () => {
-		return (
-			<>
-				{ ! includedDomainPurchase && <p>{ renderFullText() }</p> }
-
-				{ ! state.surveyShown && renderConfirmCheckbox() }
-
-				<ButtonStack>
-					{ renderCancelButton() }
-					{ renderKeepSubscriptionButton() }
-				</ButtonStack>
-			</>
-		);
-	};
-
-	const renderGSuiteAccessMessage = () => {
-		const { meta: domainName, product_slug: productSlug } = purchase;
-		if ( ! productSlug || ! selectedDomain ) {
-			return;
-		}
-		const googleMailService = getGoogleMailServiceFamily( productSlug );
-		const googleSubscriptionStatus = getGSuiteSubscriptionStatus( selectedDomain );
-
-		if ( [ 'suspended', '' ].includes( googleSubscriptionStatus ) ) {
-			return (
-				<p>
-					{ createInterpolateElement(
-						sprintf(
-							// Translators: %(domainName) is the name of the domain (e.g. example.com) and %(googleMailService)s can be either "G Suite" or "Google Workspace"
-							__(
-								'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of ' +
-									'your %(googleMailService)s features immediately</strong>, and you will ' +
-									'need to purchase a new subscription with Google if you wish to regain access to them.'
-							),
-							{
-								domainName,
-								googleMailService,
-							}
-						),
-						{
-							strong: <strong />,
-						}
-					) }
-				</p>
-			);
-		}
-
-		return (
-			<p>
-				{ createInterpolateElement(
-					sprintf(
-						// Translators: %(domainName) is the name of the domain (e.g. example.com), %(googleMailService)s can be either "G Suite" or "Google Workspace", and %(days)d is a number of days (usually '30')
-						__(
-							'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of ' +
-								'your %(googleMailService)s features in %(days)d days</strong>. After that time, ' +
-								'you will need to purchase a new subscription with Google if you wish to regain access to them.'
-						),
-						{
-							domainName,
-							googleMailService,
-							days: 30,
-						}
-					),
-					{
-						strong: <strong />,
-					}
-				) }
-			</p>
-		);
-	};
-
-	const renderMainContent = () => {
-		const atomicRevertChanges = [
-			{
-				getSlug: () => 'primarySite',
-				getTitle: () => __( 'Set your site to private.' ),
-			},
-			{
-				getSlug: () => 'primaryDomain',
-				getTitle: () =>
-					/* translators: %(domainName)s is a domain name */
-					sprintf( __( 'Use %(domainName)s as your primary domain' ), {
-						domainName: purchase.domain,
-					} ),
-			},
-			{
-				getSlug: () => 'removeThemesPluginsData',
-				getTitle: () => __( 'Remove your installed themes, plugins, and their data.' ),
-			},
-			{
-				getSlug: () => 'revertThemesAndSettings',
-				getTitle: () => __( 'Switch to the settings and theme you had before you upgraded.' ),
-			},
-		];
-
-		const defaultChanges = [];
-		if (
-			! isJetpack &&
-			! isAkismet &&
-			! isDomainRegistrationPurchase &&
-			Boolean( atomicTransfer?.created_at )
-		) {
-			defaultChanges.push( ...atomicRevertChanges );
-		}
-
-		// Get features from the API endpoint for this product
-		const cancellationFeatures = getFeaturesFromApiForProduct();
-
-		let showDefaultChanges = false;
-		if ( ! isJetpack && ! isAkismet && ! isGSuite && ! isDomainRegistrationPurchase ) {
-			showDefaultChanges = true;
-		}
-
-		const cancellationChanges = showDefaultChanges ? defaultChanges : [];
-
-		// Check if we should show domain options inline (when they don't need radio buttons)
-		const shouldShowDomainOptionsInline =
-			includedDomainPurchase &&
-			! willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase );
-
-		return (
-			<>
-				{ shouldShowDomainOptionsInline && (
-					<CancelPurchaseDomainOptions
-						includedDomainPurchase={ includedDomainPurchase }
-						cancelBundledDomain={ false }
-						purchase={ purchase }
-						onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
-						isLoading={ false }
-					/>
-				) }
-
-				{ includedDomainPurchase && atomicTransfer?.created_at && ! purchase.is_refundable && (
-					<h2 className="formatted-header__title formatted-header__title--cancellation-flow">
-						{ __( 'What happens when you cancel' ) }
-					</h2>
-				) }
-
-				<BackupRetentionOptionOnCancelPurchase siteId={ purchase.blog_id } purchase={ purchase } />
-
-				{ isGSuite && renderGSuiteAccessMessage() }
-
-				<CancelPurchaseFeatureList
-					purchase={ purchase }
-					cancellationFeatures={ cancellationFeatures }
-					cancellationChanges={ cancellationChanges }
-				/>
-
-				<CancelPurchaseRefundInformation
-					purchase={ purchase }
-					isJetpackPurchase={ isJetpack }
-					selectedDomain={ selectedDomain }
-				/>
-
-				{ renderPlanProductRevertContent() }
-			</>
-		);
-	};
-
-	const renderDomainOptionsContent = () => {
-		const { cancelBundledDomain, confirmCancelBundledDomain } = state;
-
-		if ( ! includedDomainPurchase || ! isNonDomainSubscription( purchase ) ) {
-			return null;
-		}
-
-		const onCancelConfirmationStateChange = ( newState: Partial< CancelPurchaseState > ) => {
-			setState( ( state ) => ( {
-				...state,
-				...newState,
-			} ) );
-		};
-
-		const canContinue = () => {
-			if ( ! cancelBundledDomain ) {
-				return true;
-			}
-			return confirmCancelBundledDomain;
-		};
-
-		return (
-			<>
-				<CancelPurchaseDomainOptions
-					includedDomainPurchase={ includedDomainPurchase }
-					cancelBundledDomain={ cancelBundledDomain ?? false }
-					purchase={ purchase }
-					onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
-					isLoading={ false }
-				/>
-				<ButtonStack>
-					{ renderCancelButton( {
-						disabled: ! canContinue(),
-						onClick: () => {
-							onCancellationComplete();
-						},
-					} ) }
-					{ renderKeepSubscriptionButton() }
-				</ButtonStack>
-			</>
-		);
-	};
-
-	const getTimeRemainingForSubscription = ( purchase: Purchase ) => {
-		const purchaseExpiryDate = new Date( purchase.expiry_date );
-		return intervalToDuration( { start: new Date(), end: purchaseExpiryDate } );
-	};
-
-	const renderTimeRemainingString = ( purchase: Purchase ) => {
-		// returns early if there's no product or accounting for the edge case that the plan expires today (or somehow already expired)
-		// in this case, do not show the time remaining for the plan
-		const timeRemaining = getTimeRemainingForSubscription( purchase );
-		if ( timeRemaining && ( timeRemaining?.days ?? 0 ) <= 1 ) {
-			return null;
-		}
-
-		// if this product/ plan is partner managed, it won't really "expire" from the user's perspective
-		if ( isPartnerPurchase( purchase ) || ! purchase.expiry_date ) {
-			return (
-				<Notice>
-					{ createInterpolateElement(
-						sprintf(
-							/* translators: %(productName)s is the name of the product */
-							__( 'Your <strong> %(productName)s </strong> subscription is still active. <br/>' ),
-							{ productName: purchase.product_name }
-						),
-						{
-							strong: <strong />,
-							br: <br />,
-						}
-					) }
-				</Notice>
-			);
-		}
-
-		// show how much time is left on the plan
-		return (
-			<Notice>
-				{ sprintf(
-					/* translators: 'timeRemaining' is localized string like "2 months" or "1 year". */
-					__( 'Your plan features will be available for another %(timeRemaining)s.' ),
-					{
-						timeRemaining: formatDistanceToNow( new Date( purchase.expiry_date ) ),
-						productName: purchase.product_name,
-					}
-				) }
-			</Notice>
-		);
+	const onCustomerConfirmedUnderstandingChange = ( checked: boolean ) => {
+		setState( ( state ) => ( { ...state, customerConfirmedUnderstanding: checked } ) );
 	};
 
 	if ( isHundredYearDomain ) {
@@ -1599,6 +1145,7 @@ export default function CancelPurchase() {
 
 	let heading;
 
+	const isDomainRegistrationPurchase = purchase && purchase.is_domain_registration;
 	if ( isDomainRegistrationPurchase || isOneTimePurchase( purchase ) ) {
 		/* translators: %(purchaseName)s is the name of the product which was purchased */
 		heading = sprintf( __( 'Manage %(purchaseName)s' ), {
@@ -1624,6 +1171,7 @@ export default function CancelPurchase() {
 		return __( 'Cancel product' );
 	};
 
+	const isAkismet = isAkismetProduct( purchase );
 	const planName = purchase.is_domain_registration ? purchase.meta : purchase.product_name;
 	return (
 		<>
@@ -1640,7 +1188,7 @@ export default function CancelPurchase() {
 				}
 			>
 				<VStack>
-					{ ! state.surveyShown && renderTimeRemainingString( purchase ) }
+					{ ! state.surveyShown && <TimeRemainingNotice purchase={ purchase } /> }
 
 					<Card className="cancel-purchase__wrapper-card">
 						<CancelPurchaseForm
@@ -1701,9 +1249,37 @@ export default function CancelPurchase() {
 								<Heading level={ 4 }>{ heading }</Heading>
 
 								<p className="cancel-purchase__left">
-									{ state.showDomainOptionsStep
-										? renderDomainOptionsContent()
-										: renderMainContent() }
+									{ state.showDomainOptionsStep ? (
+										<DomainOptionsContent
+											purchase={ purchase }
+											includedDomainPurchase={ includedDomainPurchase }
+											atomicTransfer={ atomicTransfer }
+											state={ state }
+											onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
+											onKeepSubscriptionClick={ onKeepSubscriptionClick }
+											onCancellationComplete={ onCancellationComplete }
+										/>
+									) : (
+										<CancellationMainContent
+											purchase={ purchase }
+											includedDomainPurchase={ includedDomainPurchase }
+											atomicTransfer={ atomicTransfer }
+											selectedDomain={ selectedDomain }
+											state={ state }
+											purchaseCancelFeatures={ purchaseCancelFeatures }
+											onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
+											onDomainConfirmationChange={ onDomainConfirmationChange }
+											onCustomerConfirmedUnderstandingChange={
+												onCustomerConfirmedUnderstandingChange
+											}
+											onKeepSubscriptionClick={ onKeepSubscriptionClick }
+											onCancelClick={
+												shouldHandleMarketplaceSubscriptions()
+													? showMarketplaceDialog
+													: onCancellationStart
+											}
+										/>
+									) }
 								</p>
 							</>
 						) }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -96,6 +96,37 @@ const willShowDomainOptionsRadioButtons = (
 	);
 };
 
+const getDowngradePlanForPurchase = (
+	plans: PlanProduct[],
+	purchase: Purchase,
+	upsell: string | undefined
+): PlanProduct | undefined => {
+	if ( ! plans ) {
+		return;
+	}
+	const plan = plans.find( ( plan ) => plan.product_id === purchase.product_id );
+	if ( ! plan ) {
+		return;
+	}
+
+	let downgradePlanInfo;
+	switch ( upsell ) {
+		case 'downgrade-monthly':
+			downgradePlanInfo = plan.downgrade_paths.find( ( path ) => {
+				return path.bill_period !== plan.bill_period;
+			} );
+			break;
+		case 'downgrade-personal':
+			downgradePlanInfo = plan.downgrade_paths.find( ( path ) => {
+				return path.bill_period === plan.bill_period;
+			} );
+			break;
+	}
+	if ( downgradePlanInfo ) {
+		return plans.find( ( plan ) => plan.product_id === downgradePlanInfo.product_id );
+	}
+};
+
 export default function CancelPurchase() {
 	const { createSuccessNotice, removeNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
@@ -266,37 +297,7 @@ export default function CancelPurchase() {
 	let questionOneOrder = [];
 	let questionTwoOrder = [];
 
-	const getDowngradePlanForPurchase = (
-		plans: PlanProduct[],
-		purchase: Purchase
-	): PlanProduct | undefined => {
-		if ( ! plans ) {
-			return;
-		}
-		const plan = plans.find( ( plan ) => plan.product_id === purchase.product_id );
-		if ( ! plan ) {
-			return;
-		}
-
-		let downgradePlanInfo;
-		switch ( state.upsell ) {
-			case 'downgrade-monthly':
-				downgradePlanInfo = plan.downgrade_paths.find( ( path ) => {
-					return path.bill_period !== plan.bill_period;
-				} );
-				break;
-			case 'downgrade-personal':
-				downgradePlanInfo = plan.downgrade_paths.find( ( path ) => {
-					return path.bill_period === plan.bill_period;
-				} );
-				break;
-		}
-		if ( downgradePlanInfo ) {
-			return plans.find( ( plan ) => plan.product_id === downgradePlanInfo.product_id );
-		}
-	};
-
-	const downgradePlan = getDowngradePlanForPurchase( plans, purchase );
+	const downgradePlan = getDowngradePlanForPurchase( plans, purchase, state.upsell );
 
 	const getAllSurveySteps = useCallback( () => {
 		let steps = [ FEEDBACK_STEP ];

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -175,7 +175,7 @@ export default function CancelPurchase() {
 	const productSlug = purchase ? purchase.product_slug : null;
 
 	const navigate = useNavigate();
-	const redirect = useCallback( () => {
+	const redirectBack = useCallback( () => {
 		if (
 			purchase &&
 			( ! purchase.can_disable_auto_renew ||
@@ -1063,7 +1063,7 @@ export default function CancelPurchase() {
 			setStateBasedOnExtendedStatus();
 		}
 		if ( ! isDataValid() ) {
-			redirect();
+			redirectBack();
 			return;
 		}
 		track();
@@ -1074,7 +1074,7 @@ export default function CancelPurchase() {
 		purchase.ID,
 		purchase.bill_period_days,
 		purchase.product_slug,
-		redirect,
+		redirectBack,
 		track,
 		createErrorNotice,
 	] );
@@ -1090,7 +1090,7 @@ export default function CancelPurchase() {
 			return;
 		}
 		if ( ! isDataValid() ) {
-			redirect();
+			redirectBack();
 			return;
 		}
 		if ( state.isLoading && ! isDataLoading ) {
@@ -1103,7 +1103,7 @@ export default function CancelPurchase() {
 		isDataLoading,
 		isDataValid,
 		state.surveyShown,
-		redirect,
+		redirectBack,
 		state.isLoading,
 		createErrorNotice,
 	] );
@@ -1131,7 +1131,7 @@ export default function CancelPurchase() {
 	};
 
 	if ( isHundredYearDomain ) {
-		redirect();
+		redirectBack();
 		return null;
 	}
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -52,6 +52,7 @@ import {
 	isPartnerPurchase,
 	willAtomicSiteRevertAfterPurchaseDeactivation,
 } from '../../../utils/purchase';
+import CancelHeaderTitle from './cancel-header-title';
 import CancelPurchaseForm from './cancel-purchase-form';
 import {
 	cancellationOptionsForPurchase,
@@ -1135,20 +1136,6 @@ export default function CancelPurchase() {
 		return null;
 	}
 
-	const getHeaderTitle = () => {
-		if ( flowType === CANCEL_FLOW_TYPE.REMOVE ) {
-			if ( purchase.is_plan ) {
-				return __( 'Remove plan' );
-			}
-			return __( 'Remove product' );
-		}
-
-		if ( purchase.is_plan ) {
-			return __( 'Cancel plan' );
-		}
-		return __( 'Cancel product' );
-	};
-
 	const isAkismet = isAkismetProduct( purchase );
 	const planName = purchase.is_domain_registration ? purchase.meta : purchase.product_name;
 	return (
@@ -1157,7 +1144,7 @@ export default function CancelPurchase() {
 				size="small"
 				header={
 					<PageHeader
-						title={ getHeaderTitle() }
+						title={ <CancelHeaderTitle flowType={ flowType } purchase={ purchase } /> }
 						prefix={ <Breadcrumbs length={ 4 } /> }
 						description={ __(
 							'Before you go, please answer a few quick questions to help us improve.'

--- a/client/dashboard/me/billing-purchases/cancel-purchase/keep-subscription-button.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/keep-subscription-button.tsx
@@ -1,0 +1,29 @@
+import { useNavigate } from '@tanstack/react-router';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { purchaseSettingsRoute } from '../../../app/router/me';
+import type { Purchase } from '@automattic/api-core';
+
+interface KeepSubscriptionButtonProps {
+	purchase: Purchase;
+	onKeepSubscriptionClick: () => void;
+}
+
+export default function KeepSubscriptionButton( {
+	purchase,
+	onKeepSubscriptionClick,
+}: KeepSubscriptionButtonProps ) {
+	const navigate = useNavigate();
+
+	return (
+		<Button
+			variant="secondary"
+			onClick={ () => {
+				navigate( { to: purchaseSettingsRoute.fullPath, params: { purchaseId: purchase.ID } } );
+				onKeepSubscriptionClick();
+			} }
+		>
+			{ __( 'Keep plan' ) }
+		</Button>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
@@ -4,12 +4,12 @@ import CancellationFullText from './cancellation-full-text';
 import ConfirmCheckbox from './confirm-checkbox';
 import KeepSubscriptionButton from './keep-subscription-button';
 import type { CancelPurchaseState } from './types';
-import type { Purchase, SiteLatestAtomicTransfer } from '@automattic/api-core';
+import type { Purchase, AtomicTransfer } from '@automattic/api-core';
 
 interface PlanProductRevertContentProps {
 	purchase: Purchase;
 	includedDomainPurchase?: Purchase;
-	atomicTransfer?: SiteLatestAtomicTransfer;
+	atomicTransfer?: AtomicTransfer;
 	state: CancelPurchaseState;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
@@ -1,0 +1,67 @@
+import { ButtonStack } from '../../../components/button-stack';
+import CancelButton from './cancel-button';
+import CancellationFullText from './cancellation-full-text';
+import ConfirmCheckbox from './confirm-checkbox';
+import KeepSubscriptionButton from './keep-subscription-button';
+import type { CancelPurchaseState } from './types';
+import type { Purchase, SiteLatestAtomicTransfer } from '@automattic/api-core';
+
+interface PlanProductRevertContentProps {
+	purchase: Purchase;
+	includedDomainPurchase?: Purchase;
+	atomicTransfer?: SiteLatestAtomicTransfer;
+	state: CancelPurchaseState;
+	onDomainConfirmationChange: ( checked: boolean ) => void;
+	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
+	onKeepSubscriptionClick: () => void;
+	onCancelClick?: () => void;
+}
+
+export default function PlanProductRevertContent( {
+	purchase,
+	includedDomainPurchase,
+	atomicTransfer,
+	state,
+	onDomainConfirmationChange,
+	onCustomerConfirmedUnderstandingChange,
+	onKeepSubscriptionClick,
+	onCancelClick,
+}: PlanProductRevertContentProps ) {
+	return (
+		<>
+			{ ! includedDomainPurchase && (
+				<p>
+					<CancellationFullText
+						purchase={ purchase }
+						cancelBundledDomain={ state.cancelBundledDomain ?? false }
+						includedDomainPurchase={ includedDomainPurchase }
+					/>
+				</p>
+			) }
+
+			{ ! state.surveyShown && (
+				<ConfirmCheckbox
+					purchase={ purchase }
+					atomicTransfer={ atomicTransfer }
+					state={ state }
+					onDomainConfirmationChange={ onDomainConfirmationChange }
+					onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+				/>
+			) }
+
+			<ButtonStack>
+				<CancelButton
+					purchase={ purchase }
+					includedDomainPurchase={ includedDomainPurchase }
+					atomicTransfer={ atomicTransfer }
+					state={ state }
+					onClick={ onCancelClick }
+				/>
+				<KeepSubscriptionButton
+					purchase={ purchase }
+					onKeepSubscriptionClick={ onKeepSubscriptionClick }
+				/>
+			</ButtonStack>
+		</>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-amount-string.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-amount-string.tsx
@@ -1,0 +1,34 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { hasAmountAvailableToRefund } from '../../../utils/purchase';
+import type { Purchase } from '@automattic/api-core';
+
+interface RefundAmountStringProps {
+	purchase: Purchase;
+	cancelBundledDomain: boolean;
+	includedDomainPurchase?: Purchase;
+}
+
+export default function RefundAmountString( {
+	purchase,
+	cancelBundledDomain,
+	includedDomainPurchase,
+}: RefundAmountStringProps ): string | null {
+	const {
+		refund_integer: refundInteger,
+		total_refund_integer: totalRefundInteger,
+		total_refund_currency: totalRefundCurrency,
+	} = purchase;
+
+	if ( hasAmountAvailableToRefund( purchase ) ) {
+		if ( cancelBundledDomain && includedDomainPurchase ) {
+			return formatCurrency( totalRefundInteger, totalRefundCurrency, {
+				isSmallestUnit: true,
+			} );
+		}
+		return formatCurrency( refundInteger, totalRefundCurrency, {
+			isSmallestUnit: true,
+		} );
+	}
+
+	return null;
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/time-remaining-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/time-remaining-notice.tsx
@@ -1,0 +1,57 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { formatDistanceToNow, intervalToDuration } from 'date-fns';
+import Notice from '../../../components/notice';
+import { isPartnerPurchase } from '../../../utils/purchase';
+import type { Purchase } from '@automattic/api-core';
+
+interface TimeRemainingNoticeProps {
+	purchase: Purchase;
+}
+
+const getTimeRemainingForSubscription = ( purchase: Purchase ) => {
+	const purchaseExpiryDate = new Date( purchase.expiry_date );
+	return intervalToDuration( { start: new Date(), end: purchaseExpiryDate } );
+};
+
+export default function TimeRemainingNotice( { purchase }: TimeRemainingNoticeProps ) {
+	// returns early if there's no product or accounting for the edge case that the plan expires today (or somehow already expired)
+	// in this case, do not show the time remaining for the plan
+	const timeRemaining = getTimeRemainingForSubscription( purchase );
+	if ( timeRemaining && ( timeRemaining?.days ?? 0 ) <= 1 ) {
+		return null;
+	}
+
+	// if this product/ plan is partner managed, it won't really "expire" from the user's perspective
+	if ( isPartnerPurchase( purchase ) || ! purchase.expiry_date ) {
+		return (
+			<Notice>
+				{ createInterpolateElement(
+					sprintf(
+						/* translators: %(productName)s is the name of the product */
+						__( 'Your <strong> %(productName)s </strong> subscription is still active. <br/>' ),
+						{ productName: purchase.product_name }
+					),
+					{
+						strong: <strong />,
+						br: <br />,
+					}
+				) }
+			</Notice>
+		);
+	}
+
+	// show how much time is left on the plan
+	return (
+		<Notice>
+			{ sprintf(
+				/* translators: 'timeRemaining' is localized string like "2 months" or "1 year". */
+				__( 'Your plan features will be available for another %(timeRemaining)s.' ),
+				{
+					timeRemaining: formatDistanceToNow( new Date( purchase.expiry_date ) ),
+					productName: purchase.product_name,
+				}
+			) }
+		</Notice>
+	);
+}


### PR DESCRIPTION
Fixes SHILL-1383

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1274/hosting-dashboard-cancellation-flow-reduce-complexity-and-repetition

## Proposed Changes

This PR refactors `CancelPurchase` inside the Multi Site Dashboard (MSD) to clean up the rendering and move all the render functions into their own components. This will improve performance of the component but also make it easier to make future refactors as it reduces the size of the file(s).

This should not affect the functionality of the component.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

`CancelPurchase` was migrated from a highly complex class component and it still has a lot of the class component concepts like render functions which are much better suited as components.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit http://calypso.localhost:3000/v2/me/billing/purchases/
- Select a purchase and go through the cancel flow to make sure things continue to work as expected.
