### PR TITLE
Change the label from Default site address to Included site address

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -31,7 +31,7 @@ export const DomainNameField = ( {
 		<VStack spacing={ 1 }>
 			<span style={ textOverflowStyles }>{ value }</span>
 			{ showPrimaryDomainBadge && domain.primary_domain && (
-				<Tooltip text={ __( 'The site address your visitors will see while viewing your site.' ) }>
+				<Tooltip text={ __( 'The address people see when visiting your site.' ) }>
 					<span
 						style={ {
 							...textOverflowStyles,

--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -1,7 +1,7 @@
 import { DomainSubtype } from '@automattic/api-core';
 import config from '@automattic/calypso-config';
 import { Link } from '@tanstack/react-router';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Tooltip, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { domainOverviewRoute, domainTransferRoute } from '../../app/router/domains';
 import { Text } from '../../components/text';
@@ -31,17 +31,19 @@ export const DomainNameField = ( {
 		<VStack spacing={ 1 }>
 			<span style={ textOverflowStyles }>{ value }</span>
 			{ showPrimaryDomainBadge && domain.primary_domain && (
-				<span
-					style={ {
-						...textOverflowStyles,
-						color: 'var(--dashboard__foreground-color-success)',
-						fontWeight: 'normal',
-						textDecoration: 'underline',
-						textDecorationStyle: 'dotted',
-					} }
-				>
-					{ __( 'Primary site address' ) }
-				</span>
+				<Tooltip text={ __( 'The site address your visitors will see while viewing your site.' ) }>
+					<span
+						style={ {
+							...textOverflowStyles,
+							color: 'var(--dashboard__foreground-color-success)',
+							fontWeight: 'normal',
+							textDecoration: 'underline',
+							textDecorationStyle: 'dotted',
+						} }
+					>
+						{ __( 'Primary site address' ) }
+					</span>
+				</Tooltip>
 			) }
 			{ domain.subtype.id !== DomainSubtype.DOMAIN_REGISTRATION && (
 				<Text variant="muted" style={ { ...textOverflowStyles, fontWeight: 'normal' } }>

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -85,7 +85,7 @@ export const useFields = ( {
 					{ value: DomainSubtype.DOMAIN_REGISTRATION, label: __( 'Domain name registration' ) },
 					{ value: DomainSubtype.DOMAIN_TRANSFER, label: __( 'Domain name transfer' ) },
 					{ value: DomainSubtype.DOMAIN_CONNECTION, label: __( 'Domain name connection' ) },
-					{ value: DomainSubtype.DEFAULT_ADDRESS, label: __( 'Default site address' ) },
+					{ value: DomainSubtype.DEFAULT_ADDRESS, label: __( 'Included site address' ) },
 				],
 				filterBy: {
 					operators: [ 'isAny' as Operator ],


### PR DESCRIPTION
Update the label we show for "Default site address" to be "Included site address". While at it I've also updated the "Primary site address" to have a tooltip.

It looks like this:

| label | tooltip |
| -- | -- |
| <img width="455" height="108" alt="Screenshot 2025-12-08 at 21 48 19" src="https://github.com/user-attachments/assets/1aacf799-4a75-4989-9dbc-b75c68772f18" /> | <img width="495" height="96" alt="Screenshot 2025-12-08 at 21 48 27" src="https://github.com/user-attachments/assets/39052076-ce73-4f93-a75c-bad2f40d2d44" /> |


Part of [DOMAINS-1803: It's unclear what the difference between a Primary and a Default site address is](https://linear.app/a8c/issue/DOMAINS-1803/its-unclear-what-the-difference-between-a-primary-and-a-default-site)

## Proposed Changes

* Update the domain datagrid filter to use the proper "Included site address" label
* Update the "Primary site address" label to have a proper tooltip

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make it easier to understand what's the difference between Primary and Default site addressess

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a site domains list and verify that it shows a tooltip if you hover over the "Primary site address" label
* If you click on the filter and select type you should see "Included site address" as option

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
