### PR TITLE
MSD Backups: fix loading/empty state vertical alignment in Backups list DataViews

### DIFF
--- a/client/dashboard/components/dataviews/dataviews-card.tsx
+++ b/client/dashboard/components/dataviews/dataviews-card.tsx
@@ -2,12 +2,18 @@ import { forwardRef } from 'react';
 import { Card, CardBody } from '../card';
 
 function UnforwardedDataViewsCard(
-	{ className, children }: { className?: string; children: React.ReactNode },
+	{
+		className,
+		children,
+		fillHeight,
+	}: { className?: string; children: React.ReactNode; fillHeight?: boolean },
 	ref: React.ForwardedRef< HTMLDivElement >
 ) {
+	const bodyStyle = fillHeight ? { height: '100%' } : undefined;
+
 	return (
 		<Card ref={ ref } className={ className }>
-			<CardBody>{ children }</CardBody>
+			<CardBody style={ bodyStyle }>{ children }</CardBody>
 		</Card>
 	);
 }

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -74,7 +74,7 @@ export function BackupsList( {
 	};
 
 	return (
-		<DataViewsCard>
+		<DataViewsCard fillHeight>
 			<DataViews< ActivityLogEntry >
 				getItemId={ ( item ) => item.activity_id }
 				data={ filteredData }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://github.com/Automattic/wp-calypso/pull/107258#discussion_r2568285042

## Proposed Changes

- Fix loading/empty state vertical alignment in Backups list DataViews
  - Add optional fillHeight prop to DataViewsCard to fill 100% of available height
  - Use fillHeight in BackupsList to enable DataViews' built-in vertical centering

| Before | After |
|---|---|
| <img width="2640" height="990" alt="CleanShot 2025-12-01 at 17 18 12@2x" src="https://github.com/user-attachments/assets/9c3b7b5b-58ef-47f2-af3d-c5ec46f1f2a0" /> | <img width="2638" height="990" alt="CleanShot 2025-12-01 at 17 17 18@2x" src="https://github.com/user-attachments/assets/47d0723d-f806-4a6d-b2f2-fc789eb6dbe5" /> |
| <img width="2644" height="986" alt="CleanShot 2025-12-01 at 17 18 31@2x" src="https://github.com/user-attachments/assets/3a61c4f7-758c-484b-8076-4da83c0aa8d7" /> | <img width="2644" height="986" alt="CleanShot 2025-12-01 at 17 18 44@2x" src="https://github.com/user-attachments/assets/64cde653-64ff-4a71-965c-a5cc35a15832" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Follow-up to #107258. DataViews provides built-in vertical centering for empty and loading states, but it requires its container to fill the available height. In the Backups Grid layout (<Grid columns={2} templateColumns="40% 1fr">), grid items stretch by default, but CardBody does not inherit that height.

The fillHeight prop sets height: 100% on CardBody, which lets DataViews' native centering work without CSS overrides that target its internals.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up a Calypso Live Branch
- Navigate to /v2/sites/[site]/backups
- Ensure the loading spinner is centered vertically (you can try updating the date range picker)
- Try the using the search to force the empty/no results state. 
- Ensure the empty/no results state is also centered vertically

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
