### PR TITLE
Disable the toggles and submit button during any mutation

### DIFF
--- a/client/dashboard/components/domain-contact-details-form/contact-form-privacy.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form-privacy.tsx
@@ -41,10 +41,10 @@ export default function ContactFormPrivacy( {
 						{ createInterpolateElement(
 							domain.private_domain
 								? __(
-										"Privacy protection must be enabled due to the registry's policies. <learnMoreLink />"
+										'Privacy protection must be enabled due to the registry’s policies. <learnMoreLink />'
 								  )
 								: __(
-										"Privacy protection is not available due to the registry's policies. <learnMoreLink />"
+										'Privacy protection is not available due to the registry’s policies. <learnMoreLink />'
 								  ),
 							{
 								learnMoreLink: (

--- a/client/dashboard/components/domain-contact-details-form/contact-form-privacy.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form-privacy.tsx
@@ -1,72 +1,29 @@
-import {
-	domainPrivacyDisableMutation,
-	domainPrivacyDiscloseMutation,
-	domainPrivacyEnableMutation,
-	domainPrivacyRedactMutation,
-	domainQuery,
-} from '@automattic/api-queries';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { domainQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	ToggleControl,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import InlineSupportLink from '../inline-support-link';
 import { SectionHeader } from '../section-header';
 
 interface ContactFormPrivacyProps {
 	domainName: string;
+	isSubmitting: boolean;
+	onTogglePrivacyProtection: () => void;
+	onTogglePrivacyDisclosure: () => void;
 }
 
-export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyProps ) {
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { data: domain, isFetching: domainQueryIsFetching } = useSuspenseQuery(
-		domainQuery( domainName )
-	);
-	const enablePrivacyMutation = useMutation( domainPrivacyEnableMutation( domainName ) );
-	const disablePrivacyMutation = useMutation( domainPrivacyDisableMutation( domainName ) );
-	const disclosePrivacyMutation = useMutation( domainPrivacyDiscloseMutation( domainName ) );
-	const redactPrivacyMutation = useMutation( domainPrivacyRedactMutation( domainName ) );
-	const isUpdatingPrivacy =
-		enablePrivacyMutation.isPending ||
-		disablePrivacyMutation.isPending ||
-		disclosePrivacyMutation.isPending ||
-		redactPrivacyMutation.isPending ||
-		domainQueryIsFetching;
-
-	const togglePrivacyProtection = () => {
-		if ( domain.private_domain ) {
-			disablePrivacyMutation.mutate( undefined, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Privacy has been successfully disabled!' ), {
-						type: 'snackbar',
-					} );
-				},
-				onError: ( error: Error ) => {
-					createErrorNotice( error.message, {
-						type: 'snackbar',
-					} );
-				},
-			} );
-		} else {
-			enablePrivacyMutation.mutate( undefined, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Privacy has been successfully enabled!' ), {
-						type: 'snackbar',
-					} );
-				},
-				onError: ( error: Error ) => {
-					createErrorNotice( error.message, {
-						type: 'snackbar',
-					} );
-				},
-			} );
-		}
-	};
+export default function ContactFormPrivacy( {
+	domainName,
+	isSubmitting,
+	onTogglePrivacyProtection,
+	onTogglePrivacyDisclosure,
+}: ContactFormPrivacyProps ) {
+	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 
 	const renderPrivacyProtection = () => {
 		return (
@@ -74,8 +31,8 @@ export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyPr
 				<ToggleControl
 					__nextHasNoMarginBottom
 					checked={ domain.private_domain }
-					disabled={ isUpdatingPrivacy || ! domain.privacy_available }
-					onChange={ togglePrivacyProtection }
+					disabled={ isSubmitting || ! domain.privacy_available }
+					onChange={ onTogglePrivacyProtection }
 					label={ __( 'Privacy protection' ) }
 				/>
 
@@ -84,10 +41,10 @@ export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyPr
 						{ createInterpolateElement(
 							domain.private_domain
 								? __(
-										'Privacy protection must be enabled due to the registry’s policies. <learnMoreLink />'
+										"Privacy protection must be enabled due to the registry's policies. <learnMoreLink />"
 								  )
 								: __(
-										'Privacy protection is not available due to the registry’s policies. <learnMoreLink />'
+										"Privacy protection is not available due to the registry's policies. <learnMoreLink />"
 								  ),
 							{
 								learnMoreLink: (
@@ -99,36 +56,6 @@ export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyPr
 				) }
 			</>
 		);
-	};
-
-	const togglePrivacyDisclosure = () => {
-		if ( domain.contact_info_disclosed ) {
-			redactPrivacyMutation.mutate( undefined, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Your contact information is now redacted!' ), {
-						type: 'snackbar',
-					} );
-				},
-				onError: ( error: Error ) => {
-					createErrorNotice( error.message, {
-						type: 'snackbar',
-					} );
-				},
-			} );
-		} else {
-			disclosePrivacyMutation.mutate( undefined, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Your contact information is now publicly visible!' ), {
-						type: 'snackbar',
-					} );
-				},
-				onError: ( error: Error ) => {
-					createErrorNotice( error.message, {
-						type: 'snackbar',
-					} );
-				},
-			} );
-		}
 	};
 
 	const renderPrivacyDisclosure = () => {
@@ -146,8 +73,8 @@ export default function ContactFormPrivacy( { domainName }: ContactFormPrivacyPr
 				<ToggleControl
 					__nextHasNoMarginBottom
 					checked={ domain.contact_info_disclosed }
-					onChange={ togglePrivacyDisclosure }
-					disabled={ isUpdatingPrivacy || domain.is_pending_icann_verification }
+					onChange={ onTogglePrivacyDisclosure }
+					disabled={ isSubmitting || domain.is_pending_icann_verification }
 					label={ __( 'Display my contact information in public WHOIS' ) }
 				/>
 

--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -24,7 +24,7 @@ import { findRegistrantWhois } from '../../utils/domain';
 import type { DomainContactDetails } from '@automattic/api-core';
 
 export default function DomainContactInfo() {
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
@@ -57,23 +57,56 @@ export default function DomainContactInfo() {
 	} );
 	const updateMutation = useMutation( {
 		...domainWhoisMutation( domainName ),
-		meta: { snackbar: { error: { source: 'server' } } },
+		meta: {
+			snackbar: {
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Contact details for %s saved.' ), domainName ),
+				error: { source: 'server' },
+			},
+		},
 	} );
 	const enablePrivacyMutation = useMutation( {
 		...domainPrivacyEnableMutation( domainName ),
-		meta: { snackbar: { error: { source: 'server' } } },
+		meta: {
+			snackbar: {
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Privacy has been successfully enabled for %s!' ), domainName ),
+				error: { source: 'server' },
+			},
+		},
 	} );
 	const disablePrivacyMutation = useMutation( {
 		...domainPrivacyDisableMutation( domainName ),
-		meta: { snackbar: { error: { source: 'server' } } },
+		meta: {
+			snackbar: {
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Privacy has been successfully disabled for %s!' ), domainName ),
+				error: { source: 'server' },
+			},
+		},
 	} );
 	const disclosePrivacyMutation = useMutation( {
 		...domainPrivacyDiscloseMutation( domainName ),
-		meta: { snackbar: { error: { source: 'server' } } },
+		meta: {
+			snackbar: {
+				success: sprintf(
+					/* translators: %s is the domain name */
+					__( 'Your contact information for %s is now publicly visible!' ),
+					domainName
+				),
+				error: { source: 'server' },
+			},
+		},
 	} );
 	const redactPrivacyMutation = useMutation( {
 		...domainPrivacyRedactMutation( domainName ),
-		meta: { snackbar: { error: { source: 'server' } } },
+		meta: {
+			snackbar: {
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Your contact information for %s is now redacted!' ), domainName ),
+				error: { source: 'server' },
+			},
+		},
 	} );
 
 	const isSubmitting =
@@ -88,17 +121,10 @@ export default function DomainContactInfo() {
 		validateMutation.mutate( normalizedFormData, {
 			onSuccess: ( data ) => {
 				if ( data.success ) {
-					updateMutation.mutate(
-						{
-							domainContactDetails: normalizedFormData,
-							transferLock: normalizedFormData.optOutTransferLock === false,
-						},
-						{
-							onSuccess: () => {
-								createSuccessNotice( __( 'Contact details saved.' ), { type: 'snackbar' } );
-							},
-						}
-					);
+					updateMutation.mutate( {
+						domainContactDetails: normalizedFormData,
+						transferLock: normalizedFormData.optOutTransferLock === false,
+					} );
 				} else {
 					createErrorNotice( data.messages_simple.join( ' ' ), {
 						type: 'snackbar',
@@ -110,41 +136,17 @@ export default function DomainContactInfo() {
 
 	const handleTogglePrivacyProtection = () => {
 		if ( domain.private_domain ) {
-			disablePrivacyMutation.mutate( undefined, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Privacy has been successfully disabled!' ), {
-						type: 'snackbar',
-					} );
-				},
-			} );
+			disablePrivacyMutation.mutate( undefined );
 		} else {
-			enablePrivacyMutation.mutate( undefined, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Privacy has been successfully enabled!' ), {
-						type: 'snackbar',
-					} );
-				},
-			} );
+			enablePrivacyMutation.mutate( undefined );
 		}
 	};
 
 	const handleTogglePrivacyDisclosure = () => {
 		if ( domain.contact_info_disclosed ) {
-			redactPrivacyMutation.mutate( undefined, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Your contact information is now redacted!' ), {
-						type: 'snackbar',
-					} );
-				},
-			} );
+			redactPrivacyMutation.mutate( undefined );
 		} else {
-			disclosePrivacyMutation.mutate( undefined, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Your contact information is now publicly visible!' ), {
-						type: 'snackbar',
-					} );
-				},
-			} );
+			disclosePrivacyMutation.mutate( undefined );
 		}
 	};
 

