### PR TITLE
Themes: Pass the locale for retrieving theme information from .org

### DIFF
--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -105,8 +105,11 @@ export function fetchThemeInformation( themeId, locale ) {
 		// This is for consistency with WP.com, which always returns the display name as `author`.
 		'request[fields][extended_author]': true,
 		'request[slug]': themeId,
-		'request[locale]': getWporgLocaleCode( locale ),
 	};
+
+	if ( locale ) {
+		query[ 'request[locale]' ] = getWporgLocaleCode( locale );
+	}
 
 	return getRequest( WPORG_THEMES_ENDPOINT, query );
 }

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -98,13 +98,14 @@ export function fetchPluginsList( options ) {
  * @param {string}     themeId  The theme identifier.
  * @returns {Promise.<Object>}  A promise that returns a `theme` object
  */
-export function fetchThemeInformation( themeId ) {
+export function fetchThemeInformation( themeId, locale ) {
 	const query = {
 		action: 'theme_information',
 		// Return an `author` object containing `user_nicename` and `display_name` attrs.
 		// This is for consistency with WP.com, which always returns the display name as `author`.
 		'request[fields][extended_author]': true,
 		'request[slug]': themeId,
+		'request[locale]': getWporgLocaleCode( locale ),
 	};
 
 	return getRequest( WPORG_THEMES_ENDPOINT, query );

--- a/client/state/themes/actions/request-theme.js
+++ b/client/state/themes/actions/request-theme.js
@@ -33,7 +33,7 @@ export function requestTheme( themeId, siteId, locale ) {
 		} );
 
 		if ( siteId === 'wporg' ) {
-			return fetchWporgThemeInformation( themeId )
+			return fetchWporgThemeInformation( themeId, locale )
 				.then( ( theme ) => {
 					// Apparently, the WP.org REST API endpoint doesn't 404 but instead returns false
 					// if a theme can't be found.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of I18N-305

## Proposed Changes

* Pass the locale parameter to api.wordpress.org for retrieving translated theme information.

Before:
<img width="1396" height="659" alt="Screenshot 2025-12-07 at 14 31 19" src="https://github.com/user-attachments/assets/b65fd477-14a8-4616-b732-5067a606b5b5" />

After:
<img width="1396" height="690" alt="Screenshot 2025-12-08 at 00 49 45" src="https://github.com/user-attachments/assets/c79d8ad9-8051-49df-99ad-902e22a102f7" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Descriptions for the themes from wordpress.org are displayed in English in the Themes Showcase.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Logged-out on calypso.live or calypso.localhost open /es/theme/newspaperup and confirm that it appears in Spanish.
* Login and set your profile locale to Spanish. Open /theme/newspaperup/<your site> and confirm that translations appear as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
