### PR TITLE
Stats: Fix date navigation arrows for sites using GMT offset

### DIFF
--- a/client/my-sites/stats/hooks/test/use-moment-site-zone.test.ts
+++ b/client/my-sites/stats/hooks/test/use-moment-site-zone.test.ts
@@ -659,3 +659,62 @@ describe( 'useMomentInSite', () => {
 		expect( secondResult ).not.toBe( firstResult );
 	} );
 } );
+
+describe( 'GMT offset date comparison logic', () => {
+	const mockState = {};
+	const siteId = 123;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( i18n.getLocaleSlug as jest.Mock ).mockReturnValue( 'en' );
+		( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+		( getSiteOption as jest.Mock ).mockReturnValue( null );
+	} );
+
+	it( 'should correctly compare dates with isSameOrAfter using GMT offset', () => {
+		( getSiteGmtOffset as jest.Mock ).mockReturnValue( -8 );
+
+		const momentFn = getMomentSiteZone( mockState, siteId );
+		const today = momentFn( '2024-11-27' );
+		const yesterday = momentFn( '2024-11-26' );
+
+		expect( today.isSameOrAfter( yesterday, 'day' ) ).toBe( true );
+		expect( yesterday.isSameOrAfter( today, 'day' ) ).toBe( false );
+	} );
+
+	it( 'should handle midnight edge case correctly', () => {
+		( getSiteGmtOffset as jest.Mock ).mockReturnValue( -8 );
+
+		const momentFn = getMomentSiteZone( mockState, siteId );
+		const lastMinute = momentFn( '2024-11-27 23:59:59' );
+		const nextDay = momentFn( '2024-11-28 00:00:00' );
+
+		expect( lastMinute.isSame( nextDay, 'day' ) ).toBe( false );
+		expect( lastMinute.isBefore( nextDay ) ).toBe( true );
+	} );
+
+	it( 'should produce consistent results between current time and string parsing', () => {
+		( getSiteGmtOffset as jest.Mock ).mockReturnValue( -5 );
+
+		const momentFn = getMomentSiteZone( mockState, siteId );
+		const now = momentFn();
+		const parsed = momentFn( now.format( 'YYYY-MM-DD HH:mm:ss' ) );
+
+		// Both should have the same offset
+		expect( now.utcOffset() ).toBe( parsed.utcOffset() );
+		expect( parsed.utcOffset() ).toBe( -300 );
+
+		// Format-reparse should maintain the same date
+		expect( parsed.isSame( now, 'second' ) ).toBe( true );
+	} );
+
+	it( 'should handle fractional GMT offset correctly', () => {
+		( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 ); // IST
+
+		const momentFn = getMomentSiteZone( mockState, siteId );
+		const date = momentFn( '2024-11-27 00:00:00' );
+
+		expect( date.utcOffset() ).toBe( 330 ); // 5.5 hours in minutes
+		expect( date.format( 'Z' ) ).toBe( '+05:30' );
+	} );
+} );

