### PR TITLE
Big Sky: Set theme by new site endpoint

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -1,5 +1,4 @@
 import { Onboard } from '@automattic/data-stores';
-import { getAssemblerDesign } from '@automattic/design-picker';
 import { addPlanToCart, addProductsToCart, AI_SITE_BUILDER_FLOW } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { resolveSelect, useDispatch as useWpDataDispatch, useSelect } from '@wordpress/data';
@@ -87,8 +86,7 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 	initialize,
 	useStepNavigation( _, navigate ) {
 		const { siteSlug: siteSlugFromSiteData, siteId: siteIdFromSiteData } = useSiteData();
-		const { setDesignOnSite, setStaticHomepageOnSite, setIntentOnSite } =
-			useWpDataDispatch( SITE_STORE );
+		const { setStaticHomepageOnSite, setIntentOnSite } = useWpDataDispatch( SITE_STORE );
 		const { gardenName } = useSelect(
 			( select ) => ( {
 				gardenName: ( select( ONBOARD_STORE ) as any ).getGardenName(),
@@ -185,9 +183,6 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 
 							// Only apply design and delete page for non-garden sites
 							if ( ! gardenName ) {
-								pendingActions.push(
-									setDesignOnSite( siteSlug, getAssemblerDesign(), { enableThemeSetup: false } )
-								);
 								pendingActions.push( deletePage( siteId || '', 1 ) );
 							}
 							pendingActions.push( setIntentOnSite( siteSlug, SiteIntent.AIAssembler ) );


### PR DESCRIPTION
This willl depend on the new site endpoint to set the appropriate theme. See 197326-ghe-Automattic/wpcom

## Testing instructions

1. Sandbox public-api
2. Patch 197326-ghe-Automattic/wpcom
3. build calypso
4. Go to http://calypso.localhost:3000/setup/ai-site-builder?prompt=mariachi+restaurant+in+warsaw+poland+called+matias+loves+mariachi&locale=en&source=landing-page
5. Verify that the new website has `pub/assembler` theme - you can see theme switches in RC
6. Continue build, verify everything works