### PR TITLE
Implement Odie in the Agent Manager

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -337,7 +337,7 @@ export default function AgentDock( {
 
 	return createAgentPortal(
 		<Routes>
-			<Route path="/" element={ OdieChat } />
+			<Route path="/" element={ Chat } />
 			<Route path="/odie" element={ OdieChat } />
 			<Route path="/chat" element={ Chat } />
 			<Route path="/history" element={ History } />

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -18,6 +18,7 @@ import {
 	type Suggestion,
 } from '@automattic/agenttic-ui';
 import { AgentsManagerSelect } from '@automattic/data-stores';
+import { useManagedOdieChat } from '@automattic/odie-client';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -89,6 +90,12 @@ export default function AgentDock( {
 		onSubmit,
 		abortCurrentRequest,
 	} = useAgentChat( agentConfig );
+
+	const {
+		messages: odieMessages,
+		isProcessing: isOdieProcessing,
+		sendMessage: sendOdieMessage,
+	} = useManagedOdieChat( 'wpcom-support-chat' );
 
 	// Handle navigation continuation if hook is provided
 	// This allows to resume conversations after full page navigation
@@ -288,6 +295,26 @@ export default function AgentDock( {
 		/>
 	);
 
+	const OdieChat = (
+		<AgentChat
+			messages={ odieMessages }
+			suggestions={ [] }
+			isProcessing={ isOdieProcessing }
+			error={ null }
+			onSubmit={ sendOdieMessage }
+			onAbort={ () => {} }
+			isLoadingConversation={ isLoadingConversation }
+			isDocked={ isDocked }
+			isOpen={ isOpen }
+			onClose={ isDocked ? closeSidebar : () => setIsOpen( false ) }
+			onExpand={ () => setIsOpen( true ) }
+			chatHeaderOptions={ getChatHeaderOptions() }
+			markdownComponents={ markdownComponents }
+			markdownExtensions={ markdownExtensions }
+			emptyViewSuggestions={ emptyViewSuggestions }
+		/>
+	);
+
 	const History = (
 		<AgentHistory
 			agentId={ agentId }
@@ -310,7 +337,8 @@ export default function AgentDock( {
 
 	return createAgentPortal(
 		<Routes>
-			<Route path="/" element={ Chat } />
+			<Route path="/" element={ OdieChat } />
+			<Route path="/odie" element={ OdieChat } />
 			<Route path="/chat" element={ Chat } />
 			<Route path="/history" element={ History } />
 			<Route path="*" element={ <Navigate to="/" replace /> } />

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -95,7 +95,7 @@ export default function AgentDock( {
 		messages: odieMessages,
 		isProcessing: isOdieProcessing,
 		sendMessage: sendOdieMessage,
-	} = useManagedOdieChat( 'wpcom-support-chat' );
+	} = useManagedOdieChat();
 
 	// Handle navigation continuation if hook is provided
 	// This allows to resume conversations after full page navigation

--- a/packages/agents-manager/tsconfig.json
+++ b/packages/agents-manager/tsconfig.json
@@ -8,5 +8,6 @@
 		"rootDir": "src"
 	},
 	"include": [ "src", "src/*.json", "types" ],
-	"exclude": [ "**/test/*" ]
+	"exclude": [ "**/test/*" ],
+	"references": [ { "path": "../odie-client" } ]
 }

--- a/packages/odie-client/src/data/use-current-support-interaction.ts
+++ b/packages/odie-client/src/data/use-current-support-interaction.ts
@@ -8,7 +8,10 @@ import { useGetSupportInteractionById } from './use-get-support-interaction-by-i
 export const useCurrentSupportInteraction = () => {
 	const { search } = useLocation();
 	const navigate = useNavigate();
-	const id = new URLSearchParams( search ).get( 'id' );
+	const oldId = new URLSearchParams( search ).get( 'id' );
+	// Adopt a new less generic ID with backwards compatibility.
+	const newId = new URLSearchParams( search ).get( 'odieInteractionId' );
+	const id = oldId || newId;
 	const query = useGetSupportInteractionById( id || null );
 
 	useEffect( () => {

--- a/packages/odie-client/src/data/use-managed-odie-chat.ts
+++ b/packages/odie-client/src/data/use-managed-odie-chat.ts
@@ -1,11 +1,19 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
-import { useCallback } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { useOdieAssistantContext } from '../context';
+import { getOdieIdFromInteraction } from '../utils';
+import { useCurrentSupportInteraction } from './use-current-support-interaction';
+import { useManageSupportInteraction } from './use-manage-support-interaction';
 import { useOdieChat } from './use-odie-chat';
-import type { ReturnedChat, Message, AgentticMessage, OdieChat } from '../types';
+import type {
+	ReturnedChat,
+	Message,
+	AgentticMessage,
+	OdieChat,
+	SupportInteraction,
+} from '../types';
 
 function convertMessageToAgentticFormat( message: Message ): AgentticMessage {
 	return {
@@ -29,27 +37,34 @@ function convertMessageFromAgentticFormat( message: string ): Message {
 
 /**
  * Sends a new message to ODIE.
- * If the chat_id is not set, it will create a new chat and send a message to the chat.
- * @param odieChatId - The Odie chat ID to send the message to.
- * @param botSlug - The bot slug to send the message to.
- * @param onSuccess - A callback function to call when the message is sent successfully.
  * @returns useMutation return object.
  */
-export const useSendOdieMessage = (
-	odieChatId: number | null,
-	botSlug: string,
-	onSuccess: ( chat: ReturnedChat ) => void
-) => {
-	const { selectedSiteId, version } = useOdieAssistantContext();
+export const useSendOdieMessage = () => {
+	const { selectedSiteId, version, newInteractionsBotSlug } = useOdieAssistantContext();
+	const {
+		data: currentSupportInteraction,
+		promise: currentSupportInteractionPromise,
+		isFetching: isFetchingCurrentSupportInteraction,
+	} = useCurrentSupportInteraction();
+	const botSlug = currentSupportInteraction?.bot_slug || newInteractionsBotSlug;
+	const chatId = getOdieIdFromInteraction( currentSupportInteraction );
+	const { startNewInteraction } = useManageSupportInteraction();
+
 	const queryClient = useQueryClient();
 
-	return useMutation< ReturnedChat, Error, Message >( {
-		mutationFn: async ( message: Message ): Promise< ReturnedChat > => {
-			const chatIdSegment = odieChatId ? `/${ odieChatId }` : '';
+	return useMutation< { chat: ReturnedChat; interaction: SupportInteraction }, Error, Message >( {
+		mutationFn: async ( message: Message ) => {
+			const chatIdSegment = chatId ? `/${ chatId }` : '';
 			const url = window.location.href;
 			const pathname = window.location.pathname;
+			let interaction = currentSupportInteraction;
 
-			return canAccessWpcomApis()
+			// This prevents a race condition where the current support interaction is not fetched yet.
+			if ( isFetchingCurrentSupportInteraction ) {
+				interaction = await currentSupportInteractionPromise;
+			}
+
+			const chat = await ( canAccessWpcomApis()
 				? wpcomRequest< ReturnedChat >( {
 						method: 'POST',
 						path: `/odie/chat/${ botSlug }${ chatIdSegment }`,
@@ -68,11 +83,20 @@ export const useSendOdieMessage = (
 							...( version && { version } ),
 							context: { selectedSiteId, url, pathname },
 						},
-				  } );
+				  } ) );
+
+			if ( ! interaction ) {
+				interaction = await startNewInteraction( {
+					event_source: 'odie',
+					event_external_id: chat.chat_id.toString(),
+				} );
+			}
+
+			return { chat, interaction };
 		},
 		onMutate( message: Message ) {
 			queryClient.setQueryData(
-				[ 'odie-chat', botSlug, odieChatId, version ],
+				[ 'odie-chat', botSlug, chatId ? Number( chatId ) : undefined, version ],
 				( currentChatCache: OdieChat ) => {
 					return {
 						...currentChatCache,
@@ -81,50 +105,41 @@ export const useSendOdieMessage = (
 				}
 			);
 		},
-		onSuccess( data: ReturnedChat ) {
-			const chatId = data.chat_id;
+		onSuccess( data ) {
 			queryClient.setQueryData(
-				[ 'odie-chat', botSlug, chatId, version ],
+				[ 'odie-chat', botSlug, data.chat.chat_id, version ],
 				( currentChatCache: OdieChat ) => {
 					return {
 						...currentChatCache,
-						messages: [ ...( currentChatCache?.messages ?? [] ), ...data.messages ],
+						messages: [ ...( currentChatCache?.messages ?? [] ), ...data.chat.messages ],
 					};
 				}
 			);
-			onSuccess( data );
+		},
+		onError() {
+			// handle errors gracefully.
 		},
 	} );
 };
 
 /**
  * Get a full API of an Odie chat.
- * @param botSlug - The bot slug to send the message to.
  */
-export const useManagedOdieChat = ( botSlug: string ) => {
-	const chatId = new URLSearchParams( useLocation().search ).get( 'odieChatId' );
+export const useManagedOdieChat = () => {
+	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
+	const chatId = getOdieIdFromInteraction( currentSupportInteraction );
 	const { data: chat, isFetching: isLoadingChat } = useOdieChat( chatId ? Number( chatId ) : null );
 	const navigate = useNavigate();
 
-	const onSuccess = useCallback(
-		( returnedChat: ReturnedChat ) => {
-			const newChatId = returnedChat.chat_id;
-			if ( newChatId !== Number( chatId ) ) {
-				navigate( `/odie?odieChatId=${ newChatId }`, { replace: true } );
-			}
-		},
-		[ chatId, navigate ]
-	);
+	const sendOdieMessage = useSendOdieMessage();
 
-	const sendOdieMessage = useSendOdieMessage(
-		chatId ? Number( chatId ) : null,
-		botSlug,
-		onSuccess
-	);
-
-	function sendMessage( message: string ) {
+	async function sendMessage( message: string ) {
 		const odieMessage = convertMessageFromAgentticFormat( message );
-		sendOdieMessage.mutateAsync( odieMessage );
+		const { interaction } = await sendOdieMessage.mutateAsync( odieMessage );
+
+		if ( interaction.uuid !== currentSupportInteraction?.uuid ) {
+			navigate( `/odie?odieInteractionId=${ interaction.uuid }`, { replace: true } );
+		}
 	}
 
 	return {

--- a/packages/odie-client/src/data/use-managed-odie-chat.ts
+++ b/packages/odie-client/src/data/use-managed-odie-chat.ts
@@ -1,9 +1,11 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { useOdieAssistantContext } from '../context';
-import type { ReturnedChat, Message, AgentticMessage } from '../types';
+import { useOdieChat } from './use-odie-chat';
+import type { ReturnedChat, Message, AgentticMessage, OdieChat } from '../types';
 
 function convertMessageToAgentticFormat( message: Message ): AgentticMessage {
 	return {
@@ -14,6 +16,14 @@ function convertMessageToAgentticFormat( message: Message ): AgentticMessage {
 		actions: [],
 		archived: false,
 		showIcon: true,
+	};
+}
+
+function convertMessageFromAgentticFormat( message: string ): Message {
+	return {
+		content: message,
+		role: 'user',
+		type: 'message',
 	};
 }
 
@@ -31,6 +41,7 @@ export const useSendOdieMessage = (
 	onSuccess: ( chat: ReturnedChat ) => void
 ) => {
 	const { selectedSiteId, version } = useOdieAssistantContext();
+	const queryClient = useQueryClient();
 
 	return useMutation< ReturnedChat, Error, Message >( {
 		mutationFn: async ( message: Message ): Promise< ReturnedChat > => {
@@ -59,37 +70,66 @@ export const useSendOdieMessage = (
 						},
 				  } );
 		},
-		onSuccess,
+		onMutate( message: Message ) {
+			queryClient.setQueryData(
+				[ 'odie-chat', botSlug, odieChatId, version ],
+				( currentChatCache: OdieChat ) => {
+					return {
+						...currentChatCache,
+						messages: [ ...( currentChatCache?.messages ?? [] ), message ],
+					};
+				}
+			);
+		},
+		onSuccess( data: ReturnedChat ) {
+			const chatId = data.chat_id;
+			queryClient.setQueryData(
+				[ 'odie-chat', botSlug, chatId, version ],
+				( currentChatCache: OdieChat ) => {
+					return {
+						...currentChatCache,
+						messages: [ ...( currentChatCache?.messages ?? [] ), ...data.messages ],
+					};
+				}
+			);
+			onSuccess( data );
+		},
 	} );
 };
 
 /**
  * Get a full API of an Odie chat.
- * @param providedChatId - The chat ID to manage.
+ * @param botSlug - The bot slug to send the message to.
  */
-export const useManagedOdieChat = ( providedChatId: number | null, botSlug: string ) => {
-	const [ chatId, setChatId ] = useState< number | null >( providedChatId );
-	const [ chatMessages, setChatMessages ] = useState< Message[] >( [] );
+export const useManagedOdieChat = ( botSlug: string ) => {
+	const chatId = new URLSearchParams( useLocation().search ).get( 'odieChatId' );
+	const { data: chat, isFetching: isLoadingChat } = useOdieChat( chatId ? Number( chatId ) : null );
+	const navigate = useNavigate();
 
 	const onSuccess = useCallback(
 		( returnedChat: ReturnedChat ) => {
-			const messages = [ ...chatMessages, ...returnedChat.messages ];
-			setChatId( returnedChat.chat_id );
-			setChatMessages( messages );
+			const newChatId = returnedChat.chat_id;
+			if ( newChatId !== Number( chatId ) ) {
+				navigate( `/odie?odieChatId=${ newChatId }`, { replace: true } );
+			}
 		},
-		[ chatMessages ]
+		[ chatId, navigate ]
 	);
 
-	const sendOdieMessage = useSendOdieMessage( chatId ?? null, botSlug, onSuccess );
+	const sendOdieMessage = useSendOdieMessage(
+		chatId ? Number( chatId ) : null,
+		botSlug,
+		onSuccess
+	);
 
-	function sendMessage( message: Message ) {
-		setChatMessages( [ ...chatMessages, message ] );
-		sendOdieMessage.mutateAsync( message );
+	function sendMessage( message: string ) {
+		const odieMessage = convertMessageFromAgentticFormat( message );
+		sendOdieMessage.mutateAsync( odieMessage );
 	}
 
 	return {
-		messages: chatMessages.map( convertMessageToAgentticFormat ) || [],
+		messages: chat?.messages.map( convertMessageToAgentticFormat ) || [],
 		sendMessage,
-		isProcessing: sendOdieMessage.isPending,
+		isProcessing: sendOdieMessage.isPending || isLoadingChat,
 	};
 };

--- a/packages/odie-client/src/data/use-odie-chat.ts
+++ b/packages/odie-client/src/data/use-odie-chat.ts
@@ -14,12 +14,12 @@ import type { OdieChat, ReturnedChat } from '../types';
 export const useOdieChat = ( chatId: number | null ) => {
 	const { version } = useOdieAssistantContext();
 	const { data: supportInteraction } = useCurrentSupportInteraction();
-
 	// Hover `ODIE_DEFAULT_BOT_SLUG_LEGACY` for more information.
 	const botSlug = supportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG_LEGACY;
+	const queryKey = [ 'odie-chat', botSlug, chatId, version ];
 
-	return useQuery< OdieChat, Error >( {
-		queryKey: [ 'odie-chat', botSlug, chatId, version ],
+	const query = useQuery< OdieChat, Error >( {
+		queryKey,
 		queryFn: async (): Promise< OdieChat > => {
 			const queryParams = new URLSearchParams( {
 				page_number: '1',
@@ -55,4 +55,9 @@ export const useOdieChat = ( chatId: number | null ) => {
 		enabled: !! chatId && !! supportInteraction,
 		staleTime: 3600, // 1 hour
 	} );
+
+	return {
+		...query,
+		queryKey,
+	};
 };

--- a/packages/odie-client/src/data/use-odie-chat.ts
+++ b/packages/odie-client/src/data/use-odie-chat.ts
@@ -14,12 +14,12 @@ import type { OdieChat, ReturnedChat } from '../types';
 export const useOdieChat = ( chatId: number | null ) => {
 	const { version } = useOdieAssistantContext();
 	const { data: supportInteraction } = useCurrentSupportInteraction();
+
 	// Hover `ODIE_DEFAULT_BOT_SLUG_LEGACY` for more information.
 	const botSlug = supportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG_LEGACY;
-	const queryKey = [ 'odie-chat', botSlug, chatId, version ];
 
-	const query = useQuery< OdieChat, Error >( {
-		queryKey,
+	return useQuery< OdieChat, Error >( {
+		queryKey: [ 'odie-chat', botSlug, chatId, version ],
 		queryFn: async (): Promise< OdieChat > => {
 			const queryParams = new URLSearchParams( {
 				page_number: '1',
@@ -55,9 +55,4 @@ export const useOdieChat = ( chatId: number | null ) => {
 		enabled: !! chatId && !! supportInteraction,
 		staleTime: 3600, // 1 hour
 	} );
-
-	return {
-		...query,
-		queryKey,
-	};
 };

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -35,3 +35,4 @@ export default OdieAssistantProvider;
 export { useOdieAssistantContext } from './context';
 export type { Conversations, OdieConversation, OdieMessage, SupportInteraction } from './types';
 export type { ZendeskConversation, ZendeskMessage } from '@automattic/zendesk-client';
+export { useManagedOdieChat } from './data/use-managed-odie-chat';

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -198,6 +198,8 @@ export type MessageAction = {
 	text: string;
 	type: string;
 	metadata: ChatFeedbackActions;
+	label: string;
+	onClick: () => void;
 };
 
 export type OdieMessage = {

--- a/packages/zendesk-client/src/types.ts
+++ b/packages/zendesk-client/src/types.ts
@@ -66,6 +66,8 @@ export type MessageAction = {
 	text: string;
 	type: string;
 	metadata: ChatFeedbackActions;
+	label: string;
+	onClick: () => void;
 };
 
 export type ZendeskContentType =


### PR DESCRIPTION
Fixes DOTCOM-15448

## Proposed Changes

Implements Odie in the Agent Manager with persistence. 

## Why are these changes being made?

For parity with the Help Center.

## Testing Instructions

1. For testing, I made Odie the default route.
2. Open the AM and chat with Odie.
3. Refresh the page; the chat should remain open with the same state.
4. Pop out the AM, should work great.