--- a/client/my-sites/stats/hooks/test/use-moment-site-zone.test.ts
+++ b/client/my-sites/stats/hooks/test/use-moment-site-zone.test.ts
@@ -1,0 +1,474 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import i18n from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getMomentSiteZone, useMomentInSite } from '../use-moment-site-zone';
+
+// Mock dependencies
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/selectors/get-site-gmt-offset' );
+jest.mock( 'calypso/state/selectors/get-site-timezone-value' );
+jest.mock( 'calypso/state/sites/selectors' );
+jest.mock( 'calypso/state/ui/selectors' );
+jest.mock( 'i18n-calypso', () => {
+	const translate = jest.fn( ( text ) => text );
+	const getLocaleSlug = jest.fn( () => 'en' );
+	const localize = jest.fn( ( component ) => component );
+
+	return {
+		__esModule: true,
+		default: {
+			getLocaleSlug,
+			translate,
+			localize,
+		},
+		getLocaleSlug,
+		localize,
+		translate,
+	};
+} );
+
+describe( 'getMomentSiteZone', () => {
+	const mockState = {};
+	const siteId = 123;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( i18n.getLocaleSlug as jest.Mock ).mockReturnValue( 'en' );
+	} );
+
+	describe( 'with IANA timezone string', () => {
+		it( 'should create moment with timezone when valid timezone string exists', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-01-15' );
+
+			expect( result.tz() ).toBe( 'America/New_York' );
+			expect( result.locale() ).toBe( 'en' );
+		} );
+
+		it( 'should create current moment when no date input is provided', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Europe/London' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn();
+
+			expect( result.tz() ).toBe( 'Europe/London' );
+			expect( result.locale() ).toBe( 'en' );
+		} );
+
+		it( 'should respect locale when creating moment with timezone', () => {
+			( i18n.getLocaleSlug as jest.Mock ).mockReturnValue( 'es' );
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/Los_Angeles' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-06-20' );
+
+			expect( result.locale() ).toBe( 'es' );
+		} );
+
+		it( 'should fall back to getSiteOption for timezone_string when getSiteTimezoneValue returns null', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockImplementation( ( state, id, option ) => {
+				if ( option === 'timezone_string' ) {
+					return 'Asia/Tokyo';
+				}
+				return null;
+			} );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-08-10' );
+
+			expect( result.tz() ).toBe( 'Asia/Tokyo' );
+		} );
+
+		it( 'should not use invalid timezone string', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Invalid/Timezone' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-03-15' );
+
+			// Should fall back to gmtOffset since timezone string is invalid
+			expect( result.utcOffset() ).toBe( 300 ); // 5 hours in minutes
+		} );
+
+		it( 'should not use empty timezone string', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( '' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( -8 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-03-15' );
+
+			// Should fall back to gmtOffset
+			expect( result.utcOffset() ).toBe( -480 ); // -8 hours in minutes
+		} );
+	} );
+
+	describe( 'with DST timezones', () => {
+		it( 'should handle America/New_York during standard time (winter)', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			// January 15, 2024 is during standard time (EST = UTC-5)
+			const result = momentFn( '2024-01-15' );
+
+			expect( result.tz() ).toBe( 'America/New_York' );
+			expect( result.utcOffset() ).toBe( -300 ); // -5 hours in minutes (EST)
+		} );
+
+		it( 'should handle America/New_York during daylight saving time (summer)', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			// July 15, 2024 is during daylight saving time (EDT = UTC-4)
+			const result = momentFn( '2024-07-15' );
+
+			expect( result.tz() ).toBe( 'America/New_York' );
+			expect( result.utcOffset() ).toBe( -240 ); // -4 hours in minutes (EDT)
+		} );
+
+		it( 'should handle Europe/London during standard time (winter)', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Europe/London' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			// January 15, 2024 is during standard time (GMT = UTC+0)
+			const result = momentFn( '2024-01-15' );
+
+			expect( result.tz() ).toBe( 'Europe/London' );
+			// Check that offset is numerically zero (handles -0 vs 0)
+			expect( result.utcOffset() === 0 ).toBe( true ); // GMT
+		} );
+
+		it( 'should handle Europe/London during daylight saving time (summer)', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Europe/London' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			// July 15, 2024 is during daylight saving time (BST = UTC+1)
+			const result = momentFn( '2024-07-15' );
+
+			expect( result.tz() ).toBe( 'Europe/London' );
+			expect( result.utcOffset() ).toBe( 60 ); // +1 hour in minutes (BST)
+		} );
+
+		it( 'should handle Australia/Sydney during standard time (winter)', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Australia/Sydney' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			// July 15, 2024 is during standard time in Australia (AEST = UTC+10)
+			const result = momentFn( '2024-07-15' );
+
+			expect( result.tz() ).toBe( 'Australia/Sydney' );
+			expect( result.utcOffset() ).toBe( 600 ); // +10 hours in minutes (AEST)
+		} );
+
+		it( 'should handle Australia/Sydney during daylight saving time (summer)', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Australia/Sydney' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			// January 15, 2024 is during daylight saving time in Australia (AEDT = UTC+11)
+			const result = momentFn( '2024-01-15' );
+
+			expect( result.tz() ).toBe( 'Australia/Sydney' );
+			expect( result.utcOffset() ).toBe( 660 ); // +11 hours in minutes (AEDT)
+		} );
+
+		it( 'should correctly handle DST transition day - spring forward', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			// March 10, 2024 is when DST starts in US (spring forward)
+			const result = momentFn( '2024-03-10T12:00:00' );
+
+			expect( result.tz() ).toBe( 'America/New_York' );
+			// At noon on the transition day, should be in EDT
+			expect( result.utcOffset() ).toBe( -240 ); // -4 hours in minutes (EDT)
+		} );
+
+		it( 'should correctly handle DST transition day - fall back', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			// November 3, 2024 is when DST ends in US (fall back)
+			const result = momentFn( '2024-11-03T12:00:00' );
+
+			expect( result.tz() ).toBe( 'America/New_York' );
+			// At noon on the transition day, should be in EST
+			expect( result.utcOffset() ).toBe( -300 ); // -5 hours in minutes (EST)
+		} );
+	} );
+
+	describe( 'with GMT offset', () => {
+		it( 'should use GMT offset when timezone string is not available', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( -5 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-02-20' );
+
+			expect( result.utcOffset() ).toBe( -300 ); // -5 hours in minutes
+		} );
+
+		it( 'should handle string date input with GMT offset', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 3.5 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-07-01' );
+
+			expect( result.utcOffset() ).toBe( 210 ); // 3.5 hours in minutes
+			expect( result.format( 'YYYY-MM-DD' ) ).toBe( '2024-07-01' );
+		} );
+
+		it( 'should handle non-string date input with GMT offset', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 2 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const dateObj = new Date( '2024-09-15T10:30:00Z' );
+			const result = momentFn( dateObj );
+
+			expect( result.utcOffset() ).toBe( 120 ); // 2 hours in minutes
+		} );
+
+		it( 'should create current moment with GMT offset when no date input', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 1 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn();
+
+			expect( result.utcOffset() ).toBe( 60 ); // 1 hour in minutes
+		} );
+
+		it( 'should fall back to getSiteOption for gmt_offset when getSiteGmtOffset returns null', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockImplementation( ( state, id, option ) => {
+				if ( option === 'gmt_offset' ) {
+					return 8;
+				}
+				return null;
+			} );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-11-05' );
+
+			expect( result.utcOffset() ).toBe( 480 ); // 8 hours in minutes
+		} );
+
+		it( 'should handle zero GMT offset', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 0 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-12-01' );
+
+			// Check that offset is numerically zero (handles -0 vs 0)
+			expect( result.utcOffset() === 0 ).toBe( true );
+		} );
+
+		it( 'should handle negative GMT offset', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( -7 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-04-10' );
+
+			expect( result.utcOffset() ).toBe( -420 ); // -7 hours in minutes
+		} );
+	} );
+
+	describe( 'with custom date format', () => {
+		it( 'should use custom date format when provided', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5 );
+
+			const customFormat = 'MM/DD/YYYY';
+			const momentFn = getMomentSiteZone( mockState, siteId, customFormat );
+			const result = momentFn();
+
+			// The custom format should be used for parseZone when creating the current moment
+			expect( result ).toBeDefined();
+		} );
+
+		it( 'should default to DATE_FORMAT when not provided', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn();
+
+			expect( result ).toBeDefined();
+		} );
+	} );
+
+	describe( 'browser fallback', () => {
+		it( 'should fall back to browser timezone when no timezone info available', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn( '2024-05-12' );
+
+			expect( result.locale() ).toBe( 'en' );
+			// Should use browser's local timezone
+			expect( result.isValid() ).toBe( true );
+		} );
+
+		it( 'should handle undefined date input with browser fallback', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const result = momentFn();
+
+			expect( result.isValid() ).toBe( true );
+			expect( result.locale() ).toBe( 'en' );
+		} );
+	} );
+
+	describe( 'memoization', () => {
+		it( 'should return the same function when dependencies do not change', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+			( i18n.getLocaleSlug as jest.Mock ).mockReturnValue( 'en' );
+
+			const firstFn = getMomentSiteZone( mockState, siteId );
+			const secondFn = getMomentSiteZone( mockState, siteId );
+
+			expect( firstFn ).toBe( secondFn );
+		} );
+	} );
+} );
+
+describe( 'useMomentInSite', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( useSelector as jest.Mock ).mockImplementation( ( selector ) => selector( {}, null ) );
+	} );
+
+	it( 'should use provided siteId when given', () => {
+		const siteId = 456;
+		( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/Chicago' );
+		( getSiteOption as jest.Mock ).mockReturnValue( null );
+		( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+		const { result } = renderHook( () => useMomentInSite( siteId ) );
+
+		const momentFn = result.current;
+		const moment = momentFn( '2024-01-01' );
+
+		expect( moment.tz() ).toBe( 'America/Chicago' );
+	} );
+
+	it( 'should use selected site ID when no siteId provided', () => {
+		const selectedSiteId = 789;
+		( getSelectedSiteId as jest.Mock ).mockReturnValue( selectedSiteId );
+		( useSelector as jest.Mock ).mockImplementation( ( selector ) => {
+			if ( selector === getSelectedSiteId ) {
+				return selectedSiteId;
+			}
+			return selector( {}, selectedSiteId );
+		} );
+		( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Europe/Paris' );
+		( getSiteOption as jest.Mock ).mockReturnValue( null );
+		( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+		const { result } = renderHook( () => useMomentInSite() );
+
+		const momentFn = result.current;
+		const moment = momentFn( '2024-06-15' );
+
+		expect( moment.tz() ).toBe( 'Europe/Paris' );
+	} );
+
+	it( 'should handle null siteId', () => {
+		( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+		( getSiteOption as jest.Mock ).mockReturnValue( null );
+		( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5 );
+
+		const { result } = renderHook( () => useMomentInSite( null ) );
+
+		const momentFn = result.current;
+		expect( momentFn ).toBeDefined();
+	} );
+
+	it( 'should return memoized function when dependencies do not change', () => {
+		const siteId = 123;
+		( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+		( getSiteOption as jest.Mock ).mockReturnValue( null );
+		( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+		const { result, rerender } = renderHook( () => useMomentInSite( siteId ) );
+		const firstResult = result.current;
+
+		rerender();
+		const secondResult = result.current;
+
+		expect( secondResult ).toBe( firstResult );
+	} );
+
+	it( 'should return different function when siteId changes', () => {
+		( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+		( getSiteOption as jest.Mock ).mockReturnValue( null );
+		( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+		const { result, rerender } = renderHook( ( props ) => useMomentInSite( props ), {
+			initialProps: 123,
+		} );
+		const firstResult = result.current;
+
+		rerender( 456 );
+		const secondResult = result.current;
+
+		expect( secondResult ).not.toBe( firstResult );
+	} );
+} );

--- a/client/my-sites/stats/hooks/test/use-moment-site-zone.test.ts
+++ b/client/my-sites/stats/hooks/test/use-moment-site-zone.test.ts
@@ -60,44 +60,17 @@ describe( 'getMomentSiteZone', () => {
 			expect( result.locale() ).toBe( 'en' );
 		} );
 
-		it( 'should create current moment when no date input is provided', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Europe/London' );
+		it( 'should handle DST correctly', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
 			( getSiteOption as jest.Mock ).mockReturnValue( null );
 			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
 
 			const momentFn = getMomentSiteZone( mockState, siteId );
-			const result = momentFn();
+			const winter = momentFn( '2024-01-15' ); // EST = UTC-5
+			const summer = momentFn( '2024-07-15' ); // EDT = UTC-4
 
-			expect( result.tz() ).toBe( 'Europe/London' );
-			expect( result.locale() ).toBe( 'en' );
-		} );
-
-		it( 'should respect locale when creating moment with timezone', () => {
-			( i18n.getLocaleSlug as jest.Mock ).mockReturnValue( 'es' );
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/Los_Angeles' );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			const result = momentFn( '2024-06-20' );
-
-			expect( result.locale() ).toBe( 'es' );
-		} );
-
-		it( 'should fall back to getSiteOption for timezone_string when getSiteTimezoneValue returns null', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-			( getSiteOption as jest.Mock ).mockImplementation( ( state, id, option ) => {
-				if ( option === 'timezone_string' ) {
-					return 'Asia/Tokyo';
-				}
-				return null;
-			} );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			const result = momentFn( '2024-08-10' );
-
-			expect( result.tz() ).toBe( 'Asia/Tokyo' );
+			expect( winter.utcOffset() ).toBe( -300 );
+			expect( summer.utcOffset() ).toBe( -240 );
 		} );
 
 		it( 'should not use invalid timezone string', () => {
@@ -109,128 +82,7 @@ describe( 'getMomentSiteZone', () => {
 			const result = momentFn( '2024-03-15' );
 
 			// Should fall back to gmtOffset since timezone string is invalid
-			expect( result.utcOffset() ).toBe( 300 ); // 5 hours in minutes
-		} );
-
-		it( 'should not use empty timezone string', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( '' );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( -8 );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			const result = momentFn( '2024-03-15' );
-
-			// Should fall back to gmtOffset
-			expect( result.utcOffset() ).toBe( -480 ); // -8 hours in minutes
-		} );
-	} );
-
-	describe( 'with DST timezones', () => {
-		it( 'should handle America/New_York during standard time (winter)', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			// January 15, 2024 is during standard time (EST = UTC-5)
-			const result = momentFn( '2024-01-15' );
-
-			expect( result.tz() ).toBe( 'America/New_York' );
-			expect( result.utcOffset() ).toBe( -300 ); // -5 hours in minutes (EST)
-		} );
-
-		it( 'should handle America/New_York during daylight saving time (summer)', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			// July 15, 2024 is during daylight saving time (EDT = UTC-4)
-			const result = momentFn( '2024-07-15' );
-
-			expect( result.tz() ).toBe( 'America/New_York' );
-			expect( result.utcOffset() ).toBe( -240 ); // -4 hours in minutes (EDT)
-		} );
-
-		it( 'should handle Europe/London during standard time (winter)', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Europe/London' );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			// January 15, 2024 is during standard time (GMT = UTC+0)
-			const result = momentFn( '2024-01-15' );
-
-			expect( result.tz() ).toBe( 'Europe/London' );
-			// Check that offset is numerically zero (handles -0 vs 0)
-			expect( result.utcOffset() === 0 ).toBe( true ); // GMT
-		} );
-
-		it( 'should handle Europe/London during daylight saving time (summer)', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Europe/London' );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			// July 15, 2024 is during daylight saving time (BST = UTC+1)
-			const result = momentFn( '2024-07-15' );
-
-			expect( result.tz() ).toBe( 'Europe/London' );
-			expect( result.utcOffset() ).toBe( 60 ); // +1 hour in minutes (BST)
-		} );
-
-		it( 'should handle Australia/Sydney during standard time (winter)', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Australia/Sydney' );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			// July 15, 2024 is during standard time in Australia (AEST = UTC+10)
-			const result = momentFn( '2024-07-15' );
-
-			expect( result.tz() ).toBe( 'Australia/Sydney' );
-			expect( result.utcOffset() ).toBe( 600 ); // +10 hours in minutes (AEST)
-		} );
-
-		it( 'should handle Australia/Sydney during daylight saving time (summer)', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'Australia/Sydney' );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			// January 15, 2024 is during daylight saving time in Australia (AEDT = UTC+11)
-			const result = momentFn( '2024-01-15' );
-
-			expect( result.tz() ).toBe( 'Australia/Sydney' );
-			expect( result.utcOffset() ).toBe( 660 ); // +11 hours in minutes (AEDT)
-		} );
-
-		it( 'should correctly handle DST transition day - spring forward', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			// March 10, 2024 is when DST starts in US (spring forward)
-			const result = momentFn( '2024-03-10T12:00:00' );
-
-			expect( result.tz() ).toBe( 'America/New_York' );
-			// At noon on the transition day, should be in EDT
-			expect( result.utcOffset() ).toBe( -240 ); // -4 hours in minutes (EDT)
-		} );
-
-		it( 'should correctly handle DST transition day - fall back', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			// November 3, 2024 is when DST ends in US (fall back)
-			const result = momentFn( '2024-11-03T12:00:00' );
-
-			expect( result.tz() ).toBe( 'America/New_York' );
-			// At noon on the transition day, should be in EST
-			expect( result.utcOffset() ).toBe( -300 ); // -5 hours in minutes (EST)
+			expect( result.utcOffset() ).toBe( 300 );
 		} );
 	} );
 
