### PR TITLE
Multi-site Dashboard: Add separate events for clicking and submitting the MSD opt in

### DIFF
--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -66,7 +66,7 @@ export default function PreferencesOptInForm() {
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
 
-		recordTracksEvent( 'calypso_dashboard_me_preferences_new_hosting_dashboard_toggle', {
+		recordTracksEvent( 'calypso_dashboard_me_preferences_new_hosting_dashboard_submit', {
 			enabled: formData.enabled,
 		} );
 
@@ -114,6 +114,14 @@ export default function PreferencesOptInForm() {
 						fields={ fields }
 						form={ form }
 						onChange={ ( edits ) => {
+							if ( edits.hasOwnProperty( 'enabled' ) ) {
+								recordTracksEvent(
+									'calypso_dashboard_me_preferences_new_hosting_dashboard_toggle_click',
+									{
+										enabled: edits.enabled,
+									}
+								);
+							}
 							setFormData( ( current ) => ( { ...current, ...edits } ) );
 						} }
 					/>

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -53,7 +53,7 @@ export default function HostingDashboardOptInForm() {
 		event.preventDefault();
 
 		dispatch(
-			recordTracksEvent( 'calypso_account_new_hosting_dashboard_toggle', {
+			recordTracksEvent( 'calypso_account_new_hosting_dashboard_submit', {
 				enabled,
 			} )
 		);
@@ -101,7 +101,14 @@ export default function HostingDashboardOptInForm() {
 							<FormCheckbox
 								checked={ enabled }
 								disabled={ isFetching || isSaving }
-								onChange={ ( event ) => setEnabled( event.target.checked ) }
+								onChange={ ( event ) => {
+									setEnabled( event.target.checked );
+									dispatch(
+										recordTracksEvent( 'calypso_account_new_hosting_dashboard_toggle_click', {
+											enabled: event.target.checked,
+										} )
+									);
+								} }
 							/>
 							<span>{ translate( 'I want to try the beta version.' ) }</span>
 						</FormLabel>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-929

## Proposed Changes

* Renames `calypso_account_new_hosting_dashboard_toggle` -> `calypso_account_new_hosting_dashboard_submit`
* Renames `calypso_dashboard_me_preferences_new_hosting_dashboard_toggle` -> `calypso_dashboard_me_preferences_new_hosting_dashboard_submit`
* Add `calypso_account_new_hosting_dashboard_toggle_click` when user clicks the checkbox
* Add `calypso_dashboard_me_preferences_new_hosting_dashboard_toggle_click` when user clicks the checkbox

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We were asked for separate tracks events for clicking the opt-in checkbox and submitting the form.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Toggle and submit the MSD opt-in, both in
  * v1: `/me/account`, and
  * v2: `/v2/me/preferences`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
