### PR TITLE
ES site list: preloads overview page (and `Site` object) when link is in view

### DIFF
--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -199,9 +199,6 @@ describe( 'SiteLogs page', () => {
 			const initialLogType = logTypeName !== LogType.PHP ? LogType.PHP : LogType.SERVER;
 			render( <SiteLogs logType={ initialLogType } /> );
 
-			// Wait for data and TabPanel to render
-			await waitFor( () => expect( nock.isDone() ).toBe( true ) );
-
 			// Click another tab
 			await userEvent.click(
 				await screen.findByRole( 'button', { name: new RegExp( logTypeName, 'i' ) } )
@@ -255,7 +252,6 @@ describe( 'SiteLogs page', () => {
 		jest.spyOn( dateRangeUtils, 'isLast7Days' ).mockReturnValue( false );
 
 		render( <SiteLogs logType={ LogType.PHP } /> );
-		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
 
 		await userEvent.click( await screen.findByRole( 'button', { name: 'Toggle auto' } ) );
 
@@ -280,7 +276,6 @@ describe( 'SiteLogs page', () => {
 		jest.spyOn( dateRangeUtils, 'isLast7Days' ).mockReturnValue( true );
 
 		render( <SiteLogs logType={ LogType.PHP } /> );
-		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
 
 		await userEvent.click( await screen.findByRole( 'button', { name: 'Toggle auto' } ) );
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -87,6 +87,7 @@ export function SiteLink__ES( {
 			{ ...props }
 			to={ `/sites/${ site.slug }` }
 			disabled={ site.deleted }
+			preload="viewport"
 			style={ { width: 'auto', minWidth: 'unset', textDecoration: 'none', ...props.style } }
 		/>
 	);

--- a/packages/api-queries/package.json
+++ b/packages/api-queries/package.json
@@ -43,6 +43,7 @@
 		"@tanstack/query-sync-storage-persister": "^5.83.0",
 		"@tanstack/react-query": "^5.83.0",
 		"@tanstack/react-query-persist-client": "^5.83.0",
+		"fast-deep-equal": "^3.1.3",
 		"react": "^18.3.1",
 		"tslib": "^2.8.1"
 	},

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -20,7 +20,9 @@ export const siteBySlugQuery = ( siteSlug: string ) =>
 		queryKey: [ 'site-by-slug', siteSlug, SITE_FIELDS, SITE_OPTIONS ],
 		queryFn: async () => {
 			try {
-				return await fetchSite( siteSlug );
+				const site = await fetchSite( siteSlug );
+				queryClient.setQueryData( [ 'site-by-id', site.ID, SITE_FIELDS, SITE_OPTIONS ], site );
+				return site;
 			} catch ( e ) {
 				if ( isWpError( e ) && e.error && KNOWN_ERRORS.includes( e.error ) ) {
 					throw notFound( { data: e.error } );
@@ -41,7 +43,9 @@ export const siteByIdQuery = ( siteId: number ) =>
 		queryKey: [ 'site-by-id', siteId, SITE_FIELDS, SITE_OPTIONS ],
 		queryFn: async () => {
 			try {
-				return await fetchSite( siteId );
+				const site = await fetchSite( siteId );
+				queryClient.setQueryData( [ 'site-by-slug', site.slug, SITE_FIELDS, SITE_OPTIONS ], site );
+				return site;
 			} catch ( e ) {
 				if ( isWpError( e ) && e.error && KNOWN_ERRORS.includes( e.error ) ) {
 					throw notFound( { data: e.error } );

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -27,9 +27,7 @@ export const siteBySlugQuery = ( siteSlug: string ) => {
 		queryKey: [ 'site-by-slug', siteSlug, SITE_FIELDS, SITE_OPTIONS ],
 		queryFn: async () => {
 			try {
-				const site = await fetchSite( siteSlug );
-				queryClient.setQueryData( [ 'site-by-id', site.ID, SITE_FIELDS, SITE_OPTIONS ], site );
-				return site;
+				return await fetchSite( siteSlug );
 			} catch ( e ) {
 				if ( isWpError( e ) && e.error && KNOWN_ERRORS.includes( e.error ) ) {
 					throw notFound( { data: e.error } );
@@ -66,9 +64,7 @@ export const siteByIdQuery = ( siteId: number ) => {
 		queryKey: [ 'site-by-id', siteId, SITE_FIELDS, SITE_OPTIONS ],
 		queryFn: async () => {
 			try {
-				const site = await fetchSite( siteId );
-				queryClient.setQueryData( [ 'site-by-slug', site.slug, SITE_FIELDS, SITE_OPTIONS ], site );
-				return site;
+				return await fetchSite( siteId );
 			} catch ( e ) {
 				if ( isWpError( e ) && e.error && KNOWN_ERRORS.includes( e.error ) ) {
 					throw notFound( { data: e.error } );

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -15,8 +15,15 @@ import type { Query } from '@tanstack/react-query';
 
 const KNOWN_ERRORS = [ 'unknown_blog', 'unauthorized' ];
 
-export const siteBySlugQuery = ( siteSlug: string ) =>
-	queryOptions( {
+export const siteBySlugQuery = ( siteSlug: string ) => {
+	// Used to find an existing Site object which is already in the `site-by-id` cache.
+	const getFromCache = () =>
+		queryClient
+			.getQueriesData< Site >( { queryKey: [ 'site-by-id' ] } )
+			.map( ( [ , data ] ) => data )
+			.find( ( site ) => site?.slug === siteSlug );
+
+	return queryOptions( {
 		queryKey: [ 'site-by-slug', siteSlug, SITE_FIELDS, SITE_OPTIONS ],
 		queryFn: async () => {
 			try {
@@ -36,10 +43,26 @@ export const siteBySlugQuery = ( siteSlug: string ) =>
 			}
 			return failureCount < 3; // default retry count
 		},
+		initialData: () => getFromCache(),
+		initialDataUpdatedAt: () => {
+			const site = getFromCache();
+			if ( site?.ID ) {
+				return queryClient.getQueryState( [ 'site-by-id', site.ID, SITE_FIELDS, SITE_OPTIONS ] )
+					?.dataUpdatedAt;
+			}
+		},
 	} );
+};
 
-export const siteByIdQuery = ( siteId: number ) =>
-	queryOptions( {
+export const siteByIdQuery = ( siteId: number ) => {
+	// Used to find an existing Site object which is already in the `site-by-slug` cache.
+	const getFromCache = () =>
+		queryClient
+			.getQueriesData< Site >( { queryKey: [ 'site-by-slug' ] } )
+			.map( ( [ , data ] ) => data )
+			.find( ( site ) => site?.ID === siteId );
+
+	return queryOptions( {
 		queryKey: [ 'site-by-id', siteId, SITE_FIELDS, SITE_OPTIONS ],
 		queryFn: async () => {
 			try {
@@ -59,7 +82,16 @@ export const siteByIdQuery = ( siteId: number ) =>
 			}
 			return failureCount < 3; // default retry count
 		},
+		initialData: () => getFromCache(),
+		initialDataUpdatedAt: () => {
+			const site = getFromCache();
+			if ( site?.ID ) {
+				return queryClient.getQueryState( [ 'site-by-slug', site.slug, SITE_FIELDS, SITE_OPTIONS ] )
+					?.dataUpdatedAt;
+			}
+		},
 	} );
+};
 
 export const siteQueryFilter = ( siteId: number ) => ( {
 	predicate: ( { queryKey, state }: Query ) => {

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -9,20 +9,12 @@ import {
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
+import equal from 'fast-deep-equal/es6';
 import { queryClient } from './query-client';
 import type { Site } from '@automattic/api-core';
 import type { Query } from '@tanstack/react-query';
 
 const KNOWN_ERRORS = [ 'unknown_blog', 'unauthorized' ];
-
-function equalStringSets( a: string[], b: string[] ): boolean {
-	const setA = new Set< string >( a );
-	const setB = new Set< string >( b );
-	if ( setA.size !== setB.size ) {
-		return false;
-	}
-	return a.every( ( item ) => setB.has( item ) ) && b.every( ( item ) => setA.has( item ) );
-}
 
 export function siteBySlugQuery( siteSlug: string ) {
 	// Used to find an existing Site object which is already in the `site-by-id` cache.
@@ -34,8 +26,8 @@ export function siteBySlugQuery( siteSlug: string ) {
 					query.queryKey[ 0 ] === 'site-by-id' &&
 					query.state.status === 'success' &&
 					( query.state.data as Site )?.slug === siteSlug &&
-					equalStringSets( query.queryKey[ 2 ] as string[], SITE_FIELDS ) &&
-					equalStringSets( query.queryKey[ 3 ] as string[], SITE_OPTIONS ),
+					equal( new Set( query.queryKey[ 2 ] as string[] ), new Set( SITE_FIELDS ) ) &&
+					equal( new Set( query.queryKey[ 3 ] as string[] ), new Set( SITE_OPTIONS ) ),
 			} )
 			.map( ( [ , data ] ) => data )[ 0 ];
 
@@ -77,8 +69,8 @@ export function siteByIdQuery( siteId: number ) {
 					query.queryKey[ 0 ] === 'site-by-slug' &&
 					query.state.status === 'success' &&
 					( query.state.data as Site )?.ID === siteId &&
-					equalStringSets( query.queryKey[ 2 ] as string[], SITE_FIELDS ) &&
-					equalStringSets( query.queryKey[ 3 ] as string[], SITE_OPTIONS ),
+					equal( new Set( query.queryKey[ 2 ] as string[] ), new Set( SITE_FIELDS ) ) &&
+					equal( new Set( query.queryKey[ 3 ] as string[] ), new Set( SITE_OPTIONS ) ),
 			} )
 			.map( ( [ , data ] ) => data )[ 0 ];
 

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -15,13 +15,29 @@ import type { Query } from '@tanstack/react-query';
 
 const KNOWN_ERRORS = [ 'unknown_blog', 'unauthorized' ];
 
-export const siteBySlugQuery = ( siteSlug: string ) => {
+function equalStringSets( a: string[], b: string[] ): boolean {
+	const setA = new Set< string >( a );
+	const setB = new Set< string >( b );
+	if ( setA.size !== setB.size ) {
+		return false;
+	}
+	return a.every( ( item ) => setB.has( item ) ) && b.every( ( item ) => setA.has( item ) );
+}
+
+export function siteBySlugQuery( siteSlug: string ) {
 	// Used to find an existing Site object which is already in the `site-by-id` cache.
 	const getFromCache = () =>
 		queryClient
-			.getQueriesData< Site >( { queryKey: [ 'site-by-id' ] } )
-			.map( ( [ , data ] ) => data )
-			.find( ( site ) => site?.slug === siteSlug );
+			.getQueriesData< Site >( {
+				predicate: ( query ) =>
+					query.queryKey.length >= 4 &&
+					query.queryKey[ 0 ] === 'site-by-id' &&
+					query.state.status === 'success' &&
+					( query.state.data as Site )?.slug === siteSlug &&
+					equalStringSets( query.queryKey[ 2 ] as string[], SITE_FIELDS ) &&
+					equalStringSets( query.queryKey[ 3 ] as string[], SITE_OPTIONS ),
+			} )
+			.map( ( [ , data ] ) => data )[ 0 ];
 
 	return queryOptions( {
 		queryKey: [ 'site-by-slug', siteSlug, SITE_FIELDS, SITE_OPTIONS ],
@@ -42,23 +58,29 @@ export const siteBySlugQuery = ( siteSlug: string ) => {
 			return failureCount < 3; // default retry count
 		},
 		initialData: () => getFromCache(),
-		initialDataUpdatedAt: () => {
+		initialDataUpdatedAt: (): number | undefined => {
 			const site = getFromCache();
 			if ( site?.ID ) {
-				return queryClient.getQueryState( [ 'site-by-id', site.ID, SITE_FIELDS, SITE_OPTIONS ] )
-					?.dataUpdatedAt;
+				return queryClient.getQueryState( siteByIdQuery( site.ID ).queryKey )?.dataUpdatedAt;
 			}
 		},
 	} );
-};
+}
 
-export const siteByIdQuery = ( siteId: number ) => {
+export function siteByIdQuery( siteId: number ) {
 	// Used to find an existing Site object which is already in the `site-by-slug` cache.
 	const getFromCache = () =>
 		queryClient
-			.getQueriesData< Site >( { queryKey: [ 'site-by-slug' ] } )
-			.map( ( [ , data ] ) => data )
-			.find( ( site ) => site?.ID === siteId );
+			.getQueriesData< Site >( {
+				predicate: ( query ) =>
+					query.queryKey.length >= 4 &&
+					query.queryKey[ 0 ] === 'site-by-slug' &&
+					query.state.status === 'success' &&
+					( query.state.data as Site )?.ID === siteId &&
+					equalStringSets( query.queryKey[ 2 ] as string[], SITE_FIELDS ) &&
+					equalStringSets( query.queryKey[ 3 ] as string[], SITE_OPTIONS ),
+			} )
+			.map( ( [ , data ] ) => data )[ 0 ];
 
 	return queryOptions( {
 		queryKey: [ 'site-by-id', siteId, SITE_FIELDS, SITE_OPTIONS ],
@@ -79,15 +101,14 @@ export const siteByIdQuery = ( siteId: number ) => {
 			return failureCount < 3; // default retry count
 		},
 		initialData: () => getFromCache(),
-		initialDataUpdatedAt: () => {
+		initialDataUpdatedAt: (): number | undefined => {
 			const site = getFromCache();
-			if ( site?.ID ) {
-				return queryClient.getQueryState( [ 'site-by-slug', site.slug, SITE_FIELDS, SITE_OPTIONS ] )
-					?.dataUpdatedAt;
+			if ( site?.slug ) {
+				return queryClient.getQueryState( siteBySlugQuery( site.slug ).queryKey )?.dataUpdatedAt;
 			}
 		},
 	} );
-};
+}
 
 export const siteQueryFilter = ( siteId: number ) => ( {
 	predicate: ( { queryKey, state }: Query ) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,6 +401,7 @@ __metadata:
     "@tanstack/query-sync-storage-persister": "npm:^5.83.0"
     "@tanstack/react-query": "npm:^5.83.0"
     "@tanstack/react-query-persist-client": "npm:^5.83.0"
+    fast-deep-equal: "npm:^3.1.3"
     react: "npm:^18.3.1"
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.3"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-913

## Proposed Changes

* Add `preload=viewport` to the site list link. This will cause the `Site` object to get primed in the query cache
* Ensure both `site-by-id` and `site-by-slug` caches are primed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Before elastic search, this optimisation of pre-filling the `site-by-slug` cache was done when the `/me/sites` endpoint was loaded. https://github.com/Automattic/wp-calypso/blob/c685488ad607b9c96c0bccfe8ba6d064719c68cf/client/dashboard/sites/index.tsx#L243-L247

This worked because we knew the `/me/sites` and `/sites/%s` response objects had the same format. But with ES we know the site list is now backed by site objects that don't match the `Site` data type. `Site` is still the definitive type for representing a site in the MSD, so we should make sure the site list loads it.

We only preload when the link is in "viewport" because the user could have a large page size. Preloading all the `Site` objects wouldn't be that bad if the user keeps the page size small.

CC @arthur791004 since I know you've been thinking about this optimisation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/sites?flags=dashboard/v2/es-site-list`
* Make your viewport small
* Delete the `REACT_QUERY_OFFLINE_CACHE` local storage
* Refresh the page
* Note which site objects are fetched in the network tools
* Scroll down the page
* Note which site objects are fetched in the network tools
* Navigate to a site overview page, and there shouldn't be a long load time

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
