### PR TITLE
Fix default interval type issues in signup

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util.ts
@@ -15,7 +15,7 @@ export type SupportedIntervalTypes = Extract<
 	UrlFriendlyTermType,
 	'monthly' | 'yearly' | '2yearly' | '3yearly'
 >;
-const supportedIntervalTypes: SupportedIntervalTypes[] = [
+export const supportedIntervalTypes: SupportedIntervalTypes[] = [
 	'monthly',
 	'yearly',
 	'2yearly',

--- a/client/my-sites/plans-features-main/components/utils/utils.ts
+++ b/client/my-sites/plans-features-main/components/utils/utils.ts
@@ -7,6 +7,7 @@ import {
 	MARKETPLACE_THEME,
 } from '@automattic/design-picker';
 import { PlansIntent } from '@automattic/plans-grid-next';
+import { supportedIntervalTypes } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util';
 import type { SupportedUrlFriendlyTermType } from '@automattic/plans-grid-next';
 
 /* For Guided Signup intents we want to force the default plans for the comparison table. See: pdDR7T-1xi-p2 */
@@ -60,16 +61,6 @@ export const getHidePlanPropsBasedOnThemeType = ( themeType: string ) => {
 };
 
 /**
- * Ordered array of interval types from shortest to longest term.
- */
-const INTERVAL_TYPES_ORDERED: SupportedUrlFriendlyTermType[] = [
-	'monthly',
-	'yearly',
-	'2yearly',
-	'3yearly',
-];
-
-/**
  * Ensures that the requested intervalType is compatible with the current plan's term.
  * Users can only select interval types that are equal to or longer than their current plan's interval.
  */
@@ -86,10 +77,10 @@ export const ensureCompatibleIntervalType = (
 		return requestedIntervalType;
 	}
 
-	const currentIndex = INTERVAL_TYPES_ORDERED.indexOf(
+	const currentIndex = supportedIntervalTypes.indexOf(
 		currentPlanIntervalType as SupportedUrlFriendlyTermType
 	);
-	const requestedIndex = INTERVAL_TYPES_ORDERED.indexOf( requestedIntervalType );
+	const requestedIndex = supportedIntervalTypes.indexOf( requestedIntervalType );
 
 	if ( currentIndex === -1 || requestedIndex === -1 || requestedIndex >= currentIndex ) {
 		return requestedIntervalType;

--- a/client/my-sites/plans-features-main/components/utils/utils.ts
+++ b/client/my-sites/plans-features-main/components/utils/utils.ts
@@ -1,3 +1,4 @@
+import { getIntervalTypeForTerm } from '@automattic/calypso-products';
 import {
 	PERSONAL_THEME,
 	PREMIUM_THEME,
@@ -6,6 +7,7 @@ import {
 	MARKETPLACE_THEME,
 } from '@automattic/design-picker';
 import { PlansIntent } from '@automattic/plans-grid-next';
+import type { SupportedUrlFriendlyTermType } from '@automattic/plans-grid-next';
 
 /* For Guided Signup intents we want to force the default plans for the comparison table. See: pdDR7T-1xi-p2 */
 export const shouldForceDefaultPlansBasedOnIntent = ( intent: PlansIntent | undefined ) => {
@@ -55,4 +57,43 @@ export const getHidePlanPropsBasedOnThemeType = ( themeType: string ) => {
 	}
 
 	return {};
+};
+
+/**
+ * Ordered array of interval types from shortest to longest term.
+ */
+const INTERVAL_TYPES_ORDERED: SupportedUrlFriendlyTermType[] = [
+	'monthly',
+	'yearly',
+	'2yearly',
+	'3yearly',
+];
+
+/**
+ * Ensures that the requested intervalType is compatible with the current plan's term.
+ * Users can only select interval types that are equal to or longer than their current plan's interval.
+ */
+export const ensureCompatibleIntervalType = (
+	currentPlanTerm: string | null | undefined,
+	requestedIntervalType: SupportedUrlFriendlyTermType
+): SupportedUrlFriendlyTermType => {
+	if ( ! currentPlanTerm ) {
+		return requestedIntervalType;
+	}
+
+	const currentPlanIntervalType = getIntervalTypeForTerm( currentPlanTerm );
+	if ( ! currentPlanIntervalType ) {
+		return requestedIntervalType;
+	}
+
+	const currentIndex = INTERVAL_TYPES_ORDERED.indexOf(
+		currentPlanIntervalType as SupportedUrlFriendlyTermType
+	);
+	const requestedIndex = INTERVAL_TYPES_ORDERED.indexOf( requestedIntervalType );
+
+	if ( currentIndex === -1 || requestedIndex === -1 || requestedIndex >= currentIndex ) {
+		return requestedIntervalType;
+	}
+
+	return currentPlanIntervalType as SupportedUrlFriendlyTermType;
 };

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -295,7 +295,9 @@ const PlansFeaturesMain = ( {
 
 	// Ensure intervalType is compatible with the current plan's term
 	// Users can only select interval types that are equal to or longer than their current plan's interval
-	const currentPlanTerm = sitePlanSlug ? getPlan( sitePlanSlug )?.term : null;
+	// Only apply this fix in the plan-upgrade flow to avoid breaking other flows
+	const currentPlanTerm =
+		isStepperUpgradeFlow && sitePlanSlug ? getPlan( sitePlanSlug )?.term : null;
 	const compatibleIntervalType = useMemo(
 		() => ensureCompatibleIntervalType( currentPlanTerm, intervalType ),
 		[ currentPlanTerm, intervalType ]

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -61,6 +61,7 @@ import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-not
 import {
 	shouldForceDefaultPlansBasedOnIntent,
 	hideEscapeHatchForIntent,
+	ensureCompatibleIntervalType,
 } from 'calypso/my-sites/plans-features-main/components/utils/utils';
 import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs';
 import usePlanTypeDestinationCallback from 'calypso/my-sites/plans-features-main/hooks/use-plan-type-destination-callback';
@@ -292,8 +293,16 @@ const PlansFeaturesMain = ( {
 		paidDomainName,
 	} );
 
+	// Ensure intervalType is compatible with the current plan's term
+	// Users can only select interval types that are equal to or longer than their current plan's interval
+	const currentPlanTerm = sitePlanSlug ? getPlan( sitePlanSlug )?.term : null;
+	const compatibleIntervalType = useMemo(
+		() => ensureCompatibleIntervalType( currentPlanTerm, intervalType ),
+		[ currentPlanTerm, intervalType ]
+	);
+
 	const term = usePlanBillingPeriod( {
-		intervalType,
+		intervalType: compatibleIntervalType,
 		...( selectedPlan ? { defaultValue: getPlan( selectedPlan )?.term } : {} ),
 	} );
 
@@ -505,7 +514,7 @@ const PlansFeaturesMain = ( {
 			isStepperUpgradeFlow,
 			isInSignup,
 			eligibleForWpcomMonthlyPlans,
-			intervalType,
+			intervalType: compatibleIntervalType,
 			customerType: _customerType,
 			siteSlug,
 			selectedPlan,
@@ -554,7 +563,7 @@ const PlansFeaturesMain = ( {
 		isStepperUpgradeFlow,
 		isInSignup,
 		eligibleForWpcomMonthlyPlans,
-		intervalType,
+		compatibleIntervalType,
 		_customerType,
 		siteSlug,
 		selectedPlan,
@@ -927,7 +936,7 @@ const PlansFeaturesMain = ( {
 													gridPlans={ gridPlansForComparisonGrid }
 													hideUnavailableFeatures={ hideUnavailableFeatures }
 													intent={ intent }
-													intervalType={ intervalType }
+													intervalType={ compatibleIntervalType }
 													isInAdmin={ ! isInSignup }
 													isInSiteDashboard={ isInSiteDashboard }
 													isInSignup={ isInSignup }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1476

## Proposed Changes

* Rather than refactor plans to ensure we are always showing an equal-duration or longer-term plan, introduce an order that does it.

## Why are these changes being made?

* The setup/plan-upgrade is defaulting to yearly even when I have a longer term plan, which results in broken upsells on the hosting dashboard

## Testing Instructions

Use a Summer Special Personal 1-year
- Go to sites/siteid.wpcomstaging.com/settings/sftp-ssh
- Click the upsell
- You should see upgrade buttons

Now repeat with a 2 or 3-year Personal
- Go to sites/siteid.wpcomstaging.com/settings/sftp-ssh
- Click the upsell
- You should see Upgrade buttons

Before:
<img width="45%" alt="Screenshot 2025-12-03 at 16 13 24" src="https://github.com/user-attachments/assets/d27fe61b-a119-4ba8-aa49-0312d91b4945" />

After:
<img width="45%" alt="Screenshot 2025-12-03 at 16 13 38" src="https://github.com/user-attachments/assets/ffa07fd5-2db9-404b-a882-6981fcefd5ac" />
<img width="45%" alt="Screenshot 2025-12-03 at 16 13 44" src="https://github.com/user-attachments/assets/1968ca72-8166-4a08-a47b-6696e92dc986" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
