### PR TITLE
Updated checkout to always use line item total

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1399,10 +1399,7 @@ function CheckoutLineItem( {
 		isSmallestUnit: true,
 		stripZeros: true,
 	} );
-	const itemSubtotalInteger =
-		isAkPro500Cart && product.quantity
-			? product.item_subtotal_integer / product.quantity
-			: product.item_subtotal_integer;
+	const itemSubtotalInteger = product.item_subtotal_integer;
 
 	const actualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
 		isSmallestUnit: true,


### PR DESCRIPTION
Resolves #CHE-265

## Proposed Changes

  - Remove the Akismet override for calculating the line item price based on quantity and always show the item subtotal (like everything else does).

## Why are these changes being made?

Akismet plans that allow quantity to be selected (e.g., ak_pro5h_yearly) caused the line item price to be calculated incorrectly and show the wrong amount.



## Testing Instructions

http://calypso.localhost:3000/checkout/akismet/ak_pro5h_yearly

Change the "Number of licenses" and "Billing period" dropdowns and check that the line item total at the top matches the expected value.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
