### PR TITLE
A4A: Update menu items to use "Sentence case"

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -100,7 +100,7 @@ const useMainMenuItems = ( path: string ) => {
 							icon: starEmpty,
 							path: '/',
 							link: A4A_AGENCY_TIER_LINK,
-							title: translate( 'Agency Tier' ),
+							title: translate( 'Agency tier' ),
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Agency Tier',
 							},
@@ -114,6 +114,9 @@ const useMainMenuItems = ( path: string ) => {
 							path: '/',
 							link: A4A_EXCLUSIVE_OFFERS_LINK,
 							title: translate( 'Exclusive offers' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Exclusive offers',
+							},
 						},
 				  ]
 				: [] ),
@@ -191,7 +194,7 @@ const useMainMenuItems = ( path: string ) => {
 				icon: commentAuthorAvatar,
 				path: '/dashboard',
 				link: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
-				title: translate( 'Partner Directories' ),
+				title: translate( 'Partner directories' ),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Partner Directory',
 				},


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1904/sidebar-update-menu-items-to-use-sentence-case

## Proposed Changes

This PR updates the sidebar menu items to use "Sentence case" on A4A.

## Why are these changes being made?

* To follow the standard for naming conventions and be consistent. 

## Testing Instructions

* Open the A4A live link
* Verify the menu items are updates as `Agency tier` and `Partner directories`

| Before | After |
|--------|--------|
| <img width="269" height="691" alt="Screenshot 2025-12-05 at 2 37 35 PM" src="https://github.com/user-attachments/assets/9fe39ded-2f3b-42b3-b686-8f5dd14b29e1" /> | <img width="269" height="691" alt="Screenshot 2025-12-05 at 2 38 08 PM" src="https://github.com/user-attachments/assets/ab46f352-4b77-4ff9-99e9-b86828636fb4" /> | 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
