### PR TITLE
MSD: Fix 'clear search' behavior in sites DataViews

### DIFF
--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -132,9 +132,7 @@ export default function CIABSites() {
 								navigate( {
 									search: {
 										...currentSearchParams,
-										view: Object.fromEntries(
-											Object.entries( view ).filter( ( [ key ] ) => key !== 'search' )
-										),
+										search: undefined,
 									},
 								} );
 							} }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -271,9 +271,7 @@ export default function Sites() {
 								navigate( {
 									search: {
 										...currentSearchParams,
-										view: Object.fromEntries(
-											Object.entries( view ).filter( ( [ key ] ) => key !== 'search' )
-										),
+										search: undefined,
 									},
 								} );
 							} }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/107368#issuecomment-3587798347

## Proposed Changes

This PR fixes the "Clear search" button on empty state when the user searches a non-existant search term in `/sites`.

This is broken after we implemented DataViews view persistence.

## Why are these changes being made?

Fixes a bug.

## Testing Instructions

1. Go to /sites.
2. In the search box, type a bogus string until you see empty state.
3. Click the Clear search button.
4. Verify the search term is actually cleared.

<img width="300" height="324" alt="image" src="https://github.com/user-attachments/assets/d1d09a5c-19c6-46fa-bc3f-87767f0bbb84" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
