### PR TITLE
Update MSD domains name-servers form to remove the hardcoded nameservers

### DIFF
--- a/client/dashboard/domains/name-servers/form.stories.tsx
+++ b/client/dashboard/domains/name-servers/form.stories.tsx
@@ -31,6 +31,7 @@ export const Default: Story = {
 	args: {
 		domainName: 'example.com',
 		domainSiteSlug: 'example.wordpress.com',
+		defaultNameServers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 		nameServers: [],
 		isBusy: false,
 		showUpsellNudge: false,
@@ -42,6 +43,7 @@ export const WithNameservers: Story = {
 	args: {
 		domainName: 'example.com',
 		domainSiteSlug: 'example.wordpress.com',
+		defaultNameServers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 		nameServers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 		isBusy: false,
 		showUpsellNudge: false,
@@ -53,6 +55,7 @@ export const WithUpsellNudge: Story = {
 	args: {
 		domainName: 'example.com',
 		domainSiteSlug: 'example.wordpress.com',
+		defaultNameServers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 		nameServers: [],
 		isBusy: false,
 		showUpsellNudge: true,
@@ -64,6 +67,7 @@ export const IsBusy: Story = {
 	args: {
 		domainName: 'example.com',
 		domainSiteSlug: 'example.wordpress.com',
+		defaultNameServers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 		nameServers: [],
 		isBusy: true,
 		showUpsellNudge: false,

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -10,13 +10,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useCallback, useMemo } from 'react';
 import InlineSupportLink from '../../components/inline-support-link';
-import {
-	MIN_NAME_SERVERS_LENGTH,
-	MAX_NAME_SERVERS_LENGTH,
-	WPCOM_DEFAULT_NAME_SERVERS,
-	FormData,
-	NameServerKey,
-} from './types';
+import { MIN_NAME_SERVERS_LENGTH, MAX_NAME_SERVERS_LENGTH, FormData, NameServerKey } from './types';
 import UpsellNudge from './upsell-nudge';
 import { validateHostname } from './utils';
 
@@ -96,6 +90,7 @@ interface Props {
 	domainSiteSlug: string;
 	showUpsellNudge?: boolean;
 	nameServers?: string[];
+	defaultNameServers: string[];
 	isUsingDefaultNameServers?: boolean;
 	isBusy?: boolean;
 	onSubmit: ( nameServers: string[] ) => void;
@@ -106,6 +101,7 @@ export default function NameServersForm( {
 	domainSiteSlug,
 	showUpsellNudge,
 	nameServers = [],
+	defaultNameServers = [],
 	isUsingDefaultNameServers = false,
 	isBusy,
 	onSubmit,
@@ -159,7 +155,7 @@ export default function NameServersForm( {
 									const ns = Object.fromEntries(
 										Array.from( { length: MAX_NAME_SERVERS_LENGTH }, ( _, i ) => [
 											`nameServer${ i + 1 }` as NameServerKey,
-											value ? WPCOM_DEFAULT_NAME_SERVERS[ i ] : '',
+											value ? defaultNameServers[ i ] : '',
 										] )
 									);
 

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -27,7 +27,7 @@ export default function NameServers() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const {
-		data: { nameServers, isUsingDefaultNameServers },
+		data: { nameServers, isUsingDefaultNameServers, defaultNameServers },
 	} = useSuspenseQuery( domainNameServersQuery( domainName ) );
 
 	const { mutate: updateNameServers, isPending: isUpdatingNameServers } = useMutation(
@@ -76,6 +76,7 @@ export default function NameServers() {
 						domainName={ domainName }
 						domainSiteSlug={ getDomainSiteSlug( domain ) }
 						nameServers={ nameServers }
+						defaultNameServers={ defaultNameServers }
 						isUsingDefaultNameServers={ isUsingDefaultNameServers }
 						isBusy={ isUpdatingNameServers }
 						showUpsellNudge={ showUpsellNudge }

--- a/client/dashboard/domains/name-servers/types.ts
+++ b/client/dashboard/domains/name-servers/types.ts
@@ -1,12 +1,6 @@
 export const MIN_NAME_SERVERS_LENGTH = 2;
 export const MAX_NAME_SERVERS_LENGTH = 4;
 
-export const WPCOM_DEFAULT_NAME_SERVERS = [
-	'ns1.wordpress.com',
-	'ns2.wordpress.com',
-	'ns3.wordpress.com',
-];
-
 // Create a union type of numbers from 1 to MAX_NAME_SERVERS_LENGTH
 export type Range< N extends number, T extends number[] = [] > = T[ 'length' ] extends N
 	? T[ number ]

--- a/packages/api-core/src/domain-name-servers/fetchers.ts
+++ b/packages/api-core/src/domain-name-servers/fetchers.ts
@@ -3,11 +3,13 @@ import { wpcom } from '../wpcom-fetcher';
 interface FetchNameServersResponse {
 	is_using_default_nameservers: boolean;
 	nameservers: string[];
+	default_nameservers: string[];
 }
 
 export interface DomainNameServersResponse {
 	nameServers: string[];
 	isUsingDefaultNameServers: boolean;
+	defaultNameServers: string[];
 }
 
 export async function fetchDomainNameServers(
@@ -22,6 +24,7 @@ export async function fetchDomainNameServers(
 			return {
 				nameServers: data.nameservers,
 				isUsingDefaultNameServers: data.is_using_default_nameservers,
+				defaultNameServers: data.default_nameservers,
 			};
 		} );
 }

--- a/packages/api-queries/src/domain-name-servers.ts
+++ b/packages/api-queries/src/domain-name-servers.ts
@@ -20,11 +20,14 @@ export const domainNameServersMutation = ( domainName: string ) =>
 			const oldData = queryClient.getQueryData( domainNameServersQuery( domainName ).queryKey ) as
 				| DomainNameServersResponse
 				| undefined;
+
 			// optimistically update the query data
 			queryClient.setQueryData( domainNameServersQuery( domainName ).queryKey, {
 				isUsingDefaultNameServers: oldData?.isUsingDefaultNameServers ?? false,
 				nameServers: data,
+				defaultNameServers: oldData?.defaultNameServers ?? [],
 			} );
+
 			queryClient.invalidateQueries( domainNameServersQuery( domainName ) );
 			queryClient.invalidateQueries( domainQuery( domainName ) );
 		},


### PR DESCRIPTION
We want to remove hardcoded strings (as the default WordPress.com name servers) from the MSD so that it can be reused. This PR will remove the hardcoded strings from the name servers form component.


Part of [DOMAINS-1918: Remove hardcoded NS records from the nameservers component in MSD](https://linear.app/a8c/issue/DOMAINS-1918/remove-hardcoded-ns-records-from-the-nameservers-component-in-msd)

Depends on: 197513-ghe-Automattic/wpcom

## Proposed Changes

* Remove hardcoded name servers and use the ones returned from the REST API


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the MSD reusable

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the backend PR
* Visit `/v2/domains/{domain_name}/name-servers` screen and verify thath when you change the toggle the default name servers for WordPress.com would be displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?