### PR TITLE
MSD Plugins: Improve Toggle Responsiveness

### DIFF
--- a/client/dashboard/plugins/plugin/components/active-toggle.tsx
+++ b/client/dashboard/plugins/plugin/components/active-toggle.tsx
@@ -1,0 +1,86 @@
+import { __, sprintf } from '@wordpress/i18n';
+import FieldActionToggle from './field-action-toggle';
+import type { SiteWithPluginData } from '../use-plugin';
+import type { Dispatch, SetStateAction } from 'react';
+
+type ActiveFieldProps = {
+	item: SiteWithPluginData;
+	plugin: { id?: string; name?: string } | null | undefined;
+	// The current active value from the server for this plugin on this site.
+	active: boolean;
+	activateMutate: ( variables: { siteId: number; pluginId: string } ) => Promise< unknown >;
+	deactivateMutate: ( variables: { siteId: number; pluginId: string } ) => Promise< unknown >;
+	optimisticActive: Record< number, boolean | undefined >;
+	setOptimisticActive: Dispatch< SetStateAction< Record< number, boolean | undefined > > >;
+	disabled?: boolean;
+};
+
+export const ActiveToggle = ( {
+	item,
+	plugin,
+	active,
+	activateMutate,
+	deactivateMutate,
+	optimisticActive,
+	setOptimisticActive,
+	disabled = false,
+}: ActiveFieldProps ) => {
+	const serverChecked = active;
+	const optimistic = optimisticActive[ item.ID ];
+
+	// Use optimistic value if we have one, otherwise use server value
+	const checked = optimistic ?? serverChecked;
+
+	return (
+		<FieldActionToggle
+			label={ __( 'Active' ) }
+			checked={ checked }
+			disabled={ disabled }
+			onToggle={ ( next ) => {
+				// what the toggle was before this click
+				const previous = checked;
+
+				setOptimisticActive( ( prev ) => ( {
+					...prev,
+					[ item.ID ]: next,
+				} ) );
+
+				const mutation = next
+					? activateMutate( { siteId: item.ID, pluginId: plugin?.id || '' } )
+					: deactivateMutate( { siteId: item.ID, pluginId: plugin?.id || '' } );
+
+				// Return the promise so FieldActionToggle can show notices
+				return mutation.catch( ( error: unknown ) => {
+					setOptimisticActive( ( prev ) => ( {
+						...prev,
+						[ item.ID ]: previous,
+					} ) );
+
+					// rethrow so FieldActionToggle shows error notice
+					throw error;
+				} );
+			} }
+			successOn={ sprintf(
+				// translators: %s is the name of the plugin.
+				__( '%s has been activated.' ),
+				plugin?.name ?? ''
+			) }
+			errorOn={ sprintf(
+				// translators: %s is the name of the plugin.
+				__( 'Failed to activate %s.' ),
+				plugin?.name ?? ''
+			) }
+			successOff={ sprintf(
+				// translators: %s is the name of the plugin.
+				__( '%s has been deactivated.' ),
+				plugin?.name ?? ''
+			) }
+			errorOff={ sprintf(
+				// translators: %s is the name of the plugin.
+				__( 'Failed to deactivate %s.' ),
+				plugin?.name ?? ''
+			) }
+			actionId="activate"
+		/>
+	);
+};

