### PR TITLE
Add Agenttic-friendly Zendesk and Odie APIs 

### DIFF
--- a/packages/odie-client/src/data/use-managed-odie-chat.ts
+++ b/packages/odie-client/src/data/use-managed-odie-chat.ts
@@ -1,0 +1,112 @@
+import { useMutation } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { useCallback, useState } from 'react';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { useOdieAssistantContext } from '../context';
+import type { ReturnedChat, Message, MessageAction } from '../types';
+interface AgentticMessage {
+	id: string;
+	role: 'user' | 'agent';
+	content: Array< {
+		type: 'text' | 'image_url' | 'component' | 'context';
+		text?: string;
+		image_url?: string;
+		component?: React.ComponentType;
+		componentProps?: unknown;
+	} >;
+	timestamp: number;
+	archived: boolean;
+	showIcon: boolean;
+	icon?: string;
+	disabled?: boolean;
+	actions?: MessageAction[];
+}
+
+function convertMessageToAgentticFormat( message: Message ): AgentticMessage {
+	return {
+		content: [ { type: 'text', text: message.content as string } ],
+		role: message.role as 'agent',
+		timestamp: message.received as number,
+		id: message.message_id?.toString() ?? '',
+		actions: [],
+		archived: false,
+		showIcon: true,
+	};
+}
+
+/**
+ * Sends a new message to ODIE.
+ * If the chat_id is not set, it will create a new chat and send a message to the chat.
+ * @param odieChatId - The Odie chat ID to send the message to.
+ * @param botSlug - The bot slug to send the message to.
+ * @param onSuccess - A callback function to call when the message is sent successfully.
+ * @returns useMutation return object.
+ */
+export const useSendOdieMessage = (
+	odieChatId: number | null,
+	botSlug: string,
+	onSuccess: ( chat: ReturnedChat ) => void
+) => {
+	const { selectedSiteId, version } = useOdieAssistantContext();
+
+	return useMutation< ReturnedChat, Error, Message >( {
+		mutationFn: async ( message: Message ): Promise< ReturnedChat > => {
+			const chatIdSegment = odieChatId ? `/${ odieChatId }` : '';
+			const url = window.location.href;
+			const pathname = window.location.pathname;
+
+			return canAccessWpcomApis()
+				? wpcomRequest< ReturnedChat >( {
+						method: 'POST',
+						path: `/odie/chat/${ botSlug }${ chatIdSegment }`,
+						apiNamespace: 'wpcom/v2',
+						body: {
+							message: message.content,
+							...( version && { version } ),
+							context: { selectedSiteId, url, pathname },
+						},
+				  } )
+				: apiFetch< ReturnedChat >( {
+						path: `/help-center/odie/chat/${ botSlug }${ chatIdSegment }`,
+						method: 'POST',
+						data: {
+							message: message.content,
+							...( version && { version } ),
+							context: { selectedSiteId, url, pathname },
+						},
+				  } );
+		},
+		onSuccess,
+	} );
+};
+
+/**
+ * Get a full API of an Odie chat.
+ * @param providedChatId - The chat ID to manage.
+ */
+export const useManagedOdieChat = ( providedChatId: number | null, botSlug: string ) => {
+	const [ chatId, setChatId ] = useState< number | null >( providedChatId );
+	const [ chatMessages, setChatMessages ] = useState< Message[] >( [] );
+
+	const onSuccess = useCallback(
+		( returnedChat: ReturnedChat ) => {
+			const messages = [ ...chatMessages, ...returnedChat.messages ];
+			setChatId( returnedChat.chat_id );
+			setChatMessages( messages );
+		},
+		[ chatMessages ]
+	);
+
+	const sendOdieMessage = useSendOdieMessage( chatId ?? null, botSlug, onSuccess );
+
+	function sendMessage( message: Message ) {
+		setChatMessages( [ ...chatMessages, message ] );
+		sendOdieMessage.mutateAsync( message );
+	}
+
+	return {
+		messages: chatMessages.map( convertMessageToAgentticFormat ) || [],
+		sendMessage,
+		isProcessing: sendOdieMessage.isPending,
+	};
+};

