### PR TITLE
Add logstash logging to CSP reports

### DIFF
--- a/client/server/lib/analytics/index.ts
+++ b/client/server/lib/analytics/index.ts
@@ -93,5 +93,24 @@ const analytics = {
 			} );
 		},
 	},
+
+	logstash: {
+		/**
+		 * Log to Logstash via WordPress.com REST API
+		 * @param {Object} params - parameters to log
+		 */
+		log: function ( params: Record< string, unknown > ) {
+			const logstashUrl = 'https://public-api.wordpress.com/rest/v1.1/logstash';
+
+			superagent
+				.post( logstashUrl )
+				.send( { params: JSON.stringify( params ) } )
+				.end( ( err ) => {
+					if ( err ) {
+						console.error( 'Failed to send to logstash:', err );
+					}
+				} );
+		},
+	},
 };
 export default analytics;

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1090,8 +1090,22 @@ export default function pages() {
 			}, {} );
 
 			if ( calypsoEnv !== 'development' ) {
+				// Send to Tracks for analytics
 				analytics.tracks.recordEvent( 'calypso_csp_report', cspReportSnakeCase, req );
 			}
+
+			// Send to Logstash for better logging/debugging
+			analytics.logstash.log( {
+				feature: 'calypso_client',
+				message: 'CSP Violation Report',
+				severity: 'info',
+				properties: {
+					env: calypsoEnv,
+					...cspReportSnakeCase,
+					user_agent: req.get( 'user-agent' ),
+					referer: req.get( 'Referer' ),
+				},
+			} );
 
 			res.status( 200 ).send( 'Got it!' );
 		},

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -94,6 +94,9 @@ jest.mock( 'calypso/server/lib/analytics', () => ( {
 	tracks: {
 		recordEvent: jest.fn(),
 	},
+	logstash: {
+		log: jest.fn(),
+	},
 } ) );
 
 jest.mock( 'calypso/lib/i18n-utils', () => ( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1347/create-csp-for-all-of-calypso

## Proposed Changes

This PR modifies the node server that runs calypso so that when it reports a CSP violation (see https://github.com/Automattic/wp-calypso/pull/107225) it will send that report to Logstash as well as Tracks.

This also enables the logging for development environments, since Logstash can filter based on the environment. That will make testing much easier.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Logstash is a much more useful way to investigate logs since it allows filtering by property and charting live data. Having this available for our CSP violations will make it much easier to track them down.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start calypso locally, then visit http://calypso.localhost:3000/
- Visit logstash (see the linked Linear issue for a link) and verify that you see violations reported.