### PR TITLE
Make connection mode card HStack clickable to control RadioControl

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -10,7 +10,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody, CardDivider } from '../../components/card';
 import Notice from '../../components/notice';
@@ -87,11 +87,35 @@ export default function ConnectionModeCard( {
 		} );
 	};
 
+	const handleModeClick = useCallback( () => {
+		onModeChange( mode );
+	}, [ mode, onModeChange ] );
+
+	const handleKeyDown = useCallback(
+		( event: React.KeyboardEvent< HTMLDivElement > ) => {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
+				event.preventDefault();
+				handleModeClick();
+			}
+		},
+		[ handleModeClick ]
+	);
+
 	return (
 		<Card>
 			<CardBody>
 				<VStack spacing={ 4 }>
-					<HStack spacing={ 2 } justify="flex-start">
+					<HStack
+						spacing={ 2 }
+						justify="flex-start"
+						role="radio"
+						tabIndex={ 0 }
+						onClick={ handleModeClick }
+						onKeyDown={ handleKeyDown }
+						aria-checked={ isSelected }
+						aria-label={ `${ title }. ${ description }` }
+						style={ { cursor: 'pointer' } }
+					>
 						<RadioControl
 							selected={ selectedMode }
 							options={ [ { label: '', value: mode } ] }

--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -87,18 +87,17 @@ export default function ConnectionModeCard( {
 		} );
 	};
 
-	const handleModeClick = useCallback( () => {
-		onModeChange( mode );
-	}, [ mode, onModeChange ] );
-
-	const handleKeyDown = useCallback(
-		( event: React.KeyboardEvent< HTMLDivElement > ) => {
-			if ( event.key === 'Enter' || event.key === ' ' ) {
-				event.preventDefault();
-				handleModeClick();
+	const handleModeClick = useCallback(
+		( event: React.MouseEvent< HTMLDivElement > ) => {
+			const target = event.target as HTMLElement;
+			// Skip if clicking directly on the RadioControl (fieldset or input)
+			if ( target.closest( 'fieldset' ) || target.tagName === 'INPUT' ) {
+				return;
 			}
+
+			onModeChange( mode );
 		},
-		[ handleModeClick ]
+		[ mode, onModeChange ]
 	);
 
 	return (
@@ -108,12 +107,7 @@ export default function ConnectionModeCard( {
 					<HStack
 						spacing={ 2 }
 						justify="flex-start"
-						role="radio"
-						tabIndex={ 0 }
 						onClick={ handleModeClick }
-						onKeyDown={ handleKeyDown }
-						aria-checked={ isSelected }
-						aria-label={ `${ title }. ${ description }` }
 						style={ { cursor: 'pointer' } }
 					>
 						<RadioControl


### PR DESCRIPTION
Closes [DOMAINS-1863](https://linear.app/a8c/issue/DOMAINS-1863/make-panel-areas-clickable)

## Proposed Changes
* Made the entire HStack area in the connection mode card clickable to control the RadioControl
* Added click event handler that prevents double-firing when clicking directly on the RadioControl
* Added visual feedback (cursor: pointer) to indicate the clickable area
* Used `useCallback` for performance optimization of the click handler

https://github.com/user-attachments/assets/d8ae6623-34f2-4c7a-884f-c5bbc6154348

## Why are these changes being made?
* Improves user experience by making the entire connection mode card header clickable, not just the small radio button
* Enhances usability by providing a larger clickable target area (title, description, and surrounding space)
* Maintains existing RadioControl functionality and accessibility (keyboard navigation and screen reader support remain intact)
* Prevents event conflicts by detecting clicks on RadioControl elements and skipping the wrapper handler to avoid double-firing

## Testing Instructions
- Navigate to the domain connection setup page
- Click anywhere in the connection mode card header (title, description, or empty space) - the mode should be selected
- Click directly on the radio button itself - the mode should be selected (no double-firing)
- Verify the cursor changes to a pointer when hovering over the card header area


## Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?