### PR TITLE
A4A: Convert development licenses to paid subscription with BD

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -22,7 +22,6 @@ import type { ShoppingCartItem } from '../types';
 import './style.scss';
 
 const debug = debugFactory( 'a4a:bd-checkout' );
-const DEV_SITE_LAUNCH_SOURCE = 'a4a_dev_site_launch';
 
 /**
  * A4A-BD Checkout Component using the WordPress.com checkout
@@ -47,7 +46,6 @@ function BillingDragonCheckoutContent( {
 	const site = useSelector( ( state ) => ( siteSlug ? getSite( state, siteSlug ) : undefined ) );
 	const siteId = site?.ID;
 	const isPlanCheckout = !! planSlug;
-	const isDevSiteLaunchFlow = Boolean( site?.is_a4a_dev_site && isPlanCheckout );
 
 	useEffect( () => {
 		if ( siteId ) {
@@ -70,7 +68,6 @@ function BillingDragonCheckoutContent( {
 		isPrivate: false,
 		siteSlug,
 		sitelessCheckoutType: 'a4a',
-		source: isDevSiteLaunchFlow ? DEV_SITE_LAUNCH_SOURCE : undefined,
 	} );
 
 	debug( '[A4A Checkout] Cart items: ', cartItems );
@@ -162,7 +159,6 @@ function BillingDragonCheckoutContent( {
 						isA4ASitelessCheckout: true,
 						agency_id: agency.id,
 						cart_item_index: cartItemIndex++,
-						...( isDevSiteLaunchFlow ? { source: DEV_SITE_LAUNCH_SOURCE } : {} ),
 					},
 				};
 				debug( '[A4A Checkout] Processing product to add: ', product_cart );
@@ -197,7 +193,6 @@ function BillingDragonCheckoutContent( {
 		cartItems,
 		siteId,
 		isPlanCheckout,
-		isDevSiteLaunchFlow,
 	] );
 
 	// Debugging: Set a timeout to force showing the checkout after 2 seconds

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -54,8 +54,12 @@ function BillingDragonCheckoutContent( {
 	useEffect( () => {
 		if ( siteId ) {
 			dispatch( setSelectedSiteId( siteId ) );
+		} else if ( ! isPlanCheckout ) {
+			// Clear selected site when navigating to siteless cart checkout
+			// This ensures the cart system uses the 'no-site' cart key
+			dispatch( setSelectedSiteId( null ) );
 		}
-	}, [ dispatch, siteId ] );
+	}, [ dispatch, siteId, isPlanCheckout ] );
 
 	// Use site's cart key when site exists, otherwise use 'no-site' for siteless checkout
 	const cartKey = siteId || 'no-site';
@@ -73,8 +77,6 @@ function BillingDragonCheckoutContent( {
 		siteSlug,
 		sitelessCheckoutType: 'a4a',
 	} );
-
-	debug( '[A4A Checkout] Cart items: ', cartItems );
 
 	// Plan Checkout Flow: This flow is used when a planSlug is provided in the URL (e.g., /checkout/:siteSlug/:planSlug).
 	// It handles direct plan purchases by:

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -4,14 +4,16 @@ import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
+import usePrepareProductsForCart from 'calypso/my-sites/checkout/src/hooks/use-prepare-products-for-cart';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import getSite from 'calypso/state/sites/selectors/get-site';
 import ClientCheckoutError from './checkout-error';
 import ClientCheckoutPlaceholder from './checkout-placeholder';
 import type { ShoppingCartItem } from '../types';
@@ -26,24 +28,75 @@ const debug = debugFactory( 'a4a:bd-checkout' );
 function BillingDragonCheckoutContent( {
 	cartItems,
 	withA8cLogo = true,
+	siteSlug,
+	planSlug,
 }: {
 	cartItems: ShoppingCartItem[];
 	withA8cLogo?: boolean;
+	siteSlug?: string;
+	planSlug?: string;
 } ) {
 	const translate = useTranslate();
 	const [ isReady, setIsReady ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
 
-	// Access the shopping cart API
+	const agency = useSelector( getActiveAgency );
+	const site = useSelector( ( state ) => ( siteSlug ? getSite( state, siteSlug ) : undefined ) );
+	const siteId = site?.ID;
+	const isSitelessCheckout = ! siteId;
+	const isPlanCheckout = useMemo( () => Boolean( planSlug ), [ planSlug ] );
+
 	const { replaceProductsInCart, responseCart } = useShoppingCart( 'no-site' );
 
-	const agency = useSelector( getActiveAgency );
+	const {
+		productsForCart,
+		isLoading: areProductsPreparing,
+		error: productsError,
+	} = usePrepareProductsForCart( {
+		productAliasFromUrl: planSlug,
+		purchaseId: null,
+		usesJetpackProducts: false,
+		isPrivate: false,
+		siteSlug,
+		sitelessCheckoutType: 'a4a',
+	} );
 
 	debug( '[A4A Checkout] Cart items: ', cartItems );
+
+	useEffect( () => {
+		if ( ! isPlanCheckout || areProductsPreparing ) {
+			return;
+		}
+
+		if ( ! productsForCart.length || productsError ) {
+			debug( '[A4A Checkout] No products created from plan slug' );
+			return;
+		}
+
+		debug( '[A4A Checkout] Replacing cart with products from plan slug', productsForCart );
+		replaceProductsInCart( productsForCart )
+			.then( () => {
+				debug( '[A4A Checkout] Products added to cart successfully (plan slug)' );
+				setIsReady( true );
+			} )
+			.catch( ( err ) => {
+				debug( '[A4A Checkout] Failed to add products to cart:', err );
+			} );
+	}, [
+		areProductsPreparing,
+		isPlanCheckout,
+		productsError,
+		productsForCart,
+		replaceProductsInCart,
+	] );
 
 	// Add products to cart when data is loaded
 	// Note: We are loading products from A4A cart to the Billing Dragon cart
 	useEffect( () => {
+		if ( isPlanCheckout ) {
+			return;
+		}
+
 		// Skip if we're already ready
 		if ( isReady ) {
 			debug( '[A4A Checkout] Already ready' );
@@ -108,7 +161,16 @@ function BillingDragonCheckoutContent( {
 			debug( '[A4A Checkout] No matching products found to add to cart' );
 			setError( 'Could not find the requested products' );
 		}
-	}, [ isReady, error, replaceProductsInCart, responseCart, agency, cartItems ] );
+	}, [
+		isReady,
+		error,
+		replaceProductsInCart,
+		responseCart,
+		agency,
+		cartItems,
+		siteId,
+		isPlanCheckout,
+	] );
 
 	// Debugging: Set a timeout to force showing the checkout after 2 seconds
 	// Todo: This was reduced from 10 seconds to 2 seconds to check if it works well. Better UX.
@@ -143,11 +205,11 @@ function BillingDragonCheckoutContent( {
 				</div>
 			) }
 			<CheckoutMain
-				sitelessCheckoutType="a4a"
+				{ ...( isSitelessCheckout ? { sitelessCheckoutType: 'a4a' as const } : {} ) }
 				redirectTo={ window.location.origin + '/purchases/licenses' }
 				customizedPreviousPath="/marketplace"
-				siteSlug=""
-				siteId={ 0 }
+				siteSlug={ siteSlug ?? '' }
+				siteId={ siteId ?? 0 }
 			/>
 		</div>
 	);
@@ -156,9 +218,13 @@ function BillingDragonCheckoutContent( {
 export default function BillingDragonCheckout( {
 	cartItems,
 	withA8cLogo = true,
+	siteSlug,
+	planSlug,
 }: {
 	cartItems: ShoppingCartItem[];
 	withA8cLogo?: boolean;
+	siteSlug?: string;
+	planSlug?: string;
 } ) {
 	const translate = useTranslate();
 	const locale = useSelector( getCurrentUserLocale );
@@ -170,7 +236,12 @@ export default function BillingDragonCheckout( {
 			<CalypsoShoppingCartProvider shouldShowPersistentErrors>
 				<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
 					<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
-						<BillingDragonCheckoutContent cartItems={ cartItems } withA8cLogo={ withA8cLogo } />
+						<BillingDragonCheckoutContent
+							cartItems={ cartItems }
+							withA8cLogo={ withA8cLogo }
+							siteSlug={ siteSlug }
+							planSlug={ planSlug }
+						/>
 					</RazorpayHookProvider>
 				</StripeHookProvider>
 			</CalypsoShoppingCartProvider>

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -184,16 +184,7 @@ function BillingDragonCheckoutContent( {
 			debug( '[A4A Checkout] No matching products found to add to cart' );
 			setError( 'Could not find the requested products' );
 		}
-	}, [
-		isReady,
-		error,
-		replaceProductsInCart,
-		responseCart,
-		agency,
-		cartItems,
-		siteId,
-		isPlanCheckout,
-	] );
+	}, [ isReady, error, replaceProductsInCart, responseCart, agency, cartItems, isPlanCheckout ] );
 
 	// Debugging: Set a timeout to force showing the checkout after 2 seconds
 	// Todo: This was reduced from 10 seconds to 2 seconds to check if it works well. Better UX.

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -4,16 +4,17 @@ import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
 import usePrepareProductsForCart from 'calypso/my-sites/checkout/src/hooks/use-prepare-products-for-cart';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import getSite from 'calypso/state/sites/selectors/get-site';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import ClientCheckoutError from './checkout-error';
 import ClientCheckoutPlaceholder from './checkout-placeholder';
 import type { ShoppingCartItem } from '../types';
@@ -41,14 +42,22 @@ function BillingDragonCheckoutContent( {
 	const [ isReady, setIsReady ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
 
+	const dispatch = useDispatch();
 	const agency = useSelector( getActiveAgency );
 	const site = useSelector( ( state ) => ( siteSlug ? getSite( state, siteSlug ) : undefined ) );
 	const siteId = site?.ID;
-	const isSitelessCheckout = ! siteId;
-	const isPlanCheckout = useMemo( () => Boolean( planSlug ), [ planSlug ] );
+	const isPlanCheckout = !! planSlug;
 	const isDevSiteLaunchFlow = Boolean( site?.is_a4a_dev_site && isPlanCheckout );
 
-	const { replaceProductsInCart, responseCart } = useShoppingCart( 'no-site' );
+	useEffect( () => {
+		if ( siteId ) {
+			dispatch( setSelectedSiteId( siteId ) );
+		}
+	}, [ dispatch, siteId ] );
+
+	// Use site's cart key when site exists, otherwise use 'no-site' for siteless checkout
+	const cartKey = siteId || 'no-site';
+	const { replaceProductsInCart, responseCart } = useShoppingCart( cartKey );
 
 	const {
 		productsForCart,
@@ -224,7 +233,7 @@ function BillingDragonCheckoutContent( {
 				</div>
 			) }
 			<CheckoutMain
-				{ ...( isSitelessCheckout ? { sitelessCheckoutType: 'a4a' as const } : {} ) }
+				sitelessCheckoutType="a4a"
 				redirectTo={ window.location.origin + '/purchases/licenses' }
 				customizedPreviousPath="/marketplace"
 				siteSlug={ siteSlug ?? '' }

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -72,6 +72,11 @@ function BillingDragonCheckoutContent( {
 
 	debug( '[A4A Checkout] Cart items: ', cartItems );
 
+	// Plan Checkout Flow: This flow is used when a planSlug is provided in the URL (e.g., /checkout/:siteSlug/:planSlug).
+	// It handles direct plan purchases by:
+	// 1. Using usePrepareProductsForCart to convert the plan slug into products
+	// 2. Adding agency metadata to the products
+	// 3. Replacing the cart with the prepared products
 	useEffect( () => {
 		if ( ! isPlanCheckout || areProductsPreparing ) {
 			return;
@@ -92,6 +97,7 @@ function BillingDragonCheckoutContent( {
 			extra: {
 				...product.extra,
 				agency_id: agency.id,
+				isA4ADevSiteCheckout: true,
 			},
 		} ) );
 
@@ -113,8 +119,12 @@ function BillingDragonCheckoutContent( {
 		replaceProductsInCart,
 	] );
 
-	// Add products to cart when data is loaded
-	// Note: We are loading products from A4A cart to the Billing Dragon cart
+	// Cart Items Flow: This flow is used when cartItems are provided via props (the traditional A4A cart flow).
+	// It handles checkout for items already in the A4A shopping cart by:
+	// 1. Waiting for cartItems to be populated from the A4A cart
+	// 2. Converting A4A cart items into BD cart format
+	// 3. Replacing the cart with the converted products
+	// This is the original flow used when users add items to their cart first, then navigate to checkout.
 	useEffect( () => {
 		if ( isPlanCheckout ) {
 			return;

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -78,6 +78,8 @@ function BillingDragonCheckoutContent( {
 		sitelessCheckoutType: 'a4a',
 	} );
 
+	debug( '[A4A Checkout] Cart items: ', cartItems );
+
 	// Plan Checkout Flow: This flow is used when a planSlug is provided in the URL (e.g., /checkout/:siteSlug/:planSlug).
 	// It handles direct plan purchases by:
 	// 1. Using usePrepareProductsForCart to convert the plan slug into products

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -1,4 +1,5 @@
 import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
+import page from '@automattic/calypso-router';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
@@ -6,6 +7,7 @@ import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
+import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
@@ -13,6 +15,7 @@ import usePrepareProductsForCart from 'calypso/my-sites/checkout/src/hooks/use-p
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import getSite from 'calypso/state/sites/selectors/get-site';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import ClientCheckoutError from './checkout-error';
@@ -44,6 +47,7 @@ function BillingDragonCheckoutContent( {
 	const dispatch = useDispatch();
 	const agency = useSelector( getActiveAgency );
 	const site = useSelector( ( state ) => ( siteSlug ? getSite( state, siteSlug ) : undefined ) );
+	const sitesLoaded = useSelector( hasLoadedSites );
 	const siteId = site?.ID;
 	const isPlanCheckout = !! planSlug;
 
@@ -82,6 +86,13 @@ function BillingDragonCheckoutContent( {
 			return;
 		}
 
+		// Check if user has access to the site when siteSlug is provided
+		if ( siteSlug && sitesLoaded && ! site ) {
+			debug( '[A4A Checkout] User does not have access to site:', siteSlug );
+			page( A4A_MARKETPLACE_LINK );
+			return;
+		}
+
 		if ( ! agency ) {
 			debug( '[A4A Checkout] Agency not loaded yet, waiting (plan checkout)...' );
 			return;
@@ -117,6 +128,9 @@ function BillingDragonCheckoutContent( {
 		productsError,
 		productsForCart,
 		replaceProductsInCart,
+		site,
+		siteSlug,
+		sitesLoaded,
 	] );
 
 	// Cart Items Flow: This flow is used when cartItems are provided via props (the traditional A4A cart flow).

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -21,6 +21,7 @@ import type { ShoppingCartItem } from '../types';
 import './style.scss';
 
 const debug = debugFactory( 'a4a:bd-checkout' );
+const DEV_SITE_LAUNCH_SOURCE = 'a4a_dev_site_launch';
 
 /**
  * A4A-BD Checkout Component using the WordPress.com checkout
@@ -45,6 +46,7 @@ function BillingDragonCheckoutContent( {
 	const siteId = site?.ID;
 	const isSitelessCheckout = ! siteId;
 	const isPlanCheckout = useMemo( () => Boolean( planSlug ), [ planSlug ] );
+	const isDevSiteLaunchFlow = Boolean( site?.is_a4a_dev_site && isPlanCheckout );
 
 	const { replaceProductsInCart, responseCart } = useShoppingCart( 'no-site' );
 
@@ -59,6 +61,7 @@ function BillingDragonCheckoutContent( {
 		isPrivate: false,
 		siteSlug,
 		sitelessCheckoutType: 'a4a',
+		source: isDevSiteLaunchFlow ? DEV_SITE_LAUNCH_SOURCE : undefined,
 	} );
 
 	debug( '[A4A Checkout] Cart items: ', cartItems );
@@ -136,6 +139,7 @@ function BillingDragonCheckoutContent( {
 						isA4ASitelessCheckout: true,
 						agency_id: agency.id,
 						cart_item_index: cartItemIndex++,
+						...( isDevSiteLaunchFlow ? { source: DEV_SITE_LAUNCH_SOURCE } : {} ),
 					},
 				};
 				debug( '[A4A Checkout] Processing product to add: ', product_cart );
@@ -170,6 +174,7 @@ function BillingDragonCheckoutContent( {
 		cartItems,
 		siteId,
 		isPlanCheckout,
+		isDevSiteLaunchFlow,
 	] );
 
 	// Debugging: Set a timeout to force showing the checkout after 2 seconds

--- a/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/billing-dragon-checkout/index.tsx
@@ -71,13 +71,26 @@ function BillingDragonCheckoutContent( {
 			return;
 		}
 
+		if ( ! agency ) {
+			debug( '[A4A Checkout] Agency not loaded yet, waiting (plan checkout)...' );
+			return;
+		}
+
 		if ( ! productsForCart.length || productsError ) {
 			debug( '[A4A Checkout] No products created from plan slug' );
 			return;
 		}
 
-		debug( '[A4A Checkout] Replacing cart with products from plan slug', productsForCart );
-		replaceProductsInCart( productsForCart )
+		const productsWithAgency = productsForCart.map( ( product ) => ( {
+			...product,
+			extra: {
+				...product.extra,
+				agency_id: agency.id,
+			},
+		} ) );
+
+		debug( '[A4A Checkout] Replacing cart with products from plan slug', productsWithAgency );
+		replaceProductsInCart( productsWithAgency )
 			.then( () => {
 				debug( '[A4A Checkout] Products added to cart successfully (plan slug)' );
 				setIsReady( true );
@@ -87,6 +100,7 @@ function BillingDragonCheckoutContent( {
 			} );
 	}, [
 		areProductsPreparing,
+		agency,
 		isPlanCheckout,
 		productsError,
 		productsForCart,

--- a/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v2.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v2.tsx
@@ -15,9 +15,13 @@ import useShoppingCart from '../hooks/use-shopping-cart';
 
 import './style-v2.scss';
 
-function CheckoutV2() {
-	const translate = useTranslate();
+interface CheckoutV2Props {
+	siteSlug?: string;
+	planSlug?: string;
+}
 
+function CheckoutV2( { siteSlug, planSlug }: CheckoutV2Props ) {
+	const translate = useTranslate();
 	const { selectedCartItems } = useShoppingCart();
 
 	// Fetch selected products by slug for site checkout
@@ -55,6 +59,8 @@ function CheckoutV2() {
 					cartItems={
 						selectedProductsBySlug.length > 0 ? selectedProductsBySlug : selectedCartItems
 					}
+					siteSlug={ siteSlug }
+					planSlug={ planSlug }
 				/>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -9,9 +9,11 @@ import CheckoutV2 from './checkout-v2';
 interface CheckoutProps {
 	referralBlogId?: number;
 	isClient?: boolean;
+	siteSlug?: string;
+	planSlug?: string;
 }
 
-function Checkout( { referralBlogId, isClient }: CheckoutProps ) {
+function Checkout( { referralBlogId, isClient, siteSlug, planSlug }: CheckoutProps ) {
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const isReferralMarketplace = marketplaceType === MARKETPLACE_TYPE_REFERRAL;
 
@@ -22,10 +24,9 @@ function Checkout( { referralBlogId, isClient }: CheckoutProps ) {
 		! isClient &&
 		! referralBlogId
 	) {
-		return <CheckoutV2 />;
+		return <CheckoutV2 siteSlug={ siteSlug } planSlug={ planSlug } />;
 	}
 
-	// Fallback to the original Checkout V1
 	return <CheckoutV1 referralBlogId={ referralBlogId } isClient={ isClient } />;
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -19,8 +19,7 @@ function Checkout( { referralBlogId, isClient, siteSlug, planSlug }: CheckoutPro
 
 	// New Billing Dragon Checkout V2 page: check for BD feature flag and it's not in a referral context
 	if (
-		// @todo: Remove this before merging as this is a temporary flag to test the new BD checkout
-		// isEnabled( 'a4a-bd-checkout' ) &&
+		isEnabled( 'a4a-bd-checkout' ) &&
 		! isReferralMarketplace &&
 		! isClient &&
 		! referralBlogId

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -19,7 +19,8 @@ function Checkout( { referralBlogId, isClient, siteSlug, planSlug }: CheckoutPro
 
 	// New Billing Dragon Checkout V2 page: check for BD feature flag and it's not in a referral context
 	if (
-		isEnabled( 'a4a-bd-checkout' ) &&
+		// @todo: Remove this before merging as this is a temporary flag to test the new BD checkout
+		// isEnabled( 'a4a-bd-checkout' ) &&
 		! isReferralMarketplace &&
 		! isClient &&
 		! referralBlogId

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -130,6 +130,21 @@ export const marketplaceReferPremiumPlanContext: Callback = ( context, next ) =>
 	next();
 };
 
+export const checkoutWithPlanContext: Callback = ( context, next ) => {
+	const { siteSlug, planSlug } = context.params;
+	const { referral_blog_id } = context.query;
+	const referralBlogId = referral_blog_id ? parseInt( referral_blog_id ) : undefined;
+
+	context.secondary = <MarketplaceSidebar path={ context.path } />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Marketplace > Checkout" path={ context.path } />
+			<Checkout referralBlogId={ referralBlogId } siteSlug={ siteSlug } planSlug={ planSlug } />
+		</>
+	);
+	next();
+};
+
 export const checkoutContext: Callback = ( context, next ) => {
 	const { referral_blog_id } = context.query;
 	const referralBlogId = referral_blog_id ? parseInt( referral_blog_id ) : undefined;

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -130,7 +130,7 @@ export const marketplaceReferPremiumPlanContext: Callback = ( context, next ) =>
 	next();
 };
 
-export const checkoutWithPlanContext: Callback = ( context, next ) => {
+export const checkoutContext: Callback = ( context, next ) => {
 	const { siteSlug, planSlug } = context.params;
 	const { referral_blog_id } = context.query;
 	const referralBlogId = referral_blog_id ? parseInt( referral_blog_id ) : undefined;
@@ -138,27 +138,12 @@ export const checkoutWithPlanContext: Callback = ( context, next ) => {
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
-			<PageViewTracker title="Marketplace > Checkout" path={ context.path } />
+			<MarketplacePageViewTracker title="Marketplace > Checkout" path={ context.path } />
 			<Checkout referralBlogId={ referralBlogId } siteSlug={ siteSlug } planSlug={ planSlug } />
 		</>
 	);
 	next();
 };
-
-export const checkoutContext: Callback = ( context, next ) => {
-	const { referral_blog_id } = context.query;
-	const referralBlogId = referral_blog_id ? parseInt( referral_blog_id ) : undefined;
-
-	context.secondary = <MarketplaceSidebar path={ context.path } />;
-	context.primary = (
-		<>
-			<MarketplacePageViewTracker title="Marketplace > Checkout" path={ context.path } />
-			<Checkout referralBlogId={ referralBlogId } />
-		</>
-	);
-	next();
-};
-
 export const assignLicenseContext: Callback = ( context, next ) => {
 	const { page, search } = context.query;
 	const initialPage = parseInt( page ) || 1;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { arrowRight } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useMemo, useState } from 'react';
@@ -142,33 +141,31 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 					/>
 				</HostingPlanSection.Details>
 
-				{ ! isEnabled( 'a4a-bd-checkout' ) && (
-					<HostingPlanSection.Aside
-						heading={ translate( 'Start building for free' ) }
-						cta={ {
-							label: translate( 'Create a development site' ),
-							variant: 'secondary',
-							icon: arrowRight,
-							disabled: ! availableDevSites,
-							onClick: onClickCreateWPCOMDevSite,
-						} }
-					>
-						<p>
-							{ translate(
-								'Included in your membership to Automattic for Agencies. Develop up to 5 WordPress.com sites with free development licenses. Only pay when you launch.'
-							) }
-						</p>
+				<HostingPlanSection.Aside
+					heading={ translate( 'Start building for free' ) }
+					cta={ {
+						label: translate( 'Create a development site' ),
+						variant: 'secondary',
+						icon: arrowRight,
+						disabled: ! availableDevSites,
+						onClick: onClickCreateWPCOMDevSite,
+					} }
+				>
+					<p>
+						{ translate(
+							'Included in your membership to Automattic for Agencies. Develop up to 5 WordPress.com sites with free development licenses. Only pay when you launch.'
+						) }
+					</p>
 
-						<i>
-							{ translate( '%(pendingSites)d of 5 free licenses available', {
-								args: {
-									pendingSites: availableDevSites,
-								},
-								comment: '%(pendingSites)s is the number of free licenses available.',
-							} ) }
-						</i>
-					</HostingPlanSection.Aside>
-				) }
+					<i>
+						{ translate( '%(pendingSites)d of 5 free licenses available', {
+							args: {
+								pendingSites: availableDevSites,
+							},
+							comment: '%(pendingSites)s is the number of free licenses available.',
+						} ) }
+					</i>
+				</HostingPlanSection.Aside>
 			</HostingPlanSection>
 
 			{ showWPCOMDevSiteConfigurationsModal && (

--- a/client/a8c-for-agencies/sections/marketplace/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/index.tsx
@@ -15,7 +15,6 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
 	assignLicenseContext,
 	checkoutContext,
-	checkoutWithPlanContext,
 	marketplaceContext,
 	marketplaceHostingContext,
 	marketplaceProductsContext,
@@ -64,7 +63,7 @@ export default function () {
 	page(
 		`${ A4A_MARKETPLACE_CHECKOUT_LINK }/:siteSlug/:planSlug`,
 		requireAccessContext,
-		checkoutWithPlanContext,
+		checkoutContext,
 		makeLayout,
 		clientRender
 	);

--- a/client/a8c-for-agencies/sections/marketplace/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/index.tsx
@@ -15,6 +15,7 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
 	assignLicenseContext,
 	checkoutContext,
+	checkoutWithPlanContext,
 	marketplaceContext,
 	marketplaceHostingContext,
 	marketplaceProductsContext,
@@ -56,6 +57,14 @@ export default function () {
 		`${ A4A_MARKETPLACE_HOSTING_LINK }/:section?`,
 		requireAccessContext,
 		marketplaceHostingContext,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		`${ A4A_MARKETPLACE_CHECKOUT_LINK }/:siteSlug/:planSlug`,
+		requireAccessContext,
+		checkoutWithPlanContext,
 		makeLayout,
 		clientRender
 	);

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -42,7 +41,7 @@ export default function MigrationsOverviewV2() {
 					<MigrationsBanner />
 					<MigrationsHostingFeatures />
 					<MigrationsTestimonials />
-					{ ! isEnabled( 'a4a-bd-checkout' ) && <MigrationsHostingOptions /> }
+					<MigrationsHostingOptions />
 					<MigrationsProcess />
 					<MigrationsClientRelationship />
 					<MigrationsCTA />

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -47,8 +47,6 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 	const availableDevSites = devLicenses?.available;
 	const hasAvailableDevSites = devLicenses?.available > 0;
 
-	// Show dev sites section if dev sites are enabled and BD checkout is not enabled
-	// @todo: Remove this before merging as this is a temporary flag to test the new BD checkout
 	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
 	const handleOnClick = useCallback(

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -48,8 +48,8 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 	const hasAvailableDevSites = devLicenses?.available > 0;
 
 	// Show dev sites section if dev sites are enabled and BD checkout is not enabled
-	const devSitesEnabled =
-		config.isEnabled( 'a4a-dev-sites' ) && ! config.isEnabled( 'a4a-bd-checkout' );
+	// @todo: Remove this before merging as this is a temporary flag to test the new BD checkout
+	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
 	const handleOnClick = useCallback(
 		( modalType: string ) => {

--- a/client/my-sites/checkout/use-cart-key.ts
+++ b/client/my-sites/checkout/use-cart-key.ts
@@ -24,6 +24,7 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 		currentUrlPath.includes( '/checkout/unified' ) && isLoggedOutCart;
 	const isA4ASitelessCheckout =
 		isA8CForAgencies() &&
+		! selectedSite &&
 		( currentUrlPath.includes( '/marketplace/checkout' ) ||
 			currentUrlPath.includes( '/client/checkout' ) );
 	const isNoSiteCart =

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -885,6 +885,7 @@ export interface ResponseCartProductExtra {
 	isAkismetSitelessCheckout?: boolean;
 	isMarketplaceSitelessCheckout?: boolean;
 	isA4ASitelessCheckout?: boolean;
+	isA4ADevSiteCheckout?: boolean;
 	referral_id?: number;
 	agency_id?: number;
 

--- a/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
+++ b/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
@@ -41,8 +41,7 @@ export function canItemBeRemovedFromCart(
 		return false;
 	}
 
-	// If the item is an A4A siteless checkout, it cannot be removed from the cart
-	if ( item.extra?.isA4ASitelessCheckout ) {
+	if ( item.extra?.isA4ASitelessCheckout || item.extra?.isA4ADevSiteCheckout ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/A4A-1611/implement-dev-site-purchase-flow-for-agencies

## Proposed Changes

<img width="1222" height="826" alt="image" src="https://github.com/user-attachments/assets/8c27e367-d70a-40bf-8473-26d1da7d8210" />

Adds direct plan checkout via URL parameters (`siteSlug` and `planSlug`) to the A4A marketplace checkout. 

Here's the list of changes being made:
- New route: /marketplace/checkout/:siteSlug/:planSlug
- Checkout component supports plan-based checkout using usePrepareProductsForCart
- Automatically selects site and populates cart when siteSlug and planSlug are provided
- Maintains backward compatibility with existing cart checkout flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These changes enable direct plan checkout in the A4A marketplace, allowing agencies to pay for development licenses upon launch.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As this patch needs to be tested with this 197935-ghe-Automattic/wpcom, visit it for testing instructions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?