### PR TITLE
Dashboard: Do not pass countryCode when creating Stripe setup intent

### DIFF
--- a/client/dashboard/me/billing-purchases/payment-methods/assign-new-card-processor.ts
+++ b/client/dashboard/me/billing-purchases/payment-methods/assign-new-card-processor.ts
@@ -74,9 +74,12 @@ export async function assignNewCardProcessor(
 			cardElement,
 		} = submitData;
 
-		// Create Stripe Setup Intent
+		// @todo: we should pass the countryCode to createStripeSetupIntent,
+		// but since `prepareAndConfirmStripeSetupIntent()` uses the `stripe`
+		// object created by `StripeHookProvider`, that object must also be
+		// created with the same countryCode, and right now it is not.
 		const setupIntentResult = await createStripeSetupIntent( {
-			country: countryCode,
+			country: undefined,
 		} );
 
 		if ( ! setupIntentResult.setup_intent_id ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1388/cant-add-us-ramp-card-in-multi-site-dashboard-via-wpcalypso

## Proposed Changes

This PR modifies the code that creates a Stripe setup intent in the Multi Site Dashboard (MSD) so that it does not pass a country code. This will force the setup intent to be created with a country code generated from a geolocation, which is the same behavior that will happen for the Stripe object itself.

This is the same fix for the same problem that happened in calypso a year ago and was fixed in https://github.com/Automattic/wp-calypso/pull/96304

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When adding a new credit card, we must first create a Setup Intent and then use it to create and attach the Payment Method. Setup Intents are created on a specific Stripe account, of which we have different ones depending on the country where that card will make its purchases. The attachment and confirmation is done using the `stripe.js` object created by `StripeHookProvider`. Even though that component accepts a country code, we don't pass one, so the object is created using geolocation to determine the country, and therefore the Stripe account. 

In https://github.com/Automattic/wp-calypso/pull/106359 I created the MSD version of the "add payment method" page and made the Setup Intent creation use the country code entered for the credit card. However, this created a problem since now that Stripe account may not match the Stripe account being used to confirm it, leading to errors like `No such setupintent: 'seti_XXXXXXXXXXX'`.

We should probably be using the user's country for both places, but that might be tricky for the `StripeHookProvider` so for now we will revert back to not passing a country code for both places.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit https://wpcalypso.wordpress.com/v2/me/billing/payment-methods/add and add a new credit card, but enter a country code that's very different from your geolocation (eg: select France with postal code 78000 if you are in the US).
- Verify the card gets added correctly.
