### PR TITLE
Fix ads upsell banner for Atomic sites

### DIFF
--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -320,7 +320,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			component = renderInstantActivationToggle( component );
 		} else if ( isWordadsInstantEligibleButNotOwner ) {
 			component = renderOwnerRequiredMessage();
-		} else if ( canUpgradeToUseWordAds && site?.jetpack ) {
+		} else if ( canUpgradeToUseWordAds && site?.jetpack && ! site?.is_wpcom_atomic ) {
 			component = renderjetpackUpsell();
 		} else if ( canUpgradeToUseWordAds ) {
 			component = renderUpsell();


### PR DESCRIPTION
Part of M4R73CH-1277

## Proposed Changes

Atomic sites are Jetpack and get the incorrect Jetpack upsell on /ads

## Why are these changes being made?

* People get the wrong cart link and can be upset

## Testing Instructions

* With an WoA site, add the Personal plan
* go to `/earn/ads-earnings/SITE`

Before: Smaller banner, pointing to a Jetpack upgrade
After: Larger Premium banner

<img width="45%" alt="Screenshot 2025-12-01 at 16 22 07" src="https://github.com/user-attachments/assets/789c133e-068e-4726-a4fe-1bb9edd4d980" />
<img width="45%"  alt="Screenshot 2025-12-01 at 16 22 21" src="https://github.com/user-attachments/assets/a839c994-d594-4739-ad23-3be464fe8fd7" />

* Click the CTA

Before: errors
After: no errors



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
