### PR TITLE
MSD: Render more fields using ES data

### DIFF
--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,3 +1,4 @@
+import { HostingFeatures } from '@automattic/api-core';
 import { queryClient } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
@@ -6,6 +7,7 @@ import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import SiteIcon, { SiteIconRenderer } from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
+import { hasHostingFeature, hasHostingFeature__ES } from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName, getSitePlanDisplayName__ES } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
@@ -69,7 +71,12 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'backup',
 			label: __( 'Backup' ),
-			render: ( { item } ) => <LastBackup site={ item } />,
+			render: ( { item } ) => (
+				<LastBackup
+					siteId={ item.ID }
+					isEligible={ hasHostingFeature( item, HostingFeatures.BACKUPS ) }
+				/>
+			),
 			enableSorting: false,
 		},
 		{
@@ -253,12 +260,17 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			getValue: ( { item } ) => item.total_wpcom_subscribers,
 			label: __( 'Subscribers' ),
 		},
-		// {
-		// 	id: 'backup',
-		// 	label: __( 'Backup' ),
-		// 	render: ( { item } ) => <LastBackup site={ item } />,
-		// 	enableSorting: false,
-		// },
+		{
+			id: 'backup',
+			label: __( 'Backup' ),
+			render: ( { item } ) => (
+				<LastBackup
+					siteId={ item.blog_id }
+					isEligible={ hasHostingFeature__ES( item, HostingFeatures.BACKUPS ) }
+				/>
+			),
+			enableSorting: false,
+		},
 		{
 			id: 'plan',
 			label: __( 'Plan' ),

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -330,6 +330,14 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			render: ( { item }: { item: DashboardSiteListSite } ) => <PHPVersion__ES site={ item } />,
 			enableSorting: false,
 		},
+		{
+			id: 'host',
+			label: __( 'Host' ),
+			getValue: ( { item } ) => {
+				return getSiteProviderName( item ) ?? DEFAULT_PROVIDER_NAME;
+			},
+			render: ( { field, item } ) => field.getValue( { item } ),
+		},
 	];
 }
 

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -173,7 +173,12 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'uptime',
 			label: __( '7-day uptime' ),
-			render: ( { item } ) => <Uptime site={ item } />,
+			render: ( { item } ) => (
+				<Uptime
+					siteId={ item.ID }
+					isEligible={ hasJetpackModule( item, JetpackModules.MONITOR ) }
+				/>
+			),
 			enableSorting: false,
 		},
 		{
@@ -375,12 +380,17 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 		// 	render: ( { item } ) =>
 		// 		item.options?.updated_at ? <TimeSince timestamp={ item.options.updated_at } /> : '',
 		// },
-		// {
-		// 	id: 'uptime',
-		// 	label: __( '7-day uptime' ),
-		// 	render: ( { item } ) => <Uptime site={ item } />,
-		// 	enableSorting: false,
-		// },
+		{
+			id: 'uptime',
+			label: __( '7-day uptime' ),
+			render: ( { item } ) => (
+				<Uptime
+					siteId={ item.blog_id }
+					isEligible={ hasJetpackModule__ES( item, JetpackModules.MONITOR ) }
+				/>
+			),
+			enableSorting: false,
+		},
 		{
 			id: 'visitors',
 			label: __( '7-day visitors' ),

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,4 +1,4 @@
-import { HostingFeatures } from '@automattic/api-core';
+import { HostingFeatures, JetpackModules } from '@automattic/api-core';
 import { queryClient } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
@@ -7,7 +7,12 @@ import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import SiteIcon, { SiteIconRenderer } from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
-import { hasHostingFeature, hasHostingFeature__ES } from '../../utils/site-features';
+import {
+	hasHostingFeature,
+	hasHostingFeature__ES,
+	hasJetpackModule,
+	hasJetpackModule__ES,
+} from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName, getSitePlanDisplayName__ES } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
@@ -174,19 +179,46 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'visitors',
 			label: __( '7-day visitors' ),
-			render: ( { item } ) => <AsyncEngagementStat site={ item } type="visitors" />,
+			render: ( { item } ) => (
+				<AsyncEngagementStat
+					siteId={ item.ID }
+					type="visitors"
+					isEligible={
+						! item.is_deleted &&
+						( ! item.jetpack || hasJetpackModule( item, JetpackModules.STATS ) )
+					}
+				/>
+			),
 			enableSorting: false,
 		},
 		{
 			id: 'views',
 			label: __( '7-day views' ),
-			render: ( { item } ) => <AsyncEngagementStat site={ item } type="views" />,
+			render: ( { item } ) => (
+				<AsyncEngagementStat
+					siteId={ item.ID }
+					type="views"
+					isEligible={
+						! item.is_deleted &&
+						( ! item.jetpack || hasJetpackModule( item, JetpackModules.STATS ) )
+					}
+				/>
+			),
 			enableSorting: false,
 		},
 		{
 			id: 'likes',
 			label: __( '7-day likes' ),
-			render: ( { item } ) => <AsyncEngagementStat site={ item } type="likes" />,
+			render: ( { item } ) => (
+				<AsyncEngagementStat
+					siteId={ item.ID }
+					type="likes"
+					isEligible={
+						! item.is_deleted &&
+						( ! item.jetpack || hasJetpackModule( item, JetpackModules.STATS ) )
+					}
+				/>
+			),
 			enableSorting: false,
 		},
 		{
@@ -361,12 +393,21 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			render: ( { item, field } ) => <EngagementStat value={ field.getValue( { item } ) } />,
 			enableSorting: false,
 		},
