### PR TITLE
Use router to generate domainConnectionSetupUrl

### DIFF
--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -1,12 +1,12 @@
 import { domainsQuery, siteBySlugQuery, siteRedirectQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
+import { Link, useRouter } from '@tanstack/react-router';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useAuth } from '../../app/auth';
-import { useAppContext } from '../../app/context';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
+import { domainConnectionSetupRoute } from '../../app/router/domains';
 import { siteRoute, siteDomainsRoute, siteSettingsRedirectRoute } from '../../app/router/sites';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
 import { Notice } from '../../components/notice';
@@ -54,8 +54,14 @@ function SiteDomains() {
 		fields
 	);
 
-	const { basePath } = useAppContext();
-	const domainConnectionSetupUrl = `${ basePath }/domains/%s/domain-connection-setup`;
+	const router = useRouter();
+
+	const domainConnectionSetupUrl = router
+		.buildLocation( {
+			to: domainConnectionSetupRoute.fullPath,
+			params: { domainName: '%s' },
+		} )
+		.href.replace( '%25s', '%s' );
 
 	return (
 		<PageLayout

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -56,12 +56,17 @@ function SiteDomains() {
 
 	const router = useRouter();
 
-	const domainConnectionSetupUrl = router
+	const domainConnectionSetupUrlRelativePath = router
 		.buildLocation( {
 			to: domainConnectionSetupRoute.fullPath,
 			params: { domainName: '%s' },
 		} )
 		.href.replace( '%25s', '%s' );
+
+	const domainConnectionSetupUrl = new URL(
+		domainConnectionSetupUrlRelativePath,
+		window.location.origin
+	).href;
 
 	return (
 		<PageLayout


### PR DESCRIPTION
## Proposed Changes
With the introduction of `my.wordpress.com` (or `my.localhost`) the MSD basePath changed from `/v2` to `/`.
This change broke the `domainConnectionSetupUrl` created in `SiteDomains` (it generates a path with two `/`).
This PR fixes the issue using the router method to build the correct url.

## Why are these changes being made?
`domainConnectionSetupUrl` is used as a redirect url to setup a new domain connection.

## Testing Instructions
- Open `http://calypso.localhost:3000/v2/sites/[SITE-SLUG/domains`
- Click _Add domain name_ button and select _Use a domain name I own_
- Verify that the `domainConnectionSetupUrl` is `http%3A%2F%2Fcalypso.localhost%3A3000%2Fv2%2Fdomains%2F%25s%2Fdomain-connection-setup`
- Do the same, but use `http://my.localhost:3000/sites/[SITE-SLUG/domains`
- This time `domainConnectionSetupUrl` should be `http%3A%2F%2Fmy.localhost%3A3000%2Fdomains%2F%25s%2Fdomain-connection-setup`


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
