### PR TITLE
SOCIAL-247 Updating E2E Jetpack Social labels

### DIFF
--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -115,13 +115,13 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			}
 		);
 
-		skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )( 'Link Preview', function () {
-			it( 'Open social preview', async function () {
-				await editorPage.expandSection( 'Link Preview' );
-				await editorPage.clickSidebarButton( 'Open Link Preview' );
+		skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )( 'Link preview', function () {
+			it( 'Open link preview', async function () {
+				await editorPage.expandSection( 'Link preview' );
+				await editorPage.clickSidebarButton( 'Open link preview' );
 			} );
 
-			it( 'Show social preview for Tumblr', async function () {
+			it( 'Show link preview for Tumblr', async function () {
 				// Action implemented as "raw" calls for now (2023-09).
 				const editorParent = await editorPage.getEditorParent();
 				const dialog = editorParent.getByRole( 'dialog' );
@@ -138,7 +138,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 					.waitFor();
 			} );
 
-			it( 'Dismiss social preview', async function () {
+			it( 'Dismiss link preview', async function () {
 				await page.keyboard.press( 'Escape' );
 			} );
 		} );

--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -115,7 +115,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				] );
 
 				// Expand the Publicize panel.
-				const section = await editorPage.expandSection( 'Share to Social Media' );
+				const section = await editorPage.expandSection( 'Share to social media' );
 
 				// Verify that the toggle is enabled.
 				const toggle = section.getByLabel( 'Auto-share post' );
@@ -144,7 +144,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await connectionTestPromise;
 
 				// Expand the Publicize panel.
-				let section = await editorPage.expandSection( 'Share to Social Media' );
+				let section = await editorPage.expandSection( 'Share to social media' );
 
 				// Verify that resharing button is not visible on new posts in the share modal
 				let sharePostModalButton = section.getByRole( 'button', {
@@ -178,7 +178,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await connectionTestPromise;
 
 				// Expand the Publicize panel.
-				section = await editorPage.expandSection( 'Share to Social Media' );
+				section = await editorPage.expandSection( 'Share to social media' );
 
 				// Verify whether the auto-share toggle is no longer visible.
 				const toggle = section.getByLabel( 'Auto-share post' );
@@ -234,7 +234,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await editorPage.openSettings( 'Jetpack' );
 
 				// Expand the Publicize panel.
-				let section = await editorPage.expandSection( 'Share to Social Media' );
+				let section = await editorPage.expandSection( 'Share to social media' );
 
 				// Verify that manual sharing is NOT available before publishing.
 				let manualSharing = section.getByRole( 'paragraph', { name: 'Manual sharing' } );
@@ -261,7 +261,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await editorPage.openSettings( 'Jetpack' );
 
 				// Expand the Publicize panel.
-				section = await editorPage.expandSection( 'Share to Social Media' );
+				section = await editorPage.expandSection( 'Share to social media' );
 
 				// Verify whether manual sharing is available in the Jetpack sidebar.
 				manualSharing = section.getByText( 'Manual sharing' );
@@ -275,7 +275,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await editorPage.openSettings( 'Jetpack' );
 
 				// Expand the Publicize panel.
-				const section = await editorPage.expandSection( 'Share to Social Media' );
+				const section = await editorPage.expandSection( 'Share to social media' );
 
 				const toggle = section.getByLabel( 'Enable Social Image' );
 

--- a/test/e2e/specs/jetpack/social__editor-smoke.ts
+++ b/test/e2e/specs/jetpack/social__editor-smoke.ts
@@ -47,7 +47,7 @@ skipDescribeIf( isPrivateSite )(
 			await editorPage.openSettings( 'Jetpack' );
 
 			// Expand the Publicize panel.
-			await editorPage.expandSection( 'Share to Social Media' );
+			await editorPage.expandSection( 'Share to social media' );
 
 			const editorParent = await editorPage.getEditorParent();
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of SOCIAL-247

## Proposed Changes

* Updating E2E labels to match the implementation from https://github.com/Automattic/jetpack/pull/46098

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* to reflect changes made for Jetpack Social

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* check if E2E tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
