### PR TITLE
Checkout: Refactor p24 payment method to use event emitter for data

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -5,7 +5,6 @@ import {
 	createGooglePayMethod,
 	createBancontactMethod,
 	createP24Method,
-	createP24PaymentMethodStore,
 	createEpsMethod,
 	createEpsPaymentMethodStore,
 	createIdealMethod,
@@ -167,16 +166,14 @@ function useCreateP24( {
 	stripeLoadingError: StripeLoadingError;
 } ): PaymentMethod | null {
 	const shouldLoad = ! isStripeLoading && ! stripeLoadingError;
-	const paymentMethodStore = useMemo( () => createP24PaymentMethodStore(), [] );
 	return useMemo(
 		() =>
 			shouldLoad
 				? createP24Method( {
-						store: paymentMethodStore,
 						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
-		[ shouldLoad, paymentMethodStore ]
+		[ shouldLoad ]
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CHE-295/payment-methods-should-not-use-wordpressdata-stores

## Proposed Changes

This PR refactors the p24 payment method to use a simple event emitter for its state instead of a `@wordpress/data` store.

<img width="616" height="358" alt="Screenshot 2025-11-27 at 3 44 52 PM" src="https://github.com/user-attachments/assets/a5dc52b4-658c-41a9-b616-2b77f224eb40" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I regret using `@wordpress/data` to create data stores for some of our payment methods. It's overkill and adds a lot of complexity and boilerplate. It's much simpler to use a basic event emitter and I've done that for more recent payment methods like Pix. I'd like to refactor the other payment methods that use stores to use basic event emitters instead.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Sandbox the store.
- Set your user currency to EUR or PLN.
- Add a product to your cart and visit checkout.
- Select Poland (`PL`) as your country in checkout.
- Select "p24" as the payment method.
- Enter a name and email in the input fields within the payment method and verify that they show up as expected.
- Submit the payment.
- On the confirmation page, you should see a "Payment Method object" which mentions the email that you entered in checkout. (You do not need to confirm the purchase.)
- NOTE: the contents of the `name` field does not appear to be shown in the "Payment Method object" data. I'm not sure what this means but it is similarly not shown in production so I think this is fine. If this is a bug, it's unrelated.

<img width="389" height="603" alt="Screenshot 2025-11-27 at 3 48 56 PM" src="https://github.com/user-attachments/assets/abc8f9f2-6f03-4dc2-963f-822e60156555" />


