### PR TITLE
Add-ons: Fix the browser back behavior after clicking either Manage add-on or Buy add-on

### DIFF
--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -117,11 +117,11 @@ const AddOnsMain = () => {
 			quantity,
 		} );
 
-		page.redirect( `${ checkoutLink( selectedSite?.ID ?? null, addOnSlug, quantity ) }` );
+		page.show( `${ checkoutLink( selectedSite?.ID ?? null, addOnSlug, quantity ) }` );
 	};
 
 	const handleActionSelected = () => {
-		page.redirect( `/purchases/subscriptions/${ selectedSite?.slug }` );
+		page.show( `/purchases/subscriptions/${ selectedSite?.slug }` );
 	};
 
 	return (

--- a/client/sites/components/add-ons/add-ons-modal/index.tsx
+++ b/client/sites/components/add-ons/add-ons-modal/index.tsx
@@ -30,11 +30,11 @@ export default function AddOnsModal( { isOpen, onClose }: AddOnsModalProps ) {
 			quantity,
 		} );
 
-		page.redirect( `${ checkoutLink( site?.ID ?? null, addOnSlug, quantity ) }` );
+		page.show( `${ checkoutLink( site?.ID ?? null, addOnSlug, quantity ) }` );
 	};
 
 	const handleActionSecondary = () => {
-		page.redirect( `/purchases/subscriptions/${ site?.slug }` );
+		page.show( `/purchases/subscriptions/${ site?.slug }` );
 	};
 
 	if ( ! isOpen ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-91

## Proposed Changes

* When you click either Manage add-on or Buy add-on, and then navigate back using the browser’s back button, the browser does not return to the previous page. This happens because we currently use `page.redirect` to open the target page, which replaces the current history state.
* To resolve this issue, this PR updates the behavior to use `page.show` instead, ensuring the previous page remains in the browser history and the back button functions as expected.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The browser back behavior is not expected

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/home/:site` on your simple site
* Navigate to `Hosting > Add-ons`
* Click either Manage add-on or Buy add-on
* Click the browser back button
* Ensure you can go back to the Add-ons page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
