### PR TITLE
Purchases (legacy): Separate cancellation from refunds

### DIFF
--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -65,6 +65,7 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
 import SupportLink from '../cancel-purchase-support-link/support-link';
+import { isCancelRefundSeparationEnabled } from '../hooks/use-cancel-refund-separation';
 import AtomicRevertChanges from './atomic-revert-changes';
 import CancelPurchaseButton from './button';
 import CancelPurchaseDomainOptions, { willShowDomainOptionsRadioButtons } from './domain-options';
@@ -136,6 +137,8 @@ export type CancelPurchaseAllProps = CancelPurchaseProps &
 	CancelPurchaseActions;
 
 class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseState > {
+	private readonly refundSeparationEnabled = isCancelRefundSeparationEnabled();
+
 	state = {
 		cancelBundledDomain: false,
 		confirmCancelBundledDomain: false,
@@ -191,6 +194,10 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 	isRemoveFlow = () => this.state.flowMode === 'remove';
 
+	isSeparationEnabled = () => this.refundSeparationEnabled;
+
+	isImmediateRemovalFlow = () => ! this.isSeparationEnabled() || this.isRemoveFlow();
+
 	redirect = () => {
 		const { purchase, siteSlug } = this.props;
 		let redirectPath = this.props.purchaseListUrl ?? purchasesRoot;
@@ -220,6 +227,8 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const { includedDomainPurchase, purchase, isJetpack, isAkismet, isDomainRegistrationPurchase } =
 			this.props;
 
+		const shouldDisplayDomainOptions = this.isSeparationEnabled() ? this.isRemoveFlow() : true;
+
 		// For Jetpack/Akismet products and domain registrations, call onCancellationComplete to show the dialog
 		if ( isJetpack || isAkismet || isDomainRegistrationPurchase ) {
 			this.onCancellationComplete();
@@ -228,7 +237,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 		// Only show domain options as a separate step if radio buttons will be displayed
 		if (
-			this.isRemoveFlow() &&
+			shouldDisplayDomainOptions &&
 			includedDomainPurchase &&
 			willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase )
 		) {
@@ -482,7 +491,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const hasRefund = hasAmountAvailableToRefund( purchase );
 
 		if ( isDomainRegistration( purchase ) ) {
-			if ( this.isRemoveFlow() && hasRefund ) {
+			if ( this.isImmediateRemovalFlow() && hasRefund ) {
 				return translate(
 					'After you confirm this removal, the domain will be removed immediately.'
 				);
@@ -495,7 +504,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			);
 		}
 
-		if ( this.isRemoveFlow() && hasRefund ) {
+		if ( this.isImmediateRemovalFlow() && hasRefund ) {
 			return translate(
 				'After you confirm this removal, the subscription will be removed immediately.'
 			);
@@ -520,7 +529,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			includedDomainPurchase
 		);
 
-		if ( this.isRemoveFlow() && refundAmountString ) {
+		const immediateRemovalMessaging = this.isImmediateRemovalFlow();
+
+		if ( immediateRemovalMessaging && refundAmountString ) {
 			return translate(
 				'If you confirm this removal, you will receive a {{span}}refund of %(refundText)s{{/span}}, and your subscription will be removed immediately.',
 				{
@@ -557,7 +568,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			this.props.includedDomainPurchase
 		);
 
-		if ( this.isRemoveFlow() && refundAmountString ) {
+		if ( this.isImmediateRemovalFlow() && refundAmountString ) {
 			return translate( '%(refundText)s to be refunded', {
 				args: {
 					refundText: refundAmountString,
@@ -657,8 +668,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			plan && 'getCancellationFeatures' in plan ? plan.getCancellationFeatures?.() ?? [] : [];
 
 		// Check if we should show domain options inline (when they don't need radio buttons)
+		const shouldUseDomainOptions = this.isSeparationEnabled() ? this.isRemoveFlow() : true;
 		const shouldShowDomainOptionsInline =
-			this.isRemoveFlow() &&
+			shouldUseDomainOptions &&
 			includedDomainPurchase &&
 			! willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase );
 
@@ -685,7 +697,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				<CancelPurchaseRefundInformation
 					purchase={ purchase }
 					isJetpackPurchase={ isJetpackPurchase }
-					flowMode={ this.state.flowMode }
+					flowMode={ this.isSeparationEnabled() ? this.state.flowMode : 'remove' }
 				/>
 
 				<CancelPurchaseFeatureList
@@ -738,7 +750,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					) }
 					<div className="cancel-purchase__footer-text-wrapper">
 						<div className="cancel-purchase__footer-text">
-							{ this.isRemoveFlow() && hasAmountAvailableToRefund( purchase ) ? (
+							{ this.isImmediateRemovalFlow() && hasAmountAvailableToRefund( purchase ) ? (
 								<p className="cancel-purchase__refund-amount">{ this.renderFooterText() }</p>
 							) : (
 								<p className="cancel-purchase__expiration-text">{ this.renderExpirationText() }</p>
@@ -781,6 +793,10 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const { cancelBundledDomain, confirmCancelBundledDomain } = this.state;
 
 		if ( ! includedDomainPurchase || ! isSubscription( purchase ) ) {
+			return null;
+		}
+
+		if ( this.isSeparationEnabled() && ! this.isRemoveFlow() ) {
 			return null;
 		}
 
@@ -839,7 +855,11 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 	renderRefundNotice = () => {
 		const { purchase, translate } = this.props;
 
-		if ( this.isRemoveFlow() || ! hasAmountAvailableToRefund( purchase ) ) {
+		if (
+			! this.isSeparationEnabled() ||
+			this.isRemoveFlow() ||
+			! hasAmountAvailableToRefund( purchase )
+		) {
 			return null;
 		}
 

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -25,6 +25,7 @@ import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
+import Notice from 'calypso/components/notice';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	getName,
@@ -68,7 +69,7 @@ import AtomicRevertChanges from './atomic-revert-changes';
 import CancelPurchaseButton from './button';
 import CancelPurchaseDomainOptions, { willShowDomainOptionsRadioButtons } from './domain-options';
 import CancelPurchaseFeatureList from './feature-list';
-import CancelPurchaseRefundInformation from './refund-information';
+import CancelPurchaseRefundInformation, { type CancelPurchaseFlowMode } from './refund-information';
 import type { Purchases, SiteDetails } from '@automattic/data-stores';
 import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
 import type { ReactNode } from 'react';
@@ -88,6 +89,7 @@ export interface CancelPurchaseState {
 	domainConfirmationConfirmed: boolean;
 	showDomainOptionsStep: boolean;
 	showDialog: boolean;
+	flowMode: CancelPurchaseFlowMode;
 }
 
 export interface CancelPurchaseActions {
@@ -144,6 +146,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		showDomainOptionsStep: false,
 		// Cancellation state moved from button component
 		showDialog: false,
+		flowMode: 'cancel' as CancelPurchaseFlowMode,
 	};
 
 	componentDidMount() {
@@ -186,6 +189,8 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		return isValidForCancellation;
 	};
 
+	isRemoveFlow = () => this.state.flowMode === 'remove';
+
 	redirect = () => {
 		const { purchase, siteSlug } = this.props;
 		let redirectPath = this.props.purchaseListUrl ?? purchasesRoot;
@@ -223,6 +228,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 		// Only show domain options as a separate step if radio buttons will be displayed
 		if (
+			this.isRemoveFlow() &&
 			includedDomainPurchase &&
 			willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase )
 		) {
@@ -473,12 +479,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const { expiryDate } = purchase;
 
 		const expirationDate = this.props.moment( expiryDate ).format( 'LL' );
+		const hasRefund = hasAmountAvailableToRefund( purchase );
 
 		if ( isDomainRegistration( purchase ) ) {
-			// Domain in AGP bought with domain credits
-			if ( isRefundable( purchase ) ) {
+			if ( this.isRemoveFlow() && hasRefund ) {
 				return translate(
-					'After you confirm this change, the domain will be removed immediately.'
+					'After you confirm this removal, the domain will be removed immediately.'
 				);
 			}
 			return translate(
@@ -486,6 +492,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				{
 					args: { expirationDate },
 				}
+			);
+		}
+
+		if ( this.isRemoveFlow() && hasRefund ) {
+			return translate(
+				'After you confirm this removal, the subscription will be removed immediately.'
 			);
 		}
 
@@ -508,9 +520,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			includedDomainPurchase
 		);
 
-		if ( refundAmountString ) {
+		if ( this.isRemoveFlow() && refundAmountString ) {
 			return translate(
-				'If you confirm this cancellation, you will receive a {{span}}refund of %(refundText)s{{/span}}, and your subscription will be removed immediately.',
+				'If you confirm this removal, you will receive a {{span}}refund of %(refundText)s{{/span}}, and your subscription will be removed immediately.',
 				{
 					args: {
 						refundText: refundAmountString,
@@ -545,7 +557,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			this.props.includedDomainPurchase
 		);
 
-		if ( refundAmountString ) {
+		if ( this.isRemoveFlow() && refundAmountString ) {
 			return translate( '%(refundText)s to be refunded', {
 				args: {
 					refundText: refundAmountString,
@@ -646,6 +658,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 		// Check if we should show domain options inline (when they don't need radio buttons)
 		const shouldShowDomainOptionsInline =
+			this.isRemoveFlow() &&
 			includedDomainPurchase &&
 			! willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase );
 
@@ -672,6 +685,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				<CancelPurchaseRefundInformation
 					purchase={ purchase }
 					isJetpackPurchase={ isJetpackPurchase }
+					flowMode={ this.state.flowMode }
 				/>
 
 				<CancelPurchaseFeatureList
@@ -724,7 +738,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					) }
 					<div className="cancel-purchase__footer-text-wrapper">
 						<div className="cancel-purchase__footer-text">
-							{ hasAmountAvailableToRefund( purchase ) ? (
+							{ this.isRemoveFlow() && hasAmountAvailableToRefund( purchase ) ? (
 								<p className="cancel-purchase__refund-amount">{ this.renderFooterText() }</p>
 							) : (
 								<p className="cancel-purchase__expiration-text">{ this.renderExpirationText() }</p>
@@ -822,6 +836,37 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		);
 	};
 
+	renderRefundNotice = () => {
+		const { purchase, translate } = this.props;
+
+		if ( this.isRemoveFlow() || ! hasAmountAvailableToRefund( purchase ) ) {
+			return null;
+		}
+
+		const refundAmountString = this.renderRefundAmountString(
+			purchase,
+			this.state.cancelBundledDomain,
+			this.props.includedDomainPurchase
+		);
+
+		if ( ! refundAmountString ) {
+			return null;
+		}
+
+		return (
+			<Notice className="cancel-purchase__refund-notice" showDismiss={ false } status="is-info">
+				{ translate(
+					"You're eligible for a %(refundAmount)s refund if you remove the plan now. Your features will be unavailable right away.",
+					{
+						args: {
+							refundAmount: refundAmountString,
+						},
+					}
+				) }
+			</Notice>
+		);
+	};
+
 	render() {
 		if ( ! this.isDataValid() ) {
 			return null;
@@ -892,6 +937,8 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 							) }
 						/>
 					</div>
+
+					{ this.renderRefundNotice() }
 
 					<FormattedHeader
 						className="cancel-purchase__formatted-header"

--- a/client/me/purchases/cancel-purchase/refund-information.tsx
+++ b/client/me/purchases/cancel-purchase/refund-information.tsx
@@ -13,6 +13,8 @@ import {
 } from 'calypso/lib/purchases';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 
+export type CancelPurchaseFlowMode = 'cancel' | 'remove';
+
 export interface CancelPurchaseRefundInformationConnectedProps {
 	isGravatarRestrictedDomain: boolean;
 }
@@ -20,53 +22,58 @@ export interface CancelPurchaseRefundInformationConnectedProps {
 export interface CancelPurchaseRefundInformationProps {
 	purchase: Purchases.Purchase;
 	isJetpackPurchase: boolean;
+	flowMode: CancelPurchaseFlowMode;
 }
 
 const CancelPurchaseRefundInformation = ( {
 	purchase,
 	isGravatarRestrictedDomain,
 	isJetpackPurchase,
+	flowMode,
 }: CancelPurchaseRefundInformationProps & CancelPurchaseRefundInformationConnectedProps ) => {
 	const { refundPeriodInDays } = purchase;
+	const productName = getName( purchase );
+	const cancelSubscriptionText = i18n.translate(
+		"When you cancel your subscription, you'll be able to use %(productName)s until your subscription expires. " +
+			'Once it expires, it will be automatically removed from your site.',
+		{
+			args: {
+				productName,
+			},
+		}
+	);
+	const isRemoveFlow = flowMode === 'remove';
 	let text;
 
-	if ( isRefundable( purchase ) ) {
-		if ( isDomainRegistration( purchase ) ) {
-			// Domain bought with domain credits, so there's no refund
-			if ( ! hasAmountAvailableToRefund( purchase ) ) {
-				text = i18n.translate(
-					'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
-						'it will be removed from your site immediately.',
-					{
-						args: { refundPeriodInDays },
-					}
-				);
-			} else {
-				text = i18n.translate(
-					'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
-						"you'll receive a refund and it will be removed from your site immediately.",
-					{
-						args: { refundPeriodInDays },
-					}
+	if ( isDomainRegistration( purchase ) ) {
+		if ( isRemoveFlow && hasAmountAvailableToRefund( purchase ) ) {
+			text = i18n.translate(
+				'When you remove your domain within %(refundPeriodInDays)d days of purchasing, ' +
+					"you'll receive a refund and it will be removed from your site immediately.",
+				{
+					args: { refundPeriodInDays },
+				}
+			);
+		} else {
+			text = [
+				i18n.translate(
+					'When you cancel your domain, it will remain registered and active until the registration expires, ' +
+						'at which point it will be automatically removed from your site.'
+				),
+			];
+
+			if ( isGravatarRestrictedDomain ) {
+				text.push(
+					i18n.translate(
+						'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
+					)
 				);
 			}
 		}
-
-		if ( isSubscription( purchase ) ) {
-			text = [
-				i18n.translate(
-					"We're sorry to hear the %(productName)s plan didn't fit your current needs, but thank you for giving it a try.",
-					{
-						args: {
-							productName: getName( purchase ),
-						},
-					}
-				),
-			];
+	} else if ( isSubscription( purchase ) ) {
+		if ( isRemoveFlow && isRefundable( purchase ) ) {
 			if ( isJetpackPurchase && config.isEnabled( 'jetpack/cancel-through-main-flow' ) ) {
-				// Refundable Jetpack subscription
-				text = [];
-				text.push(
+				text = [
 					i18n.translate(
 						'Because you are within the %(refundPeriodInDays)d day refund period, ' +
 							'your plan will be cancelled and removed from your site immediately and you will receive a full refund. ',
@@ -76,53 +83,47 @@ const CancelPurchaseRefundInformation = ( {
 					),
 					i18n.translate(
 						'If you want to keep the subscription until the renewal date, please cancel after the refund period has ended.'
-					)
-				);
+					),
+				];
 			} else {
 				text = i18n.translate(
-					'When you cancel your subscription within %(refundPeriodInDays)d days of purchasing, ' +
+					'When you remove your subscription within %(refundPeriodInDays)d days of purchasing, ' +
 						"you'll receive a refund and it will be removed from your site immediately.",
 					{
 						args: { refundPeriodInDays },
 					}
 				);
 			}
+		} else {
+			text = cancelSubscriptionText;
 		}
-
-		if ( isOneTimePurchase( purchase ) ) {
+	} else if ( isOneTimePurchase( purchase ) ) {
+		if ( isRemoveFlow && isRefundable( purchase ) ) {
 			text = i18n.translate(
-				'When you cancel this purchase within %(refundPeriodInDays)d days of purchasing, ' +
+				'When you remove this purchase within %(refundPeriodInDays)d days of purchasing, ' +
 					"you'll receive a refund and it will be removed from your site immediately.",
 				{
 					args: { refundPeriodInDays },
 				}
 			);
-		}
-	} else if ( isDomainRegistration( purchase ) ) {
-		text = [
-			i18n.translate(
-				'When you cancel your domain, it will remain registered and active until the registration expires, ' +
-					'at which point it will be automatically removed from your site.'
-			),
-		];
-
-		if ( isGravatarRestrictedDomain ) {
-			text.push(
-				i18n.translate(
-					'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
-				)
+		} else {
+			text = i18n.translate(
+				'When you cancel this purchase, it will remain active until your current access period ends.',
+				{}
 			);
 		}
 	} else {
-		text = i18n.translate(
-			"When you cancel your subscription, you'll be able to use %(productName)s until your subscription expires. " +
-				'Once it expires, it will be automatically removed from your site.',
-			{
-				args: {
-					productName: getName( purchase ),
-				},
-			}
-		);
+		text = [
+			i18n.translate(
+				"We're sorry to hear the %(productName)s plan didn't fit your current needs, but thank you for giving it a try.",
+				{
+					args: {
+						productName,
+					},
+				}
+			),
+			cancelSubscriptionText,
+		];
 	}
 
 	if ( ! text ) {

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -93,6 +93,10 @@
 	margin: 16px 0 8px;
 }
 
+.cancel-purchase__refund-notice {
+	margin-bottom: 16px;
+}
+
 .cancel-purchase__features {
 	line-height: 1.4;
 
@@ -275,4 +279,3 @@
 		}
 	}
 }
-

--- a/client/me/purchases/hooks/use-cancel-refund-separation.ts
+++ b/client/me/purchases/hooks/use-cancel-refund-separation.ts
@@ -1,0 +1,31 @@
+import config from '@automattic/calypso-config';
+import { useMemo } from '@wordpress/element';
+
+const FEATURE_FLAG = 'purchases/cancel-refund-separation';
+const QUERY_PARAM = 'cancel_refund_separation';
+
+const isQueryOverrideEnabled = (): boolean | null => {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+
+	const params = new URLSearchParams( window.location.search );
+	if ( ! params.has( QUERY_PARAM ) ) {
+		return null;
+	}
+
+	return params.get( QUERY_PARAM ) !== '0';
+};
+
+export function isCancelRefundSeparationEnabled(): boolean {
+	const override = isQueryOverrideEnabled();
+	if ( override !== null ) {
+		return override;
+	}
+
+	return config.isEnabled( FEATURE_FLAG );
+}
+
+export function useCancelRefundSeparationEligibility(): boolean {
+	return useMemo( () => isCancelRefundSeparationEnabled(), [] );
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13701/separate-cancellation-from-refunds

## Proposed Changes

We are creating an experiment that will test the separation of cancellation from refunds through the Purchase settings flows. The Linear issue contains a detailed overview of what is changing and an implementation plan with various milestones. We will cover the entire flow here and update the description as the implementation continues.

## Implementation Step Progress:

1. Eligibility gate
    - Mocked behind a feature flag:`flags=purchases/cancel-refund-separation`
2.  Step: [/cancel screen refresh (cancel-only mode)](https://linear.app/a8c/issue/DOTCOM-13701/separate-cancellation-from-refunds#cancel-screen-refresh-cancel-only-mode-36479b0f)
    - Roughly looks:
   
| Before | After |
|--------|--------|
| <img width="1106" height="540" alt="Screenshot 2025-12-04 at 3 49 32 PM" src="https://github.com/user-attachments/assets/aa1ea3f5-b510-4295-8600-20abb5e19afe" /> | <img width="1108" height="498" alt="Screenshot 2025-12-04 at 3 49 20 PM" src="https://github.com/user-attachments/assets/2de0957d-41c0-4129-811a-e67cb355e154" /> |

3. Step: [Split cancel vs remove paths (still under /cancel)](https://linear.app/a8c/issue/DOTCOM-13701/separate-cancellation-from-refunds#split-cancel-vs-remove-paths-dacf78fe)
    - In progress


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of https://linear.app/a8c/issue/DOTCOM-13701/separate-cancellation-from-refunds

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Starts here: `me/purchases/{site}/{purchase}/cancel?flags=purchases/cancel-refund-separation`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
