### PR TITLE
Dashboard backport: show holiday snow settings

### DIFF
--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -43,6 +43,17 @@ const subscriptionGiftingRoute = createRoute( {
 	)
 );
 
+const holidaySnowRoute = createRoute( {
+	...appRouterSites.siteSettingsHolidaySnowRoute.options,
+	getParentRoute: () => settingsRoute,
+} ).lazy( () =>
+	import( 'calypso/dashboard/sites/settings-holiday-snow' ).then( ( d ) =>
+		createLazyRoute( 'holiday-snow' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
 const wordpressRoute = createRoute( {
 	...appRouterSites.siteSettingsWordPressRoute.options,
 	getParentRoute: () => settingsRoute,
@@ -204,6 +215,7 @@ const createRouteTree = () =>
 				settingsIndexRoute,
 				siteVisibilityRoute,
 				subscriptionGiftingRoute,
+				holidaySnowRoute,
 				wordpressRoute,
 				phpRoute,
 				databaseRoute,


### PR DESCRIPTION
Fixes DOTCOM-15366

## Proposed Changes

This PR enables the Holiday Snow settings in the backported Site Settings, which was missed.

|Before|After|
|-|-|
|<img width="678" height="336" alt="image" src="https://github.com/user-attachments/assets/c9d5c1ef-0fa1-4ca5-a5f0-fe655fd976d1" />|<img width="732" height="304" alt="image" src="https://github.com/user-attachments/assets/21e5274a-7fa1-4c0c-9deb-5df3fa33c8fe" />|


## Why are these changes being made?

Fixed a regression.

## Testing Instructions

1. Go to /sites/:siteSlug/settings.
2. Click the Holiday snow settings.
3. Verify the setting works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
