### PR TITLE
MSD Site Domains: Do not show hover on domains that are not clickable

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -27,33 +27,37 @@ export const DomainNameField = ( {
 			? domainTransferRoute.fullPath
 			: domainOverviewRoute.fullPath;
 
+	const content = (
+		<VStack spacing={ 1 }>
+			<span style={ textOverflowStyles }>{ value }</span>
+			{ showPrimaryDomainBadge && domain.primary_domain && (
+				<span
+					style={ {
+						...textOverflowStyles,
+						color: 'var(--dashboard__foreground-color-success)',
+						fontWeight: 'normal',
+						textDecoration: 'underline',
+						textDecorationStyle: 'dotted',
+					} }
+				>
+					{ __( 'Primary site address' ) }
+				</span>
+			) }
+			{ domain.subtype.id !== DomainSubtype.DOMAIN_REGISTRATION && (
+				<Text variant="muted" style={ { ...textOverflowStyles, fontWeight: 'normal' } }>
+					{ domain.subtype.label }
+				</Text>
+			) }
+		</VStack>
+	);
+
+	if ( ! domain.subscription_id ) {
+		return content;
+	}
+
 	return (
-		<Link
-			to={ href }
-			params={ { siteSlug, domainName: domain.domain } }
-			disabled={ ! domain.subscription_id }
-		>
-			<VStack spacing={ 1 }>
-				<span style={ textOverflowStyles }>{ value }</span>
-				{ showPrimaryDomainBadge && domain.primary_domain && (
-					<span
-						style={ {
-							...textOverflowStyles,
-							color: 'var(--dashboard__foreground-color-success)',
-							fontWeight: 'normal',
-							textDecoration: 'underline',
-							textDecorationStyle: 'dotted',
-						} }
-					>
-						{ __( 'Primary site address' ) }
-					</span>
-				) }
-				{ domain.subtype.id !== DomainSubtype.DOMAIN_REGISTRATION && (
-					<Text variant="muted" style={ { ...textOverflowStyles, fontWeight: 'normal' } }>
-						{ domain.subtype.label }
-					</Text>
-				) }
-			</VStack>
+		<Link to={ href } params={ { siteSlug, domainName: domain.domain } }>
+			{ content }
 		</Link>
 	);
 };


### PR DESCRIPTION
Closes DOTMSD-737.

## Proposed Changes

Do not show the hover effect on unmanageable domains:

https://github.com/user-attachments/assets/17b67731-988d-481c-a6e0-59cc9a3065c0

## Testing Instructions

Enter `/v2/sites/%s/domains` where `%s` is a site slug with more than one domain attached to it. Verify that hovering over the default site address (free domain) do not turn the text blue.