### PR TITLE
A4A: Fix A4A checkout showing different design for wpcom products

### DIFF
--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -1,5 +1,6 @@
 export const GROUP_WPCOM = 'GROUP_WPCOM';
 export const GROUP_P2 = 'GROUP_P2';
+export const GROUP_A4A = 'GROUP_A4A';
 
 /**
  * WPCOM Search Products

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1630,6 +1630,17 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 	],
 } );
 
+const getPlanA4ABusinessDetails = (): IncompleteWPcomPlan => ( {
+	...getDotcomPlanDetails(),
+	group: GROUP_WPCOM,
+	type: TYPE_BUSINESS,
+	getTitle: getPlanBusinessTitle,
+	getDescription: () =>
+		i18n.translate(
+			'Power your business website with custom plugins and themes, storage, and the ability to remove WordPress.com branding.'
+		),
+} );
+
 const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 	...getDotcomPlanDetails(),
 	group: GROUP_WPCOM,
@@ -2971,7 +2982,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 	},
 
 	[ PLAN_A4A_BUSINESS ]: {
-		...getPlanBusinessDetails(),
+		...getPlanA4ABusinessDetails(),
 		term: TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
 		availableFor: () => false, // A4A plans not available through standard flows
@@ -2981,7 +2992,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 	},
 
 	[ PLAN_A4A_BUSINESS_MONTHLY ]: {
-		...getPlanBusinessDetails(),
+		...getPlanA4ABusinessDetails(),
 		...getMonthlyTimeframe(),
 		availableFor: () => false, // A4A plans not available through standard flows
 		getProductId: () => 3301,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -145,6 +145,7 @@ import {
 	FEATURE_WOOCOMMERCE,
 	GROUP_JETPACK,
 	GROUP_WPCOM,
+	GROUP_A4A,
 	JETPACK_LEGACY_PLANS,
 	JETPACK_SECURITY_PLANS,
 	PLAN_BLOGGER,
@@ -1632,7 +1633,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 
 const getPlanA4ABusinessDetails = (): IncompleteWPcomPlan => ( {
 	...getDotcomPlanDetails(),
-	group: GROUP_WPCOM,
+	group: GROUP_A4A,
 	type: TYPE_BUSINESS,
 	getTitle: getPlanBusinessTitle,
 	getDescription: () =>

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -2,6 +2,7 @@ import {
 	type GROUP_JETPACK,
 	type GROUP_WPCOM,
 	type GROUP_P2,
+	type GROUP_A4A,
 	type WPCOM_PRODUCTS,
 	type WPCOM_PLANS,
 	type PLAN_JETPACK_FREE,
@@ -312,7 +313,7 @@ export type FeatureGroup = {
 export type FeatureGroupMap = Record< FeatureGroupSlug, FeatureGroup >;
 
 export type Plan = BillingTerm & {
-	group: typeof GROUP_WPCOM | typeof GROUP_JETPACK | typeof GROUP_P2;
+	group: typeof GROUP_WPCOM | typeof GROUP_JETPACK | typeof GROUP_P2 | typeof GROUP_A4A;
 	type: PlanType;
 	availableFor?: ( plan: PlanSlug ) => boolean;
 	getSignupCompareAvailableFeatures?: () => string[];

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -1208,8 +1208,6 @@ describe( 'findPlansKeys', () => {
 		expect( findPlansKeys( { group: GROUP_WPCOM } ).sort() ).toEqual(
 			[
 				PLAN_100_YEARS,
-				PLAN_A4A_BUSINESS,
-				PLAN_A4A_BUSINESS_MONTHLY,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_BUSINESS,
@@ -1302,8 +1300,6 @@ describe( 'findPlansKeys', () => {
 			PLAN_BUSINESS,
 			PLAN_BUSINESS_2_YEARS,
 			PLAN_BUSINESS_3_YEARS,
-			PLAN_A4A_BUSINESS,
-			PLAN_A4A_BUSINESS_MONTHLY,
 			PLAN_MIGRATION_TRIAL_MONTHLY,
 			PLAN_HOSTING_TRIAL_MONTHLY,
 		] );

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -11,6 +11,7 @@ import {
 	GROUP_JETPACK,
 	GROUP_P2,
 	GROUP_WPCOM,
+	GROUP_A4A,
 	PLAN_100_YEARS,
 	PLAN_A4A_BUSINESS,
 	PLAN_A4A_BUSINESS_MONTHLY,
@@ -1315,6 +1316,10 @@ describe( 'findPlansKeys', () => {
 		expect( findPlansKeys( { group: GROUP_JETPACK, type: TYPE_BUSINESS } ) ).toEqual( [
 			PLAN_JETPACK_BUSINESS,
 			PLAN_JETPACK_BUSINESS_MONTHLY,
+		] );
+		expect( findPlansKeys( { group: GROUP_A4A, type: TYPE_BUSINESS } ) ).toEqual( [
+			PLAN_A4A_BUSINESS,
+			PLAN_A4A_BUSINESS_MONTHLY,
 		] );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Linear issue: https://linear.app/a8c/issue/A4A-1887/fix-checkout-display-for-wpcom-products

This bug was introduced in https://github.com/Automattic/wp-calypso/pull/107411

## Proposed Changes

* Add a separate `getPlanA4ABusinessDetails` function so A4A WPCOM products aren't seen as regular WPCOM plans in the checkout

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To keep a consistent design for all products in the checkout

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com`
* As an agency using Billing Dragon, add a WPCOM site to the cart and any other product
  * _Creating a new agency will automatically have them use BD_
* Visit checkout and you should see both products showing the monthly/yearly term as a dropdown and not radio buttons.
* Also, using the Calypso live link, run through the test plan in 197211-ghe-Automattic/wpcom to verify it still works ok.

**BEFORE**
<img width="736" height="642" alt="Screenshot 2025-12-03 at 3 44 34 PM" src="https://github.com/user-attachments/assets/158ed521-9672-466c-aa71-309f33beeca8" />

**AFTER**
<img width="722" height="553" alt="Screenshot 2025-12-03 at 3 44 41 PM" src="https://github.com/user-attachments/assets/f9fc53ba-b325-4a88-8f5b-3eccfcacdd36" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?