### PR TITLE
MSD Plugins: Plugin Sites list behaves like main Sites list

### DIFF
--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -8,11 +8,19 @@ import {
 	sitePluginUpdateMutation,
 } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
-import { __experimentalText as Text, Button, Icon } from '@wordpress/components';
+import {
+	__experimentalText as Text,
+	Button,
+	Icon,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { DataViews, filterSortAndPaginate, View, type Field } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { link, linkOff, trash } from '@wordpress/icons';
 import { useCallback, useMemo, useState } from 'react';
+import { Name, URL, SiteIconLink, SiteLink } from '../../sites/site-fields';
+import { getSiteDisplayName } from '../../utils/site-name';
 import { getSiteDisplayUrl } from '../../utils/site-url';
 import ActionRenderModal, { getModalHeader } from '../manage/components/action-render-modal';
 import { PluginsHeaderActions } from '../manage/components/plugins-header-actions';
@@ -65,8 +73,18 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 				id: 'domain',
 				label: __( 'Site' ),
 				type: 'text',
-				getValue: ( { item }: { item: SiteWithPluginData } ) => getSiteDisplayUrl( item ),
-				render: ( { field, item } ) => field.getValue( { item } ),
+				getValue: ( { item }: { item: SiteWithPluginData } ) => getSiteDisplayName( item ),
+				render: ( { field, item } ) => (
+					<HStack spacing={ 3 } alignment="center" justify="flex-start">
+						<SiteIconLink site={ item } />
+						<VStack spacing={ 0 } alignment="flex-start">
+							<SiteLink site={ item }>
+								<Name site={ item } value={ field.getValue( { item } ) } />
+							</SiteLink>
+							<URL site={ item } value={ getSiteDisplayUrl( item ) } />
+						</VStack>
+					</HStack>
+				),
 				enableHiding: false,
 				enableSorting: true,
 				enableGlobalSearch: true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTMSD-857/in-domains-and-sites-we-show-the-site-icon-but-not-in-plugins
- https://linear.app/a8c/issue/DOTMSD-863/enable-direct-site-navigation-links-from-the-plugin-overview

## Proposed Changes

* Updated the sites with plugin DataView so that we include the site icon.
* We also include the Site Name and URL.
* The field now behaves exactly how the name field of the Sites DataView behaves.

| Before | After |
|--------|--------|
|<img width="1516" height="1287" alt="Screenshot 2025-12-02 at 13 12 36" src="https://github.com/user-attachments/assets/f2abaef7-604b-4bf2-94b8-1c9fa164105c" />|<img width="1518" height="1286" alt="Screenshot 2025-12-02 at 13 12 47" src="https://github.com/user-attachments/assets/bc0ca61a-f77c-4bdc-8a3e-19f21748781a" />| 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our MSD effort.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on the Calypso Live link
* Navigate to `/v2/plugins`
* Click on plugin row
* You will navigate to the sites with plugin DataView.
* You should see the changes explained on the proposed changes section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
