### PR TITLE
Plugins redesign: Add new FAQ section

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -18,6 +18,7 @@ import { useCategories } from 'calypso/my-sites/plugins/categories/use-categorie
 import { MarketplaceFooter } from 'calypso/my-sites/plugins/education-footer';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
 import useIsVisible from 'calypso/my-sites/plugins/plugins-browser/use-is-visible';
+import { PluginsFAQ } from 'calypso/my-sites/plugins/plugins-faq';
 import SearchBoxHeader from 'calypso/my-sites/plugins/search-box-header';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useIsJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem';
@@ -240,6 +241,11 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 				{ ! category && ! search && (
 					<FullWidthSection className="plugins__marketplace-footer">
 						<MarketplaceFooter />
+					</FullWidthSection>
+				) }
+				{ ! category && ! search && isMarketplaceRedesignEnabled && (
+					<FullWidthSection className="plugins-browser__faq full-width-section--double-padding">
+						<PluginsFAQ />
 					</FullWidthSection>
 				) }
 			</div>

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -220,3 +220,7 @@ body.is-section-plugins #primary .main.is-logged-out {
 		padding-bottom: 48px;
 	}
 }
+.plugins-browser__faq {
+	background-color: var(--studio-gray-100);
+}
+

--- a/client/my-sites/plugins/plugins-faq/index.tsx
+++ b/client/my-sites/plugins/plugins-faq/index.tsx
@@ -1,0 +1,218 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import FoldableFAQ from 'calypso/components/foldable-faq';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './style.scss';
+
+interface FAQItem {
+	id: string;
+	question: string | React.ReactNode;
+	answer: string | React.ReactNode;
+}
+
+export function PluginsFAQ() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onToggle = useCallback(
+		( faqArgs: { id: string; isExpanded: boolean } ) => {
+			const { id, isExpanded } = faqArgs;
+			dispatch(
+				recordTracksEvent( isExpanded ? 'calypso_plugins_faq_open' : 'calypso_plugins_faq_closed', {
+					faq_id: id,
+				} )
+			);
+		},
+		[ dispatch ]
+	);
+
+	const faqItems: FAQItem[] = [
+		{
+			id: 'what-are-plugins',
+			question: translate( 'What are WordPress plugins?' ),
+			answer: translate(
+				'Plugins are add-ons that extend your site’s functionality. From SEO and page builders to ecommerce and memberships, plugins let you add features or integrate your site with other services, all without writing custom code.'
+			),
+		},
+		{
+			id: 'pre-installed-plugins',
+			question: translate( 'Does {{a}}WordPress.com{{/a}} come with any plugins pre-installed?', {
+				components: {
+					a: <a href={ localizeUrl( 'https://wordpress.com' ) } />,
+				},
+			} ),
+			answer: translate(
+				'A WordPress.com website has many more built-in features than a self-hosted WordPress site, meaning you won’t need a plugin for many common features. Before installing a plugin, check {{a}}this list{{/a}} to ensure the feature isn’t already available on your site.',
+				{
+					components: {
+						a: (
+							<a
+								href={ localizeUrl(
+									'https://wordpress.com/support/plugins/install-a-plugin/#before-installing-a-plugin'
+								) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				}
+			),
+		},
+		{
+			id: 'can-install-plugins',
+			question: translate( 'Can I install plugins on {{a}}WordPress.com{{/a}}?', {
+				components: {
+					a: <a href={ localizeUrl( 'https://wordpress.com' ) } />,
+				},
+			} ),
+			answer: translate(
+				'Yes. If you’re on a paid plan, you can install plugins from the directory or upload your own. Free plans include built-in features, but don’t support installing plugins.'
+			),
+		},
+		{
+			id: 'benefits-of-plugins',
+			question: translate( 'What are the benefits of installing plugins on WordPress.com?' ),
+			answer: translate(
+				'Plugins give you the power to add any type of feature imaginable to your website. With over 60,000 plugins on WordPress, your website can do almost anything.{{br /}}{{br /}}With WordPress.com, plugins run on our rock-solid infrastructure. That means automatic updates, strong security protections, fast performance, and centralized billing — without extra setup on your part.',
+				{
+					components: {
+						br: <br />,
+					},
+				}
+			),
+		},
+		{
+			id: 'plugins-security-risk',
+			question: translate( 'Do plugins increase the risk of getting hacked?' ),
+			answer: translate(
+				'Not if you’re on WordPress.com. We automatically scan, update, and secure your environment to minimize risk. As with any software, it’s important to use reputable plugins and keep them updated.'
+			),
+		},
+		{
+			id: 'free-plugins',
+			question: translate( 'Are there free plugins?' ),
+			answer: translate(
+				'Yes. Thousands of plugins in the directory are free to use. Many also offer paid upgrades for advanced features.'
+			),
+		},
+		{
+			id: 'paid-plugins',
+			question: translate( 'Why do I need to pay for some plugins?' ),
+			answer: translate(
+				'Premium plugins often include more functionality, professional support, and ongoing development. The cost helps support the developers who maintain and improve the plugin over time. These plugins can be purchased directly from the developer. You can also purchase {{a}}some popular plugins{{/a}} conveniently from within your WordPress.com account.',
+				{
+					components: {
+						a: <a href={ localizeUrl( 'https://wordpress.com/plugins/browse/paid/' ) } />,
+					},
+				}
+			),
+		},
+		{
+			id: 'make-own-plugins',
+			question: translate( 'Can I make my own plugins?' ),
+			answer: translate(
+				'Yes. Developers can create custom plugins and upload them to WordPress.com on paid plans. You can also connect GitHub and use tools like WP-CLI for advanced workflows. Check out {{a}}WordPress Studio{{/a}} for local plugin development.',
+				{
+					components: {
+						a: <a href="https://developer.wordpress.com/studio/" />,
+					},
+				}
+			),
+		},
+		{
+			id: 'popular-plugins',
+			question: translate( 'What are the most popular plugins?' ),
+			answer: translate(
+				'Popular plugins include Yoast SEO, WooCommerce, Jetpack, and Elementor. They cover everything from search optimization to online stores.'
+			),
+		},
+		{
+			id: 'how-to-install',
+			question: translate( 'How do I install plugins?' ),
+			answer: translate(
+				'On paid plans, go to your dashboard and click Plugins on the left-hand side. Browse or search the plugins directory, where you can learn about plugin features and see ratings. If you are happy with the plugin, click the “Install and activate” button to add it to your site. You can also upload a plugin ZIP file. For full instructions, see our {{a}}guide to installing plugins{{/a}}.',
+				{
+					components: {
+						a: (
+							<a
+								href={ localizeUrl( 'https://wordpress.com/support/plugins/install-a-plugin/' ) }
+							/>
+						),
+					},
+				}
+			),
+		},
+		{
+			id: 'choose-useful-plugins',
+			question: translate( 'How can I choose the most useful plugins for my site?' ),
+			answer: translate(
+				'Start with your goals. If you want more traffic, try an SEO plugin. If you need to sell products, add WooCommerce. Always check reviews, update history, and active installs to gauge reliability.'
+			),
+		},
+		{
+			id: 'plugins-and-plans',
+			question: translate( 'Do plugins work with all {{a}}WordPress.com{{/a}} plans?', {
+				components: {
+					a: <a href={ localizeUrl( 'https://wordpress.com' ) } />,
+				},
+			} ),
+			answer: translate(
+				'Plugin installation is available on all paid plans. Free plans come with a curated set of built-in features instead of external plugins.'
+			),
+		},
+		{
+			id: 'performance-impact',
+			question: translate( 'Will adding lots of plugins affect performance?' ),
+			answer: translate(
+				'Potentially, yes. Too many plugins — or poorly coded ones — can slow down your site. On WordPress.com, we optimize server resources, but it’s still best to install only the plugins you truly need.'
+			),
+		},
+		{
+			id: 'plugin-errors',
+			question: translate( 'What should I do if a plugin causes errors or conflicts?' ),
+			answer: translate(
+				'You can deactivate the plugin from your dashboard, then reactivate plugins one by one to identify the cause. If you’re on a paid plan, our support team can help you troubleshoot.'
+			),
+		},
+		{
+			id: 'good-plugin-criteria',
+			question: translate( 'What should I look for in a good plugin?' ),
+			answer: translate(
+				'Choose plugins with frequent updates, good documentation, and strong user ratings. A plugin with lots of active installs and recent support responses is generally more reliable.'
+			),
+		},
+		{
+			id: 'theme-compatibility',
+			question: translate( 'How can I tell if a plugin will be compatible with my theme?' ),
+			answer: translate(
+				'Most plugins work with any theme. Still, it’s wise to preview changes in the Site Editor and check plugin documentation for any known conflicts.'
+			),
+		},
+	];
+
+	return (
+		<div className="plugins-faq">
+			<div className="plugins-faq__header">
+				<h2 className="plugins-faq__title">{ translate( 'Plugins FAQs' ) }</h2>
+			</div>
+			<div className="plugins-faq__list">
+				{ faqItems.map( ( item ) => (
+					<FoldableFAQ
+						key={ item.id }
+						id={ item.id }
+						question={ item.question }
+						onToggle={ onToggle }
+						icon="cross-small"
+					>
+						{ item.answer }
+					</FoldableFAQ>
+				) ) }
+			</div>
+		</div>
+	);
+}
+
+export default PluginsFAQ;

--- a/client/my-sites/plugins/plugins-faq/style.scss
+++ b/client/my-sites/plugins/plugins-faq/style.scss
@@ -1,0 +1,90 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.plugins-faq {
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+	margin-block: 40px;
+
+	@include break-large {
+		flex-direction: row;
+		gap: 64px;
+	}
+
+	a, a:hover, a:active, a:visited {
+		color: inherit;
+	}
+}
+
+.plugins-faq__header {
+	flex: 0.85;
+
+	@include break-large {
+		width: 200px;
+	}
+}
+
+.plugins-faq__title {
+	font-family: $brand-serif;
+	font-size: rem(40px);
+	font-weight: 400;
+	line-height: 1.2;
+	color: var(--studio-white);
+	margin: 0;
+
+	@include break-large {
+		font-size: rem(50px);
+	}
+}
+
+.plugins-faq__list {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	gap: 16px;
+
+	.foldable-faq {
+		padding: 0;
+		background-color: var(--studio-gray-90);
+		border-radius: 4px;
+	}
+
+	.foldable-faq.is-expanded .foldable-faq__question .gridicon {
+		fill: var(--studio-gray-90);
+		background-color: var(--studio-white);
+		transform: rotate(0);
+	}
+
+	.foldable-faq__question {
+		width: 100%;
+		padding: 20px;
+
+		.gridicon {
+			fill: var(--studio-white);
+			order: 1;
+			margin-inline-start: auto;
+			border: 1px solid var(--studio-white);
+			border-radius: 50%;
+			padding: 2px;
+			box-sizing: content-box;
+			transform: rotate(-45deg);
+			transition: transform 0.2s ease-in-out, fill 0.2s ease-in-out, background-color 0.2s ease-in-out;
+		}
+	}
+
+	.foldable-faq__question-text {
+		padding-inline-start: 0;
+		font-size: rem(16px);
+		font-weight: 400;
+		color: var(--studio-white);
+	}
+
+	.foldable-faq__answer {
+		border-bottom: none;
+		color: var(--studio-gray-20);
+		font-size: rem(14px);
+		line-height: 1.6;
+		padding-inline: 20px;
+	}
+}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -44,7 +44,7 @@
 	}
 }
 
