### PR TITLE
MSD: Clean up login preferences card.

### DIFF
--- a/client/dashboard/me/preferences-login/index.tsx
+++ b/client/dashboard/me/preferences-login/index.tsx
@@ -80,8 +80,8 @@ export default function PreferencesLogin() {
 		{
 			id: 'primarySiteId',
 			label: __( 'Primary site' ),
-			description: __( 'Choose the default site dashboard you’ll see at login.' ),
-			isVisible: () => user.visible_site_count > 0,
+			isVisible: ( formDataItem ) =>
+				user.visible_site_count > 0 && formDataItem.defaultLandingPage === 'primary-site-dashboard',
 			Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 				const { id, getValue } = field;
 				const value = getValue( { item: data } )?.toString( 10 ) ?? '';
@@ -108,12 +108,15 @@ export default function PreferencesLogin() {
 		},
 		{
 			id: 'defaultLandingPage',
-			label: __( 'Default landing page' ),
+			label: __( 'Default view' ),
 			Edit: 'radio',
 			elements: [
-				{ label: __( 'Primary site dashboard' ), value: 'primary-site-dashboard' },
-				{ label: __( 'Sites' ), value: 'sites' },
-				{ label: __( 'Reader' ), value: 'reader' },
+				{ label: __( 'See a list of all your sites.' ), value: 'sites' },
+				{ label: __( 'View posts from sites you follow.' ), value: 'reader' },
+				{
+					label: __( 'Open your primary site’s dashboard.' ),
+					value: 'primary-site-dashboard',
+				},
 			] satisfies { label: string; value: LandingPage }[],
 		},
 	];
@@ -121,7 +124,7 @@ export default function PreferencesLogin() {
 	// Define form layout
 	const form = {
 		layout: { type: 'regular' as const },
-		fields: [ 'primarySiteId', 'defaultLandingPage' ],
+		fields: [ 'defaultLandingPage', 'primarySiteId' ],
 	};
 
 	const handleSubmit = ( e: React.FormEvent ) => {
@@ -166,8 +169,14 @@ export default function PreferencesLogin() {
 		<Card className="preferences-login-card">
 			<CardBody>
 				<form onSubmit={ handleSubmit }>
-					<VStack spacing={ 3 }>
-						<SectionHeader level={ 3 } title={ __( 'Login preferences' ) } />
+					<VStack spacing={ 4 }>
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'Login preferences' ) }
+							description={ __(
+								'Choose what you see by default when you log in to WordPress.com.'
+							) }
+						/>
 
 						<DataForm< LoginPreferencesFormData >
 							data={ formData }
@@ -177,11 +186,6 @@ export default function PreferencesLogin() {
 								setFormData( ( data ) => ( { ...data, ...edits } ) );
 							} }
 						/>
-
-						<Text variant="muted" as="p">
-							{ __( 'Select what you’ll see by default when visiting WordPress.com.' ) }
-						</Text>
-
 						<ButtonStack>
 							<Button
 								__next40pxDefaultSize

--- a/client/dashboard/me/preferences-login/index.tsx
+++ b/client/dashboard/me/preferences-login/index.tsx
@@ -80,8 +80,8 @@ export default function PreferencesLogin() {
 		{
 			id: 'primarySiteId',
 			label: __( 'Primary site' ),
-			isVisible: ( formDataItem ) =>
-				user.visible_site_count > 0 && formDataItem.defaultLandingPage === 'primary-site-dashboard',
+			isVisible: ( item: LoginPreferencesFormData ) =>
+				user.visible_site_count > 0 && item.defaultLandingPage === 'primary-site-dashboard',
 			Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 				const { id, getValue } = field;
 				const value = getValue( { item: data } )?.toString( 10 ) ?? '';

--- a/client/dashboard/me/preferences-login/test/index.test.tsx
+++ b/client/dashboard/me/preferences-login/test/index.test.tsx
@@ -45,7 +45,7 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 
 jest.mock( '../../../app/auth', () => ( {
-	useAuth: jest.fn( () => ( { user: { site_count: 2 } } ) ),
+	useAuth: jest.fn( () => ( { user: { visible_site_count: 2 } } ) ),
 } ) );
 
 const mockSites: DeepPartial< Site >[] = [
@@ -146,7 +146,7 @@ test( 'save button becomes enabled when form is modified', async () => {
 		{ timeout: 5000 }
 	);
 
-	const sitesRadio = screen.getByLabelText( 'Sites' );
+	const sitesRadio = screen.getByLabelText( 'See a list of all your sites.' );
 	await user.click( sitesRadio );
 
 	const saveButton = screen.getByRole( 'button', { name: 'Save' } );
@@ -179,7 +179,7 @@ test( 'saves preferences successfully', async () => {
 		.post( '/rest/v1.1/me/preferences', matchesLoginPreferencesPayload )
 		.reply( 200, {} );
 
-	const sitesRadio = screen.getByLabelText( 'Sites' );
+	const sitesRadio = screen.getByLabelText( 'See a list of all your sites.' );
 	await user.click( sitesRadio );
 
 	const saveButton = screen.getByRole( 'button', { name: 'Save' } );
@@ -218,7 +218,7 @@ test( 'handles save error gracefully', async () => {
 		.post( '/rest/v1.1/me/preferences', matchesLoginPreferencesPayload )
 		.reply( 500, { error: 'Server error' } );
 
-	const sitesRadio = screen.getByLabelText( 'Sites' );
+	const sitesRadio = screen.getByLabelText( 'See a list of all your sites.' );
 	await user.click( sitesRadio );
 
 	const saveButton = screen.getByRole( 'button', { name: 'Save' } );
@@ -258,7 +258,7 @@ test( 'hides primary site selector when user has no sites', async () => {
 
 	nock( API_BASE ).get( '/rest/v1.2/me/sites' ).query( true ).reply( 200, { sites: [] } );
 
-	( useAuth as jest.Mock ).mockReturnValue( { user: { site_count: 0 } } );
+	( useAuth as jest.Mock ).mockReturnValue( { user: { visible_site_count: 0 } } );
 
 	render( <PreferencesLogin /> );
 
@@ -271,7 +271,7 @@ test( 'hides primary site selector when user has no sites', async () => {
 
 	expect( screen.queryByText( 'Primary site' ) ).not.toBeInTheDocument();
 
-	expect( screen.getByText( 'Default landing page' ) ).toBeInTheDocument();
+	expect( screen.getByText( 'Default view' ) ).toBeInTheDocument();
 } );
 
 test( 'disables save button while saving', async () => {
@@ -296,7 +296,7 @@ test( 'disables save button while saving', async () => {
 		.delay( 100 )
 		.reply( 200, {} );
 
-	const sitesRadio = screen.getByLabelText( 'Sites' );
+	const sitesRadio = screen.getByLabelText( 'See a list of all your sites.' );
 	await user.click( sitesRadio );
 
 	const saveButton = screen.getByRole( 'button', { name: 'Save' } );

--- a/client/dashboard/me/preferences-login/test/index.test.tsx
+++ b/client/dashboard/me/preferences-login/test/index.test.tsx
@@ -274,6 +274,92 @@ test( 'hides primary site selector when user has no sites', async () => {
 	expect( screen.getByText( 'Default view' ) ).toBeInTheDocument();
 } );
 
+test( 'hides primary site selector when primary-site-dashboard is not selected', async () => {
+	nock.cleanAll();
+	nock( API_BASE ).get( '/rest/v1.1/me/settings' ).reply( 200, {
+		primary_site_ID: mockPrimarySiteId,
+	} );
+
+	nock( API_BASE )
+		.get( '/rest/v1.1/me/preferences' )
+		.query( true )
+		.reply( 200, {
+			calypso_preferences: {
+				'sites-landing-page': {
+					useSitesAsLandingPage: true,
+					updatedAt: Date.now(),
+				},
+				'reader-landing-page': {
+					useReaderAsLandingPage: false,
+					updatedAt: Date.now(),
+				},
+			},
+		} );
+
+	nock( API_BASE ).get( '/rest/v1.2/me/sites' ).query( true ).reply( 200, { sites: mockSites } );
+
+	( useAuth as jest.Mock ).mockReturnValue( { user: { visible_site_count: 2 } } );
+
+	render( <PreferencesLogin /> );
+
+	await waitFor(
+		() => {
+			expect( screen.getByText( 'Login preferences' ) ).toBeInTheDocument();
+		},
+		{ timeout: 5000 }
+	);
+
+	// Primary site should be hidden when "sites" is selected (not primary-site-dashboard)
+	expect( screen.queryByText( 'Primary site' ) ).not.toBeInTheDocument();
+
+	// Verify "sites" option is selected
+	const sitesRadio = screen.getByLabelText( 'See a list of all your sites.' );
+	expect( sitesRadio ).toBeChecked();
+} );
+
+test( 'shows primary site selector when primary-site-dashboard is selected', async () => {
+	nock.cleanAll();
+	nock( API_BASE ).get( '/rest/v1.1/me/settings' ).reply( 200, {
+		primary_site_ID: mockPrimarySiteId,
+	} );
+
+	nock( API_BASE )
+		.get( '/rest/v1.1/me/preferences' )
+		.query( true )
+		.reply( 200, {
+			calypso_preferences: {
+				'sites-landing-page': {
+					useSitesAsLandingPage: false,
+					updatedAt: Date.now(),
+				},
+				'reader-landing-page': {
+					useReaderAsLandingPage: false,
+					updatedAt: Date.now(),
+				},
+			},
+		} );
+
+	nock( API_BASE ).get( '/rest/v1.2/me/sites' ).query( true ).reply( 200, { sites: mockSites } );
+
+	( useAuth as jest.Mock ).mockReturnValue( { user: { visible_site_count: 2 } } );
+
+	render( <PreferencesLogin /> );
+
+	await waitFor(
+		() => {
+			expect( screen.getByText( 'Login preferences' ) ).toBeInTheDocument();
+		},
+		{ timeout: 5000 }
+	);
+
+	// Primary site should be visible when "primary-site-dashboard" is selected
+	expect( screen.getByText( 'Primary site' ) ).toBeInTheDocument();
+
+	// Verify "primary-site-dashboard" option is selected
+	const primarySiteRadio = screen.getByLabelText( /Open your primary site.*dashboard/i );
+	expect( primarySiteRadio ).toBeChecked();
+} );
+
 test( 'disables save button while saving', async () => {
 	const mockCreateSuccessNotice = jest.fn();
 	( useDispatch as jest.Mock ).mockReturnValue( {


### PR DESCRIPTION
Part of DOTMSD-840.

## Proposed Changes

Simplify the login preferences card to do the following:
- Update the copy to be more descriptive
- Remove redundant copy
  - I do propose removing "Sites, Primary site's dashboard, and Reader", maybe that's too aggressive and those labels are needed.  
- Reorder the list, so we can hide Primary Site when that options is not selected.

| Before | After |
|--------|--------|
| <img width="693" height="388" alt="Screenshot 2025-11-28 at 8 51 49 AM" src="https://github.com/user-attachments/assets/93930a9d-81e2-4cb6-b227-6b32820518c9" /> | <img width="709" height="367" alt="Screenshot 2025-11-28 at 8 52 15 AM" src="https://github.com/user-attachments/assets/f99e43d3-b1ad-4e81-8943-063a827d49a1" /> |
| <img width="680" height="390" alt="Screenshot 2025-11-28 at 9 25 32 AM" src="https://github.com/user-attachments/assets/e5603161-6b3c-4904-bae2-0639423d9266" /> | <img width="722" height="280" alt="Screenshot 2025-11-28 at 8 52 09 AM" src="https://github.com/user-attachments/assets/ed5a3ff0-ad17-4490-a99c-d4f494adc330" /> | 


This PR only works if the primary site is only used for login purposes. Asked here: p1764285227148779-slack-C08JZTRS6NA





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?