### PR TITLE
Restore links color

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/style.scss
+++ b/client/dashboard/domains/domain-connection-setup/style.scss
@@ -14,18 +14,6 @@
 	.summary-button.components-button .summary-button-title {
 		font-weight: 500;
 	}
-	a {
-		color: $gray-900;
-		&:hover {
-			color: $gray-900;
-		}
-	}
-	.is-link {
-		color: $gray-900;
-		&:hover {
-			color: $gray-900;
-		}
-	}
 }
 
 .verification-in-progress-next-steps {
@@ -38,18 +26,6 @@
 }
 
 .domain-connection-setup {
-	a {
-		color: $gray-900;
-		&:hover {
-			color: $gray-900;
-		}
-	}
-	button.is-link {
-		color: $gray-900;
-		&:hover {
-			color: $gray-900;
-		}
-	}
 	&__step .components-card-body{
 		padding-inline-start: 0;
 		padding-inline-end: 0;


### PR DESCRIPTION
Closes [DOMAINS-1943](https://linear.app/a8c/issue/DOMAINS-1943/restore-links-color)

## Proposed Changes
Restore links color to blue.

## Why are these changes being made?
We decided to restore links color for consistency (see https://github.com/Automattic/wp-calypso/pull/107501#issuecomment-3621895075)

## Testing Instructions
Code inspection

## Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
