### PR TITLE
MSD: Don't wrap website preview in link.

### DIFF
--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -193,9 +193,7 @@ export function Preview( { site }: { site: Site } ) {
 	// origin.
 	const iframeDisabled = is_deleted || ( site.is_a8c && is_private );
 	return (
-		<Link
-			to={ getSiteManagementUrl( site ) }
-			disabled={ site.is_deleted }
+		<div
 			style={ {
 				display: 'block',
 				height: '100%',
@@ -221,7 +219,7 @@ export function Preview( { site }: { site: Site } ) {
 			{ width && ! iframeDisabled && (
 				<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
 			) }
-		</Link>
+		</div>
 	);
 }
 


### PR DESCRIPTION
## Proposed Changes

Don't return a link from `Preview`, it's returning an error in grid mode:
```
installHook.js:1 Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>
```

This happens because [SiteLink already returns a link](https://github.com/Automattic/wp-calypso/blob/4602b20c82b763bd954e50076c726b6781afd09a/client/dashboard/sites/site-fields/index.tsx#L72), introduced in #106655.

## Why are these changes being made?

Invalid HTML.

## Testing Instructions
- Go to your site list on my.localhost:3000.
- Open your developer tools.
- Switch your DataView to grid, expect to see no console errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
