### PR TITLE
A4A: Help center improvements

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
@@ -1,43 +1,15 @@
-import { HelpCenter } from '@automattic/data-stores';
 import { HelpIcon } from '@automattic/help-center';
 import { Button } from '@wordpress/components';
-import {
-	useDispatch as useDataStoreDispatch,
-	useSelect as useDateStoreSelect,
-} from '@wordpress/data';
 import clsx from 'clsx';
-import type { HelpCenterSelect } from '@automattic/data-stores';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 
-const HELP_CENTER_STORE = HelpCenter.register();
-
-type Props = {
-	onClick?: () => void;
-};
-
-const SidebarHelpCenter = ( { onClick }: Props ) => {
-	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
-		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
-		return {
-			show: store.isHelpCenterShown(),
-			isMinimized: store.getIsMinimized(),
-		};
-	}, [] );
-
-	const { setShowHelpCenter, setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
-
-	const handleToggleHelpCenter = () => {
-		if ( isMinimized ) {
-			setIsMinimized( false );
-		} else {
-			setShowHelpCenter( ! show );
-		}
-		onClick?.();
-	};
+const SidebarHelpCenter = () => {
+	const { toggleHelpCenter, show } = useHelpCenter();
 
 	return (
 		<>
 			<Button
-				onClick={ handleToggleHelpCenter }
+				onClick={ toggleHelpCenter }
 				className={ clsx( 'sidebar__item-help', {
 					'is-active': show,
 				} ) }

--- a/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/help-center.tsx
@@ -1,21 +1,30 @@
 import { HelpIcon } from '@automattic/help-center';
-import { Button } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const SidebarHelpCenter = () => {
 	const { toggleHelpCenter, show } = useHelpCenter();
+	const dispatch = useDispatch();
+
+	const handleOnClick = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_sidebar_help_center_click' ) );
+		toggleHelpCenter();
+	};
 
 	return (
-		<>
+		<Tooltip text={ __( 'Open Help Center' ) }>
 			<Button
-				onClick={ toggleHelpCenter }
+				onClick={ handleOnClick }
 				className={ clsx( 'sidebar__item-help', {
 					'is-active': show,
 				} ) }
 				icon={ <HelpIcon /> }
 			/>
-		</>
+		</Tooltip>
 	);
 };
 

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -148,7 +148,7 @@ const A4ASidebar = ( {
 				</ul>
 			</SidebarFooter>
 
-			<A4AContactSupportWidget />
+			{ ! isEnabled( 'a4a-help-center' ) && <A4AContactSupportWidget /> }
 			<ProvideFeedback />
 		</Sidebar>
 	);

--- a/client/a8c-for-agencies/hooks/use-help-center.ts
+++ b/client/a8c-for-agencies/hooks/use-help-center.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { HelpCenter } from '@automattic/data-stores';
 import {
 	useDispatch as useDataStoreDispatch,
@@ -44,7 +45,7 @@ export default function useHelpCenter() {
 		// When the hash changes, we need to check if it contains a support form hash fragment.
 		// If it does, we need to set the show help center to true and set the navigate to route to the contact form.
 		const handleHashChange = () => {
-			if ( hasSupportFormHash ) {
+			if ( hasSupportFormHash && isEnabled( 'a4a-help-center' ) ) {
 				setShowHelpCenter( true );
 				setNavigateToRoute( '/a4a-contact-form' );
 				history.pushState( null, '', window.location.pathname + window.location.search );

--- a/client/a8c-for-agencies/hooks/use-help-center.ts
+++ b/client/a8c-for-agencies/hooks/use-help-center.ts
@@ -3,6 +3,12 @@ import {
 	useDispatch as useDataStoreDispatch,
 	useSelect as useDateStoreSelect,
 } from '@wordpress/data';
+import { useEffect } from 'react';
+import {
+	CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT,
+	CONTACT_URL_HASH_FRAGMENT,
+	CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT,
+} from '../components/a4a-contact-support-widget';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
 const HELP_CENTER_STORE = HelpCenter.register();
@@ -24,13 +30,35 @@ export default function useHelpCenter() {
 			setIsMinimized( false );
 		} else {
 			setShowHelpCenter( ! show );
+			setNavigateToRoute( '/' );
 		}
 	};
 
+	const hasSupportFormHash =
+		window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
+		window.location.hash === CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT ||
+		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
+
+	useEffect( () => {
+		// We support URL hash fragments for the contact support form.
+		// When the hash changes, we need to check if it contains a support form hash fragment.
+		// If it does, we need to set the show help center to true and set the navigate to route to the contact form.
+		const handleHashChange = () => {
+			if ( hasSupportFormHash ) {
+				setShowHelpCenter( true );
+				setNavigateToRoute( '/a4a-contact-form' );
+				history.pushState( null, '', window.location.pathname + window.location.search );
+			}
+		};
+
+		window.addEventListener( 'hashchange', handleHashChange );
+		handleHashChange();
+
+		return () => window.removeEventListener( 'hashchange', handleHashChange );
+	}, [ hasSupportFormHash, setNavigateToRoute, setShowHelpCenter ] );
+
 	return {
 		toggleHelpCenter: handleToggleHelpCenter,
-		setNavigateToRoute,
 		show,
-		isMinimized,
 	};
 }

--- a/client/a8c-for-agencies/hooks/use-help-center.ts
+++ b/client/a8c-for-agencies/hooks/use-help-center.ts
@@ -16,7 +16,8 @@ export default function useHelpCenter() {
 		};
 	}, [] );
 
-	const { setShowHelpCenter, setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setIsMinimized, setNavigateToRoute } =
+		useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const handleToggleHelpCenter = () => {
 		if ( isMinimized ) {
@@ -24,11 +25,11 @@ export default function useHelpCenter() {
 		} else {
 			setShowHelpCenter( ! show );
 		}
-		onClick?.();
 	};
 
 	return {
 		toggleHelpCenter: handleToggleHelpCenter,
+		setNavigateToRoute,
 		show,
 		isMinimized,
 	};

--- a/client/a8c-for-agencies/hooks/use-help-center.ts
+++ b/client/a8c-for-agencies/hooks/use-help-center.ts
@@ -1,0 +1,35 @@
+import { HelpCenter } from '@automattic/data-stores';
+import {
+	useDispatch as useDataStoreDispatch,
+	useSelect as useDateStoreSelect,
+} from '@wordpress/data';
+import type { HelpCenterSelect } from '@automattic/data-stores';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+export default function useHelpCenter() {
+	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return {
+			show: store.isHelpCenterShown(),
+			isMinimized: store.getIsMinimized(),
+		};
+	}, [] );
+
+	const { setShowHelpCenter, setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const handleToggleHelpCenter = () => {
+		if ( isMinimized ) {
+			setIsMinimized( false );
+		} else {
+			setShowHelpCenter( ! show );
+		}
+		onClick?.();
+	};
+
+	return {
+		toggleHelpCenter: handleToggleHelpCenter,
+		show,
+		isMinimized,
+	};
+}

--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -57,6 +57,8 @@ export default function HelpCenterLoader( {
 							pressableId: agency?.third_party?.pressable?.pressable_id,
 					  }
 					: null,
+				disableChatSupport: true,
+				hideMoreResources: true,
 		  }
 		: {};
 

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -59,7 +59,7 @@ const EllipsisMenu = () => {
 	const { __ } = useI18n();
 	const navigate = useNavigate();
 	const { recentConversations } = useGetHistoryChats();
-	const { source } = useHelpCenterContext();
+	const { disableChatSupport } = useHelpCenterContext();
 	const { areSoundNotificationsEnabled } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
@@ -99,7 +99,7 @@ const EllipsisMenu = () => {
 					<Menu.ItemLabel>{ __( 'Minimize', __i18n_text_domain__ ) }</Menu.ItemLabel>
 				</Menu.Item>
 				<Menu.Separator />
-				{ source !== 'a4a' && (
+				{ ! disableChatSupport && (
 					<>
 						<Menu.Item
 							onClick={ clearChat }

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -25,6 +25,7 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { HELP_CENTER_STORE } from '../stores';
 import { BackButton } from './back-button';
 import type { Header } from '../types';
@@ -58,6 +59,7 @@ const EllipsisMenu = () => {
 	const { __ } = useI18n();
 	const navigate = useNavigate();
 	const { recentConversations } = useGetHistoryChats();
+	const { source } = useHelpCenterContext();
 	const { areSoundNotificationsEnabled } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
@@ -97,19 +99,23 @@ const EllipsisMenu = () => {
 					<Menu.ItemLabel>{ __( 'Minimize', __i18n_text_domain__ ) }</Menu.ItemLabel>
 				</Menu.Item>
 				<Menu.Separator />
-				<Menu.Item
-					onClick={ clearChat }
-					prefix={ <Icon icon={ comment } width={ 24 } height={ 24 } /> }
-				>
-					<Menu.ItemLabel>{ __( 'New chat', __i18n_text_domain__ ) }</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu.Item
-					onClick={ handleViewChats }
-					prefix={ <Icon icon={ backup } width={ 24 } height={ 24 } /> }
-				>
-					<Menu.ItemLabel>{ __( 'Support history', __i18n_text_domain__ ) }</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu.Separator />
+				{ source !== 'a4a' && (
+					<>
+						<Menu.Item
+							onClick={ clearChat }
+							prefix={ <Icon icon={ comment } width={ 24 } height={ 24 } /> }
+						>
+							<Menu.ItemLabel>{ __( 'New chat', __i18n_text_domain__ ) }</Menu.ItemLabel>
+						</Menu.Item>
+						<Menu.Item
+							onClick={ handleViewChats }
+							prefix={ <Icon icon={ backup } width={ 24 } height={ 24 } /> }
+						>
+							<Menu.ItemLabel>{ __( 'Support history', __i18n_text_domain__ ) }</Menu.ItemLabel>
+						</Menu.Item>
+						<Menu.Separator />
+					</>
+				) }
 				<Menu.Item
 					onClick={ toggleSoundNotifications }
 					prefix={

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -32,6 +32,11 @@ export const HelpCenterMoreResources = () => {
 		trackMoreResourcesButtonClick( resourceType );
 	};
 
+	if ( source === 'a4a' ) {
+		// For A4A, we don't show the more resources section.
+		return null;
+	}
+
 	return (
 		<div className="help-center-more-resources">
 			<h3 className="help-center__section-title">
@@ -54,40 +59,36 @@ export const HelpCenterMoreResources = () => {
 						</button>
 					</div>
 				</li>
-				{ source === 'wpcom' && (
-					<>
-						<li className="help-center-more-resources__resource-item help-center-link__item">
-							<div className="help-center-more-resources__resource-cell help-center-link__cell">
-								<a
-									href={ localizeUrl( 'https://wordpress.com/support/courses' ) }
-									rel="noreferrer"
-									target="_blank"
-									onClick={ () => trackLearnButtonClick( 'courses' ) }
-									className="help-center-more-resources__institution"
-								>
-									<Icon icon={ video } size={ 24 } />
-									<span>{ __( 'Courses', __i18n_text_domain__ ) }</span>
-									<Icon icon={ external } size={ 20 } />
-								</a>
-							</div>
-						</li>
-						<li className="help-center-more-resources__resource-item help-center-link__item">
-							<div className="help-center-more-resources__resource-cell help-center-link__cell">
-								<a
-									href={ localizeUrl( 'https://wordpress.com/blog/category/product-features/' ) }
-									rel="noreferrer"
-									target="_blank"
-									className="help-center-more-resources__product-updates"
-									onClick={ () => trackMoreResourcesButtonClick( 'product-updates' ) }
-								>
-									<Icon icon={ rss } size={ 24 } />
-									<span>{ __( 'Product updates', __i18n_text_domain__ ) }</span>
-									<Icon icon={ external } size={ 20 } />
-								</a>
-							</div>
-						</li>
-					</>
-				) }
+				<li className="help-center-more-resources__resource-item help-center-link__item">
+					<div className="help-center-more-resources__resource-cell help-center-link__cell">
+						<a
+							href={ localizeUrl( 'https://wordpress.com/support/courses' ) }
+							rel="noreferrer"
+							target="_blank"
+							onClick={ () => trackLearnButtonClick( 'courses' ) }
+							className="help-center-more-resources__institution"
+						>
+							<Icon icon={ video } size={ 24 } />
+							<span>{ __( 'Courses', __i18n_text_domain__ ) }</span>
+							<Icon icon={ external } size={ 20 } />
+						</a>
+					</div>
+				</li>
+				<li className="help-center-more-resources__resource-item help-center-link__item">
+					<div className="help-center-more-resources__resource-cell help-center-link__cell">
+						<a
+							href={ localizeUrl( 'https://wordpress.com/blog/category/product-features/' ) }
+							rel="noreferrer"
+							target="_blank"
+							className="help-center-more-resources__product-updates"
+							onClick={ () => trackMoreResourcesButtonClick( 'product-updates' ) }
+						>
+							<Icon icon={ rss } size={ 24 } />
+							<span>{ __( 'Product updates', __i18n_text_domain__ ) }</span>
+							<Icon icon={ external } size={ 20 } />
+						</a>
+					</div>
+				</li>
 			</ul>
 		</div>
 	);

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -11,7 +11,7 @@ import './help-center-more-resources.scss';
 
 export const HelpCenterMoreResources = () => {
 	const { __ } = useI18n();
-	const { sectionName, source } = useHelpCenterContext();
+	const { sectionName, disableChatSupport } = useHelpCenterContext();
 	const navigate = useNavigate();
 
 	const trackMoreResourcesButtonClick = ( resource: string ) => {
@@ -32,33 +32,30 @@ export const HelpCenterMoreResources = () => {
 		trackMoreResourcesButtonClick( resourceType );
 	};
 
-	if ( source === 'a4a' ) {
-		// For A4A, we don't show the more resources section.
-		return null;
-	}
-
 	return (
 		<div className="help-center-more-resources">
 			<h3 className="help-center__section-title">
 				{ __( 'More resources', __i18n_text_domain__ ) }
 			</h3>
 			<ul aria-labelledby="help-center-more-resources__resources">
-				<li className="help-center-more-resources__resource-item help-center-link__item">
-					<div className="help-center-more-resources__resource-cell help-center-link__cell">
-						<button
-							type="button"
-							onClick={ () => {
-								trackMoreResourcesButtonClick( 'support-history' );
-								navigate( '/chat-history' );
-							} }
-							className="help-center-more-resources__support-history"
-						>
-							<Icon icon={ backup } size={ 24 } />
-							<span>{ __( 'Support history', __i18n_text_domain__ ) }</span>
-							<Icon icon={ chevronRight } size={ 20 } />
-						</button>
-					</div>
-				</li>
+				{ ! disableChatSupport && (
+					<li className="help-center-more-resources__resource-item help-center-link__item">
+						<div className="help-center-more-resources__resource-cell help-center-link__cell">
+							<button
+								type="button"
+								onClick={ () => {
+									trackMoreResourcesButtonClick( 'support-history' );
+									navigate( '/chat-history' );
+								} }
+								className="help-center-more-resources__support-history"
+							>
+								<Icon icon={ backup } size={ 24 } />
+								<span>{ __( 'Support history', __i18n_text_domain__ ) }</span>
+								<Icon icon={ chevronRight } size={ 20 } />
+							</button>
+						</div>
+					</li>
+				) }
 				<li className="help-center-more-resources__resource-item help-center-link__item">
 					<div className="help-center-more-resources__resource-cell help-center-link__cell">
 						<a

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -11,7 +11,7 @@ import './help-center-more-resources.scss';
 
 export const HelpCenterMoreResources = () => {
 	const { __ } = useI18n();
-	const { sectionName } = useHelpCenterContext();
+	const { sectionName, source } = useHelpCenterContext();
 	const navigate = useNavigate();
 
 	const trackMoreResourcesButtonClick = ( resource: string ) => {
@@ -54,36 +54,40 @@ export const HelpCenterMoreResources = () => {
 						</button>
 					</div>
 				</li>
-				<li className="help-center-more-resources__resource-item help-center-link__item">
-					<div className="help-center-more-resources__resource-cell help-center-link__cell">
-						<a
-							href={ localizeUrl( 'https://wordpress.com/support/courses' ) }
-							rel="noreferrer"
-							target="_blank"
-							onClick={ () => trackLearnButtonClick( 'courses' ) }
-							className="help-center-more-resources__institution"
-						>
-							<Icon icon={ video } size={ 24 } />
-							<span>{ __( 'Courses', __i18n_text_domain__ ) }</span>
-							<Icon icon={ external } size={ 20 } />
-						</a>
-					</div>
-				</li>
-				<li className="help-center-more-resources__resource-item help-center-link__item">
-					<div className="help-center-more-resources__resource-cell help-center-link__cell">
-						<a
-							href={ localizeUrl( 'https://wordpress.com/blog/category/product-features/' ) }
-							rel="noreferrer"
-							target="_blank"
-							className="help-center-more-resources__product-updates"
-							onClick={ () => trackMoreResourcesButtonClick( 'product-updates' ) }
-						>
-							<Icon icon={ rss } size={ 24 } />
-							<span>{ __( 'Product updates', __i18n_text_domain__ ) }</span>
-							<Icon icon={ external } size={ 20 } />
-						</a>
-					</div>
-				</li>
+				{ source === 'wpcom' && (
+					<>
+						<li className="help-center-more-resources__resource-item help-center-link__item">
+							<div className="help-center-more-resources__resource-cell help-center-link__cell">
+								<a
+									href={ localizeUrl( 'https://wordpress.com/support/courses' ) }
+									rel="noreferrer"
+									target="_blank"
+									onClick={ () => trackLearnButtonClick( 'courses' ) }
+									className="help-center-more-resources__institution"
+								>
+									<Icon icon={ video } size={ 24 } />
+									<span>{ __( 'Courses', __i18n_text_domain__ ) }</span>
+									<Icon icon={ external } size={ 20 } />
+								</a>
+							</div>
+						</li>
+						<li className="help-center-more-resources__resource-item help-center-link__item">
+							<div className="help-center-more-resources__resource-cell help-center-link__cell">
+								<a
+									href={ localizeUrl( 'https://wordpress.com/blog/category/product-features/' ) }
+									rel="noreferrer"
+									target="_blank"
+									className="help-center-more-resources__product-updates"
+									onClick={ () => trackMoreResourcesButtonClick( 'product-updates' ) }
+								>
+									<Icon icon={ rss } size={ 24 } />
+									<span>{ __( 'Product updates', __i18n_text_domain__ ) }</span>
+									<Icon icon={ external } size={ 20 } />
+								</a>
+							</div>
+						</li>
+					</>
+				) }
 			</ul>
 		</div>
 	);

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -17,7 +17,8 @@ type HelpCenterSearchProps = {
 };
 
 export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSearchProps ) => {
-	const { sectionName, site, currentUser } = useHelpCenterContext();
+	const { sectionName, site, currentUser, hideMoreResources, disableChatSupport } =
+		useHelpCenterContext();
 	const { searchQuery, setSearchQueryAndEmailSubject, redirectToArticle } =
 		useHelpCenterSearch( onSearchChange );
 
@@ -26,8 +27,12 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 
 	return (
 		<div className="inline-help__search">
-			<HelpCenterRecentConversations />
-			<BlockedZendeskNotice />
+			{ ! disableChatSupport && (
+				<>
+					<HelpCenterRecentConversations />
+					<BlockedZendeskNotice />
+				</>
+			) }
 			{ launchpadEnabled && <HelpCenterLaunchpad /> }
 			<InlineHelpSearchCard
 				searchQuery={ searchQuery }
@@ -46,7 +51,7 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 				location="help-center"
 				currentRoute={ currentRoute }
 			/>
-			{ ! searchQuery && <HelpCenterMoreResources /> }
+			{ ! searchQuery && ! hideMoreResources && <HelpCenterMoreResources /> }
 		</div>
 	);
 };

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -16,6 +16,8 @@ export type HelpCenterRequiredInformation = {
 	onboardingUrl: string;
 	isCommerceGarden: boolean;
 	source: '' | 'wpcom' | 'a4a';
+	disableChatSupport: boolean;
+	hideMoreResources: boolean;
 	// This is specific to A4A
 	agency: {
 		id: number;
@@ -70,6 +72,8 @@ const defaultContext: HelpCenterRequiredInformation = {
 	onboardingUrl: '',
 	isCommerceGarden: false,
 	source: 'wpcom',
+	disableChatSupport: false,
+	hideMoreResources: false,
 	agency: null,
 };
 


### PR DESCRIPTION
This fixes a couple of feedback during a quick testing with the new A4A help center.

Context: p1765209008877089-slack-C07T87RHK44

## Proposed Changes

* Add a `disableChatSupport` parameter in the Help center to hide the Chat functionality in the A4A Help center.
* Add a `hideMoreResources` parameter in the Help center to hide More resources for A4A.
   <img width="460" height="854" alt="Screenshot 2025-12-09 at 6 27 06 PM" src="https://github.com/user-attachments/assets/ce9d7ac0-8294-4e6f-9a30-8ff47e060da2" />
* Replace the current Contact URL hash to trigger the Help center. (Enabling existing contact form buttons to now show the help center)
* Add Tooltip and tracking to the Help center button.
   <img width="241" height="140" alt="Screenshot 2025-12-09 at 6 28 26 PM" src="https://github.com/user-attachments/assets/2855cac2-6673-4e9d-b625-15d29bb0578a" />


## Why are these changes being made?

* Part of the Cohesive support in A4A. 

## Testing Instructions

* Use the A4A live link and navigate to the `/overview` page.
* Test all the proposed changes to see if they work properly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?