### PR TITLE
A4A: Add Partner survey upcoming event in the Overview page.

### DIFF
--- a/client/a8c-for-agencies/components/upcoming-event/index.tsx
+++ b/client/a8c-for-agencies/components/upcoming-event/index.tsx
@@ -14,6 +14,7 @@ const UpcomingEvent = ( {
 	descriptions,
 	cta,
 	logoUrl,
+	logoElement,
 	imageUrl,
 	trackEventName,
 	dateClassName,
@@ -67,7 +68,7 @@ const UpcomingEvent = ( {
 			<div className="a4a-event__content">
 				<div className="a4a-event__header">
 					<div className="a4a-event__logo">
-						<img src={ logoUrl } alt={ title } />
+						{ logoElement ?? <img src={ logoUrl } alt={ title } /> }
 					</div>
 					<div className="a4a-event__date-and-title">
 						<div className={ clsx( 'a4a-event__date', dateClassName ) }>

--- a/client/a8c-for-agencies/components/upcoming-event/types.ts
+++ b/client/a8c-for-agencies/components/upcoming-event/types.ts
@@ -8,7 +8,8 @@ export type UpcomingEventProps = {
 	title: string;
 	subtitle: string;
 	descriptions: TranslateResult[];
-	logoUrl: string;
+	logoUrl?: string;
+	logoElement?: React.ReactNode;
 	imageUrl?: string;
 	trackEventName: string;
 	dateClassName?: string;

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -3,8 +3,6 @@ import moment from 'moment';
 import { useMemo } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import { UpcomingEventProps } from 'calypso/a8c-for-agencies/components/upcoming-event/types';
-import avalaraLogo from 'calypso/assets/images/a8c-for-agencies/events/avalara-logo.svg';
-import pressableLogo from 'calypso/assets/images/a8c-for-agencies/events/pressable-logo.svg';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 export const useUpcomingEvents = () => {
@@ -29,57 +27,10 @@ export const useUpcomingEvents = () => {
 				],
 				cta: {
 					label: translate( 'Take the survey now! ↗' ),
-					url: 'https://a4aprogramming.wordpress.com/2025/11/14/2025-automattic-for-agencies-satisfaction-survey/',
+					url: 'https://usabi.li/do/b8fc6strv3hm/tnzgph',
 				},
 				logoElement: <A4ALogo size={ 64 } />,
 				trackEventName: 'calypso_a4a_overview_events_a4a_partner_survey_2025_12_03_click',
-				dateClassName: 'a4a-event__date--neutral',
-			},
-			{
-				id: 'pressable-webinar-2025-11-06',
-				date: {
-					from: moment( '2025-11-06' ),
-					to: moment( '2025-11-06' ),
-				},
-				displayDate: translate( 'Thursday, November 6, 9:00-10:00 AM PT (4:00-5:00 PM UTC)' ),
-				title: translate( 'The Pressable advantage for Automattic for Agencies partners' ),
-				subtitle: translate( 'Automattic for Agencies and Pressable' ),
-				descriptions: [
-					translate(
-						"Ready to scale your agency without stretching your team thin? Join us for an exclusive live session where we'll reveal how top-performing agencies are using Pressable and Automattic for Agencies to drive faster client growth, increase recurring revenue, and hit year-end goals effortlessly."
-					),
-				],
-				cta: {
-					label: translate( 'Reserve your spot ↗' ),
-					url: 'https://us06web.zoom.us/webinar/register/WN_fUSevVhfRDOP-j7f-L-V2g',
-				},
-				logoUrl: pressableLogo,
-				trackEventName: 'calypso_a4a_overview_events_pressable_webinar_2025_11_06_click',
-				dateClassName: 'a4a-event__date--neutral',
-			},
-			{
-				id: 'avalara-webinar-2025-11-12',
-				date: {
-					from: moment( '2025-11-12' ),
-					to: moment( '2025-11-12' ),
-				},
-				displayDate: translate( 'Wednesday, November 12, 9:00-10:00 AM PT (4:00-5:00 PM UTC)' ),
-				title: translate(
-					'Global Trade & Tariff Shifts: Empowering Agencies to Navigate Compliance for WooCommerce Merchants'
-				),
-				subtitle: translate( 'Automattic for Agencies and our trusted partner, Avalara' ),
-				descriptions: [
-					translate(
-						'Is your agency ready to guide WooCommerce merchants through the evolving maze of international trade taxes and tariffs? Recent regulatory shifts are creating compliance headaches for global ecommerce sellers. Without expert insights, your clients risk costly fines, delays, and lost revenue.'
-					),
-					translate( 'Join our exclusive webinar to gain a competitive edge.' ),
-				],
-				cta: {
-					label: translate( 'Register for the webinar ↗' ),
-					url: 'https://event.on24.com/wcc/r/5101931/BB47ACD15628777E39129D43586D1C96',
-				},
-				logoUrl: avalaraLogo,
-				trackEventName: 'calso_a4a_overview_events_avalara_webinar_2025_11_12_click',
 				dateClassName: 'a4a-event__date--neutral',
 			},
 		];

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -22,7 +22,7 @@ export const useUpcomingEvents = () => {
 				subtitle: translate( 'Automattic for Agencies' ),
 				descriptions: [
 					translate(
-						"We invite you to share your input in our short Automattic for Agencies Partner Survey. Your feedback will help us better understand your experience with Automattic for Agencies and the products you use across our ecosystem. The survey is anonymous, and your insights will guide how we shape next year's incentives, tools, and product improvements to create more value for your agency and clients."
+						'We invite you to share your input in our short Automattic for Agencies Partner Survey. Your feedback will help us better understand your experience with Automattic for Agencies and the products you use across our ecosystem. The survey is anonymous, and your insights will guide how we shape next year’s incentives, tools, and product improvements to create more value for your agency and clients.'
 					),
 				],
 				cta: {

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useMemo } from 'react';
+import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import { UpcomingEventProps } from 'calypso/a8c-for-agencies/components/upcoming-event/types';
 import avalaraLogo from 'calypso/assets/images/a8c-for-agencies/events/avalara-logo.svg';
 import pressableLogo from 'calypso/assets/images/a8c-for-agencies/events/pressable-logo.svg';
@@ -12,6 +13,28 @@ export const useUpcomingEvents = () => {
 
 	return useMemo( () => {
 		const eventsData: UpcomingEventProps[] = [
+			{
+				id: 'a4a-partner-survey-2025-12-03',
+				date: {
+					from: moment( '2026-01-01' ),
+					to: moment( '2026-01-01' ),
+				},
+				displayDate: translate( 'Open until January 1, 2026' ),
+				title: translate( 'Automattic for Agencies Partner Survey' ),
+				subtitle: translate( 'Automattic for Agencies' ),
+				descriptions: [
+					translate(
+						"We invite you to share your input in our short Automattic for Agencies Partner Survey. Your feedback will help us better understand your experience with Automattic for Agencies and the products you use across our ecosystem. The survey is anonymous, and your insights will guide how we shape next year's incentives, tools, and product improvements to create more value for your agency and clients."
+					),
+				],
+				cta: {
+					label: translate( 'Take the survey now! ↗' ),
+					url: 'https://a4aprogramming.wordpress.com/2025/11/14/2025-automattic-for-agencies-satisfaction-survey/',
+				},
+				logoElement: <A4ALogo size={ 64 } />,
+				trackEventName: 'calypso_a4a_overview_events_a4a_partner_survey_2025_12_03_click',
+				dateClassName: 'a4a-event__date--neutral',
+			},
 			{
 				id: 'pressable-webinar-2025-11-06',
 				date: {


### PR DESCRIPTION
<img width="1080" height="365" alt="Screenshot 2025-12-02 at 9 06 41 PM" src="https://github.com/user-attachments/assets/ddcd6046-35a2-49c9-831d-8f0f552a576f" />

Closes https://linear.app/a8c/issue/A4AD-84/a4a-design-request-a4a-engagement-survey-in-portal#comment-f1276a0a

## Proposed Changes

* Add the A4A Partner survey upcoming event in the Overview page.

## Why are these changes being made?


*

## Testing Instructions

* Use the A4A live link and navigate to the `/overview` page.
* Confirm you see the new survey.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
