### PR TITLE
MSD: Update external links to be the external link icon if not in copy.

### DIFF
--- a/client/dashboard/components/external-text/index.tsx
+++ b/client/dashboard/components/external-text/index.tsx
@@ -1,0 +1,79 @@
+import { Icon, __experimentalHStack as HStack, FlexBlock } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import type { ReactNode } from 'react';
+
+interface ExternalTextProps {
+	/**
+	 * The text to display. If not provided, only the icon will be shown.
+	 */
+	children?: ReactNode;
+	/**
+	 * How to justify the content. 'space-between' will push the icon to the right.
+	 * Defaults to 'flex-start' which keeps them together.
+	 */
+	justify?: 'flex-start' | 'space-between';
+	/**
+	 * Size of the external icon
+	 */
+	iconSize?: number;
+	/**
+	 * Additional CSS class names
+	 */
+	className?: string;
+}
+
+export default function ExternalText( {
+	children,
+	justify = 'flex-start',
+	iconSize = 16,
+	className,
+}: ExternalTextProps ) {
+	// For simple inline rendering (like inside buttons), use a span instead of HStack
+	if ( ! className && justify === 'flex-start' ) {
+		return (
+			<span style={ { display: 'inline-flex', alignItems: 'center', gap: '4px' } }>
+				{ children }
+				<Icon
+					icon={ external }
+					size={ iconSize }
+					className="components-external-link__icon"
+					aria-label={
+						/* translators: accessibility text */
+						__( '(opens in a new tab)' )
+					}
+				/>
+			</span>
+		);
+	}
+
+	// For more complex layouts, use HStack
+	const renderChildren = () => {
+		if ( ! children ) {
+			return null;
+		}
+		if ( justify === 'space-between' ) {
+			return <FlexBlock>{ children }</FlexBlock>;
+		}
+		return children;
+	};
+
+	return (
+		<HStack
+			justify={ justify }
+			spacing={ justify === 'space-between' ? 0 : 2 }
+			className={ className }
+		>
+			{ renderChildren() }
+			<Icon
+				icon={ external }
+				size={ iconSize }
+				className="components-external-link__icon"
+				aria-label={
+					/* translators: accessibility text */
+					__( '(opens in a new tab)' )
+				}
+			/>
+		</HStack>
+	);
+}

--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -8,13 +8,14 @@ import {
 	__experimentalHeading as Heading,
 	Icon,
 } from '@wordpress/components';
-import { isRTL, __ } from '@wordpress/i18n';
+import { isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useAnalytics } from '../../app/analytics';
 import { Card, CardBody } from '../../components/card';
 import { isRelativeUrl } from '../../utils/url';
 import ComponentViewTracker from '../component-view-tracker';
+import ExternalText from '../external-text';
 import { Text } from '../text';
 import { TextSkeleton } from '../text-skeleton';
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
@@ -132,15 +133,10 @@ export default function OverviewCard( {
 						/>
 					) }
 					{ externalLink && ! progress && (
-						<span
+						<ExternalText
 							className="dashboard-overview-card__link-icon components-external-link__icon"
-							aria-label={
-								/* translators: accessibility text */
-								__( '(opens in a new tab)' )
-							}
-						>
-							&#8599;
-						</span>
+							iconSize={ 24 }
+						/>
 					) }
 				</HStack>
 				<HStack justify="flex-start" alignment="baseline">

--- a/client/dashboard/sites/overview-site-action-menu/index.tsx
+++ b/client/dashboard/sites/overview-site-action-menu/index.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../app/analytics';
+import ExternalText from '../../components/external-text';
 import { wpcomLink } from '../../utils/link';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { getSiteEditUrl } from '../../utils/site-url';
@@ -44,9 +45,11 @@ const SiteActionMenu = ( { site }: { site: Site } ) => {
 			{ () => (
 				<MenuGroup>
 					<MenuItem disabled={ isSiteUsingBlockThemeLoading } onClick={ handleEditSite }>
-						{ __( 'Edit site ↗' ) }
+						<ExternalText justify="space-between">{ __( 'Edit site' ) }</ExternalText>
 					</MenuItem>
-					<MenuItem onClick={ handleWritePost }>{ __( 'Write a post ↗' ) }</MenuItem>
+					<MenuItem onClick={ handleWritePost }>
+						<ExternalText justify="space-between">{ __( 'Write a post' ) }</ExternalText>
+					</MenuItem>
 					<MenuItem onClick={ handleImportSite }>{ __( 'Import site' ) }</MenuItem>
 				</MenuGroup>
 			) }

--- a/client/dashboard/sites/settings-database/index.tsx
+++ b/client/dashboard/sites/settings-database/index.tsx
@@ -16,6 +16,7 @@ import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
+import ExternalText from '../../components/external-text';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
@@ -130,7 +131,7 @@ export default function SiteDatabaseSettings( { siteSlug }: { siteSlug: string }
 									isBusy={ isFetchingToken }
 									onClick={ handleOpenPhpMyAdmin }
 								>
-									{ __( 'Open phpMyAdmin ↗' ) }
+									<ExternalText>{ __( 'Open phpMyAdmin' ) }</ExternalText>
 								</Button>
 							</ButtonStack>
 							<Text variant="muted" lineHeight="20px">


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

Change external links that are no inside of copy to the "external link" icon.

| Header | Header |
|--------|--------|
| <img width="347" height="177" alt="Screenshot 2025-12-05 at 3 39 10 PM" src="https://github.com/user-attachments/assets/e0941add-ff95-439e-88e6-6939197ff9b8" /> | <img width="346" height="176" alt="Screenshot 2025-12-05 at 3 38 54 PM" src="https://github.com/user-attachments/assets/5375ab19-c360-44de-820f-68a067da8748" /> |
| <img width="219" height="208" alt="Screenshot 2025-12-05 at 3 39 14 PM" src="https://github.com/user-attachments/assets/3ce58673-7673-4031-a0ee-b7060c505dd2" /> | <img width="251" height="221" alt="Screenshot 2025-12-05 at 3 38 58 PM" src="https://github.com/user-attachments/assets/00f127fd-dcda-451b-99db-59d7fda45990" /> |
| <img width="714" height="306" alt="Screenshot 2025-12-05 at 3 43 57 PM" src="https://github.com/user-attachments/assets/106c2049-0360-46de-8e3a-35ebf4e48b92" /> |  <img width="682" height="291" alt="Screenshot 2025-12-05 at 3 44 09 PM" src="https://github.com/user-attachments/assets/8652350e-83ee-4ac2-b128-16a3bd3f1769" />|










## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
