### PR TITLE
Plugins redesign: More redesign styling tweaks for the list view

### DIFF
--- a/client/components/full-width-section/style.scss
+++ b/client/components/full-width-section/style.scss
@@ -2,11 +2,6 @@
 	padding-top: 24px;
 	padding-bottom: 24px;
 
-	@media screen and ( max-width: 601px ) {
-		padding-top: 12px;
-		padding-bottom: 12px;
-	}
-
 	.full-width-section__content {
 		margin-inline: auto;
 	}
@@ -22,5 +17,15 @@
 
 	&.full-width-section--gray {
 		background-color: var(--studio-gray-0);
+	}
+
+	@media screen and ( max-width: 600px ) {
+		padding-top: 12px;
+		padding-bottom: 12px;
+
+		&.full-width-section--double-padding {
+			padding-top: 24px;
+			padding-bottom: 24px;
+		}
 	}
 }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -433,13 +433,17 @@ export default withCurrentRoute(
 			config.isEnabled( 'themes/universal-header' ) &&
 			[ 'themes', 'theme' ].includes( sectionName );
 
+		const isLoggedIn = isUserLoggedIn( state );
+
 		const isEnabledPluginsUniversalHeader =
 			config.isEnabled( 'plugins/universal-header' ) &&
 			[ 'plugins' ].includes( sectionName ) &&
 			! (
 				currentRoute.startsWith( '/plugins/manage' ) ||
 				currentRoute.startsWith( '/plugins/scheduled-updates' )
-			);
+			) &&
+			// When marketplace-redesign is enabled, only show universal header for logged out users.
+			( ! config.isEnabled( 'marketplace-redesign' ) || ! isLoggedIn );
 
 		const hasUniversalHeader =
 			hostingDashboardOptIn &&
