### PR TITLE
SSH Migration: Improve the tracks event information

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -2,6 +2,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
+import emailValidator from 'email-validator';
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -30,6 +31,31 @@ import type { Step as StepType } from '../../types';
 import type { ImporterPlatform } from 'calypso/lib/importer/types';
 
 import './styles.scss';
+
+/**
+ * Check if a string is a valid IPv4 address
+ * @param value - The string to validate
+ * @returns True if the string is a valid IPv4 address
+ */
+const isValidIPv4 = ( value: string ): boolean => {
+	return (
+		/^(\d{1,3}\.){3}\d{1,3}$/.test( value ) &&
+		value.split( '.' ).every( ( octet ) => {
+			const num = parseInt( octet, 10 );
+			return num >= 0 && num <= 255;
+		} )
+	);
+};
+
+/**
+ * Check if a string is a valid IPv6 address
+ * @param value - The string to validate
+ * @returns True if the string is a valid IPv6 address
+ */
+const isValidIPv6 = ( value: string ): boolean => {
+	// Simplified IPv6 check - looks for hex groups separated by colons
+	return /^[a-f0-9:]+$/i.test( value );
+};
 
 const SiteMigrationSshShareAccess: StepType< {
 	submits: {
@@ -226,6 +252,11 @@ const SiteMigrationSshShareAccess: StepType< {
 			step: 'share_access',
 			action: 'click_button',
 			button: 'continue',
+			authentication_method: formState.authMethod,
+			is_username_email: emailValidator.validate( formState.username ),
+			is_server_address_ip:
+				isValidIPv4( formState.serverAddress ) || isValidIPv6( formState.serverAddress ),
+			host: host,
 		} );
 		setMigrationError( null );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Add a few properties to the tracks events to help us understand the behavior of the users, and the information they input.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users are facing a few issues on the preflight checks and we are not sure what kind of data they input on the credentials field.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link or apply this PR to your local environment
* Go through the SSH Migration flow until you reach the `Securely share your access`
* Once you get on the third step in the accordion, click on continue and insure you see the following fields on the `calypso_site_migration_ssh_action[step=share_access & action=click_button]` event:
    - authentication_method
    - is_username_email
    - is_server_address_ip
    - host

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
