### PR TITLE
Tmp/hc odie derived state poc

### DIFF
--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -55,8 +55,8 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		mostRecentSupportInteractionId || null
 	);
 
-	// Early return if user is already talking to a human
-	if ( chat.provider !== 'odie' ) {
+	// Early return if user is already talking to a human or transferring to Zendesk
+	if ( chat.provider !== 'odie' || chat.status === 'transfer' ) {
 		return null;
 	}
 
@@ -102,7 +102,9 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 					} );
 				} else if ( canConnectToZendesk || contextCanConnectToZendesk ) {
 					buttons.push( {
-						text: __( 'No thanks, let’s keep it here', __i18n_text_domain__ ),
+						text: ! supportInteraction
+							? __( 'Get support', __i18n_text_domain__ )
+							: __( 'No thanks, let’s keep it here', __i18n_text_domain__ ),
 						action: async () => {
 							onClickAdditionalEvent?.( 'chat' );
 							if ( isChatLoaded ) {

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -102,9 +102,9 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 					} );
 				} else if ( canConnectToZendesk || contextCanConnectToZendesk ) {
 					buttons.push( {
-						text: ! supportInteraction
-							? __( 'Get support', __i18n_text_domain__ )
-							: __( 'No thanks, let’s keep it here', __i18n_text_domain__ ),
+						text: supportInteraction
+							? __( 'No thanks, let’s keep it here', __i18n_text_domain__ )
+							: __( 'Get support', __i18n_text_domain__ ),
 						action: async () => {
 							onClickAdditionalEvent?.( 'chat' );
 							if ( isChatLoaded ) {

--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -3,7 +3,7 @@ import cx from 'clsx';
 import { Fragment } from 'react';
 import ChatMessage from '..';
 import { useOdieAssistantContext } from '../../../context';
-import { isCSATMessage } from '../../../utils';
+import { isCSATMessage, isOdieMessage } from '../../../utils';
 import {
 	hasFeedbackForm,
 	isAttachment,
@@ -44,24 +44,15 @@ function getPresentedRole( message: Message ) {
  */
 function sortMessagesByTimestamp( messages: Message[] ) {
 	return messages.sort( ( a, b ) => {
-		// Give precedence to the local timestamp, if it exists.
-		// It's more accurate than the server timestamp because it's independent of connection status.
+		// Within same type, sort by timestamp (local_timestamp preferred over received)
 		const aTimestamp = a.metadata?.local_timestamp || a.received;
 		const bTimestamp = b.metadata?.local_timestamp || b.received;
 
-		// If messages don't have a timestamp, keep them in the order they were received.
-		// This is the case for Odie messages.
 		if ( ! aTimestamp || ! bTimestamp ) {
 			return 0;
 		}
 
-		if ( aTimestamp > bTimestamp ) {
-			return 1;
-		}
-		if ( aTimestamp < bTimestamp ) {
-			return -1;
-		}
-		return 0;
+		return aTimestamp - bTimestamp;
 	} );
 }
 

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -13,6 +13,7 @@ import {
 	getIsRequestingHumanSupport,
 	getIsLastBotMessage,
 } from '../../utils';
+import getMostRecentOpenLiveInteraction from '../notices/get-most-recent-open-live-interaction';
 import BotMessageActions from './bot-message-actions';
 import CustomALink from './custom-a-link';
 import { GetSupport } from './get-support';
@@ -21,6 +22,7 @@ import Sources from './sources';
 import type { Message } from '../../types';
 
 const getDisplayMessage = (
+	userHasRecentOpenConversation: boolean,
 	isUserEligibleForPaidSupport: boolean,
 	canConnectToZendesk: boolean,
 	forceEmailSupport?: boolean,
@@ -40,7 +42,7 @@ const getDisplayMessage = (
 	}
 
 	const forwardMessage = isUserEligibleForPaidSupport
-		? getOdieForwardToZendeskMessage()
+		? getOdieForwardToZendeskMessage( userHasRecentOpenConversation )
 		: getOdieForwardToForumsMessage();
 
 	return isErrorMessage ? getOdieErrorMessage() : forwardMessage;
@@ -65,12 +67,14 @@ export const UserMessage = ( {
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 	const isRequestingHumanSupport = getIsRequestingHumanSupport( message );
 	const isLastBotMessage = getIsLastBotMessage( chat, message );
+	const hasRecentOpenConversation = getMostRecentOpenLiveInteraction();
 
 	const isMessageShowingDisclaimer =
 		message.context?.question_tags?.inquiry_type !== 'request-for-human-support';
 
 	const messageContent = isRequestingHumanSupport
 		? getDisplayMessage(
+				!! hasRecentOpenConversation,
 				isUserEligibleForPaidSupport,
 				canConnectToZendesk,
 				forceEmailSupport,

--- a/packages/odie-client/src/components/notices/get-most-recent-open-live-interaction.tsx
+++ b/packages/odie-client/src/components/notices/get-most-recent-open-live-interaction.tsx
@@ -2,7 +2,7 @@ import Smooch from 'smooch';
 import { ZendeskConversation } from '../../types';
 
 const AGE_THRESHOLD = 1000 * 60 * 60 * 24 * 3; // 3 days
-
+// const AGE_THRESHOLD = 1; // 3 days
 /**
  * Queries the Smooch SDK and gets the latest open conversation. Try to call as late as possible and don't cache the result.
  * @returns The support interaction ID of the latest open conversation.

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -25,7 +25,8 @@ const getTextAreaPlaceholder = (
 export const OdieSendMessageButton = () => {
 	const divContainerRef = useRef< HTMLDivElement >( null );
 	const textareaRef = useRef< HTMLTextAreaElement >( null );
-	const { trackEvent, chat, canConnectToZendesk, forceEmailSupport } = useOdieAssistantContext();
+	const { trackEvent, chat, canConnectToZendesk, forceEmailSupport, isChatLoaded } =
+		useOdieAssistantContext();
 	const cantTransferToZendesk =
 		( chat.messages?.[ chat.messages.length - 1 ]?.context?.flags?.forward_to_human_support &&
 			! canConnectToZendesk ) ??
@@ -44,14 +45,14 @@ export const OdieSendMessageButton = () => {
 	}, [ textareaRef ] );
 
 	useEffect( () => {
-		if ( isLiveChat ) {
+		if ( isLiveChat && isChatLoaded ) {
 			if ( inputValue.length > 0 ) {
 				Smooch?.startTyping?.();
 			} else {
 				Smooch?.stopTyping?.();
 			}
 		}
-	}, [ inputValue, isLiveChat ] );
+	}, [ inputValue, isLiveChat, isChatLoaded ] );
 
 	const {
 		attachmentPreviews,

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -37,11 +37,16 @@ export const getOdieForwardToForumsMessage = (): string =>
 		__i18n_text_domain__
 	);
 
-export const getOdieForwardToZendeskMessage = (): string =>
-	__(
-		'We noticed you have an ongoing conversation. Would you like to continue it?',
-		__i18n_text_domain__
-	);
+export const getOdieForwardToZendeskMessage = ( userHasRecentOpenConversation: boolean ): string =>
+	! userHasRecentOpenConversation
+		? __(
+				'Would you like to continue your conversation with a support agent?',
+				__i18n_text_domain__
+		  )
+		: __(
+				'We noticed you have an ongoing conversation. Would you like to continue it?',
+				__i18n_text_domain__
+		  );
 
 export function getFlowFromBotSlug( botSlug?: OdieAllBotSlugs ): string {
 	if ( botSlug === 'ciab-workflow-support_chat' ) {

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -38,13 +38,13 @@ export const getOdieForwardToForumsMessage = (): string =>
 	);
 
 export const getOdieForwardToZendeskMessage = ( userHasRecentOpenConversation: boolean ): string =>
-	! userHasRecentOpenConversation
+	userHasRecentOpenConversation
 		? __(
-				'Would you like to continue your conversation with a support agent?',
+				'We noticed you have an ongoing conversation. Would you like to continue it?',
 				__i18n_text_domain__
 		  )
 		: __(
-				'We noticed you have an ongoing conversation. Would you like to continue it?',
+				'Would you like to continue your conversation with a support agent?',
 				__i18n_text_domain__
 		  );
 

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -5,7 +5,8 @@ import { createContext, useCallback, useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ODIE_NEW_INTERACTIONS_BOT_SLUG } from '../constants';
 import { useOdieBroadcastWithCallbacks } from '../data';
-import { useGetCombinedChat } from '../hooks';
+// Use v2 hooks for testing - can easily switch back to old implementation
+import { useGetCombinedChat } from '../hooks/v2';
 import { isOdieAllowedBot, getIsRequestingHumanSupport } from '../utils';
 import type {
 	Chat,
@@ -31,6 +32,7 @@ export const emptyChat: Chat = {
 // Create a default new context
 export const OdieAssistantContext = createContext< OdieAssistantContextInterface >( {
 	addMessage: noop,
+	updateMessage: noop,
 	botName: 'Wapuu',
 	newInteractionsBotSlug: ODIE_NEW_INTERACTIONS_BOT_SLUG,
 	chat: emptyChat,
@@ -104,11 +106,21 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	/**
 	 * The main chat thread.
 	 * This is where we manage the state of the chat.
+	 * Using v2 hooks with derived state pattern.
 	 */
-	const { mainChatState, setMainChatState } = useGetCombinedChat(
+	const {
+		mainChatState,
+		setMainChatState,
+		statusFlags,
+		messages: messagesStore,
+	} = useGetCombinedChat(
 		isUserEligibleForPaidSupport && canConnectToZendesk,
 		isLoadingCanConnectToZendesk
 	);
+
+	// Note: The sending flag is automatically cleared when the derived state
+	// changes from 'sending' to 'loaded'. The flag should be cleared by the
+	// code that sets it (e.g., in onSettled callbacks), not by watching status.
 
 	/**
 	 * Has the user ever escalated to get human support?
@@ -134,25 +146,74 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 
 	const clearChat = useCallback( () => {
 		trackEvent( 'chat_cleared', {} );
-		navigate( '/odie' );
-	}, [ trackEvent, navigate ] );
+		// Clear status flags
+		statusFlags.setSending( false );
+		statusFlags.setTransferring( false );
+		// Navigate to /odie without the id parameter to reset the interaction
+		navigate( '/odie', { replace: true } );
+	}, [ trackEvent, navigate, statusFlags ] );
 
 	/**
 	 * Add a new message to the chat.
+	 * With v2 hooks, we can use the messages store directly for better performance.
 	 */
-	const addMessage = ( message: Message | Message[] ) => {
-		setMainChatState( ( prevChat ) => ( {
-			...prevChat,
-			messages: [ ...prevChat.messages, ...( Array.isArray( message ) ? message : [ message ] ) ],
-		} ) );
-	};
+	const addMessage = useCallback(
+		( message: Message | Message[] ) => {
+			// Use setMainChatState for backward compatibility
+			// The v2 hook's setMainChatState will handle updating the message store
+			setMainChatState( ( prevChat ) => ( {
+				...prevChat,
+				messages: [ ...prevChat.messages, ...( Array.isArray( message ) ? message : [ message ] ) ],
+			} ) );
+		},
+		[ setMainChatState ]
+	);
+
+	/**
+	 * Update an existing message in the chat (e.g., when a temporary message is confirmed as received).
+	 * Matches by temporary_id, message_id, or internal_message_id.
+	 */
+	const updateMessage = useCallback(
+		(
+			updatedMessage: Message,
+			matchBy: 'temporary_id' | 'message_id' | 'internal_message_id' = 'temporary_id'
+		) => {
+			// Use the messages store directly for better performance
+			messagesStore.updateMessage( updatedMessage, matchBy );
+		},
+		[ messagesStore ]
+	);
 
 	/**
 	 * Set the status of the chat.
+	 * With v2 hooks, status is derived from flags, so we update the flags instead.
+	 * This maintains backward compatibility with the old API.
 	 */
-	const setChatStatus = ( status: ChatStatus ) => {
-		setMainChatState( ( prevChat ) => ( { ...prevChat, status } ) );
-	};
+	const setChatStatus = useCallback(
+		( status: ChatStatus ) => {
+			// Map status to status flags
+			switch ( status ) {
+				case 'sending':
+					statusFlags.setSending( true );
+					break;
+				case 'transfer':
+					statusFlags.setTransferring( true );
+					break;
+				case 'loaded':
+					// Clear both flags when going back to loaded
+					statusFlags.setSending( false );
+					statusFlags.setTransferring( false );
+					break;
+				case 'loading':
+				case 'closed':
+				case 'dislike':
+					// These are derived from other sources (API loading, interaction status, etc.)
+					// We can't directly set them, but the derived state will handle them
+					break;
+			}
+		},
+		[ statusFlags ]
+	);
 
 	/**
 	 * Set the liked status of a message.
@@ -186,6 +247,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 		<OdieAssistantContext.Provider
 			value={ {
 				addMessage,
+				updateMessage,
 				botName,
 				newInteractionsBotSlug: dynamicNewInteractionsBotSlug,
 				chat: mainChatState,

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -296,7 +296,6 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 			}
 		},
 		onSettled: () => {
-			setChatStatus( 'loaded' );
 			queryClient.invalidateQueries( {
 				queryKey: [ 'odie-chat', currentSupportInteraction?.bot_slug, odieId ],
 			} );

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -99,6 +99,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 		forceEmailSupport,
 		trackEvent,
 		newInteractionsBotSlug,
+		addMessage: addMessageToChat,
 	} = useOdieAssistantContext();
 
 	const updateInteractionContext = useCallback(
@@ -134,29 +135,14 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 		if ( ! Array.isArray( message ) ) {
 			if ( getIsRequestingHumanSupport( message ) ) {
 				if ( forceEmailSupport ) {
-					setChat( ( prevChat ) => ( {
-						...prevChat,
-						...props,
-						messages: [ ...prevChat.messages, getOdieEmailFallbackMessage() ],
-						status: 'loaded',
-					} ) );
+					addMessageToChat( getOdieEmailFallbackMessage() );
 					broadcastOdieMessage( message, odieBroadcastClientId );
 					return;
 				} else if ( warnAboutExistingConversation && ! hasBeenWarnedAboutExistingConversation ) {
-					setChat( ( prevChat ) => ( {
-						...prevChat,
-						...props,
-						messages: [ ...prevChat.messages, getExistingConversationMessage() ],
-						status: 'loaded',
-					} ) );
+					addMessageToChat( getExistingConversationMessage() );
 					broadcastOdieMessage( message, odieBroadcastClientId );
 					return;
 				} else if ( ! chat.conversationId && canConnectToZendesk && isUserEligibleForPaidSupport ) {
-					setChat( ( prevChat ) => ( {
-						...prevChat,
-						...props,
-					} ) );
-
 					// Trigger the `newConversation` mutation to be run inside `useEffect`, so the latest `chat` state is used.
 					setShouldCreateConversation( {
 						trigger: true,
@@ -178,12 +164,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 			}
 		}
 
-		setChat( ( prevChat ) => ( {
-			...prevChat,
-			...props,
-			messages: [ ...prevChat.messages, ...( Array.isArray( message ) ? message : [ message ] ) ],
-			status: 'loaded',
-		} ) );
+		addMessageToChat( message );
 	};
 
 	return useMutation< ReturnedChat, Error, Message >( {
@@ -283,6 +264,9 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 				simulateTyping: returnedChat.messages[ 0 ].simulateTyping,
 				type: 'message',
 				context: returnedChat.messages[ 0 ].context,
+				metadata: {
+					local_timestamp: Date.now() / 1000,
+				},
 			};
 			setExperimentVariationName( returnedChat.experiment_name );
 			addMessage( {
@@ -296,6 +280,8 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 			}
 		},
 		onSettled: () => {
+			// Clear sending status after message is sent (success or error)
+			setChatStatus( 'loaded' );
 			queryClient.invalidateQueries( {
 				queryKey: [ 'odie-chat', currentSupportInteraction?.bot_slug, odieId ],
 			} );

--- a/packages/odie-client/src/hooks/use-auto-scroll.ts
+++ b/packages/odie-client/src/hooks/use-auto-scroll.ts
@@ -16,8 +16,10 @@ export const useAutoScroll = (
 			return;
 		}
 
+		console.log( 'chat', chat );
+		console.log( 'chat.status', chat.status );
 		const messageCount = chat.messages.length;
-		if ( messageCount < 1 || [ 'loading', 'sending' ].includes( chat.status ) ) {
+		if ( messageCount < 1 || [ 'loading' ].includes( chat.status ) ) {
 			return;
 		}
 
@@ -44,7 +46,7 @@ export const useAutoScroll = (
 					lastMessage = messages?.length ? messages[ messages.length - 2 ] : null;
 				}
 
-				lastMessage?.scrollIntoView( { behavior: 'instant', block: 'start', inline: 'nearest' } );
+				lastMessage?.scrollIntoView( { behavior: 'instant', block: 'end', inline: 'nearest' } );
 				setIsScrolling( false );
 			} );
 		}, debounceTimeoutRef.current ) as unknown as number;

--- a/packages/odie-client/src/hooks/use-send-zendesk-message.ts
+++ b/packages/odie-client/src/hooks/use-send-zendesk-message.ts
@@ -2,9 +2,9 @@ import { useMutation } from '@tanstack/react-query';
 import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../context';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
-import { getConversationIdFromInteraction } from '../utils';
+import { getConversationIdFromInteraction, zendeskMessageConverter } from '../utils';
 import { useCreateZendeskConversation } from './use-create-zendesk-conversation';
-import type { Message } from '../types';
+import type { Message, ZendeskMessage } from '../types';
 
 /**
  * Send a message to the Zendesk conversation once.
@@ -38,22 +38,23 @@ export const useSendZendeskMessage = ( signal: AbortSignal ) => {
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 	const currentConversationId = getConversationIdFromInteraction( currentSupportInteraction );
 
-	const { chat, setChat } = useOdieAssistantContext();
+	const { chat, setChat, updateMessage } = useOdieAssistantContext();
 	const createZendeskConversation = useCreateZendeskConversation();
 
 	// < void, Error, { message: Message; signal: AbortSignal } >
 	let conversationId = currentConversationId || chat.conversationId;
-	return useMutation( {
+
+	return useMutation< ZendeskMessage, Error, Message >( {
 		mutationKey: [ 'send-zendesk-messages' ],
-		mutationFn: async ( message: Message ): Promise< Message > => {
+		mutationFn: async ( message: Message ): Promise< ZendeskMessage > => {
 			if ( ! conversationId ) {
 				// Start a new conversation if it doesn't exist
 				// TODO: this can create excess tickets. We should track down the real issue.
 				conversationId = await createZendeskConversation( { createdFrom: 'send_zendesk_message' } );
-				setChat( {
-					...chat,
+				setChat( ( prevChat ) => ( {
+					...prevChat,
 					conversationId,
-				} );
+				} ) );
 			}
 
 			const messageToSend = {
@@ -64,17 +65,17 @@ export const useSendZendeskMessage = ( signal: AbortSignal ) => {
 			};
 
 			Smooch.sendMessage( messageToSend, conversationId );
-			return new Promise< Message >( ( resolve, reject ) => {
+			return new Promise< ZendeskMessage >( ( resolve, reject ) => {
 				// If the message is not sent within 5 seconds, reject the promise.
 				// This allows Tanstack Query to retry the request if the user comes back online.
 				const timeout = setTimeout( () => {
 					reject( new Error( 'Message not sent' ) );
 				}, 5000 );
-				function onMessageSent( message: Message ) {
-					if ( message.metadata?.temporary_id === messageToSend.metadata?.temporary_id ) {
+				function onMessageSent( zendeskMessage: ZendeskMessage ) {
+					if ( zendeskMessage.metadata?.temporary_id === messageToSend.metadata?.temporary_id ) {
 						// @ts-expect-error -- 'off' is not part of the def.
 						Smooch.off( 'message:sent', onMessageSent );
-						resolve( message );
+						resolve( zendeskMessage );
 						clearTimeout( timeout );
 					}
 				}
@@ -84,16 +85,12 @@ export const useSendZendeskMessage = ( signal: AbortSignal ) => {
 				Smooch.on( 'message:sent', onMessageSent as any );
 			} );
 		},
-		onSuccess: ( data: Message ) => {
-			// Update the chat with the message that was sent
-			setChat( ( chat ) => ( {
-				...chat,
-				messages: chat.messages.map( ( message ) =>
-					message.metadata?.temporary_id === data.metadata?.temporary_id
-						? { ...data, ...message }
-						: message
-				),
-			} ) );
+		onSuccess: ( data: ZendeskMessage ) => {
+			// Convert Zendesk message to our Message format
+			const convertedMessage = zendeskMessageConverter( data );
+			// Update the existing message (matching by temporary_id) with the received version
+			// This will update the message to show it in brighter color (received status)
+			updateMessage( convertedMessage, 'temporary_id' );
 		},
 		retry: true,
 	} );

--- a/packages/odie-client/src/hooks/v2/index.ts
+++ b/packages/odie-client/src/hooks/v2/index.ts
@@ -1,0 +1,18 @@
+/**
+ * V2 Hooks - Refactored implementation using derived state pattern
+ *
+ * This folder contains the refactored version of use-get-combined-chat
+ * and related hooks. These are separate from the existing implementation
+ * to allow for testing and gradual migration.
+ *
+ * To use these hooks, import from this folder:
+ * import { useGetCombinedChat } from './hooks/v2';
+ */
+
+export { useChatMessages } from './use-chat-messages';
+export { useChatStatusFlags } from './use-chat-status-flags';
+export { useChatDerivedState } from './use-chat-derived-state';
+export { useInteractionSync } from './use-interaction-sync';
+export { useOdieChatSync } from './use-odie-chat-sync';
+export { useZendeskChatSync } from './use-zendesk-chat-sync';
+export { useGetCombinedChat } from './use-get-combined-chat';

--- a/packages/odie-client/src/hooks/v2/use-chat-derived-state.ts
+++ b/packages/odie-client/src/hooks/v2/use-chat-derived-state.ts
@@ -1,0 +1,103 @@
+import { useMemo } from 'react';
+import type { ChatStatus, SupportProvider } from '../../types';
+
+interface UseChatDerivedStateParams {
+	// Source data
+	conversationId: string | null;
+	odieId: number | null;
+	wpcomUserId: number | null;
+
+	// Loading flags
+	isOdieLoading: boolean;
+	isZendeskLoading: boolean;
+	isRefreshingAfterReconnect: boolean;
+
+	// Status flags
+	isSending: boolean;
+	isTransferring: boolean;
+
+	// Interaction data
+	interactionStatus?: 'open' | 'closed' | 'resolved' | 'solved';
+
+	// Connection status
+	connectionStatus?: 'connected' | 'disconnected' | 'reconnecting';
+}
+
+interface ChatDerivedState {
+	provider: SupportProvider;
+	status: ChatStatus;
+	odieId: number | null;
+	conversationId: string | null;
+	wpcomUserId: number | null;
+}
+
+/**
+ * Derives chat state from source data.
+ * No state is stored - everything is computed.
+ */
+export const useChatDerivedState = ( params: UseChatDerivedStateParams ): ChatDerivedState => {
+	const {
+		conversationId,
+		odieId,
+		wpcomUserId,
+		isOdieLoading,
+		isZendeskLoading,
+		isRefreshingAfterReconnect,
+		isSending,
+		isTransferring,
+		interactionStatus,
+	} = params;
+
+	console.log( 'params', params );
+	// Derive provider from conversationId
+	const provider = useMemo< SupportProvider >( () => {
+		return conversationId ? 'zendesk' : 'odie';
+	}, [ conversationId ] );
+
+	// Derive status from loading/sending flags
+	// Priority order matters here
+	const status = useMemo< ChatStatus >( () => {
+		// 1. Check if transferring (highest priority)
+		if ( isTransferring ) {
+			return 'transfer';
+		}
+
+		// 2. Check if sending message
+		if ( isSending ) {
+			return 'sending';
+		}
+
+		// 3. Check if loading data
+		if (
+			isOdieLoading ||
+			isZendeskLoading ||
+			// isUploadingUnsentMessages ||
+			isRefreshingAfterReconnect
+		) {
+			return 'loading';
+		}
+
+		// 4. Check if interaction is closed
+		if ( interactionStatus === 'closed' ) {
+			return 'closed';
+		}
+
+		// 5. Default to loaded
+		return 'loaded';
+	}, [
+		isTransferring,
+		isSending,
+		isOdieLoading,
+		isZendeskLoading,
+		isRefreshingAfterReconnect,
+		interactionStatus,
+	] );
+
+	return {
+		provider,
+		status,
+		odieId,
+		conversationId,
+		wpcomUserId,
+	};
+};

--- a/packages/odie-client/src/hooks/v2/use-chat-messages.ts
+++ b/packages/odie-client/src/hooks/v2/use-chat-messages.ts
@@ -1,0 +1,129 @@
+import { useState, useCallback } from 'react';
+import { getMessageUniqueIdentifier } from '../../components/message/utils/get-message-unique-identifier';
+import type { Message } from '../../types';
+
+/**
+ * Single source of truth for all chat messages.
+ * Handles message CRUD operations and queries.
+ * Note: Deduplication should be handled by callers before passing messages.
+ */
+export const useChatMessages = ( initialMessages: Message[] = [] ) => {
+	const [ messages, setMessages ] = useState< Message[] >( initialMessages );
+
+	// Add single message
+	const addMessage = useCallback( ( message: Message ) => {
+		setMessages( ( prev ) => [ ...prev, message ] );
+	}, [] );
+
+	// Add multiple messages
+	const addMessages = useCallback( ( newMessages: Message[] ) => {
+		setMessages( ( prev ) => [ ...prev, ...newMessages ] );
+	}, [] );
+
+	// Replace all messages (for initialization)
+	const replaceMessages = useCallback( ( newMessages: Message[] ) => {
+		setMessages( newMessages );
+	}, [] );
+
+	// Clear all messages
+	const clearMessages = useCallback( () => {
+		setMessages( [] );
+	}, [] );
+
+	// Remove message by ID
+	const removeMessage = useCallback( ( messageId: string ) => {
+		setMessages( ( prev ) =>
+			prev.filter( ( msg ) => getMessageUniqueIdentifier( msg ) !== messageId )
+		);
+	}, [] );
+
+	// Update an existing message by matching identifier (e.g., temporary_id)
+	const updateMessage = useCallback(
+		(
+			updatedMessage: Message,
+			matchBy: 'temporary_id' | 'message_id' | 'internal_message_id' = 'temporary_id'
+		) => {
+			setMessages( ( prev ) => {
+				const matchValue =
+					matchBy === 'temporary_id'
+						? updatedMessage.metadata?.temporary_id
+						: matchBy === 'message_id'
+						? updatedMessage.message_id
+						: updatedMessage.internal_message_id;
+
+				if ( ! matchValue ) {
+					console.warn( 'updateMessage: No match value found, adding as new message', {
+						matchBy,
+						updatedMessage,
+					} );
+					return [ ...prev, updatedMessage ];
+				}
+
+				const index = prev.findIndex( ( msg ) => {
+					if ( matchBy === 'temporary_id' ) {
+						return msg.metadata?.temporary_id === matchValue;
+					}
+					if ( matchBy === 'message_id' ) {
+						return msg.message_id === matchValue;
+					}
+					return msg.internal_message_id === matchValue;
+				} );
+
+				if ( index === -1 ) {
+					console.warn( 'updateMessage: Message not found, adding as new message', {
+						matchBy,
+						matchValue,
+					} );
+					return [ ...prev, updatedMessage ];
+				}
+
+				// Replace the message at the found index
+				const updated = [ ...prev ];
+				updated[ index ] = updatedMessage;
+				return updated;
+			} );
+		},
+		[]
+	);
+
+	// Query helpers
+	const getMessagesByRole = useCallback(
+		( role: string ) => {
+			return messages.filter( ( msg ) => msg.role === role );
+		},
+		[ messages ]
+	);
+
+	// Get messages by source (odie, zendesk, or local)
+	const getMessagesBySource = useCallback(
+		( source: 'odie' | 'zendesk' | 'local' ) => {
+			return messages.filter( ( msg ) => {
+				if ( source === 'local' ) {
+					return ! msg.message_id && ! msg.received;
+				}
+				if ( source === 'zendesk' ) {
+					return !! ( msg.received || msg.metadata?.temporary_id );
+				}
+				if ( source === 'odie' ) {
+					// Odie messages have both message_id and context object
+					return !! ( msg.message_id && msg.context );
+				}
+				return false;
+			} );
+		},
+		[ messages ]
+	);
+
+	return {
+		messages,
+		addMessage,
+		addMessages,
+		replaceMessages,
+		clearMessages,
+		removeMessage,
+		updateMessage,
+		getMessagesByRole,
+		getMessagesBySource,
+		setMessages, // Direct access for complex operations
+	};
+};

--- a/packages/odie-client/src/hooks/v2/use-chat-status-flags.ts
+++ b/packages/odie-client/src/hooks/v2/use-chat-status-flags.ts
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * Manages temporary status flags (sending, transferring).
+ * These are local UI states, not derived from API data.
+ */
+export const useChatStatusFlags = () => {
+	const [ isSending, setIsSending ] = useState( false );
+	const [ isTransferring, setIsTransferring ] = useState( false );
+
+	const setSending = useCallback( ( sending: boolean ) => {
+		setIsSending( sending );
+	}, [] );
+
+	const setTransferring = useCallback( ( transferring: boolean ) => {
+		setIsTransferring( transferring );
+	}, [] );
+
+	return {
+		isSending,
+		isTransferring,
+		setSending,
+		setTransferring,
+	};
+};

--- a/packages/odie-client/src/hooks/v2/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/v2/use-get-combined-chat.ts
@@ -1,0 +1,108 @@
+import { useMemo, useCallback, useEffect } from 'react';
+import { useSelect } from '@wordpress/data';
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { useCurrentSupportInteraction } from '../../data/use-current-support-interaction';
+import { getConversationIdFromInteraction, getOdieIdFromInteraction } from '../../utils';
+import { useChatMessages } from './use-chat-messages';
+import { useChatDerivedState } from './use-chat-derived-state';
+import { useChatStatusFlags } from './use-chat-status-flags';
+import { useOdieChatSync } from './use-odie-chat-sync';
+import { useZendeskChatSync } from './use-zendesk-chat-sync';
+import { useInteractionSync } from './use-interaction-sync';
+import { getMessageUniqueIdentifier } from '../../components/message/utils/get-message-unique-identifier';
+import type { Chat, OdieAllBotSlugs } from '../../types';
+import type { HelpCenterSelect } from '@automattic/data-stores';
+import { ODIE_DEFAULT_BOT_SLUG_LEGACY } from '../../constants';
+
+/**
+ * Main hook that combines all chat functionality.
+ * Uses derived state pattern - state is computed from source data.
+ *
+ * This is the refactored version using the derived state approach.
+ * Located in v2/ folder to avoid interfering with existing implementation.
+ */
+export const useGetCombinedChat = (
+	canConnectToZendesk: boolean,
+	isLoadingCanConnectToZendesk: boolean
+) => {
+	// Get current interaction
+	const { data: currentInteraction } = useCurrentSupportInteraction();
+	const odieId = getOdieIdFromInteraction( currentInteraction );
+	const conversationId = getConversationIdFromInteraction( currentInteraction ) ?? null;
+
+	// Get connection status from store
+	const { isChatLoaded, connectionStatus } = useSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return {
+			isChatLoaded: store.getIsChatLoaded(),
+			connectionStatus: store.getZendeskConnectionStatus(),
+		};
+	}, [] );
+
+	// Initialize message store
+	const messages = useChatMessages();
+
+	// Status flags for temporary UI states
+	const statusFlags = useChatStatusFlags();
+
+	// Sync data from providers
+	const odieSync = useOdieChatSync( odieId ? Number( odieId ) : null, conversationId, messages );
+	const zendeskSync = useZendeskChatSync(
+		conversationId,
+		odieId ? Number( odieId ) : null,
+		canConnectToZendesk,
+		isChatLoaded,
+		( currentInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG_LEGACY ) as OdieAllBotSlugs,
+		messages,
+		odieSync.odieChat // Pass odieChat to zendesk sync so it can get Odie messages
+	);
+
+	// Sync interaction changes
+	const interactionSync = useInteractionSync( currentInteraction, messages );
+
+	// Derive state from source data
+	const derivedState = useChatDerivedState( {
+		conversationId,
+		odieId: odieSync.odieId,
+		wpcomUserId: odieSync.wpcomUserId,
+		isOdieLoading: odieSync.isFetching,
+		isZendeskLoading: zendeskSync.isFetching,
+		isRefreshingAfterReconnect: connectionStatus === 'reconnecting',
+		isSending: statusFlags.isSending,
+		isTransferring: statusFlags.isTransferring,
+		interactionStatus: currentInteraction?.status ?? undefined,
+		connectionStatus: connectionStatus ?? undefined,
+	} );
+
+	// Combine into Chat format (for backward compatibility)
+	const mainChatState = useMemo< Chat >( () => {
+		const state = {
+			provider: derivedState.provider,
+			status: derivedState.status,
+			odieId: derivedState.odieId,
+			conversationId: derivedState.conversationId,
+			wpcomUserId: derivedState.wpcomUserId,
+			messages: messages.messages,
+			supportInteractionId: interactionSync.interactionId,
+		};
+
+		return state;
+	}, [ derivedState, messages.messages, interactionSync.interactionId ] );
+
+	// setMainChatState wrapper (for backward compatibility)
+	const setMainChatState = useCallback(
+		( updater: Chat | ( ( prev: Chat ) => Chat ) ) => {
+			const newState = typeof updater === 'function' ? updater( mainChatState ) : updater;
+
+			messages.replaceMessages( newState.messages );
+		},
+		[ mainChatState, messages ]
+	);
+
+	return {
+		mainChatState,
+		setMainChatState,
+		statusFlags,
+		messages,
+	};
+};

--- a/packages/odie-client/src/hooks/v2/use-interaction-sync.ts
+++ b/packages/odie-client/src/hooks/v2/use-interaction-sync.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from 'react';
+import type { SupportInteraction } from '../../types';
+
+interface UseChatMessagesReturn {
+	clearMessages: () => void;
+}
+
+/**
+ * Detects interaction changes and triggers resets.
+ */
+export const useInteractionSync = (
+	currentInteraction: SupportInteraction | undefined,
+	messages: UseChatMessagesReturn
+) => {
+	const previousIdRef = useRef< string | undefined >();
+	const [ hasChanged, setHasChanged ] = useState( false );
+
+	useEffect( () => {
+		const currentId = currentInteraction?.uuid;
+		const previousId = previousIdRef.current;
+
+		// Detect change
+		if ( currentId !== previousId ) {
+			setHasChanged( true );
+
+			// If interaction cleared (new chat), clear messages
+			if ( ! currentId ) {
+				messages.clearMessages();
+			}
+
+			previousIdRef.current = currentId;
+		} else {
+			setHasChanged( false );
+		}
+		// Only depend on the interaction ID and the clearMessages function, not the entire messages object
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ currentInteraction?.uuid, messages.clearMessages ] );
+
+	return {
+		interactionId: currentInteraction?.uuid ?? null,
+		hasChanged,
+	};
+};

--- a/packages/odie-client/src/hooks/v2/use-odie-chat-sync.ts
+++ b/packages/odie-client/src/hooks/v2/use-odie-chat-sync.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+import { useOdieChat } from '../../data/use-odie-chat';
+import { getIsRequestingHumanSupport } from '../../utils';
+
+interface UseChatMessagesReturn {
+	messages: import('../../types').Message[];
+	replaceMessages: ( messages: import('../../types').Message[] ) => void;
+}
+
+/**
+ * Syncs Odie chat data to message store.
+ * Handles Odie-specific message filtering and loading states.
+ */
+export const useOdieChatSync = (
+	odieId: number | null,
+	conversationId: string | null,
+	messages: UseChatMessagesReturn
+) => {
+	const { data: odieChat, isFetching, error } = useOdieChat( Number( odieId ) );
+	// Use ref to store latest messages to avoid dependency issues
+	const messagesRef = useRef( messages.messages );
+	messagesRef.current = messages.messages;
+
+	// Sync messages when Odie chat data changes
+	useEffect( () => {
+		if ( ! odieChat || isFetching ) {
+			return;
+		}
+
+		// If we have a conversationId, we're in Zendesk mode
+		// Don't sync Odie messages here - let zendesk sync handle the merge
+		// This prevents overwriting transfer messages and Zendesk messages
+		if ( conversationId ) {
+			return;
+		}
+
+		// Filter out "requesting human support" messages
+		// (these are handled separately during escalation)
+		const filteredMessages = odieChat.messages
+			.filter( ( msg ) => ! getIsRequestingHumanSupport( msg ) )
+			.map( ( msg ) => ( {
+				...msg,
+				metadata: {
+					...msg.metadata,
+					// Ensure all Odie messages have local_timestamp for proper sorting
+					local_timestamp: msg.metadata?.local_timestamp || Date.now() / 1000,
+				},
+			} ) );
+
+		// Pure Odie chat - replace messages
+		messages.replaceMessages( filteredMessages );
+		// Only sync when source data changes, not when messages change
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ odieChat, isFetching, conversationId, messages.replaceMessages ] );
+
+	return {
+		odieChat,
+		isFetching,
+		error,
+		odieId: odieChat?.odieId ?? null,
+		wpcomUserId: odieChat?.wpcomUserId ?? null,
+	};
+};

--- a/packages/odie-client/src/hooks/v2/use-zendesk-chat-sync.ts
+++ b/packages/odie-client/src/hooks/v2/use-zendesk-chat-sync.ts
@@ -1,0 +1,139 @@
+import { useEffect, useState, useRef } from 'react';
+import { useGetZendeskConversation } from '../../data/use-get-zendesk-conversation';
+import { getOdieTransferMessage } from '../../constants';
+import { deduplicateZDMessages } from '../use-get-combined-chat';
+import { getIsRequestingHumanSupport } from '../../utils';
+import Smooch from 'smooch';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import type { OdieAllBotSlugs, Message } from '../../types';
+
+interface UseChatMessagesReturn {
+	messages: Message[];
+	replaceMessages: ( messages: Message[] ) => void;
+}
+
+/**
+ * Syncs Zendesk conversation data to message store.
+ * Handles connection recovery, message deduplication, and Zendesk-specific logic.
+ */
+export const useZendeskChatSync = (
+	conversationId: string | null,
+	odieId: number | null,
+	canConnect: boolean,
+	isChatLoaded: boolean,
+	botSlug: OdieAllBotSlugs,
+	messages: UseChatMessagesReturn,
+	odieChat: any // Pass odieChat directly to get Odie messages
+) => {
+	const getZendeskConversation = useGetZendeskConversation();
+	const [ conversation, setConversation ] = useState< any >( null );
+	const [ isFetching, setIsFetching ] = useState( !! conversationId );
+	const [ error, setError ] = useState< Error | null >( null );
+	// Use ref to store latest messages to avoid dependency issues
+	const messagesRef = useRef( messages.messages );
+	messagesRef.current = messages.messages;
+
+	// Fetch and sync Zendesk conversation
+	useEffect( () => {
+		if ( ! conversationId || ! canConnect || ! isChatLoaded ) {
+			return;
+		}
+
+		setError( null );
+
+		getZendeskConversation( {
+			chatId: odieId,
+			conversationId: conversationId.toString(),
+		} )
+			?.then( ( conv ) => {
+				if ( ! conv ) {
+					throw new Error( 'Conversation not found' );
+				}
+
+				setConversation( conv );
+				setError( null );
+
+				// Load conversation in Smooch (for typing events)
+				// Only call if Smooch is initialized (isChatLoaded should ensure this, but add safety check)
+				try {
+					Smooch.loadConversation( conv.id );
+				} catch ( error ) {
+					console.warn( 'Failed to load conversation in Smooch:', error );
+					// Continue even if this fails - it's not critical
+				}
+
+				// Check if this is the same conversation (for connection recovery)
+				// Look for Zendesk messages (have received timestamp) with matching conversationId
+				const isSameConversation = messagesRef.current.some(
+					( msg ) =>
+						msg.received &&
+						messagesRef.current.some( ( m ) => m.metadata?.conversationId === conv.id )
+				);
+
+				// Get existing Odie messages from odieChat (source of truth from API)
+				// Filter out "requesting human support" messages as they're handled separately
+				const existingOdieMessages =
+					odieChat?.messages?.filter( ( msg: Message ) => ! getIsRequestingHumanSupport( msg ) ) ||
+					[];
+				// During connection recovery, preserve user messages that might be queued
+				const existingUserMessages = isSameConversation
+					? messagesRef.current.filter( ( msg ) => msg.role === 'user' && msg.received )
+					: [];
+
+				// Add transfer message if it doesn't already exist
+				// IMPORTANT: Ensure transfer messages have unique identifiers
+				const transferMessage = getOdieTransferMessage( botSlug ).map( ( msg ) => ( {
+					...msg,
+					// Ensure transfer message has a unique identifier
+					internal_message_id: msg.internal_message_id || crypto.randomUUID(),
+					metadata: {
+						...msg.metadata,
+						local_timestamp: msg.metadata?.local_timestamp || Date.now() / 1000,
+					},
+				} ) );
+
+				// Combine: Odie messages + Transfer message(s) + User messages (if same conversation) + Zendesk messages
+				// IMPORTANT: Include all Zendesk messages from conv.messages (they should include automatic messages)
+				const allMessages = [
+					...existingOdieMessages,
+					// ...existingTransferMessages, // Preserve existing transfer messages
+					...transferMessage, // Add new transfer message if needed
+					...deduplicateZDMessages( [
+						...existingUserMessages,
+						...( conv.messages || [] ), // Include all Zendesk messages (including automatic ones)
+					] ),
+				];
+
+				messages.replaceMessages( allMessages );
+			} )
+			.catch( ( err ) => {
+				const error = err instanceof Error ? err : new Error( String( err ) );
+				setError( error );
+				recordTracksEvent( 'calypso_odie_zendesk_conversation_not_found', {
+					conversation_id: conversationId,
+					odie_id: odieId,
+					error: error.message,
+				} );
+			} )
+			.finally( () => {
+				setIsFetching( false );
+			} );
+		// Only sync when source data changes, not when messages change
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [
+		conversationId,
+		canConnect,
+		isChatLoaded,
+		odieId,
+		getZendeskConversation,
+		botSlug,
+		messages.replaceMessages,
+		odieChat,
+	] );
+
+	return {
+		conversation,
+		isFetching,
+		error,
+	};
+};

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -6,6 +6,10 @@ export type OdieAssistantContextInterface = {
 	canConnectToZendesk: boolean;
 	isLoadingCanConnectToZendesk: boolean;
 	addMessage: ( message: Message | Message[] ) => void;
+	updateMessage: (
+		updatedMessage: Message,
+		matchBy?: 'temporary_id' | 'message_id' | 'internal_message_id'
+	) => void;
 	botName?: string;
 	newInteractionsBotSlug: string;
 	chat: Chat;
@@ -24,7 +28,7 @@ export type OdieAssistantContextInterface = {
 	isChatRestricted: boolean;
 	setExperimentVariationName: ( variationName: string | null | undefined ) => void;
 	setMessageLikedStatus: ( message: Message, liked: boolean ) => void;
-	setChat: ( chat: Chat | SetStateAction< Chat > ) => void;
+	setChat: ( chat: SetStateAction< Chat > ) => void;
 	setChatStatus: ( status: ChatStatus ) => void;
 	trackEvent: ( event: string, properties?: Record< string, unknown > ) => void;
 	version?: string | null;

--- a/packages/odie-client/src/utils/index.ts
+++ b/packages/odie-client/src/utils/index.ts
@@ -15,6 +15,14 @@ export const getIsRequestingHumanSupport = ( message: Message ) => {
 	return message.context?.flags?.forward_to_human_support ?? false;
 };
 
+/**
+ * Check if a message is from Odie.
+ * Odie messages have both message_id (number) and context object.
+ */
+export const isOdieMessage = ( message: Message ): boolean => {
+	return !! ( message.message_id && message.context );
+};
+
 export const getIsLastBotMessage = ( chat: Chat, message: Message ) => {
 	return (
 		chat?.messages?.length > 0 &&


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
