### PR TITLE
A4A > Exclusive offers: Remove section flag logic

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -107,19 +107,15 @@ const useMainMenuItems = ( path: string ) => {
 						},
 				  ]
 				: [] ),
-			...( isSectionNameEnabled( 'a8c-for-agencies-exclusive-offers' )
-				? [
-						{
-							icon: box,
-							path: '/',
-							link: A4A_EXCLUSIVE_OFFERS_LINK,
-							title: translate( 'Exclusive offers' ),
-							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Exclusive offers',
-							},
-						},
-				  ]
-				: [] ),
+			{
+				icon: box,
+				path: '/',
+				link: A4A_EXCLUSIVE_OFFERS_LINK,
+				title: translate( 'Exclusive offers' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Exclusive offers',
+				},
+			},
 			{
 				icon: category,
 				path: '/',


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1872/janitorial-after-launch-remove-the-feature-flag-logic-for-exclusive

## Proposed Changes

This PR removes the section flag logic for Exclusive offers.


## Why are these changes being made?

* Code cleanup

## Testing Instructions

* Open the A4A live link
* Verify the "Exclusive offers" menu item is still visible and you can view it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
