### PR TITLE
MSD: Update opt-in urls

### DIFF
--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -1,5 +1,4 @@
 import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
-import config from '@automattic/calypso-config';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Button,
@@ -18,6 +17,7 @@ import FlashMessage from '../../components/flash-message';
 import { Notice } from '../../components/notice';
 import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
+import { wpcomLink } from '../../utils/link';
 import type { Field } from '@wordpress/dataviews';
 
 interface OptInFormData {
@@ -82,7 +82,7 @@ export default function PreferencesOptInForm() {
 						createSuccessNotice( __( 'New Hosting Dashboard enabled.' ), { type: 'snackbar' } );
 					} else {
 						setIsRedirecting( true );
-						window.location.href = config( 'wpcom_url' ) + '/me/account?flash=dashboard';
+						window.location.href = wpcomLink( '/me/account?flash=dashboard' );
 					}
 				},
 				onError( _, data ) {

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -1,4 +1,5 @@
 import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Button,
@@ -81,7 +82,7 @@ export default function PreferencesOptInForm() {
 						createSuccessNotice( __( 'New Hosting Dashboard enabled.' ), { type: 'snackbar' } );
 					} else {
 						setIsRedirecting( true );
-						window.location.href = '/me/account?flash=dashboard';
+						window.location.href = config( 'wpcom_url' ) + '/me/account?flash=dashboard';
 					}
 				},
 				onError( _, data ) {

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -16,10 +16,10 @@ export function wpcomLink( path: string ) {
 /**
  * This function returns the link to the dashboard.
  */
-export function dashboardLink() {
+export function dashboardLink( path: string = '' ) {
 	return config( 'env' ) === 'development'
-		? 'http://my.localhost:3000'
-		: 'https://my.wordpress.com';
+		? `http://my.localhost:3000${ path }`
+		: `https://my.wordpress.com${ path }`;
 }
 
 /**

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -14,6 +14,15 @@ export function wpcomLink( path: string ) {
 }
 
 /**
+ * This function returns the link to the dashboard.
+ */
+export function dashboardLink() {
+	return config( 'env' ) === 'development'
+		? 'http://my.localhost:3000'
+		: 'https://my.wordpress.com';
+}
+
+/**
  * This function returns the link to the reauth page.
  *
  * Currently, the dashboard run in either Calypso or Dashboard environment. When it comes to the redirect URL:

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -6,6 +6,7 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import SectionHeader from 'calypso/components/section-header';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -73,7 +74,7 @@ export default function HostingDashboardOptInForm() {
 			);
 		} else if ( enabled ) {
 			setIsRedirecting( true );
-			window.location.href = '/v2/me/preferences?flash=dashboard';
+			window.location.href = dashboardLink() + '/me/preferences?flash=dashboard';
 		} else {
 			dispatch(
 				successNotice( translate( 'Successfully saved preference.' ), {

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -74,7 +74,7 @@ export default function HostingDashboardOptInForm() {
 			);
 		} else if ( enabled ) {
 			setIsRedirecting( true );
-			window.location.href = dashboardLink() + '/me/preferences?flash=dashboard';
+			window.location.href = dashboardLink( '/me/preferences?flash=dashboard' );
 		} else {
 			dispatch(
 				successNotice( translate( 'Successfully saved preference.' ), {

--- a/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
+++ b/client/my-sites/hosting-dashboard-opt-in-banner/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -43,7 +44,7 @@ export default function HostingDashboardOptInBanner( {
 
 	const handleClick = async () => {
 		if ( hasOptedIn ) {
-			window.location.href = '/v2';
+			window.location.href = dashboardLink();
 			return;
 		}
 
@@ -66,7 +67,7 @@ export default function HostingDashboardOptInBanner( {
 				} )
 			);
 		} else {
-			window.location.href = '/v2';
+			window.location.href = dashboardLink();
 		}
 	};
 


### PR DESCRIPTION
Fixes DOTMSD-923.

## Proposed Changes

Instead of sending users to /v2, we should be sending them to the MSD subdomain.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to v1 /sites
* Click on the MSD opt-in banner
* Ensure you are taken to MSD /sites
* In MSD, head to /me/preferences
* In the Try the new Hosting Dashboard section, uncheck "I want to try the beta version" and save
* Ensure you are taken to v1 /me/preferences
* In the v1 Preferences screen, in the Try the new Hosting Dashboard, check "I want to try the beta version" and save
* Ensure you are taken to the MSD preferences

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
