### PR TITLE
Make CollapsibleCard header clickable

### DIFF
--- a/client/dashboard/components/collapsible-card/index.tsx
+++ b/client/dashboard/components/collapsible-card/index.tsx
@@ -50,23 +50,65 @@ export const CollapsibleCard = ( {
 		// Always call onToggle if provided (for both modes)
 		onToggle?.( newExpandedState );
 	};
+
+	const handleHeaderClick = ( event: React.MouseEvent< HTMLDivElement > ) => {
+		// Check if click originated from an interactive element
+		const target = event.target as HTMLElement;
+		const headerElement = event.currentTarget;
+
+		// Check if the target or any parent is an interactive element
+		const interactiveElement = target.closest(
+			'button, a, input, select, textarea, [role="button"], [role="link"], [role="menuitem"], [role="tab"]'
+		);
+
+		// Only toggle if click is not on an interactive element within the header
+		// Exclude the header element itself (which has role="button" for accessibility)
+		const isClickOnInteractiveElement =
+			interactiveElement &&
+			interactiveElement !== headerElement &&
+			headerElement.contains( interactiveElement );
+
+		if ( ! isClickOnInteractiveElement ) {
+			handleCollapsedChange();
+		}
+	};
+
 	return (
 		<Card
 			className={ clsx( 'collapsible-card', { collapsed: ! isExpanded }, className ) }
 			isBorderless={ isBorderless }
 		>
 			<CardBody>
-				<HStack justify="space-between" className="collapsible-card__header">
-					{ header }
-					<Button
-						icon={ chevronUp }
-						className={ clsx( 'collapsible-card__toggle', { collapsed: ! isExpanded } ) }
-						onClick={ handleCollapsedChange }
-						aria-expanded={ isExpanded }
-						aria-controls={ id }
-						aria-label={ label }
-					/>
-				</HStack>
+				<div
+					className="collapsible-card__header"
+					onClick={ handleHeaderClick }
+					role="button"
+					tabIndex={ 0 }
+					onKeyDown={ ( event: React.KeyboardEvent< HTMLDivElement > ) => {
+						// Allow keyboard activation with Enter or Space
+						if ( event.key === 'Enter' || event.key === ' ' ) {
+							event.preventDefault();
+							handleCollapsedChange();
+						}
+					} }
+					aria-expanded={ isExpanded }
+					aria-label={ label }
+				>
+					<HStack justify="space-between">
+						{ header }
+						<Button
+							icon={ chevronUp }
+							className={ clsx( 'collapsible-card__toggle', { collapsed: ! isExpanded } ) }
+							onClick={ ( event: React.MouseEvent< HTMLButtonElement > ) => {
+								event.stopPropagation();
+								handleCollapsedChange();
+							} }
+							aria-expanded={ isExpanded }
+							aria-controls={ id }
+							aria-label={ label }
+						/>
+					</HStack>
+				</div>
 				{ isExpanded && (
 					<div className="collapsible-card__content" id={ id }>
 						{ children }

--- a/client/dashboard/components/collapsible-card/style.scss
+++ b/client/dashboard/components/collapsible-card/style.scss
@@ -16,4 +16,29 @@
 	.collapsible-card__toggle {
 		margin-inline-start: auto;
 	}
+
+	// Make header clickable with visual feedback
+	.collapsible-card__header {
+		cursor: pointer;
+		user-select: none;
+
+		// Ensure interactive elements within header have pointer cursor and allow text selection
+		button,
+		a,
+		[role="button"],
+		[role="link"],
+		[role="menuitem"],
+		[role="tab"] {
+			cursor: pointer;
+			user-select: auto;
+		}
+
+		// Form inputs should use default cursor
+		input,
+		select,
+		textarea {
+			cursor: auto;
+			user-select: auto;
+		}
+	}
 }

--- a/client/dashboard/me/notifications-sites/site-preview/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-preview/index.tsx
@@ -13,7 +13,12 @@ export const SitePreview = ( { site }: Props ) => {
 	return (
 		<HStack className="site-preview" spacing={ 3 }>
 			<SiteIconLink site={ site } size={ 44 } />
-			<Grid columns={ 1 } templateRows="24px 1fr" gap={ 0 } style={ { width: '100%' } }>
+			<Grid
+				columns={ 1 }
+				templateRows="24px 1fr"
+				gap={ 0 }
+				style={ { width: '100%', justifyItems: 'start' } }
+			>
 				<div className="site-preview__name">
 					<SiteLink site={ site }>
 						<Name site={ site } value={ getSiteDisplayName( site ) } />


### PR DESCRIPTION
Closes [DOMAINS-1919](https://linear.app/a8c/issue/DOMAINS-1919/make-collapsiblecard-header-fully-clickable)

## Proposed Changes
* Made the entire header of `CollapsibleCard` component clickable to expand/collapse the card
* Implemented smart event delegation to detect clicks on interactive elements (buttons, links, etc.) within the header and prevent toggling when those elements are clicked
* Added keyboard accessibility support (Enter and Space keys) for the clickable header
* Added visual feedback (cursor pointer) to indicate the header is clickable
* Wrapped the header content in a clickable div container to ensure proper event handling

## Why are these changes being made?

Previously, users could only expand/collapse the `CollapsibleCard` by clicking the small toggle button. This created a poor user experience, especially when the header contains rich content (like site previews with icons and links). Making the entire header clickable provides a much larger and more intuitive click target, improving usability and accessibility.

The implementation uses smart event delegation to ensure that interactive elements within the header (such as links in `SitePreview` components) continue to work normally without triggering the card toggle, maintaining backward compatibility with existing usage.

## Testing Instructions
1. Navigate to a page that uses `CollapsibleCard` with interactive elements in the header (e.g., `v2/me/notifications-sites` in the dashboard)
2. **Test clicking on the header:**
   - Click anywhere on the header (text, empty space, icons) - the card should expand/collapse
   - Verify the cursor changes to a pointer when hovering over the header
3. **Test interactive elements within the header:**
   - Click on links or buttons within the header (e.g., site links in `SitePreview`) - these should work normally without toggling the card
   - Click the toggle button (chevron icon) - the card should still toggle
4. **Test keyboard accessibility:**
   - Focus on the header using Tab key
   - Press Enter or Space - the card should expand/collapse
5. **Test in different contexts:**
   - Verify the component works in both controlled and uncontrolled modes
   - Test with headers that contain various interactive elements


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