@@ -243,10 +95,10 @@ describe( 'getMomentSiteZone', () => {
 			const momentFn = getMomentSiteZone( mockState, siteId );
 			const result = momentFn( '2024-02-20' );
 
-			expect( result.utcOffset() ).toBe( -300 ); // -5 hours in minutes
+			expect( result.utcOffset() ).toBe( -300 );
 		} );
 
-		it( 'should handle string date input with GMT offset', () => {
+		it( 'should handle naive string date input with GMT offset', () => {
 			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
 			( getSiteOption as jest.Mock ).mockReturnValue( null );
 			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 3.5 );
@@ -254,36 +106,21 @@ describe( 'getMomentSiteZone', () => {
 			const momentFn = getMomentSiteZone( mockState, siteId );
 			const result = momentFn( '2024-07-01' );
 
-			expect( result.utcOffset() ).toBe( 210 ); // 3.5 hours in minutes
+			expect( result.utcOffset() ).toBe( 210 );
 			expect( result.format( 'YYYY-MM-DD' ) ).toBe( '2024-07-01' );
 		} );
 
-		it( 'should handle Date object input with GMT offset by converting to site timezone', () => {
+		it( 'should handle Date object by converting to site timezone', () => {
 			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
 			( getSiteOption as jest.Mock ).mockReturnValue( null );
 			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 2 );
 
 			const momentFn = getMomentSiteZone( mockState, siteId );
-			const dateObj = new Date( '2024-09-15T10:30:00Z' ); // 10:30 UTC
+			const dateObj = new Date( '2024-09-15T10:30:00Z' );
 			const result = momentFn( dateObj );
 
-			expect( result.utcOffset() ).toBe( 120 ); // 2 hours in minutes
-			// UTC 10:30 + 2 hours = 12:30 in site timezone
+			expect( result.utcOffset() ).toBe( 120 );
 			expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-09-15 12:30' );
-		} );
-
-		it( 'should handle naive datetime string with GMT offset by interpreting as site timezone', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 2 );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			const dateTimeString = '2024-09-15 10:30:00'; // Naive string, no timezone
-			const result = momentFn( dateTimeString );
-
-			expect( result.utcOffset() ).toBe( 120 ); // 2 hours in minutes
-			// Interprets as 10:30 IN site timezone, not converts
-			expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-09-15 10:30' );
 		} );
 
 		it( 'should handle ISO string with timezone by converting to site timezone', () => {
@@ -292,245 +129,50 @@ describe( 'getMomentSiteZone', () => {
 			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 2 );
 
 			const momentFn = getMomentSiteZone( mockState, siteId );
-			const isoString = '2024-09-15T10:30:00-05:00'; // 10:30 in EST (UTC-5)
+			const isoString = '2024-09-15T10:30:00-05:00';
 			const result = momentFn( isoString );
 
-			expect( result.utcOffset() ).toBe( 120 ); // 2 hours in minutes
-			// EST 10:30 = UTC 15:30, converted to GMT+2 = 17:30
+			expect( result.utcOffset() ).toBe( 120 );
 			expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-09-15 17:30' );
 		} );
 
-		it( 'should create current moment with GMT offset when no date input', () => {
+		it( 'should correctly compare dates with isSameOrAfter', () => {
 			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
 			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 1 );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( -8 );
 
 			const momentFn = getMomentSiteZone( mockState, siteId );
-			const result = momentFn();
+			const today = momentFn( '2024-11-27' );
+			const yesterday = momentFn( '2024-11-26' );
 
-			expect( result.utcOffset() ).toBe( 60 ); // 1 hour in minutes
+			expect( today.isSameOrAfter( yesterday, 'day' ) ).toBe( true );
+			expect( yesterday.isSameOrAfter( today, 'day' ) ).toBe( false );
 		} );
 
-		it( 'should fall back to getSiteOption for gmt_offset when getSiteGmtOffset returns null', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-			( getSiteOption as jest.Mock ).mockImplementation( ( state, id, option ) => {
-				if ( option === 'gmt_offset' ) {
-					return 8;
-				}
-				return null;
-			} );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			const result = momentFn( '2024-11-05' );
-
-			expect( result.utcOffset() ).toBe( 480 ); // 8 hours in minutes
-		} );
-
-		it( 'should handle zero GMT offset', () => {
+		it( 'should handle midnight edge case correctly', () => {
 			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
 			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 0 );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( -8 );
 
 			const momentFn = getMomentSiteZone( mockState, siteId );
-			const result = momentFn( '2024-12-01' );
+			const lastMinute = momentFn( '2024-11-27 23:59:59' );
+			const nextDay = momentFn( '2024-11-28 00:00:00' );
 
-			// Check that offset is numerically zero (handles -0 vs 0)
-			expect( result.utcOffset() === 0 ).toBe( true );
+			expect( lastMinute.isSame( nextDay, 'day' ) ).toBe( false );
+			expect( lastMinute.isBefore( nextDay ) ).toBe( true );
 		} );
 
-		it( 'should handle negative GMT offset', () => {
+		it( 'should produce consistent results between current time and string parsing', () => {
 			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
 			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( -7 );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( -5 );
 
 			const momentFn = getMomentSiteZone( mockState, siteId );
-			const result = momentFn( '2024-04-10' );
+			const now = momentFn();
+			const parsed = momentFn( now.format( 'YYYY-MM-DD HH:mm:ss' ) );
 
-			expect( result.utcOffset() ).toBe( -420 ); // -7 hours in minutes
-		} );
-	} );
-
-	describe( 'naive vs absolute time distinction', () => {
-		describe( 'with IANA timezone', () => {
-			it( 'should interpret naive date string as site timezone', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const result = momentFn( '2024-07-15' ); // Summer, EDT = UTC-4
-
-				expect( result.tz() ).toBe( 'America/New_York' );
-				expect( result.format( 'YYYY-MM-DD HH:mm Z' ) ).toBe( '2024-07-15 00:00 -04:00' );
-			} );
-
-			it( 'should convert Date object to site timezone', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const dateObj = new Date( '2024-07-15T14:30:00Z' ); // 14:30 UTC
-				const result = momentFn( dateObj );
-
-				expect( result.tz() ).toBe( 'America/New_York' );
-				// UTC 14:30 - 4 hours (EDT) = 10:30
-				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 10:30' );
-			} );
-
-			it( 'should convert ISO string with Z to site timezone', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const result = momentFn( '2024-07-15T14:30:00Z' ); // 14:30 UTC
-
-				expect( result.tz() ).toBe( 'America/New_York' );
-				// UTC 14:30 - 4 hours (EDT) = 10:30
-				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 10:30' );
-			} );
-
-			it( 'should convert ISO string with offset to site timezone', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const result = momentFn( '2024-07-15T10:30:00+02:00' ); // 10:30 GMT+2
-
-				expect( result.tz() ).toBe( 'America/New_York' );
-				// GMT+2 10:30 = UTC 08:30, then to EDT (UTC-4) = 04:30
-				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 04:30' );
-			} );
-
-			it( 'should interpret naive datetime string as site timezone', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const result = momentFn( '2024-07-15 10:30:00' ); // No timezone info
-
-				expect( result.tz() ).toBe( 'America/New_York' );
-				// Should be interpreted as 10:30 IN New York time
-				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 10:30' );
-			} );
-		} );
-
-		describe( 'with GMT offset', () => {
-			it( 'should interpret naive date string as site timezone', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 ); // GMT+5:30
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const result = momentFn( '2024-07-15' );
-
-				expect( result.utcOffset() ).toBe( 330 ); // 5.5 hours in minutes
-				expect( result.format( 'YYYY-MM-DD HH:mm Z' ) ).toBe( '2024-07-15 00:00 +05:30' );
-			} );
-
-			it( 'should convert Date object to site timezone', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const dateObj = new Date( '2024-07-15T14:30:00Z' ); // 14:30 UTC
-				const result = momentFn( dateObj );
-
-				expect( result.utcOffset() ).toBe( 330 );
-				// UTC 14:30 + 5:30 = 20:00
-				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 20:00' );
-			} );
-
-			it( 'should convert ISO string with Z to site timezone', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const result = momentFn( '2024-07-15T14:30:00Z' );
-
-				expect( result.utcOffset() ).toBe( 330 );
-				// UTC 14:30 + 5:30 = 20:00
-				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 20:00' );
-			} );
-
-			it( 'should convert ISO string with offset to site timezone', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const result = momentFn( '2024-07-15T10:30:00-05:00' ); // 10:30 EST
-
-				expect( result.utcOffset() ).toBe( 330 );
-				// EST 10:30 = UTC 15:30, then to GMT+5:30 = 21:00
-				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 21:00' );
-			} );
-
-			it( 'should interpret naive datetime string as site timezone', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const result = momentFn( '2024-07-15 10:30:00' );
-
-				expect( result.utcOffset() ).toBe( 330 );
-				// Should be interpreted as 10:30 IN GMT+5:30
-				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 10:30' );
-			} );
-
-			it( 'should handle ISO format without seconds as naive', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( -8 );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const result = momentFn( '2024-07-15T10:30' ); // No timezone indicator
-
-				expect( result.utcOffset() ).toBe( -480 );
-				// Should be interpreted as 10:30 IN GMT-8
-				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 10:30' );
-			} );
-
-			it( 'should detect uppercase Z as timezone indicator', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 3 );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-				const result = momentFn( '2024-07-15T14:30:00Z' ); // UTC indicator
-
-				expect( result.utcOffset() ).toBe( 180 );
-				// UTC 14:30 + 3 hours = 17:30
-				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 17:30' );
-			} );
-
-			it( 'should handle various ISO offset formats', () => {
-				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-				( getSiteOption as jest.Mock ).mockReturnValue( null );
-				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 0 );
-
-				const momentFn = getMomentSiteZone( mockState, siteId );
-
-				// Test +HH:MM format
-				const result1 = momentFn( '2024-07-15T10:30:00+05:30' );
-				// Check that offset is numerically zero (handles -0 vs 0)
-				expect( result1.utcOffset() === 0 ).toBe( true );
-				// GMT+5:30 10:30 = UTC 05:00, then to GMT+0 = 05:00
-				expect( result1.format( 'HH:mm' ) ).toBe( '05:00' );
-
-				// Test -HH:MM format
-				const result2 = momentFn( '2024-07-15T10:30:00-08:00' );
-				expect( result2.utcOffset() === 0 ).toBe( true );
-				// GMT-8 10:30 = UTC 18:30, then to GMT+0 = 18:30
-				expect( result2.format( 'HH:mm' ) ).toBe( '18:30' );
-			} );
+			expect( now.utcOffset() ).toBe( parsed.utcOffset() );
+			expect( parsed.isSame( now, 'second' ) ).toBe( true );
 		} );
 	} );
 
