### PR TITLE
MSD Domain Connection Redesign: Do not show set as primary action if not eligible

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -49,6 +49,9 @@ export default function DomainConnectionVerification( {
 		? 'connected'
 		: 'verifying';
 
+	const connectedAndCanBeSetAsPrimary =
+		status === 'connected' && ! domainData.primary_domain && domainData.can_set_as_primary;
+
 	return (
 		<Card
 			className={ `dashboard-domain-connection-verification dashboard-domain-connection-verification--${ status }` }
@@ -104,7 +107,7 @@ export default function DomainConnectionVerification( {
 							</Text>
 						) }
 
-						{ status === 'connected' && (
+						{ connectedAndCanBeSetAsPrimary && (
 							<>
 								<Text size="medium" weight={ 500 }>
 									{ __( 'Recommended' ) }

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
@@ -37,7 +37,7 @@ jest.mock( '../components/domain-propagation-status', () => ( {
 	default: () => null,
 } ) );
 
-const createMockDomain = (): Domain => ( {
+const createMockDomain = ( overrides?: Partial< Domain > ): Domain => ( {
 	// DomainSummary properties
 	blog_id: 123,
 	domain: 'example.com',
@@ -116,6 +116,7 @@ const createMockDomain = (): Domain => ( {
 	last_transfer_error: '',
 	current_user_can_add_email: true,
 	whois_update_unmodifiable_fields: [],
+	...overrides,
 } );
 
 const createMockDomainMappingStatus = (
@@ -322,6 +323,50 @@ describe( 'DomainConnectionVerification', () => {
 			);
 
 			expect( screen.getByText( 'Name server verification' ) ).toBeVisible();
+		} );
+
+		test( 'displays "Recommended" section when domain is not primary but can be set as primary', () => {
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainData={ createMockDomain( {
+						primary_domain: false,
+						can_set_as_primary: true,
+					} ) }
+				/>
+			);
+
+			expect( screen.getByText( 'Recommended' ) ).toBeVisible();
+
+			expect( screen.getByText( 'Set example.com as your primary site address' ) ).toBeVisible();
+		} );
+
+		test( 'does not display "Recommended" section when domain is not primary and cannot be set as primary', () => {
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainData={ createMockDomain( {
+						primary_domain: false,
+						can_set_as_primary: false,
+					} ) }
+				/>
+			);
+
+			expect( screen.queryByText( 'Recommended' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'does not display "Recommended" section when domain is primary', () => {
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainData={ createMockDomain( {
+						primary_domain: true,
+						can_set_as_primary: false,
+					} ) }
+				/>
+			);
+
+			expect( screen.queryByText( 'Recommended' ) ).not.toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
Closes DOMAINS-1942.

## Proposed Changes

We were showing the "set domain as primary" button even if the connected domain already is the primary domain for a site, or cannot be made primary due to other conditions.

Let's add additional checks to ensure this CTA only shows up conditionally.

## Testing Instructions

Connect a domain but don't set it as the primary address for a site. Enter the connection verification screen again and you should see the CTA. Click the CTA and make sure it's the primary address now. Go back to the connection verification screen and verify the CTA does not show up anymore.