### PR TITLE
MSD Billing: Modify removal flow for one-time purchases

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -51,7 +51,6 @@ import {
 	isAkismetProduct,
 	isPartnerPurchase,
 	willAtomicSiteRevertAfterPurchaseDeactivation,
-	isOneTimePurchase,
 } from '../../../utils/purchase';
 import CancelHeaderTitle from './cancel-header-title';
 import CancelPurchaseForm from './cancel-purchase-form';
@@ -1041,7 +1040,7 @@ export default function CancelPurchase() {
 			! purchase.is_cancelable &&
 			! purchase.is_removable
 		) {
-			if ( ! isOneTimePurchase( purchase ) && ! createdErrorNoticeForRedirect.current ) {
+			if ( purchase.subscription_status !== 'active' && ! createdErrorNoticeForRedirect.current ) {
 				createErrorNotice(
 					__(
 						'This purchase has already been removed. Please contact support if you believe this to be in error.'

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -51,6 +51,7 @@ import {
 	isAkismetProduct,
 	isPartnerPurchase,
 	willAtomicSiteRevertAfterPurchaseDeactivation,
+	isOneTimePurchase,
 } from '../../../utils/purchase';
 import CancelHeaderTitle from './cancel-header-title';
 import CancelPurchaseForm from './cancel-purchase-form';
@@ -1044,6 +1045,28 @@ export default function CancelPurchase() {
 				createErrorNotice(
 					__(
 						'This purchase has already been removed. Please contact support if you believe this to be in error.'
+					),
+					{ type: 'snackbar' }
+				);
+				createdErrorNoticeForRedirect.current = true;
+			}
+			if (
+				isOneTimePurchase( purchase ) &&
+				! purchase.is_refundable &&
+				! createdErrorNoticeForRedirect.current
+			) {
+				createErrorNotice(
+					__(
+						'This one time purchase cannot be cancelled. Please contact support if you need assistance.'
+					),
+					{ type: 'snackbar' }
+				);
+				createdErrorNoticeForRedirect.current = true;
+			}
+			if ( ! createdErrorNoticeForRedirect.current ) {
+				createErrorNotice(
+					__(
+						'This product cannot be cancelled or removed. Please contact support if you need assistance.'
 					),
 					{ type: 'snackbar' }
 				);

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -51,6 +51,7 @@ import {
 	isAkismetProduct,
 	isPartnerPurchase,
 	willAtomicSiteRevertAfterPurchaseDeactivation,
+	isOneTimePurchase,
 } from '../../../utils/purchase';
 import CancelHeaderTitle from './cancel-header-title';
 import CancelPurchaseForm from './cancel-purchase-form';
@@ -1040,7 +1041,7 @@ export default function CancelPurchase() {
 			! purchase.is_cancelable &&
 			! purchase.is_removable
 		) {
-			if ( ! createdErrorNoticeForRedirect.current ) {
+			if ( ! isOneTimePurchase( purchase ) && ! createdErrorNoticeForRedirect.current ) {
 				createErrorNotice(
 					__(
 						'This purchase has already been removed. Please contact support if you believe this to be in error.'


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [SHILL-1404](https://linear.app/a8c/issue/SHILL-1404/hosting-dashboard-cancellation-flow-concierge-session-cancellation)

## Proposed Changes

* Hide the error notice shown when one-time purchases cannot be cancelled.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently if a one-time purchase cancellation is attempted by visiting the URL directly it will redirect the customer to the purchase management page with an error message saying that the purchase has already been removed. This isn't true - the purchase is still active.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a quick start session via SA
* Checkout the `mccluskeyc/shill-1404` branch to your sandbox
* Try to cancel that purchase in the multisite dashboard. From `/v2/me/billing/purchases` click "Manage Purchase" then append `/cancel` to the end of the URL.
* You should be redirected back to the same page you were on, but with no error message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
