### PR TITLE
A4A > Exclusive offers: Implement Exclusive offers content

### DIFF
--- a/client/a8c-for-agencies/sections/partner-offers/overview-content/constants.ts
+++ b/client/a8c-for-agencies/sections/partner-offers/overview-content/constants.ts
@@ -1,0 +1,59 @@
+import { __ } from '@wordpress/i18n';
+import {
+	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
+import WPCOMLogo from 'calypso/assets/images/a8c-for-agencies/wpcom-logo.svg';
+import type { PartnerOffer } from './types';
+
+export const filterOptions = {
+	offerTypes: [
+		{ value: 'referral', label: __( 'Referral' ) },
+		{ value: 'reseller', label: __( 'Reseller' ) },
+	],
+	products: [
+		{ value: 'wordpress', label: __( 'WordPress.com' ) },
+		{ value: 'pressable', label: __( 'Pressable' ) },
+	],
+	productTypes: [ { value: 'hosting', label: __( 'Hosting' ) } ],
+	categories: [
+		{ value: 'hosting', label: __( 'Hosting' ) },
+		{ value: 'payments', label: __( 'Payments' ) },
+	],
+};
+
+export const partnerOffers: PartnerOffer[] = [
+	{
+		id: 'wordpress-com-hosting-referral',
+		offerType: 'referral',
+		product: 'wordpress',
+		productType: 'hosting',
+		category: 'hosting',
+		logo: WPCOMLogo,
+		title: __( 'Earn a 20% recurring commission' ),
+		description: __(
+			"Earn a 20% recurring commission when you refer WordPress.com's world-class hosting to your clients. Ideal for agencies that build and hand off to clients."
+		),
+		cta: {
+			label: __( 'Refer WordPress.com' ),
+			url: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+		},
+	},
+	{
+		id: 'pressable-hosting-referral',
+		offerType: 'referral',
+		product: 'pressable',
+		productType: 'hosting',
+		category: 'hosting',
+		logo: PressableLogo,
+		title: __( 'Earn a 20% recurring commission' ),
+		description: __(
+			'Earn a 20% recurring commission when you refer Pressable’s best-in-class hosting to your clients. Ideal for agencies that build and continue to maintain sites or stores.'
+		),
+		cta: {
+			label: __( 'Refer Pressable' ),
+			url: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+		},
+	},
+];

--- a/client/a8c-for-agencies/sections/partner-offers/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-offers/overview-content/index.tsx
@@ -1,7 +1,145 @@
-import { __experimentalSpacer as Spacer, __experimentalText as Text } from '@wordpress/components';
+import { Badge } from '@automattic/ui';
+import {
+	Card,
+	CardBody,
+	Button,
+	__experimentalSpacer as Spacer,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { ButtonStack } from 'calypso/dashboard/components/button-stack';
+import { filterOptions, partnerOffers } from './constants';
+import type { PartnerOffer } from './types';
+import type { View, Field } from '@wordpress/dataviews';
+
+import './style.scss';
+
+const initialView: View = {
+	type: 'list',
+	fields: [],
+	search: '',
+	filters: [],
+	page: 1,
+	perPage: 10,
+};
+
+function PartnerOfferCard( { item }: { item: PartnerOffer } ) {
+	const offerType = filterOptions.offerTypes.find( ( option ) => option.value === item.offerType );
+	return (
+		<Card>
+			<CardBody style={ { display: 'flex', flexDirection: 'column', height: '100%' } }>
+				<VStack spacing={ 4 } style={ { flex: 1, justifyContent: 'flex-start' } }>
+					<HStack>
+						<img src={ item.logo } alt={ item.product } style={ { width: '120px' } } />
+						{ offerType?.label && <Badge>{ offerType.label }</Badge> }
+					</HStack>
+					<VStack spacing={ 1 }>
+						<Text size={ 13 } weight={ 500 }>
+							{ item.title }
+						</Text>
+						<Text variant="muted" size={ 12 }>
+							{ item.description }
+						</Text>
+					</VStack>
+				</VStack>
+				{ item.cta && (
+					<ButtonStack style={ { marginTop: '24px', alignSelf: 'flex-start' } }>
+						<Button variant="secondary" href={ item.cta.url }>
+							{ item.cta.label }
+						</Button>
+						<Button
+							variant="link"
+							href="https://automattic.com/for-agencies/program-incentives"
+							target="_blank"
+						>
+							{ __( 'View terms' ) }
+						</Button>
+					</ButtonStack>
+				) }
+			</CardBody>
+		</Card>
+	);
+}
 
 export default function PartnerOffersOverviewContent() {
+	const [ view, setView ] = useState< View >( initialView );
+
+	const fields: Field< PartnerOffer >[] = useMemo(
+		() => [
+			{
+				id: 'title',
+				getValue: ( { item } ) => item.title,
+				enableGlobalSearch: true,
+			},
+			{
+				id: 'description',
+				getValue: ( { item } ) => item.description,
+				enableGlobalSearch: true,
+			},
+			{
+				id: 'product',
+				label: __( 'Product' ),
+				type: 'text',
+				getValue: ( { item } ) => item.product,
+				elements: filterOptions.products,
+				filterBy: {
+					operators: [ 'is' ],
+				},
+				enableSorting: false,
+				enableHiding: true,
+			},
+			{
+				id: 'offerType',
+				label: __( 'Offer type' ),
+				type: 'text',
+				getValue: ( { item } ) => item.offerType,
+				elements: filterOptions.offerTypes,
+				filterBy: {
+					operators: [ 'is' ],
+				},
+				enableSorting: false,
+				enableHiding: true,
+			},
+			{
+				id: 'productType',
+				label: __( 'Product type' ),
+				type: 'text',
+				getValue: ( { item } ) => item.productType,
+				elements: filterOptions.productTypes,
+				filterBy: {
+					operators: [ 'is' ],
+				},
+				enableSorting: false,
+				enableHiding: true,
+			},
+			{
+				id: 'category',
+				label: __( 'Category' ),
+				type: 'text',
+				getValue: ( { item } ) => item.category,
+				elements: filterOptions.categories,
+				filterBy: {
+					operators: [ 'is' ],
+				},
+				enableSorting: false,
+				enableHiding: true,
+			},
+		],
+		[]
+	);
+
+	const { data: filteredData } = useMemo(
+		() => filterSortAndPaginate( partnerOffers, view, fields ),
+		[ view, fields ]
+	);
+
+	const perPage = view.perPage ?? 10;
+	const totalPages = Math.max( 1, Math.ceil( filteredData.length / perPage ) );
+
 	return (
 		<>
 			<Spacer marginBottom={ 4 } style={ { maxWidth: '600px' } }>
@@ -11,6 +149,30 @@ export default function PartnerOffersOverviewContent() {
 					) }
 				</Text>
 			</Spacer>
+
+			<DataViews< PartnerOffer >
+				data={ partnerOffers }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				paginationInfo={ {
+					totalItems: filteredData.length,
+					totalPages,
+				} }
+				defaultLayouts={ { list: {} } }
+				search
+			>
+				<HStack justify="start" style={ { paddingBlock: '16px' } }>
+					<DataViews.Search />
+					<DataViews.FiltersToggle />
+				</HStack>
+				<DataViews.FiltersToggled className="partner-offers-filters" />
+			</DataViews>
+			<div className="partner-offers-cards">
+				{ filteredData.map( ( item ) => (
+					<PartnerOfferCard key={ item.id } item={ item } />
+				) ) }
+			</div>
 		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/partner-offers/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-offers/overview-content/index.tsx
@@ -47,7 +47,14 @@ function PartnerOfferCard( { item }: { item: PartnerOffer } ) {
 					</VStack>
 				</VStack>
 				{ item.cta && (
-					<ButtonStack style={ { marginTop: '24px', alignSelf: 'flex-start' } }>
+					<ButtonStack
+						style={ {
+							marginTop: '24px',
+							alignSelf: 'flex-start',
+							justifyContent: 'flex-start',
+							gap: '16px',
+						} }
+					>
 						<Button variant="secondary" href={ item.cta.url }>
 							{ item.cta.label }
 						</Button>

--- a/client/a8c-for-agencies/sections/partner-offers/overview-content/style.scss
+++ b/client/a8c-for-agencies/sections/partner-offers/overview-content/style.scss
@@ -1,0 +1,11 @@
+@import '@wordpress/dataviews/build-style/style.css';
+
+.partner-offers-cards {
+	display: grid;
+	grid-template-columns: repeat( auto-fill, minmax( 260px, 1fr ) );
+	gap: 32px;
+}
+
+.partner-offers-filters {
+	margin-bottom: 16px;
+}

--- a/client/a8c-for-agencies/sections/partner-offers/overview-content/style.scss
+++ b/client/a8c-for-agencies/sections/partner-offers/overview-content/style.scss
@@ -2,8 +2,12 @@
 
 .partner-offers-cards {
 	display: grid;
-	grid-template-columns: repeat( auto-fill, minmax( 260px, 1fr ) );
+	grid-template-columns: repeat( auto-fill, minmax( 250px, 1fr ) );
 	gap: 32px;
+
+	@include break-large {
+		grid-template-columns: repeat( auto-fill, minmax( 270px, 1fr ) );
+	}
 }
 
 .partner-offers-filters {

--- a/client/a8c-for-agencies/sections/partner-offers/overview-content/types.ts
+++ b/client/a8c-for-agencies/sections/partner-offers/overview-content/types.ts
@@ -1,0 +1,15 @@
+export type PartnerOffer = {
+	id: string;
+	type?: string;
+	offerType: string;
+	product: string;
+	productType: string;
+	category: string;
+	logo: string;
+	title: string;
+	description: string;
+	cta: {
+		label: string;
+		url: string;
+	};
+};


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1877/implement-search-and-filter-view-for-the-partner-offers-page

Resolves https://linear.app/a8c/issue/A4A-1876/implement-cards-to-display-all-the-offers
Resolves https://linear.app/a8c/issue/A4A-1877/implement-search-and-filter-view-for-the-partner-offers-page

## Proposed Changes

This PR implements Partner Offers content, including using "Free composition" from DataViews to implement search & filter.

## Why are these changes being made?

* To implement the Partner Offers page

## Testing Instructions

* Open the A4A live link
* Click the Exclusive offers menu item > Verify that the screen below is displayed & search/filter works as expected.

<img width="1512" height="717" alt="Screenshot 2025-11-28 at 3 49 19 PM" src="https://github.com/user-attachments/assets/c39e1514-ba69-4917-9464-1522ec0d4388" />

<img width="1512" height="717" alt="Screenshot 2025-11-28 at 3 52 35 PM" src="https://github.com/user-attachments/assets/88c66bf7-6205-4361-ae94-356bacb88562" />

<img width="1512" height="717" alt="Screenshot 2025-11-28 at 3 53 01 PM" src="https://github.com/user-attachments/assets/309ce677-d378-4af7-a0cc-96f3628508fb" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
