### PR TITLE
ai-site-builder flow: Don't custom manage new site pages

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -5,7 +5,6 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { resolveSelect, useDispatch as useWpDataDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
-import wpcomRequest from 'wpcom-proxy-request';
 import { useAddBlogStickerMutation } from 'calypso/blocks/blog-stickers/use-add-blog-sticker-mutation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
@@ -18,19 +17,6 @@ import { ProcessingResult } from '../../internals/steps-repository/processing-st
 import { FlowV2, SubmitHandler } from '../../internals/types';
 
 const SiteIntent = Onboard.SiteIntent;
-const deletePage = async ( siteId: string | number, pageId: number ): Promise< boolean > => {
-	try {
-		await wpcomRequest( {
-			path: '/sites/' + siteId + '/pages/' + pageId,
-			method: 'DELETE',
-			apiNamespace: 'wp/v2',
-		} );
-		return true;
-	} catch ( error ) {
-		// fail silently here, just log an error and return false, Big Sky will still launch
-		return false;
-	}
-};
 
 function initialize() {
 	// stepsWithRequiredLogin will take care of redirecting to the login step if the user is not logged in.
@@ -164,31 +150,11 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 								resolveSelect( SITE_STORE ).getSite( siteId ), // To get the URL.
 							];
 
-							if ( ! gardenName ) {
-								// Add blog sticker - this runs independently and errors are handled by the mutation's onError callback (only for non-garden sites)
-								addBlogSticker( siteId, 'big-sky-free-trial' );
-
-								// Create a new home page if one is not set yet (only for non-garden sites)
-								pendingActions.push(
-									wpcomRequest( {
-										path: '/sites/' + siteId + '/pages',
-										method: 'POST',
-										apiNamespace: 'wp/v2',
-										body: {
-											title: 'Home',
-											status: 'publish',
-											content: '<!-- wp:paragraph -->\n<p>Hello world!</p>\n<!-- /wp:paragraph -->',
-										},
-									} )
-								);
-							}
-
-							// Only apply design and delete page for non-garden sites
+							// Only apply design for non-garden sites
 							if ( ! gardenName ) {
 								pendingActions.push(
 									setDesignOnSite( siteSlug, getAssemblerDesign(), { enableThemeSetup: false } )
 								);
-								pendingActions.push( deletePage( siteId || '', 1 ) );
 							}
 							pendingActions.push( setIntentOnSite( siteSlug, SiteIntent.AIAssembler ) );
 
@@ -211,13 +177,11 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 							}
 							const siteURL = siteData.URL;
 
-							// Handle page creation result (only exists for non-garden sites)
-							if ( ! gardenName && results.length > 1 ) {
-								const pageCreationResult = results[ 1 ];
-								if ( pageCreationResult && pageCreationResult.id ) {
-									const homePagePostId = pageCreationResult.id;
-									await setStaticHomepageOnSite( siteId, homePagePostId );
-								}
+							// Set the static homepage to the home page and add the blog sticker
+							if ( ! gardenName ) {
+								addBlogSticker( siteId, 'big-sky-free-trial' );
+
+								await setStaticHomepageOnSite( siteId, 1 );
 							}
 
 							if ( prompt ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTOBRD-355

## Proposed Changes

This flow historically created its own custom home page. I don't remember exactly the details why, but I think it was a technical issue building on the default sample page defaults. In my testing, it seems to work without. 

Removing these two requests to create and delete the sample page save ~2s on this step: 

<img width="514" height="75" alt="image" src="https://github.com/user-attachments/assets/42812d1e-1112-4de9-9d7c-2a0fa44ab6fe" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To speed up the site creation flow. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- http://calypso.localhost:3000/sites
- Add a new AI site
- Complete blue screen onboarding
- The build should be complete and paint on the canvas as expected
- The Home page should be named `Home`
- The `big-sky-free-trial` sticker should still be applied (I moved this to later after other safety checks)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
