### PR TITLE
Domain Connection Verification: minor UI updates

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/domain-propagation-status.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/domain-propagation-status.tsx
@@ -40,7 +40,7 @@ export default function DomainPropagationStatus( { domainName }: { domainName: s
 			</Text>
 			<Card>
 				<CardBody>
-					<Grid columns={ 3 } gap={ 4 }>
+					<Grid columns={ 4 } gap={ 4 }>
 						{ data.propagation_status.map( ( area ) => (
 							<HStack key={ area.area_code } spacing={ 2 } justify="flex-start">
 								<PropagationStatusIndicator propagated={ area.propagated } />

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -102,14 +102,19 @@ export default function DomainConnectionVerification( {
 						) }
 
 						{ status === 'connected' && (
-							<RouterLinkSummaryButton
-								to={ siteDomainsRoute.fullPath }
-								params={ { siteSlug } }
-								/* Translators: %s is the domain name. */
-								title={ sprintf( __( 'Set %s as your primary site address' ), domainName ) }
-								description={ __( 'It’s the URL visitors see in their browser’s address bar.' ) }
-								decoration={ <Icon icon={ atSymbol } /> }
-							/>
+							<>
+								<Text size="medium" weight={ 500 }>
+									{ __( 'Recommended' ) }
+								</Text>
+								<RouterLinkSummaryButton
+									to={ siteDomainsRoute.fullPath }
+									params={ { siteSlug } }
+									/* Translators: %s is the domain name. */
+									title={ sprintf( __( 'Set %s as your primary site address' ), domainName ) }
+									description={ __( 'It’s the URL visitors see in their browser’s address bar.' ) }
+									decoration={ <Icon icon={ atSymbol } /> }
+								/>
+							</>
 						) }
 						<RouterLinkSummaryButton
 							to={ siteOverviewRoute.fullPath }

--- a/client/dashboard/domains/domain-connection-setup/index.tsx
+++ b/client/dashboard/domains/domain-connection-setup/index.tsx
@@ -182,9 +182,7 @@ export default function DomainConnection() {
 			header={
 				<PageHeader
 					title={
-						isVerificationStep
-							? __( 'Domain connection verification' )
-							: __( 'Connect your domain name' )
+						isVerificationStep ? __( 'Connection verification' ) : __( 'Connect your domain name' )
 					}
 					description={
 						isVerificationStep


### PR DESCRIPTION
Closes [DOMAINS-1917](https://linear.app/a8c/issue/DOMAINS-1917/domain-connection-verification-fine-tuning)

## Proposed Changes
1. **Page header title**: Shortened from "Domain connection verification" to "Connection verification" for a more concise header.
2. **Recommended section**: Added a "Recommended" heading before the primary domain setup action when the domain status is "connected" to clarify the next step.
3. **Propagation status layout**: Updated the global propagation status grid from 3 to 4 columns for better use of space.

## Why are these changes being made?
CfT design feedback (1lCoIdZNpLPE9DjukYz9vUbAiqYsqeRHALTQ8xiaeosk-gdoc)

## Testing Instructions
- Verify the page header displays the new title 
- Confirm the "Recommended" section appears only when domain status is "connected"
- Check that the propagation status grid displays correctly with 4 columns

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?