### PR TITLE
Domain Connection Setup: replace CardHeader with CardDivider

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -90,24 +90,24 @@ export default function ConnectionModeCard( {
 	return (
 		<Card>
 			<CardBody>
-				<HStack spacing={ 2 } justify="flex-start">
-					<RadioControl
-						selected={ selectedMode }
-						options={ [ { label: '', value: mode } ] }
-						onChange={ ( value: string ) =>
-							onModeChange( value as DomainConnectionSetupModeValue )
-						}
-					/>
-					<VStack spacing={ 2 }>
-						<Text size="medium" weight={ 500 }>
-							{ title }
-						</Text>
-						<Text variant="muted">{ description }</Text>
-					</VStack>
-				</HStack>
-				{ isSelected && (
-					<>
-						<VStack spacing={ 4 } style={ { marginTop: '16px' } }>
+				<VStack spacing={ 4 }>
+					<HStack spacing={ 2 } justify="flex-start">
+						<RadioControl
+							selected={ selectedMode }
+							options={ [ { label: '', value: mode } ] }
+							onChange={ ( value: string ) =>
+								onModeChange( value as DomainConnectionSetupModeValue )
+							}
+						/>
+						<VStack spacing={ 2 }>
+							<Text size="medium" weight={ 500 }>
+								{ title }
+							</Text>
+							<Text variant="muted">{ description }</Text>
+						</VStack>
+					</HStack>
+					{ isSelected && (
+						<>
 							<CardDivider />
 							<VStack spacing={ 6 }>
 								{ mode === DomainConnectionSetupMode.SUGGESTED && ! hasEmailOrOtherServices && (
@@ -167,9 +167,9 @@ export default function ConnectionModeCard( {
 									{ __( 'Verify Connection' ) }
 								</Button>
 							</ButtonStack>
-						</VStack>
-					</>
-				) }
+						</>
+					) }
+				</VStack>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -12,7 +12,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
-import { Card, CardBody, CardHeader, CardDivider } from '../../components/card';
+import { Card, CardBody, CardDivider } from '../../components/card';
 import Notice from '../../components/notice';
 import SetupStep from './setup-step';
 
@@ -89,7 +89,7 @@ export default function ConnectionModeCard( {
 
 	return (
 		<Card>
-			<CardHeader>
+			<CardBody>
 				<HStack spacing={ 2 } justify="flex-start">
 					<RadioControl
 						selected={ selectedMode }
@@ -105,69 +105,72 @@ export default function ConnectionModeCard( {
 						<Text variant="muted">{ description }</Text>
 					</VStack>
 				</HStack>
-			</CardHeader>
-			{ isSelected && (
-				<CardBody>
-					<VStack spacing={ 4 }>
-						<VStack spacing={ 6 }>
-							{ mode === DomainConnectionSetupMode.SUGGESTED && ! hasEmailOrOtherServices && (
-								<Notice variant="info" title="No email or other services detected">
-									<Text>
-										{ __( 'You can safely connect your domain without affecting anything else.' ) }
-									</Text>
-								</Notice>
-							) }
-							{ mode === DomainConnectionSetupMode.SUGGESTED && hasEmailOrOtherServices && (
-								<Notice variant="warning" title="Email or other services detected">
-									<Text>
-										{ __(
-											'Warning: the services attached to your domain might be interrupted if you use this connection method'
-										) }
-									</Text>
-								</Notice>
-							) }
-							{ mode === DomainConnectionSetupMode.ADVANCED && hasEmailOrOtherServices && (
-								<Notice variant="info" title="Email or other services detected">
-									<Text>
-										{ __(
-											'To avoid disruption, this is the safest way to connect your domain name.'
-										) }
-									</Text>
-								</Notice>
-							) }
-							<Text>{ infoText }</Text>
+				{ isSelected && (
+					<>
+						<VStack spacing={ 4 } style={ { marginTop: '16px' } }>
+							<CardDivider />
+							<VStack spacing={ 6 }>
+								{ mode === DomainConnectionSetupMode.SUGGESTED && ! hasEmailOrOtherServices && (
+									<Notice variant="info" title="No email or other services detected">
+										<Text>
+											{ __(
+												'You can safely connect your domain without affecting anything else.'
+											) }
+										</Text>
+									</Notice>
+								) }
+								{ mode === DomainConnectionSetupMode.SUGGESTED && hasEmailOrOtherServices && (
+									<Notice variant="warning" title="Email or other services detected">
+										<Text>
+											{ __(
+												'Warning: the services attached to your domain might be interrupted if you use this connection method'
+											) }
+										</Text>
+									</Notice>
+								) }
+								{ mode === DomainConnectionSetupMode.ADVANCED && hasEmailOrOtherServices && (
+									<Notice variant="info" title="Email or other services detected">
+										<Text>
+											{ __(
+												'To avoid disruption, this is the safest way to connect your domain name.'
+											) }
+										</Text>
+									</Notice>
+								) }
+								<Text>{ infoText }</Text>
+							</VStack>
+							<div>
+								{ steps.map( ( step, index ) => (
+									<div key={ step.title }>
+										<SetupStep
+											className="domain-connection-setup__step"
+											expanded={ stepsExpanded[ index ] }
+											completed={ stepsCompleted[ index ] }
+											onCheckboxChange={ ( checked ) => handleStepChange( index, checked ) }
+											onToggle={ ( expanded ) => handleStepToggle( index, expanded ) }
+											title={ step.title }
+											label={ step.label }
+										>
+											{ step.content }
+										</SetupStep>
+										{ index < steps.length - 1 && <CardDivider /> }
+									</div>
+								) ) }
+							</div>
+							<ButtonStack justify="flex-start">
+								<Button
+									variant="primary"
+									onClick={ onVerifyConnection }
+									isBusy={ isUpdatingConnectionMode }
+									disabled={ verificationDisabled }
+								>
+									{ __( 'Verify Connection' ) }
+								</Button>
+							</ButtonStack>
 						</VStack>
-						<div>
-							{ steps.map( ( step, index ) => (
-								<div key={ step.title }>
-									<SetupStep
-										className="domain-connection-setup__step"
-										expanded={ stepsExpanded[ index ] }
-										completed={ stepsCompleted[ index ] }
-										onCheckboxChange={ ( checked ) => handleStepChange( index, checked ) }
-										onToggle={ ( expanded ) => handleStepToggle( index, expanded ) }
-										title={ step.title }
-										label={ step.label }
-									>
-										{ step.content }
-									</SetupStep>
-									{ index < steps.length - 1 && <CardDivider /> }
-								</div>
-							) ) }
-						</div>
-						<ButtonStack justify="flex-start">
-							<Button
-								variant="primary"
-								onClick={ onVerifyConnection }
-								isBusy={ isUpdatingConnectionMode }
-								disabled={ verificationDisabled }
-							>
-								{ __( 'Verify Connection' ) }
-							</Button>
-						</ButtonStack>
-					</VStack>
-				</CardBody>
-			) }
+					</>
+				) }
+			</CardBody>
 		</Card>
 	);
 }


### PR DESCRIPTION
Closes [DOMAINS-1868](https://linear.app/a8c/issue/DOMAINS-1868/card-divider-needs-left-and-right-margin)

## Proposed Changes
Replace `CardHeader` with `CardDivider` in `ConnectionModeCard` to add later margins.

## Why are these changes being made?
Design review (1lCoIdZNpLPE9DjukYz9vUbAiqYsqeRHALTQ8xiaeosk-gdoc)

|![Screenshot 2025-12-01 alle 14 34 24](https://github.com/user-attachments/assets/9ca55de0-b66b-406f-b7e5-bb340a42014c)|![Screenshot 2025-12-01 alle 14 34 38](https://github.com/user-attachments/assets/6554b75c-469f-43e0-9dba-f8be3cccbdee)|
|:-:|:-:|
|Before|After|

## Testing Instructions
Start a new domain connection and verify that the `CardHeader` border bottom has been replaced by a `CardDivider` component.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
