### PR TITLE
E2E: Fix Social Image Generator tests

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
@@ -100,9 +100,9 @@ export class SocialConnectionsManager {
 	}
 
 	/**
-	 * Intercept the requests and to modify the response
+	 * Intercept the requests and to modify the response to add test connections.
 	 */
-	async interceptRequests() {
+	async mockSocialConnections() {
 		await this.page.route( this.isTargetUrl, async ( route ) => {
 			// Fetch original response.
 			const response = await route.fetch();

--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -105,7 +105,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 			} );
 
 			test( 'Should verify that auto-sharing is available for new posts', async function () {
-				await socialConnectionsManager.interceptRequests();
+				await socialConnectionsManager.mockSocialConnections();
 
 				await Promise.all( [
 					// Open the Jetpack sidebar.
@@ -134,7 +134,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				features.resharing ? 'IS' : 'is NOT'
 			} available`, async function () {
 				let connectionTestPromise = Promise.resolve();
-				await socialConnectionsManager.interceptRequests();
+				await socialConnectionsManager.mockSocialConnections();
 
 				connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
 
@@ -271,7 +271,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 			test( `Should verify that Social Image Generator ${
 				features.socialImageGenerator ? 'IS' : 'is NOT'
 			} available`, async function () {
-				await socialConnectionsManager.interceptRequests();
+				await socialConnectionsManager.mockSocialConnections();
 
 				const connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
 

--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -271,8 +271,14 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 			test( `Should verify that Social Image Generator ${
 				features.socialImageGenerator ? 'IS' : 'is NOT'
 			} available`, async function () {
+				await socialConnectionsManager.interceptRequests();
+
+				const connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
+
 				// Open the Jetpack sidebar.
 				await editorPage.openSettings( 'Jetpack' );
+
+				await connectionTestPromise;
 
 				// Expand the Publicize panel.
 				const section = await editorPage.expandSection( 'Share to Social Media' );


### PR DESCRIPTION
Social Image Generator tests have been broken due to the changes in Jetpack Social related to Social Image Generator. Currently, we hide every Social UI if there are no social media accounts added.

## Proposed Changes

*  Add mocked social media accounts before asserting the Social Image Generator UI
* Rename the `interceptRequests` method to clarify the specific usage

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
