### PR TITLE
Fix missing space between Domain Connection steps and Verify Connection button

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -155,17 +155,17 @@ export default function ConnectionModeCard( {
 								</div>
 							) ) }
 						</div>
+						<ButtonStack justify="flex-start">
+							<Button
+								variant="primary"
+								onClick={ onVerifyConnection }
+								isBusy={ isUpdatingConnectionMode }
+								disabled={ verificationDisabled }
+							>
+								{ __( 'Verify Connection' ) }
+							</Button>
+						</ButtonStack>
 					</VStack>
-					<ButtonStack justify="flex-start">
-						<Button
-							variant="primary"
-							onClick={ onVerifyConnection }
-							isBusy={ isUpdatingConnectionMode }
-							disabled={ verificationDisabled }
-						>
-							{ __( 'Verify Connection' ) }
-						</Button>
-					</ButtonStack>
 				</CardBody>
 			) }
 		</Card>


### PR DESCRIPTION
Closes [DOMAINS-1860](https://linear.app/a8c/issue/DOMAINS-1860/were-missing-the-border-top-when-verifying-the-domain-connection)

## Proposed Changes
Add 16px gap between the steps accordion group and the Verify Connection button.

|![Screenshot 2025-12-01 alle 17 04 12](https://github.com/user-attachments/assets/80ae004d-11cc-4adf-b43e-bc7c96eafc6f)|![Screenshot 2025-12-01 alle 17 03 11](https://github.com/user-attachments/assets/99f4be5c-fd74-460d-a29e-135924a53e24)|
|:-:|:-:|
|Before|After|

## Why are these changes being made?
Design review (1lCoIdZNpLPE9DjukYz9vUbAiqYsqeRHALTQ8xiaeosk-gdoc)

## Testing Instructions
Start a new domain connection and verify that the button has the correct padding.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
