### PR TITLE
MSD Account Notifications: Fix site card UI responsiveness

### DIFF
--- a/client/dashboard/me/notifications-sites/site-list-settings/index.scss
+++ b/client/dashboard/me/notifications-sites/site-list-settings/index.scss
@@ -11,13 +11,13 @@
 	}
 
 	&__site-settings {
-		margin-left: -$grid-unit-20;
-		margin-right: -$grid-unit-20;
+		margin-inline-start: -$grid-unit-20;
+		margin-inline-end: -$grid-unit-20;
 	}
 
 	.components-tab-panel__tabs, .components-tab-panel__tab-content {
-		padding-left: $grid-unit-20;
-		padding-right: $grid-unit-20;
+		padding-inline-start: $grid-unit-20;
+		padding-inline-end: $grid-unit-20;
 	}
 
 	.components-tab-panel__tab-content {
@@ -26,13 +26,13 @@
 
 	@include break-medium {
 		&__site-settings {
-			margin-left: -$grid-unit-30;
-			margin-right: -$grid-unit-30;
+			margin-inline-start: -$grid-unit-30;
+			margin-inline-end: -$grid-unit-30;
 		}
 
 		.components-tab-panel__tabs, .components-tab-panel__tab-content {
-			padding-left: $grid-unit-30;
-			padding-right: $grid-unit-30;
+			padding-inline-start: $grid-unit-30;
+			padding-inline-end: $grid-unit-30;
 		}
 
 		.components-tab-panel__tab-content {

--- a/client/dashboard/me/notifications-sites/site-list-settings/index.scss
+++ b/client/dashboard/me/notifications-sites/site-list-settings/index.scss
@@ -1,21 +1,42 @@
+@import "@wordpress/base-styles/breakpoints";
+@import '@wordpress/base-styles/variables';
+
 .site-list-settings {
 	.components-tab-panel__tabs {
 		border-bottom: solid 1px #ddd;
 	}
-	&__site-settings {
-		margin-left: -24px;
-		margin-right: -24px;
-	}
-	.components-tab-panel__tabs, .components-tab-panel__tab-content {
-		padding-left: 24px;
-		padding-right: 24px;
-	}
-	.components-tab-panel__tab-content {
-		padding-top: 16px;
-	}
+
 	&__card-placeholder {
 		height: 112px;
 	}
+
+	&__site-settings {
+		margin-left: -$grid-unit-20;
+		margin-right: -$grid-unit-20;
+	}
+
+	.components-tab-panel__tabs, .components-tab-panel__tab-content {
+		padding-left: $grid-unit-20;
+		padding-right: $grid-unit-20;
+	}
+
+	.components-tab-panel__tab-content {
+		padding-top: $grid-unit-10;
+	}
+
+	@include break-medium {
+		&__site-settings {
+			margin-left: -$grid-unit-30;
+			margin-right: -$grid-unit-30;
+		}
+
+		.components-tab-panel__tabs, .components-tab-panel__tab-content {
+			padding-left: $grid-unit-30;
+			padding-right: $grid-unit-30;
+		}
+
+		.components-tab-panel__tab-content {
+			padding-top: $grid-unit-20;
+		}
+	}
 }
-
-

--- a/client/dashboard/me/notifications-sites/site-preview/index.scss
+++ b/client/dashboard/me/notifications-sites/site-preview/index.scss
@@ -17,7 +17,7 @@
 		}
 	}
 
-	&__url {
+	&__url a {
 		color: $gray-700;
 		display: flex;
 		flex: 1 1 100%;


### PR DESCRIPTION
## Proposed Changes

This PR fixes the site card content overflowing on mobile resolution.

<img width="636" height="722" alt="SCR-20251203-oqxf" src="https://github.com/user-attachments/assets/75d5e1e4-fb76-445f-93a6-ef2f060f7c40" />

This PR also fixes the site URL being blueberry blue instead of gray.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to (/v2)/me/notifications/sites
* Ensure that the site card is updated as described above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
