### PR TITLE
Add Cloudflare IP address support to domain connection verification

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
@@ -43,6 +43,7 @@ export default function DnsPropagationProgressBar( {
 	domainConnectionSetupInfo,
 }: Props ) {
 	const mode = domainMappingStatus.mode;
+	const hasCloudflareIpAddresses = domainMappingStatus.has_cloudflare_ip_addresses;
 	let progressPercentage = 0;
 
 	if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
@@ -56,6 +57,8 @@ export default function DnsPropagationProgressBar( {
 		const currentIpAddresses = domainMappingStatus.host_ip_addresses || [];
 		const expectedIpAddresses = domainConnectionSetupInfo.default_ip_addresses || [];
 		progressPercentage = calculateProgress( currentIpAddresses, expectedIpAddresses );
+	} else if ( hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom ) {
+		progressPercentage = 100;
 	} else {
 		// All other cases: 0%
 		progressPercentage = 0;

--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
@@ -46,15 +46,9 @@ export default function DnsPropagationProgressBar( {
 	const hasCloudflareIpAddresses = domainMappingStatus.has_cloudflare_ip_addresses;
 	let progressPercentage = 0;
 
-<<<<<<< HEAD
-	if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
-=======
 	if ( hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom ) {
 		progressPercentage = 100;
-	} else if ( mode === DomainConnectionSetupMode.DC ) {
-		progressPercentage = 100;
 	} else if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
->>>>>>> 29429bcb806 (Minor fixes)
 		const currentNameServers = domainMappingStatus.name_servers || [];
 		const expectedNameServers = domainConnectionSetupInfo.wpcom_name_servers || [];
 		progressPercentage = calculateProgress( currentNameServers, expectedNameServers );

--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
@@ -46,7 +46,15 @@ export default function DnsPropagationProgressBar( {
 	const hasCloudflareIpAddresses = domainMappingStatus.has_cloudflare_ip_addresses;
 	let progressPercentage = 0;
 
+<<<<<<< HEAD
 	if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
+=======
+	if ( hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom ) {
+		progressPercentage = 100;
+	} else if ( mode === DomainConnectionSetupMode.DC ) {
+		progressPercentage = 100;
+	} else if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
+>>>>>>> 29429bcb806 (Minor fixes)
 		const currentNameServers = domainMappingStatus.name_servers || [];
 		const expectedNameServers = domainConnectionSetupInfo.wpcom_name_servers || [];
 		progressPercentage = calculateProgress( currentNameServers, expectedNameServers );
@@ -57,8 +65,6 @@ export default function DnsPropagationProgressBar( {
 		const currentIpAddresses = domainMappingStatus.host_ip_addresses || [];
 		const expectedIpAddresses = domainConnectionSetupInfo.default_ip_addresses || [];
 		progressPercentage = calculateProgress( currentIpAddresses, expectedIpAddresses );
-	} else if ( hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom ) {
-		progressPercentage = 100;
 	} else {
 		// All other cases: 0%
 		progressPercentage = 0;

--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
@@ -46,19 +46,18 @@ export default function DnsPropagationProgressBar( {
 	const hasCloudflareIpAddresses = domainMappingStatus.has_cloudflare_ip_addresses;
 	let progressPercentage = 0;
 
-	if ( hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom ) {
+	if ( mode === DomainConnectionSetupMode.DC ) {
 		progressPercentage = 100;
 	} else if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
 		const currentNameServers = domainMappingStatus.name_servers || [];
 		const expectedNameServers = domainConnectionSetupInfo.wpcom_name_servers || [];
 		progressPercentage = calculateProgress( currentNameServers, expectedNameServers );
-	} else if (
-		mode === DomainConnectionSetupMode.ADVANCED ||
-		mode === DomainConnectionSetupMode.DC
-	) {
+	} else if ( mode === DomainConnectionSetupMode.ADVANCED ) {
 		const currentIpAddresses = domainMappingStatus.host_ip_addresses || [];
 		const expectedIpAddresses = domainConnectionSetupInfo.default_ip_addresses || [];
 		progressPercentage = calculateProgress( currentIpAddresses, expectedIpAddresses );
+	} else if ( hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom ) {
+		progressPercentage = 100;
 	} else {
 		// All other cases: 0%
 		progressPercentage = 0;

--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar.tsx
@@ -46,13 +46,14 @@ export default function DnsPropagationProgressBar( {
 	const hasCloudflareIpAddresses = domainMappingStatus.has_cloudflare_ip_addresses;
 	let progressPercentage = 0;
 
-	if ( mode === DomainConnectionSetupMode.DC ) {
-		progressPercentage = 100;
-	} else if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
+	if ( mode === DomainConnectionSetupMode.SUGGESTED ) {
 		const currentNameServers = domainMappingStatus.name_servers || [];
 		const expectedNameServers = domainConnectionSetupInfo.wpcom_name_servers || [];
 		progressPercentage = calculateProgress( currentNameServers, expectedNameServers );
-	} else if ( mode === DomainConnectionSetupMode.ADVANCED ) {
+	} else if (
+		mode === DomainConnectionSetupMode.ADVANCED ||
+		mode === DomainConnectionSetupMode.DC
+	) {
 		const currentIpAddresses = domainMappingStatus.host_ip_addresses || [];
 		const expectedIpAddresses = domainConnectionSetupInfo.default_ip_addresses || [];
 		progressPercentage = calculateProgress( currentIpAddresses, expectedIpAddresses );

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -49,6 +49,8 @@ export default function DomainConnectionVerification( {
 		? 'connected'
 		: 'verifying';
 
+	const hasCloudflareIpAddresses = domainMappingStatus.has_cloudflare_ip_addresses;
+
 	const connectedAndCanBeSetAsPrimary =
 		status === 'connected' && ! domainData.primary_domain && domainData.can_set_as_primary;
 
@@ -91,11 +93,27 @@ export default function DomainConnectionVerification( {
 								: __( 'DNS record verification' ) }
 						</Text>
 
-						<DnsRecordsTable
-							domainName={ domainName }
-							domainConnectionStatus={ domainMappingStatus }
-							domainConnectionSetupInfo={ domainConnectionSetupInfo }
-						/>
+						{ ! hasCloudflareIpAddresses && (
+							<DnsRecordsTable
+								domainName={ domainName }
+								domainConnectionStatus={ domainMappingStatus }
+								domainConnectionSetupInfo={ domainConnectionSetupInfo }
+							/>
+						) }
+						{ hasCloudflareIpAddresses && ! domainMappingStatus.resolves_to_wpcom && (
+							<Notice variant="error">
+								{ __(
+									'Your domain appears to be set up with Cloudflare, but does not resolve to WordPress.com'
+								) }
+							</Notice>
+						) }
+						{ hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom && (
+							<Notice variant="info">
+								{ __(
+									'Your domain appears to be set up with Cloudflare, and it resolves to WordPress.com'
+								) }
+							</Notice>
+						) }
 					</VStack>
 
 					{ status === 'connected' && <DomainPropagationStatus domainName={ domainName } /> }

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -87,12 +87,14 @@ export default function DomainConnectionVerification( {
 							{ hasCloudflareIpAddresses
 								? createInterpolateElement(
 										__(
-											'<domainName/> is using Cloudflare, which hides dns records, so we can’t verify them the usual way. We’ll still confirm that your domain name points to <appName/>.com. Please check that your <link>Cloudflare</link> dns settings include the required records.'
+											'<domainName/> is using Cloudflare, which hides DNS records, so we can’t verify them the usual way. We’ll still confirm that your domain name points to <appName/>.com. Please check that your <cloudflare/> DNS settings include the required records.'
 										),
 										{
 											domainName: <>{ domainName }</>,
 											appName: <>{ appName }</>,
-											link: <ExternalLink href="https://www.cloudflare.com/" children={ null } />,
+											cloudflare: (
+												<ExternalLink href="https://www.cloudflare.com/">Cloudflare</ExternalLink>
+											),
 										}
 								  )
 								: __(
@@ -119,8 +121,14 @@ export default function DomainConnectionVerification( {
 						) }
 						{ hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom && (
 							<Notice variant="info">
-								{ __(
-									'Your domain appears to be set up with Cloudflare and it resolves to WordPress.com.'
+								{ createInterpolateElement(
+									__(
+										'<domainName/> appears to be set up with Cloudflare and it resolves to <appName/>.'
+									),
+									{
+										domainName: <>{ domainName }</>,
+										appName: <>{ appName }</>,
+									}
 								) }
 							</Notice>
 						) }

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -103,14 +103,14 @@ export default function DomainConnectionVerification( {
 						{ hasCloudflareIpAddresses && ! domainMappingStatus.resolves_to_wpcom && (
 							<Notice variant="error">
 								{ __(
-									'Your domain appears to be set up with Cloudflare, but does not resolve to WordPress.com'
+									'Your domain appears to be set up with Cloudflare, but does not resolve to WordPress.com. Please make sure your domain is properly configured to point to WordPress.com in your Cloudflare dashboard.'
 								) }
 							</Notice>
 						) }
 						{ hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom && (
 							<Notice variant="info">
 								{ __(
-									'Your domain appears to be set up with Cloudflare, and it resolves to WordPress.com'
+									'Your domain appears to be set up with Cloudflare and it resolves to WordPress.com.'
 								) }
 							</Notice>
 						) }

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -1,14 +1,17 @@
 import { Domain, DomainConnectionSetupMode } from '@automattic/api-core';
 import { Badge } from '@automattic/ui';
 import {
+	ExternalLink,
 	Icon,
 	Button,
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { layout, swatch, atSymbol, published } from '@wordpress/icons';
+import { useAppContext } from '../../app/context';
 import { siteDomainsRoute, siteOverviewRoute } from '../../app/router/sites';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -42,6 +45,7 @@ export default function DomainConnectionVerification( {
 	onRestartConnection,
 	isRestartingConnection,
 }: DomainConnectionVerificationProps ) {
+	const { name: appName } = useAppContext();
 	const status: DomainConnectionStatus = isMappingVerificationSuccess(
 		domainMappingStatus.mode,
 		domainMappingStatus
@@ -80,9 +84,20 @@ export default function DomainConnectionVerification( {
 
 					{ status === 'verifying' && (
 						<Notice variant="info">
-							{ __(
-								'We’re checking your DNS records. Most updates happen quickly, but some providers cache old settings for up to 72 hours.'
-							) }
+							{ hasCloudflareIpAddresses
+								? createInterpolateElement(
+										__(
+											'<domainName/> is using Cloudflare, which hides dns records, so we can’t verify them the usual way. We’ll still confirm that your domain name points to <appName/>.com. Please check that your <link>Cloudflare</link> dns settings include the required records./>'
+										),
+										{
+											domainName: <>{ domainName }</>,
+											appName: <>{ appName }</>,
+											link: <ExternalLink href="https://www.cloudflare.com/" children={ null } />,
+										}
+								  )
+								: __(
+										'We’re checking your DNS records. Most updates happen quickly, but some providers cache old settings for up to 72 hours.'
+								  ) }
 						</Notice>
 					) }
 
@@ -99,13 +114,6 @@ export default function DomainConnectionVerification( {
 								domainConnectionStatus={ domainMappingStatus }
 								domainConnectionSetupInfo={ domainConnectionSetupInfo }
 							/>
-						) }
-						{ hasCloudflareIpAddresses && ! domainMappingStatus.resolves_to_wpcom && (
-							<Notice variant="error">
-								{ __(
-									'Your domain appears to be set up with Cloudflare, but does not resolve to WordPress.com. Please make sure your domain is properly configured to point to WordPress.com in your Cloudflare dashboard.'
-								) }
-							</Notice>
 						) }
 						{ hasCloudflareIpAddresses && domainMappingStatus.resolves_to_wpcom && (
 							<Notice variant="info">

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -87,7 +87,7 @@ export default function DomainConnectionVerification( {
 							{ hasCloudflareIpAddresses
 								? createInterpolateElement(
 										__(
-											'<domainName/> is using Cloudflare, which hides dns records, so we can’t verify them the usual way. We’ll still confirm that your domain name points to <appName/>.com. Please check that your <link>Cloudflare</link> dns settings include the required records./>'
+											'<domainName/> is using Cloudflare, which hides dns records, so we can’t verify them the usual way. We’ll still confirm that your domain name points to <appName/>.com. Please check that your <link>Cloudflare</link> dns settings include the required records.'
 										),
 										{
 											domainName: <>{ domainName }</>,
@@ -102,11 +102,13 @@ export default function DomainConnectionVerification( {
 					) }
 
 					<VStack spacing={ 4 }>
-						<Text size="medium" weight={ 500 }>
-							{ domainMappingStatus.mode === DomainConnectionSetupMode.SUGGESTED
-								? __( 'Name server verification' )
-								: __( 'DNS record verification' ) }
-						</Text>
+						{ ! hasCloudflareIpAddresses && (
+							<Text size="medium" weight={ 500 }>
+								{ domainMappingStatus.mode === DomainConnectionSetupMode.SUGGESTED
+									? __( 'Name server verification' )
+									: __( 'DNS record verification' ) }
+							</Text>
+						) }
 
 						{ ! hasCloudflareIpAddresses && (
 							<DnsRecordsTable

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -134,7 +134,7 @@ export default function DomainConnectionVerification( {
 						) }
 					</VStack>
 
-					{ status === 'connected' && <DomainPropagationStatus domainName={ domainName } /> }
+					<DomainPropagationStatus domainName={ domainName } />
 
 					<VStack spacing={ 4 }>
 						{ status === 'verifying' && (

--- a/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
@@ -489,25 +489,5 @@ describe( 'DnsPropagationProgressBar', () => {
 			expect( getByText( '50%' ) ).toBeVisible();
 			expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '50' );
 		} );
-
-		test( 'prioritizes DC mode over Cloudflare logic', () => {
-			const domainMappingStatus = createMockDomainMappingStatus( {
-				mode: DomainConnectionSetupMode.DC,
-				has_cloudflare_ip_addresses: true,
-				resolves_to_wpcom: true,
-			} );
-			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo();
-
-			const { getByRole, getByText } = render(
-				<DnsPropagationProgressBar
-					domainMappingStatus={ domainMappingStatus }
-					domainConnectionSetupInfo={ domainConnectionSetupInfo }
-				/>
-			);
-
-			// Should show 100% from DC mode, not from Cloudflare logic
-			expect( getByText( '100%' ) ).toBeVisible();
-			expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
-		} );
 	} );
 } );

--- a/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
@@ -366,4 +366,148 @@ describe( 'DnsPropagationProgressBar', () => {
 		expect( getByText( '0%' ) ).toBeVisible();
 		expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
 	} );
+
+	describe( 'Cloudflare IP addresses', () => {
+		test( 'renders 100% when has Cloudflare IP addresses and resolves to WordPress.com', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: DomainConnectionSetupMode.DONE,
+				has_cloudflare_ip_addresses: true,
+				resolves_to_wpcom: true,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo();
+
+			const { getByRole, getByText } = render(
+				<DnsPropagationProgressBar
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			expect( getByText( '100%' ) ).toBeVisible();
+			expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
+		} );
+
+		test( 'renders 100% when has Cloudflare IP addresses and resolves to WordPress.com with null mode', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: null,
+				has_cloudflare_ip_addresses: true,
+				resolves_to_wpcom: true,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo();
+
+			const { getByRole, getByText } = render(
+				<DnsPropagationProgressBar
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			expect( getByText( '100%' ) ).toBeVisible();
+			expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
+		} );
+
+		test( 'renders 0% when has Cloudflare IP addresses but does not resolve to WordPress.com', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: DomainConnectionSetupMode.DONE,
+				has_cloudflare_ip_addresses: true,
+				resolves_to_wpcom: false,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo();
+
+			const { getByRole, getByText } = render(
+				<DnsPropagationProgressBar
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			expect( getByText( '0%' ) ).toBeVisible();
+			expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
+		} );
+
+		test( 'renders 0% when does not have Cloudflare IP addresses even if resolves to WordPress.com', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: DomainConnectionSetupMode.DONE,
+				has_cloudflare_ip_addresses: false,
+				resolves_to_wpcom: true,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo();
+
+			const { getByRole, getByText } = render(
+				<DnsPropagationProgressBar
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			expect( getByText( '0%' ) ).toBeVisible();
+			expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '0' );
+		} );
+
+		test( 'prioritizes mode-specific logic over Cloudflare logic for SUGGESTED mode', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: DomainConnectionSetupMode.SUGGESTED,
+				has_cloudflare_ip_addresses: true,
+				resolves_to_wpcom: true,
+				name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com' ],
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+			} );
+
+			const { getByRole, getByText } = render(
+				<DnsPropagationProgressBar
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Should show 67% based on name server matching, not 100% from Cloudflare
+			expect( getByText( '67%' ) ).toBeVisible();
+			expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '67' );
+		} );
+
+		test( 'prioritizes mode-specific logic over Cloudflare logic for ADVANCED mode', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: DomainConnectionSetupMode.ADVANCED,
+				has_cloudflare_ip_addresses: true,
+				resolves_to_wpcom: true,
+				host_ip_addresses: [ '192.0.78.24' ],
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo( {
+				default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
+			} );
+
+			const { getByRole, getByText } = render(
+				<DnsPropagationProgressBar
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Should show 50% based on IP address matching, not 100% from Cloudflare
+			expect( getByText( '50%' ) ).toBeVisible();
+			expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '50' );
+		} );
+
+		test( 'prioritizes DC mode over Cloudflare logic', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				mode: DomainConnectionSetupMode.DC,
+				has_cloudflare_ip_addresses: true,
+				resolves_to_wpcom: true,
+			} );
+			const domainConnectionSetupInfo = createMockDomainConnectionSetupInfo();
+
+			const { getByRole, getByText } = render(
+				<DnsPropagationProgressBar
+					domainMappingStatus={ domainMappingStatus }
+					domainConnectionSetupInfo={ domainConnectionSetupInfo }
+				/>
+			);
+
+			// Should show 100% from DC mode, not from Cloudflare logic
+			expect( getByText( '100%' ) ).toBeVisible();
+			expect( getByRole( 'progressbar' ) ).toHaveAttribute( 'value', '100' );
+		} );
+	} );
 } );


### PR DESCRIPTION
Part of [DOMAINS-1944](https://linear.app/a8c/issue/DOMAINS-1944/show-a-message-if-the-user-is-using-cloudflare)

## Proposed Changes
* Add Cloudflare IP address detection and handling in domain connection verification
* Show 100% progress when domain has Cloudflare IPs and resolves to WordPress.com
* Display user-friendly notices for Cloudflare scenarios instead of showing DNS records table
* Add comprehensive test coverage for Cloudflare logic (7 new test cases)

## Why are these changes being made?
When users have their domains set up with Cloudflare, the DNS records are proxied through Cloudflare's network, which means we can't verify the connection using the standard DNS record checking method. This PR adds support for detecting Cloudflare IP addresses and using an alternative verification method (checking if the domain resolves to WordPress.com) to determine connection status.

## Screenshots

![Screenshot 2025-12-10 alle 12 01 53](https://github.com/user-attachments/assets/5fdcb256-288e-4925-8787-fe8d8716e15b)

![Screenshot 2025-12-10 alle 12 13 33](https://github.com/user-attachments/assets/e0055e87-0120-4f7c-b4ea-2222e610b7b8)

## Testing Instructions

The easiest way to test it is to mock the domain connection setup endpoint in the backend to simulate these scenarios:

1. **Test Cloudflare domain with successful connection:**
   - Set up a domain that uses Cloudflare and has `has_cloudflare_ip_addresses: true` and `resolves_to_wpcom: true`
   - Navigate to the domain connection verification page
   - Verify that:
     - Progress bar shows 100%
     - Status shows "Active" badge
     - Info notice appears
     - DNS records table is NOT displayed

2. **Test Cloudflare domain with failed connection:**
   - Set up a domain that uses Cloudflare with `has_cloudflare_ip_addresses: true` but `resolves_to_wpcom: false`
   - Navigate to the domain connection verification page
   - Verify that:
     - Progress bar shows 0%
     - Status shows "Verifying" badge
     - Info notice appears with guidance about configuring Cloudflare
     - DNS records table is NOT displayed

3. **Run tests:**
   ```bash
   yarn test-client client/dashboard/domains/domain-connection-setup/test/dns-propagation-progress-bar.test.tsx
   ```
   - All 23 tests should pass, including the 7 new Cloudflare-specific tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
