### PR TITLE
[Try] Move loading providers to Agents Manager

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -209,7 +209,7 @@ if ( helpCenterData.isNextAdmin ) {
 		if ( select( 'next-admin' )?.getMetaMenuItems?.( 'wp-logo' )?.length > 1 ) {
 			unsubscribe();
 			// wait for the next tick to ensure the menu items are registered
-			queueMicrotask( async () => {
+			queueMicrotask( () => {
 				select( 'next-admin' )
 					?.getMetaMenuItems?.( 'wp-logo' )
 					?.forEach( ( item ) => {
@@ -230,17 +230,6 @@ if ( helpCenterData.isNextAdmin ) {
 					? { newInteractionsBotSlug: 'ciab-workflow-support_chat' }
 					: {};
 
-				// Load external providers (e.g., from Big Sky plugin)
-				const { loadExternalProviders } = await import( './src/utils/load-external-providers' );
-				const {
-					toolProvider,
-					contextProvider,
-					suggestions,
-					markdownComponents,
-					markdownExtensions,
-					useNavigationContinuation,
-				} = await loadExternalProviders();
-
 				createRoot( container ).render(
 					<QueryClientProvider client={ queryClient }>
 						<HelpCenter
@@ -252,22 +241,15 @@ if ( helpCenterData.isNextAdmin ) {
 							onboardingUrl="https://wordpress.com/start"
 							handleClose={ () => dispatch( 'automattic/help-center' ).setShowHelpCenter( false ) }
 							isCommerceGarden={ helpCenterData.isCommerceGarden }
-							toolProvider={ toolProvider }
-							contextProvider={ contextProvider }
-							suggestions={ suggestions }
-							markdownComponents={ markdownComponents }
-							markdownExtensions={ markdownExtensions }
-							useNavigationContinuation={ useNavigationContinuation }
 							{ ...botProps }
 						/>
-					</QueryClientProvider>,
-					document.getElementById( 'jetpack-help-center' )
+					</QueryClientProvider>
 				);
 			} );
 		}
 	} );
 } else {
 	registerPlugin( 'jetpack-help-center', {
-		render: HelpCenterContentWithProvider,
+		render: () => <HelpCenterContentWithProvider />,
 	} );
 }

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -7,18 +7,12 @@ import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data'
 import { useEffect, useCallback, useState } from '@wordpress/element';
 import { createRoot } from 'react-dom/client';
 import { useMenuPanelExperiment } from './hooks/use-menu-panel-experiment';
-import { loadExternalProviders } from './src/utils/load-external-providers';
-const queryClient = new QueryClient();
+
 import './help-center.scss';
 
-function AdminHelpCenterContent( {
-	toolProvider,
-	contextProvider,
-	suggestions,
-	markdownComponents,
-	markdownExtensions,
-	useNavigationContinuation,
-} ) {
+const queryClient = new QueryClient();
+
+function AdminHelpCenterContent() {
 	const { setShowHelpCenter, setShowSupportDoc, setNavigateToRoute } =
 		useDataStoreDispatch( 'automattic/help-center' );
 	const { isShown, unreadCount } = useSelect(
@@ -227,12 +221,6 @@ function AdminHelpCenterContent( {
 			onboardingUrl="https://wordpress.com/start"
 			handleClose={ closeCallback }
 			isCommerceGarden={ helpCenterData.isCommerceGarden }
-			toolProvider={ toolProvider }
-			contextProvider={ contextProvider }
-			suggestions={ suggestions }
-			markdownComponents={ markdownComponents }
-			markdownExtensions={ markdownExtensions }
-			useNavigationContinuation={ useNavigationContinuation }
 			{ ...botProps }
 		/>
 	);
@@ -240,28 +228,9 @@ function AdminHelpCenterContent( {
 
 const target = document.getElementById( 'help-center-masterbar' );
 if ( target ) {
-	// Load external providers (e.g., from Big Sky plugin) and render
-	loadExternalProviders().then(
-		( {
-			toolProvider,
-			contextProvider,
-			suggestions,
-			markdownComponents,
-			markdownExtensions,
-			useNavigationContinuation,
-		} ) => {
-			createRoot( target ).render(
-				<QueryClientProvider client={ queryClient }>
-					<AdminHelpCenterContent
-						toolProvider={ toolProvider }
-						contextProvider={ contextProvider }
-						suggestions={ suggestions }
-						markdownComponents={ markdownComponents }
-						markdownExtensions={ markdownExtensions }
-						useNavigationContinuation={ useNavigationContinuation }
-					/>
-				</QueryClientProvider>
-			);
-		}
+	createRoot( target ).render(
+		<QueryClientProvider client={ queryClient }>
+			<AdminHelpCenterContent />
+		</QueryClientProvider>
 	);
 }

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -5,33 +5,18 @@
  */
 
 import { createOdieBotId, getAgentManager } from '@automattic/agenttic-client';
-import { useMemo, useEffect, useState } from '@wordpress/element';
+import { useMemo, useEffect, useState, useRef } from '@wordpress/element';
 import { useLocation } from 'react-router-dom';
 import { createCalypsoAuthProvider } from '../../auth/calypso-auth-provider';
 import { ORCHESTRATOR_AGENT_ID, ORCHESTRATOR_AGENT_URL } from '../../constants';
 import { SESSION_STORAGE_KEY, getSessionId } from '../../utils/agent-session';
 import { lastConversationCache } from '../../utils/conversation-cache';
+import { loadExternalProviders, type LoadedProviders } from '../../utils/load-external-providers';
 import AgentDock from '../agent-dock';
 import { PersistentRouter } from '../persistent-router';
-import type { ToolProvider, ContextProvider, ContextEntry } from '../../extension-types';
-import type {
-	UseAgentChatConfig,
-	Ability as AgenticAbility,
-	SubmitOptions,
-} from '@automattic/agenttic-client';
-import type { MarkdownComponents, MarkdownExtensions, Suggestion } from '@automattic/agenttic-ui';
+import type { ContextEntry } from '../../extension-types';
+import type { UseAgentChatConfig, Ability as AgenticAbility } from '@automattic/agenttic-client';
 import type { HelpCenterSite, CurrentUser } from '@automattic/data-stores';
-
-/**
- * Navigation continuation hook type - provided by environments that need
- * navigation with conversation continuation (e.g wp-admin/navigate)
- */
-type NavigationContinuationHook = ( props: {
-	isProcessing: boolean;
-	onSubmit: ( message: string, options?: SubmitOptions ) => Promise< void >;
-	sessionId: string;
-	agentId: string;
-} ) => void;
 
 export interface UnifiedAIAgentProps {
 	/** The current route path. */
@@ -44,18 +29,6 @@ export interface UnifiedAIAgentProps {
 	currentUser?: CurrentUser;
 	/** Called when the agent is closed. */
 	handleClose?: () => void;
-	/** Tool provider for custom abilities. */
-	toolProvider?: ToolProvider;
-	/** Context provider for environment-specific context. */
-	contextProvider?: ContextProvider;
-	/** Suggestions displayed when the chat is empty. */
-	emptyViewSuggestions?: Suggestion[];
-	/** Custom components for rendering markdown. */
-	markdownComponents?: MarkdownComponents;
-	/** Custom markdown extensions. */
-	markdownExtensions?: MarkdownExtensions;
-	/** Navigation continuation hook for post-navigation conversation resumption. */
-	useNavigationContinuation?: NavigationContinuationHook;
 }
 
 /**
@@ -100,24 +73,28 @@ export default function UnifiedAIAgent( props: UnifiedAIAgentProps ) {
 }
 
 // Separate component that uses hooks within `PersistentRouter` context
-function AgentSetup( {
-	currentRoute,
-	site = null,
-	toolProvider,
-	contextProvider,
-	emptyViewSuggestions: customSuggestions,
-	markdownComponents = {},
-	markdownExtensions = {},
-	useNavigationContinuation,
-}: UnifiedAIAgentProps ) {
+function AgentSetup( { currentRoute, site = null }: UnifiedAIAgentProps ) {
 	const [ agentConfig, setAgentConfig ] = useState< UseAgentChatConfig | null >( null );
+	const [ loadedProviders, setLoadedProviders ] = useState< LoadedProviders >( {} );
+	const providersLoadedRef = useRef( false );
 	const { state } = useLocation();
 	// Use persisted route state `sessionId` if available, otherwise fall back to stored `sessionId`
 	const sessionId = state?.sessionId || getSessionId();
 
-	// Create the initial agent configuration
-	const config = useMemo< UseAgentChatConfig >(
-		() => {
+	// Load external providers and initialize agent config
+	useEffect( () => {
+		const initializeAgent = async () => {
+			// Load external providers (only once)
+			let providers = loadedProviders;
+			if ( ! providersLoadedRef.current ) {
+				providers = await loadExternalProviders();
+				providersLoadedRef.current = true;
+				setLoadedProviders( providers );
+			}
+
+			const { toolProvider, contextProvider } = providers;
+
+			// Create the agent configuration
 			const config: UseAgentChatConfig = {
 				agentId: ORCHESTRATOR_AGENT_ID,
 				agentUrl: ORCHESTRATOR_AGENT_URL,
@@ -182,15 +159,6 @@ function AgentSetup( {
 				};
 			}
 
-			return config;
-		},
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- Only create once
-		[]
-	);
-
-	// Load config AND pre-load cached messages for progressive loading
-	useEffect( () => {
-		const initializeWithCache = async () => {
 			// Check if we have cached messages to pre-load
 			if ( sessionId ) {
 				const agentManager = getAgentManager();
@@ -211,10 +179,10 @@ function AgentSetup( {
 			setAgentConfig( config );
 		};
 
-		initializeWithCache();
-	}, [ config, sessionId ] );
+		initializeAgent();
+	}, [ currentRoute, loadedProviders, sessionId, site?.ID ] );
 
-	// Default suggestions - can be overridden via the `customSuggestions` prop
+	// Default suggestions - can be overridden by loaded providers
 	const defaultSuggestions = useMemo(
 		() => [
 			{
@@ -244,10 +212,10 @@ function AgentSetup( {
 	return (
 		<AgentDock
 			agentConfig={ agentConfig }
-			emptyViewSuggestions={ customSuggestions || defaultSuggestions }
-			markdownComponents={ markdownComponents }
-			markdownExtensions={ markdownExtensions }
-			useNavigationContinuation={ useNavigationContinuation }
+			emptyViewSuggestions={ loadedProviders.suggestions || defaultSuggestions }
+			markdownComponents={ loadedProviders.markdownComponents || {} }
+			markdownExtensions={ loadedProviders.markdownExtensions || {} }
+			useNavigationContinuation={ loadedProviders.useNavigationContinuation }
 		/>
 	);
 }

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -5,7 +5,7 @@
  * PHP filter. Each provider module should export toolProvider and/or contextProvider.
  */
 
-import type { ToolProvider, ContextProvider, Suggestion } from '@automattic/agents-manager';
+import type { ToolProvider, ContextProvider, Suggestion } from '../types';
 import type { SubmitOptions } from '@automattic/agenttic-client';
 import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 
@@ -34,14 +34,15 @@ export interface LoadedProviders {
 }
 
 /**
- * Load external agent providers from helpCenterData.agentProviders.
+ * Load external agent providers from agentsManagerData.agentProviders.
  *
  * Each provider module ID is dynamically imported using WordPress's script module
  * system. Modules should export { toolProvider, contextProvider }.
  * @returns Promise resolving to merged providers or empty object if none found.
  */
 export async function loadExternalProviders(): Promise< LoadedProviders > {
-	const agentProviders = agentsManagerData?.agentProviders || [];
+	const agentProviders =
+		typeof agentsManagerData !== 'undefined' ? agentsManagerData?.agentProviders || [] : [];
 
 	if ( agentProviders.length === 0 ) {
 		return {};
@@ -80,10 +81,10 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			}
 
 			// eslint-disable-next-line no-console
-			console.log( `[HelpCenter] Loaded provider "${ moduleId }"` );
+			console.log( `[AgentsManager] Loaded provider "${ moduleId }"` );
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
-			console.warn( `[HelpCenter] Failed to load provider "${ moduleId }":`, error );
+			console.warn( `[AgentsManager] Failed to load provider "${ moduleId }":`, error );
 		}
 	}
 

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -36,17 +36,7 @@ const HelpCenter: React.FC< Container > = ( {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return helpCenterSelect.isHelpCenterShown();
 	}, [] );
-	const {
-		currentUser,
-		site,
-		sectionName,
-		toolProvider,
-		contextProvider,
-		suggestions,
-		markdownComponents,
-		markdownExtensions,
-		useNavigationContinuation,
-	} = useHelpCenterContext();
+	const { currentUser, site, sectionName } = useHelpCenterContext();
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
 	const { data: supportInteractionsOpen, isLoading: isLoadingOpenInteractions } =
 		useGetSupportInteractions( 'zendesk' );
@@ -89,12 +79,6 @@ const HelpCenter: React.FC< Container > = ( {
 				site={ site }
 				sectionName={ sectionName }
 				handleClose={ handleClose }
-				toolProvider={ toolProvider }
-				contextProvider={ contextProvider }
-				emptyViewSuggestions={ suggestions }
-				markdownComponents={ markdownComponents }
-				markdownExtensions={ markdownExtensions }
-				useNavigationContinuation={ useNavigationContinuation }
 			/>
 		);
 	}

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -1,21 +1,7 @@
 import { ODIE_NEW_INTERACTIONS_BOT_SLUG } from '@automattic/odie-client/src/constants';
 import { useContext, createContext } from '@wordpress/element';
 import { useNewInteractionsBotConfig } from '../hooks/use-new-interaction-bot-config';
-import type { ToolProvider, ContextProvider, Suggestion } from '@automattic/agents-manager';
-import type { SubmitOptions } from '@automattic/agenttic-client';
-import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 import type { CurrentUser, HelpCenterSite } from '@automattic/data-stores';
-
-/**
- * Navigation continuation hook type - provided by plugins that support
- * navigation with conversation continuation (e.g., Big Sky's wp-admin/navigate)
- */
-export type NavigationContinuationHook = ( props: {
-	isProcessing: boolean;
-	onSubmit: ( message: string, options?: SubmitOptions ) => Promise< void >;
-	sessionId: string;
-	agentId: string;
-} ) => void;
 
 export type HelpCenterRequiredInformation = {
 	newInteractionsBotSlug: string;
@@ -30,35 +16,6 @@ export type HelpCenterRequiredInformation = {
 	googleMailServiceFamily: string;
 	onboardingUrl: string;
 	isCommerceGarden: boolean;
-	/**
-	 * Tool provider for AI agent abilities (optional)
-	 * Allows plugins to provide custom abilities to the agent
-	 */
-	toolProvider?: ToolProvider;
-	/**
-	 * Context provider for AI agent context (optional)
-	 * Allows plugins to provide rich context about current state
-	 */
-	contextProvider?: ContextProvider;
-	/**
-	 * Custom suggestions for the AI agent empty view (optional)
-	 * Allows plugins to provide context-specific suggestions
-	 */
-	suggestions?: Suggestion[];
-	/**
-	 * Custom markdown components for message rendering (optional)
-	 * Allows plugins to provide custom renderers for markdown elements
-	 */
-	markdownComponents?: MarkdownComponents;
-	/**
-	 * Custom markdown extensions (optional)
-	 */
-	markdownExtensions?: MarkdownExtensions;
-	/**
-	 * Navigation continuation hook (optional)
-	 * Provided by plugins that support navigation with conversation continuation
-	 */
-	useNavigationContinuation?: NavigationContinuationHook;
 	source: '' | 'wpcom' | 'a4a';
 };
 


### PR DESCRIPTION
## Proposed Changes

* Try moving loading providers to be an exclusive concern of the Agents Manager

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix loading in `/wp-admin/site-editor.php?flags=unified-agent`.
* Prevent slowdown of help center when Agents Manager isn't used.

## Testing Instructions


* See https://github.com/Automattic/wp-calypso/pull/107475

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
