### PR TITLE
Prevent scrolling in domain connection DataViews

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table-style.scss
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table-style.scss
@@ -1,4 +1,5 @@
 /* The Type and Name columns should be narrow */
-.dns-records-table .dataviews-view-table__cell-content-wrapper {
+.dns-records-table .dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper {
 	min-width: initial;
+	white-space: normal;
 }

--- a/client/dashboard/domains/domain-connection-setup/dns-records-dataview.tsx
+++ b/client/dashboard/domains/domain-connection-setup/dns-records-dataview.tsx
@@ -11,40 +11,18 @@ import { useMemo } from 'react';
 import { DataViewsCard } from '../../components/dataviews';
 import { matchCurrentToTargetValues } from './utils/match-records';
 
+import './components/dns-records-table-style.scss';
+
 const viewSuggested: ViewTable = {
 	type: 'table',
 	page: 1,
 	perPage: 10,
 	fields: [ 'currentValue', 'arrow', 'updateTo' ],
-	layout: {
-		styles: {
-			arrow: {
-				width: '30px',
-				maxWidth: '30px',
-			},
-		},
-	},
 };
 
 const viewAdvanced: ViewTable = {
 	...viewSuggested,
 	fields: [ 'type', 'name', 'currentValue', 'arrow', 'updateTo' ],
-	layout: {
-		styles: {
-			type: {
-				width: '50px',
-				maxWidth: '50px',
-			},
-			name: {
-				width: '50px',
-				maxWidth: '50px',
-			},
-			arrow: {
-				width: '30px',
-				maxWidth: '30px',
-			},
-		},
-	},
 };
 
 interface DNSRecord {
@@ -171,7 +149,7 @@ export default function DNSRecordsDataView( {
 	);
 
 	return (
-		<DataViewsCard>
+		<DataViewsCard className="dns-records-table">
 			<DataViews< DNSRecord >
 				data={ records }
 				fields={ fields }


### PR DESCRIPTION
Closes [DOMAINS-1864](https://linear.app/a8c/issue/DOMAINS-1864/use-word-break-on-domain-names-in-the-dataview)

## Proposed Changes
Restore normal white space behavior in the Domain Connection dataviews so long name server values wrap instead of forcing horizontal scrolling.

## Why are these changes being made?
Some domains include long name server strings. Wrapping them improves readability and avoids unnecessary horizontal scrolling.

![Screenshot 2025-12-02 alle 16 16 35](https://github.com/user-attachments/assets/300670ab-39c5-4d67-a89b-eb513c14dbc7)

![Screenshot 2025-12-02 alle 16 16 22](https://github.com/user-attachments/assets/b7a00581-f825-47bc-9913-f2465909f463)

## Testing Instructions
Open the Domain Connection setup page and the verification page. Add or view domains that use long name servers and confirm that the values wrap as expected and no horizontal scrolling appears.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
