### PR TITLE
Fix feedback message

### DIFF
--- a/packages/odie-client/src/components/message/feedback-form.tsx
+++ b/packages/odie-client/src/components/message/feedback-form.tsx
@@ -92,14 +92,12 @@ export const FeedbackForm = ( { chatFeedbackOptions }: FeedbackFormProps ) => {
 			<div className={ clsx( 'odie-conversation__feedback', { has_message: score } ) }>
 				<div className="odie-conversation-feedback__thumbs">
 					<Button
-						__next40pxDefaultSize
 						onClick={ () => postScore( 'good' ) }
 						className="odie-conversation-feedback__thumbs-button"
 					>
 						<ThumbsUpIcon />
 					</Button>
 					<Button
-						__next40pxDefaultSize
 						onClick={ () => postScore( 'bad' ) }
 						className="odie-conversation-feedback__thumbs-button"
 					>

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -319,7 +319,7 @@ $blueberry-color: #3858e9;
 		}
 
 		.odie-chatbox-message__content {
-			flex-basis: calc( 100% - 78px );
+			flex-basis: 100%;
 		}
 
 		.odie-conversation__feedback {
@@ -338,7 +338,11 @@ $blueberry-color: #3858e9;
 
 			.odie-conversation-feedback__thumbs {
 				display: flex;
-				gap: 8px;
+				gap: var(--spacing-1, .25rem);
+
+				.odie-conversation-feedback__thumbs-button:hover svg {
+					color: var(--color-foreground, oklch(.241 0 0));
+				}
 
 				&-button {
 					padding: 0;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

| Before | After |
| ------------- | ------------- |
| <img width="415" height="773" alt="Screenshot 2025-12-03 at 12 32 01" src="https://github.com/user-attachments/assets/c02ddf2e-73bc-42b4-baab-42f90f169167" />  | <img width="413" height="774" alt="Screenshot 2025-12-03 at 12 31 31" src="https://github.com/user-attachments/assets/e77a7221-dfd4-4a7a-b1e5-d9012609cd2e" />|

Part of #

## Proposed Changes

* The space between the thumbs up and thumbs down icon is a tad bit too big. Can we update the gap to var(--spacing-1) to match our AI buttons.
* The thumbs up/down icons don't have a hover (like they do for the AI chat). The icon stroke should turn black.
* The line length of the copy is being cut off for some reason. Can we extend it full width?



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the help center
* Escalate to human
* Mark the chat as closed
* Compare the feedback message and buttons

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