--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -156,7 +156,7 @@ export default function DomainContactInfo() {
 			header={
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
-					description={ __( "Update your domain's contact information for registration." ) }
+					description={ __( 'Update your domain’s contact information for registration.' ) }
 				/>
 			}
 		>

--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -1,4 +1,8 @@
 import {
+	domainPrivacyDisableMutation,
+	domainPrivacyDiscloseMutation,
+	domainPrivacyEnableMutation,
+	domainPrivacyRedactMutation,
 	domainQuery,
 	domainWhoisValidateMutation,
 	domainWhoisMutation,
@@ -47,10 +51,38 @@ export default function DomainContactInfo() {
 		return { initialData, key: JSON.stringify( initialData ) };
 	}, [ registrantWhoisData ] );
 
-	const validateMutation = useMutation( domainWhoisValidateMutation( [ domainName ] ) );
-	const updateMutation = useMutation( domainWhoisMutation( domainName ) );
+	const validateMutation = useMutation( {
+		...domainWhoisValidateMutation( [ domainName ] ),
+		meta: { snackbar: { error: { source: 'server' } } },
+	} );
+	const updateMutation = useMutation( {
+		...domainWhoisMutation( domainName ),
+		meta: { snackbar: { error: { source: 'server' } } },
+	} );
+	const enablePrivacyMutation = useMutation( {
+		...domainPrivacyEnableMutation( domainName ),
+		meta: { snackbar: { error: { source: 'server' } } },
+	} );
+	const disablePrivacyMutation = useMutation( {
+		...domainPrivacyDisableMutation( domainName ),
+		meta: { snackbar: { error: { source: 'server' } } },
+	} );
+	const disclosePrivacyMutation = useMutation( {
+		...domainPrivacyDiscloseMutation( domainName ),
+		meta: { snackbar: { error: { source: 'server' } } },
+	} );
+	const redactPrivacyMutation = useMutation( {
+		...domainPrivacyRedactMutation( domainName ),
+		meta: { snackbar: { error: { source: 'server' } } },
+	} );
 
-	const isSubmitting = validateMutation.isPending || updateMutation.isPending;
+	const isSubmitting =
+		validateMutation.isPending ||
+		updateMutation.isPending ||
+		enablePrivacyMutation.isPending ||
+		disablePrivacyMutation.isPending ||
+		disclosePrivacyMutation.isPending ||
+		redactPrivacyMutation.isPending;
 
 	const handleSubmit = ( normalizedFormData: DomainContactDetails ) => {
 		validateMutation.mutate( normalizedFormData, {
@@ -65,11 +97,6 @@ export default function DomainContactInfo() {
 							onSuccess: () => {
 								createSuccessNotice( __( 'Contact details saved.' ), { type: 'snackbar' } );
 							},
-							onError: ( error: Error ) => {
-								createErrorNotice( error.message, {
-									type: 'snackbar',
-								} );
-							},
 						}
 					);
 				} else {
@@ -78,12 +105,47 @@ export default function DomainContactInfo() {
 					} );
 				}
 			},
