### PR TITLE
Domains: Show only first year price in domains mini-cart

### DIFF
--- a/packages/domain-search/src/components/cart/test/full-cart.tsx
+++ b/packages/domain-search/src/components/cart/test/full-cart.tsx
@@ -52,7 +52,7 @@ describe( 'FullCart', () => {
 	} );
 
 	describe( 'prices', () => {
-		it( 'renders the price with the sale price when it is available', async () => {
+		it( 'renders the sale price when it is available', async () => {
 			render(
 				<TestDomainSearchWithCart
 					initialCartItems={ [
@@ -64,7 +64,6 @@ describe( 'FullCart', () => {
 				</TestDomainSearchWithCart>
 			);
 
-			expect( await screen.findByLabelText( 'Original price: $20/year' ) ).toBeInTheDocument();
 			expect( await screen.findByLabelText( 'Sale price: $10/year' ) ).toBeInTheDocument();
 			expect( screen.queryByLabelText( /Price/ ) ).not.toBeInTheDocument();
 		} );

--- a/packages/domain-search/src/components/cart/test/full-cart.tsx
+++ b/packages/domain-search/src/components/cart/test/full-cart.tsx
@@ -64,7 +64,7 @@ describe( 'FullCart', () => {
 				</TestDomainSearchWithCart>
 			);
 
-			expect( await screen.findByLabelText( 'Sale price: $10/year' ) ).toBeInTheDocument();
+			expect( await screen.findByLabelText( 'Sale price: $10' ) ).toBeInTheDocument();
 			expect( screen.queryByLabelText( /Price/ ) ).not.toBeInTheDocument();
 		} );
 
@@ -80,7 +80,7 @@ describe( 'FullCart', () => {
 				</TestDomainSearchWithCart>
 			);
 
-			expect( await screen.findByLabelText( 'Price: $20/year' ) ).toBeInTheDocument();
+			expect( await screen.findByLabelText( 'Price: $20' ) ).toBeInTheDocument();
 			expect( screen.queryByLabelText( /Original price/ ) ).not.toBeInTheDocument();
 			expect( screen.queryByLabelText( /Sale price/ ) ).not.toBeInTheDocument();
 		} );

--- a/packages/domain-search/src/ui/domains-full-cart-items/item.tsx
+++ b/packages/domain-search/src/ui/domains-full-cart-items/item.tsx
@@ -55,33 +55,16 @@ export const DomainsFullCartItem = ( {
 						<VStack className="domains-full-cart-items__price">
 							<HStack alignment="right" spacing={ 2 }>
 								{ domain.salePrice ? (
-									<>
-										<Text
-											size="small"
-											className="domains-full-cart-items__original-price"
-											aria-label={ sprintf(
-												// translators: %(price)s is the original price of the domain.
-												__( 'Original price: %(price)s/year' ),
-												{ price: domain.price }
-											) }
-										>
-											{ sprintf(
-												// translators: %(price)s is the price of the domain.
-												__( '%(price)s/year' ),
-												{ price: domain.price }
-											) }
-										</Text>
-										<Text
-											size="small"
-											aria-label={ sprintf(
-												// translators: %(price)s is the sale price of the domain.
-												__( 'Sale price: %(price)s/year' ),
-												{ price: domain.salePrice }
-											) }
-										>
-											{ domain.salePrice }
-										</Text>
-									</>
+									<Text
+										size="small"
+										aria-label={ sprintf(
+											// translators: %(price)s is the sale price of the domain.
+											__( 'Sale price: %(price)s/year' ),
+											{ price: domain.salePrice }
+										) }
+									>
+										{ domain.salePrice }
+									</Text>
 								) : (
 									<Text
 										size="small"

--- a/packages/domain-search/src/ui/domains-full-cart-items/item.tsx
+++ b/packages/domain-search/src/ui/domains-full-cart-items/item.tsx
@@ -59,7 +59,7 @@ export const DomainsFullCartItem = ( {
 										size="small"
 										aria-label={ sprintf(
 											// translators: %(price)s is the sale price of the domain.
-											__( 'Sale price: %(price)s/year' ),
+											__( 'Sale price: %(price)s' ),
 											{ price: domain.salePrice }
 										) }
 									>
@@ -70,15 +70,11 @@ export const DomainsFullCartItem = ( {
 										size="small"
 										aria-label={ sprintf(
 											// translators: %(price)s is the price of the domain.
-											__( 'Price: %(price)s/year' ),
+											__( 'Price: %(price)s' ),
 											{ price: domain.price }
 										) }
 									>
-										{ sprintf(
-											// translators: %(price)s is the price of the domain.
-											__( '%(price)s/year' ),
-											{ price: domain.price }
-										) }
+										{ domain.price }
 									</Text>
 								) }
 							</HStack>


### PR DESCRIPTION
Closes [DOMENG-260](https://linear.app/a8c/issue/DOMENG-260)

## Proposed Changes

This PR simplifies the domain mini-cart item component to display only the sale price when a domain is on sale, removing the original price. It also removes the "/year" string from the prices, as we're showing only the price paid for each domain for the first year.

Previously, both the original price (with strikethrough) and sale price were shown.

### Screenshots

| Before | After |
| --- | --- |
| <img width="1129" height="1161" alt="Screenshot 2025-12-03 at 17 00 26" src="https://github.com/user-attachments/assets/c57bca85-f05f-460e-86ef-824f930db112" /> | <img width="1129" height="1161" alt="Screenshot 2025-12-03 at 16 59 48" src="https://github.com/user-attachments/assets/e4e5623e-3613-4e3d-8efb-c1a6af3284db" /> |

## Why are these changes being made?

Displaying only the sale price makes it simpler and more straightforward for users. The renewal price is already shown in the domain suggestions list. Also, we're showing only the price that will be paid for the first year, so the "/year" string was removed.

## Testing Instructions

Unit tests:
```
yarn test-packages packages/domain-search/src/components/cart/test/full-cart.tsx
```

Manual test:
- Open the live Calypso link or build this branch locally
- Go to onboarding (`/setup`)
- Add a domain on sale to your cart
- Ensure the mini-cart shows only the domain's sale price, without the original price
- Add a premium domain on sale to your cart (e.g. `sun.blog`)
- Ensure the mini-cart shows only the domain's sale price, without the original price

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
