### PR TITLE
MSD: Fix showing cached site visibility settings

### DIFF
--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -12,7 +12,10 @@ import { ShareSiteForm } from './share-site-form';
 
 export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
+	const { data: settings } = useQuery( {
+		...siteSettingsQuery( site.ID ),
+		staleTime: 0, // Forces refetch on mount to get the latest settings.
+	} );
 
 	if ( ! settings ) {
 		return null;

--- a/client/dashboard/sites/settings-site-visibility/summary.tsx
+++ b/client/dashboard/sites/settings-site-visibility/summary.tsx
@@ -3,14 +3,16 @@ import { __ } from '@wordpress/i18n';
 import { seen } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import { canViewSiteVisibilitySettings } from '../features';
-import type { Site } from '@automattic/api-core';
+import type { Site, SiteSettings } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
 export default function SiteVisibilitySettingsSummary( {
 	site,
 	density,
+	settings,
 }: {
 	site: Site;
+	settings?: SiteSettings;
 	density?: Density;
 } ) {
 	if ( ! canViewSiteVisibilitySettings( site ) ) {
@@ -18,9 +20,9 @@ export default function SiteVisibilitySettingsSummary( {
 	}
 
 	let badges = [];
-	if ( site.launch_status === 'unlaunched' || site.is_coming_soon ) {
+	if ( settings?.wpcom_public_coming_soon === 1 ) {
 		badges = [ { text: __( 'Coming soon' ), intent: 'warning' as const } ];
-	} else if ( site.is_private ) {
+	} else if ( settings?.blog_public === -1 ) {
 		badges = [ { text: __( 'Private' ) } ];
 	} else {
 		badges = [ { text: __( 'Public' ), intent: 'success' as const } ];

--- a/client/dashboard/sites/settings-site-visibility/test/summary.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/summary.tsx
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '../../../test-utils';
+import { canViewSiteVisibilitySettings } from '../../features';
+import SiteVisibilitySettingsSummary from '../summary';
+import type { Site, SiteSettings } from '@automattic/api-core';
+
+jest.mock( '../../features', () => ( {
+	canViewSiteVisibilitySettings: jest.fn(),
+} ) );
+
+const mockCanViewSiteVisibilitySettings = canViewSiteVisibilitySettings as jest.MockedFunction<
+	typeof canViewSiteVisibilitySettings
+>;
+
+function createSite( overrides: Partial< Site > = {} ) {
+	return {
+		ID: 123,
+		slug: 'example-site.wordpress.com',
+		is_wpcom_flex: false,
+		...overrides,
+	} as Site;
+}
+
+function createSettings(
+	overrides: Partial< Pick< SiteSettings, 'blog_public' | 'wpcom_public_coming_soon' > > = {}
+) {
+	return {
+		blog_public: 1,
+		wpcom_public_coming_soon: 0,
+		...overrides,
+	} as SiteSettings;
+}
+
+function renderSummary( {
+	site = createSite(),
+	settings,
+}: {
+	site?: Site;
+	settings?: SiteSettings;
+} = {} ) {
+	return render( <SiteVisibilitySettingsSummary site={ site } settings={ settings } /> );
+}
+
+beforeEach( () => {
+	mockCanViewSiteVisibilitySettings.mockReturnValue( true );
+} );
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+test( 'renders a navigation link to the site visibility settings page', () => {
+	const site = createSite( { slug: 'my-site.com' } );
+	const { getByRole } = renderSummary( {
+		site,
+		settings: createSettings(),
+	} );
+
+	const link = getByRole( 'link', { name: 'Site visibility Public' } );
+
+	expect( link ).toHaveAttribute( 'href', '/sites/my-site.com/settings/site-visibility' );
+} );
+
+test( 'displays a coming soon badge when the site is in coming soon mode', () => {
+	const { getByText } = renderSummary( {
+		settings: createSettings( {
+			wpcom_public_coming_soon: 1,
+			blog_public: 0,
+		} ),
+	} );
+
+	expect( getByText( 'Coming soon' ) ).toBeVisible();
+} );
+
+test( 'displays a private badge when the site is private', () => {
+	const { getByText } = renderSummary( {
+		settings: createSettings( { blog_public: -1 } ),
+	} );
+
+	expect( getByText( 'Private' ) ).toBeVisible();
+} );
+
+test( 'defaults to a public badge when no specific site visibility is provided', () => {
+	const { getByText } = renderSummary();
+
+	expect( getByText( 'Public' ) ).toBeVisible();
+} );
+
+test( 'returns null when the user cannot view site visibility settings', () => {
+	mockCanViewSiteVisibilitySettings.mockReturnValue( false );
+	const { container } = renderSummary();
+
+	expect( container ).toBeEmptyDOMElement();
+} );

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -33,7 +33,10 @@ import type { SiteSettings } from '@automattic/api-core';
 
 export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
+	const { data: settings } = useQuery( {
+		...siteSettingsQuery( site.ID ),
+		staleTime: 0, // Forces refetch on mount to get the latest settings.
+	} );
 	const { supports } = useAppContext();
 	const supportsSettings = supports.sites && supports.sites.settings;
 
@@ -55,7 +58,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				<VStack spacing={ 3 }>
 					<SectionHeader title={ __( 'General' ) } level={ 3 } />
 					<SummaryButtonList>
-						<SiteVisibilitySettingsSummary site={ site } />
+						<SiteVisibilitySettingsSummary site={ site } settings={ settings } />
 						{ supportsSettings.general.redirect ? (
 							<SiteRedirectSettingsSummary site={ site } />
 						) : null }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTDEV-127

## Proposed Changes

* Always fetch the site settings on the settings and site visibility screens to avoid showing stale site visibility state.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As seen [here](https://linear.app/a8c/issue/DOTDEV-127/dotcom-nmit-7-woocommerce-coming-soon-mode-overrides-wordpresscom-un#comment-8ab5743b), when a user has the MSD site settings open (cached) and updates the site visibility through the WP Admin, the new state is not immediately reflected in MSD. This leads to confusion and a bad user experience.

https://github.com/user-attachments/assets/c726aae7-397b-452a-9f2d-227b769d96a9

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a site on Atomic.
* Go to `/v2/sites/[site].wpcomstaging.com/settings` and take a note of the site visibility state.
* Go to `https://[site].wpcomstaging.com/wp-admin/options-reading.php` and change the site vibisility.
* Go back to `/v2/sites/[site].wpcomstaging.com/settings`, refresh the page, and make sure the site visibility is up-to-date.
* Repeat the above steps for `/v2/sites/[site].wpcomstaging.com/settings/site-visibility`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
