### PR TITLE
MSD: Fix the eligibility of the leave site action

### DIFF
--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -6,8 +6,8 @@ import { lazy, Suspense } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { siteDomainsRoute } from '../../app/router/sites';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
-import { isP2, isSelfHostedJetpackConnected } from '../../utils/site-types';
-import { canManageSite } from '../features';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { canManageSite, canLeaveSite, canRestoreSite } from '../features';
 import type { Site } from '@automattic/api-core';
 import type { Action } from '@wordpress/dataviews';
 
@@ -99,8 +99,7 @@ export function useActions(): Action< Site >[] {
 			isPrimary: true,
 			icon: backup,
 			label: __( 'Restore site' ),
-			isEligible: ( item: Site ) =>
-				item.is_deleted && ! isP2( item ) && ! isSelfHostedJetpackConnected( item ),
+			isEligible: ( item: Site ) => canRestoreSite( item ),
 			RenderModal: ( { items, closeModal } ) => (
 				<Suspense fallback={ null }>
 					<SiteRestoreContentInfo site={ items[ 0 ] } onClose={ closeModal ?? noop } />
@@ -110,7 +109,7 @@ export function useActions(): Action< Site >[] {
 		{
 			id: 'leave',
 			label: __( 'Leave site' ),
-			isEligible: ( item: Site ) => ! item.is_deleted && ! isP2( item ),
+			isEligible: ( item: Site ) => canLeaveSite( item ),
 			RenderModal: ( { items, closeModal } ) => (
 				<Suspense fallback={ null }>
 					<SiteLeaveContentInfo site={ items[ 0 ] } onClose={ closeModal ?? noop } />

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -57,15 +57,24 @@ export function canViewSiteActions( site: Site ) {
 
 export function canTransferSite( site: Site, user: User ) {
 	const isSiteOwner = site.site_owner === user.ID;
-	return ! site.is_wpcom_staging_site && isSiteOwner;
+	return ! site.is_wpcom_staging_site && isSiteOwner && ! isSelfHostedJetpackConnected( site );
 }
 
 export function canLeaveSite( site: Site ) {
-	return ! site.is_wpcom_staging_site;
+	return (
+		! site.is_wpcom_staging_site &&
+		! site.is_deleted &&
+		! isP2( site ) &&
+		! isSelfHostedJetpackConnected( site )
+	);
 }
 
 export function canResetSite( site: Site ) {
 	return ! site.is_wpcom_staging_site;
+}
+
+export function canRestoreSite( site: Site ) {
+	return site.is_deleted && ! isP2( site ) && ! isSelfHostedJetpackConnected( site );
 }
 
 export function canSwitchEnvironment( site: Site ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTSITE-53

## Proposed Changes

* We don't support the transfer ownership or leave site on jetpack connected site. As a result, this PR proposes to disable it

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The owner will be confused when they want to leave the jetpack site as nothing happens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Click `...` on your jetpack connected site
* Ensure you won't see the "Leave site" action

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
