### PR TITLE
Domain connection steps: minor style adjustments

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -153,7 +153,11 @@ export default function ConnectionModeCard( {
 										>
 											{ step.content }
 										</SetupStep>
-										{ index < steps.length - 1 && <CardDivider /> }
+										{ index < steps.length - 1 && (
+											<CardDivider
+												style={ { borderColor: 'var(--dashboard-overview__divider-color)' } }
+											/>
+										) }
 									</div>
 								) ) }
 							</div>

--- a/client/dashboard/domains/domain-connection-setup/setup-step.tsx
+++ b/client/dashboard/domains/domain-connection-setup/setup-step.tsx
@@ -33,17 +33,17 @@ export default function SetupStep( {
 		<CollapsibleCard
 			className={ className }
 			header={
-				<HStack spacing={ 2 } justify="flex-start" alignment="left" expanded={ false }>
+				<HStack spacing={ 4 } justify="flex-start" alignment="left" expanded={ false }>
 					<Icon
 						size={ 24 }
 						icon={ completed ? published : swatch }
 						fill={
 							completed
 								? 'var(--dashboard__background-color-success)'
-								: 'var(--dashboard__text-color)'
+								: 'var(--dashboard-menu-item__color)'
 						}
 					/>
-					<Text size={ 14 } weight={ 500 }>
+					<Text size={ 15 } weight={ 500 }>
 						{ title }
 					</Text>
 				</HStack>
@@ -52,7 +52,7 @@ export default function SetupStep( {
 			onToggle={ onToggle }
 			isBorderless
 		>
-			<VStack spacing={ 4 } style={ { paddingLeft: '32px' } }>
+			<VStack spacing={ 6 }>
 				{ children }
 				{ label && (
 					<CheckboxControl

--- a/client/dashboard/domains/domain-connection-setup/style.scss
+++ b/client/dashboard/domains/domain-connection-setup/style.scss
@@ -31,7 +31,7 @@
 		padding-inline-end: 0;
 	}
 	&__step .collapsible-card__content {
-		padding-left: 40px;
+		padding-inline-start: 40px;
 		padding-top: 16px;
 	}
 }

--- a/client/dashboard/domains/domain-connection-setup/style.scss
+++ b/client/dashboard/domains/domain-connection-setup/style.scss
@@ -30,4 +30,8 @@
 		padding-inline-start: 0;
 		padding-inline-end: 0;
 	}
+	&__step .collapsible-card__content {
+		padding-left: 40px;
+		padding-top: 16px;
+	}
 }


### PR DESCRIPTION
Closes [DOMAINS-1888](https://linear.app/a8c/issue/DOMAINS-1888/update-steps-style)

## Proposed Changes
Minor style changes for domain connections steps.

<img width="1446" height="410" alt="image_from_clipboard (3)" src="https://github.com/user-attachments/assets/e7d206a4-ea8d-4496-9716-73bafe38c321" />

<img width="1402" height="524" alt="image_from_clipboard (4)" src="https://github.com/user-attachments/assets/a37130a6-89ed-4c24-bd7e-fd8057f7203d" />

<img width="1504" height="290" alt="image_from_clipboard (2)" src="https://github.com/user-attachments/assets/f0b06043-c7ae-46e9-82aa-02568cfa48ac" />

## Why are these changes being made?
Design feedback (1lCoIdZNpLPE9DjukYz9vUbAiqYsqeRHALTQ8xiaeosk-gdoc)

## Testing Instructions
Verify that the the feedback above have been implemented.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?