### PR TITLE
SSH Migration: Handle SSH auth error

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/hooks/use-ssh-migration-status.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/hooks/use-ssh-migration-status.ts
@@ -8,9 +8,10 @@ interface SSHMigrationStatusParams {
 
 /**
  * Response from the SSH migration status endpoint
- * @property success - Indicates if the status request was successful
- * @property status - High-level migration status (in-progress, migrating, completed, or failed)
- * @property step - Detailed migration step indicating current progress through the migration process
+ * @property {boolean} success - Indicates if the status request was successful
+ * @property {string} status - High-level migration status (in-progress, migrating, completed, or failed)
+ * @property {string} step - Detailed migration step indicating current progress through the migration process
+ * @property {string} [error_code] - Optional error code when migration fails (e.g., 'credential_failure')
  */
 interface SSHMigrationStatusResponse {
 	success: boolean;
@@ -30,6 +31,7 @@ interface SSHMigrationStatusResponse {
 		| 'migration-starting'
 		| 'migration-running'
 		| 'completed';
+	error_code?: 'credential_failure' | string;
 }
 
 /**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/hooks/use-ssh-migration-status.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-in-progress/hooks/use-ssh-migration-status.ts
@@ -31,7 +31,7 @@ interface SSHMigrationStatusResponse {
 		| 'migration-starting'
 		| 'migration-running'
 		| 'completed';
-	error_code?: 'credential_failure' | string;
+	error_code?: 'credential_failure';
 }
 
 /**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -89,6 +89,29 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 		setTimeout( () => setCopied( false ), 2000 );
 	};
 
+	const isCredentialFailure = error?.message === 'credential_failure';
+
+	const getErrorMessage = () => {
+		if ( ! isCredentialFailure ) {
+			return translate(
+				'We ran into a problem starting the migration. Please check your details and try again.'
+			);
+		}
+
+		// Provide specific guidance based on authentication method
+		if ( authMethod === 'password' ) {
+			return translate(
+				'SSH authentication failed. Please verify your SSH username and password are correct and try again.'
+			);
+		}
+
+		return translate(
+			'SSH authentication failed. Please ensure your SSH key is properly configured on the source site and try again.'
+		);
+	};
+
+	const errorMessage = getErrorMessage();
+
 	return (
 		<div className="site-migration-ssh__step-share-ssh">
 			<p className="site-migration-ssh__step-share-ssh-description">
@@ -99,13 +122,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 
 			{ helpLink }
 
-			{ error && (
-				<AccordionNotice variant="error">
-					{ translate(
-						'We ran into a problem starting the migration. Please check your details and try again.'
-					) }
-				</AccordionNotice>
-			) }
+			{ error && <AccordionNotice variant="error">{ errorMessage }</AccordionNotice> }
 
 			<div className="site-migration-ssh__step-share-ssh-auth-method">
 				<label className="site-migration-ssh__step-share-ssh-label">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -89,9 +89,9 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 		setTimeout( () => setCopied( false ), 2000 );
 	};
 
-	const isCredentialFailure = error?.message === 'credential_failure';
-
 	const getErrorMessage = () => {
+		const isCredentialFailure = error?.message === 'credential_failure';
+
 		if ( ! isCredentialFailure ) {
 			return translate(
 				'We ran into a problem starting the migration. Please check your details and try again.'
@@ -110,8 +110,6 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 		);
 	};
 
-	const errorMessage = getErrorMessage();
-
 	return (
 		<div className="site-migration-ssh__step-share-ssh">
 			<p className="site-migration-ssh__step-share-ssh-description">
@@ -122,7 +120,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 
 			{ helpLink }
 
-			{ error && <AccordionNotice variant="error">{ errorMessage }</AccordionNotice> }
+			{ error && <AccordionNotice variant="error">{ getErrorMessage() }</AccordionNotice> }
 
 			<div className="site-migration-ssh__step-share-ssh-auth-method">
 				<label className="site-migration-ssh__step-share-ssh-label">


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15349

## Proposed Changes

* Adds customized messages when we detect authentication error during the preflight checks.
* We customize the messages based on the `Authentication method`:
     * **Username and password**: `SSH authentication failed. Please verify your SSH username and password are correct and try again.`
     * **SSH Key**: `SSH authentication failed. Please ensure your SSH key is properly configured on the source site and try again.`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We noticed that many users are facing issue during the preflight checks because they input the wrong credentials and the preflights can't go through. This PR customizes the error message, so we can better guide the user.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up your sandbox: 197035-ghe-Automattic/wpcom
* Use Calypso Live or apply this PR to your local environment
* Go to `/setup/site-migration` and use a source site that can be migrated via SSH
* Once you reach the `Securely share your access` step, input unexisting username/password so the authentication fails and you see the customized error:
```text
SSH authentication failed. Please verify your SSH username and password are correct and try again.
```
* Now, switch the `Authentication method` radio to `SSH Key` and try again without setting it up on your source site. You should see the following message:
```text
SSH authentication failed. Please ensure your SSH key is properly configured on the source site and try again.
```
* Now properly set it up and ensure the migration can start.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?