### PR TITLE
MSD: Fix the breadcrumb on both Database and Transfer site page

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -733,9 +733,6 @@ export const siteSettingsDatabaseRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'database',
-	loader: ( { params: { siteSlug } } ) => {
-		queryClient.prefetchQuery( siteBySlugQuery( siteSlug ) );
-	},
 } ).lazy( () =>
 	import( '../../sites/settings-database' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-database' )( {
@@ -942,9 +939,6 @@ export const siteSettingsTransferSiteRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'transfer-site',
-	loader: ( { params: { siteSlug } } ) => {
-		queryClient.prefetchQuery( siteBySlugQuery( siteSlug ) );
-	},
 } ).lazy( () =>
 	import( '../../sites/settings-transfer-site' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-transfer-site' )( {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -733,6 +733,9 @@ export const siteSettingsDatabaseRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'database',
+	loader: ( { params: { siteSlug } } ) => {
+		queryClient.prefetchQuery( siteBySlugQuery( siteSlug ) );
+	},
 } ).lazy( () =>
 	import( '../../sites/settings-database' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-database' )( {
@@ -939,6 +942,9 @@ export const siteSettingsTransferSiteRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'transfer-site',
+	loader: ( { params: { siteSlug } } ) => {
+		queryClient.prefetchQuery( siteBySlugQuery( siteSlug ) );
+	},
 } ).lazy( () =>
 	import( '../../sites/settings-transfer-site' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-transfer-site' )( {

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -77,8 +77,8 @@ const phpRoute = createRoute( {
 );
 
 const databaseRoute = createRoute( {
+	...appRouterSites.siteSettingsDatabaseRoute.options,
 	getParentRoute: () => settingsRoute,
-	path: 'database', // Bypass type issue by hard-coding the path instead of reusing the route.
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-database' ).then( ( d ) =>
 		createLazyRoute( 'database' )( {
@@ -165,8 +165,8 @@ const sftpSshRoute = createRoute( {
 );
 
 const transferSiteRoute = createRoute( {
+	...appRouterSites.siteSettingsTransferSiteRoute.options,
 	getParentRoute: () => settingsRoute,
-	path: 'transfer-site', // Bypass type issue by hard-coding the path instead of reusing the route.
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-transfer-site' ).then( ( d ) =>
 		createLazyRoute( 'transfer-site' )( {

--- a/client/sites/v2/site-settings/router.tsx
+++ b/client/sites/v2/site-settings/router.tsx
@@ -77,7 +77,8 @@ const phpRoute = createRoute( {
 );
 
 const databaseRoute = createRoute( {
-	...appRouterSites.siteSettingsDatabaseRoute.options,
+	// Bypass type issue by omitting the loader.
+	...Object.assign( appRouterSites.siteSettingsDatabaseRoute.options, { loader: undefined } ),
 	getParentRoute: () => settingsRoute,
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-database' ).then( ( d ) =>
@@ -165,7 +166,8 @@ const sftpSshRoute = createRoute( {
 );
 
 const transferSiteRoute = createRoute( {
-	...appRouterSites.siteSettingsTransferSiteRoute.options,
+	// Bypass type issue by omitting the loader.
+	...Object.assign( appRouterSites.siteSettingsTransferSiteRoute.options, { loader: undefined } ),
 	getParentRoute: () => settingsRoute,
 } ).lazy( () =>
 	import( 'calypso/dashboard/sites/settings-transfer-site' ).then( ( d ) =>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-915

## Proposed Changes

* Reuse the route to generate the correct breadcrumb. We originally avoided this due to a type issue, but it looks like adding a loader resolves the problem.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The navigation is important to user

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites/:site/settings`
* Select Database
* Click `Settings` on breadcrumb.
* Ensure it goes back to the Settings page
* Select Transfer site
* Click `Settings` on breadcrumb.
* Ensure it goes back to the Settings page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
