### PR TITLE
A4A > Marketplace: Add missing event tracking

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -99,7 +99,11 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 				return;
 			}
 			dispatch(
-				recordTracksEvent( 'calypso_a4a_marketplace_referral_checkout_request_payment_click' )
+				recordTracksEvent(
+					flowType === 'send'
+						? 'calypso_a4a_marketplace_referral_checkout_request_payment_click'
+						: 'calypso_a4a_marketplace_referral_checkout_request_payment_copy_click'
+				)
 			);
 			requestPayment(
 				{

--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
@@ -28,7 +28,7 @@ const ReferralToggle = () => {
 		toggleMarketplaceType();
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_referral_toggle', {
-				purchase_mode: marketplaceType === 'referral' ? 'regular' : 'referral',
+				purchase_mode: marketplaceType,
 			} )
 		);
 	};

--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
@@ -5,6 +5,7 @@ import { useContext, useEffect } from 'react';
 import useReferralsGuide from 'calypso/a8c-for-agencies/components/guide-modal/guides/useReferralsGuide';
 import { useDispatch, useSelector } from 'calypso/state';
 import { hasApprovedAgencyStatus } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { MarketplaceTypeContext } from '../../context';
@@ -23,6 +24,15 @@ const ReferralToggle = () => {
 
 	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
 
+	const handleToggle = () => {
+		toggleMarketplaceType();
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_marketplace_referral_toggle', {
+				purchase_mode: marketplaceType === 'referral' ? 'regular' : 'referral',
+			} )
+		);
+	};
+
 	useEffect( () => {
 		if ( marketplaceType === 'referral' && ! guideModalSeen ) {
 			dispatch( savePreference( PREFERENCE_NAME, true ) );
@@ -35,7 +45,7 @@ const ReferralToggle = () => {
 			{ guideModal }
 
 			<ToggleControl
-				onChange={ toggleMarketplaceType }
+				onChange={ handleToggle }
 				checked={ marketplaceType === 'referral' }
 				id="a4a-marketplace__toggle-marketplace-type"
 				label={ translate( 'Refer products' ) }

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -10,6 +10,7 @@ import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors
 import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
 import Checkout from './checkout';
+import { MARKETPLACE_TYPE_SESSION_STORAGE_KEY } from './hoc/with-marketplace-type';
 import HostingOverview from './hosting-overview';
 import { getValidHostingSection } from './lib/hosting';
 import { getValidBrand } from './lib/product-brand';
@@ -17,6 +18,30 @@ import { PLAN_CATEGORY_ENTERPRISE, PLAN_CATEGORY_PREMIUM } from './pressable-ove
 import DownloadProducts from './primary/download-products';
 import ProductsOverview from './products-overview';
 import ReferHosting from './refer-hosting';
+import type { MarketplaceType } from './types';
+
+type Props = {
+	title: string;
+	path: string;
+	properties?: Record< string, string | number | boolean >;
+};
+
+function MarketplacePageViewTracker( { title, path, properties }: Props ) {
+	const marketplaceType = sessionStorage.getItem(
+		MARKETPLACE_TYPE_SESSION_STORAGE_KEY
+	) as MarketplaceType;
+
+	return (
+		<PageViewTracker
+			title={ title }
+			path={ path }
+			properties={ {
+				...properties,
+				purchase_mode: marketplaceType,
+			} }
+		/>
+	);
+}
 
 export const marketplaceContext: Callback = ( context ) => {
 	const { purchase_type } = context.query;
@@ -37,7 +62,7 @@ export const marketplaceProductsContext: Callback = ( context, next ) => {
 
 	context.primary = (
 		<>
-			<PageViewTracker title="Marketplace > Products" path={ context.path } />
+			<MarketplacePageViewTracker title="Marketplace > Products" path={ context.path } />
 			<ProductsOverview
 				siteId={ site_id }
 				suggestedProduct={ product_slug }
@@ -73,7 +98,7 @@ export const marketplaceHostingContext: Callback = ( context, next ) => {
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
-			<PageViewTracker title="Marketplace > Hosting" path={ context.path } />
+			<MarketplacePageViewTracker title="Marketplace > Hosting" path={ context.path } />
 			<HostingOverview section={ section } defaultMarketplaceType={ purchaseType } />
 		</>
 	);
@@ -112,7 +137,7 @@ export const checkoutContext: Callback = ( context, next ) => {
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
-			<PageViewTracker title="Marketplace > Checkout" path={ context.path } />
+			<MarketplacePageViewTracker title="Marketplace > Checkout" path={ context.path } />
 			<Checkout referralBlogId={ referralBlogId } />
 		</>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
@@ -1,6 +1,8 @@
 import { getQueryArg } from '@wordpress/url';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { MarketplaceTypeContext } from '../context';
 import { CART_URL_HASH_FRAGMENT } from '../shopping-cart';
 import { type ShoppingCartItem } from '../types';
@@ -9,6 +11,8 @@ const SELECTED_ITEMS_SESSION_STORAGE_KEY = 'shopping-card-selected-items';
 const SELECTED_ITEMS_SESSION_STORAGE_KEY_REFERRAL = 'referrals-shopping-card-selected-items';
 
 export default function useShoppingCart() {
+	const dispatch = useDispatch();
+
 	const [ selectedCartItems, setSelectedCartItems ] = useState< ShoppingCartItem[] >( [] );
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 
@@ -21,6 +25,11 @@ export default function useShoppingCart() {
 	}, [ marketplaceType ] );
 
 	const toggleCart = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_marketplace_toggle_cart', {
+				purchase_mode: marketplaceType,
+			} )
+		);
 		setShowCart( ( prevState ) => {
 			const nextState = ! prevState;
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/incompatible-products';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { ShoppingCartContext } from '../../context';
+import { MarketplaceTypeContext, ShoppingCartContext } from '../../context';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
 import { SelectedFilters } from '../../lib/product-filter';
 import { getSupportedBundleSizes } from '../hooks/use-product-bundle-size';
@@ -49,6 +49,7 @@ export default function ProductListing( {
 	const dispatch = useDispatch();
 
 	const { selectedCartItems, setSelectedCartItems } = useContext( ShoppingCartContext );
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
 
 	const quantity = useMemo(
 		() => ( isReferralMode ? 1 : selectedBundleSize ),
@@ -140,6 +141,7 @@ export default function ProductListing( {
 					recordTracksEvent( 'calypso_a4a_marketplace_products_overview_select_product', {
 						product: product.slug,
 						quantity,
+						purchase_mode: marketplaceType,
 					} )
 				);
 			} else {
@@ -149,11 +151,12 @@ export default function ProductListing( {
 					recordTracksEvent( 'calypso_a4a_marketplace_products_overview_unselect_product', {
 						product: product.slug,
 						quantity,
+						purchase_mode: marketplaceType,
 					} )
 				);
 			}
 		},
-		[ dispatch, quantity, selectedCartItems, setSelectedCartItems ]
+		[ dispatch, marketplaceType, quantity, selectedCartItems, setSelectedCartItems ]
 	);
 
 	const onSelectOrReplaceProduct = useCallback(
@@ -174,6 +177,7 @@ export default function ProductListing( {
 					recordTracksEvent( 'calypso_a4a_marketplace_products_overview_unselect_product', {
 						product: replace.slug,
 						quantity,
+						purchase_mode: marketplaceType,
 					} )
 				);
 
@@ -181,13 +185,21 @@ export default function ProductListing( {
 					recordTracksEvent( 'calypso_a4a_marketplace_products_overview_select_product', {
 						product: product.slug,
 						quantity,
+						purchase_mode: marketplaceType,
 					} )
 				);
 			} else {
 				handleSelectBundleLicense( product );
 			}
 		},
-		[ dispatch, handleSelectBundleLicense, quantity, selectedCartItems, setSelectedCartItems ]
+		[
+			dispatch,
+			handleSelectBundleLicense,
+			quantity,
+			selectedCartItems,
+			setSelectedCartItems,
+			marketplaceType,
+		]
 	);
 
 	const { isReady } = useSubmitForm( { selectedSite, suggestedProductSlugs } );


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1844/tracks-events-add-the-ability-to-distinguish-between-agency-and

## Proposed Changes

This PR adds missing event tracking to Marketplace, including:

- Copy link for Referrals
- Toggle referral mode
- Toggle cart

Also, updates all marketplace page views (Products, Hosting & Checkout) to include the purchase mode (referral or regular)

## Why are these changes being made?

* To be able to track the events on the Marketplace better

## Testing Instructions

* Open the A4A live link
* Open the network tab open > Filter by "t.gif"
* Go to Marketplace > Verify the "calypso_page_view" event trackings now includes "purchase_mode: regular" 
* Click "Standard", "Premier", & "Enterprise" tabs > Verify the "calypso_page_view" event trackings now includes "purchase_mode: regular" 
* Go to "Products" > Verify the "calypso_page_view" event trackings now includes "purchase_mode: regular"
* Toggle the refer mode on > Verify the event is tracked: `calypso_a4a_marketplace_referral_toggle`
* Visit "Hosting", and it's all tabs > Verify the "calypso_page_view" event trackings now includes "purchase_mode: referral"
* Go to "Products" > Verify the "calypso_page_view" event trackings now includes "purchase_mode: referral"
* Add/remove some products > Verify the event trackings now includes "purchase_mode: referral"
* Click the cart >  Verify the event is tracked: `calypso_a4a_marketplace_toggle_cart` with "purchase_mode: referral"
* Go to checkout > Verify the "calypso_page_view" event trackings now includes "purchase_mode: referral"
* Click the "Copy referral link" button > Verify the event tracking name is "calypso_a4a_marketplace_referral_checkout_request_payment_copy_click"
* Repeat the step > click the "Send to client" button > Verify the event tracking name is "calypso_a4a_marketplace_referral_checkout_request_payment_click"


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
