### PR TITLE
Domain Transfer Redesign: Enable the new Domain Transfer Redesign in production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -32,7 +32,7 @@
 		"devdocs": false,
 		"domain-search-rewrite": true,
 		"domain-connection-redesign": true,
-		"domain-transfer-redesign": false,
+		"domain-transfer-redesign": true,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/production.json
+++ b/config/production.json
@@ -41,7 +41,7 @@
 		"dashboard/v2/backport/site-overview": true,
 		"domain-search-rewrite": true,
 		"domain-connection-redesign": true,
-		"domain-transfer-redesign": false,
+		"domain-transfer-redesign": true,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": true,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,7 @@
 		"dev/store-sandbox-helper": true,
 		"domain-search-rewrite": true,
 		"domain-connection-redesign": true,
-		"domain-transfer-redesign": false,
+		"domain-transfer-redesign": true,
 		"global-styles/on-personal-plan": false,
 		"google-my-business": true,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -47,7 +47,7 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"domain-search-rewrite": true,
 		"domain-connection-redesign": true,
-		"domain-transfer-redesign": false,
+		"domain-transfer-redesign": true,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,


### PR DESCRIPTION
Part of [DOMAINS-1839](https://linear.app/a8c/issue/DOMAINS-1839)

## Proposed Changes

This PR enables the new Domain Transfer Redesign in production.

## Why are these changes being made?

We're launching the new Domain Transfer redesign. Also, this redesign lives only inside the Multi-Site Dashboard, which is still not publicly available, so it's mostly an internal soft launch.

## Testing Instructions

- Ensure the [new Domain Transfer redesigned pages](https://linear.app/a8c/project/implement-new-domain-transfer-designs-e7cf391f6e4a) are being used in production

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
