### PR TITLE
Update experiment name for new interactions bot configuration

### DIFF
--- a/packages/help-center/src/hooks/use-new-interaction-bot-config.ts
+++ b/packages/help-center/src/hooks/use-new-interaction-bot-config.ts
@@ -13,7 +13,7 @@ const botSlugMap = {
 		version: undefined, // Get active version
 	},
 	workflow_iteration: {
-		slug: 'wpcom-workflow-support_chat,',
+		slug: 'wpcom-workflow-support_chat',
 		version: '1.1.1', // Workflow iteration version
 	},
 };

--- a/packages/help-center/src/hooks/use-new-interaction-bot-config.ts
+++ b/packages/help-center/src/hooks/use-new-interaction-bot-config.ts
@@ -8,18 +8,18 @@ const botSlugMap = {
 		slug: 'wpcom-support-chat',
 		version: undefined, // Get active version
 	},
-	new_workflow: {
+	workflow: {
 		slug: 'wpcom-workflow-support_chat',
 		version: undefined, // Get active version
 	},
-	updated_legacy: {
-		slug: 'wpcom-support-chat',
-		version: '20.8.4', // Legacy chain assistant with updated prompt
+	workflow_iteration: {
+		slug: 'wpcom-workflow-support_chat,',
+		version: '1.1.1', // Workflow iteration version
 	},
 };
 
 export function useNewInteractionsBotConfig() {
-	const experimentName = 'wpcom_help_center_ai_workflow_and_prompt_changes';
+	const experimentName = 'wpcom_help_center_ai_workflow_variations';
 	const query = useQuery( {
 		queryKey: [ 'new-interactions-bot-slug', experimentName ],
 		staleTime: 10 * 60 * 1000, // 10 minutes


### PR DESCRIPTION
Fixes HAL-482

## Proposed Changes

- Wire up the Help Center bot to `wpcom_help_center_ai_workflow_and_prompt_changes` experiment. 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- We need to measure the bots performance :)

## Testing Instructions

1. Without changing anything, open DevTools > Network and filter by `odie/chat`.
2. Open the Help Center and ask Odie a question that you'd remember.
3. The message should go to `wpcom-support-chat` bot.
4. Go the experiment page and assign yourself to `control`.
5. Start a new interaction. Send a message. The message should go to `wpcom-support-chat` bot.
6. Assign yourself to `workflow` and refresh the page.
7. Start a new interaction and send a message you'd remember.
8. The message should go to `wpcom-workflow-support_chat` bot.
9. Go back to the first thread you created. Send a message.
10. It should target `wpcom-support-chat`.
11. Assign yourself to `workflow_iteration ` and refresh the page.
12. Start a new thread, send a message.
13. The message should go to `wpcom-workflow-support_chat@1.1.1` bot.
14. Open the support history, you should see all threads.

### Testing in Atomic
_Note, this was already fixed we might want to skip this particular atomic testing._

1. run `yarn dev --sync` in `apps/help-center`.
2. sandbox widgets.wp.com and activate your sandbox in write mode.
3. Visit wp-admin/post-new.php on an Atomic site.
4. Test one branch of the experiment, should be more than enough.
