### PR TITLE
MSD: Unify implementation of the reauth-required link

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -21,6 +21,7 @@ import {
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { getMonetizeSubscriptionsPageTitle } from '../../me/billing-monetize-subscriptions/title';
+import { reauthRequiredLink } from '../../utils/link';
 import { isTemporarySitePurchase, getTitleForDisplay, isDotcomPlan } from '../../utils/purchase';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
@@ -44,9 +45,7 @@ export const meRoute = createRoute( {
 		}
 		const twoStep = await fetchTwoStep();
 		if ( twoStep.two_step_reauthorization_required ) {
-			const currentPath = window.location.pathname;
-			const loginUrl = `/me/reauth-required?redirect_to=${ encodeURIComponent( currentPath ) }`;
-			window.location.href = loginUrl;
+			window.location.href = reauthRequiredLink();
 		}
 	},
 } ).lazy( () =>

--- a/client/dashboard/docs/router.md
+++ b/client/dashboard/docs/router.md
@@ -45,9 +45,7 @@ By default, the whole dashboard is protected and the user must be logged in to a
 beforeLoad: async () => {
   const twoStep = await fetchTwoStep();
   if ( twoStep.two_step_reauthorization_required ) {
-    const currentPath = window.location.pathname;
-    const loginUrl = `/me/reauth-required?redirect_to=${ encodeURIComponent( currentPath ) }`;
-    window.location.href = loginUrl;
+    window.location.href = reauthRequiredLink();
   }
 },
 ```

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -32,6 +32,7 @@ import { Card, CardBody } from '../../components/card';
 import ClipboardInputControl from '../../components/clipboard-input-control';
 import InlineSupportLink from '../../components/inline-support-link';
 import { SectionHeader } from '../../components/section-header';
+import { reauthRequiredLink } from '../../utils/link';
 import type { SftpUser, SiteSshKey, UserSshKey } from '@automattic/api-core';
 import type { DataFormControlProps, Field } from '@wordpress/dataviews';
 
@@ -280,9 +281,7 @@ export default function SshCard( {
 	};
 
 	if ( isWpError( userSshKeysError ) && userSshKeysError.code === 'reauthorization_required' ) {
-		const currentPath = window.location.pathname;
-		const loginUrl = `/me/reauth-required?redirect_to=${ encodeURIComponent( currentPath ) }`;
-		window.location.href = loginUrl;
+		window.location.href = reauthRequiredLink();
 		return null;
 	}
 

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -21,8 +21,17 @@ export function wpcomLink( path: string ) {
  * - For Dashboard, the reauth page isn't hosted on the same origin so we use window.location.href.
  */
 export function reauthRequiredLink() {
-	const wpcomUrl = config( 'wpcom_url' );
-	const isSameOrigin = window.location.origin === wpcomUrl;
+	const wpcomUrl = config( 'wpcom_url' ) || '';
+
+	let wpcomOrigin = '';
+	try {
+		wpcomOrigin = new URL( wpcomUrl as string ).origin;
+	} catch {
+		// Fallback to the current origin, so that currentPath is a relative path.
+		wpcomOrigin = window.location.origin;
+	}
+
+	const isSameOrigin = window.location.origin === wpcomOrigin;
 	const currentPath = isSameOrigin ? window.location.pathname : window.location.href;
 
 	return `${ wpcomUrl }/me/reauth-required?redirect_to=${ encodeURIComponent( currentPath ) }`;

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -21,17 +21,8 @@ export function wpcomLink( path: string ) {
  * - For Dashboard, the reauth page isn't hosted on the same origin so we use window.location.href.
  */
 export function reauthRequiredLink() {
-	const wpcomUrl = config( 'wpcom_url' ) || '';
-
-	let wpcomOrigin = '';
-	try {
-		wpcomOrigin = new URL( wpcomUrl as string ).origin;
-	} catch {
-		// Fallback to the current origin, so that currentPath is a relative path.
-		wpcomOrigin = window.location.origin;
-	}
-
-	const isSameOrigin = window.location.origin === wpcomOrigin;
+	const wpcomUrl = String( config( 'wpcom_url' ) ?? '' );
+	const isSameOrigin = wpcomUrl.startsWith( window.location.origin );
 	const currentPath = isSameOrigin ? window.location.pathname : window.location.href;
 
 	return `${ wpcomUrl }/me/reauth-required?redirect_to=${ encodeURIComponent( currentPath ) }`;

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -12,3 +12,18 @@ import config from '@automattic/calypso-config';
 export function wpcomLink( path: string ) {
 	return `${ config( 'wpcom_url' ) }${ path }`;
 }
+
+/**
+ * This function returns the link to the reauth page.
+ *
+ * Currently, the dashboard run in either Calypso or Dashboard environment. When it comes to the redirect URL:
+ * - For Calypso, the reauth page is hosted on the same origin so we use window.location.pathname.
+ * - For Dashboard, the reauth page isn't hosted on the same origin so we use window.location.href.
+ */
+export function reauthRequiredLink() {
+	const wpcomUrl = config( 'wpcom_url' );
+	const isSameOrigin = window.location.origin === wpcomUrl;
+	const currentPath = isSameOrigin ? window.location.pathname : window.location.href;
+
+	return `${ wpcomUrl }/me/reauth-required?redirect_to=${ encodeURIComponent( currentPath ) }`;
+}

--- a/client/reauth-required/component.jsx
+++ b/client/reauth-required/component.jsx
@@ -6,6 +6,10 @@ import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequiredComponent from 'calypso/me/reauth-required';
 import './style.scss';
 
+// Only allow redirects to production environments,
+// as two-step authentication is only available on production environments.
+const ALLOWED_ORIGINS = [ 'https://my.wordpress.com' ];
+
 export default function ReauthRequired() {
 	useEffect( () => {
 		const handleSuccess = () => {
@@ -19,7 +23,11 @@ export default function ReauthRequired() {
 				try {
 					// Use window.location.origin as the base URL for relative paths
 					const url = new URL( redirectTo, window.location.origin );
-					if ( url.origin === window.location.origin || redirectTo.startsWith( '/' ) ) {
+					if (
+						url.origin === window.location.origin ||
+						redirectTo.startsWith( '/' ) ||
+						ALLOWED_ORIGINS.includes( url.origin )
+					) {
 						// Use the resolved URL's href to ensure correct navigation for pathnames
 						window.location.href = url.href;
 					} else {


### PR DESCRIPTION
Part of DOTMSD-905

## Proposed Changes

We currently have the reauth-required link logic in two places, this PR creates a utility function that consolidates the implementation. Given that MSD subdomain will not have its own route reauth, the utility function will handle this scenario by ensuring that the redirect_to URL contains the MSD subdomain. Otherwise, the redirect_to URL should be relative.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open browser dev tools, go to Applications → Cookies, and delete twostep_auth.
* Head to my.wordpress.com/me
* Ensure you are redirected to Calypso's /me/reauth-required?redirect_to=...
* Ensure that the redirect_to is an absolute URL from your previous screen

Not sure how to test two-step auth on a non-production environment. So perhaps the verifying the redirect will have to be done post-merge.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
