### PR TITLE
MSD:  Reduce size of confirmation modals.

### DIFF
--- a/client/dashboard/me/notifications-sites/site-settings/apply-settings-to-all-sites-confirmation-modal/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/apply-settings-to-all-sites-confirmation-modal/index.tsx
@@ -19,6 +19,7 @@ export const ApplySettingsToAllSitesConfirmationModal = ( props: Props ) => {
 			confirmButtonProps={ { label: __( 'Yes, apply to all sites' ), isBusy } }
 			cancelButtonText={ __( 'Cancel' ) }
 			__experimentalHideHeader={ false }
+			size="small"
 		>
 			{ __( 'The selected settings will be applied to all your sites at once.' ) }
 		</ConfirmModal>

--- a/client/dashboard/me/security-account-recovery/recovery-email.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-email.tsx
@@ -223,6 +223,7 @@ export default function RecoveryEmail() {
 				} }
 				onCancel={ () => setIsRemoveDialogOpen( false ) }
 				onConfirm={ handleRemove }
+				size="small"
 			>
 				{ __( 'Are you sure you want to remove this email?' ) }
 			</ConfirmModal>

--- a/client/dashboard/me/security-account-recovery/recovery-sms.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-sms.tsx
@@ -276,6 +276,7 @@ export default function RecoverySMS() {
 				} }
 				onCancel={ () => setIsRemoveDialogOpen( false ) }
 				onConfirm={ handleRemove }
+				size="small"
 			>
 				{ __( 'Are you sure you want to remove this SMS number?' ) }
 			</ConfirmModal>

--- a/client/dashboard/me/security-connected-apps/index.tsx
+++ b/client/dashboard/me/security-connected-apps/index.tsx
@@ -185,6 +185,7 @@ export default function SecurityConnectedApps() {
 				} }
 				onCancel={ () => setSelectedApplicationToRemove( null ) }
 				onConfirm={ handleDisconnect }
+				size="small"
 			>
 				{ createInterpolateElement(
 					/* translators: <applicationName /> is the name of the application */

--- a/client/dashboard/me/security-social-logins/index.tsx
+++ b/client/dashboard/me/security-social-logins/index.tsx
@@ -141,6 +141,7 @@ const SocialLoginItem = ( {
 				} }
 				onCancel={ () => setIsRemoveDialogOpen( false ) }
 				onConfirm={ disconnectSocialLogin }
+				size="small"
 			>
 				{ sprintf(
 					/* translators: %s is the name of the social login */

--- a/client/dashboard/me/security-ssh-key/ssh-key.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key.tsx
@@ -108,6 +108,7 @@ export default function SshKey( {
 				} }
 				onCancel={ () => setIsRemoveDialogOpen( false ) }
 				onConfirm={ handleRemove }
+				size="small"
 			>
 				{ __(
 					'Are you sure you want to remove this SSH key? It will be removed from all attached sites.'

--- a/client/dashboard/me/security-two-step-auth/main-page/actions/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/actions/index.tsx
@@ -75,11 +75,11 @@ export default function TwoStepAuthActions() {
 			<ConfirmModal
 				__experimentalHideHeader={ false }
 				title={ __( 'Generate new backup codes' ) }
-				size="medium"
 				isOpen={ showGenerateBackupCodesDialog }
 				onCancel={ () => setShowGenerateBackupCodesDialog( false ) }
 				onConfirm={ () => router.navigate( { to: securityTwoStepAuthBackupCodesRoute.fullPath } ) }
 				confirmButtonProps={ { label: __( 'Continue' ) } }
+				size="small"
 			>
 				{ __(
 					'When you generate new backup codes, you must print or download the new codes. Your previous codes will no longer work.'

--- a/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
@@ -141,6 +141,7 @@ const ApplicationPasswordsList = ( {
 				} }
 				onCancel={ () => setSelectedKeyToRemove( null ) }
 				onConfirm={ handleRemove }
+				size="small"
 			>
 				{ __( 'Are you sure you want to remove this application password?' ) }
 			</ConfirmModal>

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -109,6 +109,7 @@ const SecurityKeysList = ( {
 				} }
 				onCancel={ () => setSelectedKeyToRemove( null ) }
 				onConfirm={ handleRemove }
+				size="small"
 			>
 				{ __( 'Are you sure you want to remove this security key?' ) }
 			</ConfirmModal>

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -300,6 +300,7 @@ export default function PluginsScheduledUpdates() {
 				} }
 				onCancel={ handleDeleteCancel }
 				onConfirm={ handleDeleteConfirm }
+				size="small"
 			>
 				{ __( 'Are you sure you want to delete this schedule?' ) }
 			</ConfirmModal>

--- a/client/dashboard/sites/settings-ai-assistant/ai-assistant-form.tsx
+++ b/client/dashboard/sites/settings-ai-assistant/ai-assistant-form.tsx
@@ -217,6 +217,7 @@ export function AIAssistantForm( { site }: { site: Site } ) {
 							isBusy: isPending,
 							disabled: isPending,
 						} }
+						size="small"
 					>
 						{ __(
 							'You are on a free trial. If you disable WordPress AI Assistant, you will not be able to turn it back on without a paid plan.'


### PR DESCRIPTION
Part of #DOTMSD-884

## Proposed Changes

Make the Confirm modals without input text small. This generally [matches the designs ](https://www.figma.com/design/QOBjujZah0UlGDDdLKZhzi/WordPress.com-Hosting-Dashboard?node-id=9326-180496&m=dev)although there is no agree upon convention. 

| Before | After |
|--------|--------|
| <img width="937" height="657" alt="Screenshot 2025-11-28 at 6 45 14 AM" src="https://github.com/user-attachments/assets/030fa77d-e9e4-4db3-b658-55620f0afc96" /> | <img width="702" height="486" alt="Screenshot 2025-11-28 at 6 44 36 AM" src="https://github.com/user-attachments/assets/ca3085c6-bcaa-4179-bcb5-4975dcf31da8" /> |
| <img width="930" height="705" alt="Screenshot 2025-11-28 at 6 45 09 AM" src="https://github.com/user-attachments/assets/cee953a8-9689-48f6-bf89-b90c65cc22c8" />  |  <img width="697" height="498" alt="Screenshot 2025-11-28 at 6 44 30 AM" src="https://github.com/user-attachments/assets/3c88c28e-be6f-45c6-b89b-5d0b129ec024" /> |
| <img width="922" height="418" alt="Screenshot 2025-11-28 at 6 50 45 AM" src="https://github.com/user-attachments/assets/fb1dd993-a0e0-48ec-b91d-75985e46c0aa" /> | <img width="707" height="383" alt="Screenshot 2025-11-28 at 6 48 52 AM" src="https://github.com/user-attachments/assets/7b431d99-f02c-44dc-ad88-fb90851630f6" /> |

... and more.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
