### PR TITLE
Stats: Fix line chart click handler to use literal date values

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -10,7 +10,6 @@ import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import ChartBarTooltip from 'calypso/components/chart/bar-tooltip';
-import { DATE_FORMAT } from '../../constants';
 import { useMomentInSite } from '../../hooks/use-moment-site-zone';
 import StatsEmptyState from '../../stats-empty-state';
 

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -173,16 +173,24 @@ function StatsLineChart( {
 				</div>
 			);
 		},
-		[ moment ]
+		[ moment, seriesIcons ]
 	);
 
 	const onPointerUp = useCallback(
 		( { datum }: EventHandlerParams< DataPointDate > ) => {
+			// datum.date is always in the timezone of the browser, we need to use literal date here.
 			if ( datum && datum.date ) {
-				onClick && onClick( { data: { period: moment( datum.date ).format( DATE_FORMAT ) } } );
+				onClick &&
+					onClick( {
+						data: {
+							period: `${ datum.date.getFullYear() }-${
+								datum.date.getMonth() + 1
+							}-${ datum.date.getDate() }`,
+						},
+					} );
 			}
 		},
-		[ moment, onClick ]
+		[ onClick ]
 	);
 
 	return (


### PR DESCRIPTION
## Proposed Changes

* Fixed the line chart click handler in `client/my-sites/stats/components/line-chart/index.tsx` to use literal date values instead of formatting through moment
* Added `seriesIcons` to the `renderTooltip` dependency array for completeness

## Why are these changes being made?

The line chart click handler was using moment to format dates from the chart datum, which could cause timezone conversion issues. Since `datum.date` is always in the browser's timezone, we should use the literal date values (year, month, day) directly instead of passing it through moment formatting. This ensures consistent behavior regardless of the site's timezone settings and prevents potential off-by-one date errors when clicking on chart data points.

## Testing Instructions

### Prerequisites
* Test with a site that has a GMT offset configured (e.g., GMT+10 or GMT-5)
* Navigate to Stats page

### Steps to Test
1. Go to the Stats page for a site with a configured timezone offset
2. View the traffic chart (ensure you're viewing the line chart, not bar chart - use the chart type toggle if available)
3. Click on various data points on the line chart
4. Verify that clicking on a data point:
   - Correctly navigates to or drills down to the selected date
   - The selected date matches the date label on the chart
   - No off-by-one date errors occur (e.g., clicking "Jan 15" should select Jan 15, not Jan 14 or Jan 16)
5. Test with different time periods (day, week, month, year views)
6. Verify the tooltip still displays correctly when hovering over data points

### Expected Behavior
* Clicking on any data point should correctly identify and use that exact date
* No timezone conversion issues should occur
* Date navigation should be accurate

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?