### PR TITLE
WIP: setup/plan-upgrade is broken for 2 and 3 year plans

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1,13 +1,13 @@
 import config from '@automattic/calypso-config';
 import {
 	chooseDefaultCustomerType,
+	getIntervalTypeForTerm,
 	getPlan,
 	isFreePlan,
 	isPersonalPlan,
 	PLAN_PERSONAL,
 	PLAN_FREE,
 	type PlanSlug,
-	type UrlFriendlyTermType,
 	isValidFeatureKey,
 	getFeaturesList,
 	isWooExpressPlan,
@@ -66,6 +66,7 @@ import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hook
 import usePlanTypeDestinationCallback from 'calypso/my-sites/plans-features-main/hooks/use-plan-type-destination-callback';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
+import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isDomainOnlySiteSelector from 'calypso/state/selectors/is-domain-only-site';
@@ -122,13 +123,11 @@ export interface PlansFeaturesMainProps {
 	removePaidDomain?: () => void;
 	setSiteUrlAsFreeDomainSuggestion?: ( freeDomainSuggestion: { domain_name: string } ) => void;
 	isDomainTransfer?: boolean;
-	intervalType?: Extract< UrlFriendlyTermType, 'monthly' | 'yearly' | '2yearly' | '3yearly' >;
+	intervalType?: SupportedUrlFriendlyTermType;
 	/**
 	 * An array of intervals to be displayed in the plan type selector. Defaults to [ 'yearly', '2yearly', '3yearly', 'monthly' ]
 	 */
-	displayedIntervals?: Array<
-		Extract< UrlFriendlyTermType, 'monthly' | 'yearly' | '2yearly' | '3yearly' >
-	>;
+	displayedIntervals?: SupportedUrlFriendlyTermType[];
 	planTypeSelector?: 'interval';
 	discountEndDate?: Date;
 	hidePlansFeatureComparison?: boolean;
@@ -241,6 +240,9 @@ const PlansFeaturesMain = ( {
 		isEligibleForWpComMonthlyPlan( state, siteId )
 	);
 	const siteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
+	const currentPlanTerm = useSelector( ( state: IAppState ) =>
+		siteId ? getCurrentPlanTerm( state, siteId ) : null
+	);
 	const sitePlanSlug = currentPlan?.productSlug;
 	const userCanUpgradeToPersonalPlan = useSelector(
 		( state: IAppState ) => siteId && canUpgradeToPlan( state, siteId, PLAN_PERSONAL )
@@ -292,8 +294,24 @@ const PlansFeaturesMain = ( {
 		paidDomainName,
 	} );
 
+	const hasIntervalTypeInQuery =
+		typeof window !== 'undefined' && hasQueryArg( window.location.href, 'intervalType' );
+
+	let resolvedIntervalType: SupportedUrlFriendlyTermType = intervalType;
+
+	// If no explicit intervalType is provided via query string, prefer the current plan's term.
+	if ( ! hasIntervalTypeInQuery && currentPlanTerm ) {
+		const fromCurrentPlan = getIntervalTypeForTerm(
+			currentPlanTerm
+		) as SupportedUrlFriendlyTermType | null;
+
+		if ( fromCurrentPlan ) {
+			resolvedIntervalType = fromCurrentPlan;
+		}
+	}
+
 	const term = usePlanBillingPeriod( {
-		intervalType,
+		intervalType: resolvedIntervalType,
 		...( selectedPlan ? { defaultValue: getPlan( selectedPlan )?.term } : {} ),
 	} );
 
@@ -505,7 +523,7 @@ const PlansFeaturesMain = ( {
 			isStepperUpgradeFlow,
 			isInSignup,
 			eligibleForWpcomMonthlyPlans,
-			intervalType,
+			intervalType: resolvedIntervalType,
 			customerType: _customerType,
 			siteSlug,
 			selectedPlan,
@@ -554,7 +572,7 @@ const PlansFeaturesMain = ( {
 		isStepperUpgradeFlow,
 		isInSignup,
 		eligibleForWpcomMonthlyPlans,
-		intervalType,
+		resolvedIntervalType,
 		_customerType,
 		siteSlug,
 		selectedPlan,
@@ -927,7 +945,7 @@ const PlansFeaturesMain = ( {
 													gridPlans={ gridPlansForComparisonGrid }
 													hideUnavailableFeatures={ hideUnavailableFeatures }
 													intent={ intent }
-													intervalType={ intervalType }
+													intervalType={ resolvedIntervalType }
 													isInAdmin={ ! isInSignup }
 													isInSiteDashboard={ isInSiteDashboard }
 													isInSignup={ isInSignup }


### PR DESCRIPTION
The reason is that we default to yearly for the target plan even if the user already has a plan that's not yearly

Part of M4R73CH-1476

## Proposed Changes

* Make the current plan term default if nothing is provided in the query string

## Why are these changes being made?

* 3-year plan users reaching an upsell cannot upgrade

## Testing Instructions

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
