### PR TITLE
Fix domain connection DNS records to use correct data source

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
@@ -45,13 +45,14 @@ export default function DnsPropagationProgressBar( {
 	const mode = domainMappingStatus.mode;
 	let progressPercentage = 0;
 
-	if ( mode === DomainConnectionSetupMode.DC ) {
-		progressPercentage = 100;
-	} else if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
+	if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
 		const currentNameServers = domainMappingStatus.name_servers || [];
 		const expectedNameServers = domainConnectionSetupInfo.wpcom_name_servers || [];
 		progressPercentage = calculateProgress( currentNameServers, expectedNameServers );
-	} else if ( mode === DomainConnectionSetupMode.ADVANCED ) {
+	} else if (
+		mode === DomainConnectionSetupMode.ADVANCED ||
+		mode === DomainConnectionSetupMode.DC
+	) {
 		const currentIpAddresses = domainMappingStatus.host_ip_addresses || [];
 		const expectedIpAddresses = domainConnectionSetupInfo.default_ip_addresses || [];
 		progressPercentage = calculateProgress( currentIpAddresses, expectedIpAddresses );

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -1,5 +1,4 @@
 import {
-	Domain,
 	DomainConnectionSetupMode,
 	DomainMappingSetupInfo,
 	DomainMappingStatus,
@@ -121,13 +120,13 @@ const nameServerRecordData = ( currentValue: string | null, expectedValue: strin
 };
 
 interface DnsRecordVerificationProps {
-	domainData: Domain;
+	domainName: string;
 	domainConnectionStatus: DomainMappingStatus;
 	domainConnectionSetupInfo: DomainMappingSetupInfo;
 }
 
 export default function DnsRecordsTable( {
-	domainData,
+	domainName,
 	domainConnectionStatus,
 	domainConnectionSetupInfo,
 }: DnsRecordVerificationProps ) {
@@ -146,7 +145,7 @@ export default function DnsRecordsTable( {
 			}
 		} else {
 			const currentIpAddresses = ( domainConnectionStatus?.host_ip_addresses || [] ).sort();
-			const expectedIpAddresses = ( domainData?.a_records_required_for_mapping || [] ).sort();
+			const expectedIpAddresses = ( domainConnectionSetupInfo.default_ip_addresses || [] ).sort();
 			const longestLength = Math.max( currentIpAddresses.length, expectedIpAddresses.length );
 
 			for ( let i = 0; i < longestLength; i++ ) {
@@ -154,11 +153,11 @@ export default function DnsRecordsTable( {
 			}
 
 			const wwwCnameRecordTarget = domainConnectionStatus.www_cname_record_target;
-			data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainData.domain ) );
+			data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainName ) );
 		}
 
 		return data;
-	}, [ domainData, domainConnectionStatus, domainConnectionSetupInfo, isSuggestedMode ] );
+	}, [ domainName, domainConnectionStatus, domainConnectionSetupInfo, isSuggestedMode ] );
 
 	return (
 		<DataViewsCard className="dns-records-table">

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -92,7 +92,7 @@ export default function DomainConnectionVerification( {
 						</Text>
 
 						<DnsRecordsTable
-							domainData={ domainData }
+							domainName={ domainName }
 							domainConnectionStatus={ domainMappingStatus }
 							domainConnectionSetupInfo={ domainConnectionSetupInfo }
 						/>

--- a/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
@@ -40,11 +40,14 @@ const createMockDomainConnectionSetupInfo = (
 } );
 
 describe( 'DnsPropagationProgressBar', () => {
-	test( 'renders 100% for DC mode', () => {
+	test( 'renders 100% for DC mode when all IP addresses match', () => {
 		const domainMappingStatus = createMockDomainMappingStatus( {
 			mode: DomainConnectionSetupMode.DC,
+			host_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
 		} );
-		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo();
+		const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+			default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
+		} );
 
 		const { getByRole, getByText } = render(
 			<DnsPropagationProgressBar


### PR DESCRIPTION
Closes [DOMAINS-1947](https://linear.app/a8c/issue/DOMAINS-1947/use-domain-connection-setup-data-to-check-verification)

## Proposed Changes
* Updated `DnsRecordsTable` component to use `domainConnectionSetupInfo.default_ip_addresses` instead of `domainData.a_records_required_for_mapping` for expected IP addresses
* Simplified component props by passing `domainName` string directly instead of the full `domainData` object
* Updated `DnsPropagationProgressBar` to calculate progress for DC (Domain Connect) mode based on actual IP address matching instead of hardcoding 100%
* Updated test to reflect new DC mode behavior that requires matching IP addresses for 100% progress

## Why are these changes being made?
The previous implementation used `domainData.a_records_required_for_mapping` to determine expected IP addresses for DNS verification. However, this field can differ from the actual expected IP addresses, especially in Domain Connect mode where the connection setup may use different IP addresses than what's stored in the domain data (Domain Connect templates always set simple site A records, even for Atomic sites).

This caused incorrect verification results in DC mode, as the component was comparing current DNS records against the wrong expected values. By using `domainConnectionSetupInfo.default_ip_addresses` instead, we ensure that all connection modes (ADVANCED and DC) use the correct expected IP addresses that match what the backend expects.

Additionally, the progress bar was hardcoding 100% for DC mode, which didn't reflect the actual DNS propagation status. Now it calculates progress based on IP address matching, providing users with accurate feedback about their connection status.

## Testing Instructions
- Navigate to domain connection setup for a domain that supports Domain Connect
- Complete the Domain Connect flow
- Verify that the DNS records table shows the correct expected IP addresses
- Check that the progress bar accurately reflects the DNS propagation status (not hardcoded 100%)
- Verify that progress updates correctly as DNS records propagate

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
