### PR TITLE
Add hover color in Domain Connect/Transfer card benefits section

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/option-content-v2.tsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/option-content-v2.tsx
@@ -60,7 +60,13 @@ export default function OptionContentV2( {
 				badges={ recommended ? [ { text: __( 'Recommended' ), intent: 'success' } ] : undefined }
 			/>
 			{ benefits && (
-				<VStack spacing={ 1 } className="option-content-v2__benefits">
+				<VStack
+					spacing={ 1 }
+					className={ clsx( 'option-content-v2__benefits', {
+						'option-content-v2__benefits--clickable': ! disabled && ! isPlaceholder && onSelect,
+					} ) }
+					onClick={ disabled || isPlaceholder || ! onSelect ? undefined : onSelect }
+				>
 					{ benefits.map( ( benefit, index ) => {
 						return (
 							<HStack

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -84,6 +84,11 @@
 					}
 				}
 			}
+			&:hover {
+				.option-content-v2__benefits {
+					background-color: #f3f6fc;
+				}
+			}
 		}
 
 		.option-content {

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -83,9 +83,18 @@
 						flex-shrink: 0;
 					}
 				}
+
+				&--clickable {
+					cursor: pointer;
+					transition: background-color 0.2s ease;
+
+					&:hover {
+						background-color: #f3f6fc;
+					}
+				}
 			}
 			&:hover {
-				.option-content-v2__benefits {
+				.option-content-v2__benefits--clickable {
 					background-color: #f3f6fc;
 				}
 			}


### PR DESCRIPTION
Closes [DOMAINS-1869](https://linear.app/a8c/issue/DOMAINS-1869/hover-for-card-needs-to-align-more-to-msd-hovers-all-blue).

## Proposed Changes
Adds a hover effect to the benefits section of the Domain Connect/Transfer card to improve visual feedback when users interact with the card.

![Screenshot 2025-12-04 alle 15 31 47](https://github.com/user-attachments/assets/a6bfd251-100c-47dc-9146-f532c990f17d)


## Why are these changes being made?
Design review feedback (1lCoIdZNpLPE9DjukYz9vUbAiqYsqeRHALTQ8xiaeosk-gdoc)

## Testing Instructions
Verified the hover effect works correctly on the Domain Connect/Transfer card

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?