### PR TITLE
Dashboard: run dev server on different port than 3000

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -5,7 +5,7 @@
 	"client_slug": "browser",
 	"hostname": "my.localhost",
 	"i18n_default_locale_slug": "en",
-	"port": 3000,
+	"port": 3003,
 	"logout_url": "https://|subdomain|wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
 		"start-a8c-for-agencies": "CALYPSO_ENV=a8c-for-agencies-development yarn run start",
 		"start-a8c-for-agencies-p": "PORT=3002 CALYPSO_ENV=a8c-for-agencies-development yarn run build-server && PORT=3002 CALYPSO_ENV=a8c-for-agencies-development yarn run start-build",
 		"start-dashboard": "CALYPSO_ENV=dashboard-development yarn run start",
-		"start-dashboard-p": "PORT=3003 CALYPSO_ENV=dashboard-development yarn run build-server && PORT=3003 CALYPSO_ENV=dashboard-development yarn run start-build",
+		"start-dashboard-p": "PORT=3013 CALYPSO_ENV=dashboard-development yarn run build-server && PORT=3013 CALYPSO_ENV=dashboard-development yarn run start-build",
 		"storybook:start": "storybook dev -c ./.storybook -p 6006",
 		"storybook:build": "storybook build -c ./.storybook",
 		"test": "run-s -s test-client test-packages test-server test-build-tools",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
 		"start-a8c-for-agencies": "CALYPSO_ENV=a8c-for-agencies-development yarn run start",
 		"start-a8c-for-agencies-p": "PORT=3002 CALYPSO_ENV=a8c-for-agencies-development yarn run build-server && PORT=3002 CALYPSO_ENV=a8c-for-agencies-development yarn run start-build",
 		"start-dashboard": "CALYPSO_ENV=dashboard-development yarn run start",
-		"start-dashboard-p": "PORT=3013 CALYPSO_ENV=dashboard-development yarn run build-server && PORT=3013 CALYPSO_ENV=dashboard-development yarn run start-build",
 		"storybook:start": "storybook dev -c ./.storybook -p 6006",
 		"storybook:build": "storybook build -c ./.storybook",
 		"test": "run-s -s test-client test-packages test-server test-build-tools",


### PR DESCRIPTION
Part of DOTMSD-903

## Proposed Changes

- Run `yarn start-dashboard` on port 3003
- ~Run `yarn start-dashboard-p` on port 3013~

## Why are these changes being made?

We want to be able to start both `calypso.localhost` and `my.localhost` at the same time so that links across the local domains work correctly.

## Testing Instructions

Verify the above yarn command work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