@@ -544,20 +186,7 @@ describe( 'getMomentSiteZone', () => {
 			const result = momentFn( '2024-05-12' );
 
 			expect( result.locale() ).toBe( 'en' );
-			// Should use browser's local timezone
 			expect( result.isValid() ).toBe( true );
-		} );
-
-		it( 'should handle undefined date input with browser fallback', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			const result = momentFn();
-
-			expect( result.isValid() ).toBe( true );
-			expect( result.locale() ).toBe( 'en' );
 		} );
 	} );
 
@@ -615,106 +244,5 @@ describe( 'useMomentInSite', () => {
 		const moment = momentFn( '2024-06-15' );
 
 		expect( moment.tz() ).toBe( 'Europe/Paris' );
-	} );
-
-	it( 'should handle null siteId', () => {
-		( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-		( getSiteOption as jest.Mock ).mockReturnValue( null );
-		( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5 );
-
-		const { result } = renderHook( () => useMomentInSite( null ) );
-
-		const momentFn = result.current;
-		expect( momentFn ).toBeDefined();
-	} );
-
-	it( 'should return memoized function when dependencies do not change', () => {
-		const siteId = 123;
-		( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-		( getSiteOption as jest.Mock ).mockReturnValue( null );
-		( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-		const { result, rerender } = renderHook( () => useMomentInSite( siteId ) );
-		const firstResult = result.current;
-
-		rerender();
-		const secondResult = result.current;
-
-		expect( secondResult ).toBe( firstResult );
-	} );
-
-	it( 'should return different function when siteId changes', () => {
-		( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
-		( getSiteOption as jest.Mock ).mockReturnValue( null );
-		( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
-
-		const { result, rerender } = renderHook( ( props ) => useMomentInSite( props ), {
-			initialProps: 123,
-		} );
-		const firstResult = result.current;
-
-		rerender( 456 );
-		const secondResult = result.current;
-
-		expect( secondResult ).not.toBe( firstResult );
-	} );
-} );
-
-describe( 'GMT offset date comparison logic', () => {
-	const mockState = {};
-	const siteId = 123;
-
-	beforeEach( () => {
-		jest.clearAllMocks();
-		( i18n.getLocaleSlug as jest.Mock ).mockReturnValue( 'en' );
-		( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-		( getSiteOption as jest.Mock ).mockReturnValue( null );
-	} );
-
-	it( 'should correctly compare dates with isSameOrAfter using GMT offset', () => {
-		( getSiteGmtOffset as jest.Mock ).mockReturnValue( -8 );
-
-		const momentFn = getMomentSiteZone( mockState, siteId );
-		const today = momentFn( '2024-11-27' );
-		const yesterday = momentFn( '2024-11-26' );
-
-		expect( today.isSameOrAfter( yesterday, 'day' ) ).toBe( true );
-		expect( yesterday.isSameOrAfter( today, 'day' ) ).toBe( false );
-	} );
-
-	it( 'should handle midnight edge case correctly', () => {
-		( getSiteGmtOffset as jest.Mock ).mockReturnValue( -8 );
-
-		const momentFn = getMomentSiteZone( mockState, siteId );
-		const lastMinute = momentFn( '2024-11-27 23:59:59' );
-		const nextDay = momentFn( '2024-11-28 00:00:00' );
-
-		expect( lastMinute.isSame( nextDay, 'day' ) ).toBe( false );
-		expect( lastMinute.isBefore( nextDay ) ).toBe( true );
-	} );
-
-	it( 'should produce consistent results between current time and string parsing', () => {
-		( getSiteGmtOffset as jest.Mock ).mockReturnValue( -5 );
-
-		const momentFn = getMomentSiteZone( mockState, siteId );
-		const now = momentFn();
-		const parsed = momentFn( now.format( 'YYYY-MM-DD HH:mm:ss' ) );
-
-		// Both should have the same offset
-		expect( now.utcOffset() ).toBe( parsed.utcOffset() );
-		expect( parsed.utcOffset() ).toBe( -300 );
-
-		// Format-reparse should maintain the same date
-		expect( parsed.isSame( now, 'second' ) ).toBe( true );
-	} );
-
-	it( 'should handle fractional GMT offset correctly', () => {
-		( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 ); // IST
-
-		const momentFn = getMomentSiteZone( mockState, siteId );
-		const date = momentFn( '2024-11-27 00:00:00' );
-
-		expect( date.utcOffset() ).toBe( 330 ); // 5.5 hours in minutes
-		expect( date.format( 'Z' ) ).toBe( '+05:30' );
 	} );
 } );

--- a/client/my-sites/stats/hooks/test/use-moment-site-zone.test.ts
+++ b/client/my-sites/stats/hooks/test/use-moment-site-zone.test.ts
@@ -258,16 +258,46 @@ describe( 'getMomentSiteZone', () => {
 			expect( result.format( 'YYYY-MM-DD' ) ).toBe( '2024-07-01' );
 		} );
 
-		it( 'should handle non-string date input with GMT offset', () => {
+		it( 'should handle Date object input with GMT offset by converting to site timezone', () => {
 			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
 			( getSiteOption as jest.Mock ).mockReturnValue( null );
 			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 2 );
 
 			const momentFn = getMomentSiteZone( mockState, siteId );
-			const dateObj = new Date( '2024-09-15T10:30:00Z' );
+			const dateObj = new Date( '2024-09-15T10:30:00Z' ); // 10:30 UTC
 			const result = momentFn( dateObj );
 
 			expect( result.utcOffset() ).toBe( 120 ); // 2 hours in minutes
+			// UTC 10:30 + 2 hours = 12:30 in site timezone
+			expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-09-15 12:30' );
+		} );
+
+		it( 'should handle naive datetime string with GMT offset by interpreting as site timezone', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 2 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const dateTimeString = '2024-09-15 10:30:00'; // Naive string, no timezone
+			const result = momentFn( dateTimeString );
+
+			expect( result.utcOffset() ).toBe( 120 ); // 2 hours in minutes
+			// Interprets as 10:30 IN site timezone, not converts
+			expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-09-15 10:30' );
+		} );
+
+		it( 'should handle ISO string with timezone by converting to site timezone', () => {
+			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+			( getSiteOption as jest.Mock ).mockReturnValue( null );
+			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 2 );
+
+			const momentFn = getMomentSiteZone( mockState, siteId );
+			const isoString = '2024-09-15T10:30:00-05:00'; // 10:30 in EST (UTC-5)
+			const result = momentFn( isoString );
+
+			expect( result.utcOffset() ).toBe( 120 ); // 2 hours in minutes
+			// EST 10:30 = UTC 15:30, converted to GMT+2 = 17:30
+			expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-09-15 17:30' );
 		} );
 
 		it( 'should create current moment with GMT offset when no date input', () => {
@@ -318,6 +348,189 @@ describe( 'getMomentSiteZone', () => {
 			const result = momentFn( '2024-04-10' );
 
 			expect( result.utcOffset() ).toBe( -420 ); // -7 hours in minutes
+		} );
+	} );
+
+	describe( 'naive vs absolute time distinction', () => {
+		describe( 'with IANA timezone', () => {
+			it( 'should interpret naive date string as site timezone', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const result = momentFn( '2024-07-15' ); // Summer, EDT = UTC-4
+
+				expect( result.tz() ).toBe( 'America/New_York' );
+				expect( result.format( 'YYYY-MM-DD HH:mm Z' ) ).toBe( '2024-07-15 00:00 -04:00' );
+			} );
+
+			it( 'should convert Date object to site timezone', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const dateObj = new Date( '2024-07-15T14:30:00Z' ); // 14:30 UTC
+				const result = momentFn( dateObj );
+
+				expect( result.tz() ).toBe( 'America/New_York' );
+				// UTC 14:30 - 4 hours (EDT) = 10:30
+				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 10:30' );
+			} );
+
+			it( 'should convert ISO string with Z to site timezone', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const result = momentFn( '2024-07-15T14:30:00Z' ); // 14:30 UTC
+
+				expect( result.tz() ).toBe( 'America/New_York' );
+				// UTC 14:30 - 4 hours (EDT) = 10:30
+				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 10:30' );
+			} );
+
+			it( 'should convert ISO string with offset to site timezone', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const result = momentFn( '2024-07-15T10:30:00+02:00' ); // 10:30 GMT+2
+
+				expect( result.tz() ).toBe( 'America/New_York' );
+				// GMT+2 10:30 = UTC 08:30, then to EDT (UTC-4) = 04:30
+				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 04:30' );
+			} );
+
+			it( 'should interpret naive datetime string as site timezone', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( 'America/New_York' );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( null );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const result = momentFn( '2024-07-15 10:30:00' ); // No timezone info
+
+				expect( result.tz() ).toBe( 'America/New_York' );
+				// Should be interpreted as 10:30 IN New York time
+				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 10:30' );
+			} );
+		} );
+
+		describe( 'with GMT offset', () => {
+			it( 'should interpret naive date string as site timezone', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 ); // GMT+5:30
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const result = momentFn( '2024-07-15' );
+
+				expect( result.utcOffset() ).toBe( 330 ); // 5.5 hours in minutes
+				expect( result.format( 'YYYY-MM-DD HH:mm Z' ) ).toBe( '2024-07-15 00:00 +05:30' );
+			} );
+
+			it( 'should convert Date object to site timezone', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const dateObj = new Date( '2024-07-15T14:30:00Z' ); // 14:30 UTC
+				const result = momentFn( dateObj );
+
+				expect( result.utcOffset() ).toBe( 330 );
+				// UTC 14:30 + 5:30 = 20:00
+				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 20:00' );
+			} );
+
+			it( 'should convert ISO string with Z to site timezone', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const result = momentFn( '2024-07-15T14:30:00Z' );
+
+				expect( result.utcOffset() ).toBe( 330 );
+				// UTC 14:30 + 5:30 = 20:00
+				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 20:00' );
+			} );
+
+			it( 'should convert ISO string with offset to site timezone', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const result = momentFn( '2024-07-15T10:30:00-05:00' ); // 10:30 EST
+
+				expect( result.utcOffset() ).toBe( 330 );
+				// EST 10:30 = UTC 15:30, then to GMT+5:30 = 21:00
+				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 21:00' );
+			} );
+
+			it( 'should interpret naive datetime string as site timezone', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5.5 );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const result = momentFn( '2024-07-15 10:30:00' );
+
+				expect( result.utcOffset() ).toBe( 330 );
+				// Should be interpreted as 10:30 IN GMT+5:30
+				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 10:30' );
+			} );
+
+			it( 'should handle ISO format without seconds as naive', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( -8 );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const result = momentFn( '2024-07-15T10:30' ); // No timezone indicator
+
+				expect( result.utcOffset() ).toBe( -480 );
+				// Should be interpreted as 10:30 IN GMT-8
+				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 10:30' );
+			} );
+
+			it( 'should detect uppercase Z as timezone indicator', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 3 );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+				const result = momentFn( '2024-07-15T14:30:00Z' ); // UTC indicator
+
+				expect( result.utcOffset() ).toBe( 180 );
+				// UTC 14:30 + 3 hours = 17:30
+				expect( result.format( 'YYYY-MM-DD HH:mm' ) ).toBe( '2024-07-15 17:30' );
+			} );
+
+			it( 'should handle various ISO offset formats', () => {
+				( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
+				( getSiteOption as jest.Mock ).mockReturnValue( null );
+				( getSiteGmtOffset as jest.Mock ).mockReturnValue( 0 );
+
+				const momentFn = getMomentSiteZone( mockState, siteId );
+
+				// Test +HH:MM format
+				const result1 = momentFn( '2024-07-15T10:30:00+05:30' );
+				// Check that offset is numerically zero (handles -0 vs 0)
+				expect( result1.utcOffset() === 0 ).toBe( true );
+				// GMT+5:30 10:30 = UTC 05:00, then to GMT+0 = 05:00
+				expect( result1.format( 'HH:mm' ) ).toBe( '05:00' );
+
+				// Test -HH:MM format
+				const result2 = momentFn( '2024-07-15T10:30:00-08:00' );
+				expect( result2.utcOffset() === 0 ).toBe( true );
+				// GMT-8 10:30 = UTC 18:30, then to GMT+0 = 18:30
+				expect( result2.format( 'HH:mm' ) ).toBe( '18:30' );
+			} );
 		} );
 	} );
 

