### PR TITLE
MSD: Fix the style of the env switcher button

### DIFF
--- a/client/dashboard/components/environment/index.tsx
+++ b/client/dashboard/components/environment/index.tsx
@@ -11,11 +11,7 @@ interface EnvironmentProps {
 const Environment = ( { environmentType }: EnvironmentProps ) => {
 	if ( environmentType === 'staging' ) {
 		return (
-			<HStack
-				justify="flex-start"
-				spacing={ 1 }
-				style={ { width: 'auto', flexShrink: 0, marginInlineStart: '-3px' } }
-			>
+			<HStack justify="flex-start" spacing={ 1 } style={ { width: 'auto', flexShrink: 0 } }>
 				<Icon icon={ staging } />
 				<span>{ __( 'Staging' ) }</span>
 			</HStack>
@@ -23,11 +19,7 @@ const Environment = ( { environmentType }: EnvironmentProps ) => {
 	}
 
 	return (
-		<HStack
-			justify="flex-start"
-			spacing={ 1 }
-			style={ { width: 'auto', flexShrink: 0, marginInlineStart: '-3px' } }
-		>
+		<HStack justify="flex-start" spacing={ 1 } style={ { width: 'auto', flexShrink: 0 } }>
 			<Icon icon={ production } />
 			<span>{ __( 'Production' ) }</span>
 		</HStack>

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -139,7 +139,7 @@ const EnvironmentSwitcherDropdown = ( {
 						}
 						disabled={ isStagingSiteCreating || isStagingSiteDeleting }
 					>
-						<HStack justify="flex-start">
+						<HStack justify="flex-start" spacing={ 1 }>
 							<StagingSiteActionButton
 								isStagingSiteDeleting={ isStagingSiteDeleting }
 								isStagingSiteCreating={ isStagingSiteCreating }

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -405,7 +405,11 @@ function StagingSiteSyncModalInner( {
 						a: <ExternalLink href={ `/activity-log/${ targetSiteSlug }` } children={ null } />,
 					} ) }
 				</Text>
-				<HStack spacing={ 4 } alignment="left" style={ { height: '40px' } }>
+				<HStack
+					spacing={ 4 }
+					alignment="left"
+					style={ { height: '40px', marginInlineStart: '-3px' } }
+				>
 					<EnvironmentLabel environmentType={ sourceEnvironment } siteTitle={ sourceSiteTitle } />
 					<DirectionArrow />
 					<EnvironmentLabel environmentType={ targetEnvironment } siteTitle={ targetSiteTitle } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/106679

## Proposed Changes

* https://github.com/Automattic/wp-calypso/pull/106679 introduced the issue that the env buttons were not aligned with the creating staging site button. As a result, this PR reverts changes and apply `margin-inline-start: -3px` to `StagingSiteSyncModal` itself instead

| Before | After |
| - | - |
|<img width="209" height="105" alt="image" src="https://github.com/user-attachments/assets/eb9cc53e-0070-41fa-8f78-7335ccb03bb8" />|<img width="208" height="103" alt="image" src="https://github.com/user-attachments/assets/042e551e-9bb1-48c1-afd7-c423d7bcbc4a" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Inconsistent styles

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select your site without the staging site
* Click the `Production` button
* Ensure the buttons are aligned now
* Switch to your site with the staging site
* Click `Sync` > `Pull from Production`
* Ensure the env buttons are still aligned

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
