### PR TITLE
Help Center Chat: Fix font-size on wp-admin

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -69,6 +69,10 @@ $blueberry-color: #3858e9;
 	word-break: break-word;
 	max-width: 100%;
 
+	p {
+		font-size: 100%;
+	}
+
 	&.is-sending {
 		opacity: 0.5;
 	}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-15374/update-type-heirarchy

## Testing steps

1. Sandbox widgets
2. Go to wp-admin and start a chat, escalate to live support
3. Check font-sizes
