### PR TITLE
Enable active partner themes on staging site

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -2,7 +2,9 @@ import { PremiumBadge } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { getProductionSiteId } from 'calypso/dashboard/utils/site-staging-site';
 import { useSelector } from 'calypso/state';
+import { getSite } from 'calypso/state/sites/selectors';
 import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
 import {
 	isMarketplaceThemeSubscribed,
@@ -27,9 +29,16 @@ export default function ThemeTierPartnerBadge( {
 	const translate = useTranslate();
 	const { themeId, siteId } = useThemeTierBadgeContext();
 
-	const isPartnerThemePurchased = useSelector( ( state ) =>
-		siteId ? isMarketplaceThemeSubscribed( state, themeId, siteId ) : false
-	);
+	const isPartnerThemePurchased = useSelector( ( state ) => {
+		if ( ! siteId ) {
+			return false;
+		}
+
+		const site = getSite( state, siteId );
+		const productionSiteId = getProductionSiteId( site );
+
+		return isMarketplaceThemeSubscribed( state, themeId, productionSiteId );
+	} );
 
 	const subscriptionPrices = useSelector(
 		( state ) => getMarketplaceThemeSubscriptionPrices( state, themeId ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1371,7 +1371,7 @@ export default connect(
 	( state, { id } ) => {
 		const themeId = id;
 		const site = getSelectedSite( state );
-		const productionSiteId = getProductionSiteId( site );
+		const productionSiteId = site ? getProductionSiteId( site ) : null;
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSiteSlug( state, siteId );
 		const isWpcomTheme = isThemeWpcom( state, themeId );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1411,7 +1411,7 @@ export default connect(
 
 		const isMarketplaceThemeSubscribed =
 			isExternallyManagedTheme &&
-			getIsMarketplaceThemeSubscribed( state, theme?.id, productionSiteId );
+			getIsMarketplaceThemeSubscribed( state, theme?.id, productionSiteId || siteId );
 
 		const canUserEditThemeOptions = canCurrentUser( state, siteId, 'edit_theme_options' );
 		const isLivePreviewSupported = getIsLivePreviewSupported( state, themeId, siteId );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -108,7 +108,7 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ReviewsModal } from '../marketplace/components/reviews-modal';
 import EligibilityWarningModal from '../themes/atomic-transfer-dialog';
 import ThemeDownloadCard from './theme-download-card';
@@ -397,7 +397,7 @@ class ThemeSheet extends Component {
 
 	shouldRenderForStaging() {
 		// isExternallyManagedTheme determines if a theme is paid or not
-		const { isMarketplaceThemeSubscribed, isExternallyManagedTheme, isWpcomStaging } = this.props;
+		const { isExternallyManagedTheme, isMarketplaceThemeSubscribed, isWpcomStaging } = this.props;
 		return isExternallyManagedTheme && isWpcomStaging && ! isMarketplaceThemeSubscribed;
 	}
 
@@ -1371,7 +1371,8 @@ export default connect(
 	( state, { id } ) => {
 		const themeId = id;
 		const site = getSelectedSite( state );
-		const siteId = getProductionSiteId( site );
+		const productionSiteId = getProductionSiteId( site );
+		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSiteSlug( state, siteId );
 		const isWpcomTheme = isThemeWpcom( state, themeId );
 		const backPath = getBackPath( state );
@@ -1409,7 +1410,8 @@ export default connect(
 			( isExternallyManagedTheme && Object.values( getProductsList( state ) ).length === 0 );
 
 		const isMarketplaceThemeSubscribed =
-			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
+			isExternallyManagedTheme &&
+			getIsMarketplaceThemeSubscribed( state, theme?.id, productionSiteId );
 
 		const canUserEditThemeOptions = canCurrentUser( state, siteId, 'edit_theme_options' );
 		const isLivePreviewSupported = getIsLivePreviewSupported( state, themeId, siteId );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -396,8 +396,8 @@ class ThemeSheet extends Component {
 
 	shouldRenderForStaging() {
 		// isExternallyManagedTheme determines if a theme is paid or not
-		const { isExternallyManagedTheme, isWpcomStaging } = this.props;
-		return isExternallyManagedTheme && isWpcomStaging;
+		const { isActive, isExternallyManagedTheme, isWpcomStaging } = this.props;
+		return isExternallyManagedTheme && isWpcomStaging && ! isActive;
 	}
 
 	shouldRenderPreviewButton() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -44,6 +44,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
+import { getProductionSiteId } from 'calypso/dashboard/utils/site-staging-site';
 import { HOSTING_THEME_SELCETED_HASH } from 'calypso/hosting/constants';
 import { withCompleteLaunchpadTasksWithNotice } from 'calypso/launchpad/hooks/with-complete-launchpad-tasks-with-notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -107,7 +108,7 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { ReviewsModal } from '../marketplace/components/reviews-modal';
 import EligibilityWarningModal from '../themes/atomic-transfer-dialog';
 import ThemeDownloadCard from './theme-download-card';
@@ -396,8 +397,8 @@ class ThemeSheet extends Component {
 
 	shouldRenderForStaging() {
 		// isExternallyManagedTheme determines if a theme is paid or not
-		const { isActive, isExternallyManagedTheme, isWpcomStaging } = this.props;
-		return isExternallyManagedTheme && isWpcomStaging && ! isActive;
+		const { isMarketplaceThemeSubscribed, isExternallyManagedTheme, isWpcomStaging } = this.props;
+		return isExternallyManagedTheme && isWpcomStaging && ! isMarketplaceThemeSubscribed;
 	}
 
 	shouldRenderPreviewButton() {
@@ -1369,7 +1370,8 @@ const ThemeSheetWithOptions = ( props ) => {
 export default connect(
 	( state, { id } ) => {
 		const themeId = id;
-		const siteId = getSelectedSiteId( state );
+		const site = getSelectedSite( state );
+		const siteId = getProductionSiteId( site );
 		const siteSlug = getSiteSlug( state, siteId );
 		const isWpcomTheme = isThemeWpcom( state, themeId );
 		const backPath = getBackPath( state );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-121

## Proposed Changes

* https://github.com/Automattic/wp-calypso/pull/75274 blocked the ability to purchase themes on staging, but that didn't consider themes that had already been purchased on production.
* Use the production site id to check whether a theme has been purchased, since it won't show up while using the staging site id.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As can be seen on the linear issue, a customer was not able to activate a partner theme on their staging site after purchasing it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview.
* Go to `/theme/waverly/{siteId}`, click on `Activate`.
* That will take you to the checkout page, finish the purchase.
* Go to `/sites/{siteId}`, create a staging site.
* Once the staging site is created, go to `/theme/waverly/{stagingSiteId}`.
* Check that you don't see any out of place banners and that you can customize the staging site.

|Before|After|
|---|---|
|<img width="3839" height="1303" alt="image" src="https://github.com/user-attachments/assets/2b9675ac-ea61-4ba6-b8b3-ef7c057d00f0" />|<img width="3839" height="1303" alt="image" src="https://github.com/user-attachments/assets/5fa388a7-aae5-4771-b312-94d1fcbc4309" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
