### PR TITLE
Reader: Fix race condition when the user follows tags on the onboarding flow

### DIFF
--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { SelectCardCheckbox } from '@automattic/onboarding';
+import { SelectCardCheckboxV2 } from '@automattic/onboarding';
 import {
 	Modal,
 	Button,
@@ -215,7 +215,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 							<h3 className="interests-modal__section-header">{ category.name }</h3>
 							<div className="interests-modal__topics-list">
 								{ category.topics.map( ( topic ) => (
-									<SelectCardCheckbox
+									<SelectCardCheckboxV2
 										key={ topic.name }
 										onChange={ ( checked ) => handleTopicChange( checked, topic.tag ) }
 										checked={
@@ -225,7 +225,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 										}
 									>
 										{ topic.name }
-									</SelectCardCheckbox>
+									</SelectCardCheckboxV2>
 								) ) }
 							</div>
 						</div>

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -218,6 +218,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 									<SelectCardCheckboxV2
 										key={ topic.name }
 										onChange={ ( checked ) => handleTopicChange( checked, topic.tag ) }
+										isBusy={ processingTags.has( topic.tag ) }
 										checked={
 											Array.isArray( topic.tag )
 												? topic.tag.every( ( t ) => followedTags.includes( t ) )

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -25,6 +25,7 @@ export { default as MShotsImage } from './mshots-image';
 export { useStepPersistedState, clearStepPersistedState } from './hooks/use-persisted-state';
 export * from './navigator';
 export { default as SelectCardCheckbox } from './select-card-checkbox';
+export { default as SelectCardCheckboxV2 } from './select-card-checkbox-v2';
 export * from './utils';
 export type { SelectItem } from './select-items';
 export type { SelectItemAlt } from './select-items-alt';

--- a/packages/onboarding/src/select-card-checkbox-v2/index.tsx
+++ b/packages/onboarding/src/select-card-checkbox-v2/index.tsx
@@ -1,0 +1,43 @@
+import { CheckboxControl, __experimentalHStack as HStack } from '@wordpress/components';
+import clsx from 'clsx';
+import { useId } from 'react';
+import './style.scss';
+
+type SelectCardCheckboxProps = {
+	children: React.ReactNode;
+	className?: string;
+	onChange: ( checked: boolean ) => void;
+	checked: boolean;
+};
+
+const SelectCardCheckboxV2 = ( {
+	children,
+	className,
+	onChange,
+	checked,
+}: SelectCardCheckboxProps ) => {
+	const instanceId = useId();
+	const id = `select-card-checkbox-v2-${ instanceId }`;
+
+	return (
+		<HStack
+			spacing={ 2 }
+			as="label"
+			className={ clsx( 'select-card-checkbox-v2', className ) }
+			htmlFor={ id }
+			alignment="left"
+			aria-checked={ checked }
+			aria-labelledby={ `select-card-checkbox-v2-label-${ instanceId }` }
+		>
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				checked={ checked }
+				id={ id }
+				onChange={ onChange }
+			/>
+			<span id={ `select-card-checkbox-v2-label-${ instanceId }` }>{ children }</span>
+		</HStack>
+	);
+};
+
+export default SelectCardCheckboxV2;

--- a/packages/onboarding/src/select-card-checkbox-v2/index.tsx
+++ b/packages/onboarding/src/select-card-checkbox-v2/index.tsx
@@ -6,15 +6,17 @@ import './style.scss';
 type SelectCardCheckboxProps = {
 	children: React.ReactNode;
 	className?: string;
+	checked?: boolean;
+	disabled?: boolean;
 	onChange: ( checked: boolean ) => void;
-	checked: boolean;
 };
 
 const SelectCardCheckboxV2 = ( {
 	children,
 	className,
 	onChange,
-	checked,
+	disabled = false,
+	checked = false,
 }: SelectCardCheckboxProps ) => {
 	const instanceId = useId();
 	const id = `select-card-checkbox-v2-${ instanceId }`;
@@ -34,6 +36,7 @@ const SelectCardCheckboxV2 = ( {
 				checked={ checked }
 				id={ id }
 				onChange={ onChange }
+				disabled={ disabled }
 			/>
 			<span id={ `select-card-checkbox-v2-label-${ instanceId }` }>{ children }</span>
 		</HStack>

--- a/packages/onboarding/src/select-card-checkbox-v2/index.tsx
+++ b/packages/onboarding/src/select-card-checkbox-v2/index.tsx
@@ -1,4 +1,4 @@
-import { CheckboxControl, __experimentalHStack as HStack } from '@wordpress/components';
+import { CheckboxControl, __experimentalHStack as HStack, Spinner } from '@wordpress/components';
 import clsx from 'clsx';
 import { useId } from 'react';
 import './style.scss';
@@ -8,6 +8,7 @@ type SelectCardCheckboxProps = {
 	className?: string;
 	checked?: boolean;
 	disabled?: boolean;
+	isBusy?: boolean;
 	onChange: ( checked: boolean ) => void;
 };
 
@@ -17,6 +18,7 @@ const SelectCardCheckboxV2 = ( {
 	onChange,
 	disabled = false,
 	checked = false,
+	isBusy = false,
 }: SelectCardCheckboxProps ) => {
 	const instanceId = useId();
 	const id = `select-card-checkbox-v2-${ instanceId }`;
@@ -25,20 +27,23 @@ const SelectCardCheckboxV2 = ( {
 		<HStack
 			spacing={ 2 }
 			as="label"
-			className={ clsx( 'select-card-checkbox-v2', className ) }
+			className={ clsx( 'select-card-checkbox-v2', className, { 'is-busy': isBusy } ) }
 			htmlFor={ id }
 			alignment="left"
 			aria-checked={ checked }
 			aria-labelledby={ `select-card-checkbox-v2-label-${ instanceId }` }
 		>
-			<CheckboxControl
-				__nextHasNoMarginBottom
-				checked={ checked }
-				id={ id }
-				onChange={ onChange }
-				disabled={ disabled }
-			/>
-			<span id={ `select-card-checkbox-v2-label-${ instanceId }` }>{ children }</span>
+			<HStack alignment="left" spacing={ 2 } as="span">
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					checked={ checked }
+					id={ id }
+					onChange={ onChange }
+					disabled={ disabled || isBusy }
+				/>
+				<span id={ `select-card-checkbox-v2-label-${ instanceId }` }>{ children }</span>
+			</HStack>
+			{ isBusy && <Spinner /> }
 		</HStack>
 	);
 };

--- a/packages/onboarding/src/select-card-checkbox-v2/style.scss
+++ b/packages/onboarding/src/select-card-checkbox-v2/style.scss
@@ -8,6 +8,10 @@
 	font-size: 0.875rem;
 	cursor: pointer;
 
+	&.is-busy {
+		cursor: progress;
+	}
+
 	&:has(:checked) {
 		background: var(--color-accent-5);
 		border-color: var(--color-accent);

--- a/packages/onboarding/src/select-card-checkbox-v2/style.scss
+++ b/packages/onboarding/src/select-card-checkbox-v2/style.scss
@@ -1,0 +1,21 @@
+@import "@wordpress/base-styles/mixins";
+
+.select-card-checkbox-v2 {
+	border: 1px solid var(--color-surface-backdrop);
+	background: var(--color-surface-backdrop);
+	border-radius: 4px;
+	padding: 16px;
+	font-size: 0.875rem;
+	cursor: pointer;
+
+	&:has(:checked) {
+		background: var(--color-accent-5);
+		border-color: var(--color-accent);
+	}
+
+	&:has(:focus-visible) {
+		@include button-style__focus();
+	}
+}
+
+

--- a/packages/onboarding/src/select-card-checkbox-v2/test/index.test.tsx
+++ b/packages/onboarding/src/select-card-checkbox-v2/test/index.test.tsx
@@ -38,4 +38,12 @@ describe( 'SelectCardCheckboxV2', () => {
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 		expect( onChange ).toHaveBeenCalledWith( true );
 	} );
+	it( 'disables the checkbox when isBusy is true', () => {
+		render(
+			<SelectCardCheckboxV2 onChange={ jest.fn() } isBusy>
+				Hello
+			</SelectCardCheckboxV2>
+		);
+		expect( screen.getByRole( 'checkbox', { name: 'Hello' } ) ).toBeDisabled();
+	} );
 } );

--- a/packages/onboarding/src/select-card-checkbox-v2/test/index.test.tsx
+++ b/packages/onboarding/src/select-card-checkbox-v2/test/index.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import SelectCardCheckboxV2 from '../index';
+
+describe( 'SelectCardCheckboxV2', () => {
+	it( 'renders the elements and labels', () => {
+		render( <SelectCardCheckboxV2 onChange={ jest.fn() }>Hello</SelectCardCheckboxV2> );
+		expect( screen.getByRole( 'checkbox', { name: 'Hello' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the checked state', () => {
+		render(
+			<SelectCardCheckboxV2 onChange={ jest.fn() } checked>
+				Hello
+			</SelectCardCheckboxV2>
+		);
+		expect( screen.getByRole( 'checkbox', { name: 'Hello' } ) ).toBeChecked();
+	} );
+
+	it( 'renders the disabled state', () => {
+		render(
+			<SelectCardCheckboxV2 onChange={ jest.fn() } disabled>
+				Hello
+			</SelectCardCheckboxV2>
+		);
+		expect( screen.getByRole( 'checkbox', { name: 'Hello' } ) ).toBeDisabled();
+	} );
+
+	it( 'calls onChange when the checkbox is clicked', () => {
+		const onChange = jest.fn();
+		render( <SelectCardCheckboxV2 onChange={ onChange }>Hello</SelectCardCheckboxV2> );
+		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Hello' } ) );
+
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).toHaveBeenCalledWith( true );
+	} );
+} );

--- a/packages/onboarding/src/select-card-checkbox/index.tsx
+++ b/packages/onboarding/src/select-card-checkbox/index.tsx
@@ -10,6 +10,9 @@ type SelectCardCheckboxProps = {
 	checked: boolean;
 };
 
+/**
+ * @deprecated Use SelectCardCheckboxV2 instead because it triggers onChange event twice and has accessibility issues
+ */
 const SelectCardCheckbox = ( {
 	children,
 	className,


### PR DESCRIPTION
Close READ-103

## Proposed Changes
* Deprecated `packages/onboarding/src/select-card-checkbox`, because it is triggering the onChange event twice on click and has accessibility issues.
* Add `packages/onboarding/src/select-card-checkbox-v2` with the bug fixed, accessibility issues solved, and a busy state.
* Block the user from following/unfollowing a tag before we save the latest interaction. 

## Why are these changes being made?
* I found [this logic](https://github.com/Automattic/wp-calypso/blob/fff472727b2e89565b05b30e821a0cc96940708e/packages/onboarding/src/select-card-checkbox/index.tsx#L27-L29) where a user can click on the core checkbox, triggering the onChange, which also triggers the parent onChange event attached to the div.  It was making the UI try to follow the same tag twice, instead of adding and removing. It caused a conflict with the Redux state and, as a consequence, prevented the user from following a tag.


 ## Testing Instructions
* Create a new WordPress account OR hack this logic https://github.com/Automattic/wp-calypso/blob/964f8b466b41f3318376009ac3f6c262899458ba/client/reader/onboarding/index.tsx#L57-L65 (shouldShowOnboarding always true)
* Go to /reader
* Select any tag on the `What topics interest you?`  step
* Check that no error is triggered (no global error notice). 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
