### PR TITLE
Add top padding to domain connection steps wrapper

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -108,50 +108,54 @@ export default function ConnectionModeCard( {
 			</CardHeader>
 			{ isSelected && (
 				<CardBody>
-					<VStack spacing={ 6 }>
-						{ mode === DomainConnectionSetupMode.SUGGESTED && ! hasEmailOrOtherServices && (
-							<Notice variant="info" title="No email or other services detected">
-								<Text>
-									{ __( 'You can safely connect your domain without affecting anything else.' ) }
-								</Text>
-							</Notice>
-						) }
-						{ mode === DomainConnectionSetupMode.SUGGESTED && hasEmailOrOtherServices && (
-							<Notice variant="warning" title="Email or other services detected">
-								<Text>
-									{ __(
-										'Warning: the services attached to your domain might be interrupted if you use this connection method'
-									) }
-								</Text>
-							</Notice>
-						) }
-						{ mode === DomainConnectionSetupMode.ADVANCED && hasEmailOrOtherServices && (
-							<Notice variant="info" title="Email or other services detected">
-								<Text>
-									{ __(
-										'To avoid disruption, this is the safest way to connect your domain name.'
-									) }
-								</Text>
-							</Notice>
-						) }
-						<Text>{ infoText }</Text>
-					</VStack>
-					{ steps.map( ( step, index ) => (
-						<div key={ step.title }>
-							<SetupStep
-								className="domain-connection-setup__step"
-								expanded={ stepsExpanded[ index ] }
-								completed={ stepsCompleted[ index ] }
-								onCheckboxChange={ ( checked ) => handleStepChange( index, checked ) }
-								onToggle={ ( expanded ) => handleStepToggle( index, expanded ) }
-								title={ step.title }
-								label={ step.label }
-							>
-								{ step.content }
-							</SetupStep>
-							{ index < steps.length - 1 && <CardDivider /> }
+					<VStack spacing={ 4 }>
+						<VStack spacing={ 6 }>
+							{ mode === DomainConnectionSetupMode.SUGGESTED && ! hasEmailOrOtherServices && (
+								<Notice variant="info" title="No email or other services detected">
+									<Text>
+										{ __( 'You can safely connect your domain without affecting anything else.' ) }
+									</Text>
+								</Notice>
+							) }
+							{ mode === DomainConnectionSetupMode.SUGGESTED && hasEmailOrOtherServices && (
+								<Notice variant="warning" title="Email or other services detected">
+									<Text>
+										{ __(
+											'Warning: the services attached to your domain might be interrupted if you use this connection method'
+										) }
+									</Text>
+								</Notice>
+							) }
+							{ mode === DomainConnectionSetupMode.ADVANCED && hasEmailOrOtherServices && (
+								<Notice variant="info" title="Email or other services detected">
+									<Text>
+										{ __(
+											'To avoid disruption, this is the safest way to connect your domain name.'
+										) }
+									</Text>
+								</Notice>
+							) }
+							<Text>{ infoText }</Text>
+						</VStack>
+						<div>
+							{ steps.map( ( step, index ) => (
+								<div key={ step.title }>
+									<SetupStep
+										className="domain-connection-setup__step"
+										expanded={ stepsExpanded[ index ] }
+										completed={ stepsCompleted[ index ] }
+										onCheckboxChange={ ( checked ) => handleStepChange( index, checked ) }
+										onToggle={ ( expanded ) => handleStepToggle( index, expanded ) }
+										title={ step.title }
+										label={ step.label }
+									>
+										{ step.content }
+									</SetupStep>
+									{ index < steps.length - 1 && <CardDivider /> }
+								</div>
+							) ) }
 						</div>
-					) ) }
+					</VStack>
 					<ButtonStack justify="flex-start">
 						<Button
 							variant="primary"


### PR DESCRIPTION
Closes [DOMAINS-1870](https://linear.app/a8c/issue/DOMAINS-1870/steps-need-further-padding-from-content)

## Proposed Changes
Add extra 16px padding top the domain connection steps wrapper.

<img width="1408" height="944" alt="padding - before" src="https://github.com/user-attachments/assets/1495fd56-4e90-419e-b2bf-cbefb39771e4" />
<img width="1382" height="1058" alt="padding - after" src="https://github.com/user-attachments/assets/1c4df69e-f617-47d5-b0d6-52d35d62b65e" />

## Why are these changes being made?
Design review (1lCoIdZNpLPE9DjukYz9vUbAiqYsqeRHALTQ8xiaeosk-gdoc)

## Testing Instructions
Verify that the steps component has now a top 16px gap.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?