### PR TITLE
MSD Plugins: Bulk actions and action fixes

### DIFF
--- a/client/dashboard/plugins/manage/actions/disable-autoupdate.tsx
+++ b/client/dashboard/plugins/manage/actions/disable-autoupdate.tsx
@@ -24,6 +24,7 @@ export const disableAutoupdateAction: Action< PluginListRow > = {
 			/>
 		);
 	},
+	supportsBulk: true,
 	isEligible: ( item: PluginListRow ) => {
 		return ! item.isManaged && [ 'some', 'all' ].includes( item.areAutoUpdatesEnabled );
 	},

--- a/client/dashboard/plugins/manage/actions/enable-autoupdate.tsx
+++ b/client/dashboard/plugins/manage/actions/enable-autoupdate.tsx
@@ -24,6 +24,7 @@ export const enableAutoupdateAction: Action< PluginListRow > = {
 			/>
 		);
 	},
+	supportsBulk: true,
 	isEligible: ( item: PluginListRow ) => {
 		return ! item.isManaged && [ 'some', 'none' ].includes( item.areAutoUpdatesEnabled );
 	},

--- a/client/dashboard/plugins/manage/actions/update.tsx
+++ b/client/dashboard/plugins/manage/actions/update.tsx
@@ -24,6 +24,7 @@ export const updateAction: Action< PluginListRow > = {
 			/>
 		);
 	},
+	supportsBulk: true,
 	isEligible: ( item: PluginListRow ) => {
 		return [ 'some', 'all' ].includes( item.hasUpdate );
 	},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTMSD-861/msd-plugins-bulk-actions

## Proposed Changes

* Implemented bulk actions as agreed on the Linear issue.
* Fixed some cases where the bulk action shouldn't be available for managed plugins.

| Before | After |
|--------|--------|
|<img width="1359" height="1095" alt="Screenshot 2025-11-26 at 10 36 14" src="https://github.com/user-attachments/assets/3408ceb2-2279-4ef6-a6c8-53eae77b7ae4" />|<img width="1372" height="1104" alt="Screenshot 2025-11-26 at 10 35 57" src="https://github.com/user-attachments/assets/034e0df3-818c-441d-9c54-56be78d58c48" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our Multi-Site Dashboard initiative.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live preview link.
* Go to `/v2/plugins` 
* Main Plugins DataView:
    * Verify that Update, Enable Auto-Updates, and Disable Auto-Updates appear as bulk actions when applicable.
* Plugin Details View: 
    * Verify that, in addition to update-related bulk actions, you also see Activate, Deactivate, and Delete as bulk actions when applicable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
