### PR TITLE
Dashboard: allow yarn start to access my.localhost for MSD

### DIFF
--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -17,7 +17,14 @@ import './style.scss';
 
 boot( {
 	name: 'WordPress.com',
-	basePath: isEnabled( 'dashboard/v2' ) ? '/v2' : '/',
+	basePath: ( () => {
+		if ( isEnabled( 'dashboard/v2' ) ) {
+			// Serve dashboard routes directly under my.localhost's root;
+			// otherwise serve them under /v2.
+			return window.location.hostname.startsWith( 'my.localhost' ) ? '/' : '/v2';
+		}
+		return '/';
+	} )(),
 	mainRoute: '/sites',
 	Logo,
 	supports: {

--- a/client/dashboard/section.ts
+++ b/client/dashboard/section.ts
@@ -1,3 +1,5 @@
+export const DASHBOARD_SECTION_PATHS = [ '/', '/sites', '/domains', '/emails', '/plugins', '/me' ];
+
 export const DASHBOARD_SECTION_DEFINITION = {
 	name: 'dashboard-dotcom',
 	paths: [ '/v2' ],

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -5,7 +5,7 @@
 	"client_slug": "browser",
 	"hostname": "my.localhost",
 	"i18n_default_locale_slug": "en",
-	"port": 3003,
+	"port": 3000,
 	"logout_url": "https://|subdomain|wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-903
Discussion: p1764736462342849-slack-CRWCHQGUB

## Proposed Changes

We want to be able to access both `calypso.localhost` and `my.localhost` at the same time. However, after some investigations, it's not feasible to run both `yarn start` and `yarn start-dashboard`. This is because there will be two competing dev servers which output the build to the same place, corrupting each other.

So the alternative here is to allow `my.localhost` to access the dashboard as well while Calypso is running the `development` environment. I believe this is the better approach as devs only need to run one command.

## Testing Instructions

1. Sandbox 197372-ghe-Automattic/wpcom to revert the port to 3000.
2. Run `yarn start`:
    - Verify you can access `calypso.localhost:3000/sites` and other v1 routes.
    - Verify you can access `calypso.localhost:3000/v2/sites` and other v2 routes.
    - Verify you can access `my.localhost:3000/sites` and other v2 routes.
3. Run `yarn start-dashboard`:
    - Verify you can access `my.localhost:3000/sites` and other v2 routes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?