--- a/client/my-sites/stats/hooks/test/use-moment-site-zone.test.ts
+++ b/client/my-sites/stats/hooks/test/use-moment-site-zone.test.ts
@@ -321,32 +321,6 @@ describe( 'getMomentSiteZone', () => {
 		} );
 	} );
 
-	describe( 'with custom date format', () => {
-		it( 'should use custom date format when provided', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5 );
-
-			const customFormat = 'MM/DD/YYYY';
-			const momentFn = getMomentSiteZone( mockState, siteId, customFormat );
-			const result = momentFn();
-
-			// The custom format should be used for parseZone when creating the current moment
-			expect( result ).toBeDefined();
-		} );
-
-		it( 'should default to DATE_FORMAT when not provided', () => {
-			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );
-			( getSiteOption as jest.Mock ).mockReturnValue( null );
-			( getSiteGmtOffset as jest.Mock ).mockReturnValue( 5 );
-
-			const momentFn = getMomentSiteZone( mockState, siteId );
-			const result = momentFn();
-
-			expect( result ).toBeDefined();
-		} );
-	} );
-
 	describe( 'browser fallback', () => {
 		it( 'should fall back to browser timezone when no timezone info available', () => {
 			( getSiteTimezoneValue as jest.Mock ).mockReturnValue( null );

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -7,6 +7,21 @@ import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-valu
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
+/**
+ * Selector that returns a function to create moment objects in the site's timezone.
+ *
+ * The returned function's behavior depends on the input type:
+ * - Naive date string ('2024-01-15'): Interprets AS the site's timezone (midnight in site TZ)
+ * - Date object: Converts TO the site's timezone (preserves absolute time)
+ * - ISO string with timezone ('2024-01-15T10:30:00-05:00'): Converts TO the site's timezone
+ * - Undefined: Returns current time in the site's timezone
+ *
+ * @example
+ * const momentSiteZone = getMomentSiteZone(state, siteId);
+ * momentSiteZone('2024-01-15')                    // Jan 15, 2024 at midnight in site TZ
+ * momentSiteZone(new Date('2024-01-15T10:00Z'))   // Converts UTC time to site TZ
+ * momentSiteZone()                                 // Current time in site TZ
+ */
 export const getMomentSiteZone = createSelector(
 	( state: object, siteId: number | null ) => {
 		const localeSlug = i18n.getLocaleSlug() || 'en';
@@ -18,24 +33,34 @@ export const getMomentSiteZone = createSelector(
 			( getSiteOption( state, siteId, 'gmt_offset' ) as number );
 
 		return ( dateInput?: moment.MomentInput ) => {
-			// Validate timezone string exists and is a valid IANA timezone identifier
+			// Case 1: Site has IANA timezone (e.g., 'America/New_York')
+			// This is the best option as it handles DST automatically
 			if ( timezoneString && timezoneString !== '' && moment.tz.zone( timezoneString ) ) {
 				return moment.tz( dateInput, timezoneString ).locale( localeSlug );
 			}
 
+			// Case 2: Site has GMT offset only (e.g., -5 for EST)
+			// Note: This doesn't handle DST, so times may be off during summer/winter
 			if ( Number.isFinite( gmtOffset ) ) {
-				// When parsing a date string (e.g., 'YYYY-MM-DD'), we interpret it as being in the site's timezone.
-				// We use keepLocalTime: true to preserve the date/time value while changing the offset.
-				if ( typeof dateInput === 'string' ) {
-					return moment.parseZone( dateInput ).utcOffset( gmtOffset, true ).locale( localeSlug );
+				// Determine if the input is a naive date string (no timezone info)
+				const isNaiveDateString =
+					typeof dateInput === 'string' && ! /[+-]\d{2}:\d{2}|Z/i.test( dateInput );
+
+				if ( isNaiveDateString ) {
+					// Naive string like '2024-01-15' or '2024-01-15 10:30'
+					// Parse as UTC, then shift to site offset while keeping the wall-clock time
+					// Result: '2024-01-15 00:00:00' interpreted in site timezone
+					return moment.utc( dateInput ).utcOffset( gmtOffset, true ).locale( localeSlug );
 				}
 
-				// For Date objects or undefined (current time), we convert the exact instant to the site's timezone.
+				// Date object, moment instance, or string with timezone
+				// Convert the absolute time to the site's timezone
 				return moment( dateInput ).utcOffset( gmtOffset ).locale( localeSlug );
 			}
 
-			// Falls back to the browser's local timezone if no GMT offset is found
-			return moment( dateInput ).locale( localeSlug );
+			// Case 3: No timezone info available
+			// Fall back to browser's local timezone
+			return ( dateInput !== undefined ? moment( dateInput ) : moment() ).locale( localeSlug );
 		};
 	},
 	[

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -6,10 +6,9 @@ import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { DATE_FORMAT } from '../constants';
 
 export const getMomentSiteZone = createSelector(
-	( state: object, siteId: number | null, dateFormat = DATE_FORMAT ) => {
+	( state: object, siteId: number | null ) => {
 		const localeSlug = i18n.getLocaleSlug() || 'en';
 		const timezoneString =
 			getSiteTimezoneValue( state, siteId as number ) ||
@@ -21,29 +20,17 @@ export const getMomentSiteZone = createSelector(
 		return ( dateInput?: moment.MomentInput ) => {
 			// Validate timezone string exists and is a valid IANA timezone identifier
 			if ( timezoneString && timezoneString !== '' && moment.tz.zone( timezoneString ) ) {
-				if ( dateInput === undefined ) {
-					return moment.tz( timezoneString ).locale( localeSlug );
-				}
 				return moment.tz( dateInput, timezoneString ).locale( localeSlug );
 			}
 
 			if ( Number.isFinite( gmtOffset ) ) {
-				if ( dateInput === undefined ) {
-					// Get current time in site timezone and format as date string, then create
-					// a moment with the site's UTC offset applied for consistent comparisons.
-					const todayInSiteZone = moment().utcOffset( gmtOffset ).format( dateFormat );
-					return moment
-						.parseZone( todayInSiteZone )
-						.utcOffset( gmtOffset, true )
-						.locale( localeSlug );
-				}
-				// When parsing a date string (e.g., 'YYYY-MM-DD'), we need to interpret it as
-				// that date in the site's timezone, not in the browser's local timezone. Using
-				// parseZone preserves the date as-is without timezone conversion, then we apply
-				// the site's offset while keeping the local time (second argument `true`).
+				// When parsing a date string (e.g., 'YYYY-MM-DD'), we interpret it as being in the site's timezone.
+				// We use keepLocalTime: true to preserve the date/time value while changing the offset.
 				if ( typeof dateInput === 'string' ) {
 					return moment.parseZone( dateInput ).utcOffset( gmtOffset, true ).locale( localeSlug );
 				}
+
+				// For Date objects or undefined (current time), we convert the exact instant to the site's timezone.
 				return moment( dateInput ).utcOffset( gmtOffset ).locale( localeSlug );
 			}
 

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -29,11 +29,20 @@ export const getMomentSiteZone = createSelector(
 
 			if ( Number.isFinite( gmtOffset ) ) {
 				if ( dateInput === undefined ) {
-					// In all the components, `moment` is directly used, which defaults to the browser's local timezone.
-					// As a result, we need to convert the moment object to the site's timezone for easier comparison like `isSame`.
-					return moment( moment().utcOffset( gmtOffset ).format( dateFormat ) ).locale(
-						localeSlug
-					);
+					// Get current time in site timezone and format as date string, then create
+					// a moment with the site's UTC offset applied for consistent comparisons.
+					const todayInSiteZone = moment().utcOffset( gmtOffset ).format( dateFormat );
+					return moment
+						.parseZone( todayInSiteZone )
+						.utcOffset( gmtOffset, true )
+						.locale( localeSlug );
+				}
+				// When parsing a date string (e.g., 'YYYY-MM-DD'), we need to interpret it as
+				// that date in the site's timezone, not in the browser's local timezone. Using
+				// parseZone preserves the date as-is without timezone conversion, then we apply
+				// the site's offset while keeping the local time (second argument `true`).
+				if ( typeof dateInput === 'string' ) {
+					return moment.parseZone( dateInput ).utcOffset( gmtOffset, true ).locale( localeSlug );
 				}
 				return moment( dateInput ).utcOffset( gmtOffset ).locale( localeSlug );
 			}

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -4,7 +4,6 @@ import moment from 'moment';
 import { useEffect, useState, useMemo } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { parseChartData } from 'calypso/state/stats/lists/utils';
-import { useMomentInSite } from '../../hooks/use-moment-site-zone';
 
 type Unit = 'hour' | 'day' | 'week' | 'month' | 'year';
 
@@ -27,16 +26,15 @@ const UPDATE_INTERVAL_IN_SECONDS = 5;
 const MINUTE_DATA_LENGTH = 30;
 
 const RealtimeChart = ( { siteId }: { siteId: number } ) => {
-	const momentInSite = useMomentInSite( siteId );
 	const [ viewsData, setViewsData ] = useState( {} as chartMinuteDataTypes );
 	const [ initialViewsCount, setInitialViewsCount ] = useState< number | undefined >( undefined );
 
 	useEffect( () => {
 		const intervalId = setInterval( () => {
 			// Query the chart data by site timezone YYYY-MM-DD HH:mm:00.
-			const adjustedDatetimeForQuery = momentInSite().format( 'YYYY-MM-DD HH:mm:00' );
+			const adjustedDatetimeForQuery = moment().format( 'YYYY-MM-DD HH:mm:00' );
 			// Index the chart data by local YYYY-MM-DD HH:mm:00 to compare with local time in X-axis tickFormat.
-			const localDatetimeKey = momentInSite().format( 'YYYY-MM-DD HH:mm:00' );
+			const localDatetimeKey = moment().format( 'YYYY-MM-DD HH:mm:00' );
 
 			queryStatsVisits( siteId, {
 				unit: 'hour',
@@ -67,7 +65,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 		const allDatetimeKeys = [];
 		// Display all the minutes in the last 30 minutes.
 		for ( let i = 0; i <= MINUTE_DATA_LENGTH; i++ ) {
-			const datetime = momentInSite().subtract( i, 'minute' ).format( 'YYYY-MM-DD HH:mm:00' );
+			const datetime = moment().subtract( i, 'minute' ).format( 'YYYY-MM-DD HH:mm:00' );
 			allDatetimeKeys.unshift( datetime );
 		}
 
@@ -110,7 +108,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 			chartData: data,
 			maxViews,
 		};
-	}, [ viewsData, momentInSite, initialViewsCount ] );
+	}, [ viewsData, initialViewsCount ] );
 
 	// Format the time in minute difference from now.
 	const formatTimeTick = ( value: number ) => {

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -1,5 +1,6 @@
 import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
 import clsx from 'clsx';
+import moment from 'moment';
 import { useEffect, useState, useMemo } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { parseChartData } from 'calypso/state/stats/lists/utils';
@@ -72,7 +73,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 
 		let maxViews = 1;
 		const data = allDatetimeKeys.map( ( eachMinute ) => {
-			const lastMinute = momentInSite( eachMinute )
+			const lastMinute = moment( eachMinute )
 				.subtract( 1, 'minute' )
 				.format( 'YYYY-MM-DD HH:mm:00' );
 
@@ -85,8 +86,8 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 				// The first queried minute data.
 				diffViews = viewsData[ eachMinute ] - ( initialViewsCount || 0 );
 			} else if (
-				momentInSite( lastMinute ).format( 'YYYY-MM-DD HH' ) !==
-				momentInSite( eachMinute ).format( 'YYYY-MM-DD HH' )
+				moment( lastMinute ).format( 'YYYY-MM-DD HH' ) !==
+				moment( eachMinute ).format( 'YYYY-MM-DD HH' )
 			) {
 				// If the previous minute is from a different hour, use the current minute's views.
 				diffViews = viewsData[ eachMinute ];
@@ -100,7 +101,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 			}
 
 			return {
-				date: momentInSite( eachMinute ).toDate(),
+				date: new Date( eachMinute ),
 				value: diffViews,
 			};
 		} );

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -1,6 +1,5 @@
 import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
 import clsx from 'clsx';
-import moment from 'moment';
 import { useEffect, useState, useMemo } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { parseChartData } from 'calypso/state/stats/lists/utils';
@@ -73,7 +72,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 
 		let maxViews = 1;
 		const data = allDatetimeKeys.map( ( eachMinute ) => {
-			const lastMinute = moment( eachMinute )
+			const lastMinute = momentInSite( eachMinute )
 				.subtract( 1, 'minute' )
 				.format( 'YYYY-MM-DD HH:mm:00' );
 
@@ -86,8 +85,8 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 				// The first queried minute data.
 				diffViews = viewsData[ eachMinute ] - ( initialViewsCount || 0 );
 			} else if (
-				moment( lastMinute ).format( 'YYYY-MM-DD HH' ) !==
-				moment( eachMinute ).format( 'YYYY-MM-DD HH' )
+				momentInSite( lastMinute ).format( 'YYYY-MM-DD HH' ) !==
+				momentInSite( eachMinute ).format( 'YYYY-MM-DD HH' )
 			) {
 				// If the previous minute is from a different hour, use the current minute's views.
 				diffViews = viewsData[ eachMinute ];
@@ -101,7 +100,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 			}
 
 			return {
-				date: new Date( eachMinute ),
+				date: momentInSite( eachMinute ).toDate(),
 				value: diffViews,
 			};
 		} );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -262,10 +262,13 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		// Limit navigation within the currently selected range.
 		const currentChartStart = context.query?.chartStart;
 		const currentChartEnd = context.query?.chartEnd;
-		if ( currentChartStart && momentInSite( chartStart ).isBefore( currentChartStart ) ) {
+		if (
+			currentChartStart &&
+			momentInSite( chartStart ).isBefore( momentInSite( currentChartStart ) )
+		) {
 			chartStart = currentChartStart;
 		}
-		if ( currentChartEnd && momentInSite( chartEnd ).isAfter( currentChartEnd ) ) {
+		if ( currentChartEnd && momentInSite( chartEnd ).isAfter( momentInSite( currentChartEnd ) ) ) {
 			chartEnd = currentChartEnd;
 		}
 

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -144,7 +144,7 @@ class StatsDatePicker extends Component {
 		}
 
 		// Ensure we have a moment instance here to work with.
-		const momentDate = moment.isMoment( date ) ? date : momentSiteZone( date );
+		const momentDate = moment.isMoment( date ) ? date : momentSiteZone( date ); // ??
 		const localizedDate = momentSiteZone( momentDate.format( 'YYYY-MM-DD' ) );
 		let formattedDate;
 

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -144,7 +144,8 @@ class StatsDatePicker extends Component {
 		}
 
 		// Ensure we have a moment instance here to work with.
-		const momentDate = moment.isMoment( date ) ? date : momentSiteZone( date ); // ??
+		const momentDate = moment.isMoment( date ) ? date : momentSiteZone( date );
+		// Convert moment to YYYY-MM-DD string, then parse it in the site's timezone
 		const localizedDate = momentSiteZone( momentDate.format( 'YYYY-MM-DD' ) );
 		let formattedDate;
 

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -135,7 +135,7 @@ class StatsDatePicker extends Component {
 			return selectedShortcut.label;
 		}
 
-		const { date, moment, period, translate, isShort, dateRange, momentSiteZone } = this.props;
+		const { date, period, translate, isShort, dateRange, momentSiteZone } = this.props;
 		const weekPeriodFormat = isShort ? 'll' : 'LL';
 
 		// Respect the dateRange if provided.
@@ -144,9 +144,7 @@ class StatsDatePicker extends Component {
 		}
 
 		// Ensure we have a moment instance here to work with.
-		const momentDate = moment.isMoment( date ) ? date : momentSiteZone( date );
-		// Convert moment to YYYY-MM-DD string, then parse it in the site's timezone
-		const localizedDate = momentSiteZone( momentDate.format( 'YYYY-MM-DD' ) );
+		const localizedDate = momentSiteZone( date );
 		let formattedDate;
 
 		switch ( period ) {

--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -22,7 +22,8 @@ export function formatDate( date, period ) {
 
 export function getQueryDate( queryDate, state, siteId, period, quantity ) {
 	const momentSiteZone = getMomentSiteZone( state, siteId );
-	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone().locale( 'en' ) ).endOf; //??
+	// Get the current moment in site timezone, then find the end of the current period
+	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone().locale( 'en' ) ).endOf;
 	const periodDifference = moment( endOfPeriodDate ).diff( moment( queryDate ), period );
 	if ( periodDifference >= quantity ) {
 		return moment( endOfPeriodDate )

--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -22,7 +22,7 @@ export function formatDate( date, period ) {
 
 export function getQueryDate( queryDate, state, siteId, period, quantity ) {
 	const momentSiteZone = getMomentSiteZone( state, siteId );
-	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone().locale( 'en' ) ).endOf;
+	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone().locale( 'en' ) ).endOf; //??
 	const periodDifference = moment( endOfPeriodDate ).diff( moment( queryDate ), period );
 	if ( periodDifference >= quantity ) {
 		return moment( endOfPeriodDate )

--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -22,7 +22,7 @@ export function formatDate( date, period ) {
 
 export function getQueryDate( queryDate, state, siteId, period, quantity ) {
 	const momentSiteZone = getMomentSiteZone( state, siteId );
-	// Get the current moment in site timezone, then find the end of the current period
+	// TODO: rangeOfPeriod should be using momentSiteZone instead of moment().locale( 'en' )
 	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone().locale( 'en' ) ).endOf;
 	const periodDifference = moment( endOfPeriodDate ).diff( moment( queryDate ), period );
 	if ( periodDifference >= quantity ) {


### PR DESCRIPTION
## Summary

Fixes the date navigation arrows in Jetpack Stats (Odyssey) not working correctly when the site timezone is set to a GMT offset (e.g., `gmt_offset: -8` for America/Los_Angeles) instead of an IANA timezone string.

### The Problem

When navigating dates using the arrow buttons:
1. The URL and date picker would show the correct date, but the title displayed a date off by one day
2. After clicking "Previous", clicking "Next" would do nothing (appeared disabled)

### Root Cause

In `getMomentSiteZone()`, when falling back to GMT offset handling:

1. **Date strings were parsed incorrectly**: `moment('2025-11-25')` parses as midnight in the browser's local timezone, then `.utcOffset(-8)` shifts the time, which could cross midnight and change the date
2. **Inconsistent offset handling**: The "today" moment (no dateInput) and parsed date moments had different offset settings, causing `isSameOrAfter()` comparisons to return incorrect results for enabling/disabling navigation arrows

### The Fix

Both code paths now use `moment.parseZone().utcOffset(gmtOffset, true)` where the second argument `true` is the `keepLocalTime` flag. This:
- Preserves the date/time values exactly as parsed
- Only changes the UTC offset metadata
- Ensures consistent comparisons between dates


https://github.com/user-attachments/assets/e14d1aba-3347-4d44-b7d3-39c9fa3c4531



## Related issues

Fixes STATS-186

## Testing instructions

### Pre-Requisite
1. Follow the testing instructions to test Odyssey stats - PCYsg-Pp7-p2

### Steps
1. Set up a site with timezone set to a non-UTC timezone (e.g., America/Los_Angeles which has `gmt_offset: -8`)
2. Open Jetpack Stats for a given day
3. Click the Previous arrow to navigate to the prior day
4. Verify the date shown in the title matches the URL and date picker
5. Click the Next arrow to navigate forward
6. Verify navigation works correctly and the Next arrow is not incorrectly disabled