@@ -458,7 +462,7 @@ export default withCurrentRoute(
 			isBlazePro,
 			oauth2Client,
 			wccomFrom,
-			isLoggedIn: isUserLoggedIn( state ),
+			isLoggedIn,
 			isSupportSession: isSupportSession( state ),
 			sectionGroup,
 			sectionName,

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -30,13 +30,25 @@ export type Plugin = {
 	icon: string;
 };
 
-const Categories = ( { selected, noSelection }: { selected?: string; noSelection?: boolean } ) => {
+const Categories = ( {
+	selected,
+	noSelection,
+	categories: allowedCategories = ALLOWED_CATEGORIES,
+	forceSwipe,
+	swipeEnabled,
+}: {
+	selected?: string;
+	noSelection?: boolean;
+	categories?: string[];
+	forceSwipe?: boolean;
+	swipeEnabled?: boolean;
+} ) => {
 	const dispatch = useDispatch();
 	const getCategoryUrl = useGetCategoryUrl();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	// We hide these special categories from the category selector
-	const displayCategories = ALLOWED_CATEGORIES.filter(
+	const displayCategories = allowedCategories.filter(
 		( v ) => [ 'paid', 'popular', 'featured' ].indexOf( v ) < 0
 	);
 
@@ -65,8 +77,8 @@ const Categories = ( { selected, noSelection }: { selected?: string; noSelection
 			initialActiveIndex={ activeIndex }
 			onClick={ onClick }
 			hrefList={ categoryUrls }
-			forceSwipe={ isLoggedIn ? false : 'undefined' === typeof window }
-			swipeEnabled={ ! isLoggedIn }
+			forceSwipe={ 'undefined' === typeof window || ( forceSwipe ?? false ) }
+			swipeEnabled={ swipeEnabled ?? ! isLoggedIn }
 		>
 			{ categories.map( ( category ) => (
 				<span key={ `category-${ category.slug }` } title={ category.menu }>

--- a/client/my-sites/plugins/categories/style.scss
+++ b/client/my-sites/plugins/categories/style.scss
@@ -2,9 +2,7 @@
 	.components-popover {
 		z-index: z-index("root", ".categories__menu .components-popover");
 	}
-	.full-width-section & .components-toolbar {
-		column-gap: 10px;
-	}
+
 	&.is-logged-in {
 		.components-toolbar .components-button::before {
 			height: 38px;

--- a/client/my-sites/plugins/categories/style.scss
+++ b/client/my-sites/plugins/categories/style.scss
@@ -14,5 +14,6 @@
 	span {
 		display: flex;
 		column-gap: 4px;
+		line-height: 22px;
 	}
 }

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -92,7 +92,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 			? __( 'Must-have plugins' )
 			: __( 'Must-have premium plugins' ),
 		description: isEnabled( 'marketplace-redesign' )
-			? __( 'Add the best-loved plugins on WordPress.com.' )
+			? __( 'Add the most popular plugins on WordPress.com.' )
 			: __( 'Take your site further with these premium plugins.' ),
 		slug: 'paid',
 		tags: [],
@@ -110,9 +110,11 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	featured: {
 		menu: __( 'Developer favorites' ),
-		title: __( 'Our developers’ favorites' ),
+		title: isEnabled( 'marketplace-redesign' )
+			? __( 'Our favorites' )
+			: __( 'Our developers’ favorites' ),
 		description: isEnabled( 'marketplace-redesign' )
-			? __( 'WordPress.com developer favorites. Start faster with our team`s picks.' )
+			? __( "Start faster with the WordPress.com team's picks." )
 			: __( 'Start fast with these WordPress.com team picks.' ),
 		slug: 'featured',
 		tags: [],
@@ -576,10 +578,12 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	business: {
 		menu: _x( 'Business', 'category name' ),
-		title: __( 'Setting up your local business' ),
+		title: isEnabled( 'marketplace-redesign' )
+			? __( 'Set up your business' )
+			: __( 'Setting up your local business' ),
 		slug: 'business',
 		description: isEnabled( 'marketplace-redesign' )
-			? __( 'Find the perfect plugin to build and grow your local business.' )
+			? __( 'Find the perfect plugin to build and grow.' )
 			: __( 'These plugins are here to keep your business on track.' ),
 		tags: [ 'google', 'testimonials', 'crm', 'business-directory' ],
 		preview: [

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -25,6 +25,26 @@ const ThreeColumnContainer = styled.div`
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
+
+	.full-width-section & {
+		flex-wrap: nowrap;
+		overflow: auto;
+		scrollbar-width: none;
+		gap: 16px;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
+
+		.feature-item-container {
+			min-width: 310px;
+		}
+
+		@media ( max-width: 660px ) {
+			scroll-padding: 0 32px;
+			margin: 0 -16px;
+		}
+	}
 `;
 
 const EducationFooterContainer = styled.div`
@@ -194,9 +214,13 @@ export const MarketplaceFooter = () => {
 							/>
 						}
 					>
-						{ __(
-							'Premium plugins are fully managed by the team at WordPress.com. No security patches. No update nags. It just works.'
-						) }
+						{ isEnabled( 'marketplace-redesign' )
+							? __(
+									'Plugins authored by WordPress.com are fully managed by our team. No security patches. No update nags. It just works.'
+							  )
+							: __(
+									'Premium plugins are fully managed by the team at WordPress.com. No security patches. No update nags. It just works.'
+							  ) }
 					</FeatureItem>
 					<FeatureItem
 						header={
@@ -218,9 +242,13 @@ export const MarketplaceFooter = () => {
 							/>
 						}
 					>
-						{ __(
-							'Pay yearly and save. Or keep it flexible with monthly premium plugin pricing. It’s entirely up to you.'
-						) }
+						{ isEnabled( 'marketplace-redesign' )
+							? __(
+									'Pay yearly and save. Or keep it flexible with monthly plugin pricing. It’s entirely up to you.'
+							  )
+							: __(
+									'Pay yearly and save. Or keep it flexible with monthly premium plugin pricing. It’s entirely up to you.'
+							  ) }
 					</FeatureItem>
 				</ThreeColumnContainer>
 			</Section>

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -170,6 +170,9 @@
 
 .plugins-browser-item__info {
 	overflow: hidden; // lazy clearfix
+	.full-width-section & {
+		flex: 1;
+	}
 }
 
 .plugins-browser-item__link {
@@ -194,6 +197,10 @@
 		&:focus,
 		&:hover {
 			border-color: var(--studio-blue-50);
+		}
+
+		.plugins-browser-item__author {
+			font-size: $font-body-extra-small;
 		}
 	}
 	.full-width-section .extended & {
@@ -276,8 +283,18 @@
 .plugins-browser-item__installed {
 	font-size: $font-body-small;
 	font-weight: 500;
-	line-height: 20px;
+	line-height: 1.42;
 	color: var(--studio-gray-80);
+
+	.full-width-section & {
+		&, & > * {
+			font-size: $font-body-extra-small;
+			font-weight: 500;
+		}
+		.gridicon {
+			margin-top: 1px;
+		}
+	}
 }
 
 .plugins-browser-item__active {
@@ -335,6 +352,7 @@
 	margin-bottom: auto;
 	display: flex;
 	justify-content: space-between;
+	align-items: center;
 }
 
 .plugins-browser-item__period,

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -41,15 +41,6 @@ import SearchCategories from '../search-categories';
 import './style.scss';
 
 const MASTERBAR_HEIGHT = 32;
-const CATEGORIES = [
-	'discover',
-	'design',
-	'marketing',
-	'ecommerce',
-	'photo',
-	'security',
-	'analytics',
-];
 
 // If adding new, longer search terms, ensure that the search input field is wide enough to accommodate it.
 const searchTerms = [ 'woocommerce', 'seo', 'file manager', 'jetpack', 'ecommerce', 'form' ];
@@ -240,15 +231,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 						</FullWidthSection>
 						<FullWidthSection className="plugins-browser__categories">
 							<div ref={ categoriesRef }>
-								<Categories
-									selected={ category }
-									noSelection={ !! search }
-									{ ...( isMarketplaceRedesignEnabled && {
-										categories: CATEGORIES,
-										forceSwipe: true,
-										swipeEnabled: false,
-									} ) }
-								/>
+								<Categories selected={ category } noSelection={ !! search } />
 							</div>
 						</FullWidthSection>
 					</>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -41,6 +41,15 @@ import SearchCategories from '../search-categories';
 import './style.scss';
 
 const MASTERBAR_HEIGHT = 32;
+const CATEGORIES = [
+	'discover',
+	'design',
+	'marketing',
+	'ecommerce',
+	'photo',
+	'security',
+	'analytics',
+];
 
 // If adding new, longer search terms, ensure that the search input field is wide enough to accommodate it.
 const searchTerms = [ 'woocommerce', 'seo', 'file manager', 'jetpack', 'ecommerce', 'form' ];
@@ -231,7 +240,15 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 						</FullWidthSection>
 						<FullWidthSection className="plugins-browser__categories">
 							<div ref={ categoriesRef }>
-								<Categories selected={ category } noSelection={ search ? true : false } />
+								<Categories
+									selected={ category }
+									noSelection={ !! search }
+									{ ...( isMarketplaceRedesignEnabled && {
+										categories: CATEGORIES,
+										forceSwipe: true,
+										swipeEnabled: false,
+									} ) }
+								/>
 							</div>
 						</FullWidthSection>
 					</>

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -276,7 +276,7 @@ body .is-section-plugins:has(.plugins-browser.is-full-width-layout) {
 		.x-nav-item, .x-dropdown-link, .x-menu-link {
 			color: var(--studio-gray-100);
 		}
-		.x-dropdown-link{
+		.x-dropdown-link {
 			&:hover, &:active, &:focus {
 				color: var(--studio-gray-100);
 				background-color: var(--studio-gray-0);

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -107,24 +107,30 @@ body.is-section-plugins #primary .main.is-logged-out {
 
 		}
 	}
-	.full-width-section .components-button {
-		height: 44px;
-		border-radius: 4px;
-		padding: 16px;
-
-		&:not([class*="is-pressed"]) {
-			color: var(--studio-gray-100);
+	.full-width-section {
+		.responsive-toolbar-group__swipe-list > div:not(:first-child) {
+			flex-grow: 1;
 		}
-
-		&::before {
+		.components-button {
 			height: 44px;
-			background-color: var( --studio-gray-0 );
-		}
+			border-radius: 4px;
+			padding: 16px;
+			width: 100%;
 
-		&:not([class*="is-pressed"]):hover::before {
-			background-color: var( --studio-gray-5 );
-		}
+			&:not([class*="is-pressed"]) {
+				color: var(--studio-gray-100);
+			}
 
+			&::before {
+				height: 44px;
+				background-color: var( --studio-gray-0 );
+			}
+
+			&:not([class*="is-pressed"]):hover::before {
+				background-color: var( --studio-gray-5 );
+			}
+
+		}
 	}
 
 	.components-button.is-pressed::before {
@@ -158,6 +164,7 @@ body.is-section-plugins #primary .main.is-logged-out {
 		justify-content: space-between;
 		align-items: flex-end;
 		max-width: none;
+		padding-inline: 0;
 
 		.section-header-container__header {
 			max-width: 575px;

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -153,6 +153,7 @@ body.is-section-plugins #primary .main.is-logged-out {
 .full-width-section {
 	.plugins-results-header__action {
 		font-size: $font-body-small;
+		text-decoration: none;
 	}
 }
 .plugins-browser__marketplace-footer {
@@ -238,7 +239,13 @@ body.is-section-plugins #primary .main.is-logged-out {
 .plugins-browser__marketplace-footer {
 	background-color: var(--studio-white);
 }
+.plugins-discovery-page__education-footer {
+	padding-bottom: 72px;
 
+	@media screen and ( max-width: 600px ) {
+		padding-bottom: 48px;
+	}
+}
 body .is-section-plugins:has(.plugins-browser.is-full-width-layout) {
 	.plugins-browser__content-wrapper {
 		background-color: var(--studio-white);

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -193,6 +193,14 @@ body.is-section-plugins #primary .main.is-logged-out {
 	position: relative;
 	overflow: hidden;
 
+	.is-section-plugins:not(:has(.lpc-header-nav-wrapper)) & {
+		padding-top: 165px;
+
+		@media screen and ( max-width: 600px ) {
+			padding-top: 93px;
+		}
+	}
+
 	&::before {
 		content: "";
 		position: absolute;
@@ -252,15 +260,31 @@ body .is-section-plugins:has(.plugins-browser.is-full-width-layout) {
 	}
 
 	.full-width-section__content {
-		max-width: 1040px;
+		max-width: 1220px;
 		padding-inline: 24px;
 		@media screen and ( max-width: 600px ) {
 			padding-inline: 16px;
 		}
 	}
-	.lpc-header-nav-wrapper .masterbar {
-		background: var(--studio-gray-0);
-		border-bottom: 1px solid var(--studio-gray-0);
+	.lpc-header-nav-container {
+
+		.masterbar {
+			background: var(--studio-gray-0);
+			border-bottom: 1px solid var(--studio-gray-0);
+		}
+
+		.x-nav-item, .x-dropdown-link, .x-menu-link {
+			color: var(--studio-gray-100);
+		}
+		.x-dropdown-link{
+			&:hover, &:active, &:focus {
+				color: var(--studio-gray-100);
+				background-color: var(--studio-gray-0);
+			}
+		}
+		.x-nav-link__logo {
+			--studio-blue-50: var(--studio-gray-100);
+		}
 	}
 }
 
@@ -268,6 +292,10 @@ body .is-section-plugins:has(.plugins-browser.is-full-width-layout) {
 body .is-section-plugins:has(.plugins-browser.is-full-width-layout.is-logged-out) {
 	.layout__content {
 		padding: 0;
+	}
+	.lpc-footer-nav-wrapper,
+	.lpc-footer-automattic-nav-wrapper {
+		max-width: 1220px;
 	}
 }
 

--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -40,6 +40,9 @@
 				line-height: 1.4;
 			}
 		}
+		.plugins-browser__category-results & {
+			margin-bottom: 32px;
+		}
 	}
 
 	.plugins-results-header__actions {
@@ -60,11 +63,9 @@
 				margin-left: 2px;
 			}
 			.full-width-section & {
-				font-size: $font-body-small;
+				font-size: $font-body;
+				text-decoration: none;
 			}
 		}
 	}
-}
-.plugins-results-header__action {
-	text-decoration: none;
 }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -516,14 +516,14 @@ const UniversalNavbarHeader = ( {
 												titleValue=""
 												content={ __( 'WordPress for Agencies', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/for-agencies/' ) }
-												type="dropdown"
+												type="menu"
 												target="_self"
 											/>
 											<ClickableItem
 												titleValue=""
 												content={ __( 'Become an Affiliate', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/affiliates/' ) }
-												type="dropdown"
+												type="menu"
 												target="_self"
 											/>
 											<ClickableItem
@@ -594,7 +594,7 @@ const UniversalNavbarHeader = ( {
 												titleValue=""
 												content={ __( 'WordPress Studio', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//developer.wordpress.com/studio/' ) }
-												type="dropdown"
+												type="menu"
 												target="_self"
 											/>
 											<ClickableItem


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDEV-259](https://linear.app/a8c/issue/DOTDEV-259/implement-the-design-changes-to-the-plugins-list-pages) [DOTDEV-257](https://linear.app/a8c/issue/DOTDEV-257/open-plugins-lp-in-chrome-less-full-screen-view-when-accessed-from-hd)

## Proposed Changes

* hides the universal header for logged in users and adjust the colors
* adjusts the category component to be able to restrict the shown categories
* use the latest copy
* minor adjustments to the plugin items styling and layout width

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* the changes are needed to match the new design of the plugins section

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins` (with and without the `?flags=marketplace-redesign` param)
* Ensure that the content is unchanged without the flag.
* Go to `/plugins/{SITE_DI}` (with and without the `?flags=marketplace-redesign` param)
* Ensure that the content is unchanged without the flag.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
