### PR TITLE
MSD: Render plan expiry notice using ES sites

### DIFF
--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -118,7 +118,10 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 			filterBy: {
 				operators: [ 'isAny' as Operator ],
 			},
-			render: ( { item } ) => <Status site={ item } />,
+			render: function StatusField( { item } ) {
+				const { user } = useAuth();
+				return <Status site={ item } isOwner={ item.site_owner === user.ID } />;
+			},
 			enableSorting: ! isEnabled( 'dashboard/v2/es-site-list' ),
 		},
 		{

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,16 +1,19 @@
-import { queryClient, siteBySlugQuery } from '@automattic/api-queries';
+import { queryClient } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
-import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import SiteIcon, { SiteIconRenderer } from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
 import { getSiteDisplayName } from '../../utils/site-name';
-import { getSitePlanDisplayName } from '../../utils/site-plan';
+import { getSitePlanDisplayName, getSitePlanDisplayName__ES } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
 import { getSiteStatus, getStatusLabels } from '../../utils/site-status';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import {
+	isSelfHostedJetpackConnected,
+	isSelfHostedJetpackConnected__ES,
+} from '../../utils/site-types';
 import { getSiteDisplayUrl } from '../../utils/site-url';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import {
@@ -71,14 +74,18 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 			id: 'plan',
 			label: __( 'Plan' ),
 			getValue: ( { item } ) => getSitePlanDisplayName( item ) ?? '',
-			render: ( { field, item } ) => (
-				<Plan
-					nag={ item.plan?.expired ? { isExpired: true, site: item } : { isExpired: false } }
-					isSelfHostedJetpackConnected={ isSelfHostedJetpackConnected( item ) }
-					isJetpack={ item.jetpack }
-					value={ field.getValue( { item } ) }
-				/>
-			),
+			render: function PlanField( { field, item } ) {
+				const { user } = useAuth();
+				return (
+					<Plan
+						nag={ item.plan?.expired ? { isExpired: true, site: item } : { isExpired: false } }
+						isSelfHostedJetpackConnected={ isSelfHostedJetpackConnected( item ) }
+						isJetpack={ item.jetpack }
+						isOwner={ item.site_owner === user.ID }
+						value={ field.getValue( { item } ) }
+					/>
+				);
+			},
 			getElements: async () => {
 				const { plan = [] } = await queryClient.fetchQuery( {
 					...queries.dashboardSiteFiltersQuery( [ 'plan' ] ),
@@ -244,16 +251,15 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 		{
 			id: 'plan',
 			label: __( 'Plan' ),
-			getValue: ( { item } ) => item.plan?.product_name_short ?? '',
-			render: function Plan__ES( { item, field } ) {
-				const { data: site } = useQuery( siteBySlugQuery( item.slug ) );
+			getValue: ( { item } ) => getSitePlanDisplayName__ES( item ),
+			render: function PlanField__ES( { item, field } ) {
+				const { user } = useAuth();
 				return (
 					<Plan
-						nag={ site?.plan?.expired ? { isExpired: true, site } : { isExpired: false } }
-						isSelfHostedJetpackConnected={
-							( site && isSelfHostedJetpackConnected( site ) ) ?? false
-						}
-						isJetpack={ site?.jetpack ?? false }
+						nag={ item?.plan?.expired ? { isExpired: true, site: item } : { isExpired: false } }
+						isSelfHostedJetpackConnected={ isSelfHostedJetpackConnected__ES( item ) }
+						isJetpack={ !! item?.is_jetpack }
+						isOwner={ item.owner_id === user.ID }
 						value={ field.getValue( { item } ) }
 					/>
 				);

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -87,7 +87,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 				);
 			},
 			getElements: async () => {
-				const { plan = [] } = await queryClient.fetchQuery( {
+				const { plan = [] } = await queryClient.ensureQueryData( {
 					...queries.dashboardSiteFiltersQuery( [ 'plan' ] ),
 					staleTime: 5 * 60 * 1000, // Consider valid for 5 minutes
 				} );
@@ -265,7 +265,7 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 				);
 			},
 			getElements: async () => {
-				const { plan = [] } = await queryClient.fetchQuery( {
+				const { plan = [] } = await queryClient.ensureQueryData( {
 					...queries.dashboardSiteFiltersQuery( [ 'plan' ] ),
 					staleTime: 5 * 60 * 1000, // Consider valid for 5 minutes
 				} );
@@ -282,8 +282,8 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 				operators: [ 'isAny' ],
 			},
 			sort: ( a, b, direction ) => {
-				const planA = a.plan?.product_name_short ?? '';
-				const planB = b.plan?.product_name_short ?? '';
+				const planA = getSitePlanDisplayName__ES( a ) ?? '';
+				const planB = getSitePlanDisplayName__ES( b ) ?? '';
 
 				return direction === 'asc' ? planA.localeCompare( planB ) : planB.localeCompare( planA );
 			},

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -39,6 +39,7 @@ import type {
 	Site,
 	FetchDashboardSiteListParams,
 	DashboardSiteListSite,
+	DashboardFilters,
 } from '@automattic/api-core';
 import type { View, Filter } from '@wordpress/dataviews';
 
@@ -63,8 +64,9 @@ const getFetchSitesOptions = ( view: View, isRestoringAccount: boolean ): FetchS
 };
 
 function getFetchSiteListParams(
-	view: View
-	// isRestoringAccount: boolean TODO: Add site visibility filtering
+	view: View,
+	// isRestoringAccount: boolean TODO: Add site visibility filtering,
+	siteFilters: DashboardFilters = {}
 ): FetchDashboardSiteListParams {
 	// The mapping from Dataview fields to Site Profiles fields.
 	const MAPPED_FIELDS: Record< string, keyof DashboardSiteListSite > = {
@@ -129,9 +131,30 @@ function getFetchSiteListParams(
 		}
 	} );
 
+	const planSlugsByName = siteFilters.plan?.reduce(
+		( acc, current ) => ( {
+			...acc,
+			[ current.name ]: [ ...( acc[ current.name ] || [] ), current.value ],
+		} ),
+		{} as Record< string, string[] >
+	);
+
+	const filters = view.filters?.reduce( ( acc, current ) => {
+		let value = current.value;
+		if ( current.field === 'plan' ) {
+			value = current.value.map( ( v: string ) => planSlugsByName?.[ v ] ).flat();
+		}
+
+		return {
+			...acc,
+			[ current.field ]: value,
+		};
+	}, {} );
+
 	return {
 		fields: Array.from( new Set( fields ) ).filter( Boolean ),
 		s: view.search || undefined,
+		filters,
 		sort_by: MAPPED_FIELDS[ view.sort?.field ?? '' ],
 		sort_direction: view.sort?.direction,
 		page: view.page,
@@ -145,8 +168,16 @@ function getFetchSiteListParams(
 export function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
 	const { queries } = useAppContext();
 
+	const { data: siteFilters } = useQuery( {
+		...queries.dashboardSiteFiltersQuery( [ 'plan' ] ),
+		staleTime: 5 * 60 * 1000, // Consider valid for 5 minutes
+		enabled:
+			isEnabled( 'dashboard/v2/es-site-list' ) &&
+			!! view.filters?.find( ( filter ) => filter.field === 'plan' ),
+	} );
+
 	const siteProfilesQueryResult = useQuery( {
-		...queries.dashboardSiteListQuery( getFetchSiteListParams( view ) ),
+		...queries.dashboardSiteListQuery( getFetchSiteListParams( view, siteFilters ) ),
 		placeholderData: keepPreviousData,
 		enabled: isEnabled( 'dashboard/v2/es-site-list' ),
 		meta: {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -141,7 +141,7 @@ function getFetchSiteListParams(
 
 	const filters = view.filters?.reduce( ( acc, current ) => {
 		let value = current.value;
-		if ( current.field === 'plan' ) {
+		if ( current.field === 'plan' && current.value ) {
 			value = current.value.map( ( v: string ) => planSlugsByName?.[ v ] ).flat();
 		}
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -66,7 +66,8 @@ function getFetchSiteListParams(
 	view: View
 	// isRestoringAccount: boolean TODO: Add site visibility filtering
 ): FetchDashboardSiteListParams {
-	const dataviewFieldToSiteProfileField: Record< string, keyof DashboardSiteListSite > = {
+	// The mapping from Dataview fields to Site Profiles fields.
+	const MAPPED_FIELDS: Record< string, keyof DashboardSiteListSite > = {
 		name: 'name',
 		URL: 'url',
 		'icon.ico': 'icon',
@@ -86,34 +87,52 @@ function getFetchSiteListParams(
 		// host
 	};
 
-	const fields = new Set< keyof DashboardSiteListSite >( [ 'blog_id', 'slug', 'deleted' ] ); // Always include ID and slug (for navigation), and deleted (for styling)
+	const ADDITIONAL_MAPPED_FIELDS: Record< string, ( keyof DashboardSiteListSite )[] > = {
+		name: [ 'badge' ],
+		status: [ 'wpcom_status', 'private', 'deleted' ],
+		plan: [ 'owner_id' ],
+	};
+
+	// Always include ID and slug (for navigation), deleted (for styling), is_a8c (for included a8c owned) and other (for vip & self hosted jetpack)
+	const fields: ( keyof DashboardSiteListSite )[] = [
+		'blog_id',
+		'slug',
+		'deleted',
+		'is_a8c',
+		'is_atomic',
+		'is_garden',
+		'is_jetpack',
+		'is_vip',
+	];
+
 	if ( view.showTitle && view.titleField ) {
-		fields.add( dataviewFieldToSiteProfileField[ view.titleField ] );
-		fields.add( 'badge' );
+		fields.push( MAPPED_FIELDS[ view.titleField ] );
 	}
+
 	if ( view.showMedia && view.mediaField ) {
-		fields.add( dataviewFieldToSiteProfileField[ view.mediaField ] );
+		fields.push( MAPPED_FIELDS[ view.mediaField ] );
 	}
+
 	if ( view.showDescription && view.descriptionField ) {
-		fields.add( dataviewFieldToSiteProfileField[ view.descriptionField ] );
+		fields.push( MAPPED_FIELDS[ view.descriptionField ] );
 	}
-	// Status is a composite field that comes from a number of different SiteProfile fields.
-	if ( view.fields?.includes( 'status' ) ) {
-		fields.add( 'wpcom_status' );
-		fields.add( 'private' );
-		fields.add( 'deleted' );
-	}
+
 	view.fields?.forEach( ( field ) => {
-		const mappedField = dataviewFieldToSiteProfileField[ field ];
+		const mappedField = MAPPED_FIELDS[ field ];
 		if ( mappedField ) {
-			fields.add( mappedField );
+			fields.push( mappedField );
+		}
+
+		const additionalMappedFields = ADDITIONAL_MAPPED_FIELDS[ field ];
+		if ( additionalMappedFields ) {
+			fields.push( ...additionalMappedFields );
 		}
 	} );
 
 	return {
-		fields: Array.from( fields ).filter( Boolean ),
+		fields: Array.from( new Set( fields ) ).filter( Boolean ),
 		s: view.search || undefined,
-		sort_by: dataviewFieldToSiteProfileField[ view.sort?.field ?? '' ],
+		sort_by: MAPPED_FIELDS[ view.sort?.field ?? '' ],
 		sort_direction: view.sort?.direction,
 		page: view.page,
 		per_page: view.perPage,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -69,7 +69,7 @@ function getFetchSiteListParams(
 	siteFilters: DashboardFilters = {}
 ): FetchDashboardSiteListParams {
 	// The mapping from Dataview fields to Site Profiles fields.
-	const MAPPED_FIELDS: Record< string, keyof DashboardSiteListSite > = {
+	const mappedFields: Record< string, keyof DashboardSiteListSite > = {
 		name: 'name',
 		URL: 'url',
 		'icon.ico': 'icon',
@@ -89,7 +89,7 @@ function getFetchSiteListParams(
 		// host
 	};
 
-	const ADDITIONAL_MAPPED_FIELDS: Record< string, ( keyof DashboardSiteListSite )[] > = {
+	const additionalMappedFields: Record< string, ( keyof DashboardSiteListSite )[] > = {
 		name: [ 'badge' ],
 		status: [ 'wpcom_status', 'private', 'deleted' ],
 		plan: [ 'owner_id' ],
@@ -108,26 +108,25 @@ function getFetchSiteListParams(
 	];
 
 	if ( view.showTitle && view.titleField ) {
-		fields.push( MAPPED_FIELDS[ view.titleField ] );
+		fields.push( mappedFields[ view.titleField ] );
 	}
 
 	if ( view.showMedia && view.mediaField ) {
-		fields.push( MAPPED_FIELDS[ view.mediaField ] );
+		fields.push( mappedFields[ view.mediaField ] );
 	}
 
 	if ( view.showDescription && view.descriptionField ) {
-		fields.push( MAPPED_FIELDS[ view.descriptionField ] );
+		fields.push( mappedFields[ view.descriptionField ] );
 	}
 
 	view.fields?.forEach( ( field ) => {
-		const mappedField = MAPPED_FIELDS[ field ];
+		const mappedField = mappedFields[ field ];
 		if ( mappedField ) {
 			fields.push( mappedField );
 		}
 
-		const additionalMappedFields = ADDITIONAL_MAPPED_FIELDS[ field ];
-		if ( additionalMappedFields ) {
-			fields.push( ...additionalMappedFields );
+		if ( additionalMappedFields[ field ] ) {
+			fields.push( ...additionalMappedFields[ field ] );
 		}
 	} );
 
@@ -155,7 +154,7 @@ function getFetchSiteListParams(
 		fields: Array.from( new Set( fields ) ).filter( Boolean ),
 		s: view.search || undefined,
 		filters,
-		sort_by: MAPPED_FIELDS[ view.sort?.field ?? '' ],
+		sort_by: mappedFields[ view.sort?.field ?? '' ],
 		sort_direction: view.sort?.direction,
 		page: view.page,
 		per_page: view.perPage,

--- a/client/dashboard/sites/plans.ts
+++ b/client/dashboard/sites/plans.ts
@@ -46,7 +46,7 @@ export const isSitePlanLaunchable = ( site: Site ) => {
 	] );
 };
 
-export function isSitePlanTrial( site: Site ) {
+export function isSitePlanTrial( site: Pick< Site, 'plan' > ) {
 	const trialPlans = [
 		DotcomPlans.ECOMMERCE_TRIAL_MONTHLY,
 		DotcomPlans.HOSTING_TRIAL_MONTHLY,

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -377,14 +377,8 @@ function SiteLaunchNag( { site }: { site: Site } ) {
 	);
 }
 
-function PlanRenewNag( { site, source }: { site: Site; source: string } ) {
-	const { user } = useAuth();
+function PlanRenewNag( { site, source }: { site: Pick< Site, 'slug' | 'plan' >; source: string } ) {
 	const { recordTracksEvent } = useAnalytics();
-
-	if ( site.site_owner !== user.ID ) {
-		return null;
-	}
-
 	const isTrial = isSitePlanTrial( site );
 
 	return (
@@ -433,6 +427,7 @@ function WithHostingFeaturesQuery( {
 }
 
 export function Status( { site }: { site: Site } ) {
+	const { user } = useAuth();
 	const status = getSiteStatus( site );
 	const label = getSiteStatusLabel( site );
 
@@ -456,7 +451,7 @@ export function Status( { site }: { site: Site } ) {
 		return (
 			<VStack spacing={ 1 }>
 				<Text intent="error">{ __( 'Plan expired' ) }</Text>
-				<PlanRenewNag site={ site } source="status" />
+				{ site.site_owner === user.ID && <PlanRenewNag site={ site } source="status" /> }
 			</VStack>
 		);
 	}
@@ -493,11 +488,13 @@ export function Plan( {
 	nag,
 	isSelfHostedJetpackConnected,
 	isJetpack,
+	isOwner,
 	value,
 }: {
-	nag: { isExpired: false } | { isExpired: true; site: Site };
+	nag: { isExpired: false } | { isExpired: true; site: Pick< Site, 'slug' | 'plan' > };
 	isSelfHostedJetpackConnected: boolean;
 	isJetpack: boolean;
+	isOwner: boolean;
 	value: string;
 } ) {
 	if ( isSelfHostedJetpackConnected ) {
@@ -522,7 +519,7 @@ export function Plan( {
 						value
 					) }
 				</Text>
-				<PlanRenewNag site={ nag.site } source="plan" />
+				{ isOwner && <PlanRenewNag site={ nag.site } source="plan" /> }
 			</VStack>
 		);
 	}

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -425,7 +425,7 @@ function WithHostingFeaturesQuery( {
 	return <span ref={ ref }>{ children( data?.status ) }</span>;
 }
 
-export function Status( { site, isOwner }: { site: Site; isOwner: boolean } ) {
+export function Status( { site, isOwner }: { site: Site; isOwner?: boolean } ) {
 	const status = getSiteStatus( site );
 	const label = getSiteStatusLabel( site );
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -494,7 +494,7 @@ export function Plan( {
 	nag: { isExpired: false } | { isExpired: true; site: Pick< Site, 'slug' | 'plan' > };
 	isSelfHostedJetpackConnected: boolean;
 	isJetpack: boolean;
-	isOwner: boolean;
+	isOwner?: boolean;
 	value: string;
 } ) {
 	if ( isSelfHostedJetpackConnected ) {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -19,7 +19,6 @@ import { useResizeObserver } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../../app/analytics';
-import { useAuth } from '../../app/auth';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import SiteIcon from '../../components/site-icon';
 import { Text } from '../../components/text';
@@ -426,8 +425,7 @@ function WithHostingFeaturesQuery( {
 	return <span ref={ ref }>{ children( data?.status ) }</span>;
 }
 
-export function Status( { site }: { site: Site } ) {
-	const { user } = useAuth();
+export function Status( { site, isOwner }: { site: Site; isOwner: boolean } ) {
 	const status = getSiteStatus( site );
 	const label = getSiteStatusLabel( site );
 
@@ -451,7 +449,7 @@ export function Status( { site }: { site: Site } ) {
 		return (
 			<VStack spacing={ 1 }>
 				<Text intent="error">{ __( 'Plan expired' ) }</Text>
-				{ site.site_owner === user.ID && <PlanRenewNag site={ site } source="status" /> }
+				{ isOwner && <PlanRenewNag site={ site } source="status" /> }
 			</VStack>
 		);
 	}

--- a/client/dashboard/sites/site-fields/test/plan.tsx
+++ b/client/dashboard/sites/site-fields/test/plan.tsx
@@ -96,6 +96,7 @@ describe( '<Plan>', () => {
 			<Plan
 				isJetpack={ false }
 				isSelfHostedJetpackConnected={ false }
+				isOwner
 				value="Business"
 				nag={ { isExpired: true, site } }
 			/>
@@ -121,6 +122,7 @@ describe( '<Plan>', () => {
 			<Plan
 				isJetpack={ false }
 				isSelfHostedJetpackConnected={ false }
+				isOwner
 				value="Trial"
 				nag={ { isExpired: true, site } }
 			/>

--- a/client/dashboard/sites/site-fields/test/status.tsx
+++ b/client/dashboard/sites/site-fields/test/status.tsx
@@ -117,7 +117,7 @@ describe( '<Status>', () => {
 				expired: true,
 			},
 		} as Site;
-		const { getByText, getByRole } = render( <Status site={ site } /> );
+		const { getByText, getByRole } = render( <Status site={ site } isOwner /> );
 		expect( getByText( 'Plan expired' ) ).toBeInTheDocument();
 		expect( getByRole( 'link', { name: /Renew plan/ } ) ).toHaveAttribute(
 			'href',

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -1,10 +1,4 @@
-import {
-	DotcomPlans,
-	JetpackFeatures,
-	type JetpackFeatureSlug,
-	type Purchase,
-	type Site,
-} from '@automattic/api-core';
+import { DotcomPlans, JetpackFeatures } from '@automattic/api-core';
 import { useRouter } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import {
@@ -22,6 +16,12 @@ import { hasPlanFeature } from '../utils/site-features';
 import { isDashboardBackport } from './is-dashboard-backport';
 import { wpcomLink } from './link';
 import { isCommerceGarden, isSelfHostedJetpackConnected } from './site-types';
+import type {
+	JetpackFeatureSlug,
+	Purchase,
+	Site,
+	DashboardSiteListSite,
+} from '@automattic/api-core';
 
 export const JETPACK_PRODUCTS = [
 	{
@@ -78,7 +78,7 @@ export const JETPACK_PRODUCTS = [
 	},
 ];
 
-export function getJetpackProductsForSite( site: Site ) {
+export function getJetpackProductsForSite( site: Pick< Site, 'plan' > ) {
 	return JETPACK_PRODUCTS.filter( ( product ) =>
 		hasPlanFeature( site, product.id as JetpackFeatureSlug )
 	);
@@ -89,6 +89,31 @@ export function getSitePlanDisplayName( site: Site ) {
 		return __( 'Staging Site' );
 	}
 
+	const plan = site.plan;
+	if ( ! plan ) {
+		return '';
+	}
+
+	if ( plan.product_slug === DotcomPlans.JETPACK_FREE ) {
+		const products = getJetpackProductsForSite( site );
+		if ( products.length === 1 ) {
+			return products[ 0 ].label;
+		}
+		if ( products.length > 1 ) {
+			return __( 'Jetpack' );
+		}
+	}
+
+	// Display the short name for WP.com plans.
+	// Determine if the plan is a WP.com plan by checking if the license key is empty.
+	if ( ! plan.license_key ) {
+		return plan.product_name_short;
+	}
+
+	return plan.product_name || plan.product_name_short;
+}
+
+export function getSitePlanDisplayName__ES( site: DashboardSiteListSite ) {
 	const plan = site.plan;
 	if ( ! plan ) {
 		return '';

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -129,13 +129,7 @@ export function getSitePlanDisplayName__ES( site: DashboardSiteListSite ) {
 		}
 	}
 
-	// Display the short name for WP.com plans.
-	// Determine if the plan is a WP.com plan by checking if the license key is empty.
-	if ( ! plan.license_key ) {
-		return plan.product_name_short;
-	}
-
-	return plan.product_name || plan.product_name_short;
+	return plan.product_name_short;
 }
 
 export function useSitePlanManageURL( site: Site, purchase?: Purchase ) {

--- a/client/dashboard/utils/site-types.ts
+++ b/client/dashboard/utils/site-types.ts
@@ -1,9 +1,14 @@
-import type { Site } from '@automattic/api-core';
+import type { Site, DashboardSiteListSite } from '@automattic/api-core';
 
 export function isSelfHostedJetpackConnected( site: Site ) {
 	return (
 		site.jetpack_connection && ! site.is_wpcom_atomic && ! site.is_wpcom_flex && ! site.is_garden
 	);
+}
+
+export function isSelfHostedJetpackConnected__ES( site: DashboardSiteListSite ) {
+	// TODO: Add is_wpcom_flex when ES has this property
+	return !! site.is_jetpack && ! site.is_atomic && ! site.is_garden;
 }
 
 export function isP2( site: Site ) {

--- a/packages/api-core/src/dashboard-site-list/fetchers.ts
+++ b/packages/api-core/src/dashboard-site-list/fetchers.ts
@@ -30,6 +30,7 @@ export async function fetchDashboardSiteList(
 			...params,
 			fields: [ ...fields ].join( ',' ),
 			filters: {
+				...params.filters,
 				site_types: site_types !== 'all' ? site_types : undefined,
 			},
 		}

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -49,6 +49,10 @@ export interface DashboardSiteListResponse {
 export interface FetchDashboardSiteListParams {
 	fields?: ( keyof DashboardSiteListSite )[];
 	s?: string;
+	filters?: {
+		plan?: string[];
+		is_a8c?: boolean;
+	};
 	sort_by?: keyof DashboardSiteListSite;
 	sort_direction?: 'asc' | 'desc';
 	page?: number;

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -10,11 +10,9 @@ export interface DashboardSiteListSite {
 	plan?: {
 		product_id: number;
 		product_slug: string;
-		product_name: string;
 		product_name_short: string;
 		expired: boolean;
 		is_free: boolean;
-		license_key: string;
 		features: {
 			active: string[];
 		};

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -1,18 +1,35 @@
 export interface DashboardSiteListSite {
 	badge?: null | 'staging' | 'trial' | 'p2';
 	blog_id: number; // Site ID is always fetched
+	capabilities?: {
+		manage_options: boolean;
+	};
 	deleted?: boolean;
 	has_backup?: boolean;
 	name?: string;
 	plan?: {
 		product_id: number;
+		product_slug: string;
+		product_name: string;
 		product_name_short: string;
+		expired: boolean;
+		is_free: boolean;
+		license_key: string;
+		features: {
+			active: string[];
+		};
 	};
 	private?: boolean;
 	icon?: null | {
 		ico: string;
 		img: string;
 	};
+	is_a8c?: boolean;
+	is_atomic?: boolean;
+	is_garden?: boolean;
+	is_jetpack?: boolean;
+	is_vip?: boolean;
+	owner_id?: number;
 	slug: string; // Slug is always fetched
 	visitors?: null | number;
 	total_wpcom_subscribers?: number;

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -1,11 +1,11 @@
 export interface SitePlan {
 	product_id: number;
 	product_slug: string;
-	product_name: string;
+	product_name?: string; // Only returns by /sites/:site
 	product_name_short: string;
 	expired: boolean;
 	is_free: boolean;
-	license_key: string;
+	license_key?: string; // Only returns by /sites/:site
 	billing_period?: 'Yearly' | 'Monthly';
 	features: {
 		active: string[];

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -1,12 +1,12 @@
-export interface SitePlan {
+interface SitePlan {
 	product_id: number;
 	product_slug: string;
-	product_name: string;
+	product_name?: string;
 	product_name_short: string;
 	expired: boolean;
 	is_free: boolean;
-	license_key: string;
-	billing_period: 'Yearly' | 'Monthly';
+	license_key?: string;
+	billing_period?: 'Yearly' | 'Monthly';
 	features: {
 		active: string[];
 	};
@@ -48,8 +48,7 @@ export interface Site {
 		img: string;
 		ico: string;
 	};
-	plan?: Omit< SitePlan, 'product_name' | 'license_key' | 'billing_period' > &
-		Partial< Pick< SitePlan, 'product_name' | 'license_key' | 'billing_period' > >;
+	plan?: SitePlan;
 	capabilities: SiteCapabilities;
 	subscribers_count?: number; // Can be undefined if query cache is prefilled from old Calypso Redux store.
 	options?: SiteOptions; // Can be undefined for deleted sites.

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -6,7 +6,7 @@ export interface SitePlan {
 	expired: boolean;
 	is_free: boolean;
 	license_key: string;
-	billing_period: 'Yearly' | 'Monthly';
+	billing_period?: 'Yearly' | 'Monthly';
 	features: {
 		active: string[];
 	};

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -1,12 +1,12 @@
 export interface SitePlan {
 	product_id: number;
 	product_slug: string;
-	product_name?: string; // Only returns by /sites/:site
+	product_name: string;
 	product_name_short: string;
 	expired: boolean;
 	is_free: boolean;
-	license_key?: string; // Only returns by /sites/:site
-	billing_period?: 'Yearly' | 'Monthly';
+	license_key: string;
+	billing_period: 'Yearly' | 'Monthly';
 	features: {
 		active: string[];
 	};
@@ -48,7 +48,8 @@ export interface Site {
 		img: string;
 		ico: string;
 	};
-	plan?: SitePlan;
+	plan?: Omit< SitePlan, 'product_name' | 'license_key' | 'billing_period' > &
+		Partial< Pick< SitePlan, 'product_name' | 'license_key' | 'billing_period' > >;
 	capabilities: SiteCapabilities;
 	subscribers_count?: number; // Can be undefined if query cache is prefilled from old Calypso Redux store.
 	options?: SiteOptions; // Can be undefined for deleted sites.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-896

## Proposed Changes

* Render plan expiry notice using ES sites
* Fix the plan filter on ES sites
* Make `DashboardSiteListSite.plan` compatible with `SitePlan`
* Introduce `isSelfHostedJetpackConnected__ES` and `getSitePlanDisplayName__ES`
* Mark `product_name`, `license_key`, and `billing_period` optional as the `/me/sites` endpoint doesn't include them.

<img width="1079" height="73" alt="image" src="https://github.com/user-attachments/assets/92354fee-02cd-43b7-9e7f-ed6c9c8e67d3" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It would be better to render the sites dataviews using ES sites data without additional query

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go /v2/sites?flags=dashboard/v2/es-site-list
* Ensure you can see the plan expired notice on the dataview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
