### PR TITLE
MSD: Use free composition to render the Reset view action

### DIFF
--- a/client/dashboard/components/dataviews/dataviews.tsx
+++ b/client/dashboard/components/dataviews/dataviews.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { DataViews as WPDataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { sanitizeView } from './sanitize-view';
@@ -14,33 +14,61 @@ export function DataViews< Item >( {
 	view,
 	onResetView,
 	header,
+	search = true,
+	searchLabel,
+	children,
 	...props
 }: DataViewsProps< Item > ) {
 	const sanitizedView = sanitizeView( view, props.fields );
+
+	const resetViewAction = onResetView && (
+		<Button variant="tertiary" size="compact" onClick={ onResetView }>
+			{ __( 'Reset view' ) }
+		</Button>
+	);
+
+	const renderChildren = () => {
+		if ( children ) {
+			return children;
+		}
+
+		return (
+			<>
+				<HStack
+					alignment="top"
+					justify="space-between"
+					className="dataviews__view-actions"
+					spacing={ 1 }
+				>
+					<HStack justify="start" expanded={ false } className="dataviews__search">
+						{ search && <WPDataViews.Search label={ searchLabel } /> }
+						<WPDataViews.FiltersToggle />
+					</HStack>
+					<HStack spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
+						{ resetViewAction }
+						<WPDataViews.LayoutSwitcher />
+						<WPDataViews.ViewConfig />
+						{ header }
+					</HStack>
+				</HStack>
+				<WPDataViews.FiltersToggled className="dataviews-filters__container" />
+				<WPDataViews.Layout />
+				<WPDataViews.Footer />
+			</>
+		);
+	};
 
 	// TODO: apply local styles if necessary.
 	return (
 		<WPDataViews< Item >
 			view={ sanitizedView }
-			header={
-				( header || onResetView ) && (
-					<>
-						{ header }
-						{ onResetView && (
-							<Button
-								variant="tertiary"
-								size="compact"
-								style={ { order: -1 } }
-								onClick={ onResetView }
-							>
-								{ __( 'Reset view' ) }
-							</Button>
-						) }
-					</>
-				)
-			}
+			header={ header }
+			search={ search }
+			searchLabel={ searchLabel }
 			{ ...( props as any ) }
-		/>
+		>
+			{ renderChildren() }
+		</WPDataViews>
 	);
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/106883#issuecomment-3482644870

## Proposed Changes

This PR fixes the a11y of the `Reset view` button in DataViews header.

Previously, we pass the button as `header` prop. But, that would render it after the appearance options gear icon. So, we added `order: -1` CSS hack to render it before it. However, it caused weird order when we tab around the buttons via keyboard:

https://github.com/user-attachments/assets/9a814653-c149-4f5f-8335-205309c17f62

This PR fixes that by actually rendering the button before the icons. But it means we need to use the "Free Composition" mode in DataViews, where we render everything manually. We're following this: 

https://github.com/WordPress/gutenberg/blob/8f674f6cc5b1aa9998799e7a86448f8c42424ea0/packages/dataviews/src/components/dataviews/index.tsx#L86-L121

Sadly, there's no cleaner way than this. CIAB-Admin also does similar thing by composing the DataViews elements manually like this.

## Why are these changes being made?

Fixes a11y.

## Testing Instructions

1. Go to /sites
2. Verify the DataViews still works as in wpcalypso.wordpress.com
3. Smoke-test other DataViews in other pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
