### PR TITLE
Plugins Dashboard: Clarify update and enable/disable auto-update actions

### DIFF
--- a/client/dashboard/plugins/manage/actions/activate.tsx
+++ b/client/dashboard/plugins/manage/actions/activate.tsx
@@ -28,13 +28,7 @@ export const activateAction: Action< PluginListRow > = {
 			...sitePluginActivateMutation(),
 			onSuccess: () => {},
 		} );
-		const action = async ( items: PluginListRow[] ) => {
-			const bulkActivate = buildBulkSitesPluginAction( mutateAsync );
-
-			const { successCount, errorCount } = await bulkActivate( items );
-
-			return { successCount, errorCount };
-		};
+		const action = buildBulkSitesPluginAction( mutateAsync );
 
 		return (
 			<ActionRenderModal

--- a/client/dashboard/plugins/manage/actions/deactivate.tsx
+++ b/client/dashboard/plugins/manage/actions/deactivate.tsx
@@ -28,13 +28,7 @@ export const deactivateAction: Action< PluginListRow > = {
 			...sitePluginDeactivateMutation(),
 			onSuccess: () => {},
 		} );
-		const action = async ( items: PluginListRow[] ) => {
-			const bulkDeactivate = buildBulkSitesPluginAction( mutateAsync );
-
-			const { successCount, errorCount } = await bulkDeactivate( items );
-
-			return { successCount, errorCount };
-		};
+		const action = buildBulkSitesPluginAction( mutateAsync );
 
 		return (
 			<ActionRenderModal

--- a/client/dashboard/plugins/manage/actions/disable-autoupdate.tsx
+++ b/client/dashboard/plugins/manage/actions/disable-autoupdate.tsx
@@ -28,7 +28,10 @@ export const disableAutoupdateAction: Action< PluginListRow > = {
 	},
 	modalHeader: getModalHeader( 'disable-autoupdate' ),
 	RenderModal: ( { items, closeModal } ) => {
-		const { mutateAsync } = useMutation( sitePluginAutoupdateDisableMutation() );
+		const { mutateAsync } = useMutation( {
+			...sitePluginAutoupdateDisableMutation(),
+			onSuccess: () => {},
+		} );
 		const action = buildBulkSitesPluginAction( mutateAsync );
 
 		return (

--- a/client/dashboard/plugins/manage/actions/disable-autoupdate.tsx
+++ b/client/dashboard/plugins/manage/actions/disable-autoupdate.tsx
@@ -1,6 +1,10 @@
-import { sitePluginAutoupdateDisableMutation } from '@automattic/api-queries';
+import {
+	invalidatePlugins,
+	invalidateSitePlugins,
+	sitePluginAutoupdateDisableMutation,
+} from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { __ } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 import ActionRenderModal, { getModalHeader } from '../components/action-render-modal';
 import { buildBulkSitesPluginAction } from '../utils';
 import type { PluginListRow } from '../types';
@@ -8,18 +12,44 @@ import type { Action } from '@wordpress/dataviews';
 
 export const disableAutoupdateAction: Action< PluginListRow > = {
 	id: 'disable-autoupdate',
-	label: __( 'Disable auto‑updates' ),
+	label: ( items ) => {
+		const [ plugin ] = items;
+		const enabledCount = plugin.sitesWithPluginAutoupdated.length;
+
+		return sprintf(
+			// translators: %(count)d is the number of sites the plugin will have auto-updates disabled on.
+			_n(
+				'Disable auto‑updates on %(count)d site',
+				'Disable auto‑updates on %(count)d sites',
+				enabledCount
+			),
+			{ count: enabledCount }
+		);
+	},
 	modalHeader: getModalHeader( 'disable-autoupdate' ),
-	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
+	RenderModal: ( { items, closeModal } ) => {
 		const { mutateAsync } = useMutation( sitePluginAutoupdateDisableMutation() );
 		const action = buildBulkSitesPluginAction( mutateAsync );
 
 		return (
 			<ActionRenderModal
 				actionId="disable-autoupdate"
-				items={ items }
+				items={ items.map( ( item ) => ( {
+					...item,
+					siteIds: item.siteIds.filter( ( siteId ) =>
+						item.sitesWithPluginAutoupdated.includes( siteId )
+					),
+				} ) ) }
 				closeModal={ closeModal }
-				onActionPerformed={ onActionPerformed }
+				onActionPerformed={ ( items: PluginListRow[] ) => {
+					items
+						.flatMap( ( item ) => item.siteIds )
+						.forEach( ( siteId ) => {
+							invalidateSitePlugins( siteId );
+						} );
+
+					invalidatePlugins();
+				} }
 				onExecute={ action }
 			/>
 		);

--- a/client/dashboard/plugins/manage/actions/enable-autoupdate.tsx
+++ b/client/dashboard/plugins/manage/actions/enable-autoupdate.tsx
@@ -1,6 +1,10 @@
-import { sitePluginAutoupdateEnableMutation } from '@automattic/api-queries';
+import {
+	invalidatePlugins,
+	invalidateSitePlugins,
+	sitePluginAutoupdateEnableMutation,
+} from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { __ } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 import ActionRenderModal, { getModalHeader } from '../components/action-render-modal';
 import { buildBulkSitesPluginAction } from '../utils';
 import type { PluginListRow } from '../types';
@@ -8,18 +12,44 @@ import type { Action } from '@wordpress/dataviews';
 
 export const enableAutoupdateAction: Action< PluginListRow > = {
 	id: 'enable-autoupdate',
-	label: __( 'Enable auto‑updates' ),
+	label: ( items ) => {
+		const [ plugin ] = items;
+		const disabledCount = plugin.sitesWithPluginNotAutoupdated.length;
+
+		return sprintf(
+			// translators: %(count)d is the number of sites the plugin will have auto-updates enabled on.
+			_n(
+				'Enable auto‑updates on %(count)d site',
+				'Enable auto‑updates on %(count)d sites',
+				disabledCount
+			),
+			{ count: disabledCount }
+		);
+	},
 	modalHeader: getModalHeader( 'enable-autoupdate' ),
-	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
+	RenderModal: ( { items, closeModal } ) => {
 		const { mutateAsync } = useMutation( sitePluginAutoupdateEnableMutation() );
 		const action = buildBulkSitesPluginAction( mutateAsync );
 
 		return (
 			<ActionRenderModal
 				actionId="enable-autoupdate"
-				items={ items }
+				items={ items.map( ( item ) => ( {
+					...item,
+					siteIds: item.siteIds.filter( ( siteId ) =>
+						item.sitesWithPluginNotAutoupdated.includes( siteId )
+					),
+				} ) ) }
 				closeModal={ closeModal }
-				onActionPerformed={ onActionPerformed }
+				onActionPerformed={ ( items: PluginListRow[] ) => {
+					items
+						.flatMap( ( item ) => item.siteIds )
+						.forEach( ( siteId ) => {
+							invalidateSitePlugins( siteId );
+						} );
+
+					invalidatePlugins();
+				} }
 				onExecute={ action }
 			/>
 		);

--- a/client/dashboard/plugins/manage/actions/enable-autoupdate.tsx
+++ b/client/dashboard/plugins/manage/actions/enable-autoupdate.tsx
@@ -28,7 +28,10 @@ export const enableAutoupdateAction: Action< PluginListRow > = {
 	},
 	modalHeader: getModalHeader( 'enable-autoupdate' ),
 	RenderModal: ( { items, closeModal } ) => {
-		const { mutateAsync } = useMutation( sitePluginAutoupdateEnableMutation() );
+		const { mutateAsync } = useMutation( {
+			...sitePluginAutoupdateEnableMutation(),
+			onSuccess: () => {},
+		} );
 		const action = buildBulkSitesPluginAction( mutateAsync );
 
 		return (

--- a/client/dashboard/plugins/manage/actions/update.tsx
+++ b/client/dashboard/plugins/manage/actions/update.tsx
@@ -1,6 +1,10 @@
-import { sitePluginUpdateMutation } from '@automattic/api-queries';
+import {
+	invalidatePlugins,
+	invalidateSitePlugins,
+	sitePluginUpdateMutation,
+} from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { __ } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 import ActionRenderModal, { getModalHeader } from '../components/action-render-modal';
 import { buildBulkSitesPluginAction } from '../utils';
 import type { PluginListRow } from '../types';
@@ -8,18 +12,43 @@ import type { Action } from '@wordpress/dataviews';
 
 export const updateAction: Action< PluginListRow > = {
 	id: 'update',
-	label: __( 'Update' ),
+	label: ( items ) => {
+		const [ plugin ] = items;
+		const updatedCount = plugin.sitesWithPluginUpdate.length;
+
+		return sprintf(
+			// translators: %(count)d is the number of sites the plugin will be updated on.
+			_n( 'Update on %(count)d site', 'Update on %(count)d sites', updatedCount ),
+			{ count: updatedCount }
+		);
+	},
 	modalHeader: getModalHeader( 'update' ),
-	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
-		const { mutateAsync } = useMutation( sitePluginUpdateMutation() );
+	RenderModal: ( { items, closeModal } ) => {
+		const { mutateAsync } = useMutation( {
+			...sitePluginUpdateMutation(),
+			onSuccess: () => {},
+		} );
 		const action = buildBulkSitesPluginAction( mutateAsync );
 
 		return (
 			<ActionRenderModal
 				actionId="update"
-				items={ items }
+				items={ items.map( ( item ) => ( {
+					...item,
+					siteIds: item.siteIds.filter( ( siteId ) =>
+						item.sitesWithPluginUpdate.includes( siteId )
+					),
+				} ) ) }
 				closeModal={ closeModal }
-				onActionPerformed={ onActionPerformed }
+				onActionPerformed={ ( items: PluginListRow[] ) => {
+					items
+						.flatMap( ( item ) => item.siteIds )
+						.forEach( ( siteId ) => {
+							invalidateSitePlugins( siteId );
+						} );
+
+					invalidatePlugins();
+				} }
 				onExecute={ action }
 			/>
 		);

--- a/client/dashboard/plugins/manage/components/action-render-modal.tsx
+++ b/client/dashboard/plugins/manage/components/action-render-modal.tsx
@@ -95,17 +95,19 @@ function getConfirmText( actionId: string, items: PluginListRow[] ) {
 					activeCount
 				);
 			}
-			case 'update':
+			case 'update': {
+				const updateCount = items[ 0 ].sitesWithPluginUpdate.length;
 				return sprintf(
 					// Translators: %1$s is the plugin name. %2$d is the number of sites.
 					_n(
 						'You are about to update the %1$s plugin installed on %2$d site.',
 						'You are about to update the %1$s plugin installed on %2$d sites.',
-						count
+						updateCount
 					),
 					pluginName,
-					count
+					updateCount
 				);
+			}
 			case 'enable-autoupdate': {
 				const disabledCount = items[ 0 ].sitesWithPluginNotAutoupdated.length;
 				return sprintf(
@@ -221,41 +223,50 @@ function getConfirmText( actionId: string, items: PluginListRow[] ) {
 }
 
 function getSiteList( actionId: string, items: PluginListRow[], sitesById: Map< number, Site > ) {
-	if (
-		items.length === 1 &&
-		[ 'activate', 'deactivate', 'enable-autoupdate', 'disable-autoupdate' ].includes( actionId )
-	) {
-		const [ plugin ] = items;
-
-		let sites: number[] = [];
-		if ( actionId === 'activate' ) {
-			sites = plugin.sitesWithPluginInactive;
-		} else if ( actionId === 'deactivate' ) {
-			sites = plugin.sitesWithPluginActive;
-		} else if ( actionId === 'enable-autoupdate' ) {
-			sites = plugin.sitesWithPluginNotAutoupdated;
-		} else if ( actionId === 'disable-autoupdate' ) {
-			sites = plugin.sitesWithPluginAutoupdated;
-		}
-
-		if ( ! sites?.length ) {
-			return null;
-		}
-
-		return (
-			<ul>
-				{ sites.map( ( siteId ) => {
-					const site = sitesById.get( siteId );
-
-					if ( ! site ) {
-						return null;
-					}
-
-					return <li key={ siteId }>{ `${ site.name } (${ site.slug })` }</li>;
-				} ) }
-			</ul>
-		);
+	if ( items.length !== 1 ) {
+		return null;
 	}
+
+	const [ plugin ] = items;
+
+	let sites: number[] = [];
+	switch ( actionId ) {
+		case 'activate':
+			sites = plugin.sitesWithPluginInactive;
+			break;
+		case 'deactivate':
+			sites = plugin.sitesWithPluginActive;
+			break;
+		case 'update':
+			sites = plugin.sitesWithPluginUpdate;
+			break;
+		case 'enable-autoupdate':
+			sites = plugin.sitesWithPluginNotAutoupdated;
+			break;
+		case 'disable-autoupdate':
+			sites = plugin.sitesWithPluginAutoupdated;
+			break;
+		default:
+			return null;
+	}
+
+	if ( ! sites?.length ) {
+		return null;
+	}
+
+	return (
+		<ul>
+			{ sites.map( ( siteId ) => {
+				const site = sitesById.get( siteId );
+
+				if ( ! site ) {
+					return null;
+				}
+
+				return <li key={ siteId }>{ `${ site.name } (${ site.slug })` }</li>;
+			} ) }
+		</ul>
+	);
 }
 
 export default function ActionRenderModal( {

--- a/client/dashboard/plugins/manage/components/action-render-modal.tsx
+++ b/client/dashboard/plugins/manage/components/action-render-modal.tsx
@@ -68,10 +68,9 @@ function getConfirmText( actionId: string, items: PluginListRow[] ) {
 	if ( items.length === 1 ) {
 		const pluginName = items[ 0 ].name;
 		const count = items[ 0 ].sitesCount;
-		const activeCount = items[ 0 ].sitesWithPluginActive.length;
-		const inactiveCount = items[ 0 ].sitesWithPluginInactive.length;
 		switch ( actionId ) {
-			case 'activate':
+			case 'activate': {
+				const inactiveCount = items[ 0 ].sitesWithPluginInactive.length;
 				return sprintf(
 					// translators: %1$s is the plugin name. %2$d is the number of sites.
 					_n(
@@ -82,7 +81,9 @@ function getConfirmText( actionId: string, items: PluginListRow[] ) {
 					pluginName,
 					inactiveCount
 				);
-			case 'deactivate':
+			}
+			case 'deactivate': {
+				const activeCount = items[ 0 ].sitesWithPluginActive.length;
 				return sprintf(
 					// Translators: %1$s is the plugin name. %2$d is the number of sites.
 					_n(
@@ -93,6 +94,7 @@ function getConfirmText( actionId: string, items: PluginListRow[] ) {
 					pluginName,
 					activeCount
 				);
+			}
 			case 'update':
 				return sprintf(
 					// Translators: %1$s is the plugin name. %2$d is the number of sites.
@@ -104,28 +106,32 @@ function getConfirmText( actionId: string, items: PluginListRow[] ) {
 					pluginName,
 					count
 				);
-			case 'enable-autoupdate':
+			case 'enable-autoupdate': {
+				const disabledCount = items[ 0 ].sitesWithPluginNotAutoupdated.length;
 				return sprintf(
 					// Translators: %1$s is the plugin name. %2$d is the number of sites.
 					_n(
 						'You are about to enable auto‑updates for the %1$s plugin installed on %2$d site.',
 						'You are about to enable auto‑updates for the %1$s plugin installed on %2$d sites.',
-						count
+						disabledCount
 					),
 					pluginName,
-					count
+					disabledCount
 				);
-			case 'disable-autoupdate':
+			}
+			case 'disable-autoupdate': {
+				const enabledCount = items[ 0 ].sitesWithPluginAutoupdated.length;
 				return sprintf(
 					// Translators: %1$s is the plugin name. %2$d is the number of sites.
 					_n(
 						'You are about to disable auto‑updates for the %1$s plugin installed on %2$d site.',
 						'You are about to disable auto‑updates for the %1$s plugin installed on %2$d sites.',
-						count
+						enabledCount
 					),
 					pluginName,
-					count
+					enabledCount
 				);
+			}
 			case 'delete':
 				return sprintf(
 					// Translators: %1$s is the plugin name. %2$d is the number of sites.
@@ -215,7 +221,10 @@ function getConfirmText( actionId: string, items: PluginListRow[] ) {
 }
 
 function getSiteList( actionId: string, items: PluginListRow[], sitesById: Map< number, Site > ) {
-	if ( items.length === 1 && [ 'activate', 'deactivate' ].includes( actionId ) ) {
+	if (
+		items.length === 1 &&
+		[ 'activate', 'deactivate', 'enable-autoupdate', 'disable-autoupdate' ].includes( actionId )
+	) {
 		const [ plugin ] = items;
 
 		let sites: number[] = [];
@@ -223,6 +232,10 @@ function getSiteList( actionId: string, items: PluginListRow[], sitesById: Map< 
 			sites = plugin.sitesWithPluginInactive;
 		} else if ( actionId === 'deactivate' ) {
 			sites = plugin.sitesWithPluginActive;
+		} else if ( actionId === 'enable-autoupdate' ) {
+			sites = plugin.sitesWithPluginNotAutoupdated;
+		} else if ( actionId === 'disable-autoupdate' ) {
+			sites = plugin.sitesWithPluginAutoupdated;
 		}
 
 		if ( ! sites?.length ) {

--- a/client/dashboard/plugins/manage/types.ts
+++ b/client/dashboard/plugins/manage/types.ts
@@ -8,6 +8,8 @@ export type PluginListRow = {
 	sitesCount: number;
 	sitesWithPluginActive: number[];
 	sitesWithPluginInactive: number[];
+	sitesWithPluginAutoupdated: number[];
+	sitesWithPluginNotAutoupdated: number[];
 	isActive: 'all' | 'some' | 'none';
 	hasUpdate: 'all' | 'some' | 'none';
 	areAutoUpdatesAllowed: 'all' | 'some' | 'none';

--- a/client/dashboard/plugins/manage/types.ts
+++ b/client/dashboard/plugins/manage/types.ts
@@ -8,6 +8,7 @@ export type PluginListRow = {
 	sitesCount: number;
 	sitesWithPluginActive: number[];
 	sitesWithPluginInactive: number[];
+	sitesWithPluginUpdate: number[];
 	sitesWithPluginAutoupdated: number[];
 	sitesWithPluginNotAutoupdated: number[];
 	isActive: 'all' | 'some' | 'none';

--- a/client/dashboard/plugins/manage/utils/map-api-plugins-to-dataview.ts
+++ b/client/dashboard/plugins/manage/utils/map-api-plugins-to-dataview.ts
@@ -10,7 +10,8 @@ type Aggregated = {
 	inactiveSites: number[];
 	updateCount: number;
 	autoupdateAllowedCount: number;
-	autoupdateCount: number;
+	autoupdatedSites: number[];
+	notAutoupdatedSites: number[];
 	siteIds: number[];
 	isManaged: boolean;
 };
@@ -50,8 +51,9 @@ export function mapApiPluginsToDataViewPlugins(
 				activeSites: [],
 				inactiveSites: [],
 				updateCount: 0,
+				autoupdatedSites: [],
+				notAutoupdatedSites: [],
 				autoupdateAllowedCount: 0,
-				autoupdateCount: 0,
 				isManaged: false,
 				siteIds: [],
 			};
@@ -66,9 +68,6 @@ export function mapApiPluginsToDataViewPlugins(
 			if ( p.update ) {
 				entry.updateCount += 1;
 			}
-			if ( p.autoupdate ) {
-				entry.autoupdateCount += 1;
-			}
 			if ( p.is_managed ) {
 				entry.isManaged = true;
 			}
@@ -79,7 +78,16 @@ export function mapApiPluginsToDataViewPlugins(
 					{ isPluginActive: p.active, ...site, isPluginManaged: entry.isManaged },
 					p.slug
 				);
+
 				entry.autoupdateAllowedCount += autoupdate ? 1 : 0;
+
+				if ( autoupdate ) {
+					if ( p.autoupdate ) {
+						entry.autoupdatedSites.push( siteId );
+					} else {
+						entry.notAutoupdatedSites.push( siteId );
+					}
+				}
 			}
 
 			map.set( p.id, entry );
@@ -96,8 +104,9 @@ export function mapApiPluginsToDataViewPlugins(
 				activeSites,
 				inactiveSites,
 				updateCount,
+				autoupdatedSites,
+				notAutoupdatedSites,
 				autoupdateAllowedCount,
-				autoupdateCount,
 				siteIds,
 				isManaged,
 			},
@@ -109,10 +118,12 @@ export function mapApiPluginsToDataViewPlugins(
 			sitesCount: count,
 			sitesWithPluginActive: activeSites,
 			sitesWithPluginInactive: inactiveSites,
+			sitesWithPluginAutoupdated: autoupdatedSites,
+			sitesWithPluginNotAutoupdated: notAutoupdatedSites,
 			hasUpdate: mapCountToQuantifier( updateCount, count ),
 			isActive: mapCountToQuantifier( activeSites.length, count ),
 			areAutoUpdatesAllowed: mapCountToQuantifier( autoupdateAllowedCount, count ),
-			areAutoUpdatesEnabled: mapCountToQuantifier( autoupdateCount, count ),
+			areAutoUpdatesEnabled: mapCountToQuantifier( autoupdatedSites.length, count ),
 			siteIds,
 			isManaged,
 		} )

--- a/client/dashboard/plugins/manage/utils/map-api-plugins-to-dataview.ts
+++ b/client/dashboard/plugins/manage/utils/map-api-plugins-to-dataview.ts
@@ -8,7 +8,7 @@ type Aggregated = {
 	count: number;
 	activeSites: number[];
 	inactiveSites: number[];
-	updateCount: number;
+	updatableSites: number[];
 	autoupdateAllowedCount: number;
 	autoupdatedSites: number[];
 	notAutoupdatedSites: number[];
@@ -50,7 +50,7 @@ export function mapApiPluginsToDataViewPlugins(
 				count: 0,
 				activeSites: [],
 				inactiveSites: [],
-				updateCount: 0,
+				updatableSites: [],
 				autoupdatedSites: [],
 				notAutoupdatedSites: [],
 				autoupdateAllowedCount: 0,
@@ -66,7 +66,7 @@ export function mapApiPluginsToDataViewPlugins(
 				entry.inactiveSites.push( siteId );
 			}
 			if ( p.update ) {
-				entry.updateCount += 1;
+				entry.updatableSites.push( siteId );
 			}
 			if ( p.is_managed ) {
 				entry.isManaged = true;
@@ -103,7 +103,7 @@ export function mapApiPluginsToDataViewPlugins(
 				count,
 				activeSites,
 				inactiveSites,
-				updateCount,
+				updatableSites,
 				autoupdatedSites,
 				notAutoupdatedSites,
 				autoupdateAllowedCount,
@@ -118,9 +118,10 @@ export function mapApiPluginsToDataViewPlugins(
 			sitesCount: count,
 			sitesWithPluginActive: activeSites,
 			sitesWithPluginInactive: inactiveSites,
+			sitesWithPluginUpdate: updatableSites,
 			sitesWithPluginAutoupdated: autoupdatedSites,
 			sitesWithPluginNotAutoupdated: notAutoupdatedSites,
-			hasUpdate: mapCountToQuantifier( updateCount, count ),
+			hasUpdate: mapCountToQuantifier( updatableSites.length, count ),
 			isActive: mapCountToQuantifier( activeSites.length, count ),
 			areAutoUpdatesAllowed: mapCountToQuantifier( autoupdateAllowedCount, count ),
 			areAutoUpdatesEnabled: mapCountToQuantifier( autoupdatedSites.length, count ),

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -12,6 +12,7 @@ import { useLocale } from '../../app/locale';
 
 export interface SiteWithPluginData extends Site {
 	actionLinks?: SitePlugin[ 'action_links' ];
+	hasPluginUpdate?: boolean;
 	isPluginActive: boolean;
 	isPluginAutoupdated?: boolean;
 	isPluginManaged: boolean;
@@ -95,6 +96,7 @@ export const usePlugin = ( pluginSlug: string ) => {
 						if ( siteIdsWithThisPlugin.includes( site.ID ) ) {
 							const plugin = pluginBySiteId.get( site.ID );
 
+							const hasPluginUpdate = plugin?.update ?? false;
 							const isPluginActive = plugin?.active ?? false;
 							const isPluginAutoupdated = plugin?.autoupdate ?? false;
 							const isPluginManaged = plugin?.is_managed ?? false;
@@ -104,6 +106,7 @@ export const usePlugin = ( pluginSlug: string ) => {
 
 							acc[ 0 ].push( {
 								...site,
+								hasPluginUpdate,
 								isPluginActive,
 								isPluginAutoupdated,
 								actionLinks,

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -13,6 +13,7 @@ import { useLocale } from '../../app/locale';
 export interface SiteWithPluginData extends Site {
 	actionLinks?: SitePlugin[ 'action_links' ];
 	isPluginActive: boolean;
+	isPluginAutoupdated?: boolean;
 	isPluginManaged: boolean;
 }
 
@@ -92,13 +93,22 @@ export const usePlugin = ( pluginSlug: string ) => {
 				.reduce(
 					( acc, site ) => {
 						if ( siteIdsWithThisPlugin.includes( site.ID ) ) {
-							const isPluginActive = pluginBySiteId.get( site.ID )?.active ?? false;
-							const isPluginManaged = pluginBySiteId.get( site.ID )?.is_managed ?? false;
+							const plugin = pluginBySiteId.get( site.ID );
+
+							const isPluginActive = plugin?.active ?? false;
+							const isPluginAutoupdated = plugin?.autoupdate ?? false;
+							const isPluginManaged = plugin?.is_managed ?? false;
 							const actionLinks = actionLinksBySiteId.get( Number( site.ID ) ) || {
 								Settings: `${ site.URL }/wp-admin/plugins.php`,
 							};
 
-							acc[ 0 ].push( { ...site, isPluginActive, actionLinks, isPluginManaged } );
+							acc[ 0 ].push( {
+								...site,
+								isPluginActive,
+								isPluginAutoupdated,
+								actionLinks,
+								isPluginManaged,
+							} );
 						} else {
 							acc[ 1 ].push( site );
 						}

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -96,7 +96,7 @@ export const usePlugin = ( pluginSlug: string ) => {
 						if ( siteIdsWithThisPlugin.includes( site.ID ) ) {
 							const plugin = pluginBySiteId.get( site.ID );
 
-							const hasPluginUpdate = plugin?.update ?? false;
+							const hasPluginUpdate = !! plugin?.update;
 							const isPluginActive = plugin?.active ?? false;
 							const isPluginAutoupdated = plugin?.autoupdate ?? false;
 							const isPluginManaged = plugin?.is_managed ?? false;

--- a/client/dashboard/plugins/plugin/utils/map-to-plugin-list-row.ts
+++ b/client/dashboard/plugins/plugin/utils/map-to-plugin-list-row.ts
@@ -15,6 +15,9 @@ export const mapToPluginListRow = (
 		sitesWithPluginInactive: items
 			.filter( ( item ) => ! item.isPluginActive )
 			.map( ( item ) => item.ID ),
+		sitesWithPluginUpdate: items
+			.filter( ( item ) => item.hasPluginUpdate )
+			.map( ( item ) => item.ID ),
 		sitesWithPluginAutoupdated: items
 			.filter( ( item ) => item.isPluginAutoupdated )
 			.map( ( item ) => item.ID ),

--- a/client/dashboard/plugins/plugin/utils/map-to-plugin-list-row.ts
+++ b/client/dashboard/plugins/plugin/utils/map-to-plugin-list-row.ts
@@ -15,6 +15,12 @@ export const mapToPluginListRow = (
 		sitesWithPluginInactive: items
 			.filter( ( item ) => ! item.isPluginActive )
 			.map( ( item ) => item.ID ),
+		sitesWithPluginAutoupdated: items
+			.filter( ( item ) => item.isPluginAutoupdated )
+			.map( ( item ) => item.ID ),
+		sitesWithPluginNotAutoupdated: items
+			.filter( ( item ) => ! item.isPluginAutoupdated )
+			.map( ( item ) => item.ID ),
 		siteIds: items.map( ( item ) => item.ID ),
 		sitesCount: items.length,
 	};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DES-276

## Proposed Changes

* As it was done on https://github.com/Automattic/wp-calypso/pull/107355 for activate/deactivate:
* Add the site count to the update and enable/disable auto-update actions' label so the user can better understand what they are doing.
* List the sites that will have updates and auto-updates enabled/disabled on the confirmation modal for the same reason.
* Invalidate the plugins query cache just once after those changes, since currently there's one API call for every site that got updated.

<img width="925" height="860" alt="image" src="https://github.com/user-attachments/assets/645419c9-a5c7-427a-a3da-ebc1f3d62939" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So users can better understand what changes will be applied to which sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/v2/plugins`
* Check that you see the site count near to the update and enable/disable auto-update actions when clicking on a plugins' kebab icon:

<img width="2735" height="603" alt="image" src="https://github.com/user-attachments/assets/cdefa977-f1a0-4f80-be9f-514708ce3a98" />


* After clicking on one of the actions, check that you see a list of the affected sites:

<img width="1202" height="1146" alt="image" src="https://github.com/user-attachments/assets/d0af8bbe-0fc9-441d-bec2-2e199c0eacb2" />

* Open the dev tools, Network tab, `Fetch/XHR` requests
* Proceed with the action, check that it worked and that only one request to `/me/sites/plugins` was triggered in order to invalidate the cache:

<img width="1909" height="649" alt="image" src="https://github.com/user-attachments/assets/d8085666-6eed-4df2-bfdb-99ba2636fd01" />

* Click on any plugin
* Check that the enable/disable auto-update actions do not show a site count
* Check that the sites are listed on the confirmation modal
* Proceed with the action, check that it worked

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
