### PR TITLE
End of year survey for Creators

### DIFF
--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -80,7 +80,7 @@ function FollowingStream( { ...props } ) {
 						dismissPreferenceName="reader-creator-survey-2026-banner"
 						dismissTemporary
 						horizontal
-						href="https://docs.google.com/forms/d/e/1FAIpQLSfvXsita2C3T5e4cpVmsvecSvY-bi7VCTbewDVgS3ieOdZMtg/viewform?usp=dialog"
+						href="https://automattic.survey.fm/creating-consuming-on-wordpress-com"
 						title={ translate( 'Help shape WordPress.com for creators' ) }
 						tracksImpressionName="calypso_reader_creator_survey_banner_view"
 						tracksClickName="calypso_reader_creator_survey_banner_click"

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { fixMe, translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
+import Banner from 'calypso/components/banner';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
 import QuickPost from 'calypso/reader/components/quick-post';
@@ -71,6 +72,20 @@ function FollowingStream( { ...props } ) {
 					>
 						<ViewToggle />
 					</NavigationHeader>
+					<Banner
+						callToAction={ translate( 'Take the survey' ) }
+						description={ translate(
+							'Got a minute? Share feedback to help shape WordPress.com for creators and content consumption in 2026.'
+						) }
+						dismissPreferenceName="reader-creator-survey-2026-banner"
+						dismissTemporary
+						horizontal
+						href="https://docs.google.com/forms/d/e/1FAIpQLSfvXsita2C3T5e4cpVmsvecSvY-bi7VCTbewDVgS3ieOdZMtg/viewform?usp=dialog"
+						title={ translate( 'Help shape WordPress.com for creators' ) }
+						tracksImpressionName="calypso_reader_creator_survey_banner_view"
+						tracksClickName="calypso_reader_creator_survey_banner_click"
+						tracksDismissName="calypso_reader_creator_survey_banner_dismiss"
+					/>
 					{ config.isEnabled( 'reader/quick-post' ) && hasSites && (
 						<FoldableCard
 							header={ translate( 'Write a quick post' ) }

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -79,7 +79,6 @@ function FollowingStream( { ...props } ) {
 							'Got a minute? Share feedback to help shape WordPress.com for creators and content consumption in 2026.'
 						) }
 						dismissPreferenceName="reader-creator-survey-2026-banner"
-						dismissTemporary
 						horizontal
 						href="https://automattic.survey.fm/creating-consuming-on-wordpress-com"
 						title={ translate( 'Help shape WordPress.com for creators' ) }

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -13,6 +13,7 @@ import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider
 import ReaderStream from 'calypso/reader/stream';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
 import Recent from '../recent';
@@ -28,6 +29,11 @@ function FollowingStream( { ...props } ) {
 	const currentUser = useSelector( getCurrentUser );
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 	const hasSites = ( currentUser?.site_count ?? 0 ) > 0;
+
+	const handleSurveyClick = () => {
+		// Dismiss the banner permanently when the survey button is clicked
+		dispatch( savePreference( 'dismissible-card-reader-creator-survey-2026-banner', true ) );
+	};
 
 	// Set the selected feed based on route param.
 	useEffect( () => {
@@ -82,8 +88,7 @@ function FollowingStream( { ...props } ) {
 						horizontal
 						href="https://automattic.survey.fm/creating-consuming-on-wordpress-com"
 						title={ translate( 'Help shape WordPress.com for creators' ) }
-						tracksImpressionName="calypso_reader_creator_survey_banner_view"
-						tracksClickName="calypso_reader_creator_survey_banner_click"
+						onClick={ handleSurveyClick }
 						event="reader_creator_survey_2026"
 						tracksImpressionName="calypso_reader_creator_survey_banner_view"
 						tracksClickName="calypso_reader_creator_survey_banner_click"

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -82,8 +82,6 @@ function FollowingStream( { ...props } ) {
 						horizontal
 						href="https://automattic.survey.fm/creating-consuming-on-wordpress-com"
 						title={ translate( 'Help shape WordPress.com for creators' ) }
-						tracksImpressionName="calypso_reader_creator_survey_banner_view"
-						tracksClickName="calypso_reader_creator_survey_banner_click"
 						event="reader_creator_survey_2026"
 						tracksImpressionName="calypso_reader_creator_survey_banner_view"
 						tracksClickName="calypso_reader_creator_survey_banner_click"

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -73,6 +73,7 @@ function FollowingStream( { ...props } ) {
 						<ViewToggle />
 					</NavigationHeader>
 					<Banner
+						target="_blank"
 						callToAction={ translate( 'Take the survey' ) }
 						description={ translate(
 							'Got a minute? Share feedback to help shape WordPress.com for creators and content consumption in 2026.'

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -84,6 +84,9 @@ function FollowingStream( { ...props } ) {
 						title={ translate( 'Help shape WordPress.com for creators' ) }
 						tracksImpressionName="calypso_reader_creator_survey_banner_view"
 						tracksClickName="calypso_reader_creator_survey_banner_click"
+						event="reader_creator_survey_2026"
+						tracksImpressionName="calypso_reader_creator_survey_banner_view"
+						tracksClickName="calypso_reader_creator_survey_banner_click"
 						tracksDismissName="calypso_reader_creator_survey_banner_dismiss"
 					/>
 					{ config.isEnabled( 'reader/quick-post' ) && hasSites && (


### PR DESCRIPTION
## Description

[Linear Project](https://linear.app/a8c/project/creators-end-of-year-survey-d2e8f80e43be/overview)

I'd like to solicit feedback directly from our customers. I've drafted [this 3 question survey](https://automattic.survey.fm/creating-consuming-on-wordpress-com). The banner is dismissible. My plan is to keep it up for a week. After 1 week we'll remove the banner and share a P2 with the results from the survey.

## Goal
The goal of this survey will be to gather context and insights around what works, what doesn't, where there is friction, where we should focus our attention in 2026.

## Preview
<img width="2940" height="972" alt="CleanShot 2025-12-04 at 06 12 06@2x" src="https://github.com/user-attachments/assets/8e4bcb23-e63f-4ec5-8197-791eb7f6bf33" />

