### PR TITLE
MSD: Include csp route in dashboard.

### DIFF
--- a/client/server/pages/csp-report.js
+++ b/client/server/pages/csp-report.js
@@ -1,0 +1,48 @@
+import config from '@automattic/calypso-config';
+import bodyParser from 'body-parser';
+import { snakeCase } from 'lodash';
+import analytics from 'calypso/server/lib/analytics';
+
+/**
+ * Registers the CSP report route on the Express app
+ * This route handles Content Security Policy violation reports sent by browsers.
+ */
+export function registerCspReportRoute( app ) {
+	const calypsoEnv = config( 'env_id' );
+
+	app.post(
+		'/cspreport',
+		bodyParser.json( { type: [ 'json', 'application/csp-report' ] } ),
+		function ( req, res ) {
+			const cspReport = req.body[ 'csp-report' ] || {};
+			const cspReportSnakeCase = Object.keys( cspReport ).reduce( ( report, key ) => {
+				report[ snakeCase( key ) ] = cspReport[ key ];
+				return report;
+			}, {} );
+
+			if ( calypsoEnv !== 'development' ) {
+				// Send to Tracks for analytics
+				analytics.tracks.recordEvent( 'calypso_csp_report', cspReportSnakeCase, req );
+			}
+
+			// Send to Logstash for better logging/debugging
+			analytics.logstash.log( {
+				feature: 'calypso_client',
+				message: 'CSP Violation Report',
+				severity: 'info',
+				properties: {
+					env: calypsoEnv,
+					...cspReportSnakeCase,
+					user_agent: req.get( 'user-agent' ),
+					referer: req.get( 'Referer' ),
+				},
+			} );
+
+			res.status( 200 ).send( 'Got it!' );
+		},
+		// eslint-disable-next-line no-unused-vars
+		function ( err, req, res, next ) {
+			res.status( 500 ).send( 'Bad report!' );
+		}
+	);
+}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -11,11 +11,10 @@ import {
 	getLanguageSlugs,
 	localizeUrl,
 } from '@automattic/i18n-utils';
-import bodyParser from 'body-parser';
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
 import express from 'express';
-import { get, includes, snakeCase } from 'lodash';
+import { get, includes } from 'lodash';
 import { stringify } from 'qs';
 // eslint-disable-next-line no-restricted-imports
 import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
@@ -37,7 +36,6 @@ import loginRouter, { LOGIN_SECTION_DEFINITION } from 'calypso/login';
 import sections from 'calypso/sections';
 import isSectionEnabled from 'calypso/sections-filter';
 import { serverRouter, getCacheKey } from 'calypso/server/isomorphic-routing';
-import analytics from 'calypso/server/lib/analytics';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/server/lib/is-mobile-app';
 import performanceMark from 'calypso/server/lib/performance-mark/index';
 import {
@@ -63,6 +61,7 @@ import middlewareAssets from '../middleware/assets.js';
 import middlewareCache from '../middleware/cache.js';
 import middlewareUnsupportedBrowser from '../middleware/unsupported-browser.js';
 import { logSectionResponse } from './analytics';
+import { registerCspReportRoute } from './csp-report';
 const debug = debugFactory( 'calypso:pages' );
 
 const calypsoEnv = config( 'env_id' );
@@ -165,7 +164,6 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		'dashboard-development',
 	];
 	const isDebug = devEnvironments.includes( calypsoEnv ) || request.query.debug !== undefined;
-
 	const reactQueryDevtoolsHelper = config.isEnabled( 'dev/react-query-devtools' );
 	const authHelper = config.isEnabled( 'dev/auth-helper' );
 	const accountSettingsHelper = config.isEnabled( 'dev/account-settings-helper' );
@@ -1137,6 +1135,9 @@ export default function pages() {
 	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', 'entry-login' );
 	loginRouter( serverRouter( app, setUpRoute, null ) );
 
+	// Register CSP report route for dashboard
+	registerCspReportRoute( app );
+
 	// Multi-site Dashboard routing for my.wordpress.com.
 	// Return earlier since we don't need to set up any other routes.
 	if ( config.isEnabled( 'dashboard' ) ) {
@@ -1177,44 +1178,6 @@ export default function pages() {
 		const redirectUrl = localizeUrl( `https://wordpress.com/support`, req.context.locale );
 		return res.redirect( 301, redirectUrl );
 	} );
-
-	// This is used to log to tracks Content Security Policy violation reports sent by browsers
-	app.post(
-		'/cspreport',
-		bodyParser.json( { type: [ 'json', 'application/csp-report' ] } ),
-		function ( req, res ) {
-			const cspReport = req.body[ 'csp-report' ] || {};
-			const cspReportSnakeCase = Object.keys( cspReport ).reduce( ( report, key ) => {
-				report[ snakeCase( key ) ] = cspReport[ key ];
-				return report;
-			}, {} );
-
-			if ( calypsoEnv !== 'development' ) {
-				// Send to Tracks for analytics
-				analytics.tracks.recordEvent( 'calypso_csp_report', cspReportSnakeCase, req );
-			}
-
-			// Send to Logstash for better logging/debugging
-			analytics.logstash.log( {
-				feature: 'calypso_client',
-				message: 'CSP Violation Report',
-				severity: 'info',
-				properties: {
-					env: calypsoEnv,
-					...cspReportSnakeCase,
-					user_agent: req.get( 'user-agent' ),
-					referer: req.get( 'Referer' ),
-				},
-			} );
-
-			res.status( 200 ).send( 'Got it!' );
-		},
-		// eslint-disable-next-line no-unused-vars
-		function ( err, req, res, next ) {
-			res.status( 500 ).send( 'Bad report!' );
-		}
-	);
-
 	// catchall to render 404 for all routes not explicitly allowed in client/sections
 	app.use( render404() );
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1135,7 +1135,7 @@ export default function pages() {
 	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', 'entry-login' );
 	loginRouter( serverRouter( app, setUpRoute, null ) );
 
-	// Register CSP report route for dashboard
+	// Register CSP report route
 	registerCspReportRoute( app );
 
 	// Multi-site Dashboard routing for my.wordpress.com.


### PR DESCRIPTION
Fixes: DOTMSD-928

## Proposed Changes

Include the cspreport endpoint in the dashboard.

## Why are these changes being made?

It's currently broken on my.wordpress.com

## Considerations

There was a concern that this change may increased the bundle size. I ran some tests, I don't believe it does.

## Testing Instructions

- Open the **Dashboard live** link.
- Open networking tools, filter requests for `cspreport`, expect to have received a 200.
- Load your site list.
- Verify we have a logstash record (see DOTMSD-928 comments for link)

Do the same for the **Calypso Live** link.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