-		// {
-		// 	id: 'likes',
-		// 	label: __( '7-day likes' ),
-		// 	render: ( { item } ) => <AsyncEngagementStat site={ item } type="likes" />,
-		// 	enableSorting: false,
-		// },
+		{
+			id: 'likes',
+			label: __( '7-day likes' ),
+			render: ( { item } ) => (
+				<AsyncEngagementStat
+					siteId={ item.blog_id }
+					type="likes"
+					isEligible={
+						! item.deleted &&
+						( ! item.is_jetpack || hasJetpackModule__ES( item, JetpackModules.STATS ) )
+					}
+				/>
+			),
+			enableSorting: false,
+		},
 		{
 			id: 'php_version',
 			label: __( 'PHP version' ),

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,4 +1,3 @@
-import { JetpackModules } from '@automattic/api-core';
 import { queryClient, siteBySlugQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
@@ -8,7 +7,6 @@ import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import SiteIcon, { SiteIconRenderer } from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
-import { hasJetpackModule } from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName, getSitePlanDisplayName__ES } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
@@ -170,16 +168,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'visitors',
 			label: __( '7-day visitors' ),
-			render: ( { item } ) => (
-				<AsyncEngagementStat
-					siteId={ item.ID }
-					type="visitors"
-					isEligible={
-						! item.is_deleted &&
-						( ! item.jetpack || hasJetpackModule( item, JetpackModules.STATS ) )
-					}
-				/>
-			),
+			render: ( { item } ) => <AsyncEngagementStat site={ item } type="visitors" />,
 			enableSorting: false,
 		},
 		{

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -373,13 +373,13 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			enableHiding: false,
 			enableSorting: false,
 		},
