### PR TITLE
Domain Transfer Redesign: Make small updates

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -548,7 +548,7 @@ export const domainTransferIndexRoute = createRoute( {
 		}
 
 		if ( domain.transfer_status === DomainTransferStatus.PENDING_START ) {
-			if ( domain.last_transfer_error === null ) {
+			if ( ! domain.last_transfer_error ) {
 				throw redirect( { to: domainTransferSetupRoute.fullPath, params: { domainName } } );
 			}
 			// If there was a transfer error, the user should see the transfer failed page

--- a/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
@@ -3,6 +3,7 @@ import {
 	domainConnectionSetupInfoQuery,
 	startDomainInboundTransferMutation,
 	purchaseQuery,
+	siteByIdQuery,
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
@@ -18,7 +19,8 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import { domainTransferSetupRoute, domainTransferIndexRoute } from '../../app/router/domains';
+import { domainTransferSetupRoute } from '../../app/router/domains';
+import { siteDomainsRoute } from '../../app/router/sites';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody, CardDivider } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -43,6 +45,7 @@ export default function DomainTransferSetup() {
 	const { data: purchase } = useQuery(
 		purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
 	);
+	const { data: site } = useQuery( siteByIdQuery( domain.blog_id ) );
 
 	const registrar = domainConnectionSetupInfo?.registrar || null;
 	const registrar_url = domainConnectionSetupInfo?.registrar_url || null;
@@ -154,12 +157,14 @@ export default function DomainTransferSetup() {
 					),
 					{ type: 'snackbar' }
 				);
-				navigate( {
-					to: domainTransferIndexRoute.fullPath,
-					params: {
-						domainName,
-					},
-				} );
+				if ( site?.slug ) {
+					navigate( {
+						to: siteDomainsRoute.fullPath,
+						params: {
+							siteSlug: site.slug,
+						},
+					} );
+				}
 			},
 			onError: ( err ) => {
 				const errorMessage =

--- a/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
@@ -5,7 +5,7 @@ import {
 	purchaseQuery,
 	siteByIdQuery,
 } from '@automattic/api-queries';
-import { useSuspenseQuery, useMutation, useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalVStack as VStack,
@@ -37,6 +37,7 @@ export default function DomainTransferSetup() {
 	const { domainName } = domainTransferSetupRoute.useParams();
 	const navigate = useNavigate();
 	const { createSuccessNotice } = useDispatch( noticesStore );
+	const queryClient = useQueryClient();
 
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { data: domainConnectionSetupInfo } = useSuspenseQuery(
@@ -149,6 +150,7 @@ export default function DomainTransferSetup() {
 		setError( null );
 		startTransfer( authorizationCode, {
 			onSuccess: () => {
+				queryClient.invalidateQueries( domainQuery( domainName ) );
 				createSuccessNotice(
 					sprintf(
 						// translators: %s is a domain name

--- a/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
@@ -266,7 +266,7 @@ export default function DomainTransferSetup() {
 								<InlineSupportLink supportContext="general-support-options">
 									{ __( 'Contact support' ) }
 								</InlineSupportLink>
-								{ shouldShowRemoveAction( domain, purchase ) && (
+								{ purchase && shouldShowRemoveAction( domain, purchase ) && (
 									<a href={ `/me/purchases/${ purchase?.site_slug }/${ purchase?.ID }` }>
 										{ __( 'Cancel transfer' ) }
 									</a>

--- a/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
@@ -113,6 +113,8 @@ export default function DomainTransferSetup() {
 								setAuthorizationCode( value || '' );
 								setError( null );
 							} }
+							type="password"
+							autoComplete="off"
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 						/>

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/failed.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/failed.tsx
@@ -1,3 +1,4 @@
+import { Domain, type Purchase } from '@automattic/api-core';
 import { domainInboundTransferStatusQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Icon, __experimentalVStack as VStack } from '@wordpress/components';
@@ -11,15 +12,15 @@ import { Text } from '../../../components/text';
 import { InboundTransferStep } from './transfer-step';
 
 export const InboundTransferFailed = ( {
-	domainName,
-	lastTransferError,
+	domain,
+	purchase,
 }: {
-	domainName: string;
-	lastTransferError?: string | null;
+	domain: Domain;
+	purchase?: Purchase;
 } ) => {
 	const { name: appName } = useAppContext();
 	const { data: domainInboundTransferStatus } = useQuery(
-		domainInboundTransferStatusQuery( domainName )
+		domainInboundTransferStatusQuery( domain.domain )
 	);
 
 	return (
@@ -31,8 +32,10 @@ export const InboundTransferFailed = ( {
 					fill="var(--dashboard__foreground-color-error)"
 				/>
 			}
-			title={ domainName }
+			title={ domain.domain }
 			progress={ { currentStep: 3, color: 'var(--dashboard__foreground-color-error)' } }
+			domain={ domain }
+			purchase={ purchase }
 		>
 			<VStack spacing={ 8 }>
 				<VStack spacing={ 4 }>
@@ -59,10 +62,10 @@ export const InboundTransferFailed = ( {
 							<Text>{ __( 'Your current provider blocked the transfer.' ) }</Text>
 						</li>
 					</ul>
-					{ lastTransferError && (
+					{ domain.last_transfer_error && (
 						<>
 							<Text>{ __( 'The last transfer error message we got was:' ) }</Text>
-							<Notice variant="error">{ lastTransferError }</Notice>
+							<Notice variant="error">{ domain.last_transfer_error }</Notice>
 						</>
 					) }
 					<Text>
@@ -83,7 +86,7 @@ export const InboundTransferFailed = ( {
 						variant="primary"
 						__next40pxDefaultSize
 						to={ domainTransferSetupRoute.fullPath }
-						params={ { domainName } }
+						params={ { domainName: domain.domain } }
 					>
 						{ __( 'Restart transfer' ) }
 					</RouterLinkButton>

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/failed.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/failed.tsx
@@ -1,5 +1,5 @@
-import { Domain, type Purchase } from '@automattic/api-core';
-import { domainInboundTransferStatusQuery } from '@automattic/api-queries';
+import { Domain } from '@automattic/api-core';
+import { domainInboundTransferStatusQuery, purchaseQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Icon, __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -11,16 +11,13 @@ import RouterLinkButton from '../../../components/router-link-button';
 import { Text } from '../../../components/text';
 import { InboundTransferStep } from './transfer-step';
 
-export const InboundTransferFailed = ( {
-	domain,
-	purchase,
-}: {
-	domain: Domain;
-	purchase?: Purchase;
-} ) => {
+export const InboundTransferFailed = ( { domain }: { domain: Domain } ) => {
 	const { name: appName } = useAppContext();
 	const { data: domainInboundTransferStatus } = useQuery(
 		domainInboundTransferStatusQuery( domain.domain )
+	);
+	const { data: purchase } = useQuery(
+		purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
 	);
 
 	return (

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/in-progress.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/in-progress.tsx
@@ -1,4 +1,4 @@
-import { Domain, type Purchase } from '@automattic/api-core';
+import { Domain } from '@automattic/api-core';
 import { domainInboundTransferStatusQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
@@ -11,13 +11,7 @@ import RouterLinkSummaryButton from '../../../components/router-link-summary-but
 import { Text } from '../../../components/text';
 import { InboundTransferStep } from './transfer-step';
 
-export const InboundTransferInProgress = ( {
-	domain,
-	purchase,
-}: {
-	domain: Domain;
-	purchase?: Purchase;
-} ) => {
+export const InboundTransferInProgress = ( { domain }: { domain: Domain } ) => {
 	const { data: domainInboundTransferStatus } = useQuery(
 		domainInboundTransferStatusQuery( domain.domain )
 	);
@@ -31,7 +25,6 @@ export const InboundTransferInProgress = ( {
 			subtitle={ __( 'Estimated: 5–7 days' ) }
 			progress={ { currentStep: 2, color: 'var(--wp-admin-theme-color)' } }
 			domain={ domain }
-			purchase={ purchase }
 		>
 			<VStack spacing={ 8 }>
 				<Notice>

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/in-progress.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/in-progress.tsx
@@ -1,3 +1,4 @@
+import { Domain, type Purchase } from '@automattic/api-core';
 import { domainInboundTransferStatusQuery } from '@automattic/api-queries';
 import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
@@ -11,15 +12,16 @@ import { Text } from '../../../components/text';
 import { InboundTransferStep } from './transfer-step';
 
 export const InboundTransferInProgress = ( {
-	domainName,
-	siteSlug,
+	domain,
+	purchase,
 }: {
-	domainName: string;
-	siteSlug: string;
+	domain: Domain;
+	purchase?: Purchase;
 } ) => {
 	const { data: domainInboundTransferStatus } = useQuery(
-		domainInboundTransferStatusQuery( domainName )
+		domainInboundTransferStatusQuery( domain.domain )
 	);
+	const { domain: domainName, site_slug: siteSlug } = domain;
 
 	return (
 		<InboundTransferStep
@@ -28,6 +30,8 @@ export const InboundTransferInProgress = ( {
 			badge={ <Badge intent="warning">{ __( 'In progress' ) }</Badge> }
 			subtitle={ __( 'Estimated: 5–7 days' ) }
 			progress={ { currentStep: 2, color: 'var(--wp-admin-theme-color)' } }
+			domain={ domain }
+			purchase={ purchase }
 		>
 			<VStack spacing={ 8 }>
 				<Notice>

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/index.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/index.tsx
@@ -1,18 +1,19 @@
 import { type Domain, DomainTransferStatus } from '@automattic/api-core';
+import { purchaseQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { InboundTransferFailed } from './failed';
 import { InboundTransferInProgress } from './in-progress';
 
 import './style.scss';
 
 export default function InboundTransfer( { domain }: { domain: Domain } ) {
+	const { data: purchase } = useQuery(
+		purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
+	);
+
 	if ( domain.transfer_status === DomainTransferStatus.PENDING_REGISTRY ) {
-		return <InboundTransferInProgress domainName={ domain.domain } siteSlug={ domain.site_slug } />;
+		return <InboundTransferInProgress domain={ domain } purchase={ purchase } />;
 	}
 
-	return (
-		<InboundTransferFailed
-			domainName={ domain.domain }
-			lastTransferError={ domain.last_transfer_error }
-		/>
-	);
+	return <InboundTransferFailed domain={ domain } purchase={ purchase } />;
 }

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/index.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/index.tsx
@@ -1,19 +1,13 @@
 import { type Domain, DomainTransferStatus } from '@automattic/api-core';
-import { purchaseQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
 import { InboundTransferFailed } from './failed';
 import { InboundTransferInProgress } from './in-progress';
 
 import './style.scss';
 
 export default function InboundTransfer( { domain }: { domain: Domain } ) {
-	const { data: purchase } = useQuery(
-		purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
-	);
-
 	if ( domain.transfer_status === DomainTransferStatus.PENDING_REGISTRY ) {
-		return <InboundTransferInProgress domain={ domain } purchase={ purchase } />;
+		return <InboundTransferInProgress domain={ domain } />;
 	}
 
-	return <InboundTransferFailed domain={ domain } purchase={ purchase } />;
+	return <InboundTransferFailed domain={ domain } />;
 }

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/transfer-step.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/transfer-step.tsx
@@ -1,3 +1,4 @@
+import { Domain, Purchase } from '@automattic/api-core';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -7,6 +8,7 @@ import { Card, CardBody } from '../../../components/card';
 import InlineSupportLink from '../../../components/inline-support-link';
 import SegmentedBar, { type SegmentedBarSegment } from '../../../components/segmented-bar';
 import { Text } from '../../../components/text';
+import { shouldShowRemoveAction } from '../../domain-overview/actions.utils';
 import type { ReactNode } from 'react';
 
 interface InboundTransferStepProps {
@@ -15,7 +17,9 @@ interface InboundTransferStepProps {
 	badge?: ReactNode;
 	subtitle?: ReactNode;
 	progress: { currentStep: number; color: string };
-	children: React.ReactNode;
+	children: ReactNode;
+	domain: Domain;
+	purchase?: Purchase;
 }
 
 const segment = ( step: number, currentStep: number, color: string ): SegmentedBarSegment => {
@@ -33,6 +37,8 @@ export const InboundTransferStep = ( {
 	subtitle,
 	progress,
 	children,
+	domain,
+	purchase,
 }: InboundTransferStepProps ) => {
 	return (
 		<Card>
@@ -74,6 +80,11 @@ export const InboundTransferStep = ( {
 							<InlineSupportLink supportContext="general-support-options">
 								{ __( 'Contact support' ) }
 							</InlineSupportLink>
+							{ purchase && shouldShowRemoveAction( domain, purchase ) && (
+								<a href={ `/me/purchases/${ purchase?.site_slug }/${ purchase?.ID }` }>
+									{ __( 'Cancel transfer' ) }
+								</a>
+							) }
 						</VStack>
 					</VStack>
 				</VStack>


### PR DESCRIPTION
Closes [DOMAINS-1938](https://linear.app/a8c/issue/DOMAINS-1938)

## Proposed Changes

This PR:
- Adds a "Cancel transfer" link to the "Transfer failed" page
- Makes the auth code input password masked
- Redirects user to site domains list after they submit the domain's auth code
    - Previously, the user was being redirected to the "Transfer progress" page, but at that point, the domain data wasn't refreshed yet, so it's like the transfer hasn't started
- Invalidates domain query when transfer is started successfully
    - This ensures that the site domains list will be updated as soon as possible with the domain's new transfer status

### Screenshots

| Description | Screenshot |
| --- | --- |
| Cancel link in transfer failed page | <img width="705" height="750" alt="Screenshot 2025-12-05 at 18 28 37" src="https://github.com/user-attachments/assets/bd254893-5c5c-4e15-b57f-a5ec82450e8d" /> |
| Auth code input is masked | <img width="947" height="1161" alt="Screenshot 2025-12-05 at 16 21 42" src="https://github.com/user-attachments/assets/1c6d476b-d207-4acf-afb6-593ffad97351" /> |

## Why are these changes being made?

These changes make the domain transfer flow more polished, creating a better experience for users.

## Testing Instructions

The best way to test this is by using a real domain.

- Open the live Calypso link or build this branch locally
- Go to a test site and start a domain transfer
- Ensure all the changes described in the PR description are there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
