### PR TITLE
Backup: fix card title

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/style.scss
+++ b/client/components/jetpack/daily-backup-status/status-card/style.scss
@@ -211,7 +211,7 @@
 
 	.status-card__title {
 		font-size: $font-headline-small;
-		margin: 8px 0 12px;
+		margin: 8px 8px 12px 0;
 	}
 
 	.status-card__label {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTMSD-916][1].

## Proposed Changes

Improve the spacing between title columns for the Backup card.

| Before | After |
| - | - |
| <img width="738" height="244" alt="image" src="https://github.com/user-attachments/assets/9ec38913-fd9a-4231-8144-3e5cf8173959" /> | <img width="737" height="238" alt="image" src="https://github.com/user-attachments/assets/f3cbe702-5b8d-44bd-8c11-3786b8d90a00" /> |

The screenshot isn't completely translated as the strings originally reported were used, not the current Spanish translation:

- `Copia de seguridad del contenido del:`
- `Más información sobre el explorador de archivos`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Depending on the length of the translated string, the text from both columns can end up "touching" each other. Fixing the spacing between improves this situation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the `/backup/:site/contents/:period` page.
  - This can be done in the `Jetpack -> Backup` page, by selecting `View files` from the `Latest backup`.
- Check the spacing between the title columns on translations that have longer strings than the original English one.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://linear.app/a8c/issue/DOTMSD-916