-body.is-section-plugins {
+body .is-section-plugins {
 	.is-section-plugins.is-global-sidebar-visible {
 		.layout__content {
 			min-height: 100vh;
@@ -717,16 +717,20 @@ body.is-section-plugins #primary {
 }
 
 .plugin-details__reviews {
-	margin-bottom: 40px;
+	margin-bottom: 80px;
 
 	@media screen and ( max-width: 1040px ) {
 		padding: 16px;
 	}
 }
 
-.plugins__marketplace-footer {
+.full-width-section.plugins__marketplace-footer {
 	--scss-font-title-large: 2.5rem;
 	--scss-font-body: 1.375rem;
+
+	@media screen and ( min-width: 601px ) {
+		padding-bottom: 40px;
+	}
 
 	.section-header-container {
 		display: flex;
@@ -753,6 +757,10 @@ body.is-section-plugins #primary {
 	}
 	.feature-item-container__header {
 		font-weight: 400;
+	}
+
+	.feature-item-container__content {
+		font-size: $font-body;
 	}
 }
 
@@ -830,21 +838,19 @@ body.is-section-plugins:has(.is-full-width-layout) {
 }
 
 // Remove layout padding for logged-out full-width layout (covers both actually logged out and logged-in showing logged-out UI)
-body.is-section-plugins:has(.plugins-browser.is-full-width-layout.is-logged-out),
-body.is-section-plugins:has(.is-plugin-details.is-full-width-layout) {
+body .is-section-plugins:has(.plugins-browser.is-full-width-layout.is-logged-out),
+body .is-section-plugins:has(.is-plugin-details.is-full-width-layout) {
 	.lpc-footer-nav-wrapper,
 	.lpc-footer-automattic-nav-wrapper {
 		max-width: 1220px;
 	}
 }
-body.is-section-plugins:has(.plugins-browser.is-full-width-layout.is-logged-out) .layout__content {
+body .is-section-plugins:has(.plugins-browser.is-full-width-layout.is-logged-out) .layout__content,
+body .is-section-plugins.has-no-sidebar:has(.is-plugin-details.is-full-width-layout) .layout__content {
 	padding: 0;
 }
-body.is-section-plugins:has(.is-plugin-details.is-full-width-layout) .layout__content {
-	padding-block: 0;
-}
 
-body.is-section-plugins .is-logged-in {
+body .is-section-plugins .is-logged-in {
 	$full-width-main: "main:not(.hosting-dashboard-layout):not(.hosting-dashboard-layout-column):not(.is-logged-out).plugins-browser.is-full-width-layout";
 
 	#{$full-width-main} {
@@ -886,3 +892,4 @@ body.is-section-plugins .is-logged-in {
 		padding-top: 0;
 	}
 }
+

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/style.scss
@@ -62,7 +62,7 @@ $breakpoints: 320px, 360px, 480px, 660px, 782px, 960px, 1140px, 1366px, 1440px, 
 	font-size: 1rem;
 	line-height: 36px;
 	font-family: $lp-font-stack-default;
-	background: #141517;
+	background: var(--studio-black);
 	padding: 25px 20px 80px;
 
 	ul {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTDEV-274](https://linear.app/a8c/issue/DOTDEV-274/faq-section)

## Proposed Changes

* adds the FAQ section on the plugins discovery page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* the changes are needed to match the new design of the plugins section

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins` (with and without the `?flags=marketplace-redesign` param)
* You should see the FAQ section only with the flags param

| Before (without flag) | After (with flag) |
|--------|--------|
|<img width="1426" height="1191" alt="Screenshot 2025-12-05 at 15 33 22" src="https://github.com/user-attachments/assets/1d89a01b-5ca6-4da8-a839-1ca2ab922b13" />|<img width="1417" height="1193" alt="Screenshot 2025-12-05 at 15 27 33" src="https://github.com/user-attachments/assets/77ff8ab1-b258-42a1-9880-ad2704123800" />|
<img width="397" height="1192" alt="Screenshot 2025-12-05 at 15 33 13" src="https://github.com/user-attachments/assets/bee7f592-b44a-4033-aed8-9697aa8f4c75" />|<img width="392" height="1187" alt="Screenshot 2025-12-05 at 15 27 47" src="https://github.com/user-attachments/assets/fd204cc2-af16-45de-b9a7-f9b6b156b909" />|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
