### PR TITLE
Fix GitHub PR comment format

### DIFF
--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -30,6 +30,10 @@ jobs:
             const hasComment = existingComment ? "true" : "false";
             console.log( `Has existing comment: ${ hasComment }` );
             return hasComment;
+      - name: Build calypso.live link
+        run: |
+          echo "LINK=https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+        id: build_link
       - name: Post comment on PR
         uses: actions/github-script@v6
         if: steps.has_comment.outputs.result == 'false'
@@ -37,59 +41,68 @@ jobs:
           # Skip adding a comment if we already have one.
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
+            function trimIndent(str) {
+              const lines = str.replace(/^\n+|\n+$/g, '').split('\n');
+              const min = Math.min(...lines.filter(l => l.trim()).map(l => l.match(/^ */)[0].length));
+              return lines.map(l => l.slice(min)).join('\n');
+            }
+
+            const link = "${{steps.build_link.outputs.LINK}}";
+            const body = trimIndent(`
+              <!--calypso-live-watermark:apr@v1-->
+              <details>
+                <summary>
+                  Calypso Live <a href="${link}">(direct link)</a>
+                </summary>
+                <table>
+                  <tr>
+                    <td>
+                      <a href="${link}">${link}</a>
+                    </td>
+                  </tr>
+                </table>
+              </details>
+              <details>
+                <summary>
+                  Jetpack Cloud live <a href="${link}&env=jetpack">(direct link)</a>
+                </summary>
+                <table>
+                  <tr>
+                    <td>
+                      <a href="${link}&env=jetpack">${link}&env=jetpack</a>
+                    </td>
+                  </tr>
+                </table>
+              </details>
+              <details>
+                <summary>
+                  Automattic for Agencies live <a href="${link}&env=a8c-for-agencies">(direct link)</a>
+                </summary>
+                <table>
+                  <tr>
+                    <td>
+                      <a href="${link}&env=a8c-for-agencies">${link}&env=a8c-for-agencies</a>
+                    </td>
+                  </tr>
+                </table>
+              </details>
+              <details>
+                <summary>
+                  Dashboard live <a href="${link}&env=dashboard">(direct link)</a>
+                </summary>
+                <table>
+                  <tr>
+                    <td>
+                      <a href="${link}&env=dashboard">${link}&env=dashboard</a>
+                    </td>
+                  </tr>
+                </table>
+              </details>`
+            );
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `
-                <!--calypso-live-watermark:apr@v1-->
-                <details>
-                  <summary>
-                    Calypso Live <a href="${{steps.build_link.outputs.LINK}}">(direct link)</a>
-                  </summary>
-                  <table>
-                    <tr>
-                      <td>
-                        <a href="${{steps.build_link.outputs.LINK}}">${{steps.build_link.outputs.LINK}}</a>
-                      </td>
-                    </tr>
-                  </table>
-                </details>
-                <details>
-                  <summary>
-                    Jetpack Cloud live <a href="${{steps.build_link.outputs.LINK}}&env=jetpack">(direct link)</a>
-                  </summary>
-                  <table>
-                    <tr>
-                      <td>
-                        <a href="${{steps.build_link.outputs.LINK}}&env=jetpack">${{steps.build_link.outputs.LINK}}&env=jetpack</a>
-                      </td>
-                    </tr>
-                  </table>
-                </details>
-                <details>
-                  <summary>
-                    Automattic for Agencies live <a href="${{steps.build_link.outputs.LINK}}&env=a8c-for-agencies">(direct link)</a>
-                  </summary>
-                  <table>
-                    <tr>
-                      <td>
-                        <a href="${{steps.build_link.outputs.LINK}}&env=a8c-for-agencies">${{steps.build_link.outputs.LINK}}&env=a8c-for-agencies</a>
-                      </td>
-                    </tr>
-                  </table>
-                </details>
-                <details>
-                  <summary>
-                    Dashboard live <a href="${{steps.build_link.outputs.LINK}}&env=dashboard">(direct link)</a>
-                  </summary>
-                  <table>
-                    <tr>
-                      <td>
-                        <a href="${{steps.build_link.outputs.LINK}}&env=dashboard">${{steps.build_link.outputs.LINK}}&env=dashboard</a>
-                      </td>
-                    </tr>
-                  </table>
-                </details>
-              `
+              body,
             })


### PR DESCRIPTION
## Proposed Changes

Follow up of https://github.com/Automattic/wp-calypso/pull/107398. This PR fixes the GitHub comment format so that it's parsed as Markdown and not plaintext.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check that the PR comment below from GitHub action contains the correct link.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
