### PR TITLE
SSH Migration: Use the SSH stickers to display the progress

### DIFF
--- a/client/dashboard/sites/migration-overview/pending-content-info.tsx
+++ b/client/dashboard/sites/migration-overview/pending-content-info.tsx
@@ -50,7 +50,7 @@ const getContinueMigrationUrl = ( site: Site, sshSourceSiteDomain?: string ): st
 	}
 
 	if ( migrationState?.type === 'ssh' ) {
-		return addQueryArgs( '/setup/site-migration/site-migration-ssh-verification', {
+		return addQueryArgs( wpcomLink( '/setup/site-migration/site-migration-ssh-verification' ), {
 			...queryArgs,
 			from: sourceSiteDomain || undefined,
 		} );

--- a/client/dashboard/sites/migration-overview/pending-content-info.tsx
+++ b/client/dashboard/sites/migration-overview/pending-content-info.tsx
@@ -1,6 +1,7 @@
 import {
 	deleteSiteMigrationPendingStatusQuery,
 	siteMigrationKeyQuery,
+	sshMigrationQuery,
 } from '@automattic/api-queries';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
@@ -26,9 +27,9 @@ import { HostingCards } from './hosting-cards';
 import type { MigrationStatus } from '../../utils/site-status';
 import type { Site } from '@automattic/api-core';
 
-const getContinueMigrationUrl = ( site: Site ): string | null => {
+const getContinueMigrationUrl = ( site: Site, sshSourceSiteDomain?: string ): string | null => {
 	const migrationState = getSiteMigrationState( site );
-	const sourceSiteDomain = site.options?.migration_source_site_domain;
+	const sourceSiteDomain = sshSourceSiteDomain ?? site.options?.migration_source_site_domain;
 
 	const queryArgs = {
 		siteId: site.ID,
@@ -46,6 +47,13 @@ const getContinueMigrationUrl = ( site: Site ): string | null => {
 			wpcomLink( '/setup/site-migration/site-migration-instructions' ),
 			queryArgs
 		);
+	}
+
+	if ( migrationState?.type === 'ssh' ) {
+		return addQueryArgs( '/setup/site-migration/site-migration-ssh-verification', {
+			...queryArgs,
+			from: sourceSiteDomain || undefined,
+		} );
 	}
 
 	return addQueryArgs( wpcomLink( '/setup/site-migration/site-migration-credentials' ), queryArgs );
@@ -116,10 +124,14 @@ export function PendingContentInfo( {
 	const { recordTracksEvent } = useAnalytics();
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { data: migrationKey, isLoading } = useQuery( siteMigrationKeyQuery( site.ID ) );
+	const {
+		data: { migration_source_site_domain: sshSourceSiteDomain } = {},
+		isLoading: isSshSourceSiteDomainLoading,
+	} = useQuery( { ...sshMigrationQuery( site.ID ), enabled: type === 'ssh' } );
 	const [ isCancellationModalOpen, setIsCancellationModalOpen ] = useState( false );
-	const continueMigrationUrl = getContinueMigrationUrl( site );
+	const continueMigrationUrl = getContinueMigrationUrl( site, sshSourceSiteDomain );
 
-	if ( isLoading ) {
+	if ( isLoading || ( type === 'ssh' && isSshSourceSiteDomainLoading ) ) {
 		return null;
 	}
 

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -3,11 +3,11 @@ import type { Site } from '@automattic/api-core';
 
 export interface MigrationStatus {
 	status: 'pending' | 'started' | 'completed';
-	type: 'difm' | 'diy';
+	type: 'difm' | 'diy' | 'ssh';
 }
 
 const MIGRATION_STATUSES: MigrationStatus[ 'status' ][] = [ 'pending', 'started', 'completed' ];
-const MIGRATION_TYPES: MigrationStatus[ 'type' ][] = [ 'difm', 'diy' ];
+const MIGRATION_TYPES: MigrationStatus[ 'type' ][] = [ 'difm', 'diy', 'ssh' ];
 
 export function getStatusLabels() {
 	return {

--- a/client/data/site-migration/index.ts
+++ b/client/data/site-migration/index.ts
@@ -1,7 +1,7 @@
 import { SiteExcerptData } from '@automattic/sites';
 
 type MigrationStatus = 'pending' | 'started' | 'completed';
-type MigrationType = 'difm' | 'diy';
+type MigrationType = 'difm' | 'diy' | 'ssh';
 
 export type MigrationStatusInfo = SiteExcerptData[ 'site_migration' ];
 
@@ -11,7 +11,7 @@ export type MigrationState = {
 };
 
 const POSSIBLE_STATUSES = [ 'pending', 'started', 'completed' ] as const;
-const POSSIBLE_TYPES = [ 'difm', 'diy' ] as const;
+const POSSIBLE_TYPES = [ 'difm', 'diy', 'ssh' ] as const;
 
 export const getMigrationState = (
 	site: MigrationStatusInfo | undefined

--- a/client/data/site-migration/test/index.test.ts
+++ b/client/data/site-migration/test/index.test.ts
@@ -42,6 +42,36 @@ describe( 'getMigrationState', () => {
 		} );
 	} );
 
+	it( 'returns status pending and type ssh for migration-pending-ssh', () => {
+		const migrationInfo = {
+			migration_status: 'migration-pending-ssh',
+		};
+		expect( getMigrationState( migrationInfo ) ).toEqual( {
+			status: 'pending',
+			type: 'ssh',
+		} );
+	} );
+
+	it( 'returns status started and type ssh for migration-started-ssh', () => {
+		const migrationInfo = {
+			migration_status: 'migration-started-ssh',
+		};
+		expect( getMigrationState( migrationInfo ) ).toEqual( {
+			status: 'started',
+			type: 'ssh',
+		} );
+	} );
+
+	it( 'returns status completed and type ssh for migration-completed-ssh', () => {
+		const migrationInfo = {
+			migration_status: 'migration-completed-ssh',
+		};
+		expect( getMigrationState( migrationInfo ) ).toEqual( {
+			status: 'completed',
+			type: 'ssh',
+		} );
+	} );
+
 	it( 'returns type DIFM and status started when the migration was started by DAMS', () => {
 		const migrationInfo = {
 			migration_status: 'migration-in-progress',
@@ -84,6 +114,7 @@ describe( 'isMigrationInProgress', () => {
 		{ site: {} },
 		{ site: { site_migration: { migration_status: 'migration-completed-diy' } } },
 		{ site: { site_migration: { migration_status: 'migration-completed-difm' } } },
+		{ site: { site_migration: { migration_status: 'migration-completed-ssh' } } },
 		{ site: { site_migration: { migration_status: 'migration-cancelled-difm' } } },
 	] )( 'returns false when the migration is not in progress', ( scenario ) => {
 		return expect( isMigrationInProgress( scenario?.site as SiteExcerptData ) ).toBe( false );
@@ -92,6 +123,8 @@ describe( 'isMigrationInProgress', () => {
 	it.each( [
 		{ site: { site_migration: { migration_status: 'migration-started-diy' } } },
 		{ site: { site_migration: { migration_status: 'migration-pending-diy' } } },
+		{ site: { site_migration: { migration_status: 'migration-started-ssh' } } },
+		{ site: { site_migration: { migration_status: 'migration-pending-ssh' } } },
 		{ site: { site_migration: { migration_status: 'migration-in-progress' } } },
 	] )( 'returns true when the migration is in progress', ( scenario ) => {
 		return expect( isMigrationInProgress( scenario?.site as SiteExcerptData ) ).toBe( true );

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -41,6 +41,10 @@ const getContinueMigrationUrl = (
 		return addQueryArgs( baseQueryArgs, '/setup/site-migration/site-migration-instructions' );
 	}
 
+	if ( migrationState?.type === 'ssh' ) {
+		return addQueryArgs( baseQueryArgs, '/setup/site-migration/site-migration-ssh-verification' );
+	}
+
 	return addQueryArgs( baseQueryArgs, '/setup/site-migration/site-migration-credentials' );
 };
 

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -42,7 +42,13 @@ const getContinueMigrationUrl = (
 	}
 
 	if ( migrationState?.type === 'ssh' ) {
-		return addQueryArgs( baseQueryArgs, '/setup/site-migration/site-migration-ssh-verification' );
+		return addQueryArgs(
+			{
+				...baseQueryArgs,
+				from: migrationSourceSiteDomain || undefined,
+			},
+			'/setup/site-migration/site-migration-ssh-verification'
+		);
 	}
 
 	return addQueryArgs( baseQueryArgs, '/setup/site-migration/site-migration-credentials' );

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -42,6 +42,10 @@ const getContinueMigrationUrl = (
 	}
 
 	if ( migrationState?.type === 'ssh' ) {
+		if ( ! migrationSourceSiteDomain ) {
+			return null;
+		}
+
 		return addQueryArgs(
 			{
 				...baseQueryArgs,

--- a/packages/api-core/src/site-migration-status/fetchers.ts
+++ b/packages/api-core/src/site-migration-status/fetchers.ts
@@ -17,3 +17,16 @@ export async function fetchSiteMigrationZendeskTicket( siteId: number ): Promise
 
 	return ticket_id;
 }
+
+export interface SSHMigrationData {
+	migration_source_site_domain?: string;
+}
+
+export async function fetchSSHMigration( siteId: number ): Promise< SSHMigrationData > {
+	const response = await wpcom.req.get( {
+		path: `/sites/${ siteId }/ssh-migration`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+	return response;
+}

--- a/packages/api-queries/src/site-migration-status.ts
+++ b/packages/api-queries/src/site-migration-status.ts
@@ -3,6 +3,7 @@ import {
 	deleteSiteMigrationPendingStatus,
 	fetchSiteMigrationKey,
 	fetchSiteMigrationZendeskTicket,
+	fetchSSHMigration,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
@@ -18,6 +19,12 @@ export const siteMigrationZendeskTicketQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'migration', 'zendesk', 'ticket' ],
 		queryFn: () => fetchSiteMigrationZendeskTicket( siteId ),
+	} );
+
+export const sshMigrationQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'ssh-migration' ],
+		queryFn: () => fetchSSHMigration( siteId ),
 	} );
 
 export const cancelSiteMigrationQuery = ( siteId: number ) =>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15233

## Proposed Changes

 Add frontend support for SSH migration flow to match backend implementation.

* Add `'ssh'` to migration type definitions in `client/data/site-migration/index.ts` and `client/dashboard/utils/site-status.ts`
* Update migration-pending component to redirect SSH migrations to the verification step
* Add test coverage for SSH migration stickers (`migration-pending-ssh`, `migration-started-ssh`, `migration-completed-ssh`)
* Added the support for the new stickers on the new Hosting Dashboard.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  The backend now supports SSH migrations with new stickers. Without these changes, the frontend wouldn't recognize SSH migrations, and users would see incorrect UI states or broken redirects.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions on: 197299-ghe-Automattic/wpcom
* Use Calypso Live or apply this PR to your local environment.
* Navigate to `/setup/site-migration`, input a site that supports the SSH Migration.
* Go through the flow, until you reach the `Securely share your access` 
* Now go through the steps, and input an invalid credentials. This will leave you on the pending state. 
* Navigate to `/sites/YOUR_SITE` and you should the site on the pending state.
* Also visit `/v2/sites/YOUR_SITE` and ensure it also works on the new dashboard.
* In both pages, please validate that you can go back to the migration.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?