### PR TITLE
MSD: point more external links to wordpress.com/

### DIFF
--- a/client/dashboard/app/primary-menu/index.tsx
+++ b/client/dashboard/app/primary-menu/index.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import ResponsiveMenu from '../../components/responsive-menu';
+import { wpcomLink } from '../../utils/link';
 import { useAppContext } from '../context';
 
 function PrimaryMenu() {
@@ -18,7 +19,11 @@ function PrimaryMenu() {
 				<ResponsiveMenu.Item to="/plugins/manage">{ __( 'Plugins' ) }</ResponsiveMenu.Item>
 			) }
 			{ supports.themes && (
-				<ResponsiveMenu.Item href="/themes" target="_blank" rel="noopener noreferrer">
+				<ResponsiveMenu.Item
+					href={ wpcomLink( '/themes' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
 					{ __( 'Themes' ) }
 				</ResponsiveMenu.Item>
 			) }

--- a/client/dashboard/domains/name-servers/upsell-nudge.tsx
+++ b/client/dashboard/domains/name-servers/upsell-nudge.tsx
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Callout } from '../../components/callout';
 import InlineSupportLink from '../../components/inline-support-link';
 import UpsellCTAButton from '../../components/upsell-cta-button';
+import { wpcomLink } from '../../utils/link';
 import illustrationUrl from './upsell-nudge-illustration.svg';
 
 interface Props {
@@ -42,7 +43,7 @@ export default function UpsellNudge( { domainName, domainSiteSlug }: Props ) {
 					upsellId="domain-nameservers-primary-domain"
 					upsellFeatureId="domain"
 					variant="primary"
-					href={ `/checkout/${ domainSiteSlug }/business` }
+					href={ wpcomLink( `/checkout/${ domainSiteSlug }/business` ) }
 				/>
 			}
 		/>

--- a/client/dashboard/emails/hooks/use-add-to-cart.ts
+++ b/client/dashboard/emails/hooks/use-add-to-cart.ts
@@ -6,6 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../app/analytics';
 import { emailsRoute, mailboxesReadyRoute } from '../../app/router/emails';
 import { CartActionError } from '../../shopping-cart/errors';
+import { wpcomLink } from '../../utils/link';
 import { MailboxOperations } from '../entities/mailbox-operations';
 import { getCartItems } from '../utils/get-cart-items';
 import { getEmailProductProperties } from '../utils/get-email-product-properties';
@@ -57,7 +58,7 @@ export const useAddToCart = () => {
 				to: emailsRoute.to,
 			} ).href;
 
-		const checkoutPath = addQueryArgs( '/checkout/' + site?.slug || '', {
+		const checkoutPath = addQueryArgs( wpcomLink( '/checkout/' + site?.slug || '' ), {
 			redirect_to: redirectPath,
 			checkoutBackUrl: backUrl,
 		} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -16,6 +16,7 @@ import imgMonthlyPayments from 'calypso/assets/images/cancellation/monthly-payme
 import imgSwitchPlan from 'calypso/assets/images/cancellation/switch-plan.png';
 import { useAnalytics } from '../../../../../app/analytics';
 import { useHelpCenter } from '../../../../../app/help-center';
+import { wpcomLink } from '../../../../../utils/link';
 import type { PlanProduct, Purchase } from '@automattic/api-core';
 
 type UpsellProps = {
@@ -62,13 +63,13 @@ function Upsell( { image, ...props }: UpsellProps ) {
 function getLiveChatUrl( type: string, purchase: Purchase ) {
 	switch ( type ) {
 		case 'live-chat:plans':
-			return `/purchases/subscriptions/${ purchase.site_slug }/${ purchase.ID }`;
+			return wpcomLink( `/purchases/subscriptions/${ purchase.site_slug }/${ purchase.ID }` );
 		case 'live-chat:plugins':
-			return `/plugins/${ purchase.site_slug }`;
+			return wpcomLink( `/plugins/${ purchase.site_slug }` );
 		case 'live-chat:themes':
-			return `/themes/${ purchase.site_slug }`;
+			return wpcomLink( `/themes/${ purchase.site_slug }` );
 		case 'live-chat:domains':
-			return `/domains/manage/${ purchase.site_slug }`;
+			return wpcomLink( `/domains/manage/${ purchase.site_slug }` );
 	}
 
 	return '';
@@ -204,11 +205,13 @@ export default function UpsellStep( {
 					acceptButtonText={ sprintf( __( 'I want the %(businessPlanName)s plan' ), {
 						businessPlanName,
 					} ) }
-					acceptButtonUrl={ `/checkout/${
-						purchase.site_slug
-					}/business?coupon=${ couponCode }&cancel_to=${ window.location.href
-						.replace( window.location.origin, '' )
-						.replace( '/cancel', '' ) }` }
+					acceptButtonUrl={ wpcomLink(
+						`/checkout/${
+							purchase.site_slug
+						}/business?coupon=${ couponCode }&cancel_to=${ window.location.href
+							.replace( window.location.origin, '' )
+							.replace( '/cancel', '' ) }`
+					) }
 					onAccept={ () => {
 						recordTracksEvent( 'calypso_cancellation_upgrade_at_step_upgrade_click' );
 					} }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -114,15 +114,15 @@ function getUpgradeUrl( purchase: Purchase ): string | undefined {
 
 	const upgradeProductSlug = ProductUpgradeMap[ purchase.product_slug ];
 	if ( upgradeProductSlug ) {
-		return `/checkout/${ purchase.site_slug }/${ upgradeProductSlug }`;
+		return wpcomLink( `/checkout/${ purchase.site_slug }/${ upgradeProductSlug }` );
 	}
 
 	if ( purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase ) ) {
-		return `/plans/storage/${ purchase.site_slug }`;
+		return wpcomLink( `/plans/storage/${ purchase.site_slug }` );
 	}
 
 	if ( purchase.is_jetpack_plan_or_product ) {
-		return `/plans/${ purchase.site_slug }`;
+		return wpcomLink( `/plans/${ purchase.site_slug }` );
 	}
 
 	if ( purchase.is_woo_hosted_product ) {
@@ -134,18 +134,18 @@ function getUpgradeUrl( purchase: Purchase ): string | undefined {
 
 function getExpiredNewPlanUrl( purchase: Purchase ): string {
 	if ( purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase ) ) {
-		return `/plans/storage/${ purchase.site_slug }`;
+		return wpcomLink( `/plans/storage/${ purchase.site_slug }` );
 	}
 
 	if ( purchase.is_jetpack_plan_or_product ) {
-		return `/plans/${ purchase.site_slug }`;
+		return wpcomLink( `/plans/${ purchase.site_slug }` );
 	}
 
 	if ( purchase.is_plan ) {
 		return getWpcomPlanGridUrl( purchase.site_slug );
 	}
 
-	return `/plans/${ purchase.site_slug }`;
+	return wpcomLink( `/plans/${ purchase.site_slug }` );
 }
 
 function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
@@ -207,7 +207,7 @@ function upgradePurchase( upgradeUrl: string ): void {
 
 function ProductLink( { purchase }: { purchase: Purchase } ) {
 	if ( purchase.is_plan && purchase.site_slug ) {
-		const url = '/plans/my-plan/' + purchase.site_slug;
+		const url = wpcomLink( '/plans/my-plan/' + purchase.site_slug );
 		const text = __( 'Plan features' );
 		return (
 			<MetadataItem>
@@ -440,7 +440,7 @@ function JetpackCRMDownloadsButton( { purchase }: { purchase: Purchase } ) {
 	}
 
 	// We'll pass the purchase ID in the URL, and the CRM Downloads component will fetch the actual license key
-	const path = `/purchases/crm-downloads/${ purchase.ID }`;
+	const path = wpcomLink( `/purchases/crm-downloads/${ purchase.ID }` );
 
 	return (
 		<ActionList.ActionItem

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -259,7 +259,7 @@ function TrialNotice( { purchase }: { purchase: Purchase } ) {
 				to_checkout: false,
 			} );
 
-			window.location.href = `/plans/${ purchase.site_slug ?? '' }`;
+			window.location.href = wpcomLink( `/plans/${ purchase.site_slug ?? '' }` );
 			return;
 		}
 
@@ -270,7 +270,9 @@ function TrialNotice( { purchase }: { purchase: Purchase } ) {
 		} );
 
 		const siteSlug = purchase.site_slug ?? purchase.blog_id;
-		window.location.href = `/checkout/${ siteSlug }/business?redirectTo=/plans/my-plan/trial-upgraded/${ siteSlug }`;
+		window.location.href = wpcomLink(
+			`/checkout/${ siteSlug }/business?redirectTo=/plans/my-plan/trial-upgraded/${ siteSlug }`
+		);
 		return;
 	};
 

--- a/client/dashboard/plugins/plugins-menu/index.tsx
+++ b/client/dashboard/plugins/plugins-menu/index.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
+import { wpcomLink } from '../../utils/link';
 
 const PluginsMenu = () => {
 	return (
@@ -9,7 +10,11 @@ const PluginsMenu = () => {
 			<ResponsiveMenu.Item to="/plugins/scheduled-updates">
 				{ __( 'Scheduled updates' ) }
 			</ResponsiveMenu.Item>
-			<ResponsiveMenu.Item href="/plugins" target="_blank" rel="noopener noreferrer">
+			<ResponsiveMenu.Item
+				href={ wpcomLink( '/plugins' ) }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
 				{ __( 'Browse plugins' ) }
 			</ResponsiveMenu.Item>
 		</ResponsiveMenu>

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -13,6 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
+import { wpcomLink } from '../../utils/link';
 import { userHasFlag } from '../../utils/user';
 import type { Field } from '@wordpress/dataviews';
 
@@ -102,7 +103,7 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 			return createInterpolateElement(
 				'Your site plan doesn’t allow you to set a custom domain as a primary site address.<br/><upgradeLink>Upgrade to an annual paid plan</upgradeLink> and get a free one-year domain name registration or transfer. <learnMoreLink />',
 				{
-					upgradeLink: <a href={ `/plans/${ site.slug }` } />,
+					upgradeLink: <a href={ wpcomLink( `/plans/${ site.slug }` ) } />,
 					br: <br />,
 					learnMoreLink: <InlineSupportLink supportContext="primary-site-address" />,
 				}

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -10,6 +10,7 @@ import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import { Callout } from '../../components/callout';
 import { TextBlur } from '../../components/text-blur';
 import UpsellCTAButton from '../../components/upsell-cta-button';
+import { wpcomLink } from '../../utils/link';
 import { DomainUpsellIllustraction } from './upsell-illustration';
 import type { Site } from '@automattic/api-core';
 
@@ -69,23 +70,27 @@ const DomainUpsellCardContent = ( {
 		}
 
 		if ( requiresPlanUpgrade( site ) ) {
-			window.location.href = getDomainAndPlanUpsellUrl( {
-				siteSlug: site.slug,
-				backUrl,
-				step: 'plans',
-			} );
+			window.location.href = wpcomLink(
+				getDomainAndPlanUpsellUrl( {
+					siteSlug: site.slug,
+					backUrl,
+					step: 'plans',
+				} )
+			);
 		} else {
-			window.location.href = addQueryArgs( `/checkout/${ site.slug }`, {
+			window.location.href = addQueryArgs( wpcomLink( `/checkout/${ site.slug }` ), {
 				cancel_to: backUrl,
 				redirect_to: backUrl,
 			} );
 		}
 	};
 
-	const chooseYourOwnUrl = getDomainAndPlanUpsellUrl( {
-		siteSlug: site.slug,
-		backUrl,
-	} );
+	const chooseYourOwnUrl = wpcomLink(
+		getDomainAndPlanUpsellUrl( {
+			siteSlug: site.slug,
+			backUrl,
+		} )
+	);
 
 	return (
 		<Callout
@@ -120,7 +125,6 @@ const DomainUpsellCardContent = ( {
 			imageVariant="full-bleed"
 			actions={
 				<UpsellCTAButton
-					target="_blank"
 					text={ upsellCTAButtonText }
 					variant="primary"
 					size="compact"

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -6,6 +6,7 @@ import { shield } from '@wordpress/icons';
 import OverviewCard from '../../components/overview-card';
 import { useTimeSince } from '../../components/time-since';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
+import { wpcomLink } from '../../utils/link';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
 import type { SiteScan, Site } from '@automattic/api-core';
@@ -22,7 +23,7 @@ function getScanURL( site: Site ) {
 	}
 
 	return isDashboardBackport()
-		? `https://wordpress.com/scan/${ site.slug }`
+		? wpcomLink( `/scan/${ site.slug }` )
 		: `/sites/${ site.slug }/scan/active`;
 }
 

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { lockOutline, published } from '@wordpress/icons';
 import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
+import { wpcomLink } from '../../utils/link';
 import { getSiteVisibilityURL } from '../../utils/site-url';
 import type { Site } from '@automattic/api-core';
 
@@ -51,7 +52,7 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 				: {
 						heading: __( 'Coming soon' ),
 						description: __( 'Finish setting up your site.' ),
-						externalLink: `/home/${ site.slug }`,
+						externalLink: wpcomLink( `/home/${ site.slug }` ),
 				  } ) }
 			progress={ {
 				value: completedTasks,

--- a/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
+++ b/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
@@ -8,6 +8,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 import { Card, CardBody } from '../../components/card';
 import { Notice } from '../../components/notice';
+import { wpcomLink } from '../../utils/link';
 import SiteRedirectForm, { SiteRedirectFormData } from './site-redirect-form';
 
 export default function CreateSiteRedirect( {
@@ -53,7 +54,7 @@ export default function CreateSiteRedirect( {
 				meta: formData.redirect,
 			},
 		] );
-		window.location.href = addQueryArgs( `/checkout/${ siteSlug }`, {
+		window.location.href = addQueryArgs( wpcomLink( `/checkout/${ siteSlug }` ), {
 			cancel_to: backUrl,
 			redirect_to: backUrl,
 		} );

--- a/client/dashboard/sites/settings-site-visibility/trial-upsell-notice.tsx
+++ b/client/dashboard/sites/settings-site-visibility/trial-upsell-notice.tsx
@@ -3,6 +3,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Notice from '../../components/notice';
 import UpsellCTAButton from '../../components/upsell-cta-button';
+import { wpcomLink } from '../../utils/link';
 import { isSitePlanLaunchable } from '../plans';
 import type { Site } from '@automattic/api-core';
 
@@ -30,7 +31,7 @@ export default function TrialUpsellNotice( { site }: { site: Site } ) {
 		const upsellCTALink = (
 			<UpsellCTAButton
 				variant="link"
-				href={ `/plans/${ site.slug }` }
+				href={ wpcomLink( `/plans/${ site.slug }` ) }
 				upsellId={ `site-settings-visibility-trial-notice:${ getTrialType() }` }
 				upsellFeatureId="site-trial"
 			/>

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -27,6 +27,7 @@ import { TextBlur } from '../../components/text-blur';
 import TimeSince from '../../components/time-since';
 import { addTransientViewPropertiesToQueryParams } from '../../utils/dashboard-v1-sync';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
+import { wpcomLink } from '../../utils/link';
 import { isAtomicTransferInProgress } from '../../utils/site-atomic-transfers';
 import { hasHostingFeature, hasJetpackModule, hasPlanFeature } from '../../utils/site-features';
 import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
@@ -365,7 +366,7 @@ function SiteLaunchNag( { site }: { site: Site } ) {
 		<>
 			<ComponentViewTracker eventName="calypso_dashboard_sites_site_launch_nag_impression" />
 			<ExternalLink
-				href={ `/home/${ site.slug }` }
+				href={ wpcomLink( `/home/${ site.slug }` ) }
 				onClick={ () => {
 					recordTracksEvent( 'calypso_dashboard_sites_site_launch_nag_click' );
 				} }
@@ -395,8 +396,8 @@ function PlanRenewNag( { site, source }: { site: Site; source: string } ) {
 			<ExternalLink
 				href={
 					isTrial
-						? `/plans/${ site.slug }`
-						: `/checkout/${ site.slug }/${ site.plan?.product_slug }`
+						? wpcomLink( `/plans/${ site.slug }` )
+						: wpcomLink( `/checkout/${ site.slug }/${ site.plan?.product_slug }` )
 				}
 				onClick={ () => {
 					recordTracksEvent( 'calypso_dashboard_sites_plan_renew_nag_click', {

--- a/client/dashboard/sites/site-fields/test/plan.tsx
+++ b/client/dashboard/sites/site-fields/test/plan.tsx
@@ -3,6 +3,7 @@
  */
 import { AuthContext } from '../../../app/auth';
 import { render as testUtilsRender } from '../../../test-utils';
+import { wpcomLink } from '../../../utils/link';
 import { Plan } from '../index';
 import type { User, Site } from '@automattic/api-core';
 
@@ -102,7 +103,7 @@ describe( '<Plan>', () => {
 		expect( getByText( 'Business-expired' ) ).toBeInTheDocument();
 		expect( getByRole( 'link', { name: /Renew plan/ } ) ).toHaveAttribute(
 			'href',
-			'/checkout/test.wordpress.com/business-bundle'
+			wpcomLink( '/checkout/test.wordpress.com/business-bundle' )
 		);
 	} );
 
@@ -127,7 +128,7 @@ describe( '<Plan>', () => {
 		expect( getByText( 'Trial-expired' ) ).toBeInTheDocument();
 		expect( getByRole( 'link', { name: /Upgrade/ } ) ).toHaveAttribute(
 			'href',
-			'/plans/test.wordpress.com'
+			wpcomLink( '/plans/test.wordpress.com' )
 		);
 	} );
 } );

--- a/client/dashboard/sites/site-fields/test/status.tsx
+++ b/client/dashboard/sites/site-fields/test/status.tsx
@@ -3,6 +3,7 @@
  */
 import { render as testingLibraryRender } from '@testing-library/react';
 import { AuthContext } from '../../../app/auth';
+import { wpcomLink } from '../../../utils/link';
 import { Status } from '../index';
 import type { User, Site } from '@automattic/api-core';
 
@@ -62,7 +63,7 @@ describe( '<Status>', () => {
 		expect( container.textContent ).toBe( 'Finish setup↗' );
 		expect( getByRole( 'link', { name: /Finish setup/ } ) ).toHaveAttribute(
 			'href',
-			'/home/test.wordpress.com'
+			wpcomLink( '/home/test.wordpress.com' )
 		);
 	} );
 
@@ -120,7 +121,7 @@ describe( '<Status>', () => {
 		expect( getByText( 'Plan expired' ) ).toBeInTheDocument();
 		expect( getByRole( 'link', { name: /Renew plan/ } ) ).toHaveAttribute(
 			'href',
-			'/checkout/test.wordpress.com/business-bundle'
+			wpcomLink( '/checkout/test.wordpress.com/business-bundle' )
 		);
 	} );
 } );

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -13,6 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import filesize from 'filesize';
 import { useState } from 'react';
+import { wpcomLink } from '../../utils/link';
 import { StorageCapacityStat } from './storage-capacity-stat';
 import {
 	getStorageAddOnProduct,
@@ -121,7 +122,9 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 
 		const backUrl = window.location.href.replace( window.location.origin, '' );
 		const checkoutUrl = addQueryArgs(
-			`/checkout/${ site.slug }/${ storageProduct.product_slug }:-q-${ selectedTier.quantity }`,
+			wpcomLink(
+				`/checkout/${ site.slug }/${ storageProduct.product_slug }:-q-${ selectedTier.quantity }`
+			),
 			{
 				cancel_to: backUrl,
 				return_to: backUrl,

--- a/client/dashboard/sites/trial-ended/index.tsx
+++ b/client/dashboard/sites/trial-ended/index.tsx
@@ -16,6 +16,7 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
+import { wpcomLink } from '../../utils/link';
 import { wasEcommerceTrial } from '../../utils/site-trial';
 import SiteDeleteModal from '../site-delete-modal';
 import type { Site } from '@automattic/api-core';
@@ -105,10 +106,13 @@ const SiteTrialEnded = ( { siteSlug }: { siteSlug: string } ) => {
 									upsellId="site-trial-ended"
 									upsellFeatureId="site-trial"
 									variant="primary"
-									href={ addQueryArgs( `/checkout/${ site.slug }/${ product.pathSlug }`, {
-										cancel_to: backUrl,
-										redirect_to: backUrl,
-									} ) }
+									href={ addQueryArgs(
+										wpcomLink( `/checkout/${ site.slug }/${ product.pathSlug }` ),
+										{
+											cancel_to: backUrl,
+											redirect_to: backUrl,
+										}
+									) }
 								/>
 							</ButtonStack>
 						</VStack>

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -12,6 +12,7 @@ import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { isWithinLast, isWithinNext, getDateFromCreditCardExpiry } from './datetime';
 import { isGSuiteProductSlug } from './gsuite';
+import { wpcomLink } from './link';
 import { encodeProductForUrl } from './wpcom-checkout';
 import type { Product, Purchase, Site } from '@automattic/api-core';
 
@@ -451,7 +452,9 @@ export function getRenewUrlForPurchases(
 	const checkoutSiteSlug = checkoutSiteSlugForUrl || firstPurchase.site_slug || '';
 	const servicePath = getServicePathForCheckoutFromPurchase( firstPurchase );
 	const purchaseIds = purchases.map( ( purchase ) => purchase.ID ).join( ',' );
-	return `/checkout/${ servicePath }${ checkoutProductSlug }/renew/${ purchaseIds }/${ checkoutSiteSlug }`;
+	return wpcomLink(
+		`/checkout/${ servicePath }${ checkoutProductSlug }/renew/${ purchaseIds }/${ checkoutSiteSlug }`
+	);
 }
 
 /**

--- a/client/dashboard/utils/site-backup.ts
+++ b/client/dashboard/utils/site-backup.ts
@@ -1,4 +1,5 @@
 import { isDashboardBackport } from './is-dashboard-backport';
+import { wpcomLink } from './link';
 import { isSelfHostedJetpackConnected } from './site-types';
 import type { Site } from '@automattic/api-core';
 
@@ -8,6 +9,6 @@ export function getBackupUrl( site: Site ) {
 	}
 
 	return isDashboardBackport()
-		? `https://wordpress.com/backup/${ site.slug }`
+		? wpcomLink( `/backup/${ site.slug }` )
 		: `/sites/${ site.slug }/backups`;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -18,6 +18,7 @@
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
 	"survicate_enabled": true,
+	"wpcom_url": "http://calypso.localhost:3000",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-903

## Proposed Changes

This PR points the links from MSD to wordpress.com for the following routes:

**Logged-out**

- `/themes`
- `/plugins`

**Nav-unification**

- `/home/*`
- `/plans/*`
- `/backup/*`
- `/scan/*`
- `/purchases/*`

**Signup/Stepper**

- `/checkout/*`

## Why are these changes being made?

`my.wordpress.com` don't serve those routes; `wordpress.com` does.

## Testing Instructions

1. Verify the changes visually.
2. Smoke-test some links.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
