### PR TITLE
Reader: Hide item when there is an error to load the site details

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -2,6 +2,7 @@ import { ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose, isEmpty, get } from 'lodash';
+import { useEffect, useCallback } from 'react';
 import { connect } from 'react-redux';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
@@ -22,7 +23,6 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import { getReaderFollowForFeed } from 'calypso/state/reader/follows/selectors';
 import { registerLastActionRequiresLogin } from 'calypso/state/reader-ui/actions';
-
 import './style.scss';
 
 function ReaderSubscriptionListItem( {
@@ -58,23 +58,29 @@ function ReaderSubscriptionListItem( {
 	const siteUrl = getSiteUrl( { feed, site } );
 	const isMultiAuthor = get( site, 'is_multi_author', false );
 	const preferGravatar = ! isMultiAuthor;
+	const hasSiteError = site?.is_error;
 
-	if ( ! site && ! feed ) {
-		return <ReaderSubscriptionListItemPlaceholder />;
-	}
+	const recordEvent = useCallback(
+		( name ) => {
+			const props = {
+				blog_id: siteId,
+				feed_id: feedId,
+				source: followSource,
+			};
+			if ( railcar ) {
+				recordTrackWithRailcar( name, railcar, props );
+			} else {
+				recordTrack( name, props );
+			}
+		},
+		[ feedId, followSource, railcar, siteId ]
+	);
 
-	function recordEvent( name ) {
-		const props = {
-			blog_id: siteId,
-			feed_id: feedId,
-			source: followSource,
-		};
-		if ( railcar ) {
-			recordTrackWithRailcar( name, railcar, props );
-		} else {
-			recordTrack( name, props );
+	useEffect( () => {
+		if ( hasSiteError ) {
+			recordEvent( 'calypso_reader_subscription_list_item_site_error' );
 		}
-	}
+	}, [ feedId, followSource, hasSiteError, recordEvent, siteId ] );
 
 	const recordTitleClick = () => recordEvent( 'calypso_reader_feed_link_clicked' );
 	const recordAuthorClick = () => recordEvent( 'calypso_reader_author_link_clicked' );
@@ -116,6 +122,14 @@ function ReaderSubscriptionListItem( {
 	const handleClick = () => {
 		onItemClick();
 	};
+
+	if ( hasSiteError ) {
+		return null;
+	}
+
+	if ( ! site && ! feed ) {
+		return <ReaderSubscriptionListItemPlaceholder />;
+	}
 
 	return (
 		<div

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -58,7 +58,7 @@ function ReaderSubscriptionListItem( {
 	const siteUrl = getSiteUrl( { feed, site } );
 	const isMultiAuthor = get( site, 'is_multi_author', false );
 	const preferGravatar = ! isMultiAuthor;
-	const hasSiteError = site?.is_error;
+	const hasSiteError = site?.is_error || feed?.is_error;
 
 	const recordEvent = useCallback(
 		( name ) => {


### PR DESCRIPTION
Closes READ-106

## Proposed Changes
* Hide the item when there is an error loading the site detail 


<img width="3290" height="1632" alt="CleanShot 2025-11-27 at 13 10 10@2x" src="https://github.com/user-attachments/assets/7c44fdd2-151c-4ab2-ae9e-360914598f8b" />


## Why are these changes being made?
* If we have any error in loading a site detail, the UI is showing a weird error message that is useless to our final users. 
This PR hides it. 

## Testing Instructions
* Create a new WordPress account OR hack this logic https://github.com/Automattic/wp-calypso/blob/964f8b466b41f3318376009ac3f6c262899458ba/client/reader/onboarding/index.tsx#L57-L65 (shouldShowOnboarding always true)
* Go to /reader
* Select any topic on the `What topics interest you?`  modal step
* Wait to see the list of recommendations
* Open your Chrome Dev Tools > Network
* Block at least one of the requests to ("rest/v1.1/read/feed/63349823?http_envelope=1"), video showing how to do it.
* Reload the page and check that the item is not rendered anymore.


https://github.com/user-attachments/assets/41ce80ee-c974-4d4b-be2f-5a0e453b7db2


> [!IMPORTANT]
>  I checked and confirmed all hardcoded suggestions [available on this file](https://github.com/Automattic/wp-calypso/blob/f4a051f265caa93e443091720bea0bc5d1e02d60/client/reader/onboarding/curated-blogs/index.tsx) are working 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
