### PR TITLE
Dashboard: make /start/* and /setup/* links as external links

### DIFF
--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -27,10 +27,14 @@ export function AddDomainButton( {
 		return false;
 	};
 
-	const onSearchClick = () => navigateTo( '/setup/domain', '/start/domain' );
+	const onSearchClick = () =>
+		navigateTo( 'https://wordpress.com/setup/domain', 'https://wordpress.com/start/domain' );
 
 	const onTransferOrConnectClick = () =>
-		navigateTo( '/setup/domain/use-my-domain', '/setup/domain-transfer' );
+		navigateTo(
+			'https://wordpress.com/setup/domain/use-my-domain',
+			'https://wordpress.com/setup/domain-transfer'
+		);
 
 	return (
 		<Dropdown

--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -2,6 +2,7 @@ import { Button, Dropdown, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { search, globe, chevronUp, chevronDown } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
+import { wpcomLink } from '../utils/link';
 
 export function AddDomainButton( {
 	siteSlug,
@@ -28,13 +29,10 @@ export function AddDomainButton( {
 	};
 
 	const onSearchClick = () =>
-		navigateTo( 'https://wordpress.com/setup/domain', 'https://wordpress.com/start/domain' );
+		navigateTo( wpcomLink( '/setup/domain' ), wpcomLink( '/start/domain' ) );
 
 	const onTransferOrConnectClick = () =>
-		navigateTo(
-			'https://wordpress.com/setup/domain/use-my-domain',
-			'https://wordpress.com/setup/domain-transfer'
-		);
+		navigateTo( wpcomLink( '/setup/domain/use-my-domain' ), wpcomLink( '/setup/domain-transfer' ) );
 
 	return (
 		<Dropdown

--- a/client/dashboard/emails/components/no-domains-available-empty-state.tsx
+++ b/client/dashboard/emails/components/no-domains-available-empty-state.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { DataViewsEmptyState } from '../../components/dataviews';
+import { wpcomLink } from '../../utils/link';
 import DomainEmptyIllustration from '../resources/domain-empty-illustration';
 
 const NoDomainsAvailableEmptyState = () => {
@@ -12,7 +13,7 @@ const NoDomainsAvailableEmptyState = () => {
 			) }
 			illustration={ <DomainEmptyIllustration /> }
 			actions={
-				<Button variant="primary" href="https://wordpress.com/setup/domain">
+				<Button variant="primary" href={ wpcomLink( '/setup/domain' ) }>
 					{ __( 'Choose a domain' ) }
 				</Button>
 			}

--- a/client/dashboard/emails/components/no-domains-available-empty-state.tsx
+++ b/client/dashboard/emails/components/no-domains-available-empty-state.tsx
@@ -12,7 +12,7 @@ const NoDomainsAvailableEmptyState = () => {
 			) }
 			illustration={ <DomainEmptyIllustration /> }
 			actions={
-				<Button variant="primary" href="/setup/domain">
+				<Button variant="primary" href="https://wordpress.com/setup/domain">
 					{ __( 'Choose a domain' ) }
 				</Button>
 			}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -125,7 +125,7 @@ function getUpgradeUrl( purchase: Purchase ): string | undefined {
 	}
 
 	if ( purchase.is_woo_hosted_product ) {
-		return `/setup/woo-hosted-plans?siteSlug=${ purchase.site_slug }`;
+		return `https://wordpress.com/setup/woo-hosted-plans?siteSlug=${ purchase.site_slug }`;
 	}
 
 	return getWpcomPlanGridUrl( purchase.site_slug );
@@ -149,7 +149,7 @@ function getExpiredNewPlanUrl( purchase: Purchase ): string {
 
 function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
 	const backUrl = window.location.href.replace( window.location.origin, '' );
-	return addQueryArgs( '/setup/plan-upgrade', {
+	return addQueryArgs( 'https://wordpress.com/setup/plan-upgrade', {
 		...( siteSlug && { siteSlug } ),
 		cancel_to: backUrl,
 	} );
@@ -811,7 +811,7 @@ function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
 							{
 								SubmitContent: (
 									<a
-										href={ `/start/site-content-collection/website-content?siteSlug=${ purchase.site_slug }` }
+										href={ `https://wordpress.com/start/site-content-collection/website-content?siteSlug=${ purchase.site_slug }` }
 									>
 										{ __( 'Submit content' ) }
 									</a>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -60,6 +60,7 @@ import SiteIcon from '../../../components/site-icon';
 import SiteBandwidthStat from '../../../sites/overview-plan-card/site-bandwidth-stat';
 import SiteStorageStat from '../../../sites/overview-plan-card/site-storage-stat';
 import { formatDate } from '../../../utils/datetime';
+import { wpcomLink } from '../../../utils/link';
 import {
 	getBillPeriodLabel,
 	getTitleForDisplay,
@@ -125,7 +126,7 @@ function getUpgradeUrl( purchase: Purchase ): string | undefined {
 	}
 
 	if ( purchase.is_woo_hosted_product ) {
-		return `https://wordpress.com/setup/woo-hosted-plans?siteSlug=${ purchase.site_slug }`;
+		return wpcomLink( `/setup/woo-hosted-plans?siteSlug=${ purchase.site_slug }` );
 	}
 
 	return getWpcomPlanGridUrl( purchase.site_slug );
@@ -149,7 +150,7 @@ function getExpiredNewPlanUrl( purchase: Purchase ): string {
 
 function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
 	const backUrl = window.location.href.replace( window.location.origin, '' );
-	return addQueryArgs( 'https://wordpress.com/setup/plan-upgrade', {
+	return addQueryArgs( wpcomLink( '/setup/plan-upgrade' ), {
 		...( siteSlug && { siteSlug } ),
 		cancel_to: backUrl,
 	} );
@@ -811,7 +812,9 @@ function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
 							{
 								SubmitContent: (
 									<a
-										href={ `https://wordpress.com/start/site-content-collection/website-content?siteSlug=${ purchase.site_slug }` }
+										href={ wpcomLink(
+											`/start/site-content-collection/website-content?siteSlug=${ purchase.site_slug }`
+										) }
 									>
 										{ __( 'Submit content' ) }
 									</a>

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -246,7 +246,9 @@ function TrialNotice( { purchase }: { purchase: Purchase } ) {
 				to_checkout: false,
 			} );
 
-			window.location.href = `/setup/woo-hosted-plans?siteSlug=${ purchase.site_slug ?? '' }`;
+			window.location.href = `https://wordpress.com/setup/woo-hosted-plans?siteSlug=${
+				purchase.site_slug ?? ''
+			}`;
 			return;
 		}
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -10,6 +10,7 @@ import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import { changePaymentMethodRoute, purchaseSettingsRoute } from '../../../app/router/me';
 import Notice from '../../../components/notice';
+import { wpcomLink } from '../../../utils/link';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -246,9 +247,9 @@ function TrialNotice( { purchase }: { purchase: Purchase } ) {
 				to_checkout: false,
 			} );
 
-			window.location.href = `https://wordpress.com/setup/woo-hosted-plans?siteSlug=${
-				purchase.site_slug ?? ''
-			}`;
+			window.location.href = wpcomLink(
+				`/setup/woo-hosted-plans?siteSlug=${ purchase.site_slug ?? '' }`
+			);
 			return;
 		}
 

--- a/client/dashboard/me/profile-deletion/alternatives-modal.tsx
+++ b/client/dashboard/me/profile-deletion/alternatives-modal.tsx
@@ -11,6 +11,7 @@ import { chevronLeft, chevronRight, help } from '@wordpress/icons';
 import ActionList from '../../components/action-list';
 import { ButtonStack } from '../../components/button-stack';
 import RouterLinkButton from '../../components/router-link-button';
+import { wpcomLink } from '../../utils/link';
 
 interface AlternativeOption {
 	text: string;
@@ -49,7 +50,7 @@ export default function AlternativesModal( {
 			: [] ),
 		{
 			text: __( 'Start a new site' ),
-			to: 'https://wordpress.com/start?ref=me-account-close',
+			to: wpcomLink( '/start?ref=me-account-close' ),
 			supportLink: localizeUrl( 'https://wordpress.com/support/create-a-blog/' ),
 			useRouterButton: false,
 		},

--- a/client/dashboard/me/profile-deletion/alternatives-modal.tsx
+++ b/client/dashboard/me/profile-deletion/alternatives-modal.tsx
@@ -49,7 +49,7 @@ export default function AlternativesModal( {
 			: [] ),
 		{
 			text: __( 'Start a new site' ),
-			to: '/start?ref=me-account-close',
+			to: 'https://wordpress.com/start?ref=me-account-close',
 			supportLink: localizeUrl( 'https://wordpress.com/support/create-a-blog/' ),
 			useRouterButton: false,
 		},

--- a/client/dashboard/me/security-social-logins/apple-login.tsx
+++ b/client/dashboard/me/security-social-logins/apple-login.tsx
@@ -4,6 +4,7 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
+import { wpcomLink } from '../../utils/link';
 import { getSocialServiceResponse } from './utils';
 import type { SocialLoginButtonProps, AppleClient } from './types';
 
@@ -45,7 +46,7 @@ export default function AppleLogin( {
 		windowObj.AppleID.auth.init( {
 			clientId: config( 'apple_oauth_client_id' ),
 			scope: 'name email',
-			redirectURI: 'https://wordpress.com/start/user',
+			redirectURI: wpcomLink( '/start/user' ),
 			state: JSON.stringify( {
 				oauth2State,
 				originalUrlPath: window?.location?.pathname,

--- a/client/dashboard/me/security-social-logins/apple-login.tsx
+++ b/client/dashboard/me/security-social-logins/apple-login.tsx
@@ -4,7 +4,7 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
-import { getRedirectUri, getSocialServiceResponse } from './utils';
+import { getSocialServiceResponse } from './utils';
 import type { SocialLoginButtonProps, AppleClient } from './types';
 
 const APPLE_CLIENT_URL =
@@ -45,7 +45,7 @@ export default function AppleLogin( {
 		windowObj.AppleID.auth.init( {
 			clientId: config( 'apple_oauth_client_id' ),
 			scope: 'name email',
-			redirectURI: getRedirectUri(),
+			redirectURI: 'https://wordpress.com/start/user',
 			state: JSON.stringify( {
 				oauth2State,
 				originalUrlPath: window?.location?.pathname,

--- a/client/dashboard/me/security-social-logins/google-login.tsx
+++ b/client/dashboard/me/security-social-logins/google-login.tsx
@@ -9,7 +9,6 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
-import { getRedirectUri } from './utils';
 import type { SocialLoginButtonProps } from './types';
 
 // This component supports only Social Login from Google.
@@ -125,7 +124,7 @@ export default function GoogleLogin( {
 			client_id: config( 'google_oauth_client_id' ),
 			scope: 'openid profile email',
 			ux_mode: 'popup',
-			redirect_uri: getRedirectUri(),
+			redirect_uri: 'https://wordpress.com/start/user',
 			state: nonce,
 			callback: async ( response: { error: string; code: string; state: string } ) => {
 				if ( response.error ) {

--- a/client/dashboard/me/security-social-logins/google-login.tsx
+++ b/client/dashboard/me/security-social-logins/google-login.tsx
@@ -9,6 +9,7 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
+import { wpcomLink } from '../../utils/link';
 import type { SocialLoginButtonProps } from './types';
 
 // This component supports only Social Login from Google.
@@ -124,7 +125,7 @@ export default function GoogleLogin( {
 			client_id: config( 'google_oauth_client_id' ),
 			scope: 'openid profile email',
 			ux_mode: 'popup',
-			redirect_uri: 'https://wordpress.com/start/user',
+			redirect_uri: wpcomLink( '/start/user' ),
 			state: nonce,
 			callback: async ( response: { error: string; code: string; state: string } ) => {
 				if ( response.error ) {

--- a/client/dashboard/me/security-social-logins/utils.ts
+++ b/client/dashboard/me/security-social-logins/utils.ts
@@ -1,14 +1,3 @@
-export const getRedirectUri = () => {
-	const host = typeof window !== 'undefined' && window.location.host;
-
-	let protocol = 'https';
-	if ( typeof window !== 'undefined' && window.location.hostname === 'calypso.localhost' ) {
-		protocol = 'http';
-	}
-
-	return `${ protocol }://${ host }/start/user`;
-};
-
 export const getSocialServiceResponse = () => {
 	const hash = window.location.hash.substring( 1 );
 	const params = new URLSearchParams( hash );

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -28,6 +28,7 @@ import {
 import noSitesIllustration from '../sites/no-sites-illustration.svg';
 import { SitesNotices } from '../sites/notices';
 import { SiteLink, SiteLink__ES } from '../sites/site-fields';
+import { wpcomLink } from '../utils/link';
 import type { DashboardSiteListSite, Site } from '@automattic/api-core';
 
 export default function CIABSites() {
@@ -104,7 +105,7 @@ export default function CIABSites() {
 		}
 	}, [ sites, queryClient ] );
 
-	const addNewStoreUrl = addQueryArgs( 'https://wordpress.com/setup/ai-site-builder-spec', {
+	const addNewStoreUrl = addQueryArgs( wpcomLink( '/setup/ai-site-builder-spec' ), {
 		source: 'ciab-sites-dashboard',
 		ref: 'new-site-popover',
 	} );

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -104,7 +104,7 @@ export default function CIABSites() {
 		}
 	}, [ sites, queryClient ] );
 
-	const addNewStoreUrl = addQueryArgs( '/setup/ai-site-builder-spec', {
+	const addNewStoreUrl = addQueryArgs( 'https://wordpress.com/setup/ai-site-builder-spec', {
 		source: 'ciab-sites-dashboard',
 		ref: 'new-site-popover',
 	} );

--- a/client/dashboard/sites-ciab/site-switcher/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher/index.tsx
@@ -4,6 +4,7 @@ import { plus } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../app/analytics';
 import { SiteSwitcherBase } from '../../sites/site-switcher/base';
+import { wpcomLink } from '../../utils/link';
 
 const CIABSiteSwitcher = () => {
 	const { recordTracksEvent } = useAnalytics();
@@ -13,7 +14,7 @@ const CIABSiteSwitcher = () => {
 			context: 'ciab-sites-dashboard',
 		} );
 
-		const addNewStoreUrl = addQueryArgs( 'https://wordpress.com/setup/ai-site-builder-spec', {
+		const addNewStoreUrl = addQueryArgs( wpcomLink( '/setup/ai-site-builder-spec' ), {
 			source: 'ciab-sites-dashboard',
 			ref: 'new-site-popover',
 		} );

--- a/client/dashboard/sites-ciab/site-switcher/index.tsx
+++ b/client/dashboard/sites-ciab/site-switcher/index.tsx
@@ -13,7 +13,7 @@ const CIABSiteSwitcher = () => {
 			context: 'ciab-sites-dashboard',
 		} );
 
-		const addNewStoreUrl = addQueryArgs( '/setup/ai-site-builder-spec', {
+		const addNewStoreUrl = addQueryArgs( 'https://wordpress.com/setup/ai-site-builder-spec', {
 			source: 'ciab-sites-dashboard',
 			ref: 'new-site-popover',
 		} );

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -126,7 +126,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					title={ __( 'Via the Jetpack plugin' ) }
 					description={ __( 'Install the Jetpack plugin on an existing site.' ) }
 					onClick={ jetpackClick }
-					href={ wpcomLink( `/start/jetpack/connect?cta_from=${ context }&cta_id=add-site` ) }
+					href={ wpcomLink( `/jetpack/connect?cta_from=${ context }&cta_id=add-site` ) }
 					aria-label={ __( 'Add site via the Jetpack plugin' ) }
 				/>
 			</Column>

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -103,7 +103,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 							action: 'big-sky',
 						} );
 					} }
-					href={ addQueryArgs( wpcomLink( '/start/setup/ai-site-builder' ), {
+					href={ addQueryArgs( wpcomLink( '/setup/ai-site-builder' ), {
 						source: context,
 						ref: 'new-site-popover',
 					} ) }
@@ -116,9 +116,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					title={ __( 'Migrate to WordPress.com' ) }
 					description={ __( 'Bring your site to the world’s best WordPress host.' ) }
 					onClick={ migrateClick }
-					href={ wpcomLink(
-						`/start/setup/site-migration?source=${ context }&ref=new-site-popover`
-					) }
+					href={ wpcomLink( `/setup/site-migration?source=${ context }&ref=new-site-popover` ) }
 					aria-label={ __( 'Migrate an existing WordPress site' ) }
 				/>
 				<MenuItem

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -77,7 +77,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 								action: 'flex-site',
 							} );
 						} }
-						href={ `/setup/flex-site?source=${ context }&ref=new-site-popover` }
+						href={ `https://wordpress.com/setup/flex-site?source=${ context }&ref=new-site-popover` }
 						aria-label={ __( 'Create a Flex site' ) }
 					/>
 				) }
@@ -86,7 +86,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					title="Create it yourself"
 					description={ __( 'Start with a clean WordPress site and make it yours.' ) }
 					onClick={ wordpressClick }
-					href={ addQueryArgs( '/start', {
+					href={ addQueryArgs( 'https://wordpress.com/start', {
 						source: context,
 						ref: 'new-site-popover',
 					} ) }
@@ -102,7 +102,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 							action: 'big-sky',
 						} );
 					} }
-					href={ addQueryArgs( '/setup/ai-site-builder', {
+					href={ addQueryArgs( 'https://wordpress.com/start/setup/ai-site-builder', {
 						source: context,
 						ref: 'new-site-popover',
 					} ) }
@@ -115,7 +115,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					title={ __( 'Migrate to WordPress.com' ) }
 					description={ __( 'Bring your site to the world’s best WordPress host.' ) }
 					onClick={ migrateClick }
-					href={ `/setup/site-migration?source=${ context }&ref=new-site-popover` }
+					href={ `https://wordpress.com/start/setup/site-migration?source=${ context }&ref=new-site-popover` }
 					aria-label={ __( 'Migrate an existing WordPress site' ) }
 				/>
 				<MenuItem
@@ -123,7 +123,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					title={ __( 'Via the Jetpack plugin' ) }
 					description={ __( 'Install the Jetpack plugin on an existing site.' ) }
 					onClick={ jetpackClick }
-					href={ `/jetpack/connect?cta_from=${ context }&cta_id=add-site` }
+					href={ `https://wordpress.com/start/jetpack/connect?cta_from=${ context }&cta_id=add-site` }
 					aria-label={ __( 'Add site via the Jetpack plugin' ) }
 				/>
 			</Column>

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -17,6 +17,7 @@ import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banne
 import { useAnalytics } from '../../app/analytics';
 import { AuthContext } from '../../app/auth';
 import { useHelpCenter } from '../../app/help-center';
+import { wpcomLink } from '../../utils/link';
 import { userHasFlag } from '../../utils/user';
 import Column from './column';
 import MenuItem from './menu-item';
@@ -77,7 +78,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 								action: 'flex-site',
 							} );
 						} }
-						href={ `https://wordpress.com/setup/flex-site?source=${ context }&ref=new-site-popover` }
+						href={ wpcomLink( `/setup/flex-site?source=${ context }&ref=new-site-popover` ) }
 						aria-label={ __( 'Create a Flex site' ) }
 					/>
 				) }
@@ -86,7 +87,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					title="Create it yourself"
 					description={ __( 'Start with a clean WordPress site and make it yours.' ) }
 					onClick={ wordpressClick }
-					href={ addQueryArgs( 'https://wordpress.com/start', {
+					href={ addQueryArgs( wpcomLink( '/start' ), {
 						source: context,
 						ref: 'new-site-popover',
 					} ) }
@@ -102,7 +103,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 							action: 'big-sky',
 						} );
 					} }
-					href={ addQueryArgs( 'https://wordpress.com/start/setup/ai-site-builder', {
+					href={ addQueryArgs( wpcomLink( '/start/setup/ai-site-builder' ), {
 						source: context,
 						ref: 'new-site-popover',
 					} ) }
@@ -115,7 +116,9 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					title={ __( 'Migrate to WordPress.com' ) }
 					description={ __( 'Bring your site to the world’s best WordPress host.' ) }
 					onClick={ migrateClick }
-					href={ `https://wordpress.com/start/setup/site-migration?source=${ context }&ref=new-site-popover` }
+					href={ wpcomLink(
+						`/start/setup/site-migration?source=${ context }&ref=new-site-popover`
+					) }
 					aria-label={ __( 'Migrate an existing WordPress site' ) }
 				/>
 				<MenuItem
@@ -123,13 +126,13 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 					title={ __( 'Via the Jetpack plugin' ) }
 					description={ __( 'Install the Jetpack plugin on an existing site.' ) }
 					onClick={ jetpackClick }
-					href={ `https://wordpress.com/start/jetpack/connect?cta_from=${ context }&cta_id=add-site` }
+					href={ wpcomLink( `/start/jetpack/connect?cta_from=${ context }&cta_id=add-site` ) }
 					aria-label={ __( 'Add site via the Jetpack plugin' ) }
 				/>
 			</Column>
 
 			<Button
-				href="https://wordpress.com/setup/onboarding"
+				href={ wpcomLink( '/setup/onboarding' ) }
 				onClick={ offerClick }
 				style={ {
 					display: 'block',

--- a/client/dashboard/sites/difm-lite-in-progress/index.tsx
+++ b/client/dashboard/sites/difm-lite-in-progress/index.tsx
@@ -115,7 +115,7 @@ function WebsiteContentSubmissionPending( { site }: { site: Site } ) {
 			<ButtonStack justify="start">
 				<Button
 					variant="primary"
-					href={ `/start/site-content-collection/website-content?siteSlug=${ site.slug }` }
+					href={ `https://wordpress.com/start/site-content-collection/website-content?siteSlug=${ site.slug }` }
 				>
 					{ __( 'Provide website content' ) }
 				</Button>

--- a/client/dashboard/sites/difm-lite-in-progress/index.tsx
+++ b/client/dashboard/sites/difm-lite-in-progress/index.tsx
@@ -17,6 +17,7 @@ import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 import { formatDate } from '../../utils/datetime';
 import { hasGSuiteWithUs, hasTitanMailWithUs } from '../../utils/domain';
+import { wpcomLink } from '../../utils/link';
 import type { Site } from '@automattic/api-core';
 
 function WebsiteContentSubmitted( { site }: { site: Site } ) {
@@ -115,7 +116,9 @@ function WebsiteContentSubmissionPending( { site }: { site: Site } ) {
 			<ButtonStack justify="start">
 				<Button
 					variant="primary"
-					href={ `https://wordpress.com/start/site-content-collection/website-content?siteSlug=${ site.slug }` }
+					href={ wpcomLink(
+						`/start/site-content-collection/website-content?siteSlug=${ site.slug }`
+					) }
 				>
 					{ __( 'Provide website content' ) }
 				</Button>

--- a/client/dashboard/sites/hosting-feature-gate/activation.tsx
+++ b/client/dashboard/sites/hosting-feature-gate/activation.tsx
@@ -44,7 +44,7 @@ export default function HostingFeatureActivation( {
 			feature_id: tracksFeatureId,
 		} );
 
-		window.location.href = addQueryArgs( '/setup/transferring-hosted-site', {
+		window.location.href = addQueryArgs( 'https://wordpress.com/setup/transferring-hosted-site', {
 			siteId: String( site.ID ),
 			feature,
 			initiate_transfer_context: 'hosting',

--- a/client/dashboard/sites/hosting-feature-gate/activation.tsx
+++ b/client/dashboard/sites/hosting-feature-gate/activation.tsx
@@ -4,6 +4,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { lazy, useEffect, useState, ReactNode, Suspense } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
+import { wpcomLink } from '../../utils/link';
 import HostingFeatureActivationModal from '../hosting-feature-activation-modal';
 import type { HostingFeatureSlug, Site } from '@automattic/api-core';
 
@@ -44,7 +45,7 @@ export default function HostingFeatureActivation( {
 			feature_id: tracksFeatureId,
 		} );
 
-		window.location.href = addQueryArgs( 'https://wordpress.com/setup/transferring-hosted-site', {
+		window.location.href = addQueryArgs( wpcomLink( '/setup/transferring-hosted-site' ), {
 			siteId: String( site.ID ),
 			feature,
 			initiate_transfer_context: 'hosting',

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -6,6 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import React from 'react';
 import { Callout } from '../../components/callout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
+import { wpcomLink } from '../../utils/link';
 import illustrationUrl from './upsell-illustration.svg';
 import type { CalloutProps } from '../../components/callout/types';
 import type { HostingFeatureSlug, Site } from '@automattic/api-core';
@@ -38,7 +39,7 @@ export default function UpsellCallout( {
 	const handleUpsellClick = () => {
 		const backUrl = window.location.href.replace( window.location.origin, '' );
 
-		window.location.href = addQueryArgs( 'https://wordpress.com/setup/plan-upgrade/', {
+		window.location.href = addQueryArgs( wpcomLink( '/setup/plan-upgrade/' ), {
 			siteSlug: site.slug,
 			cancel_to: backUrl,
 			redirect_to: backUrl,

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -38,7 +38,7 @@ export default function UpsellCallout( {
 	const handleUpsellClick = () => {
 		const backUrl = window.location.href.replace( window.location.origin, '' );
 
-		window.location.href = addQueryArgs( '/setup/plan-upgrade/', {
+		window.location.href = addQueryArgs( 'https://wordpress.com/setup/plan-upgrade/', {
 			siteSlug: site.slug,
 			cancel_to: backUrl,
 			redirect_to: backUrl,

--- a/client/dashboard/sites/migration-overview/pending-content-info.tsx
+++ b/client/dashboard/sites/migration-overview/pending-content-info.tsx
@@ -20,6 +20,7 @@ import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import { PageHeader } from '../../components/page-header';
 import { Text } from '../../components/text';
+import { wpcomLink } from '../../utils/link';
 import { getSiteMigrationState } from '../../utils/site-status';
 import { HostingCards } from './hosting-cards';
 import type { MigrationStatus } from '../../utils/site-status';
@@ -42,15 +43,12 @@ const getContinueMigrationUrl = ( site: Site ): string | null => {
 		}
 
 		return addQueryArgs(
-			'https://wordpress.com/setup/site-migration/site-migration-instructions',
+			wpcomLink( '/setup/site-migration/site-migration-instructions' ),
 			queryArgs
 		);
 	}
 
-	return addQueryArgs(
-		'https://wordpress.com/setup/site-migration/site-migration-credentials',
-		queryArgs
-	);
+	return addQueryArgs( wpcomLink( '/setup/site-migration/site-migration-credentials' ), queryArgs );
 };
 
 function CancellationModal( { site, onClose }: { site: Site; onClose: () => void } ) {

--- a/client/dashboard/sites/migration-overview/pending-content-info.tsx
+++ b/client/dashboard/sites/migration-overview/pending-content-info.tsx
@@ -41,10 +41,16 @@ const getContinueMigrationUrl = ( site: Site ): string | null => {
 			return addQueryArgs( `${ url }wp-admin/admin.php`, { page: 'wpcom-migration' } );
 		}
 
-		return addQueryArgs( '/setup/site-migration/site-migration-instructions', queryArgs );
+		return addQueryArgs(
+			'https://wordpress.com/setup/site-migration/site-migration-instructions',
+			queryArgs
+		);
 	}
 
-	return addQueryArgs( '/setup/site-migration/site-migration-credentials', queryArgs );
+	return addQueryArgs(
+		'https://wordpress.com/setup/site-migration/site-migration-credentials',
+		queryArgs
+	);
 };
 
 function CancellationModal( { site, onClose }: { site: Site; onClose: () => void } ) {

--- a/client/dashboard/sites/overview-difm-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-difm-upsell-card/index.tsx
@@ -2,6 +2,7 @@ import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Callout } from '../../components/callout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
+import { wpcomLink } from '../../utils/link';
 import illustrationUrl from './upsell-illustration.svg';
 import type { Site } from '@automattic/api-core';
 
@@ -37,8 +38,7 @@ export default function DIFMUpsellCard( { site }: { site: Site } ) {
 			imageVariant="full-bleed"
 			actions={
 				<UpsellCTAButton
-					href="https://wordpress.com/start/do-it-for-me/new-or-existing-site?ref=site-overview"
-					target="_blank"
+					href={ wpcomLink( '/start/do-it-for-me/new-or-existing-site?ref=site-overview' ) }
 					text={ __( 'Build it for me' ) }
 					variant="secondary"
 					upsellId="site-overview-difm"

--- a/client/dashboard/sites/overview-difm-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-difm-upsell-card/index.tsx
@@ -37,7 +37,7 @@ export default function DIFMUpsellCard( { site }: { site: Site } ) {
 			imageVariant="full-bleed"
 			actions={
 				<UpsellCTAButton
-					href="/start/do-it-for-me/new-or-existing-site?ref=site-overview"
+					href="https://wordpress.com/start/do-it-for-me/new-or-existing-site?ref=site-overview"
 					target="_blank"
 					text={ __( 'Build it for me' ) }
 					variant="secondary"

--- a/client/dashboard/sites/overview-domain-transfer-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-transfer-upsell-card/index.tsx
@@ -2,6 +2,7 @@ import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Callout } from '../../components/callout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
+import { wpcomLink } from '../../utils/link';
 import illustrationTransferDomainUrl from './upsell-illustration-transfer-domain.svg';
 
 export default function DomainTransferUpsellCard() {
@@ -20,7 +21,7 @@ export default function DomainTransferUpsellCard() {
 			imageVariant="full-bleed"
 			actions={
 				<UpsellCTAButton
-					href="https://wordpress.com/setup/domain-transfer"
+					href={ wpcomLink( '/setup/domain-transfer' ) }
 					text={ __( 'Transfer domain' ) }
 					size="compact"
 					upsellId="site-overview-transfer-domain"

--- a/client/dashboard/sites/overview-domain-transfer-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-transfer-upsell-card/index.tsx
@@ -20,7 +20,7 @@ export default function DomainTransferUpsellCard() {
 			imageVariant="full-bleed"
 			actions={
 				<UpsellCTAButton
-					href="/setup/domain-transfer"
+					href="https://wordpress.com/setup/domain-transfer"
 					text={ __( 'Transfer domain' ) }
 					size="compact"
 					upsellId="site-overview-transfer-domain"

--- a/client/dashboard/sites/overview-migrate-site-card/index.tsx
+++ b/client/dashboard/sites/overview-migrate-site-card/index.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { shuffle } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import OverviewCard from '../../components/overview-card';
+import { wpcomLink } from '../../utils/link';
 import type { Site } from '@automattic/api-core';
 
 export default function MigrateSiteCard( { site }: { site: Site } ) {
@@ -11,7 +12,7 @@ export default function MigrateSiteCard( { site }: { site: Site } ) {
 			title={ __( 'Migrate' ) }
 			heading={ __( 'Migrate site' ) }
 			description={ __( 'Bring your site to WordPress.com.' ) }
-			externalLink={ addQueryArgs( 'https://wordpress.com/setup/site-migration', {
+			externalLink={ addQueryArgs( wpcomLink( '/setup/site-migration' ), {
 				siteSlug: site.slug,
 			} ) }
 			intent="upsell"

--- a/client/dashboard/sites/overview-migrate-site-card/index.tsx
+++ b/client/dashboard/sites/overview-migrate-site-card/index.tsx
@@ -11,7 +11,9 @@ export default function MigrateSiteCard( { site }: { site: Site } ) {
 			title={ __( 'Migrate' ) }
 			heading={ __( 'Migrate site' ) }
 			description={ __( 'Bring your site to WordPress.com.' ) }
-			externalLink={ addQueryArgs( '/setup/site-migration', { siteSlug: site.slug } ) }
+			externalLink={ addQueryArgs( 'https://wordpress.com/setup/site-migration', {
+				siteSlug: site.slug,
+			} ) }
 			intent="upsell"
 			tracksId="site-overview-migrate-site"
 			upsellFeatureId="site-migration"

--- a/client/dashboard/sites/overview-site-action-menu/index.tsx
+++ b/client/dashboard/sites/overview-site-action-menu/index.tsx
@@ -32,7 +32,7 @@ const SiteActionMenu = ( { site }: { site: Site } ) => {
 	const handleImportSite = () => {
 		const url = isSelfHostedJetpackConnected( site )
 			? 'https://wordpress.com/move'
-			: addQueryArgs( '/setup/site-migration', { siteSlug: site.slug } );
+			: addQueryArgs( 'https://wordpress.com/setup/site-migration', { siteSlug: site.slug } );
 
 		trackActionClick( 'import-site' );
 		window.open( url, '_blank', 'noreferrer,noopener' );

--- a/client/dashboard/sites/overview-site-action-menu/index.tsx
+++ b/client/dashboard/sites/overview-site-action-menu/index.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../app/analytics';
+import { wpcomLink } from '../../utils/link';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { getSiteEditUrl } from '../../utils/site-url';
 import type { Site } from '@automattic/api-core';
@@ -32,10 +33,10 @@ const SiteActionMenu = ( { site }: { site: Site } ) => {
 	const handleImportSite = () => {
 		const url = isSelfHostedJetpackConnected( site )
 			? 'https://wordpress.com/move'
-			: addQueryArgs( 'https://wordpress.com/setup/site-migration', { siteSlug: site.slug } );
+			: addQueryArgs( wpcomLink( '/setup/site-migration' ), { siteSlug: site.slug } );
 
 		trackActionClick( 'import-site' );
-		window.open( url, '_blank', 'noreferrer,noopener' );
+		window.location.href = url;
 	};
 
 	return (
@@ -46,7 +47,7 @@ const SiteActionMenu = ( { site }: { site: Site } ) => {
 						{ __( 'Edit site ↗' ) }
 					</MenuItem>
 					<MenuItem onClick={ handleWritePost }>{ __( 'Write a post ↗' ) }</MenuItem>
-					<MenuItem onClick={ handleImportSite }>{ __( 'Import site ↗' ) }</MenuItem>
+					<MenuItem onClick={ handleImportSite }>{ __( 'Import site' ) }</MenuItem>
 				</MenuGroup>
 			) }
 		</DropdownMenu>

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -54,7 +54,7 @@ const DuplicateSite = ( { site }: { site: Site } ) => {
 				<Button
 					variant="secondary"
 					size="compact"
-					href={ addQueryArgs( '/setup/copy-site', {
+					href={ addQueryArgs( 'https://wordpress.com/setup/copy-site', {
 						sourceSlug: site.slug,
 					} ) }
 				>

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ActionList } from '../../components/action-list';
 import { SectionHeader } from '../../components/section-header';
+import { wpcomLink } from '../../utils/link';
 import { hasPlanFeature } from '../../utils/site-features';
 import { canViewSiteActions } from '../features';
 import type { Site } from '@automattic/api-core';
@@ -54,7 +55,7 @@ const DuplicateSite = ( { site }: { site: Site } ) => {
 				<Button
 					variant="secondary"
 					size="compact"
-					href={ addQueryArgs( 'https://wordpress.com/setup/copy-site', {
+					href={ addQueryArgs( wpcomLink( '/setup/copy-site' ), {
 						sourceSlug: site.slug,
 					} ) }
 				>

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -53,7 +53,7 @@ export function SiteLaunchButton( { site, tracksContext }: { site: Site; tracksC
 
 	const getLaunchUrl = () => {
 		if ( isSitePlanBigSkyTrial( site ) ) {
-			return addQueryArgs( '/setup/ai-site-builder/domains', {
+			return addQueryArgs( 'https://wordpress.com/setup/ai-site-builder/domains', {
 				siteId: site.ID,
 				source: 'general-settings',
 				redirect: 'site-launch',
@@ -62,7 +62,7 @@ export function SiteLaunchButton( { site, tracksContext }: { site: Site; tracksC
 			} );
 		}
 
-		return addQueryArgs( '/start/launch-site', {
+		return addQueryArgs( 'https://wordpress.com/start/launch-site', {
 			siteSlug: site.slug,
 			new: site.name,
 			hide_initial_query: 'yes',

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
+import { wpcomLink } from '../../utils/link';
 import {
 	isSitePlanLaunchable as getIsSitePlanLaunchable,
 	isSitePlanBigSkyTrial,
@@ -53,7 +54,7 @@ export function SiteLaunchButton( { site, tracksContext }: { site: Site; tracksC
 
 	const getLaunchUrl = () => {
 		if ( isSitePlanBigSkyTrial( site ) ) {
-			return addQueryArgs( 'https://wordpress.com/setup/ai-site-builder/domains', {
+			return addQueryArgs( wpcomLink( '/setup/ai-site-builder/domains' ), {
 				siteId: site.ID,
 				source: 'general-settings',
 				redirect: 'site-launch',
@@ -62,7 +63,7 @@ export function SiteLaunchButton( { site, tracksContext }: { site: Site; tracksC
 			} );
 		}
 
-		return addQueryArgs( 'https://wordpress.com/start/launch-site', {
+		return addQueryArgs( wpcomLink( '/start/launch-site' ), {
 			siteSlug: site.slug,
 			new: site.name,
 			hide_initial_query: 'yes',

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -1,0 +1,5 @@
+import config from '@automattic/calypso-config';
+
+export function wpcomLink( path: string ) {
+	return `${ config( 'wpcom_url' ) }${ path }`;
+}

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -1,5 +1,14 @@
 import config from '@automattic/calypso-config';
 
+/**
+ * This function essentially returns `https://wordpress.com${ path }`.
+ *
+ * However, the hostname is configurable in the `wpcom_url` key, so that
+ * we can point to different hostname in different environments.
+ *
+ * For example, the value is set to `calypso.localhost:3000` in `config/dashboard-development.json`,
+ * so that the link points to the local Calypso dev server.
+ */
 export function wpcomLink( path: string ) {
 	return `${ config( 'wpcom_url' ) }${ path }`;
 }

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -131,8 +131,8 @@ export function useSitePlanManageURL( site: Site, purchase?: Purchase ) {
 
 	if ( site.plan?.is_free ) {
 		return isCommerceGarden( site )
-			? `${ protocol }//${ host }/setup/woo-hosted-plans?siteSlug=${ site.slug }`
-			: `${ protocol }//${ host }/setup/plan-upgrade?siteSlug=${ site.slug }`;
+			? `https://wordpress.com/setup/woo-hosted-plans?siteSlug=${ site.slug }`
+			: `https://wordpress.com/setup/plan-upgrade?siteSlug=${ site.slug }`;
 	}
 
 	if ( isDashboardBackport() ) {

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -20,6 +20,7 @@ import {
 import { purchaseSettingsRoute, purchasesRoute } from '../app/router/me';
 import { hasPlanFeature } from '../utils/site-features';
 import { isDashboardBackport } from './is-dashboard-backport';
+import { wpcomLink } from './link';
 import { isCommerceGarden, isSelfHostedJetpackConnected } from './site-types';
 
 export const JETPACK_PRODUCTS = [
@@ -131,8 +132,8 @@ export function useSitePlanManageURL( site: Site, purchase?: Purchase ) {
 
 	if ( site.plan?.is_free ) {
 		return isCommerceGarden( site )
-			? `https://wordpress.com/setup/woo-hosted-plans?siteSlug=${ site.slug }`
-			: `https://wordpress.com/setup/plan-upgrade?siteSlug=${ site.slug }`;
+			? wpcomLink( `/setup/woo-hosted-plans?siteSlug=${ site.slug }` )
+			: wpcomLink( `/setup/plan-upgrade?siteSlug=${ site.slug }` );
 	}
 
 	if ( isDashboardBackport() ) {

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -16,6 +16,7 @@
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",
 	"login_url": false,
 	"logout_url": false,
+	"wpcom_url": false,
 	"wpcom_signup_url": false,
 	"wpcom_login_url": false,
 	"wpcom_authorize_endpoint": false,

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -7,6 +7,7 @@
 	"i18n_default_locale_slug": "en",
 	"port": 3003,
 	"logout_url": "https://|subdomain|wordpress.com",
+	"wpcom_url": "http://calypso.localhost:3000",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",
 	"features": {

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -5,6 +5,7 @@
 	"client_slug": "browser",
 	"hostname": "my.wordpress.com",
 	"i18n_default_locale_slug": "en",
+	"wpcom_url": "https://wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",
 	"features": {

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -5,7 +5,7 @@
 	"client_slug": "browser",
 	"hostname": "my.wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"wpcom_url": "https://wordpress.com",
+	"wpcom_url": "https://wpcalypso.wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",
 	"features": {

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -5,6 +5,7 @@
 	"client_slug": "browser",
 	"hostname": "my.wordpress.com",
 	"i18n_default_locale_slug": "en",
+	"wpcom_url": "https://wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",
 	"features": {

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -5,6 +5,7 @@
 	"client_slug": "browser",
 	"hostname": "my.wordpress.com",
 	"i18n_default_locale_slug": "en",
+	"wpcom_url": "https://wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",
 	"features": {


### PR DESCRIPTION
Part of DOTMSD-903

## Proposed Changes

This PR prepends `/start/*` and `/setup/*` links in the dashboard, with `https://wordpress.com`. This makes the links as absolute link so they always open `wordpress.com` regardless of origin host.

---

~Now the question is, should those links open in new tab? Are they "external" links just because the domains are different? Right now, the behavior is inconsistent for those links. Some have explicit "Back" button from Stepper, so they should open in existing tab. Some don't have Back button, but I think they should. I spent some time today to investigate but I think it's better as separate follow-up~ 🥹

EDIT: we now always open in the same tab. We add a new config `wpcom_url` which points to local `calypso.localhots` for development env.

## Why are these changes being made?

We are deploying the dashboard in `my.wordpress.com`, so such links must now open in that subdomain.

## Testing Instructions

I think it's easiest to visually check the code changes. Plus you can smoke-test some links and verify they open as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
