### PR TITLE
SSH Migration: Add button to request help on the authentication error message

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -6,6 +6,8 @@ import emailValidator from 'email-validator';
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { MigrationStatus } from 'calypso/data/site-migration/landing/types';
+import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/use-update-migration-status';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -87,6 +89,7 @@ const SiteMigrationSshShareAccess: StepType< {
 	const locale = useLocale();
 	const siteSlug = useSiteSlugParam() ?? '';
 	const { sendTicketAsync, isPending: isSubmittingTicket } = useSubmitMigrationTicket();
+	const { mutateAsync: updateMigrationStatus } = useUpdateMigrationStatus( siteId );
 
 	// Redirect back to verification step if transferId is missing
 	useEffect( () => {
@@ -173,6 +176,9 @@ const SiteMigrationSshShareAccess: StepType< {
 				blog_url: siteSlug,
 			} );
 
+			// Update migration status to pending DIY
+			await updateMigrationStatus( { status: MigrationStatus.STARTED_DIFM } );
+
 			// Reset the site in the state to ensure the correct overview screen is shown.
 			siteId && dispatch( resetSite( siteId ) );
 
@@ -182,7 +188,16 @@ const SiteMigrationSshShareAccess: StepType< {
 		} catch ( error ) {
 			// TODO: Handle error
 		}
-	}, [ locale, fromUrl, siteSlug, siteId, dispatch, navigation, sendTicketAsync ] );
+	}, [
+		locale,
+		fromUrl,
+		siteSlug,
+		siteId,
+		dispatch,
+		navigation,
+		sendTicketAsync,
+		updateMigrationStatus,
+	] );
 
 	const navigateToDoItForMe = useCallback( () => {
 		handleSkip();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -156,6 +156,38 @@ const SiteMigrationSshShareAccess: StepType< {
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 
+	const handleSkip = useCallback( async () => {
+		recordTracksEvent( 'calypso_site_migration_ssh_action', {
+			step: 'share_access',
+			action: 'click_assisted_migration',
+		} );
+		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
+			path: window.location.pathname,
+			automated_migration: true,
+		} );
+
+		try {
+			await sendTicketAsync( {
+				locale,
+				from_url: fromUrl,
+				blog_url: siteSlug,
+			} );
+
+			// Reset the site in the state to ensure the correct overview screen is shown.
+			siteId && dispatch( resetSite( siteId ) );
+
+			return navigation.submit?.( {
+				destination: 'do-it-for-me',
+			} );
+		} catch ( error ) {
+			// TODO: Handle error
+		}
+	}, [ locale, fromUrl, siteSlug, siteId, dispatch, navigation, sendTicketAsync ] );
+
+	const navigateToDoItForMe = useCallback( () => {
+		handleSkip();
+	}, [ handleSkip ] );
+
 	// Poll for migration status after starting migration
 	const { data: migrationStatus } = useSSHMigrationStatus( {
 		siteId,
@@ -180,11 +212,13 @@ const SiteMigrationSshShareAccess: StepType< {
 		siteName: site?.name ?? '',
 		host,
 		onNoSSHAccess: handleNoSSHAccess,
+		onAskForHelp: navigateToDoItForMe,
 		migrationStatus: migrationStatus?.status,
 		isTransferring,
 		isInputDisabled:
 			isStartingMigration || migrationStarted || shouldStartMigration || isProcessingNoSSH,
 		isProcessingNoSSH,
+		isProcessingAssistedMigration: isSubmittingTicket,
 	} );
 
 	// Redirect to in-progress step when status becomes 'migrating', or show error if failed
@@ -275,38 +309,6 @@ const SiteMigrationSshShareAccess: StepType< {
 			triggerSSHMigration();
 		}
 	}, [ transferStatus, shouldStartMigration, triggerSSHMigration ] );