-		// {
-		// 	id: 'last_published',
-		// 	label: __( 'Last published' ),
-		// 	getValue: ( { item } ) => item.options?.updated_at ?? '',
-		// 	render: ( { item } ) =>
-		// 		item.options?.updated_at ? <TimeSince timestamp={ item.options.updated_at } /> : '',
-		// },
+		{
+			id: 'last_published',
+			label: __( 'Last published' ),
+			getValue: ( { item } ) => item.last_publish ?? '',
+			render: ( { item } ) =>
+				item.last_publish ? <TimeSince timestamp={ item.last_publish } /> : '',
+		},
 		{
 			id: 'uptime',
 			label: __( '7-day uptime' ),

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -16,7 +16,7 @@ import {
 	isSelfHostedJetpackConnected__ES,
 } from '../../utils/site-types';
 import { getSiteDisplayUrl } from '../../utils/site-url';
-import { getFormattedWordPressVersion, getFormattedWPVersion } from '../../utils/wp-version';
+import { getFormattedWordPressVersion, formatWordPressVersion } from '../../utils/wp-version';
 import {
 	AsyncEngagementStat,
 	EngagementStat,
@@ -307,7 +307,7 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 		{
 			id: 'wp_version',
 			label: __( 'WP version' ),
-			getValue: ( { item } ) => getFormattedWPVersion( item.wordpress_version ?? '' ),
+			getValue: ( { item } ) => formatWordPressVersion( item.wordpress_version ?? '' ),
 		},
 		{
 			id: 'is_a8c',

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -235,7 +235,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'storage',
 			label: __( 'Storage' ),
-			render: ( { item } ) => <MediaStorage site={ item } />,
+			render: ( { item } ) => <MediaStorage siteId={ item.ID } />,
 			enableSorting: false,
 		},
 		{
@@ -424,12 +424,12 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			render: ( { item }: { item: DashboardSiteListSite } ) => <PHPVersion__ES site={ item } />,
 			enableSorting: false,
 		},
-		// {
-		// 	id: 'storage',
-		// 	label: __( 'Storage' ),
-		// 	render: ( { item } ) => <MediaStorage site={ item } />,
-		// 	enableSorting: false,
-		// },
+		{
+			id: 'storage',
+			label: __( 'Storage' ),
+			render: ( { item } ) => <MediaStorage siteId={ item.blog_id } />,
+			enableSorting: false,
+		},
 		{
 			id: 'host',
 			label: __( 'Host' ),

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -26,6 +26,7 @@ import {
 	PHPVersion,
 	Plan,
 	Preview,
+	Preview__ES,
 	Status,
 	URL,
 	Uptime,
@@ -303,6 +304,13 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 				operators: [ 'is' as Operator ],
 			},
 			render: ( { item } ) => ( item.is_a8c ? __( 'Yes' ) : __( 'No' ) ),
+		},
+		{
+			id: 'preview',
+			label: __( 'Preview' ),
+			render: ( { item } ) => <Preview__ES site={ item } />,
+			enableHiding: false,
+			enableSorting: false,
 		},
 		{
 			id: 'visitors',

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -15,7 +15,7 @@ import {
 	isSelfHostedJetpackConnected__ES,
 } from '../../utils/site-types';
 import { getSiteDisplayUrl } from '../../utils/site-url';
-import { getFormattedWordPressVersion } from '../../utils/wp-version';
+import { getFormattedWordPressVersion, getFormattedWPVersion } from '../../utils/wp-version';
 import {
 	AsyncEngagementStat,
 	EngagementStat,
@@ -291,6 +291,11 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 
 				return direction === 'asc' ? planA.localeCompare( planB ) : planB.localeCompare( planA );
 			},
+		},
+		{
+			id: 'wp_version',
+			label: __( 'WP version' ),
+			getValue: ( { item } ) => getFormattedWPVersion( item.wordpress_version ?? '' ),
 		},
 		{
 			id: 'is_a8c',

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -343,12 +343,12 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			render: ( { item, field } ) => <EngagementStat value={ field.getValue( { item } ) } />,
 			enableSorting: false,
 		},
-		// {
-		// 	id: 'views',
-		// 	label: __( '7-day views' ),
-		// 	render: ( { item } ) => <AsyncEngagementStat site={ item } type="views" />,
-		// 	enableSorting: false,
-		// },
+		{
+			id: 'views',
+			label: __( '7-day views' ),
+			render: ( { item, field } ) => <EngagementStat value={ field.getValue( { item } ) } />,
+			enableSorting: false,
+		},
 		// {
 		// 	id: 'likes',
 		// 	label: __( '7-day likes' ),

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -1,18 +1,14 @@
-import { HostingFeatures, JetpackModules } from '@automattic/api-core';
-import { queryClient } from '@automattic/api-queries';
+import { JetpackModules } from '@automattic/api-core';
+import { queryClient, siteBySlugQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
+import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import SiteIcon, { SiteIconRenderer } from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
-import {
-	hasHostingFeature,
-	hasHostingFeature__ES,
-	hasJetpackModule,
-	hasJetpackModule__ES,
-} from '../../utils/site-features';
+import { hasJetpackModule } from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName, getSitePlanDisplayName__ES } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
@@ -76,12 +72,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'backup',
 			label: __( 'Backup' ),
-			render: ( { item } ) => (
-				<LastBackup
-					siteId={ item.ID }
-					isEligible={ hasHostingFeature( item, HostingFeatures.BACKUPS ) }
-				/>
-			),
+			render: ( { item } ) => <LastBackup site={ item } />,
 			enableSorting: false,
 		},
 		{
@@ -173,12 +164,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'uptime',
 			label: __( '7-day uptime' ),
-			render: ( { item } ) => (
-				<Uptime
-					siteId={ item.ID }
-					isEligible={ hasJetpackModule( item, JetpackModules.MONITOR ) }
-				/>
-			),
+			render: ( { item } ) => <Uptime site={ item } />,
 			enableSorting: false,
 		},
 		{
@@ -199,31 +185,13 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'views',
 			label: __( '7-day views' ),
-			render: ( { item } ) => (
-				<AsyncEngagementStat
-					siteId={ item.ID }
-					type="views"
-					isEligible={
-						! item.is_deleted &&
-						( ! item.jetpack || hasJetpackModule( item, JetpackModules.STATS ) )
-					}
-				/>
-			),
+			render: ( { item } ) => <AsyncEngagementStat site={ item } type="views" />,
 			enableSorting: false,
 		},
 		{
 			id: 'likes',
 			label: __( '7-day likes' ),
-			render: ( { item } ) => (
-				<AsyncEngagementStat
-					siteId={ item.ID }
-					type="likes"
-					isEligible={
-						! item.is_deleted &&
-						( ! item.jetpack || hasJetpackModule( item, JetpackModules.STATS ) )
-					}
-				/>
-			),
+			render: ( { item } ) => <AsyncEngagementStat site={ item } type="likes" />,
 			enableSorting: false,
 		},
 		{
@@ -235,7 +203,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'storage',
 			label: __( 'Storage' ),
-			render: ( { item } ) => <MediaStorage siteId={ item.ID } />,
+			render: ( { item } ) => <MediaStorage site={ item } />,
 			enableSorting: false,
 		},
 		{
@@ -249,6 +217,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 	];
 }
 
