### PR TITLE
Theme Showcase: Update the theme preview modal CTA

### DIFF
--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -185,7 +185,7 @@ class PreviewToolbar extends Component {
 					{ showEditHeaderLink && canUserEditThemeOptions && isLivePreviewSupported && (
 						<Button
 							borderless
-							aria-label={ translate( 'Try and customize' ) }
+							aria-label={ translate( 'Preview with your content' ) }
 							className={
 								this.state.isRedirecting
 									? 'web-preview__loading-spinner'
@@ -197,7 +197,7 @@ class PreviewToolbar extends Component {
 							{ this.state.isRedirecting ? (
 								<Spinner size={ 16 } />
 							) : (
-								translate( 'Try and customize' )
+								translate( 'Preview with your content' )
 							) }
 						</Button>
 					) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-116

## Proposed Changes

* Update the theme preview modal CTA with the same phrasing as the "preview" dropdown introduced in #107208.

| Before | After |
|--------|--------|
| <img width="1088" height="1111" alt="Screenshot 2025-12-08 at 16 13 41" src="https://github.com/user-attachments/assets/7eca8f10-e08c-4c93-9875-7cfb35cb1fc0" /> | <img width="1088" height="1111" alt="Screenshot 2025-12-08 at 16 13 30" src="https://github.com/user-attachments/assets/f0c5729a-b39f-4ca1-91dd-697af0bf27c5" /> | 

## Why are these changes being made?

The "Try and customize" phrasing was obsolete and inconsistent.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Theme Showcase with a site selected (`/themes/:SITE`).
* Find a block theme (excluding the active one). Twenty Twenty-Five works fine.
* In the theme details screen, hover on the preview.
* Click on the "Preview demo site" that appears in the middle of the preview.
* A modal with the theme demo will pop up.
* Confirm the link in the top-right corner now says "Preview with your content".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
