### PR TITLE
MSD: Improve login preferences section language.

### DIFF
--- a/client/dashboard/me/preferences-login/index.tsx
+++ b/client/dashboard/me/preferences-login/index.tsx
@@ -80,7 +80,6 @@ export default function PreferencesLogin() {
 		{
 			id: 'primarySiteId',
 			label: __( 'Primary site' ),
-			description: __( 'Choose the default site dashboard you’ll see at login.' ),
 			isVisible: () => user.visible_site_count > 0,
 			Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 				const { id, getValue } = field;
@@ -109,11 +108,12 @@ export default function PreferencesLogin() {
 		{
 			id: 'defaultLandingPage',
 			label: __( 'Default landing page' ),
+			description: __( 'Select what you’ll see by default when visiting WordPress.com.' ),
 			Edit: 'radio',
 			elements: [
-				{ label: __( 'Primary site dashboard' ), value: 'primary-site-dashboard' },
-				{ label: __( 'Sites' ), value: 'sites' },
-				{ label: __( 'Reader' ), value: 'reader' },
+				{ label: __( 'Open your primary site’s dashboard.' ), value: 'primary-site-dashboard' },
+				{ label: __( 'See a list of all your sites.' ), value: 'sites' },
+				{ label: __( 'View posts from sites you follow.' ), value: 'reader' },
 			] satisfies { label: string; value: LandingPage }[],
 		},
 	];
@@ -163,11 +163,11 @@ export default function PreferencesLogin() {
 	};
 
 	return (
-		<Card className="preferences-login-card">
+		<Card>
 			<CardBody>
 				<form onSubmit={ handleSubmit }>
 					<VStack spacing={ 3 }>
-						<SectionHeader level={ 3 } title={ __( 'Login preferences' ) } />
+						<SectionHeader level={ 3 } title={ __( 'Account preferences' ) } />
 
 						<DataForm< LoginPreferencesFormData >
 							data={ formData }
@@ -177,10 +177,6 @@ export default function PreferencesLogin() {
 								setFormData( ( data ) => ( { ...data, ...edits } ) );
 							} }
 						/>
-
-						<Text variant="muted" as="p">
-							{ __( 'Select what you’ll see by default when visiting WordPress.com.' ) }
-						</Text>
 
 						<ButtonStack>
 							<Button


### PR DESCRIPTION
Fixes: DOTMSD-840
Context: p1764285227148779-slack-C08JZTRS6NA

## Proposed Changes

This PR uses suggestions from the associated ticket to clarify the language in the Login preferences card.

| V2 Before | V2 After |
|--------|--------|
|  <img width="702" height="394" alt="Screenshot 2025-12-05 at 2 12 40 PM" src="https://github.com/user-attachments/assets/b510d74a-caed-4f69-a68c-8f28068c3755" /> | <img width="704" height="372" alt="Screenshot 2025-12-05 at 2 12 34 PM" src="https://github.com/user-attachments/assets/abddbc9d-1ea1-4983-ba1f-b4c5f28efe47" /> | 


### V1 for reference

<img width="836" height="848" alt="Screenshot 2025-12-05 at 2 13 47 PM" src="https://github.com/user-attachments/assets/2ae32452-ab78-425b-ae09-41caf9604d23" />

## Considerations

In moving over to V2, the account primary site and login preferences were moved into the same card. That's slightly misleading as the Primary site is used for more than login preferences. As a result, I've changed the card heading to "Account preferences" to be more generic. I'm open to suggestions.

Also, if this is the approach we want to go with, we'll need to update [these docs](https://wordpress.com/support/account-settings/).


## Why are these changes being made?

.

## Testing Instructions

Go to your preferences, expect so see the updates above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?