### PR TITLE
MSD: fix isDashboardBackport() condition for my.localhost

### DIFF
--- a/client/dashboard/utils/is-dashboard-backport.ts
+++ b/client/dashboard/utils/is-dashboard-backport.ts
@@ -2,7 +2,13 @@ import isDashboard from './is-dashboard';
 
 export function isDashboardBackport() {
 	// No need to check for backport if it's a dashboard Calypso environment.
-	if ( isDashboard() || window?.location?.hostname?.startsWith( 'my.localhost' ) ) {
+	if ( isDashboard() ) {
+		return false;
+	}
+
+	// Calypso development environment can also load the dashboard via the following hostname,
+	// in which case it's also not the backport.
+	if ( window?.location?.hostname?.startsWith( 'my.localhost' ) ) {
 		return false;
 	}
 

--- a/client/dashboard/utils/is-dashboard-backport.ts
+++ b/client/dashboard/utils/is-dashboard-backport.ts
@@ -2,7 +2,7 @@ import isDashboard from './is-dashboard';
 
 export function isDashboardBackport() {
 	// No need to check for backport if it's a dashboard Calypso environment.
-	if ( isDashboard() ) {
+	if ( isDashboard() || window?.location?.hostname?.startsWith( 'my.localhost' ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes `isDashboardBackport()` when `my.localhost:3000` is accessed on `development` environment; i.e., during `yarn start`.

## Testing Instructions

1. Check out this PR locally.
2. Run `yarn start`.
3. Visit `http://my.localhost:3000/sites/:siteSlug` of a Free site.
4. Verify the `Back up your site` is now an internal link rather than external one.

|Before|After|
|-|-|
|<img width="328" height="152" alt="image" src="https://github.com/user-attachments/assets/c628c9ad-0ffd-4103-96f5-bb9df67bba24" />|<img width="328" height="149" alt="image" src="https://github.com/user-attachments/assets/110a8ef2-50cf-4dcd-b62d-d4788504ab94" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