-
-	const handleSkip = useCallback( async () => {
-		recordTracksEvent( 'calypso_site_migration_ssh_action', {
-			step: 'share_access',
-			action: 'click_assisted_migration',
-		} );
-		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
-			path: window.location.pathname,
-			automated_migration: true,
-		} );
-
-		try {
-			await sendTicketAsync( {
-				locale,
-				from_url: fromUrl,
-				blog_url: siteSlug,
-			} );
-
-			// Reset the site in the state to ensure the correct overview screen is shown.
-			siteId && dispatch( resetSite( siteId ) );
-
-			return navigation.submit?.( {
-				destination: 'do-it-for-me',
-			} );
-		} catch ( error ) {
-			// TODO: Handle error
-		}
-	}, [ locale, fromUrl, siteSlug, siteId, dispatch, navigation, sendTicketAsync ] );
-
-	const navigateToDoItForMe = useCallback( () => {
-		handleSkip();
-	}, [ handleSkip ] );
 
 	const displaySiteName = urlToDomain( fromUrl );
 	const hostDisplayName = getSSHHostDisplayName( host );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -115,28 +115,29 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 				} }
 				type="button"
 				disabled={ isProcessingAssistedMigration }
-			/>
+			>
+				{ translate( 'Need help? Let us migrate your site' ) }
+				{ isProcessingAssistedMigration && <Spinner /> }
+			</Button>
 		);
 
 		// Provide specific guidance based on authentication method with link to assisted migration
 		if ( authMethod === 'password' ) {
 			return translate(
-				'SSH authentication failed. Please verify your SSH username and password are correct and try again. {{button}}Need help? Let us migrate your site{{spinner/}}{{/button}}',
+				'SSH authentication failed. Please verify your SSH username and password are correct and try again. {{button/}}',
 				{
 					components: {
 						button: AskForHelpButton,
-						spinner: isProcessingAssistedMigration ? <Spinner /> : null,
 					},
 				}
 			);
 		}
 
 		return translate(
-			'SSH authentication failed. Please ensure your SSH key is properly configured on the source site and try again. {{button}}Need help? Let us migrate your site{{spinner/}}{{/button}}',
+			'SSH authentication failed. Please ensure your SSH key is properly configured on the source site and try again. {{button/}}',
 			{
 				components: {
 					button: AskForHelpButton,
-					spinner: isProcessingAssistedMigration ? <Spinner /> : null,
 				},
 			}
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon } from '@wordpress/components';
+import { Button, Icon, Spinner } from '@wordpress/components';
 import { check, edit, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode, useState } from 'react';
@@ -24,10 +24,12 @@ interface StepShareSSHAccessProps {
 	onPasswordChange: ( password: string ) => void;
 	onGenerateSSHKey: () => void;
 	onEditUsername: () => void;
+	onAskForHelp: () => void;
 	helpLink: ReactNode;
 	isTransferring: boolean;
 	shouldGenerateKey: boolean;
 	isInputDisabled: boolean;
+	isProcessingAssistedMigration: boolean;
 }
 
 export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
@@ -45,10 +47,12 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 	onPasswordChange,
 	onGenerateSSHKey,
 	onEditUsername,
+	onAskForHelp,
 	helpLink,
 	isTransferring,
 	shouldGenerateKey,
 	isInputDisabled,
+	isProcessingAssistedMigration,
 } ) => {
 	const translate = useTranslate();
 	const [ copied, setCopied ] = useState( false );
@@ -98,15 +102,43 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 			);
 		}
 