--- a/client/dashboard/plugins/plugin/components/autoupdate-toggle.tsx
+++ b/client/dashboard/plugins/plugin/components/autoupdate-toggle.tsx
@@ -1,0 +1,88 @@
+import { __, sprintf } from '@wordpress/i18n';
+import FieldActionToggle from './field-action-toggle';
+import type { SiteWithPluginData } from '../use-plugin';
+import type { Dispatch, SetStateAction } from 'react';
+
+type AutoupdateFieldProps = {
+	item: SiteWithPluginData;
+	plugin: { id?: string; name?: string } | null | undefined;
+	autoupdate: boolean;
+	enableAutoupdateMutate: ( variables: { siteId: number; pluginId: string } ) => Promise< unknown >;
+	disableAutoupdateMutate: ( variables: {
+		siteId: number;
+		pluginId: string;
+	} ) => Promise< unknown >;
+	optimisticAutoupdate: Record< number, boolean | undefined >;
+	setOptimisticAutoupdate: Dispatch< SetStateAction< Record< number, boolean | undefined > > >;
+	disabled?: boolean;
+};
+
+export const AutoupdateToggle = ( {
+	item,
+	plugin,
+	autoupdate,
+	enableAutoupdateMutate,
+	disableAutoupdateMutate,
+	optimisticAutoupdate,
+	setOptimisticAutoupdate,
+	disabled,
+}: AutoupdateFieldProps ) => {
+	const serverChecked = autoupdate;
+	const optimistic = optimisticAutoupdate[ item.ID ];
+
+	// Use optimistic value if we have one, otherwise use server value
+	const checked = optimistic ?? serverChecked;
+
+	return (
+		<FieldActionToggle
+			label={ __( 'Autoupdate' ) }
+			checked={ checked }
+			disabled={ disabled }
+			onToggle={ ( next ) => {
+				// what the toggle was before this click
+				const previous = checked;
+
+				setOptimisticAutoupdate( ( prev ) => ( {
+					...prev,
+					[ item.ID ]: next,
+				} ) );
+
+				const mutation = next
+					? enableAutoupdateMutate( { siteId: item.ID, pluginId: plugin?.id || '' } )
+					: disableAutoupdateMutate( { siteId: item.ID, pluginId: plugin?.id || '' } );
+
+				// Return the promise so FieldActionToggle can show notices
+				return mutation.catch( ( error: unknown ) => {
+					setOptimisticAutoupdate( ( prev ) => ( {
+						...prev,
+						[ item.ID ]: previous,
+					} ) );
+
+					// rethrow so FieldActionToggle shows error notice
+					throw error;
+				} );
+			} }
+			successOn={ sprintf(
+				// translators: %s is the name of the plugin.
+				__( 'Auto‑updates for %s have been enabled.' ),
+				plugin?.name ?? ''
+			) }
+			errorOn={ sprintf(
+				// translators: %s is the name of the plugin.
+				__( 'Failed to enable auto‑updates for %s.' ),
+				plugin?.name ?? ''
+			) }
+			successOff={ sprintf(
+				// translators: %s is the name of the plugin.
+				__( 'Auto‑updates for %s have been disabled.' ),
+				plugin?.name ?? ''
+			) }
+			errorOff={ sprintf(
+				// translators: %s is the name of the plugin.
+				__( 'Failed to disable auto‑updates for %s.' ),
+				plugin?.name ?? ''
+			) }
+			actionId="autoupdate"
+		/>
+	);
+};

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -15,7 +15,13 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { DataViews, filterSortAndPaginate, View, type Field } from '@wordpress/dataviews';
+import {
+	DataViews,
+	filterSortAndPaginate,
+	View,
+	type Field,
+	type DataViewRenderFieldProps,
+} from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { link, linkOff, trash } from '@wordpress/icons';
 import { useCallback, useMemo, useState } from 'react';
@@ -27,7 +33,8 @@ import { PluginsHeaderActions } from '../manage/components/plugins-header-action
 import { buildBulkSitesPluginAction } from '../manage/utils';
 import { getViewFilteredByUpdates } from '../utils/update-filters';
 import { ActionRenderModalWrapper } from './components/action-render-modal-wrapper';
-import FieldActionToggle from './components/field-action-toggle';
+import { ActiveToggle } from './components/active-toggle';
+import { AutoupdateToggle } from './components/autoupdate-toggle';
 import { SiteWithPluginData, usePlugin } from './use-plugin';
 import { getAllowedPluginActions } from './utils/get-allowed-plugin-actions';
 import { mapToPluginListRow } from './utils/map-to-plugin-list-row';
