### PR TITLE
MSD: Add badge for dashboard-horizon

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -277,10 +277,6 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 	if ( calypsoEnv === 'dashboard-horizon' ) {
 		context.badge = 'dashboard-horizon';
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
-
-		if ( request.query.branch ) {
-			context.branchName = request.query.branch;
-		}
 	}
 
 	if ( calypsoEnv === 'dashboard-stage' ) {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -274,6 +274,15 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		context.commitChecksum = getCurrentCommitShortChecksum();
 	}
 
+	if ( calypsoEnv === 'dashboard-horizon' ) {
+		context.badge = 'dashboard-horizon';
+		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
+
+		if ( request.query.branch ) {
+			context.branchName = request.query.branch;
+		}
+	}
+
 	if ( calypsoEnv === 'dashboard-stage' ) {
 		context.badge = 'dashboard-staging';
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -11,10 +11,10 @@
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",
 	"features": {
-		"dashboard": true,
-		"dashboard/v2": false,
 		"always_use_logout_url": true,
 		"cookie-banner": false,
+		"dashboard": true,
+		"dashboard/v2": false,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true
 	},

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -9,9 +9,11 @@
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",
 	"features": {
+		"cookie-banner": false,
 		"dashboard": true,
 		"dashboard/v2": false,
-		"cookie-banner": false
+		"dev/auth-helper": true,
+		"dev/preferences-helper": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -9,9 +9,9 @@
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",
 	"features": {
+		"cookie-banner": true,
 		"dashboard": false,
-		"dashboard/v2": false,
-		"cookie-banner": true
+		"dashboard/v2": false
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -9,9 +9,9 @@
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"site_name": "Hosting Dashboard",
 	"features": {
+		"cookie-banner": false,
 		"dashboard": true,
-		"dashboard/v2": false,
-		"cookie-banner": false
+		"dashboard/v2": false
 	},
 	"enable_all_sections": false,
 	"site_filter": [],


### PR DESCRIPTION
## Proposed Changes

Adds the developer tool for the dashboard-horizon environment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Open the Dashboard Calypso live link and ensure you see the developer tool badge.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
