### PR TITLE
Try devcontainer for codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,73 @@
+{
+	"name": "Playwright Test Dev Container",
+	"image": "mcr.microsoft.com/playwright:v1.57.0",
+	"forwardPorts": [ 6080 ],
+	"postCreateCommand": "yarn && yarn start",
+	"features": {
+		"desktop-lite": {
+			"webPort": "6080"
+		},
+		"git-lfs": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-playwright.playwright",
+				"github.copilot",
+				"github.copilot-chat",
+				"dbaeumer.vscode-eslint",
+				"esbenp.prettier-vscode",
+				"github.vscode-github-actions",
+				"stylelint.vscode-stylelint",
+				"firefox-devtools.vscode-firefox-debug"
+			],
+			// File settings
+			"files.eol": "\n",
+			"files.exclude": {
+				"**/node_modules": true,
+				".cache": true
+			},
+			"files.associations": {
+				// VS Code treats ".prettierrc" as JSON, by default
+				".prettierrc": "yaml"
+			},
+			// Editor settings
+			"editor.formatOnSave": false,
+			"editor.codeActionsOnSave": {
+				"source.fixAll": "explicit",
+				"source.fixAll.eslint": "explicit",
+				"source.fixAll.tslint": "explicit",
+				"source.fixAll.stylelint": "explicit"
+			},
+			// Use prettier for formatting JS/TS
+			"[javascript][javascriptreact][typescript][typescriptreact]": {
+				// auto format on save will be done by ESLint
+				"editor.formatOnSave": false,
+				"editor.defaultFormatter": "esbenp.prettier-vscode"
+			},
+			"[jsonc][json][yaml][markdown]": {
+				"editor.formatOnSave": true,
+				"editor.defaultFormatter": "esbenp.prettier-vscode"
+			},
+			// Use stylint for formatting CSS/SCSS
+			"[css][scss][sass]": {
+				"editor.formatOnSave": false,
+				"editor.defaultFormatter": "stylelint.vscode-stylelint"
+			},
+			// Settings for extensions
+			"eslint.validate": [
+				"javascript",
+				"javascriptreact",
+				"typescript",
+				"typescriptreact",
+				"json",
+				"jsonc"
+			],
+			"css.validate": false,
+			"scss.validate": false,
+			"stylelint.validate": [ "css", "scss", "postcss" ],
+			// Use the installed version of TypeScript, not the ones bundled with VS Code
+			"typescript.tsdk": "node_modules/typescript/lib"
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
