### PR TITLE
A4A: Add monthly_product_id and yearly_product_id to be able to find Pressable plans

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-get-pressable-plan-by-product-id.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-get-pressable-plan-by-product-id.ts
@@ -12,6 +12,13 @@ export default function useGetPressablePlanByProductId( { product_id }: Props ) 
 	} );
 
 	return useMemo( () => {
-		return pressablePlans.find( ( plan ) => plan.product_id === product_id ) ?? null;
+		return (
+			pressablePlans.find(
+				( plan ) =>
+					plan.product_id === product_id ||
+					plan.monthly_product_id === product_id ||
+					plan.yearly_product_id === product_id
+			) ?? null
+		);
 	}, [ pressablePlans, product_id ] );
 }

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -106,6 +106,8 @@ export interface APIProductFamilyProduct {
 	name: string;
 	slug: string;
 	product_id: number;
+	monthly_product_id?: number;
+	yearly_product_id?: number;
 	alternative_product_id?: number;
 	currency: string;
 	amount: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of Linear: A4A-1817
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/3090

## Proposed Changes

- **Marketplace Section**

<img width="1371" height="446" alt="image" src="https://github.com/user-attachments/assets/ee683ba0-434f-4862-9f63-e5678a83cccc" />

- **Purchase Section**

<img width="806" height="391" alt="image" src="https://github.com/user-attachments/assets/bb3efa99-9433-493d-b464-db0c727d2728" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Apply this backend PR: 197262-ghe-Automattic/wpcom (follow the instructions there)
- You need a monthly Pressable license (BD).
- Go to the Marketplace section check the Pressable usage data
- Go to the Purchase section and open the Pressable license
- In trunk you won't see the Pressable usage data card.
- With this fix, you will see the Pressable usage data card.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?