### PR TITLE
MSD: Throw unknown blog error via loader to keep displaying the header

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -89,7 +89,13 @@ export const siteRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites/$siteSlug',
 	beforeLoad: async ( { cause, params: { siteSlug }, location, matches } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		let site;
+		try {
+			site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		} catch ( e ) {
+			// Do nothing and propagate the error through the loader function.
+			return;
+		}
 
 		const overviewUrl = `/sites/${ siteSlug }`;
 		if ( isSelfHostedJetpackConnected( site ) && ! location.pathname.endsWith( overviewUrl ) ) {

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -6,7 +6,7 @@ import { isSelfHostedJetpackConnected, isP2 } from '../utils/site-types';
 import type { Site, User } from '@automattic/api-core';
 
 export function canManageSite( site: Site ) {
-	if ( site.is_deleted || ! site.capabilities.manage_options ) {
+	if ( site.is_deleted || ! site.capabilities?.manage_options ) {
 		return false;
 	}
 

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -13,6 +13,8 @@ import { queryClient } from './query-client';
 import type { Site } from '@automattic/api-core';
 import type { Query } from '@tanstack/react-query';
 
+const KNOWN_ERRORS = [ 'unknown_blog', 'unauthorized' ];
+
 export const siteBySlugQuery = ( siteSlug: string ) =>
 	queryOptions( {
 		queryKey: [ 'site-by-slug', siteSlug, SITE_FIELDS, SITE_OPTIONS ],
@@ -20,14 +22,14 @@ export const siteBySlugQuery = ( siteSlug: string ) =>
 			try {
 				return await fetchSite( siteSlug );
 			} catch ( e ) {
-				if ( isWpError( e ) && e.error === 'unknown_blog' ) {
+				if ( isWpError( e ) && e.error && KNOWN_ERRORS.includes( e.error ) ) {
 					throw notFound( { data: e.error } );
 				}
 				throw e;
 			}
 		},
 		retry: ( failureCount, e: { data?: string } ) => {
-			if ( e.data === 'unknown_blog' ) {
+			if ( e.data && KNOWN_ERRORS.includes( e.data ) ) {
 				return false;
 			}
 			return failureCount < 3; // default retry count
@@ -41,14 +43,14 @@ export const siteByIdQuery = ( siteId: number ) =>
 			try {
 				return await fetchSite( siteId );
 			} catch ( e ) {
-				if ( isWpError( e ) && e.error === 'unknown_blog' ) {
+				if ( isWpError( e ) && e.error && KNOWN_ERRORS.includes( e.error ) ) {
 					throw notFound( { data: e.error } );
 				}
 				throw e;
 			}
 		},
 		retry: ( failureCount, e: { data?: string } ) => {
-			if ( e.data === 'unknown_blog' ) {
+			if ( e.data && KNOWN_ERRORS.includes( e.data ) ) {
 				return false;
 			}
 			return failureCount < 3; // default retry count

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -21,10 +21,16 @@ export const siteBySlugQuery = ( siteSlug: string ) =>
 				return await fetchSite( siteSlug );
 			} catch ( e ) {
 				if ( isWpError( e ) && e.error === 'unknown_blog' ) {
-					throw notFound();
+					throw notFound( { data: e.error } );
 				}
 				throw e;
 			}
+		},
+		retry: ( failureCount, e: { data?: string } ) => {
+			if ( e.data === 'unknown_blog' ) {
+				return false;
+			}
+			return failureCount < 3; // default retry count
 		},
 	} );
 
@@ -36,10 +42,16 @@ export const siteByIdQuery = ( siteId: number ) =>
 				return await fetchSite( siteId );
 			} catch ( e ) {
 				if ( isWpError( e ) && e.error === 'unknown_blog' ) {
-					throw notFound();
+					throw notFound( { data: e.error } );
 				}
 				throw e;
 			}
+		},
+		retry: ( failureCount, e: { data?: string } ) => {
+			if ( e.data === 'unknown_blog' ) {
+				return false;
+			}
+			return failureCount < 3; // default retry count
 		},
 	} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-899

## Proposed Changes

* Don’t throw the error from the `beforeLoad `function. Instead, throw it from the `loader` function to keep the behavior consistent with blogs that the user doesn’t have permission to access
* Don't retry if it's unknown blog

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It would be better to keep the screen the same when accessing an unknown blog or a blog without permission

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites/234asdfsdomainnot.com (unknown blog)
* Go to /v2/sites/abstractingscom.wordpress.com (blog without permission)
* Ensure the result is the same, and you can see 404 error with the top header

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
