### PR TITLE
MSD: show correct list of available hosting features in activation callout

### DIFF
--- a/client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx
@@ -2,13 +2,17 @@ import { __experimentalText as Text, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Callout } from '../../components/callout';
 import { CalloutOverlay } from '../../components/callout-overlay';
+import HostingFeatureList from '../hosting-feature-list';
 import illustrationUrl from './upsell-illustration.svg';
+import type { Site } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
 export default function ActivationCallout( {
+	site,
 	main,
 	onClick,
 }: {
+	site: Site;
 	main?: ReactNode;
 	onClick: () => void;
 } ) {
@@ -24,23 +28,7 @@ export default function ActivationCallout( {
 						) }
 					</Text>
 
-					<ul style={ { paddingInlineStart: '15px', margin: 0 } }>
-						<Text as="li" variant="muted">
-							{ __( 'Git-based deployments' ) }
-						</Text>
-						<Text as="li" variant="muted">
-							{ __( 'Server monitoring' ) }
-						</Text>
-						<Text as="li" variant="muted">
-							{ __( 'Access and error logs' ) }
-						</Text>
-						<Text as="li" variant="muted">
-							{ __( 'Secure access via SFTP/SSH' ) }
-						</Text>
-						<Text as="li" variant="muted">
-							{ __( 'Advanced server settings' ) }
-						</Text>
-					</ul>
+					<HostingFeatureList site={ site } />
 				</>
 			}
 			actions={

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
@@ -69,7 +69,7 @@ export default function HostingFeatureGatedWithCallout( {
 			} }
 			renderActivationComponent={ ( { onClick } ) => (
 				<>
-					<ActivationCallout main={ overlay } onClick={ onClick } />
+					<ActivationCallout site={ site } main={ overlay } onClick={ onClick } />
 					{ backButton }
 				</>
 			) }

--- a/client/dashboard/sites/hosting-feature-list/index.tsx
+++ b/client/dashboard/sites/hosting-feature-list/index.tsx
@@ -1,0 +1,53 @@
+import { DotcomFeatures, HostingFeatures, Site } from '@automattic/api-core';
+import { __ } from '@wordpress/i18n';
+import { Text } from '../../components/text';
+import { hasPlanFeature } from '../../utils/site-features';
+
+export default function HostingFeatureList( { site }: { site: Site } ) {
+	const features = [
+		hasPlanFeature( site, HostingFeatures.DEPLOYMENT ) && (
+			<Text as="li" variant="muted">
+				{ __( 'Git-based deployments' ) }
+			</Text>
+		),
+		hasPlanFeature( site, HostingFeatures.MONITOR ) && (
+			<Text as="li" variant="muted">
+				{ __( 'Server monitoring' ) }
+			</Text>
+		),
+		hasPlanFeature( site, HostingFeatures.LOGS ) && (
+			<Text as="li" variant="muted">
+				{ __( 'Access and error logs' ) }
+			</Text>
+		),
+		hasPlanFeature( site, HostingFeatures.SSH ) && (
+			<Text as="li" variant="muted">
+				{ __( 'Secure access via SFTP/SSH' ) }
+			</Text>
+		),
+		hasPlanFeature( site, HostingFeatures.SFTP ) && (
+			<Text as="li" variant="muted">
+				{ __( 'Advanced server settings' ) }
+			</Text>
+		),
+		hasPlanFeature( site, HostingFeatures.BACKUPS ) && (
+			<Text as="li" variant="muted">
+				{ __( 'Backup and restore' ) }
+			</Text>
+		),
+		hasPlanFeature( site, HostingFeatures.SCAN ) && (
+			<Text as="li" variant="muted">
+				{ __( 'Security scans' ) }
+			</Text>
+		),
+		hasPlanFeature( site, DotcomFeatures.ATOMIC ) && (
+			<Text as="li" variant="muted">
+				{ __( 'Install plugins and themes' ) }
+			</Text>
+		),
+	]
+		.filter( Boolean )
+		.slice( 0, 5 );
+
+	return <ul style={ { paddingInlineStart: '15px', margin: 0 } }>{ features }</ul>;
+}

--- a/client/dashboard/sites/hosting-feature-list/index.tsx
+++ b/client/dashboard/sites/hosting-feature-list/index.tsx
@@ -5,49 +5,46 @@ import { hasPlanFeature } from '../../utils/site-features';
 
 export default function HostingFeatureList( { site }: { site: Site } ) {
 	const features = [
-		hasPlanFeature( site, HostingFeatures.DEPLOYMENT ) && (
-			<Text as="li" variant="muted">
-				{ __( 'Git-based deployments' ) }
-			</Text>
-		),
-		hasPlanFeature( site, HostingFeatures.MONITOR ) && (
-			<Text as="li" variant="muted">
-				{ __( 'Server monitoring' ) }
-			</Text>
-		),
-		hasPlanFeature( site, HostingFeatures.LOGS ) && (
-			<Text as="li" variant="muted">
-				{ __( 'Access and error logs' ) }
-			</Text>
-		),
-		hasPlanFeature( site, HostingFeatures.SSH ) && (
-			<Text as="li" variant="muted">
-				{ __( 'Secure access via SFTP/SSH' ) }
-			</Text>
-		),
-		hasPlanFeature( site, HostingFeatures.SFTP ) && (
-			<Text as="li" variant="muted">
-				{ __( 'Advanced server settings' ) }
-			</Text>
-		),
-		hasPlanFeature( site, HostingFeatures.BACKUPS ) && (
-			<Text as="li" variant="muted">
-				{ __( 'Backup and restore' ) }
-			</Text>
-		),
-		hasPlanFeature( site, HostingFeatures.SCAN ) && (
-			<Text as="li" variant="muted">
-				{ __( 'Security scans' ) }
-			</Text>
-		),
-		hasPlanFeature( site, DotcomFeatures.ATOMIC ) && (
-			<Text as="li" variant="muted">
-				{ __( 'Install plugins and themes' ) }
-			</Text>
-		),
+		{
+			feature: HostingFeatures.DEPLOYMENT,
+			text: __( 'Git-based deployments' ),
+		},
+		{
+			feature: HostingFeatures.MONITOR,
+			text: __( 'Server monitoring' ),
+		},
+		{
+			feature: HostingFeatures.LOGS,
+			text: __( 'Access and error logs' ),
+		},
+		{
+			feature: HostingFeatures.SSH,
+			text: __( 'Secure access via SFTP/SSH' ),
+		},
+		{
+			feature: HostingFeatures.SFTP,
+			text: __( 'Advanced server settings' ),
+		},
+		{
+			feature: HostingFeatures.BACKUPS,
+			text: __( 'Backup and restore' ),
+		},
+		{
+			feature: HostingFeatures.SCAN,
+			text: __( 'Security scans' ),
+		},
+		{
+			feature: DotcomFeatures.ATOMIC,
+			text: __( 'Install plugins and themes' ),
+		},
 	]
-		.filter( Boolean )
-		.slice( 0, 5 );
+		.filter( ( { feature } ) => hasPlanFeature( site, feature ) )
+		.slice( 0, 5 )
+		.map( ( { text } ) => (
+			<Text as="li" key={ text } variant="muted">
+				{ text }
+			</Text>
+		) );
 
 	return <ul style={ { paddingInlineStart: '15px', margin: 0 } }>{ features }</ul>;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-813

## Proposed Changes

This PR fixes two things that were missed when Personal and Premium sites can go Atomic.

First, it allows SIMPLE Personal and Premium sites to access `/hosting-features/:siteSlug` and see an activation callout instead of upsell. It's required to fix DOTMSD-813.

But it's still not enough, as we show a hardcoded list of hosting features in the activation callout that's available to Business plan, regardless of the actual plan. In this PR, we're replacing them with the actual offered features based on the site plan.

|||
|-|-|
|Personal & Premium<br><br><br><br><img width="596" height="274" alt="image" src="https://github.com/user-attachments/assets/71e3eb55-7341-484a-89ed-d4767bf22aec" />|Personal & Premium<br>with<br><code>summer-special-logs-monitoring-performance-on-personal-and-premium</code><br>sticker<img width="594" height="310" alt="image" src="https://github.com/user-attachments/assets/c65c295a-19d1-40f3-8a6c-e51c874c6a5b" />|
|Business and above<br><br><img width="593" height="312" alt="image" src="https://github.com/user-attachments/assets/f0207744-d15f-47e6-b606-c3a266e1882e" />||

## Testing Instructions

1. With a Free site:
    - Go to `/hosting-features/:siteSlug`; verify you see a generic upsell callout. (UNCHANGED)
2. With a SIMPLE Personal/Premium site:
    - Go to `/hosting-features/:siteSlug`; verify you see an activation callout with the correct features.
    - Go to `/v2/sites/:siteSlug/backups`; verify you see the same activation callout.
3. With a SIMPLE Personal/Premium site with <code>summer-special-logs-monitoring-performance-on-personal-and-premium</code> sticker:
    - Go to `/hosting-features/:siteSlug`; verify you see an activation callout with the correct features.
    - Go to `/v2/sites/:siteSlug/backups`; verify you see the same activation callout.
4. With a SIMPLE Business site:
    - Go to `/hosting-features/:siteSlug`; verify you see an activation callout with the correct features.
    - Go to `/v2/sites/:siteSlug/backups`; verify you see the same activation callout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
