### PR TITLE
Add more exceptions to CSP number 2

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -536,6 +536,10 @@ function setUpCSP( req, res, next ) {
 			// User feedback and support tools
 			'survey.survicate.com', // Survicate survey tool
 			'surveys-static-prd.survicate-cdn.com', // Survicate CDN
+			'https://cdn.smooch.io', // Smooch/Sunshine Conversations (Zendesk messaging)
+			'https://static.zdassets.com', // Zendesk static assets
+			// Google static content
+			'https://www.gstatic.com', // Google Charts and other static content
 			// Advertising and analytics tracking scripts
 			'https://static.ads-twitter.com', // Twitter/X advertising tag
 			'https://connect.facebook.net', // Facebook Pixel
@@ -547,6 +551,8 @@ function setUpCSP( req, res, next ) {
 			'https://fonts.googleapis.com',
 			'use.typekit.net',
 			'surveys-static-prd.survicate-cdn.com', // Survicate survey styles
+			'https://cdn.smooch.io', // Smooch/Sunshine Conversations styles
+			'https://www.gstatic.com', // Google Charts styles
 			// per https://helpx.adobe.com/ca/fonts/using/content-security-policy.html
 			"'unsafe-inline'",
 		],
@@ -583,6 +589,8 @@ function setUpCSP( req, res, next ) {
 			'https://hexagon-analytics.com', // Hexagon analytics tracking pixels
 			'https://img.youtube.com',
 			'https://ps.w.org', // WordPress.org plugin directory (plugin icons)
+			'https://ts.w.org', // WordPress.org theme directory (theme screenshots)
+			'https://s.w.org', // WordPress.org static assets (SVG icons, etc.)
 			'https://woocommerce.com', // WooCommerce marketplace
 			'localhost:8888',
 			'p.typekit.net',
@@ -607,6 +615,7 @@ function setUpCSP( req, res, next ) {
 			'use.typekit.net',
 			'https://woocommerce.com',
 			'surveys-static-prd.survicate-cdn.com', // Survicate fonts
+			'https://cdn.smooch.io', // Smooch/Sunshine Conversations fonts
 			'data:', // should remove 'data:' ASAP
 		],
 		'media-src': [ "'self'" ],
@@ -616,6 +625,7 @@ function setUpCSP( req, res, next ) {
 			'wss://*.wordpress.com', // WebSocket connections (realtime API, notifications)
 			'https://*.wp.com',
 			'https://wordpress.com',
+			'https://api.wordpress.org', // WordPress.org API (plugin/theme info)
 			// Payment provider APIs (for tokenization and payment processing)
 			'*.stripe.com', // Stripe API calls
 			'api.stripe.com', // Stripe API endpoint
@@ -623,6 +633,9 @@ function setUpCSP( req, res, next ) {
 			'*.paypal.com', // PayPal API calls
 			// Support and feedback tools
 			'*.zendesk.com', // Zendesk support chat
+			'wss://*.zendesk.com', // Zendesk WebSocket connections
+			'https://ekr.zdassets.com', // Zendesk composer
+			'https://*.config.smooch.io', // Smooch/Sunshine Conversations config
 		],
 		'report-uri': [ '/cspreport' ],
 	};

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -543,6 +543,10 @@ function setUpCSP( req, res, next ) {
 			// Advertising and analytics tracking scripts
 			'https://static.ads-twitter.com', // Twitter/X advertising tag
 			'https://connect.facebook.net', // Facebook Pixel
+			'www.redditstatic.com', // Reddit tracking pixel
+			'www.googletagmanager.com',
+			'https://accounts.google.com',
+			'https://bat.bing.com', // Bing Ads JS
 		],
 		'base-uri': [ "'none'" ],
 		'style-src': [
@@ -562,15 +566,19 @@ function setUpCSP( req, res, next ) {
 			"'self'",
 			'data:', // data: URI scheme (e.g., data:image/svg+xml;base64,...)
 			'*.wp.com',
+			'*.wp.org',
 			'https://wordpress.com', // WordPress.com assets (mu-plugins, etc.)
+			'*.wordpress.com',
 			'*.files.wordpress.com',
 			'*.gravatar.com',
+			'https://t.co', // Twitter image links
 			'https://www.google-analytics.com',
 			'*.doubleclick.net', // Google DoubleClick tracking pixels (ad.doubleclick.net, *.fls.doubleclick.net, etc.)
 			'https://analytics.twitter.com', // Twitter/X analytics tracking pixels
 			'https://www.facebook.com', // Facebook Pixel tracking endpoint
 			'https://alb.reddit.com', // Reddit tracking pixel
 			'https://*.google.com', // Google Ads remarketing pixels (www.google.com and subdomains)
+			'https://*.google.com.my',
 			'https://*.google.co.uk', // Google Ads remarketing pixels (United Kingdom)
 			'https://*.google.de', // Google Ads remarketing pixels (Germany)
 			'https://*.google.fr', // Google Ads remarketing pixels (France)
@@ -580,6 +588,7 @@ function setUpCSP( req, res, next ) {
 			'https://*.google.com.au', // Google Ads remarketing pixels (Australia)
 			'https://*.google.co.jp', // Google Ads remarketing pixels (Japan)
 			'https://*.google.com.br', // Google Ads remarketing pixels (Brazil)
+			'https://*.google.com.pk', // Google Ads remarketing pixels (Pakistan)
 			'https://*.google.co.in', // Google Ads remarketing pixels (India)
 			'https://*.google.com.mx', // Google Ads remarketing pixels (Mexico)
 			'https://*.google.nl', // Google Ads remarketing pixels (Netherlands)
@@ -588,6 +597,7 @@ function setUpCSP( req, res, next ) {
 			'https://amplifypixel.outbrain.com',
 			'https://hexagon-analytics.com', // Hexagon analytics tracking pixels
 			'https://img.youtube.com',
+			'*.ads.linkedin.com',
 			'https://ps.w.org', // WordPress.org plugin directory (plugin icons)
 			'https://ts.w.org', // WordPress.org theme directory (theme screenshots)
 			'https://s.w.org', // WordPress.org static assets (SVG icons, etc.)
@@ -600,6 +610,7 @@ function setUpCSP( req, res, next ) {
 			'https://public-api.wordpress.com',
 			'https://accounts.google.com/',
 			'https://jetpack.com',
+			'*.doubleclick.net', // Google DoubleClick tracking pixels (ad.doubleclick.net, *.fls.doubleclick.net, etc.)
 			'*.wordpress.com', // User WordPress.com sites (site previews, embeds)
 			// Payment provider iframes (secure card input elements)
 			'js.stripe.com', // Stripe Elements iframes
@@ -625,7 +636,13 @@ function setUpCSP( req, res, next ) {
 			'wss://*.wordpress.com', // WebSocket connections (realtime API, notifications)
 			'https://*.wp.com',
 			'https://wordpress.com',
+			'*.doubleclick.net', // Google DoubleClick tracking pixels (ad.doubleclick.net, *.fls.doubleclick.net, etc.)
 			'https://api.wordpress.org', // WordPress.org API (plugin/theme info)
+			'https://*.google.com',
+			'www.google-analytics.com',
+			'https://www.facebook.com', // Facebook Pixel tracking endpoint
+			'*.sentry.io',
+			'*.reddit.com',
 			// Payment provider APIs (for tokenization and payment processing)
 			'*.stripe.com', // Stripe API calls
 			'api.stripe.com', // Stripe API endpoint


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1347/create-csp-for-all-of-calypso

## Proposed Changes

Like https://github.com/Automattic/wp-calypso/pull/107384, This is a follow-up to https://github.com/Automattic/wp-calypso/pull/107225 to add more domains to the allow list for calypso's report-only CSP.