@@ -44,24 +51,26 @@ const defaultView: View = {
 export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) => {
 	const { mutateAsync } = useMutation( sitePluginUpdateMutation() );
 	const updateAction = buildBulkSitesPluginAction( mutateAsync );
-	const { isLoading, plugin, pluginBySiteId, sitesWithThisPlugin, isFetching } =
-		usePlugin( pluginSlug );
+	const { isLoading, plugin, pluginBySiteId, sitesWithThisPlugin } = usePlugin( pluginSlug );
 	const [ view, setView ] = useState< View >( defaultView );
-	const { mutateAsync: activateMutate, isPending: isActivating } = useMutation(
-		sitePluginActivateMutation()
-	);
-	const { mutateAsync: deactivateMutate, isPending: isDeactivating } = useMutation(
-		sitePluginDeactivateMutation()
-	);
-	const { mutateAsync: enableAutoupdateMutate, isPending: isEnablingAutoupdate } = useMutation(
+	const { mutateAsync: activateMutate } = useMutation( sitePluginActivateMutation() );
+	const { mutateAsync: deactivateMutate } = useMutation( sitePluginDeactivateMutation() );
+	const { mutateAsync: enableAutoupdateMutate } = useMutation(
 		sitePluginAutoupdateEnableMutation()
 	);
-	const { mutateAsync: disableAutoupdateMutate, isPending: isDisablingAutoupdate } = useMutation(
+	const { mutateAsync: disableAutoupdateMutate } = useMutation(
 		sitePluginAutoupdateDisableMutation()
 	);
 	const [ selection, setSelection ] = useState< SiteWithPluginData[] >( [] );
 	const [ updateModalOpen, setUpdateModalOpen ] = useState( false );
 	const [ siteToUpdate, setSiteToUpdate ] = useState< SiteWithPluginData | null >( null );
+	const [ optimisticActive, setOptimisticActive ] = useState<
+		Record< number, boolean | undefined >
+	>( {} );
+	const [ optimisticAutoupdate, setOptimisticAutoupdate ] = useState<
+		Record< number, boolean | undefined >
+	>( {} );
+
 	const closeUpdateModal = () => {
 		setUpdateModalOpen( false );
 		setSiteToUpdate( null );
@@ -93,47 +102,25 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 				id: 'active',
 				label: __( 'Active' ),
 				type: 'boolean',
-				getValue: ( { item }: { item: SiteWithPluginData } ) =>
-					pluginBySiteId.get( item.ID )?.active ?? false,
-				render: ( { item }: { item: SiteWithPluginData } ) => {
+				getValue: ( { item }: { item: SiteWithPluginData } ) => {
 					const pluginItem = pluginBySiteId.get( item.ID );
-					const checked = pluginItem?.active ?? false;
-					const isBusy = isActivating || isDeactivating || isFetching;
-					return (
-						<FieldActionToggle
-							label={ __( 'Active' ) }
-							checked={ checked }
-							disabled={ isBusy }
-							onToggle={ ( next ) => {
-								if ( next ) {
-									return activateMutate( { siteId: item.ID, pluginId: plugin?.id || '' } );
-								}
-								return deactivateMutate( { siteId: item.ID, pluginId: plugin?.id || '' } );
-							} }
-							successOn={ sprintf(
-								// translators: %s is the name of the plugin.
-								__( '%s has been activated.' ),
-								plugin?.name ?? ''
-							) }
-							errorOn={ sprintf(
-								// translators: %s is the name of the plugin.
-								__( 'Failed to activate %s.' ),
-								plugin?.name ?? ''
-							) }
-							successOff={ sprintf(
-								// translators: %s is the name of the plugin.
-								__( '%s has been deactivated.' ),
-								plugin?.name ?? ''
-							) }
-							errorOff={ sprintf(
-								// translators: %s is the name of the plugin.
-								__( 'Failed to deactivate %s.' ),
-								plugin?.name ?? ''
-							) }
-							actionId="activate"
-						/>
-					);
+					const serverChecked = pluginItem?.active ?? false;
+					const optimistic = optimisticActive[ item.ID ];
+
+					// Use optimistic value if we have one, otherwise use server value
+					return optimistic ?? serverChecked;
 				},
+				render: ( { field, item }: DataViewRenderFieldProps< SiteWithPluginData > ) => (
+					<ActiveToggle
+						item={ item }
+						plugin={ plugin }
+						active={ field.getValue?.( { item } ) as boolean }
+						activateMutate={ activateMutate }
+						deactivateMutate={ deactivateMutate }
+						optimisticActive={ optimisticActive }
+						setOptimisticActive={ setOptimisticActive }
+					/>
+				),
 				enableHiding: false,
 				enableSorting: true,
 			},
@@ -141,50 +128,28 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 				id: 'autoupdate',
 				label: __( 'Autoupdate' ),
 				type: 'boolean',
-				getValue: ( { item }: { item: SiteWithPluginData } ) =>
-					pluginBySiteId.get( item.ID )?.autoupdate ?? false,
-				render: ( { item }: { item: SiteWithPluginData } ) => {
+				getValue: ( { item }: { item: SiteWithPluginData } ) => {
 					const pluginItem = pluginBySiteId.get( item.ID );
 					const checked = pluginItem?.autoupdate ?? false;
-					const isBusy = isEnablingAutoupdate || isDisablingAutoupdate || isFetching;
-
+					const optimistic = optimisticAutoupdate[ item.ID ];
+					return optimistic ?? checked;
+				},
+				render: ( { field, item }: DataViewRenderFieldProps< SiteWithPluginData > ) => {
 					// Determine if this plugin is managed on this site; if so, disable interaction
 					const { autoupdate } = getAllowedPluginActions( item, pluginSlug );
 					// when not allowed, it's either managed or user lacks permission
 					const isManaged = ! autoupdate;
 
 					return (
-						<FieldActionToggle
-							label={ __( 'Autoupdate' ) }
-							checked={ checked }
-							disabled={ isBusy || isManaged }
-							onToggle={ ( next ) => {
-								if ( next ) {
-									return enableAutoupdateMutate( { siteId: item.ID, pluginId: plugin?.id || '' } );
-								}
-								return disableAutoupdateMutate( { siteId: item.ID, pluginId: plugin?.id || '' } );
-							} }
-							successOn={ sprintf(
-								// translators: %s is the name of the plugin.
-								__( 'Auto‑updates for %s have been enabled.' ),
-								plugin?.name ?? ''
-							) }
-							errorOn={ sprintf(
-								// translators: %s is the name of the plugin.
-								__( 'Failed to enable auto‑updates for %s.' ),
-								plugin?.name ?? ''
-							) }
-							successOff={ sprintf(
-								// translators: %s is the name of the plugin.
-								__( 'Auto‑updates for %s have been disabled.' ),
-								plugin?.name ?? ''
-							) }
-							errorOff={ sprintf(
-								// translators: %s is the name of the plugin.
-								__( 'Failed to disable auto‑updates for %s.' ),
-								plugin?.name ?? ''
-							) }
-							actionId="autoupdate"
+						<AutoupdateToggle
+							item={ item }
+							plugin={ plugin }
+							autoupdate={ field.getValue?.( { item } ) as boolean }
+							enableAutoupdateMutate={ enableAutoupdateMutate }
+							disableAutoupdateMutate={ disableAutoupdateMutate }
+							optimisticAutoupdate={ optimisticAutoupdate }
+							setOptimisticAutoupdate={ setOptimisticAutoupdate }
+							disabled={ isManaged }
 						/>
 					);
 				},
@@ -258,18 +223,15 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 		],
 		[
 			pluginBySiteId,
-			isActivating,
-			isDeactivating,
-			isFetching,
-			plugin?.name,
-			plugin?.id,
-			deactivateMutate,
+			optimisticActive,
+			optimisticAutoupdate,
+			plugin,
 			activateMutate,
-			isEnablingAutoupdate,
-			isDisablingAutoupdate,
+			deactivateMutate,
 			pluginSlug,
 			disableAutoupdateMutate,
 			enableAutoupdateMutate,
+			setOptimisticAutoupdate,
 		]
 	);
 

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -386,7 +386,7 @@ export const SitesWithThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) =>
 						isEligible: ( item ) => {
 							const { autoupdate } = getAllowedPluginActions( item, pluginSlug );
 
-							return !! autoupdate && ! ( pluginBySiteId.get( item.ID )?.autoupdate ?? false );
+							return !! autoupdate && ( pluginBySiteId.get( item.ID )?.autoupdate ?? false );
 						},
 						supportsBulk: true,
 					},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTMSD-859/msd-plugins-improve-toggle-responsiveness-and-ensure-tanstack-cache

## Proposed Changes

* Improved the responsiveness of the toggle fields.
* Fixed an issue with the enable and disable auto-updates actions incorrectly displaying the affected sites.


https://github.com/user-attachments/assets/9b00cbcb-c090-4ef5-b65d-26943948393b



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our MSD Plugins v2 effort.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Navigate to `/v2/plugins`.
* Click on a non-managed plugin.
* Play around with the `active` and `auto-update` toggles.
* They should be more responsive than in prod.
* Check that the Dataview actions display the correct actions.
* Check that bulk actions display the correct items to be changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
