### PR TITLE
Checkout: Fix date localization in the message that is shown when renewing a recently purchased subscription

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -26,6 +26,7 @@ import {
 	useFormStatus,
 	Theme,
 } from '@automattic/composite-checkout';
+import { useLocale } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -971,6 +972,7 @@ function getApproximateDifferenceInMonths( dateFrom: Date, dateTo: Date ): numbe
 }
 
 function LineItemExpiryDates( { product }: { product: ResponseCartProduct } ) {
+	const locale = useLocale();
 	const translate = useTranslate();
 
 	// We only currently show the expiry date for renewals when the current
@@ -990,10 +992,10 @@ function LineItemExpiryDates( { product }: { product: ResponseCartProduct } ) {
 	}
 
 	const expiryDate = product.subscription_current_expiry_date
-		? formatDate( product.subscription_current_expiry_date )
+		? formatDate( new Date( product.subscription_current_expiry_date ), locale )
 		: undefined;
 	const postRenewExpiry = product.subscription_post_purchase_expiry_date
-		? formatDate( product.subscription_post_purchase_expiry_date )
+		? formatDate( new Date( product.subscription_post_purchase_expiry_date ), locale )
 		: undefined;
 	return (
 		<>
@@ -1015,15 +1017,15 @@ function LineItemExpiryDates( { product }: { product: ResponseCartProduct } ) {
 	);
 }
 
-function formatDate( isoDate: string ): string {
-	// This somewhat mimics `moment.format('ll')` (used here formerly) without
-	// needing the deprecated `moment` package.
-	return new Date( Date.parse( isoDate ) ).toLocaleDateString( 'en-US', {
-		weekday: undefined,
-		month: 'short',
-		day: 'numeric',
-		year: 'numeric',
-	} );
+function formatDate(
+	date: Date,
+	locale: string,
+	formatOptions: Intl.DateTimeFormatOptions = { dateStyle: 'medium' }
+) {
+	if ( isNaN( date.getTime() ) ) {
+		return '';
+	}
+	return new Intl.DateTimeFormat( locale, formatOptions ).format( date );
 }
 
 function GetBillingIntervalLabel( { product }: { product: ResponseCartProduct } ) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-296/checkout-page-spanish-localization-issue

## Proposed Changes

When renewing a recently-purchased subscription, the dates in the message shown during checkout are formatted for English only, rather than for the user's selected locale.

This pull request fixes that by switching the code to use a copy of the `formatDate()` function from the Multi-Site Dashboard.  I didn't feel great about copying the code, but I'm not sure there's a better way?  (I assume code in the `packages` directory should not be pulling in and using code from the dashboard?)  In any case, it's a very short and simple function.

## Testing Instructions

For a subscription purchased recently, go to the purchase management page and click through to renew it.  Look for the message about the expiration date shown in checkout.  Then switch to a different language via https://wordpress.com/me/account and reload checkout again.

**English (same behavior both before and after this pull request):**

<img width="361" height="144" alt="english-before-and-after" src="https://github.com/user-attachments/assets/cf6abe09-74c9-42d4-a670-96a043deacc6" />

**Spanish (before this pull request):**

<img width="361" height="144" alt="spanish-before" src="https://github.com/user-attachments/assets/4f081391-567a-42fb-bf5e-b85055cf69b3" />

**Spanish (after this pull request):**

<img width="361" height="144" alt="spanish-after" src="https://github.com/user-attachments/assets/c1175486-ade5-4b16-94f3-8c9b4fa7b77c" />