+// Use the site returned by siteBySlugQuery to render async fields (e.g. Backup) so the structure remains consistent.
 function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< DashboardSiteListSite >[] {
 	return [
 		{
@@ -300,12 +269,10 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 		{
 			id: 'backup',
 			label: __( 'Backup' ),
-			render: ( { item } ) => (
-				<LastBackup
-					siteId={ item.blog_id }
-					isEligible={ hasHostingFeature__ES( item, HostingFeatures.BACKUPS ) }
-				/>
-			),
+			render: function BackupField( { item } ) {
+				const { data: site } = useQuery( siteBySlugQuery( item.slug ) );
+				return <LastBackup site={ site } />;
+			},
 			enableSorting: false,
 		},
 		{
@@ -383,12 +350,10 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 		{
 			id: 'uptime',
 			label: __( '7-day uptime' ),
-			render: ( { item } ) => (
-				<Uptime
-					siteId={ item.blog_id }
-					isEligible={ hasJetpackModule__ES( item, JetpackModules.MONITOR ) }
-				/>
-			),
+			render: function UptimeField( { item } ) {
+				const { data: site } = useQuery( siteBySlugQuery( item.slug ) );
+				return <Uptime site={ site } />;
+			},
 			enableSorting: false,
 		},
 		{
@@ -406,16 +371,10 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 		{
 			id: 'likes',
 			label: __( '7-day likes' ),
-			render: ( { item } ) => (
-				<AsyncEngagementStat
-					siteId={ item.blog_id }
-					type="likes"
-					isEligible={
-						! item.deleted &&
-						( ! item.is_jetpack || hasJetpackModule__ES( item, JetpackModules.STATS ) )
-					}
-				/>
-			),
+			render: function LikesField( { item } ) {
+				const { data: site } = useQuery( siteBySlugQuery( item.slug ) );
+				return <AsyncEngagementStat site={ site } type="likes" />;
+			},
 			enableSorting: false,
 		},
 		{
@@ -427,7 +386,10 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 		{
 			id: 'storage',
 			label: __( 'Storage' ),
-			render: ( { item } ) => <MediaStorage siteId={ item.blog_id } />,
+			render: function StorageField( { item } ) {
+				const { data: site } = useQuery( siteBySlugQuery( item.slug ) );
+				return <MediaStorage site={ site } />;
+			},
 			enableSorting: false,
 		},
 		{

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -24,6 +24,7 @@ import {
 	Name,
 	NameRenderer,
 	PHPVersion,
+	PHPVersion__ES,
 	Plan,
 	Preview,
 	Preview__ES,
@@ -321,6 +322,12 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			id: 'visitors',
 			label: __( '7-day visitors' ),
 			render: ( { item, field } ) => <EngagementStat value={ field.getValue( { item } ) } />,
+			enableSorting: false,
+		},
+		{
+			id: 'php_version',
+			label: __( 'PHP version' ),
+			render: ( { item }: { item: DashboardSiteListSite } ) => <PHPVersion__ES site={ item } />,
 			enableSorting: false,
 		},
 	];

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -253,6 +253,12 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			getValue: ( { item } ) => item.total_wpcom_subscribers,
 			label: __( 'Subscribers' ),
 		},
+		// {
+		// 	id: 'backup',
+		// 	label: __( 'Backup' ),
+		// 	render: ( { item } ) => <LastBackup site={ item } />,
+		// 	enableSorting: false,
+		// },
 		{
 			id: 'plan',
 			label: __( 'Plan' ),
@@ -318,18 +324,49 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			enableHiding: false,
 			enableSorting: false,
 		},
+		// {
+		// 	id: 'last_published',
+		// 	label: __( 'Last published' ),
+		// 	getValue: ( { item } ) => item.options?.updated_at ?? '',
+		// 	render: ( { item } ) =>
+		// 		item.options?.updated_at ? <TimeSince timestamp={ item.options.updated_at } /> : '',
+		// },
+		// {
+		// 	id: 'uptime',
+		// 	label: __( '7-day uptime' ),
+		// 	render: ( { item } ) => <Uptime site={ item } />,
+		// 	enableSorting: false,
+		// },
 		{
 			id: 'visitors',
 			label: __( '7-day visitors' ),
 			render: ( { item, field } ) => <EngagementStat value={ field.getValue( { item } ) } />,
 			enableSorting: false,
 		},
+		// {
+		// 	id: 'views',
+		// 	label: __( '7-day views' ),
+		// 	render: ( { item } ) => <AsyncEngagementStat site={ item } type="views" />,
+		// 	enableSorting: false,
+		// },
+		// {
+		// 	id: 'likes',
+		// 	label: __( '7-day likes' ),
+		// 	render: ( { item } ) => <AsyncEngagementStat site={ item } type="likes" />,
+		// 	enableSorting: false,
+		// },
 		{
 			id: 'php_version',
 			label: __( 'PHP version' ),
 			render: ( { item }: { item: DashboardSiteListSite } ) => <PHPVersion__ES site={ item } />,
 			enableSorting: false,
 		},
+		// {
+		// 	id: 'storage',
+		// 	label: __( 'Storage' ),
+		// 	render: ( { item } ) => <MediaStorage site={ item } />,
+		// 	enableSorting: false,
+		// },
 		{
 			id: 'host',
 			label: __( 'Host' ),

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -81,6 +81,7 @@ function getFetchSiteListParams(
 		// preview
 		// last_published
 		// uptime
+		views: 'views',
 		visitors: 'visitors',
 		subscribers_count: 'total_wpcom_subscribers',
 		// links

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -93,6 +93,7 @@ function getFetchSiteListParams(
 		name: [ 'badge' ],
 		status: [ 'wpcom_status', 'private', 'deleted' ],
 		plan: [ 'owner_id' ],
+		preview: [ 'name', 'icon', 'url', 'private', 'deleted' ],
 	};
 
 	// Always include ID and slug (for navigation), deleted (for styling), is_a8c (for included a8c owned) and other (for vip & self hosted jetpack)

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -84,7 +84,7 @@ function getFetchSiteListParams(
 		visitors: 'visitors',
 		subscribers_count: 'total_wpcom_subscribers',
 		// links
-		// php_version
+		php_version: 'php_version',
 		// storage
 		// host
 	};

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -91,6 +91,7 @@ function getFetchSiteListParams(
 	};
 
 	const additionalMappedFields: Record< string, ( keyof DashboardSiteListSite )[] > = {
+		likes: [ 'enabled_modules' ],
 		name: [ 'badge' ],
 		status: [ 'wpcom_status', 'private', 'deleted' ],
 		plan: [ 'owner_id' ],

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -79,7 +79,7 @@ function getFetchSiteListParams(
 		wp_version: 'wordpress_version',
 		is_a8c: 'is_a8c',
 		// preview
-		// last_published
+		last_published: 'last_publish',
 		// uptime
 		views: 'views',
 		visitors: 'visitors',

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -76,7 +76,7 @@ function getFetchSiteListParams(
 		backup: 'has_backup',
 		// views: 'stats_views',
 		plan: 'plan',
-		// wp_version
+		wp_version: 'wordpress_version',
 		is_a8c: 'is_a8c',
 		// preview
 		// last_published

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -86,7 +86,7 @@ function getFetchSiteListParams(
 		// links
 		php_version: 'php_version',
 		// storage
-		// host
+		host: 'hosting_provider_guess',
 	};
 
 	const additionalMappedFields: Record< string, ( keyof DashboardSiteListSite )[] > = {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -390,14 +390,14 @@ export function PHPVersion__ES( { site }: { site: DashboardSiteListSite } ) {
 	return site.php_version ? <span>{ site.php_version }</span> : <IneligibleIndicator />;
 }
 
-export function MediaStorage( { site }: { site: Site } ) {
+export function MediaStorage( { siteId }: { siteId: number } ) {
 	const { ref, inView } = useInView( {
 		triggerOnce: true,
 		fallbackInView: true,
 	} );
 
 	const { data: mediaStorage, isLoading } = useQuery( {
-		...siteMediaStorageQuery( site.ID ),
+		...siteMediaStorageQuery( siteId ),
 		enabled: inView,
 	} );
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -20,7 +20,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useInView } from 'react-intersection-observer';
 import { useAnalytics } from '../../app/analytics';
 import ComponentViewTracker from '../../components/component-view-tracker';
-import SiteIcon from '../../components/site-icon';
+import SiteIcon, { SiteIconRenderer } from '../../components/site-icon';
 import { Text } from '../../components/text';
 import { TextBlur } from '../../components/text-blur';
 import TimeSince from '../../components/time-since';
@@ -233,6 +233,50 @@ export function Preview( { site }: { site: Site } ) {
 				<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
 			) }
 		</div>
+	);
+}
+
+export function Preview__ES( { site }: { site: DashboardSiteListSite } ) {
+	const [ resizeListener, { width } ] = useResizeObserver();
+
+	// If the site is a private A8C site, X-Frame-Options is set to same
+	// origin.
+	const iframeDisabled = site.deleted || ( site.is_a8c && site.private );
+	return (
+		<Link
+			to={ getSiteManagementUrl__ES( site ) }
+			disabled={ site.deleted }
+			style={ {
+				display: 'block',
+				height: '100%',
+				width: '100%',
+				borderRadius: 'inherit',
+				overflow: 'hidden',
+			} }
+		>
+			{ resizeListener }
+			{ iframeDisabled && (
+				<div
+					style={ {
+						fontSize: '24px',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						height: '100%',
+					} }
+				>
+					<SiteIconRenderer
+						alt={ site.name ?? '' }
+						fallbackInitial={ site.name?.charAt( 0 ) ?? '' }
+						icon={ site.icon ?? undefined }
+						isMigration={ false }
+					/>
+				</div>
+			) }
+			{ width && ! iframeDisabled && (
+				<SitePreview url={ site.url?.with_scheme ?? '' } scale={ width / 1200 } height={ 1200 } />
+			) }
+		</Link>
 	);
 }
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -390,7 +390,7 @@ export function PHPVersion( { site }: { site: Site } ) {
 
 export function PHPVersion__ES( { site }: { site: DashboardSiteListSite } ) {
 	return site.php_version ? (
-		<span>{ site.php_version.split( '.' ).slice( 0, 2 ).join( '.' ) }</span> // Drop patch version.
+		site.php_version.split( '.' ).slice( 0, 2 ).join( '.' ) // Drop patch version.
 	) : (
 		<IneligibleIndicator />
 	);

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -279,18 +279,18 @@ export function Preview__ES( { site }: { site: DashboardSiteListSite } ) {
 }
 
 export function AsyncEngagementStat( {
-	site,
+	siteId,
 	type,
+	isEligible,
 }: {
-	site: Site;
+	siteId: number;
 	type: 'visitors' | 'views' | 'likes';
+	isEligible?: boolean;
 } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
-	const isEligible =
-		! site.is_deleted && ( ! site.jetpack || hasJetpackModule( site, JetpackModules.STATS ) );
 
 	const { data: stats, isLoading } = useQuery( {
-		...siteEngagementStatsQuery( site.ID ),
+		...siteEngagementStatsQuery( siteId ),
 		enabled: isEligible && inView,
 	} );
 
@@ -313,7 +313,7 @@ export function EngagementStat( { value }: { value: number | null } ) {
 	return typeof value !== 'number' ? <IneligibleIndicator /> : value;
 }
 
-export function LastBackup( { siteId, isEligible }: { siteId: number; isEligible: boolean } ) {
+export function LastBackup( { siteId, isEligible }: { siteId: number; isEligible?: boolean } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
 
 	const {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -390,6 +390,10 @@ export function PHPVersion( { site }: { site: Site } ) {
 	return <span ref={ ref }>{ ! isLoading ? data : <LoadingIndicator label="X.Y" /> }</span>;
 }
 
+export function PHPVersion__ES( { site }: { site: DashboardSiteListSite } ) {
+	return site.php_version ? <span>{ site.php_version }</span> : <IneligibleIndicator />;
+}
+
 export function MediaStorage( { site }: { site: Site } ) {
 	const { ref, inView } = useInView( {
 		triggerOnce: true,

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -243,9 +243,7 @@ export function Preview__ES( { site }: { site: DashboardSiteListSite } ) {
 	// origin.
 	const iframeDisabled = site.deleted || ( site.is_a8c && site.private );
 	return (
-		<Link
-			to={ getSiteManagementUrl__ES( site ) }
-			disabled={ site.deleted }
+		<div
 			style={ {
 				display: 'block',
 				height: '100%',
@@ -276,7 +274,7 @@ export function Preview__ES( { site }: { site: DashboardSiteListSite } ) {
 			{ width && ! iframeDisabled && (
 				<SitePreview url={ site.url?.with_scheme ?? '' } scale={ width / 1200 } height={ 1200 } />
 			) }
-		</Link>
+		</div>
 	);
 }
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -1,4 +1,4 @@
-import { DotcomFeatures, HostingFeatures } from '@automattic/api-core';
+import { DotcomFeatures, HostingFeatures, JetpackModules } from '@automattic/api-core';
 import {
 	siteLatestAtomicTransferQuery,
 	siteLastBackupQuery,
@@ -28,7 +28,7 @@ import { addTransientViewPropertiesToQueryParams } from '../../utils/dashboard-v
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { isAtomicTransferInProgress } from '../../utils/site-atomic-transfers';
-import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
+import { hasHostingFeature, hasJetpackModule, hasPlanFeature } from '../../utils/site-features';
 import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
 import { isP2 } from '../../utils/site-types';
 import { getSiteFormattedUrl } from '../../utils/site-url';
@@ -279,28 +279,28 @@ export function Preview__ES( { site }: { site: DashboardSiteListSite } ) {
 }
 
 export function AsyncEngagementStat( {
-	siteId,
+	site,
 	type,
-	isEligible,
 }: {
-	siteId: number;
+	site?: Site;
 	type: 'visitors' | 'views' | 'likes';
-	isEligible?: boolean;
 } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
+	const isEligible =
+		! site?.is_deleted && ( ! site?.jetpack || hasJetpackModule( site, JetpackModules.STATS ) );
 
 	const { data: stats, isLoading } = useQuery( {
-		...siteEngagementStatsQuery( siteId ),
-		enabled: isEligible && inView,
+		...siteEngagementStatsQuery( site?.ID ?? 0 ),
+		enabled: !! site?.ID && isEligible && inView,
 	} );
 
-	if ( ! isEligible ) {
-		return <IneligibleIndicator />;
-	}
-
 	const renderContent = () => {
-		if ( isLoading ) {
+		if ( ! site || isLoading ) {
 			return <LoadingIndicator label="100" />;
+		}
+
+		if ( ! isEligible ) {
+			return <IneligibleIndicator />;
 		}
 
 		return stats?.currentData[ type ];
@@ -313,25 +313,26 @@ export function EngagementStat( { value }: { value: number | null } ) {
 	return typeof value !== 'number' ? <IneligibleIndicator /> : value;
 }
 
-export function LastBackup( { siteId, isEligible }: { siteId: number; isEligible?: boolean } ) {
+export function LastBackup( { site }: { site?: Site } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
+	const isEligible = site && hasHostingFeature( site, HostingFeatures.BACKUPS );
 
 	const {
 		data: lastBackup,
 		isLoading,
 		isError,
 	} = useQuery( {
-		...siteLastBackupQuery( siteId ),
-		enabled: isEligible && inView,
+		...siteLastBackupQuery( site?.ID ?? 0 ),
+		enabled: !! site?.ID && isEligible && inView,
 	} );
 
-	if ( ! isEligible ) {
-		return <IneligibleIndicator />;
-	}
-
 	const renderContent = () => {
-		if ( isLoading ) {
+		if ( ! site || isLoading ) {
 			return <LoadingIndicator label="Unknown" />;
+		}
+
+		if ( ! isEligible ) {
+			return <IneligibleIndicator />;
 		}
 
 		if ( ! lastBackup || isError ) {
@@ -344,21 +345,22 @@ export function LastBackup( { siteId, isEligible }: { siteId: number; isEligible
 	return <span ref={ ref }>{ renderContent() }</span>;
 }
 
-export function Uptime( { siteId, isEligible }: { siteId: number; isEligible?: boolean } ) {
+export function Uptime( { site }: { site?: Site } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
+	const isEligible = site && hasJetpackModule( site, JetpackModules.MONITOR );
 
 	const { data: uptime, isLoading } = useQuery( {
-		...siteUptimeQuery( siteId, 'week' ),
-		enabled: isEligible && inView,
+		...siteUptimeQuery( site?.ID ?? 0, 'week' ),
+		enabled: !! site?.ID && isEligible && inView,
 	} );
 
-	if ( ! isEligible ) {
-		return <IneligibleIndicator />;
-	}
-
 	const renderContent = () => {
-		if ( isLoading ) {
+		if ( ! site || isLoading ) {
 			return <LoadingIndicator label="100%" />;
+		}
+
+		if ( ! isEligible ) {
+			return <IneligibleIndicator />;
 		}
 
 		return uptime ? `${ uptime }%` : <IneligibleIndicator />;
@@ -394,26 +396,31 @@ export function PHPVersion__ES( { site }: { site: DashboardSiteListSite } ) {
 	);
 }
 
-export function MediaStorage( { siteId }: { siteId: number } ) {
+export function MediaStorage( { site }: { site?: Site } ) {
 	const { ref, inView } = useInView( {
 		triggerOnce: true,
 		fallbackInView: true,
 	} );
 
 	const { data: mediaStorage, isLoading } = useQuery( {
-		...siteMediaStorageQuery( siteId ),
-		enabled: inView,
+		...siteMediaStorageQuery( site?.ID ?? 0 ),
+		enabled: !! site?.ID && inView,
 	} );
 
-	const value = mediaStorage ? (
-		`${
-			Math.round( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10
-		}%`
-	) : (
-		<IneligibleIndicator />
-	);
+	const renderContent = () => {
+		if ( ! site || isLoading ) {
+			return <LoadingIndicator label="100%" />;
+		}
 
-	return <span ref={ ref }>{ ! isLoading ? value : <LoadingIndicator label="100%" /> }</span>;
+		if ( ! mediaStorage ) {
+			return <IneligibleIndicator />;
+		}
+
+		const { storage_used_bytes, max_storage_bytes } = mediaStorage;
+		return `${ Math.round( ( storage_used_bytes / max_storage_bytes ) * 1000 ) / 10 }%`;
+	};
+
+	return <span ref={ ref }>{ renderContent() }</span>;
 }
 
 function SiteLaunchNag( { site }: { site: Site } ) {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -1,4 +1,4 @@
-import { DotcomFeatures, HostingFeatures, JetpackModules } from '@automattic/api-core';
+import { DotcomFeatures, HostingFeatures } from '@automattic/api-core';
 import {
 	siteLatestAtomicTransferQuery,
 	siteLastBackupQuery,
@@ -28,7 +28,7 @@ import { addTransientViewPropertiesToQueryParams } from '../../utils/dashboard-v
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { isAtomicTransferInProgress } from '../../utils/site-atomic-transfers';
-import { hasHostingFeature, hasJetpackModule, hasPlanFeature } from '../../utils/site-features';
+import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
 import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
 import { isP2 } from '../../utils/site-types';
 import { getSiteFormattedUrl } from '../../utils/site-url';
@@ -344,12 +344,11 @@ export function LastBackup( { siteId, isEligible }: { siteId: number; isEligible
 	return <span ref={ ref }>{ renderContent() }</span>;
 }
 
-export function Uptime( { site }: { site: Site } ) {
+export function Uptime( { siteId, isEligible }: { siteId: number; isEligible?: boolean } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
-	const isEligible = hasJetpackModule( site, JetpackModules.MONITOR );
 
 	const { data: uptime, isLoading } = useQuery( {
-		...siteUptimeQuery( site.ID, 'week' ),
+		...siteUptimeQuery( siteId, 'week' ),
 		enabled: isEligible && inView,
 	} );
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -387,7 +387,11 @@ export function PHPVersion( { site }: { site: Site } ) {
 }
 
 export function PHPVersion__ES( { site }: { site: DashboardSiteListSite } ) {
-	return site.php_version ? <span>{ site.php_version }</span> : <IneligibleIndicator />;
+	return site.php_version ? (
+		<span>{ site.php_version.split( '.' ).slice( 0, 2 ).join( '.' ) }</span> // Drop patch version.
+	) : (
+		<IneligibleIndicator />
+	);
 }
 
 export function MediaStorage( { siteId }: { siteId: number } ) {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -313,16 +313,15 @@ export function EngagementStat( { value }: { value: number | null } ) {
 	return typeof value !== 'number' ? <IneligibleIndicator /> : value;
 }
 
-export function LastBackup( { site }: { site: Site } ) {
+export function LastBackup( { siteId, isEligible }: { siteId: number; isEligible: boolean } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
-	const isEligible = hasHostingFeature( site, HostingFeatures.BACKUPS );
 
 	const {
 		data: lastBackup,
 		isLoading,
 		isError,
 	} = useQuery( {
-		...siteLastBackupQuery( site.ID ),
+		...siteLastBackupQuery( siteId ),
 		enabled: isEligible && inView,
 	} );
 

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -45,3 +45,10 @@ export function hasHostingFeature__ES( site: DashboardSiteListSite, feature: Hos
 export function hasJetpackModule( site: Site, module: `${ JetpackModuleSlug }` ) {
 	return site.jetpack && site.jetpack_modules?.includes( module );
 }
+
+export function hasJetpackModule__ES(
+	site: DashboardSiteListSite,
+	module: `${ JetpackModuleSlug }`
+) {
+	return site.is_jetpack && site.enabled_modules?.includes( module );
+}

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -5,7 +5,6 @@ import type {
 	JetpackFeatureSlug,
 	JetpackModuleSlug,
 	Site,
-	DashboardSiteListSite,
 } from '@automattic/api-core';
 
 // Returns whether the plan supports a specific feature.
@@ -32,23 +31,6 @@ export function hasHostingFeature( site: Site, feature: HostingFeatureSlug ) {
 	return hasPlanFeature( site, feature );
 }
 
-export function hasHostingFeature__ES( site: DashboardSiteListSite, feature: HostingFeatureSlug ) {
-	if ( hasPlanFeature( site, DotcomFeatures.ATOMIC ) ) {
-		// TODO: Check flex site when it's supported.
-		if ( site.plan?.expired || ! site.is_atomic ) {
-			return false;
-		}
-	}
-	return hasPlanFeature( site, feature );
-}
-
 export function hasJetpackModule( site: Site, module: `${ JetpackModuleSlug }` ) {
 	return site.jetpack && site.jetpack_modules?.includes( module );
-}
-
-export function hasJetpackModule__ES(
-	site: DashboardSiteListSite,
-	module: `${ JetpackModuleSlug }`
-) {
-	return site.is_jetpack && site.enabled_modules?.includes( module );
 }

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -5,6 +5,7 @@ import type {
 	JetpackFeatureSlug,
 	JetpackModuleSlug,
 	Site,
+	DashboardSiteListSite,
 } from '@automattic/api-core';
 
 // Returns whether the plan supports a specific feature.
@@ -25,6 +26,16 @@ export function hasHostingFeature( site: Site, feature: HostingFeatureSlug ) {
 	if ( hasPlanFeature( site, DotcomFeatures.ATOMIC ) ) {
 		const isWoAOrFlexSite = site.is_wpcom_atomic || site.is_wpcom_flex;
 		if ( site.plan?.expired || ! isWoAOrFlexSite ) {
+			return false;
+		}
+	}
+	return hasPlanFeature( site, feature );
+}
+
+export function hasHostingFeature__ES( site: DashboardSiteListSite, feature: HostingFeatureSlug ) {
+	if ( hasPlanFeature( site, DotcomFeatures.ATOMIC ) ) {
+		// TODO: Check flex site when it's supported.
+		if ( site.plan?.expired || ! site.is_atomic ) {
 			return false;
 		}
 	}

--- a/client/dashboard/utils/site-provider.ts
+++ b/client/dashboard/utils/site-provider.ts
@@ -2,7 +2,7 @@ import type { Site } from '@automattic/api-core';
 
 export const DEFAULT_PROVIDER_NAME = 'WordPress.com';
 
-export function getSiteProviderName( site: Site ) {
+export function getSiteProviderName( site: Pick< Site, 'hosting_provider_guess' > ) {
 	const provider = site.hosting_provider_guess;
 	let providerName;
 	if ( provider === 'jurassic_ninja' ) {

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -15,10 +15,10 @@ export function getFormattedWordPressVersion(
 	site: Site,
 	versionTag: string | undefined = undefined
 ) {
-	return getFormattedWPVersion( site.options?.software_version ?? '', versionTag );
+	return formatWordPressVersion( site.options?.software_version ?? '', versionTag );
 }
 
-export function getFormattedWPVersion(
+export function formatWordPressVersion(
 	wpVersion: string,
 	versionTag: string | undefined = undefined
 ) {

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -15,7 +15,13 @@ export function getFormattedWordPressVersion(
 	site: Site,
 	versionTag: string | undefined = undefined
 ) {
-	let wpVersion = site.options?.software_version;
+	return getFormattedWPVersion( site.options?.software_version ?? '', versionTag );
+}
+
+export function getFormattedWPVersion(
+	wpVersion: string,
+	versionTag: string | undefined = undefined
+) {
 	if ( ! wpVersion ) {
 		return '';
 	}

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -5,6 +5,7 @@ export interface DashboardSiteListSite {
 		manage_options: boolean;
 	};
 	deleted?: boolean;
+	enabled_modules?: null | string[];
 	has_backup?: boolean;
 	hosting_provider_guess?: string;
 	name?: string;

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -6,6 +6,7 @@ export interface DashboardSiteListSite {
 	};
 	deleted?: boolean;
 	has_backup?: boolean;
+	hosting_provider_guess?: string;
 	name?: string;
 	plan?: {
 		product_id: number;

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -32,6 +32,7 @@ export interface DashboardSiteListSite {
 	owner_id?: number;
 	php_version?: string;
 	slug: string; // Slug is always fetched
+	views?: null | number;
 	visitors?: null | number;
 	total_wpcom_subscribers?: number;
 	url?: { value: string; with_scheme: string };

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -29,6 +29,7 @@ export interface DashboardSiteListSite {
 	is_p2?: boolean;
 	is_vip?: boolean;
 	owner_id?: number;
+	php_version?: string;
 	slug: string; // Slug is always fetched
 	visitors?: null | number;
 	total_wpcom_subscribers?: number;

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -33,6 +33,7 @@ export interface DashboardSiteListSite {
 	visitors?: null | number;
 	total_wpcom_subscribers?: number;
 	url?: { value: string; with_scheme: string };
+	wordpress_version?: string;
 	wpcom_status?: {
 		is_staging: boolean;
 		is_coming_soon: boolean;

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -30,6 +30,7 @@ export interface DashboardSiteListSite {
 	is_jetpack?: boolean;
 	is_p2?: boolean;
 	is_vip?: boolean;
+	last_publish?: string;
 	owner_id?: number;
 	php_version?: string;
 	slug: string; // Slug is always fetched


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-868

## Proposed Changes

* Render more fields using ES data as below
  * Preview (only in Grid view) 
  * WordPress version
  * PHP Version
  * Host
  * Views
  * Backup
  * Liks
  * Last published
  * Uptime
  * Storage

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Migration to ES site list

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/sites
* Enable following fields
  * WordPress version
  * PHP Version
  * Host
* Ensure it works as expected
* Switch to Grid view
* Ensure preview works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