-			onError: ( error: Error ) => {
-				createErrorNotice( error.message, {
-					type: 'snackbar',
-				} );
-			},
 		} );
+	};
+
+	const handleTogglePrivacyProtection = () => {
+		if ( domain.private_domain ) {
+			disablePrivacyMutation.mutate( undefined, {
+				onSuccess: () => {
+					createSuccessNotice( __( 'Privacy has been successfully disabled!' ), {
+						type: 'snackbar',
+					} );
+				},
+			} );
+		} else {
+			enablePrivacyMutation.mutate( undefined, {
+				onSuccess: () => {
+					createSuccessNotice( __( 'Privacy has been successfully enabled!' ), {
+						type: 'snackbar',
+					} );
+				},
+			} );
+		}
+	};
+
+	const handleTogglePrivacyDisclosure = () => {
+		if ( domain.contact_info_disclosed ) {
+			redactPrivacyMutation.mutate( undefined, {
+				onSuccess: () => {
+					createSuccessNotice( __( 'Your contact information is now redacted!' ), {
+						type: 'snackbar',
+					} );
+				},
+			} );
+		} else {
+			disclosePrivacyMutation.mutate( undefined, {
+				onSuccess: () => {
+					createSuccessNotice( __( 'Your contact information is now publicly visible!' ), {
+						type: 'snackbar',
+					} );
+				},
+			} );
+		}
 	};
 
 	return (
@@ -92,7 +154,7 @@ export default function DomainContactInfo() {
 			header={
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
-					description={ __( 'Update your domain’s contact information for registration.' ) }
+					description={ __( "Update your domain's contact information for registration." ) }
 				/>
 			}
 		>
@@ -103,7 +165,12 @@ export default function DomainContactInfo() {
 					! domain.is_hundred_year_domain && (
 						<Card>
 							<CardBody>
-								<ContactFormPrivacy domainName={ domainName } />
+								<ContactFormPrivacy
+									domainName={ domainName }
+									isSubmitting={ isSubmitting }
+									onTogglePrivacyProtection={ handleTogglePrivacyProtection }
+									onTogglePrivacyDisclosure={ handleTogglePrivacyDisclosure }
+								/>
 							</CardBody>
 						</Card>
 					)

--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -1,8 +1,6 @@
 import {
-	domainPrivacyDisableMutation,
-	domainPrivacyDiscloseMutation,
-	domainPrivacyEnableMutation,
-	domainPrivacyRedactMutation,
+	domainPrivacySaveMutation,
+	domainPrivacyDiscloseSaveMutation,
 	domainQuery,
 	domainWhoisValidateMutation,
 	domainWhoisMutation,
@@ -65,28 +63,19 @@ export default function DomainContactInfo() {
 			},
 		},
 	} );
-	const enablePrivacyMutation = useMutation( {
-		...domainPrivacyEnableMutation( domainName ),
+	const savePrivacyMutation = useMutation( {
+		...domainPrivacySaveMutation( domainName ),
 		meta: {
 			snackbar: {
 				/* translators: %s is the domain name */
-				success: sprintf( __( 'Privacy has been successfully enabled for %s!' ), domainName ),
+				success: sprintf( __( 'Privacy has been successfully updated for %s!' ), domainName ),
 				error: { source: 'server' },
 			},
 		},
 	} );
-	const disablePrivacyMutation = useMutation( {
-		...domainPrivacyDisableMutation( domainName ),
-		meta: {
-			snackbar: {
-				/* translators: %s is the domain name */
-				success: sprintf( __( 'Privacy has been successfully disabled for %s!' ), domainName ),
-				error: { source: 'server' },
-			},
-		},
-	} );
+
 	const disclosePrivacyMutation = useMutation( {
-		...domainPrivacyDiscloseMutation( domainName ),
+		...domainPrivacyDiscloseSaveMutation( domainName ),
 		meta: {
 			snackbar: {
 				success: sprintf(
@@ -99,7 +88,7 @@ export default function DomainContactInfo() {
 		},
 	} );
 	const redactPrivacyMutation = useMutation( {
-		...domainPrivacyRedactMutation( domainName ),
+		...domainPrivacyDiscloseSaveMutation( domainName ),
 		meta: {
 			snackbar: {
 				/* translators: %s is the domain name */
@@ -112,8 +101,7 @@ export default function DomainContactInfo() {
 	const isSubmitting =
 		validateMutation.isPending ||
 		updateMutation.isPending ||
-		enablePrivacyMutation.isPending ||
-		disablePrivacyMutation.isPending ||
+		savePrivacyMutation.isPending ||
 		disclosePrivacyMutation.isPending ||
 		redactPrivacyMutation.isPending;
 
@@ -135,18 +123,14 @@ export default function DomainContactInfo() {
 	};
 
 	const handleTogglePrivacyProtection = () => {
-		if ( domain.private_domain ) {
-			disablePrivacyMutation.mutate( undefined );
-		} else {
-			enablePrivacyMutation.mutate( undefined );
-		}
+		savePrivacyMutation.mutate( domain.private_domain ? false : true );
 	};
 
 	const handleTogglePrivacyDisclosure = () => {
 		if ( domain.contact_info_disclosed ) {
-			redactPrivacyMutation.mutate( undefined );
+			redactPrivacyMutation.mutate( false );
 		} else {
-			disclosePrivacyMutation.mutate( undefined );
+			disclosePrivacyMutation.mutate( true );
 		}
 	};
 

--- a/packages/api-queries/src/domain-privacy.ts
+++ b/packages/api-queries/src/domain-privacy.ts
@@ -3,39 +3,36 @@ import {
 	discloseDomainPrivacy,
 	enableDomainPrivacy,
 	redactDomainPrivacy,
+	type Domain,
 } from '@automattic/api-core';
 import { mutationOptions } from '@tanstack/react-query';
 import { domainQuery } from './domain';
 import { queryClient } from './query-client';
 
-export const domainPrivacyEnableMutation = ( domainName: string ) =>
+export const domainPrivacySaveMutation = ( domainName: string ) =>
 	mutationOptions( {
-		mutationFn: () => enableDomainPrivacy( domainName ),
-		onSuccess: () => {
+		mutationFn: ( enable_privacy: boolean ) =>
+			enable_privacy ? enableDomainPrivacy( domainName ) : disableDomainPrivacy( domainName ),
+		onSuccess: ( _, enable_privacy: boolean ) => {
+			const oldDomain = queryClient.getQueryData( domainQuery( domainName ).queryKey );
+			queryClient.setQueryData( domainQuery( domainName ).queryKey, {
+				...oldDomain,
+				private_domain: enable_privacy,
+			} as Domain );
 			queryClient.invalidateQueries( domainQuery( domainName ) );
 		},
 	} );
 
-export const domainPrivacyDisableMutation = ( domainName: string ) =>
+export const domainPrivacyDiscloseSaveMutation = ( domainName: string ) =>
 	mutationOptions( {
-		mutationFn: () => disableDomainPrivacy( domainName ),
-		onSuccess: () => {
-			queryClient.invalidateQueries( domainQuery( domainName ) );
-		},
-	} );
-
-export const domainPrivacyDiscloseMutation = ( domainName: string ) =>
-	mutationOptions( {
-		mutationFn: () => discloseDomainPrivacy( domainName ),
-		onSuccess: () => {
-			queryClient.invalidateQueries( domainQuery( domainName ) );
-		},
-	} );
-
-export const domainPrivacyRedactMutation = ( domainName: string ) =>
-	mutationOptions( {
-		mutationFn: () => redactDomainPrivacy( domainName ),
-		onSuccess: () => {
+		mutationFn: ( disclose: boolean ) =>
+			disclose ? discloseDomainPrivacy( domainName ) : redactDomainPrivacy( domainName ),
+		onSuccess: ( _, disclose: boolean ) => {
+			const oldDomain = queryClient.getQueryData( domainQuery( domainName ).queryKey );
+			queryClient.setQueryData( domainQuery( domainName ).queryKey, {
+				...oldDomain,
+				contact_info_disclosed: disclose,
+			} as Domain );
 			queryClient.invalidateQueries( domainQuery( domainName ) );
 		},
 	} );


### PR DESCRIPTION
Since there's no loading state for the toggles it would make sense to disable the toggles during the contact form save operation and the other way around - if you're toggling the privacy you should not be able to submit the contact form.

Part of [DOMAINS-1789: Add loading state to toggles](https://linear.app/a8c/issue/DOMAINS-1789/add-loading-state-to-toggles)

## Proposed Changes

* Move the mutation operations out of `ContactFormPrivacy` so that we can have a common state for updating
* Use `meta.snackbar` instead of manually handling errors returned from the API

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the user experience consistent so it's. clear that something is happening

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a domain contact information form in /v2/domains
* Edit a field in the contact form and then click on the privacy toggle - the submit button should not be clickable while the privacy is being updated
* Same with contact form Save - while contact information is saved you should not be able to click on the privacy toggle

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
