### PR TITLE
MSD: use prefetchQuery() instead of ensureQueryData() when applicable

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -52,8 +52,8 @@ export const domainsIndexRoute = createRoute( {
 	getParentRoute: () => domainsRoute,
 	path: '/',
 	loader: async ( { context } ) => {
-		queryClient.ensureQueryData( domainsQuery() );
-		queryClient.ensureQueryData( context.config.queries.sitesQuery() );
+		queryClient.prefetchQuery( domainsQuery() );
+		queryClient.prefetchQuery( context.config.queries.sitesQuery() );
 		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 	},
 } ).lazy( () =>
@@ -163,8 +163,8 @@ export const domainOverviewRoute = createRoute( {
 	loader: async ( { params: { domainName } } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
 
-		queryClient.ensureQueryData( siteByIdQuery( domain.blog_id ) );
-		queryClient.ensureQueryData( mailboxesQuery( domain.blog_id ) );
+		queryClient.prefetchQuery( siteByIdQuery( domain.blog_id ) );
+		queryClient.prefetchQuery( mailboxesQuery( domain.blog_id ) );
 	},
 } ).lazy( () =>
 	import( '../../domains/domain-overview' ).then( ( d ) =>

--- a/client/dashboard/app/router/emails.tsx
+++ b/client/dashboard/app/router/emails.tsx
@@ -78,7 +78,7 @@ export const chooseDomainRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'emails/choose-domain',
 	loader: async () => {
-		queryClient.ensureQueryData( domainsQuery() );
+		queryClient.prefetchQuery( domainsQuery() );
 	},
 } ).lazy( () =>
 	import( '../../emails/choose-domain' ).then( ( d ) =>

--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -53,8 +53,8 @@ export const pluginsManageRoute = createRoute( {
 	getParentRoute: () => pluginsRoute,
 	path: 'manage',
 	loader: async () => {
-		queryClient.ensureQueryData( marketplacePluginsQuery() );
-		queryClient.ensureQueryData( pluginsQuery() );
+		queryClient.prefetchQuery( marketplacePluginsQuery() );
+		queryClient.prefetchQuery( pluginsQuery() );
 		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 	},
 } );
@@ -81,8 +81,8 @@ export const pluginRoute = createRoute( {
 	getParentRoute: () => pluginsManageRoute,
 	path: '$pluginId',
 	loader: async () => {
-		queryClient.ensureQueryData( marketplacePluginsQuery() );
-		queryClient.ensureQueryData( pluginsQuery() );
+		queryClient.prefetchQuery( marketplacePluginsQuery() );
+		queryClient.prefetchQuery( pluginsQuery() );
 	},
 } ).lazy( () =>
 	import( '../../plugins/plugin' ).then( ( d ) =>
@@ -126,7 +126,7 @@ export const pluginsScheduledUpdatesNewRoute = createRoute( {
 	getParentRoute: () => pluginsScheduledUpdatesRoute,
 	path: '/new',
 	loader: async ( { context } ) => {
-		queryClient.ensureQueryData( context.config.queries.sitesQuery() );
+		queryClient.prefetchQuery( context.config.queries.sitesQuery() );
 	},
 } ).lazy( () =>
 	import( '../../plugins/scheduled-updates/new' ).then( ( d ) =>
@@ -147,7 +147,7 @@ export const pluginsScheduledUpdatesEditRoute = createRoute( {
 	getParentRoute: () => pluginsScheduledUpdatesRoute,
 	path: '/edit/$scheduleId',
 	loader: async ( { context } ) => {
-		queryClient.ensureQueryData( context.config.queries.sitesQuery() );
+		queryClient.prefetchQuery( context.config.queries.sitesQuery() );
 	},
 } ).lazy( () =>
 	import( '../../plugins/scheduled-updates/edit' ).then( ( d ) =>


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/pull/107269#discussion_r2554599870

## Proposed Changes

This PR replaces the usage of `ensureQueryData()`, where it does not actually ensuring that the data is in the query cache (because we don't need it at the time), with `prefetchQuery()`. This is actually the recommended way by TanStack. 

Also, the original implementation is a bit misleading to devs. It's unclear what data is actually needed before the component mounts. With this PR, they now read better.

## Why are these changes being made?

Dev QoL upgrade.

## Testing Instructions

1. Visually check the code chages.
2. Smoke test the routes in the code changes; verify they still work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
