### PR TITLE
MSD: set default staleTime back to 0

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-site.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-site.tsx
@@ -11,7 +11,10 @@ import { Truncate } from '../../components/truncate';
 import type { DomainSummary } from '@automattic/api-core';
 
 export const DomainSiteField = ( { domain, value }: { domain: DomainSummary; value: string } ) => {
-	const { data: site } = useQuery( siteBySlugQuery( domain.site_slug ) );
+	const { data: site } = useQuery( {
+		...siteBySlugQuery( domain.site_slug ),
+		staleTime: 60_000,
+	} );
 
 	if ( domain.is_domain_only_site ) {
 		return (

--- a/client/dashboard/domains/dataviews/field-ssl.tsx
+++ b/client/dashboard/domains/dataviews/field-ssl.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 export const DomainSslField = ( { domain }: { domain: DomainSummary } ) => {
 	const { data: sslDetails } = useQuery( {
 		...sslDetailsQuery( domain.domain ),
+		staleTime: 60_000,
 		enabled:
 			domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER &&
 			domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS,

--- a/packages/api-queries/src/query-client.ts
+++ b/packages/api-queries/src/query-client.ts
@@ -20,7 +20,7 @@ const reactQueryCacheKey = 'REACT_QUERY_OFFLINE_CACHE';
 const queryClient = new QueryClient( {
 	defaultOptions: {
 		queries: {
-			staleTime: 60_000, // 1 minute
+			staleTime: 0,
 			refetchOnWindowFocus: true,
 			refetchOnMount: true,
 			retry: ( failureCount: number, error: Error ) => {


### PR DESCRIPTION
Part of DOTDEV-127
Context: p1765179806747569-slack-C08BWTSP7AS
Supersedes https://github.com/Automattic/wp-calypso/pull/107503

## Proposed Changes

This PR sets the default query client's `staleTime` back to `0` for MSD.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Default non-zero stale time is causing issue where user is seeing stale data when the update is done outside MSD; e.g., from wp-admin.

## Testing Instructions

(Stolen from the linked PR)

- Have a site on Atomic.
- Go to /v2/sites/[site].wpcomstaging.com/settings and take a note of the site visibility state.
- Go to https://[site].wpcomstaging.com/wp-admin/options-reading.php and change the site visibility.
- Go back to /v2/sites/[site].wpcomstaging.com/settings, wait a few secs, and make sure the site visibility is now up-to-date.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?