### PR TITLE
Prevent login heading snap by seeding context

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -7,7 +7,6 @@ import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
-import LoginContextProvider from './login-context';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import HandleEmailedLinkFormJetpackConnect from './magic-login/handle-emailed-link-form-jetpack-connect';
@@ -57,21 +56,19 @@ const enhanceContextWithLogin = ( context ) => {
 	const isJetpackLogin = isJetpack === 'jetpack';
 
 	context.primary = (
-		<LoginContextProvider>
-			<WPLogin
-				action={ action }
-				isJetpack={ isJetpackLogin }
-				isGravPoweredClient={ isGravPoweredClient }
-				path={ path }
-				twoFactorAuthType={ twoFactorAuthType }
-				socialService={ socialService }
-				socialServiceResponse={ socialServiceResponse }
-				socialConnect={ flow === 'social-connect' }
-				domain={ ( query && query.domain ) || null }
-				fromSite={ ( query && query.site ) || null }
-				signupUrl={ ( query && query.signup_url ) || null }
-			/>
-		</LoginContextProvider>
+		<WPLogin
+			action={ action }
+			isJetpack={ isJetpackLogin }
+			isGravPoweredClient={ isGravPoweredClient }
+			path={ path }
+			twoFactorAuthType={ twoFactorAuthType }
+			socialService={ socialService }
+			socialServiceResponse={ socialServiceResponse }
+			socialConnect={ flow === 'social-connect' }
+			domain={ ( query && query.domain ) || null }
+			fromSite={ ( query && query.site ) || null }
+			signupUrl={ ( query && query.signup_url ) || null }
+		/>
 	);
 };
 
@@ -174,11 +171,7 @@ export async function magicLogin( context, next ) {
 		}
 	}
 
-	context.primary = (
-		<LoginContextProvider>
-			<MagicLogin path={ path } />
-		</LoginContextProvider>
-	);
+	context.primary = <MagicLogin path={ path } />;
 
 	next();
 }
@@ -190,13 +183,11 @@ export function qrCodeLogin( context, next ) {
 	const isJetpack = context.path.includes( '/jetpack' );
 
 	context.primary = (
-		<LoginContextProvider>
-			<QrCodeLoginPage
-				locale={ context.params.lang }
-				redirectTo={ redirect_to }
-				isJetpack={ isJetpack }
-			/>
-		</LoginContextProvider>
+		<QrCodeLoginPage
+			locale={ context.params.lang }
+			redirectTo={ redirect_to }
+			isJetpack={ isJetpack }
+		/>
 	);
 
 	next();

--- a/client/login/login-context.tsx
+++ b/client/login/login-context.tsx
@@ -16,18 +16,30 @@ export interface LoginContextType {
 	} ) => void;
 }
 
+export interface LoginContextProviderProps {
+	children: React.ReactNode;
+	initialHeading?: TranslateResult | null;
+	initialSubHeading?: TranslateResult | null;
+	initialSubHeadingSecondary?: TranslateResult | null;
+}
+
 export const LoginContext = createContext< LoginContextType >( {} as LoginContextType );
 
