### PR TITLE
Add tests for the name servers form in MSD

### DIFF
--- a/client/dashboard/domains/name-servers/test/form.test.tsx
+++ b/client/dashboard/domains/name-servers/test/form.test.tsx
@@ -1,0 +1,304 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import NameServersForm from '../form';
+
+// Mock InlineSupportLink to render a simple link
+jest.mock( '../../../components/inline-support-link', () => ( {
+	__esModule: true,
+	default: ( { supportContext }: { supportContext: string } ) => (
+		// eslint-disable-next-line jsx-a11y/anchor-is-valid
+		<a href="#" data-support-context={ supportContext }>
+			Look up
+		</a>
+	),
+} ) );
+
+describe( 'NameServersForm', () => {
+	const defaultProps = {
+		domainName: 'example.com',
+		domainSiteSlug: 'example.wordpress.com',
+		nameServers: [],
+		isUsingDefaultNameServers: false,
+		isBusy: false,
+		onSubmit: jest.fn(),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Basic Rendering', () => {
+		it( 'renders form with nameserver fields', () => {
+			render( <NameServersForm { ...defaultProps } /> );
+
+			// Labels include "(Required)" suffix, so use partial matching
+			expect( screen.getByText( /Name server 1/ ) ).toBeVisible();
+			expect( screen.getByText( /Name server 2/ ) ).toBeVisible();
+		} );
+
+		it( 'renders toggle for "Use WordPress.com name servers"', () => {
+			render( <NameServersForm { ...defaultProps } /> );
+
+			expect( screen.getByText( 'Use WordPress.com name servers' ) ).toBeVisible();
+		} );
+
+		it( 'renders save button', () => {
+			render( <NameServersForm { ...defaultProps } /> );
+
+			expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'Toggle Behavior', () => {
+		it( 'populates default nameservers when toggle is enabled', async () => {
+			const user = userEvent.setup();
+
+			render( <NameServersForm { ...defaultProps } /> );
+
+			const toggle = screen.getByRole( 'checkbox', { name: 'Use WordPress.com name servers' } );
+			await user.click( toggle );
+
+			await waitFor( () => {
+				expect( screen.getByDisplayValue( 'ns1.wordpress.com' ) ).toBeVisible();
+				expect( screen.getByDisplayValue( 'ns2.wordpress.com' ) ).toBeVisible();
+				expect( screen.getByDisplayValue( 'ns3.wordpress.com' ) ).toBeVisible();
+			} );
+		} );
+
+		it( 'clears nameservers when toggle is disabled', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<NameServersForm
+					{ ...defaultProps }
+					isUsingDefaultNameServers
+					nameServers={ [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ] }
+				/>
+			);
+
+			const toggle = screen.getByRole( 'checkbox', { name: 'Use WordPress.com name servers' } );
+			await user.click( toggle );
+
+			await waitFor( () => {
+				expect( screen.queryByDisplayValue( 'ns1.wordpress.com' ) ).not.toBeInTheDocument();
+			} );
+		} );
+	} );
+
+	describe( 'Validation', () => {
+		it( 'accepts valid hostnames without showing errors', async () => {
+			const user = userEvent.setup();
+
+			render( <NameServersForm { ...defaultProps } /> );
+
+			const input1 = screen.getByRole( 'textbox', { name: /Name server 1/ } );
+			const input2 = screen.getByRole( 'textbox', { name: /Name server 2/ } );
+
+			await user.type( input1, 'ns1.example.com' );
+			await user.type( input2, 'ns2.example.com' );
+
+			// Valid hostnames should enable the submit button
+			await waitFor( () => {
+				const submitButton = screen.getByRole( 'button', { name: 'Save' } );
+				expect( submitButton ).not.toBeDisabled();
+			} );
+		} );
+	} );
+
+	describe( 'Submit Button State', () => {
+		it( 'disables submit button when form is empty', () => {
+			render( <NameServersForm { ...defaultProps } /> );
+
+			const submitButton = screen.getByRole( 'button', { name: 'Save' } );
+			expect( submitButton ).toBeDisabled();
+		} );
+
+		it( 'disables submit button when isBusy is true', () => {
+			render(
+				<NameServersForm
+					{ ...defaultProps }
+					isBusy
+					nameServers={ [ 'ns1.example.com', 'ns2.example.com' ] }
+				/>
+			);
+
+			const submitButton = screen.getByRole( 'button', { name: 'Save' } );
+			expect( submitButton ).toBeDisabled();
+		} );
+
+		it( 'disables submit button when form is unchanged', () => {
+			render(
+				<NameServersForm
+					{ ...defaultProps }
+					nameServers={ [ 'ns1.example.com', 'ns2.example.com' ] }
+				/>
+			);
+
+			const submitButton = screen.getByRole( 'button', { name: 'Save' } );
+			expect( submitButton ).toBeDisabled();
+		} );
+
+		it( 'enables submit button when form has valid changes', async () => {
+			const user = userEvent.setup();
+
+			render( <NameServersForm { ...defaultProps } /> );
+
+			const input1 = screen.getByRole( 'textbox', { name: /Name server 1/ } );
+			const input2 = screen.getByRole( 'textbox', { name: /Name server 2/ } );
+
+			await user.type( input1, 'ns1.example.com' );
+			await user.type( input2, 'ns2.example.com' );
+
+			await waitFor( () => {
+				const submitButton = screen.getByRole( 'button', { name: 'Save' } );
+				expect( submitButton ).not.toBeDisabled();
+			} );
+		} );
+	} );
+
+	describe( 'Additional Nameserver Fields', () => {
+		it( 'shows additional nameserver fields only when previous field has value', async () => {
+			const user = userEvent.setup();
+
+			render( <NameServersForm { ...defaultProps } /> );
+
+			// Initially, field 3 should not be visible
+			expect( screen.queryByText( 'Name server 3' ) ).not.toBeInTheDocument();
+
+			// Fill in first two fields
+			const input1 = screen.getByRole( 'textbox', { name: /Name server 1/ } );
+			const input2 = screen.getByRole( 'textbox', { name: /Name server 2/ } );
+
+			await user.type( input1, 'ns1.example.com' );
+			await user.type( input2, 'ns2.example.com' );
+
+			// Field 3 should now be visible
+			await waitFor( () => {
+				expect( screen.getByText( 'Name server 3' ) ).toBeVisible();
+			} );
+		} );
+
+		it( 'shows field 4 only when field 3 has value', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<NameServersForm
+					{ ...defaultProps }
+					nameServers={ [ 'ns1.example.com', 'ns2.example.com' ] }
+				/>
+			);
+
+			// Initially, field 4 should not be visible
+			expect( screen.queryByText( 'Name server 4' ) ).not.toBeInTheDocument();
+
+			// Fill in field 3
+			const input3 = screen.getByRole( 'textbox', { name: /Name server 3/ } );
+			await user.type( input3, 'ns3.example.com' );
+
+			// Field 4 should now be visible
+			await waitFor( () => {
+				expect( screen.getByText( 'Name server 4' ) ).toBeVisible();
+			} );
+		} );
+	} );
+
+	describe( 'Read-only Fields', () => {
+		it( 'shows read-only nameserver fields when using WPCOM nameservers', () => {
+			render(
+				<NameServersForm
+					{ ...defaultProps }
+					isUsingDefaultNameServers
+					nameServers={ [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ] }
+				/>
+			);
+
+			// Fields should be disabled when using WPCOM nameservers
+			const inputs = screen.getAllByRole( 'textbox' );
+			inputs.forEach( ( input ) => {
+				expect( input ).toBeDisabled();
+			} );
+		} );
+
+		it( 'shows editable nameserver fields when using custom nameservers', () => {
+			render(
+				<NameServersForm
+					{ ...defaultProps }
+					isUsingDefaultNameServers={ false }
+					nameServers={ [ 'ns1.custom.com', 'ns2.custom.com' ] }
+				/>
+			);
+
+			const input1 = screen.getByRole( 'textbox', { name: /Name server 1/ } );
+			const input2 = screen.getByRole( 'textbox', { name: /Name server 2/ } );
+
+			expect( input1 ).not.toBeDisabled();
+			expect( input2 ).not.toBeDisabled();
+		} );
+	} );
+
+	describe( 'Form Submission', () => {
+		it( 'calls onSubmit with correct data when form is submitted', async () => {
+			const user = userEvent.setup();
+			const mockOnSubmit = jest.fn();
+
+			render( <NameServersForm { ...defaultProps } onSubmit={ mockOnSubmit } /> );
+
+			const input1 = screen.getByRole( 'textbox', { name: /Name server 1/ } );
+			const input2 = screen.getByRole( 'textbox', { name: /Name server 2/ } );
+
+			await user.type( input1, 'ns1.example.com' );
+			await user.type( input2, 'ns2.example.com' );
+
+			await waitFor( () => {
+				const submitButton = screen.getByRole( 'button', { name: 'Save' } );
+				expect( submitButton ).not.toBeDisabled();
+			} );
+
+			const submitButton = screen.getByRole( 'button', { name: 'Save' } );
+			await user.click( submitButton );
+
+			expect( mockOnSubmit ).toHaveBeenCalledWith( [ 'ns1.example.com', 'ns2.example.com' ] );
+		} );
+
+		it( 'calls onSubmit with WPCOM nameservers when toggle is enabled', async () => {
+			const user = userEvent.setup();
+			const mockOnSubmit = jest.fn();
+
+			render( <NameServersForm { ...defaultProps } onSubmit={ mockOnSubmit } /> );
+
+			const toggle = screen.getByRole( 'checkbox', { name: 'Use WordPress.com name servers' } );
+			await user.click( toggle );
+
+			await waitFor( () => {
+				const submitButton = screen.getByRole( 'button', { name: 'Save' } );
+				expect( submitButton ).not.toBeDisabled();
+			} );
+
+			const submitButton = screen.getByRole( 'button', { name: 'Save' } );
+			await user.click( submitButton );
+
+			expect( mockOnSubmit ).toHaveBeenCalledWith( [
+				'ns1.wordpress.com',
+				'ns2.wordpress.com',
+				'ns3.wordpress.com',
+			] );
+		} );
+	} );
+
+	describe( 'Support Link', () => {
+		it( 'shows support link when using custom nameservers', async () => {
+			render( <NameServersForm { ...defaultProps } isUsingDefaultNameServers={ false } /> );
+
+			// The support link should be visible when not using WPCOM nameservers
+			expect( screen.getByText( 'Look up' ) ).toBeVisible();
+			expect( screen.getByText( 'Look up' ) ).toHaveAttribute(
+				'data-support-context',
+				'change-name-servers-finding-out-new-ns'
+			);
+		} );
+	} );
+} );

