### PR TITLE
MSD: Make notifications tab list overflow scrollable.

### DIFF
--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -100,7 +100,11 @@ const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
 						</HStack>
 					</HStack>
 					<Tabs selectedTabId={ filterName } onSelect={ handleSelect }>
-						<Tabs.TabList>
+						<Tabs.TabList
+							style={ {
+								maxWidth: '100%',
+							} }
+						>
 							{ NOTIFICATION_TABS.map( ( { name, title } ) => (
 								<Tabs.Tab
 									key={ name }


### PR DESCRIPTION
Fixes: DOTCOM-15246

## Proposed Changes

Add a `maxWidth` to the tabList to make the list scrollable when the viewport is less than the total width of the items.

Reference: 
https://wordpress.github.io/gutenberg/?path=/story/components-tabs--size-and-overflow-playground

### Before

https://github.com/user-attachments/assets/6ea180a8-1a32-4570-9bdc-159ead486a3f

### After

https://github.com/user-attachments/assets/a5c37fce-737b-4b05-ba4e-b351e96726e9


## Why are these changes being made?

It's currently cut off.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
