### PR TITLE
Reader: Fix global notice z-index when modal is open

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -118,7 +118,7 @@ $z-layers: (
 		".layout__secondary": 176,
 		".popover.comment__author-more-info-popover": 178,
 		".screen-options-tab": 178,
-		".global-notices": 179,
+		".global-notices": 100001,
 		".masterbar": 180,
 		".legal-updates-banner": 185,
 		".detail-page__backdrop": 190,


### PR DESCRIPTION

Closes READ-107

## Proposed Changes

* Fiz global-notice z-index

## Why are these changes being made?
* When the reader's model is open, all notices appear behind the model. 

## Testing Instructions
* Download and apply this patch [diff.patch](https://github.com/user-attachments/files/23778112/diff.patch) to always trigger the modal and a notice error
* Verify whether the result matches the image below. 

<img width="2656" height="2636" alt="CleanShot 2025-11-26 at 18 39 59@2x" src="https://github.com/user-attachments/assets/cfe680d4-db20-4bed-a05d-ff6d5bba4752" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
