### PR TITLE
Checkout: Add return url to stripe.confirmCardPayment

### DIFF
--- a/client/my-sites/checkout/src/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/src/lib/existing-card-processor.ts
@@ -10,6 +10,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { recordTransactionBeginAnalytics, logStashEvent } from '../lib/analytics';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
+import { addUrlToPendingPageRedirect } from './pending-page';
 import {
 	doesTransactionResponseRequire3DS,
 	handle3DSChallenge,
@@ -105,11 +106,24 @@ export default async function existingCardProcessor(
 					  } )
 					: undefined;
 
+				// Generate the return URL for redirect-based 3DS flows.
+				// This wraps the thank you URL in a pending page redirect so that
+				// after 3DS authentication, the user lands on the pending page which
+				// polls for order completion before redirecting to the final thank you page.
+				const thankYouUrl = dataForProcessor.getThankYouUrl();
+				const returnUrl = addUrlToPendingPageRedirect( thankYouUrl, {
+					siteSlug: dataForProcessor.siteSlug,
+					orderId: stripeResponse.order_id,
+					urlType: 'absolute',
+					fromSiteSlug: dataForProcessor.fromSiteSlug,
+				} );
+
 				await handle3DSChallenge(
 					reduxDispatch,
 					cardSpecificStripe ?? stripe,
 					stripeResponse.message.payment_intent_client_secret,
-					paymentIntentId
+					paymentIntentId,
+					returnUrl
 				);
 				// We must return the original authentication response in order
 				// to have access to the order_id so that we can display a

--- a/client/my-sites/checkout/src/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/src/lib/multi-partner-card-processor.ts
@@ -14,6 +14,7 @@ import { logStashEvent, recordTransactionBeginAnalytics } from '../lib/analytics
 import existingCardProcessor from './existing-card-processor';
 import getDomainDetails from './get-domain-details';
 import getPostalCode from './get-postal-code';
+import { addUrlToPendingPageRedirect } from './pending-page';
 import {
 	doesTransactionResponseRequire3DS,
 	handle3DSChallenge,
@@ -145,11 +146,25 @@ async function stripeCardProcessor(
 			if ( doesTransactionResponseRequire3DS( stripeResponse ) ) {
 				debug( 'transaction requires authentication' );
 				paymentIntentId = stripeResponse.message.payment_intent_id;
+
+				// Generate the return URL for redirect-based 3DS flows.
+				// This wraps the thank you URL in a pending page redirect so that
+				// after 3DS authentication, the user lands on the pending page which
+				// polls for order completion before redirecting to the final thank you page.
+				const thankYouUrl = transactionOptions.getThankYouUrl();
+				const returnUrl = addUrlToPendingPageRedirect( thankYouUrl, {
+					siteSlug: transactionOptions.siteSlug,
+					orderId: stripeResponse.order_id,
+					urlType: 'absolute',
+					fromSiteSlug: transactionOptions.fromSiteSlug,
+				} );
+
 				await handle3DSChallenge(
 					reduxDispatch,
 					submitData.stripe,
 					stripeResponse.message.payment_intent_client_secret,
-					paymentIntentId
+					paymentIntentId,
+					returnUrl
 				);
 				// We must return the original authentication response in order
 				// to have access to the order_id so that we can display a

--- a/client/my-sites/checkout/src/lib/stripe-3ds.ts
+++ b/client/my-sites/checkout/src/lib/stripe-3ds.ts
@@ -8,7 +8,8 @@ export async function handle3DSChallenge(
 	reduxDispatch: CalypsoDispatch,
 	stripe: Stripe,
 	paymentIntentClientSecret: string,
-	paymentIntentId: string
+	paymentIntentId: string,
+	returnUrl?: string
 ): Promise< void > {
 	// 3DS authentication required
 	reduxDispatch(
@@ -25,7 +26,7 @@ export async function handle3DSChallenge(
 		'info'
 	);
 	// If this fails, it will reject (throw).
-	await confirmStripePaymentIntent( stripe, paymentIntentClientSecret );
+	await confirmStripePaymentIntent( stripe, paymentIntentClientSecret, returnUrl );
 }
 
 export function doesTransactionResponseRequire3DS(

--- a/packages/calypso-stripe/src/index.tsx
+++ b/packages/calypso-stripe/src/index.tsx
@@ -267,12 +267,21 @@ export async function confirmStripeSetupIntentAndAttachCard(
 
 // Confirm any PaymentIntent from Stripe response and carry out 3DS or
 // other next_actions if they are required.
+//
+// If returnUrl is provided, Stripe will redirect to that URL after 3DS
+// authentication is complete (for redirect-based 3DS flows). If not provided,
+// Stripe will use the default modal/iframe approach.
 export async function confirmStripePaymentIntent(
 	stripe: Stripe,
-	paymentIntentClientSecret: string
+	paymentIntentClientSecret: string,
+	returnUrl?: string
 ): Promise< StripeAuthenticationResponse > {
 	debug( 'Confirming paymentIntent...', paymentIntentClientSecret );
-	const { paymentIntent, error } = await stripe.confirmCardPayment( paymentIntentClientSecret );
+	const options = returnUrl ? { return_url: returnUrl } : {};
+	const { paymentIntent, error } = await stripe.confirmCardPayment(
+		paymentIntentClientSecret,
+		options
+	);
 	if ( error || ! paymentIntent ) {
 		debug( 'Confirming paymentIntent failed', error );
 		// Note that this is a promise rejection


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1386/checkout-may-not-handle-3ds-confirmations-that-perform-a-redirect

## Proposed Changes

This PR modifies the call to `stripe.confirmCardPayment()` which is used when Stripe tells us that we need to take action to confirm a charge to a credit card that implements 3DS (also known as a 3DS challenge). With this change, we will provide a `return_url` to the confirmation so that if the call to `confirmCardPayment` redirects the user to their bank, the user is redirected to the post-checkout pending page when they come back. That page will poll our order endpoint to see if the payment was successful or not. When the user confirms their payment, Stripe should send us a webhook that will complete the order and the pending page will detect that change, notifying the user that their purchase has completed.

> [!NOTE]
> We're not sure this will do anything. The Stripe documentation is not clear as to when or if a full page redirect would happen as a result of calling `confirmCardPayment`. Previously we had thought this impossible ([the docs](https://docs.stripe.com/js/payment_intents/confirm_card_payment) do not mention it as a possibility), but a recent incident (https://linear.app/a8c/issue/SHILL-1386) suggests that it might be. There don't appear to be [test cards](https://docs.stripe.com/testing?testing-method=card-numbers#regulatory-cards) for a full page redirect scenario so it's not clear how to test this correctly.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We had thought that 3DS confirmations always were either in a modal dialog or via an app, but one user’s response suggests that some might be a full page redirect to their bank and back, which would explain why they can’t pay, since if they return to checkout they will be presented with a brand new checkout form.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Since we cannot recreate the bug we are trying to resolve, this PR should not change the behavior of 3DS cards.

- Add a product to your cart.
- Visit checkout.
- Use a 3DS card to complete the purchase.
- Verify you are able to confirm the purchase in a modal.
- Verify that you are redirected to a post-checkout page.
