### PR TITLE
A4A: Fix A4A Help center submit form missing token.

### DIFF
--- a/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
+++ b/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
@@ -21,11 +21,18 @@ export function useSubmitA4ATicketMutation() {
 				path = '/agency/help/pressable/support';
 			}
 
+			// Get OAuth token from localStorage
+			const token = localStorage.getItem( 'wpcom_token' );
+
+			// Remove quotes from token
+			const tokenWithoutQuotes = token?.substring( 1, token.length - 1 );
+
 			return wpcomRequest( {
 				path,
 				apiNamespace: 'wpcom/v2',
 				method: 'POST',
 				body: ticket,
+				token: tokenWithoutQuotes ?? undefined,
 			} );
 		},
 	} );

--- a/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
+++ b/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
@@ -24,15 +24,12 @@ export function useSubmitA4ATicketMutation() {
 			// Get OAuth token from localStorage
 			const token = localStorage.getItem( 'wpcom_token' );
 
-			// Remove quotes from token
-			const tokenWithoutQuotes = token?.substring( 1, token.length - 1 );
-
 			return wpcomRequest( {
 				path,
 				apiNamespace: 'wpcom/v2',
 				method: 'POST',
 				body: ticket,
-				token: tokenWithoutQuotes ?? undefined,
+				token: token ? JSON.parse( token ) : undefined,
 			} );
 		},
 	} );


### PR DESCRIPTION
This PR resolves the problem with the A4A help center not submitting because of a missing OAuth token in the header.

## Proposed Changes

* Pass the `wpcom_token` from the Local storage to the token parameter.

## Why are these changes being made?

* The A4A Help Center contact form does not work outside the Horizon environment.

## Testing Instructions

* Test this locally and navigate to http://agencies.localhost:3000/overview
* Test the Help center contact form and confirm you can submit.
<img width="518" height="861" alt="Screenshot 2025-12-08 at 10 02 01 PM" src="https://github.com/user-attachments/assets/315012af-dee9-40a1-854a-89e39d7fc0dd" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
