### PR TITLE
Log dashboard error message as the official logstash "message"

### DIFF
--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -73,6 +73,7 @@ export const getRouter = ( config: AppConfig ) => {
 				properties: {
 					dashboard_backport: false,
 					env: calypsoConfig( 'env_id' ),
+					message: error.message,
 					stack: errorInfo.componentStack,
 				},
 			} );

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -67,12 +67,12 @@ export const getRouter = ( config: AppConfig ) => {
 		defaultOnCatch: ( error: Error, errorInfo: ErrorInfo ) => {
 			logToLogstash( {
 				feature: 'calypso_client',
-				message: 'Unknown error',
+				message: error.message,
 				severity: calypsoConfig( 'env_id' ) === 'production' ? 'error' : 'debug',
 				tags: [ 'dashboard' ],
 				properties: {
+					dashboard_backport: false,
 					env: calypsoConfig( 'env_id' ),
-					message: error.message,
 					stack: errorInfo.componentStack,
 				},
 			} );

--- a/client/sites/v2/utils/router.ts
+++ b/client/sites/v2/utils/router.ts
@@ -22,6 +22,7 @@ export function getRouterOptions( config: AppConfig ) {
 				properties: {
 					dashboard_backport: true,
 					env: calypsoConfig( 'env_id' ),
+					message: error.message,
 					stack: errorInfo.componentStack,
 				},
 			} );

--- a/client/sites/v2/utils/router.ts
+++ b/client/sites/v2/utils/router.ts
@@ -16,12 +16,12 @@ export function getRouterOptions( config: AppConfig ) {
 		defaultOnCatch: ( error: Error, errorInfo: ErrorInfo ) => {
 			logToLogstash( {
 				feature: 'calypso_client',
-				message: 'Unknown error (backport)',
+				message: error.message,
 				severity: calypsoConfig( 'env_id' ) === 'production' ? 'error' : 'debug',
 				tags: [ 'dashboard' ],
 				properties: {
+					dashboard_backport: true,
 					env: calypsoConfig( 'env_id' ),
-					message: error.message,
 					stack: errorInfo.componentStack,
 				},
 			} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/107233

## Proposed Changes

* Logs the `defaultOnCatch` error message as the official logstash message
* Add a `dashboard_backport` property to the message, so that we can still filter on that if we want
* Leave `properties.message` property unchanged so that it keeps working with 196687-ghe-Automattic/wpcom

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The log stash message view is just a bunch of messages that all look identical

<img width="1156" height="1110" alt="CleanShot 2025-11-27 at 10 03 36@2x" src="https://github.com/user-attachments/assets/6389847f-a596-474b-8209-e2e6b8cd2292" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?