### PR TITLE
Help Center + Big Sky Integration Updates

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -209,7 +209,7 @@ if ( helpCenterData.isNextAdmin ) {
 		if ( select( 'next-admin' )?.getMetaMenuItems?.( 'wp-logo' )?.length > 1 ) {
 			unsubscribe();
 			// wait for the next tick to ensure the menu items are registered
-			queueMicrotask( async () => {
+			queueMicrotask( () => {
 				select( 'next-admin' )
 					?.getMetaMenuItems?.( 'wp-logo' )
 					?.forEach( ( item ) => {
@@ -230,17 +230,6 @@ if ( helpCenterData.isNextAdmin ) {
 					? { newInteractionsBotSlug: 'ciab-workflow-support_chat' }
 					: {};
 
-				// Load external providers (e.g., from Big Sky plugin)
-				const { loadExternalProviders } = await import( './src/utils/load-external-providers' );
-				const {
-					toolProvider,
-					contextProvider,
-					suggestions,
-					markdownComponents,
-					markdownExtensions,
-					useNavigationContinuation,
-				} = await loadExternalProviders();
-
 				createRoot( container ).render(
 					<QueryClientProvider client={ queryClient }>
 						<HelpCenter
@@ -252,22 +241,15 @@ if ( helpCenterData.isNextAdmin ) {
 							onboardingUrl="https://wordpress.com/start"
 							handleClose={ () => dispatch( 'automattic/help-center' ).setShowHelpCenter( false ) }
 							isCommerceGarden={ helpCenterData.isCommerceGarden }
-							toolProvider={ toolProvider }
-							contextProvider={ contextProvider }
-							suggestions={ suggestions }
-							markdownComponents={ markdownComponents }
-							markdownExtensions={ markdownExtensions }
-							useNavigationContinuation={ useNavigationContinuation }
 							{ ...botProps }
 						/>
-					</QueryClientProvider>,
-					document.getElementById( 'jetpack-help-center' )
+					</QueryClientProvider>
 				);
 			} );
 		}
 	} );
 } else {
 	registerPlugin( 'jetpack-help-center', {
-		render: HelpCenterContentWithProvider,
+		render: () => <HelpCenterContentWithProvider />,
 	} );
 }

--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -205,16 +205,17 @@ function HelpCenterContentWithProvider() {
 if ( helpCenterData.isNextAdmin ) {
 	const unsubscribe = subscribe( () => {
 		// Make sure the wp-logo menu item is registered before unregistering its default items.
-		if ( select( 'next-admin' ).getMetaMenuItems?.( 'wp-logo' ).length > 1 ) {
+		// Use optional chaining since 'next-admin' store only exists in next-admin context
+		if ( select( 'next-admin' )?.getMetaMenuItems?.( 'wp-logo' )?.length > 1 ) {
 			unsubscribe();
 			// wait for the next tick to ensure the menu items are registered
 			queueMicrotask( async () => {
 				select( 'next-admin' )
-					.getMetaMenuItems( 'wp-logo' )
-					.forEach( ( item ) => {
-						dispatch( 'next-admin' ).unregisterSiteHubHelpMenuItem( item.id );
+					?.getMetaMenuItems?.( 'wp-logo' )
+					?.forEach( ( item ) => {
+						dispatch( 'next-admin' )?.unregisterSiteHubHelpMenuItem?.( item.id );
 					} );
-				dispatch( 'next-admin' ).registerSiteHubHelpMenuItem( 'help-center', {
+				dispatch( 'next-admin' )?.registerSiteHubHelpMenuItem?.( 'help-center', {
 					label: __( 'Help Center', __i18n_text_domain__ ),
 					parent: 'wp-logo',
 					callback: () => {

--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -238,6 +238,7 @@ if ( helpCenterData.isNextAdmin ) {
 					suggestions,
 					markdownComponents,
 					markdownExtensions,
+					useNavigationContinuation,
 				} = await loadExternalProviders();
 
 				createRoot( container ).render(
@@ -256,6 +257,7 @@ if ( helpCenterData.isNextAdmin ) {
 							suggestions={ suggestions }
 							markdownComponents={ markdownComponents }
 							markdownExtensions={ markdownExtensions }
+							useNavigationContinuation={ useNavigationContinuation }
 							{ ...botProps }
 						/>
 					</QueryClientProvider>,

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -17,6 +17,7 @@ function AdminHelpCenterContent( {
 	suggestions,
 	markdownComponents,
 	markdownExtensions,
+	useNavigationContinuation,
 } ) {
 	const { setShowHelpCenter, setShowSupportDoc, setNavigateToRoute } =
 		useDataStoreDispatch( 'automattic/help-center' );
@@ -231,6 +232,7 @@ function AdminHelpCenterContent( {
 			suggestions={ suggestions }
 			markdownComponents={ markdownComponents }
 			markdownExtensions={ markdownExtensions }
+			useNavigationContinuation={ useNavigationContinuation }
 			{ ...botProps }
 		/>
 	);
@@ -240,7 +242,14 @@ const target = document.getElementById( 'help-center-masterbar' );
 if ( target ) {
 	// Load external providers (e.g., from Big Sky plugin) and render
 	loadExternalProviders().then(
-		( { toolProvider, contextProvider, suggestions, markdownComponents, markdownExtensions } ) => {
+		( {
+			toolProvider,
+			contextProvider,
+			suggestions,
+			markdownComponents,
+			markdownExtensions,
+			useNavigationContinuation,
+		} ) => {
 			createRoot( target ).render(
 				<QueryClientProvider client={ queryClient }>
 					<AdminHelpCenterContent
@@ -249,6 +258,7 @@ if ( target ) {
 						suggestions={ suggestions }
 						markdownComponents={ markdownComponents }
 						markdownExtensions={ markdownExtensions }
+						useNavigationContinuation={ useNavigationContinuation }
 					/>
 				</QueryClientProvider>
 			);

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -7,18 +7,12 @@ import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data'
 import { useEffect, useCallback, useState } from '@wordpress/element';
 import { createRoot } from 'react-dom/client';
 import { useMenuPanelExperiment } from './hooks/use-menu-panel-experiment';
-import { loadExternalProviders } from './src/utils/load-external-providers';
-const queryClient = new QueryClient();
+
 import './help-center.scss';
 
-function AdminHelpCenterContent( {
-	toolProvider,
-	contextProvider,
-	suggestions,
-	markdownComponents,
-	markdownExtensions,
-	useNavigationContinuation,
-} ) {
+const queryClient = new QueryClient();
+
+function AdminHelpCenterContent() {
 	const { setShowHelpCenter, setShowSupportDoc, setNavigateToRoute } =
 		useDataStoreDispatch( 'automattic/help-center' );
 	const { isShown, unreadCount } = useSelect(
@@ -227,12 +221,6 @@ function AdminHelpCenterContent( {
 			onboardingUrl="https://wordpress.com/start"
 			handleClose={ closeCallback }
 			isCommerceGarden={ helpCenterData.isCommerceGarden }
-			toolProvider={ toolProvider }
-			contextProvider={ contextProvider }
-			suggestions={ suggestions }
-			markdownComponents={ markdownComponents }
-			markdownExtensions={ markdownExtensions }
-			useNavigationContinuation={ useNavigationContinuation }
 			{ ...botProps }
 		/>
 	);
@@ -240,28 +228,9 @@ function AdminHelpCenterContent( {
 
 const target = document.getElementById( 'help-center-masterbar' );
 if ( target ) {
-	// Load external providers (e.g., from Big Sky plugin) and render
-	loadExternalProviders().then(
-		( {
-			toolProvider,
-			contextProvider,
-			suggestions,
-			markdownComponents,
-			markdownExtensions,
-			useNavigationContinuation,
-		} ) => {
-			createRoot( target ).render(
-				<QueryClientProvider client={ queryClient }>
-					<AdminHelpCenterContent
-						toolProvider={ toolProvider }
-						contextProvider={ contextProvider }
-						suggestions={ suggestions }
-						markdownComponents={ markdownComponents }
-						markdownExtensions={ markdownExtensions }
-						useNavigationContinuation={ useNavigationContinuation }
-					/>
-				</QueryClientProvider>
-			);
-		}
+	createRoot( target ).render(
+		<QueryClientProvider client={ queryClient }>
+			<AdminHelpCenterContent />
+		</QueryClientProvider>
 	);
 }

--- a/apps/help-center/src/utils/load-external-providers.ts
+++ b/apps/help-center/src/utils/load-external-providers.ts
@@ -6,10 +6,23 @@
  */
 
 import type { ToolProvider, ContextProvider, Suggestion } from '@automattic/agents-manager';
+import type { SubmitOptions } from '@automattic/agenttic-client';
 import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 
 // agentsManagerData is set as a global const via wp_add_inline_script
 declare const agentsManagerData: { agentProviders?: string[] } | undefined;
+
+/**
+ * Navigation continuation hook type - provided by environments that support
+ * navigation with conversation continuation (e.g., wp-admin/navigate)
+ * This is needed to send a follow-up after full page reloads in wp-admin
+ */
+export type NavigationContinuationHook = ( props: {
+	isProcessing: boolean;
+	onSubmit: ( message: string, options?: SubmitOptions ) => Promise< void >;
+	sessionId: string;
+	agentId: string;
+} ) => void;
 
 export interface LoadedProviders {
 	toolProvider?: ToolProvider;
@@ -17,6 +30,7 @@ export interface LoadedProviders {
 	suggestions?: Suggestion[];
 	markdownComponents?: MarkdownComponents;
 	markdownExtensions?: MarkdownExtensions;
+	useNavigationContinuation?: NavigationContinuationHook;
 }
 
 /**
@@ -38,6 +52,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	let mergedSuggestions: Suggestion[] | undefined;
 	let mergedMarkdownComponents: MarkdownComponents | undefined;
 	let mergedMarkdownExtensions: MarkdownExtensions | undefined;
+	let mergedNavigationContinuation: NavigationContinuationHook | undefined;
 
 	for ( const moduleId of agentProviders ) {
 		try {
@@ -60,6 +75,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			if ( module.markdownExtensions ) {
 				mergedMarkdownExtensions = module.markdownExtensions;
 			}
+			if ( module.useNavigationContinuation ) {
+				mergedNavigationContinuation = module.useNavigationContinuation;
+			}
 
 			// eslint-disable-next-line no-console
 			console.log( `[HelpCenter] Loaded provider "${ moduleId }"` );
@@ -75,5 +93,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		suggestions: mergedSuggestions,
 		markdownComponents: mergedMarkdownComponents,
 		markdownExtensions: mergedMarkdownExtensions,
+		useNavigationContinuation: mergedNavigationContinuation,
 	};
 }

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -14,9 +14,24 @@ import { lastConversationCache } from '../../utils/conversation-cache';
 import AgentDock from '../agent-dock';
 import { PersistentRouter } from '../persistent-router';
 import type { ToolProvider, ContextProvider, ContextEntry } from '../../extension-types';
-import type { UseAgentChatConfig, Ability as AgenticAbility } from '@automattic/agenttic-client';
+import type {
+	UseAgentChatConfig,
+	Ability as AgenticAbility,
+	SubmitOptions,
+} from '@automattic/agenttic-client';
 import type { MarkdownComponents, MarkdownExtensions, Suggestion } from '@automattic/agenttic-ui';
 import type { HelpCenterSite, CurrentUser } from '@automattic/data-stores';
+
+/**
+ * Navigation continuation hook type - provided by environments that need
+ * navigation with conversation continuation (e.g wp-admin/navigate)
+ */
+type NavigationContinuationHook = ( props: {
+	isProcessing: boolean;
+	onSubmit: ( message: string, options?: SubmitOptions ) => Promise< void >;
+	sessionId: string;
+	agentId: string;
+} ) => void;
 
 export interface UnifiedAIAgentProps {
 	/** The current route path. */
@@ -39,6 +54,8 @@ export interface UnifiedAIAgentProps {
 	markdownComponents?: MarkdownComponents;
 	/** Custom markdown extensions. */
 	markdownExtensions?: MarkdownExtensions;
+	/** Navigation continuation hook for post-navigation conversation resumption. */
+	useNavigationContinuation?: NavigationContinuationHook;
 }
 
 /**
@@ -91,6 +108,7 @@ function AgentSetup( {
 	emptyViewSuggestions: customSuggestions,
 	markdownComponents = {},
 	markdownExtensions = {},
+	useNavigationContinuation,
 }: UnifiedAIAgentProps ) {
 	const [ agentConfig, setAgentConfig ] = useState< UseAgentChatConfig | null >( null );
 	const { state } = useLocation();
@@ -229,6 +247,7 @@ function AgentSetup( {
 			emptyViewSuggestions={ customSuggestions || defaultSuggestions }
 			markdownComponents={ markdownComponents }
 			markdownExtensions={ markdownExtensions }
+			useNavigationContinuation={ useNavigationContinuation }
 		/>
 	);
 }

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -5,33 +5,18 @@
  */
 
 import { createOdieBotId, getAgentManager } from '@automattic/agenttic-client';
-import { useMemo, useEffect, useState } from '@wordpress/element';
+import { useMemo, useEffect, useState, useRef } from '@wordpress/element';
 import { useLocation } from 'react-router-dom';
 import { createCalypsoAuthProvider } from '../../auth/calypso-auth-provider';
 import { ORCHESTRATOR_AGENT_ID, ORCHESTRATOR_AGENT_URL } from '../../constants';
 import { SESSION_STORAGE_KEY, getSessionId } from '../../utils/agent-session';
 import { lastConversationCache } from '../../utils/conversation-cache';
+import { loadExternalProviders, type LoadedProviders } from '../../utils/load-external-providers';
 import AgentDock from '../agent-dock';
 import { PersistentRouter } from '../persistent-router';
-import type { ToolProvider, ContextProvider, ContextEntry } from '../../extension-types';
-import type {
-	UseAgentChatConfig,
-	Ability as AgenticAbility,
-	SubmitOptions,
-} from '@automattic/agenttic-client';
-import type { MarkdownComponents, MarkdownExtensions, Suggestion } from '@automattic/agenttic-ui';
+import type { ContextEntry } from '../../extension-types';
+import type { UseAgentChatConfig, Ability as AgenticAbility } from '@automattic/agenttic-client';
 import type { HelpCenterSite, CurrentUser } from '@automattic/data-stores';
-
-/**
- * Navigation continuation hook type - provided by environments that need
- * navigation with conversation continuation (e.g wp-admin/navigate)
- */
-type NavigationContinuationHook = ( props: {
-	isProcessing: boolean;
-	onSubmit: ( message: string, options?: SubmitOptions ) => Promise< void >;
-	sessionId: string;
-	agentId: string;
-} ) => void;
 
 export interface UnifiedAIAgentProps {
 	/** The current route path. */
@@ -44,18 +29,6 @@ export interface UnifiedAIAgentProps {
 	currentUser?: CurrentUser;
 	/** Called when the agent is closed. */
 	handleClose?: () => void;
-	/** Tool provider for custom abilities. */
-	toolProvider?: ToolProvider;
-	/** Context provider for environment-specific context. */
-	contextProvider?: ContextProvider;
-	/** Suggestions displayed when the chat is empty. */
-	emptyViewSuggestions?: Suggestion[];
-	/** Custom components for rendering markdown. */
-	markdownComponents?: MarkdownComponents;
-	/** Custom markdown extensions. */
-	markdownExtensions?: MarkdownExtensions;
-	/** Navigation continuation hook for post-navigation conversation resumption. */
-	useNavigationContinuation?: NavigationContinuationHook;
 }
 
 /**
@@ -100,24 +73,28 @@ export default function UnifiedAIAgent( props: UnifiedAIAgentProps ) {
 }
 
 // Separate component that uses hooks within `PersistentRouter` context
-function AgentSetup( {
-	currentRoute,
-	site = null,
-	toolProvider,
-	contextProvider,
-	emptyViewSuggestions: customSuggestions,
-	markdownComponents = {},
-	markdownExtensions = {},
-	useNavigationContinuation,
-}: UnifiedAIAgentProps ) {
+function AgentSetup( { currentRoute, site = null }: UnifiedAIAgentProps ) {
 	const [ agentConfig, setAgentConfig ] = useState< UseAgentChatConfig | null >( null );
+	const [ loadedProviders, setLoadedProviders ] = useState< LoadedProviders >( {} );
+	const providersLoadedRef = useRef( false );
 	const { state } = useLocation();
 	// Use persisted route state `sessionId` if available, otherwise fall back to stored `sessionId`
 	const sessionId = state?.sessionId || getSessionId();
 
-	// Create the initial agent configuration
-	const config = useMemo< UseAgentChatConfig >(
-		() => {
+	// Load external providers and initialize agent config
+	useEffect( () => {
+		const initializeAgent = async () => {
+			// Load external providers (only once)
+			let providers = loadedProviders;
+			if ( ! providersLoadedRef.current ) {
+				providers = await loadExternalProviders();
+				providersLoadedRef.current = true;
+				setLoadedProviders( providers );
+			}
+
+			const { toolProvider, contextProvider } = providers;
+
+			// Create the agent configuration
 			const config: UseAgentChatConfig = {
 				agentId: ORCHESTRATOR_AGENT_ID,
 				agentUrl: ORCHESTRATOR_AGENT_URL,
@@ -182,15 +159,6 @@ function AgentSetup( {
 				};
 			}
 
-			return config;
-		},
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- Only create once
-		[]
-	);
-
-	// Load config AND pre-load cached messages for progressive loading
-	useEffect( () => {
-		const initializeWithCache = async () => {
 			// Check if we have cached messages to pre-load
 			if ( sessionId ) {
 				const agentManager = getAgentManager();
@@ -211,10 +179,10 @@ function AgentSetup( {
 			setAgentConfig( config );
 		};
 
-		initializeWithCache();
-	}, [ config, sessionId ] );
+		initializeAgent();
+	}, [ currentRoute, loadedProviders, sessionId, site?.ID ] );
 
-	// Default suggestions - can be overridden via the `customSuggestions` prop
+	// Default suggestions - can be overridden by loaded providers
 	const defaultSuggestions = useMemo(
 		() => [
 			{
@@ -244,10 +212,10 @@ function AgentSetup( {
 	return (
 		<AgentDock
 			agentConfig={ agentConfig }
-			emptyViewSuggestions={ customSuggestions || defaultSuggestions }
-			markdownComponents={ markdownComponents }
-			markdownExtensions={ markdownExtensions }
-			useNavigationContinuation={ useNavigationContinuation }
+			emptyViewSuggestions={ loadedProviders.suggestions || defaultSuggestions }
+			markdownComponents={ loadedProviders.markdownComponents || {} }
+			markdownExtensions={ loadedProviders.markdownExtensions || {} }
+			useNavigationContinuation={ loadedProviders.useNavigationContinuation }
 		/>
 	);
 }

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -5,7 +5,7 @@
  * PHP filter. Each provider module should export toolProvider and/or contextProvider.
  */
 
-import type { ToolProvider, ContextProvider, Suggestion } from '@automattic/agents-manager';
+import type { ToolProvider, ContextProvider, Suggestion } from '../types';
 import type { SubmitOptions } from '@automattic/agenttic-client';
 import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 
@@ -34,14 +34,15 @@ export interface LoadedProviders {
 }
 
 /**
- * Load external agent providers from helpCenterData.agentProviders.
+ * Load external agent providers from agentsManagerData.agentProviders.
  *
  * Each provider module ID is dynamically imported using WordPress's script module
  * system. Modules should export { toolProvider, contextProvider }.
  * @returns Promise resolving to merged providers or empty object if none found.
  */
 export async function loadExternalProviders(): Promise< LoadedProviders > {
-	const agentProviders = agentsManagerData?.agentProviders || [];
+	const agentProviders =
+		typeof agentsManagerData !== 'undefined' ? agentsManagerData?.agentProviders || [] : [];
 
 	if ( agentProviders.length === 0 ) {
 		return {};
@@ -80,10 +81,10 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			}
 
 			// eslint-disable-next-line no-console
-			console.log( `[HelpCenter] Loaded provider "${ moduleId }"` );
+			console.log( `[AgentsManager] Loaded provider "${ moduleId }"` );
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
-			console.warn( `[HelpCenter] Failed to load provider "${ moduleId }":`, error );
+			console.warn( `[AgentsManager] Failed to load provider "${ moduleId }":`, error );
 		}
 	}
 

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -45,6 +45,7 @@ const HelpCenter: React.FC< Container > = ( {
 		suggestions,
 		markdownComponents,
 		markdownExtensions,
+		useNavigationContinuation,
 	} = useHelpCenterContext();
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
 	const { data: supportInteractionsOpen, isLoading: isLoadingOpenInteractions } =
@@ -93,6 +94,7 @@ const HelpCenter: React.FC< Container > = ( {
 				emptyViewSuggestions={ suggestions }
 				markdownComponents={ markdownComponents }
 				markdownExtensions={ markdownExtensions }
+				useNavigationContinuation={ useNavigationContinuation }
 			/>
 		);
 	}

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -36,17 +36,7 @@ const HelpCenter: React.FC< Container > = ( {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return helpCenterSelect.isHelpCenterShown();
 	}, [] );
-	const {
-		currentUser,
-		site,
-		sectionName,
-		toolProvider,
-		contextProvider,
-		suggestions,
-		markdownComponents,
-		markdownExtensions,
-		useNavigationContinuation,
-	} = useHelpCenterContext();
+	const { currentUser, site, sectionName } = useHelpCenterContext();
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
 	const { data: supportInteractionsOpen, isLoading: isLoadingOpenInteractions } =
 		useGetSupportInteractions( 'zendesk' );
@@ -89,12 +79,6 @@ const HelpCenter: React.FC< Container > = ( {
 				site={ site }
 				sectionName={ sectionName }
 				handleClose={ handleClose }
-				toolProvider={ toolProvider }
-				contextProvider={ contextProvider }
-				emptyViewSuggestions={ suggestions }
-				markdownComponents={ markdownComponents }
-				markdownExtensions={ markdownExtensions }
-				useNavigationContinuation={ useNavigationContinuation }
 			/>
 		);
 	}

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -2,8 +2,20 @@ import { ODIE_NEW_INTERACTIONS_BOT_SLUG } from '@automattic/odie-client/src/cons
 import { useContext, createContext } from '@wordpress/element';
 import { useNewInteractionsBotConfig } from '../hooks/use-new-interaction-bot-config';
 import type { ToolProvider, ContextProvider, Suggestion } from '@automattic/agents-manager';
+import type { SubmitOptions } from '@automattic/agenttic-client';
 import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 import type { CurrentUser, HelpCenterSite } from '@automattic/data-stores';
+
+/**
+ * Navigation continuation hook type - provided by plugins that support
+ * navigation with conversation continuation (e.g., Big Sky's wp-admin/navigate)
+ */
+export type NavigationContinuationHook = ( props: {
+	isProcessing: boolean;
+	onSubmit: ( message: string, options?: SubmitOptions ) => Promise< void >;
+	sessionId: string;
+	agentId: string;
+} ) => void;
 
 export type HelpCenterRequiredInformation = {
 	newInteractionsBotSlug: string;
@@ -42,6 +54,11 @@ export type HelpCenterRequiredInformation = {
 	 * Custom markdown extensions (optional)
 	 */
 	markdownExtensions?: MarkdownExtensions;
+	/**
+	 * Navigation continuation hook (optional)
+	 * Provided by plugins that support navigation with conversation continuation
+	 */
+	useNavigationContinuation?: NavigationContinuationHook;
 	source: '' | 'wpcom' | 'a4a';
 };
 

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -1,21 +1,7 @@
 import { ODIE_NEW_INTERACTIONS_BOT_SLUG } from '@automattic/odie-client/src/constants';
 import { useContext, createContext } from '@wordpress/element';
 import { useNewInteractionsBotConfig } from '../hooks/use-new-interaction-bot-config';
-import type { ToolProvider, ContextProvider, Suggestion } from '@automattic/agents-manager';
-import type { SubmitOptions } from '@automattic/agenttic-client';
-import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 import type { CurrentUser, HelpCenterSite } from '@automattic/data-stores';
-
-/**
- * Navigation continuation hook type - provided by plugins that support
- * navigation with conversation continuation (e.g., Big Sky's wp-admin/navigate)
- */
-export type NavigationContinuationHook = ( props: {
-	isProcessing: boolean;
-	onSubmit: ( message: string, options?: SubmitOptions ) => Promise< void >;
-	sessionId: string;
-	agentId: string;
-} ) => void;
 
 export type HelpCenterRequiredInformation = {
 	newInteractionsBotSlug: string;
@@ -30,35 +16,6 @@ export type HelpCenterRequiredInformation = {
 	googleMailServiceFamily: string;
 	onboardingUrl: string;
 	isCommerceGarden: boolean;
-	/**
-	 * Tool provider for AI agent abilities (optional)
-	 * Allows plugins to provide custom abilities to the agent
-	 */
-	toolProvider?: ToolProvider;
-	/**
-	 * Context provider for AI agent context (optional)
-	 * Allows plugins to provide rich context about current state
-	 */
-	contextProvider?: ContextProvider;
-	/**
-	 * Custom suggestions for the AI agent empty view (optional)
-	 * Allows plugins to provide context-specific suggestions
-	 */
-	suggestions?: Suggestion[];
-	/**
-	 * Custom markdown components for message rendering (optional)
-	 * Allows plugins to provide custom renderers for markdown elements
-	 */
-	markdownComponents?: MarkdownComponents;
-	/**
-	 * Custom markdown extensions (optional)
-	 */
-	markdownExtensions?: MarkdownExtensions;
-	/**
-	 * Navigation continuation hook (optional)
-	 * Provided by plugins that support navigation with conversation continuation
-	 */
-	useNavigationContinuation?: NavigationContinuationHook;
 	source: '' | 'wpcom' | 'a4a';
 };
 


### PR DESCRIPTION
This PR includes two changes for the Help Center +  Big Sky & CIAB integration:

## 1. Fix: Add optional chaining for next-admin store access

When `helpCenterData.isNextAdmin` is true but the `next-admin` store hasn't been registered yet (i.e. still loading), calling `select('next-admin').getMetaMenuItems()` throws a TypeError because `select('next-admin')` returns undefined. This was causing crashes for me. The check reruns when the store changes so it still works and loads the help center after CIAB loads in.

## 2. Support navigation continuation hook

Adds support for a `useNavigationContinuation` hook that can be provided by external plugins (Big Sky). This enables conversation continuation after page navigation when using the `wp-admin/navigate` ability specifically.

This pattern was already in use for `wp-admin` navigation. It is needed because the page does a full page reload, and we need to follow-up with the model after the app has re-rendered.

## Testing Steps

### Loading
1. Load CIAB without the `unified-agent` feature flag (i.e. `/wp-admin/admin.php?page=next-admin&p=%2F`)
2. Verify the Help Center loads without console errors
3. Verify the agent chat panel appears and functions correctly
4. (Optional) Load with `flags=unified-agent` and see the unified agent correctly loads instead

### Navigation 
1. Load CIAB without the `unified-agent` feature flag (i.e. `/wp-admin/admin.php?page=next-admin&p=%2F`)
2. Verify the Help Center loads without console errors
3. Verify the agent chat panel appears and functions correctly
4. Load with `?flags=unified-agent` to test the unified agent
5. Ask the agent to navigate to a wp-admin page (e.g., "take me to the posts page")
6. Verify the page navigates and the conversation resumes with the agent acknowledging the navigation