--- a/client/dashboard/domains/name-servers/test/utils.test.ts
+++ b/client/dashboard/domains/name-servers/test/utils.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @jest-environment node
+ */
+import { validateHostname, shouldShowUpsellNudge } from '../utils';
+import type { Domain, User, Site } from '@automattic/api-core';
+
+describe( 'name-servers utils', () => {
+	describe( 'validateHostname', () => {
+		it( 'returns true for a valid hostname', () => {
+			expect( validateHostname( 'ns1.example.com' ) ).toBe( true );
+		} );
+
+		it( 'returns true for a valid hostname with multiple subdomains', () => {
+			expect( validateHostname( 'ns1.sub.example.com' ) ).toBe( true );
+		} );
+
+		it( 'returns true for a hostname with numbers', () => {
+			expect( validateHostname( 'ns1.example123.com' ) ).toBe( true );
+		} );
+
+		it( 'returns true for a hostname with hyphens', () => {
+			expect( validateHostname( 'ns-1.example-domain.com' ) ).toBe( true );
+		} );
+
+		it( 'returns true for different TLDs', () => {
+			expect( validateHostname( 'ns1.example.org' ) ).toBe( true );
+			expect( validateHostname( 'ns1.example.net' ) ).toBe( true );
+			expect( validateHostname( 'ns1.example.co.uk' ) ).toBe( true );
+		} );
+
+		it( 'returns false for an empty string', () => {
+			expect( validateHostname( '' ) ).toBe( false );
+		} );
+
+		it( 'returns false for a hostname with special characters', () => {
+			expect( validateHostname( 'ns1.example!.com' ) ).toBe( false );
+			expect( validateHostname( 'ns1.example@.com' ) ).toBe( false );
+			expect( validateHostname( 'ns1.example#.com' ) ).toBe( false );
+		} );
+
+		it( 'returns false for a hostname starting with a hyphen', () => {
+			expect( validateHostname( '-ns1.example.com' ) ).toBe( false );
+		} );
+
+		it( 'returns false for a hostname ending with a hyphen', () => {
+			expect( validateHostname( 'ns1-.example.com' ) ).toBe( false );
+		} );
+
+		it( 'returns true for a hostname without a traditional TLD (two-letter minimum)', () => {
+			// "example" is 7 characters which satisfies the TLD requirement of 2+ chars
+			expect( validateHostname( 'ns1.example' ) ).toBe( true );
+		} );
+
+		it( 'returns false for a hostname with single character TLD', () => {
+			expect( validateHostname( 'ns1.example.a' ) ).toBe( false );
+		} );
+
+		it( 'returns false for a hostname with spaces', () => {
+			expect( validateHostname( 'ns1 .example.com' ) ).toBe( false );
+			expect( validateHostname( 'ns1.example .com' ) ).toBe( false );
+		} );
+
+		it( 'returns false for an IP address', () => {
+			expect( validateHostname( '192.168.1.1' ) ).toBe( false );
+		} );
+
+		it( 'returns false for a single word', () => {
+			expect( validateHostname( 'localhost' ) ).toBe( false );
+		} );
+
+		it( 'returns false for a hostname with consecutive dots', () => {
+			expect( validateHostname( 'ns1..example.com' ) ).toBe( false );
+		} );
+
+		it( 'returns false for a hostname with underscores', () => {
+			expect( validateHostname( 'ns_1.example.com' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'shouldShowUpsellNudge', () => {
+		const createMockUser = ( hasFlag: boolean ): User =>
+			( {
+				meta: {
+					data: {
+						flags: {
+							active_flags: hasFlag ? [ 'calypso_allow_nonprimary_domains_without_plan' ] : [],
+						},
+					},
+				},
+			} ) as unknown as User;
+
+		const createMockDomain = ( overrides: Partial< Domain > = {} ): Domain =>
+			( {
+				primary_domain: false,
+				is_domain_only_site: false,
+				...overrides,
+			} ) as Domain;
+
+		const createMockSite = ( overrides: Partial< Site > = {} ): Site =>
+			( {
+				plan: {
+					is_free: true,
+				},
+				...overrides,
+			} ) as Site;
+
+		it( 'returns true when all conditions are met for showing upsell', () => {
+			const user = createMockUser( true );
+			const domain = createMockDomain();
+			const site = createMockSite();
+
+			expect( shouldShowUpsellNudge( user, domain, site ) ).toBe( true );
+		} );
+
+		it( 'returns false when site has a paid plan', () => {
+			const user = createMockUser( true );
+			const domain = createMockDomain();
+			const site = createMockSite( { plan: { is_free: false } } as Partial< Site > );
+
+			expect( shouldShowUpsellNudge( user, domain, site ) ).toBe( false );
+		} );
+
+		it( 'returns false when user does not have the feature flag', () => {
+			const user = createMockUser( false );
+			const domain = createMockDomain();
+			const site = createMockSite();
+
+			expect( shouldShowUpsellNudge( user, domain, site ) ).toBe( false );
+		} );
+
+		it( 'returns false when domain is the primary domain', () => {
+			const user = createMockUser( true );
+			const domain = createMockDomain( { primary_domain: true } );
+			const site = createMockSite();
+
+			expect( shouldShowUpsellNudge( user, domain, site ) ).toBe( false );
+		} );
+
+		it( 'returns false when domain is on a domain-only site', () => {
+			const user = createMockUser( true );
+			const domain = createMockDomain( { is_domain_only_site: true } );
+			const site = createMockSite();
+
+			expect( shouldShowUpsellNudge( user, domain, site ) ).toBe( false );
+		} );
+
+		it( 'returns false when site is undefined', () => {
+			const user = createMockUser( true );
+			const domain = createMockDomain();
+
+			expect( shouldShowUpsellNudge( user, domain, undefined ) ).toBe( false );
+		} );
+
+		it( 'returns false when site plan is undefined', () => {
+			const user = createMockUser( true );
+			const domain = createMockDomain();
+			const site = {} as Site;
+
+			expect( shouldShowUpsellNudge( user, domain, site ) ).toBe( false );
+		} );
+
+		it( 'returns false when multiple conditions are not met', () => {
+			const user = createMockUser( false );
+			const domain = createMockDomain( { primary_domain: true, is_domain_only_site: true } );
+			const site = createMockSite( { plan: { is_free: false } } as Partial< Site > );
+
+			expect( shouldShowUpsellNudge( user, domain, site ) ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMAINS-1795: Add e2e and other tests for the Domain Forwarding form](https://linear.app/a8c/issue/DOMAINS-1795/add-e2e-and-other-tests-for-the-domain-forwarding-form)

## Proposed Changes

* Add tests for the name server form
* Add tests for the utils

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better test coverage means easier to refactor and fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run tests with `yarn run test-client client/dashboard/domains/name-servers/test/`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
