### PR TITLE
Help Center: Maintain search query when going to chat

### DIFF
--- a/packages/help-center/src/components/help-center-footer.tsx
+++ b/packages/help-center/src/components/help-center-footer.tsx
@@ -1,12 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { HelpCenterSelect } from '@automattic/data-stores';
 import { Button, CardFooter } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useStillNeedHelpURL } from '../hooks';
-import { HELP_CENTER_STORE } from '../stores';
 
 import './help-center-footer.scss';
 
@@ -16,10 +13,6 @@ export const HelpCenterContactButton = () => {
 	const { sectionName } = useHelpCenterContext();
 	const redirectToWpcom = url === 'https://wordpress.com/help/contact';
 	const navigate = useNavigate();
-	const searchQuery = useSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getMessage(),
-		[]
-	);
 
 	const handleClick = () => {
 		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
@@ -29,13 +22,7 @@ export const HelpCenterContactButton = () => {
 			button_type: 'Still need help?',
 		} );
 
-		let to: string | { pathname: string } = redirectToWpcom ? { pathname: url } : url;
-
-		// Pass search query to chat if navigating to /odie
-		if ( url === '/odie' && searchQuery ) {
-			to = `/odie?query=${ encodeURIComponent( searchQuery ) }`;
-		}
-
+		const to: string | { pathname: string } = redirectToWpcom ? { pathname: url } : url;
 		navigate( to );
 	};
 

--- a/packages/help-center/src/components/help-center-footer.tsx
+++ b/packages/help-center/src/components/help-center-footer.tsx
@@ -22,8 +22,7 @@ export const HelpCenterContactButton = () => {
 			button_type: 'Still need help?',
 		} );
 
-		const to: string | { pathname: string } = redirectToWpcom ? { pathname: url } : url;
-		navigate( to );
+		navigate( redirectToWpcom ? { pathname: url } : url );
 	};
 
 	return (

--- a/packages/help-center/src/components/help-center-footer.tsx
+++ b/packages/help-center/src/components/help-center-footer.tsx
@@ -1,9 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { HelpCenterSelect } from '@automattic/data-stores';
 import { Button, CardFooter } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useStillNeedHelpURL } from '../hooks';
+import { HELP_CENTER_STORE } from '../stores';
 
 import './help-center-footer.scss';
 
@@ -13,6 +16,10 @@ export const HelpCenterContactButton = () => {
 	const { sectionName } = useHelpCenterContext();
 	const redirectToWpcom = url === 'https://wordpress.com/help/contact';
 	const navigate = useNavigate();
+	const searchQuery = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getMessage(),
+		[]
+	);
 
 	const handleClick = () => {
 		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
@@ -22,7 +29,13 @@ export const HelpCenterContactButton = () => {
 			button_type: 'Still need help?',
 		} );
 
-		const to = redirectToWpcom ? { pathname: url } : url;
+		let to: string | { pathname: string } = redirectToWpcom ? { pathname: url } : url;
+
+		// Pass search query to chat if navigating to /odie
+		if ( url === '/odie' && searchQuery ) {
+			to = `/odie?query=${ encodeURIComponent( searchQuery ) }`;
+		}
+
 		navigate( to );
 	};
 

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -383,7 +383,9 @@ function HelpSearchResults( {
 					</p>
 					<Button
 						variant="secondary"
-						onClick={ () => setNavigateToRoute( '/odie' ) }
+						onClick={ () =>
+							setNavigateToRoute( `/odie?query=${ encodeURIComponent( searchQuery ) }` )
+						}
 						className="show-more-button"
 					>
 						{ __( 'Ask AI assistant', __i18n_text_domain__ ) }

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -383,9 +383,7 @@ function HelpSearchResults( {
 					</p>
 					<Button
 						variant="secondary"
-						onClick={ () =>
-							setNavigateToRoute( `/odie?query=${ encodeURIComponent( searchQuery ) }` )
-						}
+						onClick={ () => setNavigateToRoute( '/odie' ) }
 						className="show-more-button"
 					>
 						{ __( 'Ask AI assistant', __i18n_text_domain__ ) }

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -1,9 +1,11 @@
 import '@automattic/agenttic-ui/index.css';
 import { useInput } from '@automattic/agenttic-ui';
+import { HelpCenterSelect } from '@automattic/data-stores';
 import { EmailFallbackNotice } from '@automattic/help-center/src/components/notices';
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearchParams } from 'react-router-dom';
 import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
@@ -35,9 +37,11 @@ export const OdieSendMessageButton = () => {
 	const isChatBusy = chat.status === 'loading' || chat.status === 'sending';
 	const isInitialLoading = chat.status === 'loading';
 	const isLiveChat = chat.provider?.startsWith( 'zendesk' );
-	const [ searchParams ] = useSearchParams();
-	const initialQuery = searchParams.get( 'query' ) || '';
-	const [ inputValue, setInputValue ] = useState( initialQuery );
+	const searchQuery = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getMessage(),
+		[]
+	);
+	const [ inputValue, setInputValue ] = useState( searchQuery || '' );
 	const messageSizeNotice = useMessageSizeErrorNotice( inputValue.trim().length );
 	const connectionNotice = useConnectionStatusNotice( isLiveChat );
 

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -3,6 +3,7 @@ import { useInput } from '@automattic/agenttic-ui';
 import { EmailFallbackNotice } from '@automattic/help-center/src/components/notices';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useSearchParams } from 'react-router-dom';
 import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
@@ -34,7 +35,9 @@ export const OdieSendMessageButton = () => {
 	const isChatBusy = chat.status === 'loading' || chat.status === 'sending';
 	const isInitialLoading = chat.status === 'loading';
 	const isLiveChat = chat.provider?.startsWith( 'zendesk' );
-	const [ inputValue, setInputValue ] = useState( '' );
+	const [ searchParams ] = useSearchParams();
+	const initialQuery = searchParams.get( 'query' ) || '';
+	const [ inputValue, setInputValue ] = useState( initialQuery );
 	const messageSizeNotice = useMessageSizeErrorNotice( inputValue.trim().length );
 	const connectionNotice = useConnectionStatusNotice( isLiveChat );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-373/preserve-user-input-when-transitioning-from-help-center-search-to

## What

Pass the search query as a parameter when launching the support chat, pre-filling the chat input field

## Testing steps

1. Open Help Center
2. Search something that returns no results and click on "Ask AI assistant"
3. Search input should be populated with your query
4. Go back and the search should be populated
5. Try to click "Need help? Get in touch". The chat should be populated.

The input does not grow with more text, it will be addressed here https://linear.app/a8c/issue/DOTCOM-15462/help-center-make-chat-input-grow-with-more-text