### PR TITLE
Add more events for the v1 hosting feature activation

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -54,6 +54,7 @@ interface ExternalProps {
 	showDataCenterPicker?: boolean;
 	disableContinueButton?: boolean;
 	showFreeTrial?: boolean;
+	path?: string;
 }
 
 type Props = ExternalProps & ReturnType< typeof mergeProps > & LocalizeProps;
@@ -84,6 +85,7 @@ export const EligibilityWarnings = ( {
 	translate,
 	disableContinueButton,
 	showFreeTrial,
+	path = '',
 }: Props ) => {
 	const warnings = eligibilityData.eligibilityWarnings || [];
 	const listHolds = eligibilityData.eligibilityHolds || [];
@@ -158,6 +160,14 @@ export const EligibilityWarnings = ( {
 				eventName="calypso_automated_transfer_eligibility_show_warnings"
 				eventProperties={ { context } }
 			/>
+
+			{ /* Additional event to align analysis across dashboards.
+			     See: https://wp.me/pgz0xU-qp */ }
+			<TrackComponentView
+				eventName="calypso_dashboard_hosting_feature_activation_modal_impression"
+				eventProperties={ { context, path } }
+			/>
+
 			{ ! isPlaceholder && context === 'plugin-details' && hasBlockingHold( listHolds ) && (
 				<CompactCard>
 					<HardBlockingNotice

--- a/client/sites/hosting/components/hosting-activation-button.tsx
+++ b/client/sites/hosting/components/hosting-activation-button.tsx
@@ -12,11 +12,13 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { ComponentProps } from 'react';
 
 interface HostingActivationButtonProps {
+	path?: string;
 	redirectUrl?: string;
 }
 
 export default function HostingActivationButton( {
 	text,
+	path = '',
 	redirectUrl,
 	...props
 }: HostingActivationButtonProps & ComponentProps< typeof Button > ) {
@@ -29,6 +31,15 @@ export default function HostingActivationButton( {
 
 	const handleTransfer = ( options: { geo_affinity?: string } ) => {
 		dispatch( recordTracksEvent( 'calypso_hosting_features_activate_confirm' ) );
+
+		// Additional event to align analysis across dashboards.
+		// See: https://wp.me/pgz0xU-qp
+		dispatch(
+			recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_confirm', {
+				path,
+			} )
+		);
+
 		const params = new URLSearchParams( {
 			siteId: String( siteId ),
 			redirect_to: addQueryArgs( redirectUrl, {
@@ -48,6 +59,15 @@ export default function HostingActivationButton( {
 				text={ text ?? translate( 'Activate now' ) }
 				onClick={ () => {
 					dispatch( recordTracksEvent( 'calypso_hosting_features_activate_click' ) );
+
+					// Additional event to align analysis across dashboards.
+					// See: https://wp.me/pgz0xU-qp
+					dispatch(
+						recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_click', {
+							path,
+						} )
+					);
+
 					return setShowEligibility( true );
 				} }
 			/>
@@ -67,6 +87,7 @@ export default function HostingActivationButton( {
 						showDataCenterPicker
 						standaloneProceed
 						currentContext="hosting-features"
+						path={ path }
 					/>
 				</Modal>
 			) }

--- a/client/sites/hosting/components/hosting-callout/index.tsx
+++ b/client/sites/hosting/components/hosting-callout/index.tsx
@@ -13,15 +13,18 @@ import {
 	isAtomicTransferredSite,
 } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import HostingActivationButton from '../hosting-activation-button';
 import illustrationUrl from './hosting-callout-illustration.svg';
 
 export function HostingActivationCallout( {
 	site,
+	path,
 	redirectUrl,
 }: {
 	site: Site;
+	path: string;
 	redirectUrl?: string;
 } ) {
 	const dispatch = useDispatch();
@@ -79,6 +82,16 @@ export function HostingActivationCallout( {
 		}
 	}, [ isActivated, site.ID, redirectUrl, dispatch ] );
 
+	// Additional event to align analysis across dashboards.
+	// See: https://wp.me/pgz0xU-qp
+	useEffect( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_impression', {
+				path,
+			} )
+		);
+	}, [ dispatch, path ] );
+
 	return (
 		<Callout
 			title={ __( 'Activate hosting features' ) }
@@ -98,6 +111,7 @@ export function HostingActivationCallout( {
 				<HostingActivationButton
 					text={ isActivating ? __( 'Activating…' ) : __( 'Activate' ) }
 					size="compact"
+					path={ path }
 					redirectUrl={ redirectUrl ?? window.location.href.replace( window.location.origin, '' ) }
 				/>
 			}

--- a/client/sites/hosting/components/hosting-features.tsx
+++ b/client/sites/hosting/components/hosting-features.tsx
@@ -37,10 +37,11 @@ const PromoCard = ( { title, text, supportContext }: PromoCardProps ) => (
 );
 
 type HostingFeaturesProps = {
+	path?: string;
 	showAsTools?: boolean;
 };
 
-const HostingFeatures = ( { showAsTools }: HostingFeaturesProps ) => {
+const HostingFeatures = ( { path, showAsTools }: HostingFeaturesProps ) => {
 	const dispatch = useDispatch();
 	const { searchParams } = new URL( document.location.toString() );
 	const siteId = useSelector( getSelectedSiteId );
@@ -204,7 +205,7 @@ const HostingFeatures = ( { showAsTools }: HostingFeaturesProps ) => {
 	} else if ( showActivationButton ) {
 		title = showAsTools ? activateTitleAsTools : activateTitle;
 		description = showAsTools ? activateDescriptionAsTools : activateDescription;
-		buttons = <HostingActivationButton redirectUrl={ redirectUrl } />;
+		buttons = <HostingActivationButton path={ path } redirectUrl={ redirectUrl } />;
 	} else {
 		title = showAsTools ? unlockTitleAsTools : unlockTitle;
 		description = showAsTools ? unlockDescriptionAsTools : unlockDescription;

--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -18,6 +18,7 @@ import './style.scss';
 export function hostingFeatures( context: PageJSContext, next: () => void ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state ) as unknown as Site;
+	const path = getRouteFromContext( context );
 
 	let content;
 	if ( site ) {
@@ -33,12 +34,12 @@ export function hostingFeatures( context: PageJSContext, next: () => void ) {
 
 		content = (
 			<>
-				<PageViewTracker title="Sites > Hosting Features" path={ getRouteFromContext( context ) } />
+				<PageViewTracker title="Sites > Hosting Features" path={ path } />
 				<PageLayout>
 					<CalloutOverlay
 						callout={
 							shouldShowActivationCallout ? (
-								<HostingActivationCallout site={ site } redirectUrl={ redirectUrl } />
+								<HostingActivationCallout path={ path } site={ site } redirectUrl={ redirectUrl } />
 							) : (
 								<HostingUpsellCallout siteSlug={ site.slug } />
 							)
@@ -48,12 +49,12 @@ export function hostingFeatures( context: PageJSContext, next: () => void ) {
 			</>
 		);
 	} else {
-		content = <HostingFeatures />;
+		content = <HostingFeatures path={ path } />;
 	}
 
 	context.primary = (
 		<>
-			<PageViewTracker title="Sites > Hosting Features" path={ getRouteFromContext( context ) } />
+			<PageViewTracker title="Sites > Hosting Features" path={ path } />
 			{ content }
 		</>
 	);
@@ -83,7 +84,7 @@ export function hostingFeaturesCallout(
 				! site.is_wpcom_atomic &&
 				! site.plan?.expired &&
 				site.plan?.features.active.includes( feature ) ? (
-					<HostingActivationCallout site={ site as unknown as Site } />
+					<HostingActivationCallout path={ path } site={ site as unknown as Site } />
 				) : (
 					<HostingFeatureCallout path={ path }>
 						<CalloutComponent siteSlug={ site.slug } titleAs="h3" />


### PR DESCRIPTION
Part of DOTMSD-925
Related to https://github.com/Automattic/wp-calypso/pull/107486

## Proposed Changes

Context: pgz0xU-qp-p2.
This PR introduces more Tracks events with the goal of having the same events for the same actions in both dashboard. All events in this PR has been added to the v1 dashboard.

| Trigger | Event name |
| --- | --- |
| "Before you continue" modal impression | `calypso_dashboard_hosting_feature_activation_modal_impression` |
| "Before you continue" modal → "Activate hosting features" button click  | `calypso_dashboard_hosting_feature_activation_confirm` |
| "Activate hosting features" callout impression | `calypso_dashboard_hosting_feature_activation_impression` |
| "Activate hosting features" callout → "Activate" button click | `calypso_dashboard_hosting_feature_activation_click` |
| Site-level tab click | `calypso_dashboard_menu_item_click`


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the Tracks event work as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?