### PR TITLE
MSD: Update confirm modal default size as 'small'.

### DIFF
--- a/client/dashboard/components/confirm-modal/index.tsx
+++ b/client/dashboard/components/confirm-modal/index.tsx
@@ -21,7 +21,7 @@ interface Props {
 export default function ConfirmModal( {
 	__experimentalHideHeader = true,
 	title,
-	size = 'large',
+	size = 'small',
 	cancelButtonText,
 	confirmButtonProps,
 	children,

--- a/client/dashboard/me/security-two-step-auth/main-page/actions/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/actions/index.tsx
@@ -75,7 +75,6 @@ export default function TwoStepAuthActions() {
 			<ConfirmModal
 				__experimentalHideHeader={ false }
 				title={ __( 'Generate new backup codes' ) }
-				size="medium"
 				isOpen={ showGenerateBackupCodesDialog }
 				onCancel={ () => setShowGenerateBackupCodesDialog( false ) }
 				onConfirm={ () => router.navigate( { to: securityTwoStepAuthBackupCodesRoute.fullPath } ) }


### PR DESCRIPTION
Alternative to #107365.

## Proposed Changes

Set the `ConfirmModal` to `small`. Are confirmations are typically simple and don't contain much content. Confirmation modals that do should be considered the exception.

This also updates the Backup code generation to "small" to match the other account related confirmations. 

## Why are these changes being made?
 
Fit and finish.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
