### PR TITLE
Odie: Isolate thinking placeholder

### DIFF
--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -1,7 +1,4 @@
-import { HelpCenterSelect } from '@automattic/data-stores';
-import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { Spinner } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import clx from 'classnames';
 import { useEffect, useRef, useState } from 'react';
 import { NavigationType, useNavigate, useNavigationType, useSearchParams } from 'react-router-dom';
@@ -19,8 +16,8 @@ import getMostRecentOpenLiveInteraction from '../notices/get-most-recent-open-li
 import { JumpToRecent } from './jump-to-recent';
 import { MessagesClusterizer } from './messages-cluster/messages-cluster';
 import { ThinkingPlaceholder } from './thinking-placeholder';
-import { TypingPlaceholder } from './typing-placeholder';
 import { getMessageUniqueIdentifier } from './utils/get-message-unique-identifier';
+import { ZendeskTypingIndicator } from './zendesk-typing-indicator';
 import ChatMessage from '.';
 import type { CurrentUser } from '../../types';
 interface ChatMessagesProps {
@@ -40,13 +37,6 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	const [ shouldEnableAutoScroll, setShouldEnableAutoScroll ] = useState( true );
 	const { data: supportInteraction } = useCurrentSupportInteraction();
 	const navType: NavigationType = useNavigationType();
-	const typingStatus = useSelect(
-		( select ) =>
-			( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getSupportTypingStatus(
-				chat.conversationId ?? ''
-			),
-		[ chat.conversationId ]
-	);
 
 	const messagesContainerRef = useRef< HTMLDivElement >( null );
 	const scrollParentRef = useRef< HTMLElement | null >( null );
@@ -183,13 +173,8 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 						<ThinkingPlaceholder />
 					</div>
 				) }
-				{ chat.provider.startsWith( 'zendesk' ) && typingStatus && (
-					<div
-						className="odie-chatbox__action-message"
-						ref={ ( div ) => div?.scrollIntoView( { behavior: 'smooth', block: 'end' } ) }
-					>
-						<TypingPlaceholder />
-					</div>
+				{ chat.provider.startsWith( 'zendesk' ) && (
+					<ZendeskTypingIndicator conversationId={ chat.conversationId } />
 				) }
 			</>
 		</div>

--- a/packages/odie-client/src/components/message/zendesk-typing-indicator.tsx
+++ b/packages/odie-client/src/components/message/zendesk-typing-indicator.tsx
@@ -1,0 +1,36 @@
+import { HelpCenterSelect } from '@automattic/data-stores';
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { useSelect } from '@wordpress/data';
+import { TypingPlaceholder } from './typing-placeholder';
+
+type ZendeskTypingIndicatorProps = {
+	conversationId: string | null | undefined;
+};
+
+/**
+ * Isolated component for Zendesk typing indicator.
+ * This component subscribes to the typing status store independently,
+ * preventing unnecessary rerenders of MessagesContainer when typing status changes.
+ */
+export const ZendeskTypingIndicator = ( { conversationId }: ZendeskTypingIndicatorProps ) => {
+	const typingStatus = useSelect(
+		( select ) =>
+			( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getSupportTypingStatus(
+				conversationId ?? ''
+			),
+		[ conversationId ]
+	);
+
+	if ( ! typingStatus ) {
+		return null;
+	}
+
+	return (
+		<div
+			className="odie-chatbox__action-message"
+			ref={ ( div ) => div?.scrollIntoView( { behavior: 'smooth', block: 'end' } ) }
+		>
+			<TypingPlaceholder />
+		</div>
+	);
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTCOM-15414

https://github.com/user-attachments/assets/f0b9532e-2d96-4aa0-bd79-9ef90449543b

## Proposed Changes

* Isolate zendesk typing indicator

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Minimize re-renders 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
The issue is difficult to reproduce but follow the following steps
* Open the HC
* As first message escalate to human
* Do this few times to open multiple chats
* Mark all of them as solved without typing any other messages
* For all of them submit feedback by clicking either thumbs up or down
* For all of them the form should display after clicking the feedback button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
