### PR TITLE
Plugins Dashboard: Clarify delete action

### DIFF
--- a/client/dashboard/plugins/manage/actions/delete.tsx
+++ b/client/dashboard/plugins/manage/actions/delete.tsx
@@ -1,6 +1,10 @@
-import { sitePluginRemoveMutation } from '@automattic/api-queries';
+import {
+	invalidatePlugins,
+	invalidateSitePlugins,
+	sitePluginRemoveMutation,
+} from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { __ } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 import ActionRenderModal, { getModalHeader } from '../components/action-render-modal';
 import { buildBulkSitesPluginAction } from '../utils';
 import type { PluginListRow } from '../types';
@@ -8,11 +12,23 @@ import type { Action } from '@wordpress/dataviews';
 
 export const deleteAction: Action< PluginListRow > = {
 	id: 'delete',
-	label: __( 'Delete' ),
+	label: ( items ) => {
+		const [ plugin ] = items;
+		const count = plugin.siteIds.length;
+
+		return sprintf(
+			// translators: %(count)d is the number of sites the plugin will be deleted on.
+			_n( 'Delete on %(count)d site', 'Delete on %(count)d sites', count ),
+			{ count: count }
+		);
+	},
 	isPrimary: false,
 	modalHeader: getModalHeader( 'delete' ),
-	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
-		const { mutateAsync } = useMutation( sitePluginRemoveMutation() );
+	RenderModal: ( { items, closeModal } ) => {
+		const { mutateAsync } = useMutation( {
+			...sitePluginRemoveMutation(),
+			onSuccess: () => {},
+		} );
 		const action = buildBulkSitesPluginAction( mutateAsync );
 
 		return (
@@ -20,7 +36,15 @@ export const deleteAction: Action< PluginListRow > = {
 				actionId="delete"
 				items={ items }
 				closeModal={ closeModal }
-				onActionPerformed={ onActionPerformed }
+				onActionPerformed={ ( items: PluginListRow[] ) => {
+					items
+						.flatMap( ( item ) => item.siteIds )
+						.forEach( ( siteId ) => {
+							invalidateSitePlugins( siteId );
+						} );
+
+					invalidatePlugins();
+				} }
 				onExecute={ action }
 			/>
 		);

--- a/client/dashboard/plugins/manage/components/action-render-modal.tsx
+++ b/client/dashboard/plugins/manage/components/action-render-modal.tsx
@@ -246,6 +246,9 @@ function getSiteList( actionId: string, items: PluginListRow[], sitesById: Map< 
 		case 'disable-autoupdate':
 			sites = plugin.sitesWithPluginAutoupdated;
 			break;
+		case 'delete':
+			sites = plugin.siteIds;
+			break;
 		default:
 			return null;
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DES-276

## Proposed Changes

* As it was done on https://github.com/Automattic/wp-calypso/pull/107355 / https://github.com/Automattic/wp-calypso/pull/107385 for other actions:
* Add the site count to the delete actions' label so the user can better understand what they are doing.
* List the sites that will be deleted on the confirmation modal for the same reason.
* Invalidate the plugins query cache just once after those changes, since currently there's one API call for every site that got updated.

<img width="880" height="578" alt="image" src="https://github.com/user-attachments/assets/dddca320-e526-442d-b8a7-9c8807d5222b" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So users can better understand what changes will be applied to which sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
