### PR TITLE
A4A > Exclusive offers: Initial implementation of Exclusive offers page

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -13,6 +13,7 @@ import {
 	starEmpty,
 	plugins,
 	chartBar,
+	box,
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -39,6 +40,7 @@ import {
 	A4A_AGENCY_TIER_LINK,
 	A4A_MIGRATIONS_OVERVIEW_LINK,
 	A4A_WOOPAYMENTS_LINK,
+	A4A_PARTNER_OFFERS_LINK,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
 
@@ -99,6 +101,16 @@ const useMainMenuItems = ( path: string ) => {
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Agency Tier',
 							},
+						},
+				  ]
+				: [] ),
+			...( isSectionNameEnabled( 'a8c-for-agencies-partner-offers' )
+				? [
+						{
+							icon: box,
+							path: '/',
+							link: A4A_PARTNER_OFFERS_LINK,
+							title: translate( 'Exclusive offers' ),
 						},
 				  ]
 				: [] ),

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -55,6 +55,7 @@ export const A4A_WOOPAYMENTS_DASHBOARD_LINK = `${ A4A_WOOPAYMENTS_LINK }/dashboa
 export const A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK = `${ A4A_WOOPAYMENTS_LINK }/payment-settings`;
 export const A4A_WOOPAYMENTS_SITE_SETUP_LINK = `${ A4A_WOOPAYMENTS_LINK }/site-setup`;
 export const A4A_WOOPAYMENTS_OVERVIEW_LINK = `${ A4A_WOOPAYMENTS_LINK }/overview`;
+export const A4A_PARTNER_OFFERS_LINK = '/exclusive-offers';
 
 // Client
 export const A4A_CLIENT_LANDING_LINK = '/client/landing';

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -53,6 +53,7 @@ import {
 	A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
 	A4A_WOOPAYMENTS_SITE_SETUP_LINK,
 	A4A_WOOPAYMENTS_OVERVIEW_LINK,
+	A4A_PARTNER_OFFERS_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
 
@@ -109,6 +110,8 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK ]: [ 'a4a_read_referrals' ],
 	[ A4A_WOOPAYMENTS_SITE_SETUP_LINK ]: [ 'a4a_read_referrals' ],
 	[ A4A_WOOPAYMENTS_OVERVIEW_LINK ]: [ 'a4a_read_referrals' ],
+	// FIXME: Add the correct capability for Partner Offers
+	[ A4A_PARTNER_OFFERS_LINK ]: [ 'a4a_read_marketplace' ],
 };
 
 const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {

--- a/client/a8c-for-agencies/sections/partner-offers/controller.tsx
+++ b/client/a8c-for-agencies/sections/partner-offers/controller.tsx
@@ -1,0 +1,15 @@
+import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
+import MainSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/main';
+import PartnerOffersOverview from './primary/overview';
+
+export const partnerOffersContext: Callback = ( context, next ) => {
+	context.secondary = <MainSidebar path={ context.path } />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Exclusive offers" path={ context.path } />
+			<PartnerOffersOverview />
+		</>
+	);
+	next();
+};

--- a/client/a8c-for-agencies/sections/partner-offers/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-offers/index.tsx
@@ -1,0 +1,15 @@
+import page from '@automattic/calypso-router';
+import { A4A_PARTNER_OFFERS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { partnerOffersContext } from './controller';
+
+export default function () {
+	page(
+		A4A_PARTNER_OFFERS_LINK,
+		requireAccessContext,
+		partnerOffersContext,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/a8c-for-agencies/sections/partner-offers/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-offers/overview-content/index.tsx
@@ -1,0 +1,16 @@
+import { __experimentalSpacer as Spacer, __experimentalText as Text } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function PartnerOffersOverviewContent() {
+	return (
+		<>
+			<Spacer marginBottom={ 4 } style={ { maxWidth: '600px' } }>
+				<Text size={ 15 }>
+					{ __(
+						'Discover exclusive offers, events, training, and tools from Automattic and our partners. Everything you need to help your agency grow and support your clients.'
+					) }
+				</Text>
+			</Spacer>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/partner-offers/primary/overview/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-offers/primary/overview/index.tsx
@@ -1,0 +1,31 @@
+import { useTranslate } from 'i18n-calypso';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from 'calypso/layout/hosting-dashboard/header';
+import PartnerOffersOverviewContent from '../../overview-content';
+
+export default function PartnerOffersOverview() {
+	const translate = useTranslate();
+	const title = translate( 'Exclusive offers' );
+	return (
+		<Layout title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+					<Actions>
+						<MobileSidebarNavigation />
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<PartnerOffersOverviewContent />
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -911,6 +911,12 @@ const sections = [
 		module: 'calypso/a8c-for-agencies/sections/woopayments',
 		group: 'a8c-for-agencies',
 	},
+	{
+		name: 'a8c-for-agencies-partner-offers',
+		paths: [ '/exclusive-offers' ],
+		module: 'calypso/a8c-for-agencies/sections/partner-offers',
+		group: 'a8c-for-agencies',
+	},
 ];
 
 module.exports = sections;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -178,6 +178,7 @@
 		"a8c-for-agencies-agency-tier": false,
 		"a8c-for-agencies-woopayments": false,
 		"a8c-for-agencies-express-checkout": false,
+		"a8c-for-agencies-partner-offers": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -73,7 +73,8 @@
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
 		"a8c-for-agencies-woopayments": true,
-		"a8c-for-agencies-express-checkout": true
+		"a8c-for-agencies-express-checkout": true,
+		"a8c-for-agencies-partner-offers": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -66,7 +66,8 @@
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
 		"a8c-for-agencies-woopayments": true,
-		"a8c-for-agencies-express-checkout": true
+		"a8c-for-agencies-express-checkout": true,
+		"a8c-for-agencies-partner-offers": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -66,7 +66,8 @@
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
 		"a8c-for-agencies-woopayments": true,
-		"a8c-for-agencies-express-checkout": false
+		"a8c-for-agencies-express-checkout": false,
+		"a8c-for-agencies-partner-offers": false
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -68,7 +68,8 @@
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
 		"a8c-for-agencies-woopayments": true,
-		"a8c-for-agencies-express-checkout": false
+		"a8c-for-agencies-express-checkout": false,
+		"a8c-for-agencies-partner-offers": false
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1868/janitorial-add-feature-flag-and-section-that-enables-this-feature
Resolves https://linear.app/a8c/issue/A4A-1869/janitorial-enable-feature-flag-in-dev-horizon

## Proposed Changes

This PR does the initial implementation of the Partner Offers page, including adding the necessary section flag logic, and foundational work.

## Why are these changes being made?

* To implement the Partner Offers page

## Testing Instructions

* Open the A4A live link
* Click the `Exclusive offers` menu item > Verify that the screen below is displayed

<img width="1512" height="717" alt="Screenshot 2025-11-28 at 2 37 42 PM" src="https://github.com/user-attachments/assets/5de397c4-025e-4450-a1f8-1d84dd204afc" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
