### PR TITLE
MSD: Use ENTRY_LIMIT=entry-dashboard-dotcom,entry-dashboard-ciab for start-dashboard

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1106,18 +1106,19 @@ export default function pages() {
 	loginRouter( serverRouter( app, setUpRoute, null ) );
 
 	// Multi-site Dashboard routing fo my.wordpress.com.
+	// Return earlier since we don't need to set up any other routes.
 	if ( config.isEnabled( 'dashboard' ) ) {
 		[ '/', '/sites', '/domains', '/emails', '/plugins', '/me' ].forEach( ( route ) => {
 			handleSectionPath( DASHBOARD_SECTION_DEFINITION, route, 'entry-dashboard-dotcom' );
 		} );
+
+		handleSectionPath( DASHBOARD_CIAB_SECTION_DEFINITION, '/ciab', 'entry-dashboard-ciab' );
+		return app;
 	}
 
 	// Multi-site Dashboard routing for wordpress.com.
 	if ( config.isEnabled( 'dashboard/v2' ) ) {
 		handleSectionPath( DASHBOARD_SECTION_DEFINITION, '/v2', 'entry-dashboard-dotcom' );
-	}
-
-	if ( config.isEnabled( 'dashboard' ) || config.isEnabled( 'dashboard/v2' ) ) {
 		handleSectionPath( DASHBOARD_CIAB_SECTION_DEFINITION, '/ciab', 'entry-dashboard-ciab' );
 	}
 

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
 		"start-jetpack-cloud-p": "PORT=3001 CALYPSO_ENV=jetpack-cloud-development yarn run build-server && PORT=3001 CALYPSO_ENV=jetpack-cloud-development yarn run start-build",
 		"start-a8c-for-agencies": "CALYPSO_ENV=a8c-for-agencies-development yarn run start",
 		"start-a8c-for-agencies-p": "PORT=3002 CALYPSO_ENV=a8c-for-agencies-development yarn run build-server && PORT=3002 CALYPSO_ENV=a8c-for-agencies-development yarn run start-build",
-		"start-dashboard": "CALYPSO_ENV=dashboard-development yarn run start",
+		"start-dashboard": "CALYPSO_ENV=dashboard-development ENTRY_LIMIT=entry-dashboard-dotcom,entry-dashboard-ciab yarn run start",
 		"storybook:start": "storybook dev -c ./.storybook -p 6006",
 		"storybook:build": "storybook build -c ./.storybook",
 		"test": "run-s -s test-client test-packages test-server test-build-tools",


### PR DESCRIPTION
Fixes DOTMSD-898

## Proposed Changes

Update the start-dashboard script to use ENTRY_LIMIT=entry-dashboard-dotcom,entry-dashboard-ciab with the purpose of speeding up build time.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke test the MSD to ensure it works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
