### PR TITLE
MSD Billing: Prevent redirect to expired purchase after upgrade

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -204,7 +204,11 @@ export default function UpsellStep( {
 					acceptButtonText={ sprintf( __( 'I want the %(businessPlanName)s plan' ), {
 						businessPlanName,
 					} ) }
-					acceptButtonUrl={ `/checkout/${ purchase.site_slug }/business?coupon=${ couponCode }` }
+					acceptButtonUrl={ `/checkout/${
+						purchase.site_slug
+					}/business?coupon=${ couponCode }&cancel_to=${ window.location.href
+						.replace( window.location.origin, '' )
+						.replace( '/cancel', '' ) }` }
 					onAccept={ () => {
 						recordTracksEvent( 'calypso_cancellation_upgrade_at_step_upgrade_click' );
 					} }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -151,7 +151,6 @@ function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
 	const backUrl = window.location.href.replace( window.location.origin, '' );
 	return addQueryArgs( '/setup/plan-upgrade', {
 		...( siteSlug && { siteSlug } ),
-		redirect_to: backUrl,
 		cancel_to: backUrl,
 	} );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [SHILL-1369](https://linear.app/a8c/issue/SHILL-1369/msd-upgrade-flow-after-upgrade-user-is-returned-to-old-plan)

## Proposed Changes

* Remove `redirect_to` on upgrade purchase to allow upgrades via `/checkout` to finish on "thank you" page. (Keep `cancel_to` as-is so cancelling checkout redirects the user to the purchase settings page.)
* Add `cancel_to` on upgrade purchase from cancel flow to allow upgrades via `/setup/plan-upgrade` so cancelling checkout redirects the user to the purchase settings page.)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `redirect_to` URL would send the customer to the old (now expired) purchase settings page. We only want to do this when the user aborts the upgrade flow so that the customer is redirected to the (still active) purchase settings page. This replicates the behavior of the v1 upgrade (via cancel) flow, sending the user to the "thank you" page (because that's how the `/checkout` URL behaves when there's no `redirect_to` query argument). NOTE: `/checkout` is used here so that a specific plan can be purchased whereas `/setup/plan-upgrade` would let the user choose a plan - something we only want to do outside of the cancel flow.
* Adding `cancel_to` to the `/setup/plan-upgrade` URL (when upgrading via the purchase settings page directly and not via the cancel flow) replicates the behavior of the v1 upgrade flow, sending the user to the purchase settings page if they cancel. Omitting `redirect_to` or `back_to` via this flow sends the user to the `/sites` page after upgrade, replicating the v1 upgrade flow's redirect after upgrade.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test Upgrade Flow
* Visit the MSD billing active upgrades page (`/v2/me/billing/purchases`)
* Choose a Personal, Premium or Business plan and click "Manage purchase"
* Click "Upgrade", "Upgrade Subscription" or "Pick a Plan" (if the purchase is expired).
* Do not checkout. Instead, click the "< Back" or "< Back to dashboard" button in the upper left corner. Empty or cart or leave items. You should be returned to the MSD purchase settings page.
* Click "Upgrade", "Upgrade Subscription" or "Pick a Plan" and checkout with an upgraded plan. You should be redirected to the `/sites` page.

### Test Upgrade via Cancel Flow
* Visit the MSD billing active upgrades page (`/v2/me/billing/purchases`)
* Choose a Premium plan and click "Manage purchase"
* Click "Downgrade or cancel" and click the checkbox to confirm you understand and click "Cancel plan".
* When prompted, choose "Missing features" and "Cannot upload custom themes", click continue. When offered, choose the WordPress.com Business plan.
* Do not checkout. Instead, click the "< Back" or "< Back to dashboard" button in the upper left corner. Empty or cart or leave items. You should be returned to the MSD purchase settings page.
* Click "Downgrade or cancel" and click the checkbox to confirm you understand and click "Cancel plan".
* When prompted, choose "Missing features" and "Cannot upload custom themes", click continue. When offered, choose the WordPress.com Business plan and complete checkout. You should land on the "thank you" page.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
