### PR TITLE
Dashboard: remove trailing slash and query params from `path` prop in Tracks events

### DIFF
--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -40,7 +40,7 @@ export const getSuperProps = ( user: User, router: AnyRouter, queryClient: Query
 };
 
 /**
- * Normalize the path by removing leading double slashes.
+ * Normalize the path by removing leading double slashes and trailing slashes.
  */
 export function getNormalizedPath( router: AnyRouter ) {
 	const leafMatch = router.state.matches.at( -1 );
@@ -48,7 +48,7 @@ export function getNormalizedPath( router: AnyRouter ) {
 	const routeId = leafMatch?.routeId ?? '';
 
 	const normalizedBasePath = basePath.endsWith( '/' ) ? basePath.slice( 0, -1 ) : basePath;
-	return normalizedBasePath + routeId;
+	return normalizedBasePath + routeId.replace( /\/$/, '' );
 }
 
 /**

--- a/client/sites/v2/hooks/use-analytics-client.ts
+++ b/client/sites/v2/hooks/use-analytics-client.ts
@@ -11,9 +11,11 @@ export const useAnalyticsClient = ( router?: AnyRouter, currentPath?: string ) =
 		() => ( {
 			recordTracksEvent( eventName, properties ) {
 				const path = currentPath || router?.state.matches.at( -1 )?.fullPath;
+				const normalizedPath = path?.replace( /\/$/, '' );
+
 				dispatch(
 					recordTracksEvent( eventName, {
-						path,
+						path: normalizedPath,
 						...properties,
 					} )
 				);

--- a/client/utils.ts
+++ b/client/utils.ts
@@ -59,7 +59,7 @@ export function getRouteFromContext( context: Context ) {
 			route = route.replace( value, ':' + key );
 		}
 	}
-	return route;
+	return route.split( '?' )[ 0 ];
 }
 
 export interface RedirectRouteList {


### PR DESCRIPTION
## Proposed Changes

I noticed this while testing Tracks event-related PRs yesterday.

This PR cleans up the `path` prop that was added recently to dashboard Tracks events:

- Removed query params (that were not supposed to be there in the first place)
- Removed trailing slashes (that are present in some routes depending on how TanStack Router routing is set up)

||Before|After|
|-|-|-|
|v1|<img width="297" height="20" alt="image" src="https://github.com/user-attachments/assets/9258968f-7065-4355-a162-b0610db354eb" />|<img width="194" height="20" alt="image" src="https://github.com/user-attachments/assets/faec78ab-b0d9-43fe-863b-403de38dd8f4" />
|v2 (and backport)|<img width="150" height="22" alt="image" src="https://github.com/user-attachments/assets/29a077b9-4b5a-4a51-825d-15ac32844e2e" />|<img width="154" height="22" alt="image" src="https://github.com/user-attachments/assets/6f0dbb6e-c832-4076-be01-6c48fb4638e2" />


## Why are these changes being made?

Tracks event hygiene and consistency between v1 and v2.

## Testing Instructions

### v1

1. Prepare a BUSINESS SIMPLE site.
2. Go to `/sites/performance/:siteSlug?back_to=overview`
3. Verify you see the activation callout
4. Check any `calypso_dashboard_*` Track events; verify the `path` now does not have the `?back_to` param.

### v2

1. Go to `<Dashboard live link>/sites/:siteSlug`
2. Check any `calypso_dashboard_*` Track events; verify the `path` now does not have trailing slash.

### v2 backport

1. Go to `<Calypso live link>/v2/sites/:siteSlug`
2. Check any `calypso_dashboard_*` Track events; verify the `path` now does not have trailing slash.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
