### PR TITLE
Review all snackbar notices in domains

### DIFF
--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -1,9 +1,7 @@
 import { domainDnsMutation, domainQuery } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
+import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
@@ -17,10 +15,18 @@ import type { DnsRecord } from '@automattic/api-core';
 
 export default function DomainAddDNS() {
 	const navigate = useNavigate();
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const mutation = useMutation( domainDnsMutation( domainName ) );
+	const mutation = useMutation( {
+		...domainDnsMutation( domainName ),
+		meta: {
+			snackbar: {
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'DNS record added successfully for %s.' ), domainName ),
+				error: { source: 'server' },
+			},
+		},
+	} );
 
 	const navigateToDNSOverviewPage = () => {
 		navigate( {
@@ -35,21 +41,7 @@ export default function DomainAddDNS() {
 
 		const recordsToAdd: DnsRecord[] = [ formattedData ];
 
-		mutation.mutate(
-			{ recordsToAdd },
-			{
-				onSuccess: () => {
-					createSuccessNotice( __( 'DNS record added successfully.' ), { type: 'snackbar' } );
-					navigateToDNSOverviewPage();
-				},
-				onError: () => {
-					// TODO: Get DNS exception class and display correct error message
-					createErrorNotice( __( 'Failed to add DNS record.' ), {
-						type: 'snackbar',
-					} );
-				},
-			}
-		);
+		mutation.mutate( { recordsToAdd } );
 	};
 
 	return (

--- a/client/dashboard/domains/dns/add.tsx
+++ b/client/dashboard/domains/dns/add.tsx
@@ -41,7 +41,7 @@ export default function DomainAddDNS() {
 
 		const recordsToAdd: DnsRecord[] = [ formattedData ];
 
-		mutation.mutate( { recordsToAdd } );
+		mutation.mutate( { recordsToAdd }, { onSuccess: () => navigateToDNSOverviewPage() } );
 	};
 
 	return (

--- a/client/dashboard/domains/dns/edit.tsx
+++ b/client/dashboard/domains/dns/edit.tsx
@@ -50,7 +50,10 @@ export default function DomainEditDNS() {
 		const recordsToAdd: DnsRecord[] = [ recordToAdd ];
 		const recordsToRemove: DnsRecord[] = [ recordToEdit ];
 
-		mutation.mutate( { recordsToAdd, recordsToRemove } );
+		mutation.mutate(
+			{ recordsToAdd, recordsToRemove },
+			{ onSuccess: () => navigateToDNSOverviewPage() }
+		);
 	};
 
 	return (

--- a/client/dashboard/domains/dns/edit.tsx
+++ b/client/dashboard/domains/dns/edit.tsx
@@ -1,9 +1,7 @@
 import { domainDnsMutation, domainDnsQuery, domainQuery } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
+import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
@@ -18,11 +16,19 @@ import type { DnsRecord } from '@automattic/api-core';
 
 export default function DomainEditDNS() {
 	const navigate = useNavigate();
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
 	const { recordId } = domainRoute.useSearch();
-	const mutation = useMutation( domainDnsMutation( domainName ) );
+	const mutation = useMutation( {
+		...domainDnsMutation( domainName ),
+		meta: {
+			snackbar: {
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'DNS record updated successfully for %s.' ), domainName ),
+				error: { source: 'server' },
+			},
+		},
+	} );
 
 	const { data: dnsRecords } = useSuspenseQuery( domainDnsQuery( domainName ) );
 	const recordToEdit = getProcessedRecord(
@@ -44,21 +50,7 @@ export default function DomainEditDNS() {
 		const recordsToAdd: DnsRecord[] = [ recordToAdd ];
 		const recordsToRemove: DnsRecord[] = [ recordToEdit ];
 
-		mutation.mutate(
-			{ recordsToAdd, recordsToRemove },
-			{
-				onSuccess: () => {
-					createSuccessNotice( __( 'DNS record updated successfully.' ), { type: 'snackbar' } );
-					navigateToDNSOverviewPage();
-				},
-				onError: () => {
-					// TODO: Get DNS exception class and display correct error message
-					createErrorNotice( __( 'Failed to update DNS record.' ), {
-						type: 'snackbar',
-					} );
-				},
-			}
-		);
+		mutation.mutate( { recordsToAdd, recordsToRemove } );
 	};
 
 	return (

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -8,7 +8,7 @@ import {
 	CheckboxControl,
 	__experimentalDivider as Divider,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import type { DnsRecord } from '@automattic/api-core';
@@ -34,8 +34,9 @@ export default function DnsImportDialog( {
 		...domainDnsMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'DNS records saved.' ),
-				error: __( 'Failed to save DNS records.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'DNS records saved for %s.' ), domainName ),
+				error: { source: 'server' },
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-dns/email-setup-form.tsx
+++ b/client/dashboard/domains/domain-dns/email-setup-form.tsx
@@ -54,10 +54,12 @@ export default function EmailSetupForm( {
 				// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365; %(domainName)s will be replaced with the domain name
 				success: sprintf( __( '%(provider)s email set up for %(domainName)s.' ), {
 					provider: label,
+					domainName,
 				} ),
 				// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365; %(domainName)s will be replaced with the domain name
 				error: sprintf( __( 'Failed to complete %(provider)s email setup for %(domainName)s.' ), {
 					provider: label,
+					domainName,
 				} ),
 			},
 		},

--- a/client/dashboard/domains/domain-dns/email-setup-form.tsx
+++ b/client/dashboard/domains/domain-dns/email-setup-form.tsx
@@ -51,12 +51,12 @@ export default function EmailSetupForm( {
 		...domainDnsApplyTemplateMutation( domainName ),
 		meta: {
 			snackbar: {
-				// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365
-				success: sprintf( __( '%(provider)s email set up.' ), {
+				// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365; %(domainName)s will be replaced with the domain name
+				success: sprintf( __( '%(provider)s email set up for %(domainName)s.' ), {
 					provider: label,
 				} ),
-				// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365
-				error: sprintf( __( 'Failed to complete %(provider)s email setup.' ), {
+				// translators: %(providerName)s will be replaced with the name of the service provider that this template is used for, for example Google Workspace or Office 365; %(domainName)s will be replaced with the domain name
+				error: sprintf( __( 'Failed to complete %(provider)s email setup for %(domainName)s.' ), {
 					provider: label,
 				} ),
 			},

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -70,7 +70,8 @@ export default function DomainDns() {
 		...domainDnsMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Default A records restored.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Default A records restored for %s.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},
@@ -79,8 +80,9 @@ export default function DomainDns() {
 		...domainDnsEmailMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Default email DNS records restored.' ),
-				error: __( 'Failed to restore default email DNS records.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Default email DNS records restored for %s.' ), domainName ),
+				error: { source: 'server' },
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-forwarding/add.tsx
+++ b/client/dashboard/domains/domain-forwarding/add.tsx
@@ -1,7 +1,7 @@
 import { domainQuery, domainForwardingSaveMutation } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainForwardingRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
@@ -19,7 +19,8 @@ export default function AddDomainForwarding() {
 		...domainForwardingSaveMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Domain forwarding rule saved.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Domain forwarding rule for %s saved.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},

--- a/client/dashboard/domains/domain-forwarding/delete-modal.tsx
+++ b/client/dashboard/domains/domain-forwarding/delete-modal.tsx
@@ -5,7 +5,7 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import type { DomainForwarding } from '@automattic/api-core';
@@ -25,7 +25,8 @@ const DomainForwardingDeleteModal = ( {
 		...domainForwardingDeleteMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Domain forwarding rule deleted.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Domain forwarding rule for %s deleted.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},

--- a/client/dashboard/domains/domain-forwarding/edit.tsx
+++ b/client/dashboard/domains/domain-forwarding/edit.tsx
@@ -6,7 +6,7 @@ import {
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { notFound, useRouter } from '@tanstack/react-router';
 import { useMemo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainForwardingRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
@@ -25,7 +25,8 @@ export default function EditDomainForwarding() {
 		...domainForwardingSaveMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Domain forwarding rule saved.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Domain forwarding rule for %s saved.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},

--- a/client/dashboard/domains/domain-glue-records/add.tsx
+++ b/client/dashboard/domains/domain-glue-records/add.tsx
@@ -2,7 +2,7 @@ import { DomainGlueRecord } from '@automattic/api-core';
 import { domainGlueRecordCreateMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainGlueRecordsRoute } from '../../app/router/domains';
@@ -17,7 +17,8 @@ export default function AddDomainGlueRecords() {
 		...domainGlueRecordCreateMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Glue record saved.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Glue record for %s saved.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},

--- a/client/dashboard/domains/domain-glue-records/delete-modal.tsx
+++ b/client/dashboard/domains/domain-glue-records/delete-modal.tsx
@@ -5,7 +5,7 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import type { DomainGlueRecord } from '@automattic/api-core';
@@ -25,7 +25,8 @@ const DomainGlueRecordDeleteModal = ( {
 		...domainGlueRecordDeleteMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Glue record deleted.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Glue record for %s deleted.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},

--- a/client/dashboard/domains/domain-glue-records/edit.tsx
+++ b/client/dashboard/domains/domain-glue-records/edit.tsx
@@ -2,7 +2,7 @@ import { DomainGlueRecord } from '@automattic/api-core';
 import { domainGlueRecordsQuery, domainGlueRecordUpdateMutation } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute, domainGlueRecordsRoute } from '../../app/router/domains';
@@ -18,7 +18,8 @@ export default function EditDomainGlueRecords() {
 		...domainGlueRecordUpdateMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Glue record saved.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Glue record for %s saved.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},

--- a/client/dashboard/domains/domain-security/dnssec.tsx
+++ b/client/dashboard/domains/domain-security/dnssec.tsx
@@ -7,7 +7,7 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -26,8 +26,9 @@ export default function DnsSec( { domainName, domain }: DnsSecProps ) {
 		...domainDnssecMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'DNSSEC setting saved.' ),
-				error: __( 'Failed to save DNSSEC settings.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'DNSSEC setting for %s saved.' ), domainName ),
+				error: { source: 'server' },
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -10,7 +10,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { ReactElement } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { domainSecurityRoute } from '../../app/router/domains';
@@ -32,8 +32,9 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 		...provisionSslCertificateMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'New SSL certificate requested.' ),
-				error: __( 'Failed to provision SSL certificate.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'New SSL certificate requested for %s.' ), domainName ),
+				error: { source: 'server' },
 			},
 		},
 	} );

--- a/client/dashboard/domains/domain-transfer/outbound-transfer.tsx
+++ b/client/dashboard/domains/domain-transfer/outbound-transfer.tsx
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
 import { useLocale } from '../../app/locale';
@@ -66,7 +66,11 @@ export default function OutboundTransfer( { domain }: { domain: Domain } ) {
 				} );
 
 				createSuccessNotice(
-					enabled ? __( 'Transfer lock enabled.' ) : __( 'Transfer lock disabled.' ),
+					enabled
+						? /* translators: %s is the domain name */
+						  sprintf( __( 'Transfer lock enabled for %s.' ), domainName )
+						: /* translators: %s is the domain name */
+						  sprintf( __( 'Transfer lock disabled for %s.' ), domainName ),
 					{ type: 'snackbar' }
 				);
 			},

--- a/client/dashboard/domains/name-servers/index.tsx
+++ b/client/dashboard/domains/name-servers/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useCallback } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
@@ -33,7 +33,8 @@ export default function NameServers() {
 		...domainNameServersMutation( domainName ),
 		meta: {
 			snackbar: {
-				success: __( 'Name servers updated successfully.' ),
+				/* translators: %s is the domain name */
+				success: sprintf( __( 'Name servers for %s updated successfully.' ), domainName ),
 				error: { source: 'server' },
 			},
 		},


### PR DESCRIPTION
to include the domain name + move to meta.snackbar if necessary

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMAINS-1790: Notice snackbar: Review usage within domains/domain product part](https://linear.app/a8c/issue/DOMAINS-1790/notice-snackbar-review-usage-within-domainsdomain-product-part)

## Proposed Changes

* Move all domain related notices to use mutation `meta.snackbar`
* Add the domain name in all domain notices
* Show REST API errors that would have more details instead of a generic error message

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the domain experience more consistent
* Make the code more consistent

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can go over all the places I've updated and test the messages - it's:
  * DNS add/edit/delete + email setup form + DNS import
  * Domain forwarding add/edit/delete
  * Glue records add/edit/delete
  * Name servers
  * DNSSEC
  * Domain transfer lock/unlock
  * SSL cert retrigger


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