-const LoginContextProvider = ( { children }: { children: React.ReactNode } ) => {
+const LoginContextProvider = ( {
+	children,
+	initialHeading,
+	initialSubHeading,
+	initialSubHeadingSecondary,
+}: LoginContextProviderProps ) => {
 	const [ headingText, setHeadingText ] = useState< TranslateResult | undefined | null >(
-		undefined
+		initialHeading ?? undefined
 	);
 	const [ subHeadingText, setSubHeadingText ] = useState< TranslateResult | undefined | null >(
-		undefined
+		initialSubHeading ?? undefined
 	);
 	const [ subHeadingTextSecondary, setSubHeadingTextSecondary ] = useState<
 		TranslateResult | undefined | null
-	>( undefined );
+	>( initialSubHeadingSecondary ?? undefined );
 
 	const setHeaders = useCallback(
 		( {

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { localize, fixMe } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { useSelector, connect } from 'react-redux';
@@ -36,10 +36,16 @@ import getMagicLoginRequestEmailError from 'calypso/state/selectors/get-magic-lo
 import isMagicLoginEmailRequested from 'calypso/state/selectors/is-magic-login-email-requested';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { withEnhancers } from 'calypso/state/utils';
+import LoginContextProvider from '../login-context';
 import GravPoweredMagicLogin from './gravatar';
 import MainContentWooCoreProfiler from './main-content-woo-core-profiler';
 import RequestLoginCode from './request-login-code';
 import RequestLoginEmailForm from './request-login-email-form';
+import {
+	getCheckYourEmailHeaders,
+	getEmailCodeHeaders,
+	getEmailLinkHeaders,
+} from './utils/heading-utils';
 import './style.scss';
 
 export const MagicLoginLocaleSuggestions = ( { path, showCheckYourEmail } ) => {
@@ -316,6 +322,41 @@ class MagicLogin extends Component {
 	}
 }
 
+const getMagicLoginInitialHeaders = ( props, translate ) => {
+	if ( isGravPoweredOAuth2Client( props.oauth2Client ) ) {
+		return {};
+	}
+
+	if ( props.isWooJPC ) {
+		const emailAddress = props.userEmail?.includes( '@' ) ? props.userEmail : null;
+		return getCheckYourEmailHeaders( translate, { emailAddress } );
+	}
+
+	const isMagicCodeFlow = shouldUseMagicCode( { isJetpack: props.isJetpackLogin } );
+
+	if ( isMagicCodeFlow ) {
+		return getEmailCodeHeaders( translate );
+	}
+
+	if ( props.showCheckYourEmail ) {
+		const emailAddress = props.userEmail?.includes( '@' ) ? props.userEmail : null;
+		return getCheckYourEmailHeaders( translate, { emailAddress } );
+	}
+
+	return getEmailLinkHeaders( translate );
+};
+
+const MagicLoginWithContext = ( props ) => {
+	const translate = useTranslate();
+	const { heading, subHeading } = getMagicLoginInitialHeaders( props, translate );
+
+	return (
+		<LoginContextProvider initialHeading={ heading } initialSubHeading={ subHeading }>
+			<MagicLogin { ...props } translate={ translate } />
+		</LoginContextProvider>
+	);
+};
+
 const mapState = ( state ) => ( {
 	locale: getCurrentLocaleSlug( state ),
 	query: getCurrentQueryArguments( state ),
@@ -343,4 +384,4 @@ const mapDispatch = {
 	recordTracksEvent: withEnhancers( recordTracksEvent, [ enhanceWithSiteType ] ),
 };
 
-export default connect( mapState, mapDispatch )( localize( MagicLogin ) );
+export default connect( mapState, mapDispatch )( MagicLoginWithContext );

--- a/client/login/magic-login/main-content-woo-core-profiler.tsx
+++ b/client/login/magic-login/main-content-woo-core-profiler.tsx
@@ -1,9 +1,10 @@
 import { useTranslate } from 'i18n-calypso';
-import { FC, useEffect, useState } from 'react';
+import { FC, useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
 import { useLoginContext } from '../login-context';
 import { MagicLoginEmailWrapper } from './magic-login-email/magic-login-email-wrapper';
+import { getCheckYourEmailHeaders } from './utils/heading-utils';
 
 interface Props {
 	emailAddress: string;
@@ -19,16 +20,16 @@ const MainContentWooCoreProfiler: FC< Props > = ( { emailAddress, redirectTo } )
 	const [ resendEmailCountdown, setResendEmailCountdown ] = useState( RESEND_EMAIL_COUNTDOWN_TIME );
 	const { setHeaders } = useLoginContext();
 
-	const resetResendEmailCountdown = () => {
+	const resetResendEmailCountdown = useCallback( () => {
 		if ( ! resendEmailCountdownId ) {
 			return;
 		}
 		clearInterval( resendEmailCountdownId );
 		resendEmailCountdownId = null;
 		setResendEmailCountdown( RESEND_EMAIL_COUNTDOWN_TIME );
-	};
+	}, [] );
 
-	const startResendEmailCountdown = () => {
+	const startResendEmailCountdown = useCallback( () => {
 		resetResendEmailCountdown();
 
 		resendEmailCountdownId = setInterval( () => {
@@ -40,7 +41,7 @@ const MainContentWooCoreProfiler: FC< Props > = ( { emailAddress, redirectTo } )
 				return prevState - 1;
 			} );
 		}, 1000 );
-	};
+	}, [ resetResendEmailCountdown ] );
 
 	const sendEmail = () => {
 		dispatch(
@@ -62,21 +63,13 @@ const MainContentWooCoreProfiler: FC< Props > = ( { emailAddress, redirectTo } )
 		return () => {
 			resetResendEmailCountdown();
 		};
-	}, [] );
+	}, [ resetResendEmailCountdown, startResendEmailCountdown ] );
 
 	useEffect( () => {
+		const { heading, subHeading } = getCheckYourEmailHeaders( translate, { emailAddress } );
 		setHeaders( {
-			heading: translate( 'Check your email' ),
-			subHeading: emailAddress
-				? translate( "We've sent a login link to {{strong}}%(emailAddress)s{{/strong}}.", {
-						args: {
-							emailAddress,
-						},
-						components: {
-							strong: <strong />,
-						},
-				  } )
-				: translate( 'We just emailed you a link.' ),
+			heading,
+			subHeading,
 		} );
 	}, [ emailAddress, setHeaders, translate ] );
 

--- a/client/login/magic-login/request-login-code.jsx
+++ b/client/login/magic-login/request-login-code.jsx
@@ -16,7 +16,6 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getMagicLoginRequestEmailError from 'calypso/state/selectors/get-magic-login-request-email-error';
 import isFetchingMagicLoginEmail from 'calypso/state/selectors/is-fetching-magic-login-email';
-import { useLoginContext } from '../login-context';
 import VerifyLoginCode from './verify-login-code';
 
 const RequestLoginCode = ( {
@@ -39,22 +38,11 @@ const RequestLoginCode = ( {
 } ) => {
 	const [ usernameOrEmail, setUsernameOrEmail ] = useState( userEmail || '' );
 	const usernameOrEmailRef = useRef( null );
-	const { setHeaders } = useLoginContext();
-
 	useEffect( () => {
 		if ( onReady ) {
 			onReady();
 		}
-	}, [ onReady, setHeaders, translate ] );
-
-	useEffect( () => {
-		setHeaders( {
-			heading: translate( 'Email me a login code' ),
-			subHeading: translate(
-				"We'll send you an email with a code that will log you in right away."
-			),
-		} );
-	}, [] );
+	}, [ onReady ] );
 
 	const onUsernameOrEmailFieldChange = ( event ) => {
 		setUsernameOrEmail( event.target.value );

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -31,6 +31,7 @@ import getMagicLoginRequestedEmailSuccessfully from 'calypso/state/selectors/get
 import isFetchingMagicLoginEmail from 'calypso/state/selectors/is-fetching-magic-login-email';
 import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
 import EmailedLoginLinkSuccessfullyJetpackConnect from './emailed-login-link-successfully-jetpack-connect';
+import { getCheckYourEmailHeaders, getEmailLinkHeaders } from './utils/heading-utils';
 
 class RequestLoginEmailForm extends Component {
 	static propTypes = {
@@ -80,9 +81,18 @@ class RequestLoginEmailForm extends Component {
 	usernameOrEmailRef = createRef();
 
 	setRequestLoginHeaders() {
+		const { translate, headerText, subHeaderText } = this.props;
+		const siteName = this.state.site?.name ?? null;
+
+		const { heading, subHeading } = getEmailLinkHeaders( translate, {
+			headingOverride: headerText,
+			subHeadingOverride: subHeaderText,
+			siteName,
+		} );
+
 		this.context?.setHeaders( {
-			heading: this.props.headerText || this.props.translate( 'Email me a login link' ),
-			subHeading: this.getSubHeaderText(),
+			heading,
+			subHeading,
 		} );
 	}
 
@@ -93,19 +103,13 @@ class RequestLoginEmailForm extends Component {
 		const usernameOrEmail = this.getUsernameOrEmailFromState();
 		const emailAddress = usernameOrEmail.indexOf( '@' ) > 0 ? usernameOrEmail : null;
 
+		const { heading, subHeading } = getCheckYourEmailHeaders( this.props.translate, {
+			emailAddress,
+		} );
+
 		this.context?.setHeaders( {
-			heading: this.props.translate( 'Check your email' ),
-			subHeading: preventWidows(
-				emailAddress
-					? this.props.translate(
-							"We've sent a login link to {{strong}}%(emailAddress)s{{/strong}}",
-							{
-								args: { emailAddress },
-								components: { strong: <strong /> },
-							}
-					  )
-					: this.props.translate( 'We just emailed you a link.' )
-			),
+			heading,
+			subHeading: preventWidows( subHeading ),
 		} );
 	}
 
@@ -184,28 +188,6 @@ class RequestLoginEmailForm extends Component {
 
 	getUsernameOrEmailFromState() {
 		return this.state.usernameOrEmail;
-	}
-
-	getSubHeaderText() {
-		const { translate, subHeaderText } = this.props;
-		const siteName = this.state.site?.name;
-
-		if ( subHeaderText ) {
-			return subHeaderText;
-		}
-
-		if ( siteName ) {
-			return translate(
-				'We’ll send you an email with a link that will log you in right away to %(siteName)s.',
-				{
-					args: {
-						siteName,
-					},
-				}
-			);
-		}
-
-		return translate( 'We’ll send you an email with a link that will log you in right away.' );
 	}
 
 	getGravatarHeader() {

--- a/client/login/magic-login/utils/heading-utils.tsx
+++ b/client/login/magic-login/utils/heading-utils.tsx
@@ -1,0 +1,88 @@
+import { createElement } from '@wordpress/element';
+import type { TranslateResult } from 'i18n-calypso';
+
+type TranslateFn = (
+	text: string,
+	options?: {
+		args?: Record< string, unknown >;
+		components?: Record< string, JSX.Element >;
+	}
+) => TranslateResult;
+
+interface EmailLinkHeaderOptions {
+	headingOverride?: TranslateResult | string | null;
+	subHeadingOverride?: TranslateResult | string | null;
+	siteName?: string | null;
+}
+
+interface CheckEmailHeaderOptions {
+	emailAddress?: string | null;
+	headingOverride?: TranslateResult | string | null;
+	subHeadingOverride?: TranslateResult | string | null;
+}
+
+const normalizeOverride = (
+	value?: TranslateResult | string | null
+): TranslateResult | string | undefined => {
+	if ( value === null || value === undefined ) {
+		return undefined;
+	}
+	return value;
+};
+
+export const getEmailLinkHeaders = (
+	translate: TranslateFn,
+	{ headingOverride, subHeadingOverride, siteName }: EmailLinkHeaderOptions = {}
+) => {
+	const heading = normalizeOverride( headingOverride ) ?? translate( 'Email me a login link' );
+
+	let subHeading = normalizeOverride( subHeadingOverride );
+	if ( ! subHeading ) {
+		if ( siteName ) {
+			subHeading = translate(
+				'We’ll send you an email with a link that will log you in right away to %(siteName)s.',
+				{
+					args: {
+						siteName,
+					},
+				}
+			);
+		} else {
+			subHeading = translate(
+				'We’ll send you an email with a link that will log you in right away.'
+			);
+		}
+	}
+
+	return { heading, subHeading };
+};
+
+export const getCheckYourEmailHeaders = (
+	translate: TranslateFn,
+	{ emailAddress, headingOverride, subHeadingOverride }: CheckEmailHeaderOptions = {}
+) => {
+	const heading = normalizeOverride( headingOverride ) ?? translate( 'Check your email' );
+
+	let subHeading = normalizeOverride( subHeadingOverride );
+	if ( ! subHeading ) {
+		if ( emailAddress ) {
+			subHeading = translate( "We've sent a login link to {{strong}}%(emailAddress)s{{/strong}}.", {
+				args: {
+					emailAddress,
+				},
+				components: {
+					strong: createElement( 'strong', null ),
+				},
+			} );
+		} else {
+			subHeading = translate( 'We just emailed you a link.' );
+		}
+	}
+
+	return { heading, subHeading };
+};
+
+export const getEmailCodeHeaders = ( translate: TranslateFn ) => ( {
+	heading: translate( 'Email me a login code' ),
+	subHeading: translate( "We'll send you an email with a code that will log you in right away." ),
+} );

--- a/client/login/qr-code-login-page/index.jsx
+++ b/client/login/qr-code-login-page/index.jsx
@@ -1,11 +1,10 @@
 import { Card } from '@automattic/components';
-import { useEffect } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import Main from 'calypso/components/main';
 import { login } from 'calypso/lib/paths';
-import { useLoginContext } from 'calypso/login/login-context';
+import LoginContextProvider from 'calypso/login/login-context';
 import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
 
@@ -17,14 +16,6 @@ function QrCodeLoginPlaceholder() {
 
 function QrCodeLoginPage( { locale, redirectTo, isJetpack = false } ) {
 	const translate = useTranslate();
-	const { setHeaders } = useLoginContext();
-
-	useEffect( () => {
-		setHeaders( {
-			heading: translate( 'Log in via Jetpack app' ),
-			subHeading: translate( 'Open the Jetpack app on your phone to scan this code.' ),
-		} );
-	}, [ setHeaders, translate ] );
 
 	const mainContent = (
 		<Main className={ clsx( 'qr-code-login-page', { 'is-jetpack': isJetpack } ) }>
@@ -55,4 +46,16 @@ function QrCodeLoginPage( { locale, redirectTo, isJetpack = false } ) {
 	);
 }
 
-export default QrCodeLoginPage;
+const QrCodeLoginPageWithContext = ( props ) => {
+	const translate = useTranslate();
+	return (
+		<LoginContextProvider
+			initialHeading={ translate( 'Log in via Jetpack app' ) }
+			initialSubHeading={ translate( 'Open the Jetpack app on your phone to scan this code.' ) }
+		>
+			<QrCodeLoginPage { ...props } />
+		</LoginContextProvider>
+	);
+};
+
+export default QrCodeLoginPageWithContext;

--- a/client/login/test/login-context-provider.test.tsx
+++ b/client/login/test/login-context-provider.test.tsx
@@ -1,0 +1,26 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import LoginContextProvider, { useLoginContext } from '../login-context';
+
+const TestConsumer = () => {
+	const { headingText, subHeadingText } = useLoginContext();
+
+	return (
+		<div>
+			<span data-testid="heading">{ headingText }</span>
+			<span data-testid="subheading">{ subHeadingText }</span>
+		</div>
+	);
+};
+
+describe( 'LoginContextProvider (SSR)', () => {
+	test( 'renders initial headings without relying on effects', () => {
+		const html = renderToStaticMarkup(
+			<LoginContextProvider initialHeading="Hello" initialSubHeading="World">
+				<TestConsumer />
+			</LoginContextProvider>
+		);
+
+		expect( html ).toContain( 'Hello' );
+		expect( html ).toContain( 'World' );
+	} );
+} );

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useLocale } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, type TranslateResult } from 'i18n-calypso';
 import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import { useLoginContext } from 'calypso/login/login-context';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -12,6 +12,18 @@ import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-qu
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import HeadingLogo from './heading-logo';
 import './one-login-layout.scss';
+
+export const ensureHeadingProvided = (
+	heading: TranslateResult | null | undefined
+): TranslateResult | null => {
+	if ( process.env.NODE_ENV !== 'production' && ( heading === undefined || heading === null ) ) {
+		throw new Error(
+			'OneLoginLayout rendered without heading text. Seed LoginContextProvider before render.'
+		);
+	}
+
+	return heading ?? null;
+};
 
 interface OneLoginLayoutProps {
 	isJetpack: boolean;
@@ -51,6 +63,7 @@ const OneLoginLayout = ( {
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const dispatch = useDispatch();
 	const { headingText, subHeadingText, subHeadingTextSecondary } = useLoginContext();
+	const validatedHeadingText = ensureHeadingProvided( headingText );
 
 	const SignUpLink = () => {
 		// use '?signup_url' if explicitly passed as URL query param
@@ -133,7 +146,11 @@ const OneLoginLayout = ( {
 				<div className="wp-login__one-login-layout-heading">
 					<HeadingLogo isJetpack={ isJetpack } />
 					<Step.Heading
-						text={ <div className="wp-login__one-login-layout-heading-text">{ headingText }</div> }
+						text={
+							<div className="wp-login__one-login-layout-heading-text">
+								{ validatedHeadingText }
+							</div>
+						}
 					/>
 					<div className="wp-login__one-login-layout-heading-subtext-wrapper">
 						<h2 className="wp-login__one-login-layout-heading-subtext">{ subHeadingText }</h2>

--- a/client/login/wp-login/components/test/one-login-layout.test.ts
+++ b/client/login/wp-login/components/test/one-login-layout.test.ts
@@ -1,0 +1,24 @@
+import { ensureHeadingProvided } from '../one-login-layout';
+
+describe( 'ensureHeadingProvided', () => {
+	const originalEnv = process.env.NODE_ENV;
+
+	afterEach( () => {
+		process.env.NODE_ENV = originalEnv;
+	} );
+
+	test( 'returns the heading when provided', () => {
+		expect( ensureHeadingProvided( 'Hello' ) ).toBe( 'Hello' );
+	} );
+
+	test( 'throws in non-production environments when heading is missing', () => {
+		expect( () => ensureHeadingProvided( undefined ) ).toThrow(
+			/OneLoginLayout rendered without heading text/i
+		);
+	} );
+
+	test( 'does not throw in production even when heading is missing', () => {
+		process.env.NODE_ENV = 'production';
+		expect( ensureHeadingProvided( undefined ) ).toBeNull();
+	} );
+} );

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -43,7 +43,7 @@ import isWooJPCFlow, {
 	isWooCommercePaymentsOnboardingFlow,
 } from 'calypso/state/selectors/is-woo-jpc-flow';
 import { withEnhancers } from 'calypso/state/utils';
-import { LoginContext } from '../login-context';
+import LoginContextProvider, { LoginContext } from '../login-context';
 import OneLoginFooter from './components/one-login-footer';
 import OneLoginLayout from './components/one-login-layout';
 import GravPoweredLoginBlockFooter from './gravatar/grav-powered-login-block-footer';
@@ -288,60 +288,16 @@ export class Login extends Component {
 	}
 
 	updateHeadingText() {
-		const {
-			twoFactorAuthType,
-			isManualRenewalImmediateLoginAttempt,
-			socialConnect,
-			linkingSocialService,
-			action,
-			oauth2Client,
-			isWooJPC,
-			isJetpack,
-			isWCCOM,
-			isBlazePro,
-			isFromAkismet,
-			isFromAutomatticForAgenciesPlugin,
-			isGravPoweredClient,
-			currentQuery,
-			translate,
-			isUserLoggedIn: isLoggedIn,
-		} = this.props;
-
-		// TODO: remove isGravPoweredClient when login pages are unified.
-		const isSocialFirst = ! isGravPoweredClient;
-
-		const headingText = getHeaderText( {
-			isSocialFirst,
-			twoFactorAuthType,
-			isManualRenewalImmediateLoginAttempt,
-			socialConnect,
-			linkingSocialService,
-			action,
-			oauth2Client,
-			isWooJPC,
-			isJetpack,
-			isWCCOM,
-			isBlazePro,
-			isFromAkismet,
-			isFromAutomatticForAgenciesPlugin,
-			isGravPoweredClient,
-			currentQuery,
-			translate,
-			isUserLoggedIn: isLoggedIn,
-		} );
-
-		const headingSubText = getHeadingSubText( {
-			isSocialFirst,
-			twoFactorAuthType,
-			action,
-			translate,
-			isWooJPC,
-		} );
+		const { translate } = this.props;
+		const { headingText, subHeadingPrimary, subHeadingSecondary } = getInitialHeadingState(
+			this.props,
+			translate
+		);
 
 		this.context.setHeaders( {
 			heading: headingText,
-			subHeading: headingSubText?.primary,
-			subHeadingSecondary: headingSubText?.secondary,
+			subHeading: subHeadingPrimary,
+			subHeadingSecondary,
 		} );
 	}
 
@@ -412,6 +368,80 @@ export class Login extends Component {
 	}
 }
 
+function getInitialHeadingState( props, translate ) {
+	const {
+		twoFactorAuthType,
+		isManualRenewalImmediateLoginAttempt,
+		socialConnect,
+		linkingSocialService,
+		action,
+		oauth2Client,
+		isWooJPC,
+		isJetpack,
+		isWCCOM,
+		isBlazePro,
+		isFromAkismet,
+		isFromAutomatticForAgenciesPlugin,
+		isGravPoweredClient,
+		currentQuery,
+		isUserLoggedIn: isLoggedIn,
+	} = props;
+
+	const isSocialFirst = ! isGravPoweredClient;
+
+	const headingText = getHeaderText( {
+		isSocialFirst,
+		twoFactorAuthType,
+		isManualRenewalImmediateLoginAttempt,
+		socialConnect,
+		linkingSocialService,
+		action,
+		oauth2Client,
+		isWooJPC,
+		isJetpack,
+		isWCCOM,
+		isBlazePro,
+		isFromAkismet,
+		isFromAutomatticForAgenciesPlugin,
+		isGravPoweredClient,
+		currentQuery,
+		translate,
+		isUserLoggedIn: isLoggedIn,
+	} );
+
+	const headingSubText = getHeadingSubText( {
+		isSocialFirst,
+		twoFactorAuthType,
+		action,
+		translate,
+		isWooJPC,
+	} );
+
+	return {
+		headingText,
+		subHeadingPrimary: headingSubText?.primary,
+		subHeadingSecondary: headingSubText?.secondary,
+	};
+}
+
+const LoginWithContext = ( props ) => {
+	const translate = useTranslate();
+	const { headingText, subHeadingPrimary, subHeadingSecondary } = getInitialHeadingState(
+		props,
+		translate
+	);
+
+	return (
+		<LoginContextProvider
+			initialHeading={ headingText }
+			initialSubHeading={ subHeadingPrimary }
+			initialSubHeadingSecondary={ subHeadingSecondary }
+		>
+			<Login { ...props } translate={ translate } />
+		</LoginContextProvider>
+	);
+};
+
 export default connect(
 	( state, props ) => {
 		const currentQuery = getCurrentQueryArguments( state );
@@ -464,4 +494,4 @@ export default connect(
 		recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),
 		recordTracksEvent,
 	}
-)( localize( Login ) );
+)( LoginWithContext );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -530,7 +530,7 @@ export class UserStep extends Component {
 			return translate( 'Create your account' );
 		}
 
-		return headerText;
+		return headerText ?? translate( 'Create your account' );
 	}
 
 	submitButtonText() {
@@ -654,17 +654,21 @@ export class UserStep extends Component {
 		const query = this.props.initialContext?.query || {};
 		const noThanksRedirectUrl = getNoThanksRedirectUrl( { currentQuery: query } );
 
+		const headerText = this.getHeaderText();
+		const subHeaderText = getHeadingSubText( {
+			isSocialFirst: true,
+			twoFactorAuthType: false,
+			translate: this.props.translate,
+			isWooJPC: this.props.isWooJPC,
+		} );
+
 		return (
-			<LoginContextProvider>
-				<LoginContextWrapper
-					headerText={ this.getHeaderText() }
-					subHeaderText={ getHeadingSubText( {
-						isSocialFirst: true,
-						twoFactorAuthType: false,
-						translate: this.props.translate,
-						isWooJPC: this.props.isWooJPC,
-					} ) }
-				>
+			<LoginContextProvider
+				initialHeading={ headerText }
+				initialSubHeading={ subHeaderText?.primary }
+				initialSubHeadingSecondary={ subHeaderText?.secondary }
+			>
+				<LoginContextWrapper headerText={ headerText } subHeaderText={ subHeaderText }>
 					<OneLoginLayout
 						isJetpack={ false }
 						isSectionSignup


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/M4R73CH-1469/login-headings-missing-on-first-paint-snap-before-hydration

## Proposed Changes

* Seed `LoginContextProvider` with `initialHeading` / `initialSubHeading` so SSR markup already contains the hero copy.
* Reuse consolidated heading helpers for WP login, magic login, and QR login to avoid duplicate translation strings and remove redundant `setHeaders` calls.
* Add SSR/regression and runtime tests (`login-context-provider` SSR render + `ensureHeadingProvided` assertion) to catch missing headings going forward.

## Why are these changes being made?

* The login experience flashed because headings/subheadings were injected only after React mounted, so the static HTML lacked the hero content. Seeding the provider during render eliminates that snap and the tests guard against regressions.

## Testing Instructions

* Automated tests
* Go to several Login entry points and confirm the headings/subheadings render correctly and there is no snapping when reloading
  * Default `/log-in` 
  * Link `/log-in/link` 
  * JP `/log-in/jetpack`
  * JP Link/Code`/log-in/jetpack/link`
  * QR `/log-in/qr`
  * Try any of the OAuth2 client Logins to confirm customised headings/subheadings render properly - use the list from https://linear.app/a8c/project/login-and-signup-unify-design-and-layout-16a857e58712/overview
    * Try WooJPC that includes secondary subheadings

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing docs.
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
