### PR TITLE
Add a notice when we get an error back from the ODIE api.

### DIFF
--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -255,7 +255,7 @@ export const PerformanceInsight = ( {
 } ) => {
 	const locale = useLocale();
 	const isDesktop = useViewportMatch( 'medium' );
-	const { data: llmAnswer } = useQuery( {
+	const { data: llmAnswer, isError } = useQuery( {
 		...odieAssistantPerformanceProfilerQuery( {
 			hash,
 			insight,
@@ -265,6 +265,14 @@ export const PerformanceInsight = ( {
 		} ),
 		enabled: !! insight,
 	} );
+
+	if ( isError ) {
+		return (
+			<Notice variant="error" title={ __( 'Error' ) }>
+				{ __( 'An error occurred while generating the insight. Please try again later.' ) }
+			</Notice>
+		);
+	}
 
 	return (
 		<VStack spacing={ 4 } style={ { padding: '0 16px' } }>

--- a/client/dashboard/sites/performance/performance-insight.tsx
+++ b/client/dashboard/sites/performance/performance-insight.tsx
@@ -269,7 +269,7 @@ export const PerformanceInsight = ( {
 	if ( isError ) {
 		return (
 			<Notice variant="error" title={ __( 'Error' ) }>
-				{ __( 'An error occurred while generating the insight. Please try again later.' ) }
+				{ __( 'An error occurred while generating this insight. Please try again later.' ) }
 			</Notice>
 		);
 	}


### PR DESCRIPTION
Fixes: DOTMSD-797

## Proposed Changes

Handle the API error when fetching insights for performance.

## Screenshot

<img width="910" height="377" alt="Screenshot 2025-12-04 at 1 45 12 PM" src="https://github.com/user-attachments/assets/39b760c1-00e2-4d3c-99d7-75797dd835d9" />



## Why are these changes being made?

Currently the UI just hangs making it seem like we're still fetching.

## Testing Instructions

- Patch sandbox to return a `500` in `can_access_performance_profiler_assistant`. 
- Load the performance page.
- Open an insight.
- Expect to see the notice saying insights are being fetched.
- Expect to see the error notice a few seconds later.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
