### PR TITLE
Update e2e testing AI rules to support multiple tools

### DIFF
--- a/.cursor/rules/e2e-test-rules.mdc
+++ b/.cursor/rules/e2e-test-rules.mdc
@@ -1,0 +1,5 @@
+---
+description: Rules that applies for e2e testing
+---
+Use the rules in [e2e-test-rules.mdc](mdc:.rules/e2e-test-rules.mdc)
+

--- a/.rules/e2e-test-rules.mdc
+++ b/.rules/e2e-test-rules.mdc
@@ -3,38 +3,38 @@
 ## Documentation
 
 Full documentation is available in:
-- `docs/` - Legacy framework documentation
-- `docs-new/` - New Playwright Test framework documentation
+- `test/e2e/docs/` - Legacy framework documentation
+- `test/e2e/docs-new/` - New Playwright Test framework documentation
 
 Key docs to reference:
-- [Overview](docs-new/overview.md)
-- [Setup](docs-new/setup.md)
-- [Running and Debugging Tests](docs-new/running_debugging_tests.md)
-- [Creating Reliable Tests](docs-new/creating_reliable_tests.md)
-- [New Style Guide](docs-new/new_style_guide.md)
-- [Custom Fixtures](docs-new/custom_fixtures.md)
+- [Overview](test/e2e/docs-new/overview.md)
+- [Setup](test/e2e/docs-new/setup.md)
+- [Running and Debugging Tests](test/e2e/docs-new/running_debugging_tests.md)
+- [Creating Reliable Tests](test/e2e/docs-new/creating_reliable_tests.md)
+- [New Style Guide](test/e2e/docs-new/new_style_guide.md)
+- [Custom Fixtures](test/e2e/docs-new/custom_fixtures.md)
 
 ## Framework Migration Status
 
 We are migrating from the legacy framework to Playwright Test:
 
 **Legacy Framework (Playwright + Jest runner)**
-- Test files: `specs/**/*.ts` (without `.spec.` in filename)
+- Test files: `test/e2e/specs/**/*.ts` (without `.spec.` in filename)
 - Examples: `specs/blocks/blocks__core.ts`, `specs/published-content/likes__post.ts`
-- Documentation: `docs/`
+- Documentation: `test/e2e/docs/`
 - Status: Being phased out, do not write new tests in this format
 
 **New Framework (Playwright Test)**
-- Test files: `specs/**/*.spec.ts` (with `.spec.` in filename)
+- Test files: `test/e2e/specs/**/*.spec.ts` (with `.spec.` in filename)
 - Examples: `specs/tools/import__sites-squarespace.spec.ts`, `specs/tools/marketing__seo.spec.ts`
-- Documentation: `docs-new/`
+- Documentation: `test/e2e/docs-new/`
 - Status: Target framework for all new and migrated tests
 
 ## Guidelines
 
 - Always write new tests using Playwright Test (`.spec.ts` files)
 - When modifying existing tests, consider migrating them to the new framework
-- Follow the patterns and style guide in `docs-new/`
+- Follow the patterns and style guide in `test/e2e/docs-new/`
 - Reference legacy docs only for understanding existing code
 
 ## Running Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Before you start, please read the following files:
 - @.rules/calypso-client-rules.mdc – Rules that applies for all Clients within repository
 - @.rules/wordpress-imports.mdc – WordPress imports
 - @.rules/a4a-custom-rules.mdc – Rules that applies for Automattic for Agencies related development
+- @.rules/e2e-test-rules.mdc – Rules for E2E testing in test/e2e/ and packages/calypso-e2e
 
 If you are not sure about something, ask the user to clarify.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,5 +7,6 @@ Before you start, please read the following files:
 - @.rules/calypso-client-rules.mdc – Rules that applies for all Clients within repository
 - @.rules/wordpress-imports.mdc – WordPress imports
 - @.rules/a4a-custom-rules.mdc – Rules that applies for Automattic for Agencies related development
+- @.rules/e2e-test-rules.mdc – Rules for E2E testing in test/e2e/ and packages/calypso-e2e
 
 If you are not sure about something, ask the user to clarify.


### PR DESCRIPTION


## Proposed Changes

The AI instructions for e2e testing were written in a `CLAUDE.md` file in test/e2e folder, limiting the support to Claude Code only. I moved the instructions in a new rules mdc file in the .rules folder and referenced in the main Claude file, a Cursor rule and the Codex agents file.


