### PR TITLE
Setup/domain flow: Improve domain connection post-checkout redirect

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -93,7 +93,21 @@ const domain: FlowV2< typeof initialize > = {
 		const defaultRedirect = `/v2/sites/${ siteSlug }/domains`;
 
 		const goToCheckout = ( siteSlug: string ) => {
-			const destination = `/v2/sites/${ siteSlug }/domains`;
+			// Check if cart contains only one domain product and it's a domain connection
+			// Domain connections require a paid plan. When purchased with a plan, after checkout
+			// completes, we redirect to the domain connection setup page instead of the generic
+			// domains page to guide users through the connection process.
+			const hasOnlyDomainConnection =
+				domainCartItems && domainCartItems.length === 1 && isDomainMapping( domainCartItems[ 0 ] );
+
+			let destination = `/v2/sites/${ siteSlug }/domains`;
+
+			if ( hasOnlyDomainConnection ) {
+				const domain = domainCartItems[ 0 ].meta;
+				if ( domain ) {
+					destination = `/v2/domains/${ domain }/domain-connection-setup`;
+				}
+			}
 
 			// replace the location to delete processing step from history.
 			return window.location.replace(


### PR DESCRIPTION
Closes [DOMAINS-1859](https://linear.app/a8c/issue/DOMAINS-1859/when-connecting-a-domain-to-a-free-site-we-dont-get-the-setup-flow)

## Proposed Changes
 * **Enhanced domain connection post-checkout flow**: After users complete checkout with a domain connection purchase (along with a paid plan), they are now automatically redirected to the domain connection setup page (`/v2/domains/{domain}/domain-connection-setup`) instead of the generic domains page.

* **Improved user experience**: Users purchasing domain connections are now guided directly to the setup process, reducing friction and making it clearer what the next steps are.

## Why are these changes being made?
Previously, when users purchased a domain connection along with a paid plan through the domain flow, they were redirected to the generic domains management page after checkout. This created a suboptimal experience because:

1. **Users had to navigate manually** to find the domain connection setup page
2. **The next step wasn't clear** - users might not realize they need to complete the connection setup
3. **Inconsistent with other flows** - domain connections added via API (when site already has a paid plan) redirect directly to setup

This change ensures that users who purchase domain connections are immediately guided to the setup process, creating a smoother, more intuitive flow that matches the behavior when domain connections are added via API for sites with existing paid plans.

The implementation detects when the cart contains only a domain connection product and adjusts the post-checkout redirect destination accordingly, while maintaining backward compatibility for all other domain purchase scenarios.

## Testing Instructions
### Test Case 1: Domain Connection Purchase with Plan
1. Navigate to `/setup/domain` with a site that doesn't have a paid plan
2. Select "Use my domain" and choose to connect an existing domain
3. Select a paid plan (required for domain connections)
4. Complete the checkout process
5. **Expected**: After checkout, you should be redirected to `/v2/domains/{domain}/domain-connection-setup` instead of `/v2/sites/{siteSlug}/domains`

### Test Case 2: Domain Connection with Existing Paid Plan
1. Navigate to `/setup/domain` with a site that already has a paid plan
2. Select "Use my domain" and choose to connect an existing domain
3. **Expected**: Domain should be added via API directly (not through checkout), and you should be redirected to the connection setup page (existing behavior, unchanged)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
