### PR TITLE
MSD: fix manage purchase links site filtering

### DIFF
--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -111,7 +111,7 @@ function SiteDeleteWarningContent( { site, onClose }: { site: Site; onClose: () 
 			<RouterLinkButton
 				{ ...buttonProps }
 				to={ purchasesRoute.fullPath }
-				search={ { site: site.slug } }
+				search={ { site: site.ID } }
 			>
 				{ isTrialSite( site ) ? __( 'Cancel trial' ) : __( 'Manage purchases' ) }
 			</RouterLinkButton>

--- a/client/dashboard/sites/site-leave-modal/content-info.tsx
+++ b/client/dashboard/sites/site-leave-modal/content-info.tsx
@@ -71,7 +71,7 @@ function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
 					<RouterLinkButton
 						{ ...managePurchasesButtonProps }
 						to={ purchasesRoute.fullPath }
-						search={ { site: site.slug } }
+						search={ { site: site.ID } }
 					/>
 				) }
 			</ButtonStack>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to: https://linear.app/a8c/issue/SHILL-1411/

## Proposed Changes

This uses the site's ID instead of slug to pre-filter the list of purchases for the "leave site" and "delete site" modals.

## Why are these changes being made?

The purchases list uses the site's ID to filter by site. If a slug is passed, the query parameter is silently dropped.

## Testing Instructions

- Visit the dashboard's site list: `calypso.localhost:3000/v2/sites/`
- For a site with an existing purchase, click "Leave Site" under the action menu.
- In the resulting modal, click "Manage Purchases"
- Verify that you are taken to the purchase list, with the site filter applied for the given site