### PR TITLE
Checkout: Refactor Bancontact to use simple event emitter for state

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -4,7 +4,6 @@ import {
 	createApplePayMethod,
 	createGooglePayMethod,
 	createBancontactMethod,
-	createBancontactPaymentMethodStore,
 	createP24Method,
 	createP24PaymentMethodStore,
 	createEpsMethod,
@@ -189,16 +188,14 @@ function useCreateBancontact( {
 	stripeLoadingError: StripeLoadingError;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
-	const paymentMethodStore = useMemo( () => createBancontactPaymentMethodStore(), [] );
 	return useMemo(
 		() =>
 			shouldLoad
 				? createBancontactMethod( {
-						store: paymentMethodStore,
 						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore ]
+		[ shouldLoad ]
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CHE-295/payment-methods-should-not-use-wordpressdata-stores

## Proposed Changes

This PR refactors the Bancontact payment method to use a simple event emitter for its state instead of a `@wordpress/data` store.

<img width="627" height="292" alt="Screenshot 2025-11-27 at 1 19 02 PM" src="https://github.com/user-attachments/assets/1c458165-98bb-4d5f-9c72-841a1e8b5b82" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I regret using `@wordpress/data` to create data stores for some of our payment methods. It's overkill and adds a lot of complexity and boilerplate. It's much simpler to use a basic event emitter and I've done that for more recent payment methods like Pix. I'd like to refactor the other payment methods that use stores to use basic event emitters instead.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Sandbox the store.
- Set your user currency to EUR.
- Add a product to your cart and visit checkout.
- Select Belgium (`BE`) as your country in checkout.
- Select "Bancontact" as the payment method.
- Enter a name in the input field within the payment method and verify that it shows up as expected.
- Submit the payment.
- On the confirmation page, you should see a "Payment Method object" which mentions the `name` that you entered in checkout. (You do not need to confirm the purchase.)

<img width="435" height="445" alt="Screenshot 2025-11-27 at 1 20 01 PM" src="https://github.com/user-attachments/assets/69dfb30e-ebe7-4267-9617-396f41841c43" />

