### PR TITLE
Billing history: make sure that all fields getValue return strings

### DIFF
--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -137,8 +137,8 @@ export function getFields( receipts: Receipt[] ): Fields< Receipt > {
 				const { label: firstLabel } = summarizeReceiptItems( firstReceipt.items );
 				const { label: secondLabel } = summarizeReceiptItems( secondReceipt.items );
 				return direction === 'asc'
-					? firstLabel.localeCompare( secondLabel )
-					: secondLabel.localeCompare( firstLabel );
+					? String( firstLabel ).localeCompare( String( secondLabel ) )
+					: String( secondLabel ).localeCompare( String( firstLabel ) );
 			},
 			filterBy: {
 				operators: [ 'is' as Operator ],
@@ -302,7 +302,7 @@ function getServicesForFiltering( receipts: Receipt[] ): Array< { value: string;
 }
 
 function getServiceForFiltering( receipt: Receipt ): string {
-	return receipt.service;
+	return String( receipt.service || '' );
 }
 
 function renderServiceNameDescription( receipt: Receipt ) {
@@ -359,7 +359,7 @@ function getReceiptItemTypesForFiltering(
  */
 function getReceiptItemTypeForDisplay( receipt: Receipt ): string {
 	const [ receiptItem ] = groupDomainProducts( receipt.items );
-	return receiptItem.type_localized || receiptItem.type;
+	return String( receiptItem.type_localized || receiptItem.type || '' );
 }
 
 function renderReceiptAmount( receipt: Receipt ) {

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -100,7 +100,7 @@ function getUniqueTransactionTypes(
 		} );
 
 	return Array.from( typeMap.entries() )
-		.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+		.sort( ( [ a ], [ b ] ) => String( a ).localeCompare( String( b ) ) )
 		.map( ( [ value, label ] ) => ( {
 			value,
 			label,
@@ -157,7 +157,7 @@ export function getFieldDefinitions(
 			getValue: ( { item }: { item: BillingTransaction } ) => {
 				const [ transactionItem ] = groupDomainProducts( item.items, translate );
 				if ( transactionItem.product === transactionItem.variation ) {
-					return transactionItem.product;
+					return String( transactionItem.product );
 				}
 				return capitalPDangit( transactionItem.variation );
 			},
@@ -179,7 +179,7 @@ export function getFieldDefinitions(
 			},
 			getValue: ( { item }: { item: BillingTransaction } ) => {
 				const [ transactionItem ] = groupDomainProducts( item.items, translate );
-				return transactionItem.type;
+				return String( transactionItem.type || '' );
 			},
 		},
 		{
@@ -191,7 +191,7 @@ export function getFieldDefinitions(
 			enableHiding: false,
 			filterBy: false,
 			getValue: ( { item }: { item: BillingTransaction } ) => {
-				return item.amount_integer;
+				return String( item.amount_integer );
 			},
 			render: ( { item }: { item: BillingTransaction } ) => {
 				return <TransactionAmount transaction={ item } />;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-901/purchases-dataviews-javascript-errors

## Proposed Changes

This PR forces all DataViews fields in billing-history (both calypso and Multi Site Dashboard) to return a string.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Despite its TypeScript types saying otherwise, when a DataViews field getValue() function does not return a string, we end up with the error message: `e.name.localeCompare is not a function`. It's not clear how, but somehow there are non-strings getting into the fields.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit https://wpcalypso.wordpress.com/v2/me/billing/history and verify that everything renders the same before and after this PR.
- Visit https://wordpress.com/me/purchases/billing and verify that everything renders the same before and after this PR.