--- a/packages/odie-client/src/data/use-managed-odie-chat.ts
+++ b/packages/odie-client/src/data/use-managed-odie-chat.ts
@@ -3,24 +3,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useState } from 'react';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { useOdieAssistantContext } from '../context';
-import type { ReturnedChat, Message, MessageAction } from '../types';
-interface AgentticMessage {
-	id: string;
-	role: 'user' | 'agent';
-	content: Array< {
-		type: 'text' | 'image_url' | 'component' | 'context';
-		text?: string;
-		image_url?: string;
-		component?: React.ComponentType;
-		componentProps?: unknown;
-	} >;
-	timestamp: number;
-	archived: boolean;
-	showIcon: boolean;
-	icon?: string;
-	disabled?: boolean;
-	actions?: MessageAction[];
-}
+import type { ReturnedChat, Message, AgentticMessage } from '../types';
 
 function convertMessageToAgentticFormat( message: Message ): AgentticMessage {
 	return {

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -252,3 +252,20 @@ export type SupportInteraction = {
 	events: SupportInteractionEvent[];
 	environment: 'staging' | 'production';
 };
+export interface AgentticMessage {
+	id: string;
+	role: 'user' | 'agent';
+	content: Array< {
+		type: 'text' | 'image_url' | 'component' | 'context';
+		text?: string;
+		image_url?: string;
+		component?: React.ComponentType;
+		componentProps?: unknown;
+	} >;
+	timestamp: number;
+	archived: boolean;
+	showIcon: boolean;
+	icon?: string;
+	disabled?: boolean;
+	actions?: MessageAction[];
+}

--- a/packages/zendesk-client/src/types.ts
+++ b/packages/zendesk-client/src/types.ts
@@ -131,3 +131,25 @@ export type MessageType =
 	| 'introduction'
 	| 'form'
 	| 'formResponse';
+
+/**
+ * Agenttic-UI Message interface
+ * Used for components that require the standardized Message interface
+ */
+export interface AgentticMessage {
+	id: string;
+	role: 'user' | 'agent';
+	content: Array< {
+		type: 'text' | 'image_url' | 'component' | 'context';
+		text?: string;
+		image_url?: string;
+		component?: React.ComponentType;
+		componentProps?: unknown;
+	} >;
+	timestamp: number;
+	archived: boolean;
+	showIcon: boolean;
+	icon?: string;
+	actions?: MessageAction[];
+	disabled?: boolean;
+}

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -1,0 +1,280 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useQueryClient, QueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import Smooch from 'smooch';
+import { SMOOCH_INTEGRATION_ID, SMOOCH_INTEGRATION_ID_STAGING } from './constants';
+import { ZendeskConversation } from './types';
+import {
+	useAuthenticateZendeskMessaging,
+	fetchMessagingAuth,
+} from './use-authenticate-zendesk-messaging';
+import { useLoadZendeskMessaging } from './use-load-zendesk-messaging';
+import { isTestModeEnvironment, convertZendeskMessageToAgentticFormat } from './util';
+import type { ZendeskMessage } from './types';
+
+const destroy = () => {
+	try {
+		Smooch.destroy();
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Error destroying Smooch', error );
+	}
+};
+
+const initSmooch = (
+	{
+		jwt,
+		externalId,
+	}: {
+		isLoggedIn: boolean;
+		jwt: string;
+		externalId: string | undefined;
+	},
+	queryClient: QueryClient
+) => {
+	const isTestMode = isTestModeEnvironment();
+
+	return Smooch.init( {
+		integrationId: isTestMode ? SMOOCH_INTEGRATION_ID_STAGING : SMOOCH_INTEGRATION_ID,
+		delegate: {
+			async onInvalidAuth() {
+				recordTracksEvent( 'calypso_smooch_messenger_auth_error' );
+
+				await queryClient.invalidateQueries( {
+					queryKey: [ 'getMessagingAuth', 'zendesk', isTestMode ],
+				} );
+				const authData = await queryClient.fetchQuery( {
+					queryKey: [ 'getMessagingAuth', 'zendesk', isTestMode ],
+					queryFn: () => fetchMessagingAuth( 'zendesk' ),
+				} );
+
+				return authData.jwt;
+			},
+		},
+		embedded: true,
+		soundNotificationEnabled: false,
+		externalId,
+		jwt,
+	} );
+};
+
+const playNotificationSound = () => {
+	// @ts-expect-error expected because of fallback webkitAudioContext
+	const audioContext = new ( window.AudioContext || window.webkitAudioContext )();
+
+	const duration = 0.7;
+	const oscillator = audioContext.createOscillator();
+	const gainNode = audioContext.createGain();
+
+	// Configure oscillator
+	oscillator.type = 'sine';
+	oscillator.frequency.setValueAtTime( 660, audioContext.currentTime );
+
+	// Configure gain for a smoother fade-out
+	gainNode.gain.setValueAtTime( 0.3, audioContext.currentTime );
+	gainNode.gain.exponentialRampToValueAtTime( 0.001, audioContext.currentTime + duration );
+
+	// Connect & start
+	oscillator.connect( gainNode );
+	gainNode.connect( audioContext.destination );
+	oscillator.start();
+	oscillator.stop( audioContext.currentTime + duration );
+};
+
+const smoochContainer = document.createElement( 'div' );
+smoochContainer.style.display = 'none';
+smoochContainer.style.position = 'absolute';
+smoochContainer.style.top = '0';
+smoochContainer.style.left = '0';
+smoochContainer.style.width = '100%';
+smoochContainer.style.height = '100%';
+smoochContainer.style.zIndex = '1000';
+document.body.appendChild( smoochContainer );
+
+/**
+ * Returns a complete API for managing a Zendesk chat.
+ * @param enabled - Whether the chat is enabled.
+ * @param conversationId - The ID of the conversation to manage.
+ * @returns An object with the following properties:
+ * - isChatLoaded: Whether the chat is loaded.
+ * - typingStatus: The status of the typing.
+ * - clientId: The ID of the client.
+ * - conversation: The conversation.
+ * - connectionStatus: The status of the connection.
+ * - agentticMessages: The messages in the conversation in Agenttic-compatible format.
+ * - sendMessage: A function to send a message to the conversation.
+ */
+export const useManagedZendeskChat = ( enabled: boolean, conversationId?: string ) => {
+	const queryClient = useQueryClient();
+	const [ isChatLoaded, setIsChatLoaded ] = useState( false );
+	const [ conversation, setConversation ] = useState< ZendeskConversation | undefined >();
+	const [ typingStatus, setTypingStatus ] = useState< Record< string, boolean > >( {} );
+	const [ connectionStatus, setConnectionStatus ] = useState<
+		'connected' | 'disconnected' | 'reconnecting' | undefined
+	>( undefined );
+
+	const { data: authData } = useAuthenticateZendeskMessaging( enabled, 'messenger' );
+
+	const { isMessagingScriptLoaded } = useLoadZendeskMessaging( enabled, enabled );
+
+	// const getUnreadNotifications = useGetUnreadConversations();
+
+	const getUnreadListener = useCallback(
+		( message: ZendeskMessage, data: { conversation: { id: string } } ) => {
+			playNotificationSound();
+			Smooch.getConversationById( data?.conversation?.id ).then( ( conversation ) => {
+				setConversation( conversation );
+				//getUnreadNotifications();
+			} );
+		},
+		[]
+	);
+
+	const disconnectedListener = useCallback( () => {
+		setConnectionStatus( 'disconnected' );
+		recordTracksEvent( 'calypso_smooch_messenger_disconnected' );
+	}, [ setConnectionStatus ] );
+
+	const reconnectingListener = useCallback( () => {
+		setConnectionStatus( 'reconnecting' );
+		recordTracksEvent( 'calypso_smooch_messenger_reconnecting' );
+	}, [ setConnectionStatus ] );
+
+	const typingStartListener = useCallback(
+		( { conversation }: ConversationData ) => {
+			setTypingStatus( ( typingStatus ) => ( { ...typingStatus, [ conversation.id ]: true } ) );
+		},
+		[ setTypingStatus ]
+	);
+	const typingStopListener = useCallback(
+		( { conversation }: ConversationData ) => {
+			setTypingStatus( ( typingStatus ) => ( { ...typingStatus, [ conversation.id ]: false } ) );
+		},
+		[ setTypingStatus ]
+	);
+
+	const connectedListener = useCallback( () => {
+		// We only want to revert the connection status to connected if it was disconnected before.
+		// We don't want a "connected" status on page load, it's only useful as a sign of a recovered connection.
+		if ( connectionStatus ) {
+			setConnectionStatus( 'connected' );
+			recordTracksEvent( 'calypso_smooch_messenger_connected' );
+		}
+	}, [ setConnectionStatus, connectionStatus ] );
+
+	// Initialize Smooch which communicates with Zendesk
+	useEffect( () => {
+		if (
+			! isMessagingScriptLoaded ||
+			! authData?.isLoggedIn ||
+			! authData?.jwt ||
+			! authData?.externalId ||
+			! enabled
+		) {
+			return;
+		}
+
+		let retryTimeout: ReturnType< typeof setTimeout > | undefined;
+
+		const initializeSmooch = async () => {
+			return initSmooch( authData, queryClient )
+				.then( () => {
+					setIsChatLoaded( true );
+					recordTracksEvent( 'calypso_smooch_messenger_init', {
+						success: true,
+						error: '',
+					} );
+				} )
+				.catch( ( error ) => {
+					setIsChatLoaded( false );
+					retryTimeout = setTimeout( initializeSmooch, 30000 );
+					recordTracksEvent( 'calypso_smooch_messenger_init', {
+						success: false,
+						error: error.message,
+					} );
+				} );
+		};
+
+		initializeSmooch().then( () => {
+			if ( conversationId ) {
+				Smooch.getConversationById( conversationId ).then( setConversation );
+			} else {
+				Smooch.createConversation( {
+					metadata: {
+						createdAt: Date.now(),
+					},
+				} ).then( setConversation );
+			}
+		} );
+
+		Smooch.render( smoochContainer );
+
+		return () => {
+			clearTimeout( retryTimeout );
+			destroy();
+		};
+	}, [ isMessagingScriptLoaded, authData, setIsChatLoaded, queryClient, enabled, conversationId ] );
+
+	const agentticMessages = useMemo( () => {
+		return conversation?.messages.map( convertZendeskMessageToAgentticFormat ) ?? [];
+	}, [ conversation?.messages ] );
+
+	useEffect( () => {
+		if ( isChatLoaded ) {
+			Smooch.on( 'message:received', getUnreadListener );
+			Smooch.on( 'disconnected', disconnectedListener );
+			Smooch.on( 'reconnecting', reconnectingListener );
+			Smooch.on( 'connected', connectedListener );
+			Smooch.on( 'typing:start', typingStartListener );
+			Smooch.on( 'typing:stop', typingStopListener );
+		}
+
+		return () => {
+			// @ts-expect-error -- 'off' is not part of the def.
+			Smooch?.off?.( 'message:received', getUnreadListener );
+			// @ts-expect-error -- 'off' is not part of the def.
+			Smooch?.off?.( 'message:sent', clientIdListener );
+			// @ts-expect-error -- 'off' is not part of the def.
+			Smooch?.off?.( 'disconnected', disconnectedListener );
+			// @ts-expect-error -- 'off' is not part of the def.
+			Smooch?.off?.( 'reconnecting', reconnectingListener );
+			// @ts-expect-error -- 'off' is not part of the def.
+			Smooch?.off?.( 'connected', connectedListener );
+			// @ts-expect-error -- 'off' is not part of the def.
+			Smooch?.off?.( 'typing:stop', typingStopListener );
+			// @ts-expect-error -- 'off' is not part of the def.
+			Smooch?.off?.( 'typing:start', typingStartListener );
+		};
+	}, [
+		getUnreadListener,
+		setConnectionStatus,
+		isChatLoaded,
+		typingStartListener,
+		typingStopListener,
+		//getUnreadNotifications,
+		disconnectedListener,
+		reconnectingListener,
+		connectedListener,
+	] );
+
+	return {
+		isChatLoaded,
+		typingStatus,
+		conversation,
+		connectionStatus,
+		agentticMessages,
+		sendMessage: ( message: ZendeskMessage ) => {
+			if ( conversation?.id ) {
+				// Todo: mark the message as `is_sending`.
+				setConversation( {
+					...conversation,
+					messages: [ ...conversation.messages, message ],
+				} );
+				// Todo: mark the message as sent after the following resolves.
+				Smooch.sendMessage( message, conversation.id );
+			}
+		},
+	};
+};
+
+export default useManagedZendeskChat;

--- a/packages/zendesk-client/src/util.tsx
+++ b/packages/zendesk-client/src/util.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { isInSupportSession } from '@automattic/data-stores';
 import { __ } from '@wordpress/i18n';
+import { AgentticMessage, ZendeskMessage } from './types';
 
 const IS_TEST_MODE_ENVIRONMENT = true;
 const IS_PRODUCTION_ENVIRONMENT = false;
@@ -47,4 +48,91 @@ export const getBadRatingReasons = () => {
 		{ label: __( 'The issue was not resolved.', __i18n_text_domain__ ), value: '1002' },
 		{ label: __( 'The Happiness Engineer was unhelpful.', __i18n_text_domain__ ), value: '1003' },
 	];
+};
+
+/**
+ * Converts a ZendeskMessage to the agenttic-ui Message interface format
+ * Used for components that require the standardized Message interface
+ * @param message - The Zendesk message to convert
+ * @returns An AgentticMessage compatible with the agenttic-ui components
+ */
+export const convertZendeskMessageToAgentticFormat = (
+	message: ZendeskMessage
+): AgentticMessage => {
+	// Convert role: 'business' maps to 'agent', everything else to 'user'
+	const role = message.role === 'business' ? 'agent' : 'user';
+
+	// Build content array based on message type
+	const content: AgentticMessage[ 'content' ] = [];
+
+	switch ( message.type ) {
+		case 'text': {
+			// Handle text content - prefer htmlText over text
+			const textContent = message.htmlText || message.text || '';
+			content.push( {
+				type: 'text',
+				text: textContent,
+			} );
+			break;
+		}
+
+		case 'image':
+		case 'image-placeholder':
+			// Handle image content
+			if ( message.mediaUrl ) {
+				content.push( {
+					type: 'image_url',
+					image_url: message.mediaUrl,
+				} );
+			}
+			// Include alt text if available
+			if ( message.altText ) {
+				content.push( {
+					type: 'text',
+					text: message.altText,
+				} );
+			}
+			break;
+
+		case 'file': {
+			// Handle file attachments as text links
+			if ( message.mediaUrl ) {
+				const fileName = message.mediaUrl.split( '/' ).pop()?.split( '?' )[ 0 ] || 'file';
+				content.push( {
+					type: 'text',
+					text: `📎 ${ message.altText || fileName }`,
+				} );
+			}
+			break;
+		}
+
+		default:
+			// For unsupported types, add the text if available
+			if ( message.text ) {
+				content.push( {
+					type: 'text',
+					text: message.text,
+				} );
+			}
+	}
+
+	// If no content was added, provide a fallback
+	if ( content.length === 0 ) {
+		content.push( {
+			type: 'text',
+			text: '',
+		} );
+	}
+
+	return {
+		id: message.id,
+		role,
+		content,
+		timestamp: message.received,
+		archived: false,
+		showIcon: true,
+		icon: message.avatarUrl,
+		actions: message.actions,
+		disabled: false,
+	};
 };


### PR DESCRIPTION
Fixes DOTCOM-15347

## Proposed Changes

This re-orgs the code a bit and adds two new hooks that mimic the style of `useAgentChat` hook. This allows us to plug in Zendesk and Odie right into the Agenttic UI.

## Why are these changes being made?
To make incorporating Odie and ZD in the AI sidebar easier.

## Testing Instructions

1. Green PR.

This doesn't touch any production code. 