### PR TITLE
Help center: better handling of classic admin

### DIFF
--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -100,6 +100,7 @@ $admin-background-color: #f1f1f1;
 		border-left: 1px solid $border-color;
 		border-bottom: 1px solid $border-color;
 		border-radius: 0 0 0 $main-border-radius;
+		overflow: scroll;
 	}
 
 	#wpcontent {
@@ -127,7 +128,7 @@ $admin-background-color: #f1f1f1;
 
 	#wpfooter {
 		margin-right: calc( $sidebar-width + 1px ) !important;
-		bottom: 15px;
+		bottom: 17px;
 		left: 18px;
 		background-color: $admin-background-color;
 		border-radius: 0 0 $main-border-radius 0;

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -68,14 +68,17 @@ $transition-timing: $transition-duration cubic-bezier( 0.4, 0, 0.2, 1 );
 
 // TODO: AI-679 will fix it...
 /* WP Admin */
-$admin-menu-width: 272px;
+$admin-menu-width-unified: 272px;
+$admin-menu-width-classic: 160px;
+$admin-menu-width-folded: 37px;
 $admin-content-top: calc( $admin-bar-height + $layout-spacing );
 $admin-content-height: calc( 100vh - $admin-bar-height - ( $layout-spacing * 2 ) );
 $border-color: #545454;
+$admin-background-color: #f1f1f1;
 
 // Mixin for wp-admin sidebar open styles
 // Used by both body-level and #wpwrap-level containers
-@mixin wp-admin-sidebar-open {
+@mixin wp-admin-sidebar-open-general() {
 	#wpadminbar {
 		position: fixed !important;
 		top: $layout-spacing;
@@ -95,39 +98,39 @@ $border-color: #545454;
 		bottom: $layout-spacing;
 		height: $admin-content-height !important;
 		border-left: 1px solid $border-color;
-		border-right: 1px solid $border-color;
 		border-bottom: 1px solid $border-color;
 		border-radius: 0 0 0 $main-border-radius;
 	}
 
 	#wpcontent {
-		margin-left: calc( $admin-menu-width + $layout-spacing ) !important;
 		margin-right: $sidebar-width !important;
 	}
 
 	#wpbody {
 		position: fixed !important;
 		top: $admin-content-top;
-		left: calc( $admin-menu-width + $layout-spacing );
 		right: $sidebar-width;
 		bottom: $layout-spacing;
-		width: calc( 100% - $admin-menu-width - $layout-spacing - $sidebar-width ) !important;
 		height: $admin-content-height !important;
 		max-height: $admin-content-height !important;
 		min-height: 0;
 		box-sizing: border-box;
 		padding-left: $layout-spacing;
-		border-radius: 0 0 $main-border-radius $main-border-radius;
+		border-radius: 0 0 $main-border-radius 0;
 		border: 1px solid $border-color;
 		border-top: none;
 		overflow-y: auto;
 		overflow-x: hidden;
-		background-color: $white;
+		background-color: $admin-background-color;
 		margin: 0 !important;
 	}
 
 	#wpfooter {
-		margin-right: $sidebar-width !important;
+		margin-right: calc( $sidebar-width + 1px ) !important;
+		bottom: 15px;
+		left: 18px;
+		background-color: $admin-background-color;
+		border-radius: 0 0 $main-border-radius 0;
 	}
 
 	.agents-manager-chat--docked {
@@ -142,19 +145,54 @@ $border-color: #545454;
 	}
 }
 
+@mixin wp-admin-sidebar-open-specific( $admin-menu-width ) {
+	#wpcontent {
+		margin-left: calc( $admin-menu-width + $layout-spacing ) !important;
+	}
+
+	#wpbody {
+		left: calc( $admin-menu-width + $layout-spacing );
+		width: calc( 100% - $admin-menu-width - $layout-spacing - $sidebar-width ) !important;
+	}
+}
+
 // When container is body (legacy behavior)
+body.wp-admin:has( #wpwrap.agents-manager-sidebar-container--sidebar-open ),
+body.is-nav-unification.wp-admin.agents-manager-sidebar-container--sidebar-open,
+body.folded.wp-admin.agents-manager-sidebar-container--sidebar-open,
 body.wp-admin.agents-manager-sidebar-container--sidebar-open {
 	background-color: $gray-900;
-	@include wp-admin-sidebar-open;
+	@include wp-admin-sidebar-open-general();
 }
 
-// When container is #wpwrap (used by big-sky-plugin)
-body.wp-admin:has( #wpwrap.agents-manager-sidebar-container--sidebar-open ) {
-	background-color: $gray-900;
+body.is-nav-unification.wp-admin.agents-manager-sidebar-container--sidebar-open {
+	@include wp-admin-sidebar-open-specific( $admin-menu-width-unified );
 }
 
-#wpwrap.agents-manager-sidebar-container--sidebar-open {
-	@include wp-admin-sidebar-open;
+body.folded.wp-admin.agents-manager-sidebar-container--sidebar-open {
+	@include wp-admin-sidebar-open-specific( $admin-menu-width-folded );
+}
+
+body.wp-admin.agents-manager-sidebar-container--sidebar-open {
+	@include wp-admin-sidebar-open-specific( $admin-menu-width-classic );
+}
+
+body.is-nav-unification #wpwrap.agents-manager-sidebar-container--sidebar-open {
+	@include wp-admin-sidebar-open-specific( $admin-menu-width-unified );
+}
+
+body #wpwrap.agents-manager-sidebar-container--sidebar-open {
+	@include wp-admin-sidebar-open-general();
+	@include wp-admin-sidebar-open-specific( $admin-menu-width-classic );
+}
+
+body.folded #wpwrap.agents-manager-sidebar-container--sidebar-open {
+	@include wp-admin-sidebar-open-general();
+	@include wp-admin-sidebar-open-specific( $admin-menu-width-folded );
+}
+
+#wp-admin-bar-top-secondary {
+	border-radius: $main-border-radius $main-border-radius 0 0 !important;
 }
 
 // TODO: This solution will impact other pages, we need to find a better way in AI-679...


### PR DESCRIPTION
Improves the help centre styling in various situations:
- Classic wp-admin
- Classic wp-admin (narrow)
- Default wp-admin
- Default wp-admin (narrow)

Fixes DOTCOM-15348

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Why are these changes being made?

There are some display issues in classic wp-admin, as well as narrow wp-admin (where the admin sidebar is shrunk). It also fixes a few minor CSS issues that affect all admins.

## Testing Instructions

* `cd apps/help-center`
* `npm dev --sync`
* Go to the Settings > General page of a sandboxed simple site and add `?flags=unified-agent` to the URL. Start in 'default style'
* Open the AI thing in sidebar mode. Confirm the page is wrapped properly
* Press the 'collapse menu' option and confirm the page is still wrapped properly
* Change the admin style to 'Classic style' and check both the collapsed and uncollapse styles

Things to look for:
- Background is WP grey
- Borders are curved in the right places

Note that the footer will stick to the bottom of the page in classic mode, but scroll in default mode. This is due to the position of the footer in the DOM, and seems an acceptable compromise.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
