### PR TITLE
Switch to using new agentsManagerData for tool and context loading

### DIFF
--- a/apps/help-center/src/utils/load-external-providers.ts
+++ b/apps/help-center/src/utils/load-external-providers.ts
@@ -8,8 +8,8 @@
 import type { ToolProvider, ContextProvider, Suggestion } from '@automattic/agents-manager';
 import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 
-// agentManagerData is set as a global const via wp_add_inline_script
-declare const agentManagerData: { agentProviders?: string[] } | undefined;
+// agentsManagerData is set as a global const via wp_add_inline_script
+declare const agentsManagerData: { agentProviders?: string[] } | undefined;
 
 export interface LoadedProviders {
 	toolProvider?: ToolProvider;
@@ -27,7 +27,7 @@ export interface LoadedProviders {
  * @returns Promise resolving to merged providers or empty object if none found.
  */
 export async function loadExternalProviders(): Promise< LoadedProviders > {
-	const agentProviders = agentManagerData?.agentProviders || [];
+	const agentProviders = agentsManagerData?.agentProviders || [];
 
 	if ( agentProviders.length === 0 ) {
 		return {};

--- a/apps/help-center/src/utils/load-external-providers.ts
+++ b/apps/help-center/src/utils/load-external-providers.ts
@@ -8,8 +8,8 @@
 import type { ToolProvider, ContextProvider, Suggestion } from '@automattic/agents-manager';
 import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 
-// helpCenterData is set as a global const via wp_add_inline_script
-declare const helpCenterData: { agentProviders?: string[] } | undefined;
+// agentManagerData is set as a global const via wp_add_inline_script
+declare const agentManagerData: { agentProviders?: string[] } | undefined;
 
 export interface LoadedProviders {
 	toolProvider?: ToolProvider;
@@ -27,7 +27,7 @@ export interface LoadedProviders {
  * @returns Promise resolving to merged providers or empty object if none found.
  */
 export async function loadExternalProviders(): Promise< LoadedProviders > {
-	const agentProviders = helpCenterData?.agentProviders || [];
+	const agentProviders = agentManagerData?.agentProviders || [];
 
 	if ( agentProviders.length === 0 ) {
 		return {};


### PR DESCRIPTION
## Proposed Changes
Switch to using Agents Manager instead of Help Center to inject this data.

## Why are these changes being made?
* We're going to have the Agents Manager plugin inject this data instead of Help Center.

## Testing Instructions
* Green tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
