### PR TITLE
Domain connection:update DNS propagation progress bar to use dns records match

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
@@ -15,25 +15,25 @@ interface Props {
 }
 
 /**
- * Calculates the progress percentage based on name server comparison.
- * @param currentNameServers - Current name servers from domainMappingStatus
- * @param expectedNameServers - Expected name servers from domainConnectionSetupInfo
+ * Calculates the progress percentage based on comparing current values with expected values.
+ * @param currentValues - Current values (name servers or IP addresses)
+ * @param expectedValues - Expected values to match against
  * @returns Progress percentage (0-100)
  */
-function calculateProgress( currentNameServers: string[], expectedNameServers: string[] ): number {
-	// Normalize name servers to lowercase for comparison
-	const normalizedCurrent = currentNameServers.map( ( ns ) => ns.toLowerCase() );
-	const normalizedExpected = expectedNameServers.map( ( ns ) => ns.toLowerCase() );
+function calculateProgress( currentValues: string[], expectedValues: string[] ): number {
+	// Normalize values to lowercase for comparison
+	const normalizedCurrent = currentValues.map( ( value ) => value.toLowerCase() );
+	const normalizedExpected = expectedValues.map( ( value ) => value.toLowerCase() );
 
 	// Create a Set for efficient lookup
 	const currentSet = new Set( normalizedCurrent );
 
-	// Count how many expected name servers are present in current name servers
+	// Count how many expected values are present in current values
 	const matchedCount = normalizedExpected.filter( ( expected ) =>
 		currentSet.has( expected )
 	).length;
 
-	// Calculate percentage based on how many expected name servers are matched
+	// Calculate percentage based on how many expected values are matched
 	const totalExpected = normalizedExpected.length;
 	return totalExpected > 0 ? Math.round( ( matchedCount / totalExpected ) * 100 ) : 0;
 }
@@ -47,13 +47,14 @@ export default function DnsPropagationProgressBar( {
 
 	if ( mode === DomainConnectionSetupMode.DC ) {
 		progressPercentage = 100;
-	} else if (
-		mode === DomainConnectionSetupMode.SUGGESTED ||
-		mode === DomainConnectionSetupMode.ADVANCED
-	) {
+	} else if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
 		const currentNameServers = domainMappingStatus.name_servers || [];
 		const expectedNameServers = domainConnectionSetupInfo.wpcom_name_servers || [];
 		progressPercentage = calculateProgress( currentNameServers, expectedNameServers );
+	} else if ( mode === DomainConnectionSetupMode.ADVANCED ) {
+		const currentIpAddresses = domainMappingStatus.host_ip_addresses || [];
+		const expectedIpAddresses = domainConnectionSetupInfo.default_ip_addresses || [];
+		progressPercentage = calculateProgress( currentIpAddresses, expectedIpAddresses );
 	} else {
 		// All other cases: 0%
 		progressPercentage = 0;

--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
@@ -1,5 +1,4 @@
-import { domainPropagationStatusQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
+import { DomainConnectionSetupMode } from '@automattic/api-core';
 import './dns-propagation-progress-bar-style.scss';
 import {
 	ProgressBar,
@@ -8,22 +7,57 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import type { DomainMappingSetupInfo, DomainMappingStatus } from '@automattic/api-core';
 
 interface Props {
-	domainName: string;
+	domainMappingStatus: DomainMappingStatus;
+	domainConnectionSetupInfo: DomainMappingSetupInfo;
 }
 
-export default function DnsPropagationProgressBar( { domainName }: Props ) {
-	const { data, isLoading, isError } = useQuery( domainPropagationStatusQuery( domainName ) );
+/**
+ * Calculates the progress percentage based on name server comparison.
+ * @param currentNameServers - Current name servers from domainMappingStatus
+ * @param expectedNameServers - Expected name servers from domainConnectionSetupInfo
+ * @returns Progress percentage (0-100)
+ */
+function calculateProgress( currentNameServers: string[], expectedNameServers: string[] ): number {
+	// Normalize name servers to lowercase for comparison
+	const normalizedCurrent = currentNameServers.map( ( ns ) => ns.toLowerCase() );
+	const normalizedExpected = expectedNameServers.map( ( ns ) => ns.toLowerCase() );
 
-	if ( isError || isLoading || ! data ) {
-		return null;
+	// Create a Set for efficient lookup
+	const currentSet = new Set( normalizedCurrent );
+
+	// Count how many expected name servers are present in current name servers
+	const matchedCount = normalizedExpected.filter( ( expected ) =>
+		currentSet.has( expected )
+	).length;
+
+	// Calculate percentage based on how many expected name servers are matched
+	const totalExpected = normalizedExpected.length;
+	return totalExpected > 0 ? Math.round( ( matchedCount / totalExpected ) * 100 ) : 0;
+}
+
+export default function DnsPropagationProgressBar( {
+	domainMappingStatus,
+	domainConnectionSetupInfo,
+}: Props ) {
+	const mode = domainMappingStatus.mode;
+	let progressPercentage = 0;
+
+	if ( mode === DomainConnectionSetupMode.DC ) {
+		progressPercentage = 100;
+	} else if (
+		mode === DomainConnectionSetupMode.SUGGESTED ||
+		mode === DomainConnectionSetupMode.ADVANCED
+	) {
+		const currentNameServers = domainMappingStatus.name_servers || [];
+		const expectedNameServers = domainConnectionSetupInfo.wpcom_name_servers || [];
+		progressPercentage = calculateProgress( currentNameServers, expectedNameServers );
+	} else {
+		// All other cases: 0%
+		progressPercentage = 0;
 	}
-
-	const propagatedCount = data.propagation_status.filter( ( area ) => area.propagated ).length;
-	const totalCount = data.propagation_status.length;
-	const progressPercentage =
-		totalCount > 0 ? Math.round( ( propagatedCount / totalCount ) * 100 ) : 0;
 
 	return (
 		<VStack spacing={ 2 }>

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -95,7 +95,7 @@ export default function DomainConnectionVerification( {
 						/>
 					</VStack>
 
-					<DomainPropagationStatus domainName={ domainName } />
+					{ status === 'connected' && <DomainPropagationStatus domainName={ domainName } /> }
 
 					<VStack spacing={ 4 }>
 						{ status === 'verifying' && (

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -68,7 +68,10 @@ export default function DomainConnectionVerification( {
 						</Badge>
 					</HStack>
 
-					<DnsPropagationProgressBar domainName={ domainName } />
+					<DnsPropagationProgressBar
+						domainMappingStatus={ domainMappingStatus }
+						domainConnectionSetupInfo={ domainConnectionSetupInfo }
+					/>
 
 					{ status === 'verifying' && (
 						<Notice variant="info">

--- a/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
@@ -1,153 +1,306 @@
 /**
  * @jest-environment jsdom
  */
-import { DomainPropagationStatus } from '@automattic/api-core';
-import { useQuery } from '@tanstack/react-query';
+import { DomainConnectionSetupMode } from '@automattic/api-core';
 import { render } from '../../../test-utils';
 import DnsPropagationProgressBar from '../components/dns-propagation-progress-bar';
+import type { DomainMappingSetupInfo, DomainMappingStatus } from '@automattic/api-core';
 
-jest.mock( '@tanstack/react-query', () => ( {
-	...jest.requireActual( '@tanstack/react-query' ),
-	useQuery: jest.fn(),
-} ) );
+const createMockDomainMappingStatus = (
+	overrides?: Partial< DomainMappingStatus >
+): DomainMappingStatus => ( {
+	has_mapping_records: false,
+	has_wpcom_nameservers: false,
+	has_wpcom_ip_addresses: false,
+	has_cloudflare_ip_addresses: false,
+	has_mx_records: false,
+	www_cname_record_target: null,
+	resolves_to_wpcom: false,
+	host_ip_addresses: [],
+	name_servers: [],
+	mode: null,
+	...overrides,
+} );
 
-const createMockPropagationStatus = (
-	overrides?: Partial< DomainPropagationStatus >
-): DomainPropagationStatus => ( {
-	propagation_status: [
-		{ area_code: 'NA', area_name: 'North America', propagated: true },
-		{ area_code: 'EU', area_name: 'Europe', propagated: false },
-	],
-	last_updated: '2025-11-12 13:15:48',
+const createMockDomainConnectionSetupInfo = (
+	overrides?: Partial< DomainMappingSetupInfo >
+): DomainMappingSetupInfo => ( {
+	connection_mode: null,
+	domain_connect_apply_wpcom_hosting: null,
+	domain_connect_provider_id: null,
+	default_ip_addresses: [],
+	wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+	is_subdomain: false,
+	root_domain: 'example.com',
+	registrar_url: null,
+	registrar: null,
+	registrar_iana_id: null,
+	reseller: null,
 	...overrides,
 } );
 
 describe( 'DnsPropagationProgressBar', () => {
-	const mockUseQuery = useQuery as jest.MockedFunction< typeof useQuery >;
-
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
-	test( 'renders progress bar with correct percentage', () => {
-		const mockData = createMockPropagationStatus();
-
-		mockUseQuery.mockReturnValue( {
-			data: mockData,
-			isLoading: false,
-			isError: false,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any );
+	test( 'renders 100% for DC mode', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.DC,
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo();
 
 		const { getByRole, getByText } = render(
-			<DnsPropagationProgressBar domainName="example.com" />
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
 		);
 
 		expect( getByText( 'Progress' ) ).toBeVisible();
-		expect( getByText( '50%' ) ).toBeVisible();
-		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '50' );
+		expect( getByText( '100%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
 	} );
 
-	test( 'rounds the progress percentage to the nearest whole number', () => {
-		const mockData = createMockPropagationStatus( {
-			propagation_status: [
-				{ area_code: 'NA', area_name: 'North America', propagated: true },
-				{ area_code: 'EU', area_name: 'Europe', propagated: true },
-				{ area_code: 'AS', area_name: 'Asia', propagated: false },
-			],
+	test( 'renders 100% when all name servers match in suggested mode', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.SUGGESTED,
+			name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 		} );
 
-		mockUseQuery.mockReturnValue( {
-			data: mockData,
-			isLoading: false,
-			isError: false,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any );
-
 		const { getByRole, getByText } = render(
-			<DnsPropagationProgressBar domainName="example.com" />
-		);
-
-		expect( getByText( '67%' ) ).toBeVisible();
-		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '67' );
-	} );
-
-	test( 'renders 100% when every region is propagated', () => {
-		const mockData = createMockPropagationStatus( {
-			propagation_status: [
-				{ area_code: 'NA', area_name: 'North America', propagated: true },
-				{ area_code: 'EU', area_name: 'Europe', propagated: true },
-			],
-		} );
-
-		mockUseQuery.mockReturnValue( {
-			data: mockData,
-			isLoading: false,
-			isError: false,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any );
-
-		const { getByRole, getByText } = render(
-			<DnsPropagationProgressBar domainName="example.com" />
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
 		);
 
 		expect( getByText( '100%' ) ).toBeVisible();
 		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
 	} );
 
-	test( 'renders 0% when no propagation data is available', () => {
-		const mockData = createMockPropagationStatus( {
-			propagation_status: [],
+	test( 'renders 100% when all name servers match in advanced mode', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.ADVANCED,
+			name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 		} );
 
-		mockUseQuery.mockReturnValue( {
-			data: mockData,
-			isLoading: false,
-			isError: false,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any );
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '100%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
+	} );
+
+	test( 'renders 67% when 2 out of 3 name servers match in suggested mode', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.SUGGESTED,
+			name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns1.other.com' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
 
 		const { getByRole, getByText } = render(
-			<DnsPropagationProgressBar domainName="example.com" />
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '67%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '67' );
+	} );
+
+	test( 'renders 33% when 1 out of 3 name servers match in advanced mode', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.ADVANCED,
+			name_servers: [ 'ns1.wordpress.com', 'ns1.other.com', 'ns2.other.com' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '33%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '33' );
+	} );
+
+	test( 'renders 0% when no name servers match in suggested mode', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.SUGGESTED,
+			name_servers: [ 'ns1.other.com', 'ns2.other.com', 'ns3.other.com' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
 		);
 
 		expect( getByText( '0%' ) ).toBeVisible();
 		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
 	} );
 
-	test.each( [
-		{
-			title: 'loading',
-			queryResult: {
-				data: undefined,
-				isLoading: true,
-				isError: false,
-			},
-		},
-		{
-			title: 'errored',
-			queryResult: {
-				data: undefined,
-				isLoading: false,
-				isError: true,
-			},
-		},
-		{
-			title: 'without data',
-			queryResult: {
-				data: undefined,
-				isLoading: false,
-				isError: false,
-			},
-		},
-	] )( 'returns null when query is $title', ( { queryResult } ) => {
-		mockUseQuery.mockReturnValue( {
-			...queryResult,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any );
+	test( 'renders 0% when name servers array is empty in suggested mode', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.SUGGESTED,
+			name_servers: [],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
 
-		const { container } = render( <DnsPropagationProgressBar domainName="example.com" /> );
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
 
-		expect( container ).toBeEmptyDOMElement();
+		expect( getByText( '0%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
+	} );
+
+	test( 'renders 0% when expected name servers array is empty in suggested mode', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.SUGGESTED,
+			name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '0%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
+	} );
+
+	test( 'handles case-insensitive name server comparison', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.SUGGESTED,
+			name_servers: [ 'NS1.WORDPRESS.COM', 'ns2.wordpress.com', 'Ns3.WordPress.Com' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '100%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
+	} );
+
+	test( 'handles extra name servers in current list (only counts matches)', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.SUGGESTED,
+			name_servers: [
+				'ns1.wordpress.com',
+				'ns2.wordpress.com',
+				'ns3.wordpress.com',
+				'ns4.other.com',
+				'ns5.other.com',
+			],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '100%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
+	} );
+
+	test( 'rounds progress percentage correctly (66.67% becomes 67%)', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.SUGGESTED,
+			name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '67%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '67' );
+	} );
+
+	test( 'renders 0% for other connection modes', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.DONE,
+			name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '0%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
+	} );
+
+	test( 'renders 0% when mode is null', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: null,
+			name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '0%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
 	} );
 } );

--- a/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
@@ -28,7 +28,7 @@ const createMockDomainConnectionSetupInfo = (
 	connection_mode: null,
 	domain_connect_apply_wpcom_hosting: null,
 	domain_connect_provider_id: null,
-	default_ip_addresses: [],
+	default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
 	wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 	is_subdomain: false,
 	root_domain: 'example.com',
@@ -78,13 +78,13 @@ describe( 'DnsPropagationProgressBar', () => {
 		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
 	} );
 
-	test( 'renders 100% when all name servers match in advanced mode', () => {
+	test( 'renders 100% when all IP addresses match in advanced mode', () => {
 		const domainMappingStatus = createMockDomainMappingStatus( {
 			mode: DomainConnectionSetupMode.ADVANCED,
-			name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+			host_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
 		} );
 		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
-			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+			default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
 		} );
 
 		const { getByRole, getByText } = render(
@@ -118,13 +118,13 @@ describe( 'DnsPropagationProgressBar', () => {
 		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '67' );
 	} );
 
-	test( 'renders 33% when 1 out of 3 name servers match in advanced mode', () => {
+	test( 'renders 50% when 1 out of 2 IP addresses match in advanced mode', () => {
 		const domainMappingStatus = createMockDomainMappingStatus( {
 			mode: DomainConnectionSetupMode.ADVANCED,
-			name_servers: [ 'ns1.wordpress.com', 'ns1.other.com', 'ns2.other.com' ],
+			host_ip_addresses: [ '192.0.78.24', '185.230.63.186' ],
 		} );
 		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
-			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+			default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
 		} );
 
 		const { getByRole, getByText } = render(
@@ -134,8 +134,48 @@ describe( 'DnsPropagationProgressBar', () => {
 			/>
 		);
 
-		expect( getByText( '33%' ) ).toBeVisible();
-		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '33' );
+		expect( getByText( '50%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '50' );
+	} );
+
+	test( 'renders 0% when no IP addresses match in advanced mode', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.ADVANCED,
+			host_ip_addresses: [ '185.230.63.186', '185.230.63.187' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '0%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
+	} );
+
+	test( 'renders 0% when IP addresses array is empty in advanced mode', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.ADVANCED,
+			host_ip_addresses: [],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '0%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
 	} );
 
 	test( 'renders 0% when no name servers match in suggested mode', () => {
@@ -231,6 +271,26 @@ describe( 'DnsPropagationProgressBar', () => {
 		} );
 		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
 			wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		} );
+
+		const { getByRole, getByText } = render(
+			<DnsPropagationProgressBar
+				domainMappingStatus={ domainMappingStatus }
+				domainConnectionSetupInfo={ domainConnectionSetupInfo }
+			/>
+		);
+
+		expect( getByText( '100%' ) ).toBeVisible();
+		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
+	} );
+
+	test( 'handles extra IP addresses in current list for advanced mode (only counts matches)', () => {
+		const domainMappingStatus = createMockDomainMappingStatus( {
+			mode: DomainConnectionSetupMode.ADVANCED,
+			host_ip_addresses: [ '192.0.78.24', '192.0.78.25', '185.230.63.186', '185.230.63.187' ],
+		} );
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
 		} );
 
 		const { getByRole, getByText } = render(


### PR DESCRIPTION
Closes [DOMAINS-1885](https://linear.app/a8c/issue/DOMAINS-1885/dont-use-global-propagation-status-to-set-the-verification-progress)

## Proposed Changes

* **Refactored DNS propagation progress calculation** - Replaced API-based propagation status with direct DNS record comparison logic
* **Mode-based progress calculation**:
  * **DC mode**: Always shows 100% (domain connect handles everything automatically)
  * **Suggested mode**: Compares current name servers (`domainMappingStatus.name_servers`) with expected WordPress.com name servers (`domainConnectionSetupInfo.wpcom_name_servers`)
  * **Advanced mode**: Compares current IP addresses (`domainMappingStatus.host_ip_addresses`) with expected WordPress.com IP addresses (`domainConnectionSetupInfo.default_ip_addresses`)
  * **Other modes**: Shows 0% (not applicable)

## Why are these changes being made?

The previous implementation relied on DNS propagation status from an external API, which could be slow, unreliable, or show misleading progress. The new approach directly compares the actual DNS configuration against the expected WordPress.com values, providing:

1. **More accurate progress tracking** - Shows real-time progress based on actual DNS configuration rather than propagation delays
2. **Better user experience** - Users see immediate feedback when they update their DNS records, without waiting for global DNS propagation
3. **Mode-appropriate comparisons** - Advanced mode customers (who use A records) now see meaningful progress based on IP address matching, not name servers
4. **Reduced API calls** - Eliminates an unnecessary API query, improving performance
5. **Clearer logic** - Progress calculation is now transparent and directly tied to the connection setup requirements for each mode

This change aligns the progress bar with the actual verification logic used elsewhere in the domain connection flow, making it more consistent and reliable across all connection modes.

## Testing Instructions

### Manual Testing

1. **Navigate to domain connection setup** for a domain that supports connection
2. **Test DC mode**:
   - If domain supports Domain Connect, select DC mode
   - Verify progress bar shows **100%** immediately
3. **Test Suggested mode**:
   - Select "I only use this domain for my website" (Suggested mode)
   - Before updating name servers: progress should show **0%**
   - After updating 1 of 3 name servers: progress should show **33%**
   - After updating 2 of 3 name servers: progress should show **67%**
   - After updating all 3 name servers: progress should show **100%**
4. **Test Advanced mode**:
   - Select "I use email or other services" (Advanced mode)
   - Before updating A records: progress should show **0%**
   - After updating 1 of 2 IP addresses: progress should show **50%**
   - After updating all IP addresses: progress should show **100%**
   - Verify progress is based on IP address matching, not name servers
5. **Test edge cases**:
   - Empty arrays show **0%**
   - Case-insensitive matching works (e.g., `NS1.WORDPRESS.COM` matches `ns1.wordpress.com`)
   - Extra values in current list don't affect percentage (only matches count)

^^^ To easily test those case, the easiest thing to do is mock the results in the domain mapping status endpoint (see 
fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Sqbznvaf%2Sraqcbvagf%2Sznccvat%2Qfgnghf.cuc%3Se%3Q348rqr12%2323%2Q32-og)

### Automated Testing

Run the test suite:
```
yarn test-client client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
```
All 16 test cases should pass, covering:
- DC mode (100%)
- Suggested mode: Full/partial/no name server matches
- Advanced mode: Full/partial/no IP address matches
- Edge cases (empty arrays, case sensitivity, extra values)
- Other connection modes (0%)
- Rounding logic
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?