### PR TITLE
MSD Billing: Show remove button if auto renew is not enabled

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -293,7 +293,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 	// FIXME: render renderWordAdsEligibilityWarningDialog for refund/cancel
 	// FIXME: render renderNonPrimaryDomainWarningDialog for refund/cancel
 	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete." next to cancel button (see domainTransferDuration)
-	if ( purchase.is_cancelable ) {
+	if ( purchase.is_cancelable && purchase.is_auto_renew_enabled ) {
 		return (
 			<ActionList.ActionItem
 				title={ __( 'Downgrade or cancel your subscription' ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [SHILL-1402](https://linear.app/a8c/issue/SHILL-1402/hosting-dashboard-cancellation-flow-improve-remove-flow-for-non)

## Proposed Changes

* Show the "Remove subscription" button instead of the "Downgrade or cancel" button if auto renew is not enabled.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To have parity with the v1 purchase settings page and the v2 cancel purchase page
* To avoid confusion when entering the cancel purchase page which will assume that the "remove" flow has been entered given that auto renew is disabled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Cancel a subscription (via v2 or v1) but don't remove it.
* Visit the `/v2/me/billing/purchases` page and click manage purchase for the subscription you just cancelled.
* Observe that the button at the bottom says "Remove subscription". Click it.
* Observe that the flow mentions "Remove" at the top (the other language will be incorrect, which will be handled with [SHILL-1350](https://linear.app/a8c/issue/SHILL-1350/hosting-dashboard-cancellation-flow-prevent-cancel-language-from))
* Continue through the flow and observe that the purchase was removed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
