### PR TITLE
feat: App banner provides reader post ID to Android apps

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -147,8 +147,14 @@ export class AppBanner extends Component {
 					return `intent://details?id=${ packageName }&url=${ scheme }://home&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case NOTES:
 					return `intent://details?id=${ packageName }&url=${ scheme }://notifications&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
-				case READER:
-					return `intent://details?id=${ packageName }&url=${ scheme }://read&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+				case READER: {
+					// Extract post details from route if available (e.g., /read/feeds/:feedId/posts/:postId)
+					const readerPath =
+						currentRoute && currentRoute.startsWith( '/reader' )
+							? currentRoute.replace( /^\/reader/, '' )
+							: '';
+					return `intent://details?id=${ packageName }&url=${ scheme }://read${ readerPath }&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+				}
 				case STATS:
 					return `intent://details?id=${ packageName }&url=${ scheme }://stats&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 			}

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -148,12 +148,8 @@ export class AppBanner extends Component {
 				case NOTES:
 					return `intent://details?id=${ packageName }&url=${ scheme }://notifications&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case READER: {
-					// Extract post details from route if available (e.g., /read/feeds/:feedId/posts/:postId)
-					const readerPath =
-						currentRoute && currentRoute.startsWith( '/reader' )
-							? currentRoute.replace( /^\/reader/, '' )
-							: '';
-					return `intent://details?id=${ packageName }&url=${ scheme }://read${ readerPath }&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					const readerPath = getReaderPath( currentRoute );
+					return `intent://details?id=${ packageName }&url=${ scheme }:/${ readerPath }&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				}
 				case STATS:
 					return `intent://details?id=${ packageName }&url=${ scheme }://stats&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
@@ -250,6 +246,26 @@ function getEditorPath( currentRoute ) {
 }
 
 /**
+ * Returns the Reader path for deep linking.
+ * Transforms /reader routes to /read for app compatibility.
+ * @param {string} currentRoute The current route.
+ * @returns {string} The Reader path for the deep link.
+ */
+function getReaderPath( currentRoute ) {
+	// The Reader is generally accessed at the root of WordPress.com ('/').
+	// In this case, we need to manually add the section name to the
+	// URL so that the iOS app knows which section to open.
+	const hasRoute = currentRoute && currentRoute !== '/' && currentRoute !== null;
+
+	if ( ! hasRoute ) {
+		return '/read';
+	}
+
+	// Replacing '/reader' with '/read' to ensure backwards compatibility i.e. updating the URL on web app should not break the deep link.
+	return currentRoute.replace( /^\/reader/, '/read' );
+}
+
+/**
  * Builds the deep link fragment for the iOS app.
  * @param {string} currentRoute The current route.
  * @param {string} currentSection The current section.
@@ -265,15 +281,7 @@ export function buildDeepLinkFragment( currentRoute, currentSection ) {
 			case NOTES:
 				return '/notifications';
 			case READER:
-				// The Reader is generally accessed at the root of WordPress.com ('/').
-				// In this case, we need to manually add the section name to the
-				// URL so that the iOS app knows which section to open.
-				if ( ! hasRoute ) {
-					return '/read';
-				}
-
-				// Replacing '/reader' with '/read' to ensure backwards compatibility i.e. updating the URL on web app should not break the deep link.
-				return currentRoute.replace( /^\/reader/, '/read' );
+				return getReaderPath( currentRoute );
 			case STATS:
 				return hasRoute ? currentRoute : '/stats';
 			default:


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fix CMM-1005. 

## Proposed Changes

* Include the site ID and post ID in the Android deep link path. 
* Extract common `getReaderPath` logic used by both the iOS and Android platforms. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Android app could not load the content for the currently viewed reader post without this information in the deep link URL. This aligns Android with the existing capabilities of iOS. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use an Android device for the following steps.
1. Install the Jetpack mobile app beta prototype build from https://github.com/wordpress-mobile/WordPress-Android/pull/22380 and log in.
1. In your Android browser, navigate to the [Calypso Live environment](https://github.com/Automattic/wp-calypso/pull/107407#issuecomment-3598456713) for this PR and log in.
1. Navigate to an individual post detail view in your accounts Reader feed. 
1. Connect your Android device to your development machine via USB. 
1. Visit `chrome://inspect/#devices` in Chrome on your development machine.
1. Inspect the Android device's browser.
1. Execute the following in the console: 
    ```
    dispatch( { type: 'PREFERENCES_SET', key: 'appBannerDismissTimes', value: null } );
    ```
1. Inspect the _Open in the Jetpack app_ button and append `.beta` the `id` parameter value in its `href`. I.e., modify the `id` from `id=com.jetpack.android` → `id=com.jetpack.android.beta`. This directs the deep link to open the Jetpack Android beta build installed earlier. 
1. Tap the _Open in the Jetpack app_ button.
1. **Verify** the Jetpack mobile app launches and loads the same post in the app's Reader post detail view. 
1. In your Android web browser, navigate to the top-level Reader view for your account.
1. Repeat steps 5–10. 
1. **Verify** the Jetpack mobile app launches and loads the app's Reader index view. 

https://github.com/user-attachments/assets/51043384-a058-41f1-8a17-5ab6f79baf9b

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
