### PR TITLE
Domain Connection Verification: update "Expected Value" column font color

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -5,6 +5,7 @@ import {
 	DomainMappingStatus,
 } from '@automattic/api-core';
 import { Badge } from '@automattic/ui';
+import { __experimentalText as Text } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
@@ -79,7 +80,7 @@ const fields: Field< DnsRecordVerification >[] = [
 		enableHiding: false,
 		enableSorting: false,
 		filterBy: false,
-		render: ( { field, item } ) => field.getValue( { item } ) || '-',
+		render: ( { field, item } ) => <Text>{ field.getValue( { item } ) || '-' }</Text>,
 	},
 	{
 		id: 'status',


### PR DESCRIPTION
Closes [DOMAINS-1877](https://linear.app/a8c/issue/DOMAINS-1877/data-table-refinement)

## Proposed Changes
Update "Expected Value" column font-color in Domain Records table to match the design.

## Why are these changes being made?
Design feedback (1lCoIdZNpLPE9DjukYz9vUbAiqYsqeRHALTQ8xiaeosk-gdoc)

## Testing Instructions
Verify that the table uses the correct color (`gray-900`) in the "Expected Value" column

![Screenshot 2025-12-02 alle 15 28 38](https://github.com/user-attachments/assets/dc8f298b-11ea-43ff-b437-01528998173e)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?