### PR TITLE
MSD Plugins: Plugin details DataView filterable by update status

### DIFF
--- a/client/dashboard/plugins/manage/components/plugins-header-actions.scss
+++ b/client/dashboard/plugins/manage/components/plugins-header-actions.scss
@@ -1,4 +1,0 @@
-.plugins-header-actions__updates-link {
-	text-decoration: none;
-	cursor: pointer;
-}

--- a/client/dashboard/plugins/manage/components/plugins-header-actions.tsx
+++ b/client/dashboard/plugins/manage/components/plugins-header-actions.tsx
@@ -1,8 +1,6 @@
 import { Button, __experimentalText as Text } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
-import './plugins-header-actions.scss';
-
 type PluginsHeaderActionsProps = {
 	updateCount: number;
 	onFilterUpdates: () => void;
@@ -23,12 +21,7 @@ export const PluginsHeaderActions = ( {
 
 	if ( hasUpdates ) {
 		return (
-			<Button
-				variant="tertiary"
-				size="compact"
-				className="plugins-header-actions__updates-link"
-				onClick={ onFilterUpdates }
-			>
+			<Button variant="tertiary" size="compact" onClick={ onFilterUpdates }>
 				<Text>
 					{ sprintf(
 						// translators: %d is the number of plugins with an update available.

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -178,10 +178,19 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 				label: __( 'Update' ),
 				getValue: ( { item }: { item: SiteWithPluginData } ) => {
 					const pluginItem = pluginBySiteId.get( item.ID );
-					const { autoupdate } = getAllowedPluginActions( item, pluginSlug );
+					const { autoupdate, isManagedPlugin } = getAllowedPluginActions( item, pluginSlug );
 
-					return autoupdate && !! pluginItem?.update;
+					if ( isManagedPlugin ) {
+						return 0;
+					}
+
+					return autoupdate && !! pluginItem?.update ? 2 : 1;
 				},
+				elements: [
+					{ value: 2, label: __( 'Update available' ) },
+					{ value: 1, label: __( 'Up to date' ) },
+					{ value: 0, label: __( 'Updates auto-managed' ) },
+				],
 				render: ( { item }: { item: SiteWithPluginData } ) => {
 					const update = pluginBySiteId.get( item.ID )?.update;
 					const version = pluginBySiteId.get( item.ID )?.version;
@@ -266,7 +275,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 			return;
 		}
 
-		setView( getViewFilteredByUpdates( view, 'update', true ) );
+		setView( getViewFilteredByUpdates( view, 'update', 2 ) );
 	}, [ updateCount, view, setView ] );
 
 	return (

--- a/client/dashboard/plugins/plugin/utils/get-allowed-plugin-actions.ts
+++ b/client/dashboard/plugins/plugin/utils/get-allowed-plugin-actions.ts
@@ -12,5 +12,6 @@ export const getAllowedPluginActions = ( site: SiteWithPluginData, pluginSlug: s
 
 	return {
 		autoupdate: ! isManagedPlugin && canManagePlugins,
+		isManagedPlugin,
 	};
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTMSD-909/msd-plugins-plugin-details-dataview-doesnt-include-update-filter
## Proposed Changes

* The plugin details dataview is now filterable by update status.


https://github.com/user-attachments/assets/0ad47338-fc2b-4b29-9226-4bfbef52b8bb



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our MSD effort.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link
* Navigate to '/v2/plugins' and pick a plugin.
* On the plugin details view, you should be able to filter by update status.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
