### PR TITLE
Domain Connection card: minor style updates

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.scss
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.scss
@@ -1,0 +1,10 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.connection-mode-card__body {
+	padding-top: 16px;
+	padding-bottom: 16px;
+	@include break-medium {
+		padding-top: 24px;
+		padding-bottom: 24px;
+	}
+}

--- a/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
+++ b/client/dashboard/domains/domain-connection-setup/connection-mode-card.tsx
@@ -88,8 +88,8 @@ export default function ConnectionModeCard( {
 	};
 
 	return (
-		<Card>
-			<CardBody>
+		<Card className="connection-mode-card">
+			<CardBody className="connection-mode-card__body">
 				<VStack spacing={ 4 }>
 					<HStack spacing={ 2 } justify="flex-start">
 						<RadioControl
@@ -99,11 +99,13 @@ export default function ConnectionModeCard( {
 								onModeChange( value as DomainConnectionSetupModeValue )
 							}
 						/>
-						<VStack spacing={ 2 }>
+						<VStack spacing={ 1 }>
 							<Text size="medium" weight={ 500 }>
 								{ title }
 							</Text>
-							<Text variant="muted">{ description }</Text>
+							<Text variant="muted" size={ 12 }>
+								{ description }
+							</Text>
 						</VStack>
 					</HStack>
 					{ isSelected && (


### PR DESCRIPTION
Closes [DOMAINS-1866](https://linear.app/a8c/issue/DOMAINS-1866/card-spec-refinement)

## Proposed Changes
Minor styles fixes for the Domain Connection cards:
- fixed radio button alignment
- added (visually hidden) legend  to improve accessibility
- increased vertical card paddings (24px)
- updated description font size (12px)
- decreased padding between title and description (4px)

## Why are these changes being made?
Design CfT review (1lCoIdZNpLPE9DjukYz9vUbAiqYsqeRHALTQ8xiaeosk-gdoc)

## Testing Instructions
Verify that the domain connection style has been updated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?