-		// Provide specific guidance based on authentication method
+		const AskForHelpButton = (
+			<Button
+				variant="link"
+				onClick={ () => {
+					recordTracksEvent( 'calypso_site_migration_ssh_action', {
+						step: 'share-ssh-access',
+						action: 'click_assisted_migration_from_error',
+						auth_method: authMethod,
+					} );
+					onAskForHelp();
+				} }
+				type="button"
+				disabled={ isProcessingAssistedMigration }
+			/>
+		);
+
+		// Provide specific guidance based on authentication method with link to assisted migration
 		if ( authMethod === 'password' ) {
 			return translate(
-				'SSH authentication failed. Please verify your SSH username and password are correct and try again.'
+				'SSH authentication failed. Please verify your SSH username and password are correct and try again. {{button}}Need help? Let us migrate your site{{spinner/}}{{/button}}',
+				{
+					components: {
+						button: AskForHelpButton,
+						spinner: isProcessingAssistedMigration ? <Spinner /> : null,
+					},
+				}
 			);
 		}
 
 		return translate(
-			'SSH authentication failed. Please ensure your SSH key is properly configured on the source site and try again.'
+			'SSH authentication failed. Please ensure your SSH key is properly configured on the source site and try again. {{button}}Need help? Let us migrate your site{{spinner/}}{{/button}}',
+			{
+				components: {
+					button: AskForHelpButton,
+					spinner: isProcessingAssistedMigration ? <Spinner /> : null,
+				},
+			}
 		);
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -38,12 +38,14 @@ interface StepsDataOptions {
 	onGenerateSSHKey: () => void;
 	onEditUsername: () => void;
 	onFindSSHDetailsSuccess: () => void;
+	onAskForHelp: () => void;
 	host?: string;
 	onNoSSHAccess: () => void;
 	isTransferring: boolean;
 	shouldGenerateKey: boolean;
 	isInputDisabled: boolean;
 	isProcessingNoSSH: boolean;
+	isProcessingAssistedMigration: boolean;
 }
 
 interface StepData {
@@ -78,10 +80,12 @@ interface UseStepsOptions {
 	siteName: string;
 	host?: string;
 	onNoSSHAccess: () => void;
+	onAskForHelp: () => void;
 	migrationStatus?: 'queued' | 'in-progress' | 'migrating' | 'completed' | 'failed';
 	isTransferring: boolean;
 	isInputDisabled: boolean;
 	isProcessingNoSSH?: boolean;
+	isProcessingAssistedMigration?: boolean;
 }
 
 interface SSHFormState {
@@ -164,6 +168,7 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 					onPasswordChange={ options.onPasswordChange }
 					onGenerateSSHKey={ options.onGenerateSSHKey }
 					onEditUsername={ options.onEditUsername }
+					onAskForHelp={ options.onAskForHelp }
 					helpLink={
 						<HelpLink
 							supportLink={ supportDoc.url }
@@ -174,6 +179,7 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 					isTransferring={ options.isTransferring }
 					shouldGenerateKey={ options.shouldGenerateKey }
 					isInputDisabled={ options.isInputDisabled }
+					isProcessingAssistedMigration={ options.isProcessingAssistedMigration }
 				/>
 			),
 		},
@@ -187,11 +193,13 @@ export const useSteps = ( {
 	siteId,
 	siteName,
 	onNoSSHAccess,
+	onAskForHelp,
 	host,
 	migrationStatus,
 	isTransferring,
 	isInputDisabled,
 	isProcessingNoSSH = false,
+	isProcessingAssistedMigration = false,
 }: UseStepsOptions ): StepsObject => {
 	const [ currentStep, setCurrentStep ] = useState( -1 );
 	const [ lastCompleteStep, setLastCompleteStep ] = useState( -1 );
@@ -349,12 +357,14 @@ export const useSteps = ( {
 		onGenerateSSHKey: handleGenerateSSHKey,
 		onEditUsername: handleEditUsername,
 		onFindSSHDetailsSuccess: handleFindSSHDetailsSuccess,
+		onAskForHelp,
 		onNoSSHAccess,
 		host,
 		isTransferring,
 		shouldGenerateKey,
 		isInputDisabled,
 		isProcessingNoSSH,
+		isProcessingAssistedMigration,
 	} );
 
 	const isComplete = ( stepKey: string ) => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCOM-15416

## Proposed Changes

- Added a link to the assisted migration flow in SSH authentication error messages
- Implemented loading state (spinner + disabled) when clicking the link
- Added tracking events for user interactions with the error link
- Follows the same pattern as the existing "Having trouble? Let us migrate your site" support nudge

<img width="889" height="637" alt="Captura de Tela 2025-12-04 às 23 53 30" src="https://github.com/user-attachments/assets/fa90d6fe-1818-4c07-8fdb-102468a6efce" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* Go through the SSH Migration flow until you reach the `Securely share your access` step
* Go through the steps and input an incorrect username/password so you can get an authentication error
* You should see the button inviting the user to ask for help.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
