### PR TITLE
Help center: fixes for Woo pages

### DIFF
--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-woocommerce.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-woocommerce.scss
@@ -6,7 +6,6 @@ body.wp-admin.woocommerce-admin-page.agents-manager-sidebar-container--sidebar-o
 		padding-left: 0 !important;
 		margin-top: 60px !important;
 		height: calc(100vh - 32px - 92px) !important;
-		border-right: none !important;
 	}
 
 	#wpcontent {
@@ -52,6 +51,7 @@ body.wp-admin.woocommerce_page_wc-settings.agents-manager-sidebar-container--sid
 		background-color: #fff;
 		margin-top: 88px !important;
 		height: calc(100vh - 32px - 120px) !important;
+		border-right: none !important;
 	}
 
 	#wpfooter {

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-woocommerce.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-woocommerce.scss
@@ -1,0 +1,60 @@
+$woo-border-width-fix: 1px;
+
+// These are various fixes for the WooCommerce layout when the sidebar is open
+body.wp-admin.woocommerce-admin-page.agents-manager-sidebar-container--sidebar-open {
+	#wpbody {
+		padding-left: 0 !important;
+		margin-top: 60px !important;
+		height: calc(100vh - 32px - 92px) !important;
+		border-right: none !important;
+	}
+
+	#wpcontent {
+		min-height: calc(100vh - 48px) !important;
+		border-radius: 0 $main-border-radius $main-border-radius 0 !important;
+	}
+
+	// Reduce the WooCommerce layout header width to account for the sidebar
+	.woocommerce-layout__header {
+		margin-top: 17px;
+		width: calc(100% - $admin-menu-width-classic - $sidebar-width - $layout-spacing - $woo-border-width-fix) !important;
+	}
+
+	// Reduce the WooCommerce layout header width to account for the sidebar in classic mode
+	&.is-nav-unification .woocommerce-layout__header {
+		width: calc(100% - $admin-menu-width-unified - $sidebar-width - $layout-spacing - $woo-border-width-fix) !important;
+	}
+
+	// Reduce the WooCommerce layout header width to account for the sidebar in folded mode
+	&.folded .woocommerce-layout__header {
+		width: calc(100% - $admin-menu-width-folded - $sidebar-width - $layout-spacing - $woo-border-width-fix) !important;
+	}
+
+	// We need to hide the activity panel when the sidebar is open otherwise the color shows through
+	.woocommerce-layout__activity-panel-wrapper {
+		opacity: 0;
+
+		// But make it visible when the activity panel is open
+		&.is-open {
+			opacity: 1;
+		}
+	}
+
+	// This brings the sidebar to the top so it's clickable.
+	.agents-manager-chat--docked {
+		z-index: $agents-manager-z-index-docked !important;
+	}
+}
+
+// The payments page is special
+body.wp-admin.woocommerce_page_wc-settings.agents-manager-sidebar-container--sidebar-open {
+	#wpbody {
+		background-color: #fff;
+		margin-top: 88px !important;
+		height: calc(100vh - 32px - 120px) !important;
+	}
+
+	#wpfooter {
+		background-color: #fff;
+	}
+}

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -7,6 +7,7 @@ $chat-header-height: 38px;
 $main-border-radius: 8px;
 $transition-duration: 0.2s;
 $transition-timing: $transition-duration cubic-bezier( 0.4, 0, 0.2, 1 );
+$agents-manager-z-index-docked: 999999;
 
 @mixin sidebar-base( $main-container-selector ) {
 	background-color: $gray-900 !important;
@@ -113,6 +114,16 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open {
 		border: 1px solid $border-color;
 		border-bottom: none;
 		overflow: hidden;
+
+		// Fix the border radius of the first in the admin bar
+		#wp-admin-bar-wpcom-logo > .ab-item {
+			border-radius: $main-border-radius 0 0 0;
+		}
+	}
+
+	// Fix the border radius of the last item in the admin bar
+	#wp-admin-bar-my-account a {
+		border-radius: 0 $main-border-radius 0 0;
 	}
 
 	#adminmenuback,
@@ -173,6 +184,9 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open {
 		@include wp-admin-sidebar-open-specific( $admin-menu-width-folded );
 	}
 }
+
+// Import fixes for specific pages. This is done after the base styles are applied to ensure the fixes are applied after the base styles.
+@import './fixes-woocommerce.scss';
 
 /* Calypso */
 body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-container {
@@ -273,7 +287,7 @@ body.post-php.agents-manager-sidebar-container {
 	padding: $layout-spacing;
 	width: $sidebar-width;
 	box-sizing: border-box;
-	z-index: 999999;
+	z-index: $agents-manager-z-index-docked;
 
 	.agents-manager-chat-header {
 		position: absolute;

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -114,16 +114,6 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open {
 		border: 1px solid $border-color;
 		border-bottom: none;
 		overflow: hidden;
-
-		// Fix the border radius of the first in the admin bar
-		#wp-admin-bar-wpcom-logo > .ab-item {
-			border-radius: $main-border-radius 0 0 0;
-		}
-	}
-
-	// Fix the border radius of the last item in the admin bar
-	#wp-admin-bar-my-account a {
-		border-radius: 0 $main-border-radius 0 0;
 	}
 
 	#adminmenuback,


### PR DESCRIPTION
Fixes DOTCOM-15187

Various ‘fixes’ to make the sidebar look better on Woo pages. These are not long-term solutions, but other than making changes in Woo itself there currently doesn't appear to be another way.

There are a couple of minor non-Woo sidebar fixes too.

## Why are these changes being made?

The help center sidebar doesn't fit properly in some Woo pages.

<img width="1180" height="232" alt="image" src="https://github.com/user-attachments/assets/183e4fb8-ae4e-45cd-8920-0d3b27a198da" />


## Testing Instructions

- `cd apps/help-center`
- `npm run dev --sync`
- Load an appropriate site with Woo + help center sidebar. You may need to sandbox `widgets.wp.com`
- Try various Woo admin pages with `flags=unified-agent` and the sidebar activated. Some particular ones are:
  - `wp-admin/admin.php?page=wc-settings&tab=checkout&flags=unified-agent`
  - `/wp-admin/admin.php?page=wc-orders&flags=unified-agent`
- In each case, the page should be contained correctly within the sidebar chrome, and the Woo activity log should still function
- Hover over the W logo (far left) and the avatar (far right) in the admin menu with the sidebar enabled and check the hover state has a correct border radius (i.e it doesn't crop to a square)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
