### PR TITLE
MSD Plugins: Available on section

### DIFF
--- a/client/dashboard/plugins/plugin/components/plugin-site-field-content.tsx
+++ b/client/dashboard/plugins/plugin/components/plugin-site-field-content.tsx
@@ -1,0 +1,30 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { Name, URL, SiteIconLink, SiteLink } from '../../../sites/site-fields';
+import type { Site } from '@automattic/api-core';
+
+type PluginSiteFieldContentProps< T extends Site > = {
+	site: T;
+	name: string;
+	url: string;
+};
+
+export function PluginSiteFieldContent< T extends Site >( {
+	site,
+	name,
+	url,
+}: PluginSiteFieldContentProps< T > ) {
+	return (
+		<HStack spacing={ 3 } alignment="center" justify="flex-start">
+			<SiteIconLink site={ site } />
+			<VStack spacing={ 0 } alignment="flex-start">
+				<SiteLink site={ site }>
+					<Name site={ site } value={ name } />
+				</SiteLink>
+				<URL site={ site } value={ url } />
+			</VStack>
+		</HStack>
+	);
+}

--- a/client/dashboard/plugins/plugin/index.tsx
+++ b/client/dashboard/plugins/plugin/index.tsx
@@ -1,3 +1,4 @@
+import { type PluginItem, Site } from '@automattic/api-core';
 import { __experimentalVStack as VStack, privateApis } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
@@ -12,7 +13,7 @@ import { Text } from '../../components/text';
 import { TextBlur } from '../../components/text-blur';
 import { SitesWithThisPlugin } from './sites-with-this-plugin';
 import { SitesWithoutThisPlugin } from './sites-without-this-plugin';
-import { usePlugin } from './use-plugin';
+import { SiteWithPluginData, usePlugin } from './use-plugin';
 
 import './style.scss';
 
@@ -26,11 +27,11 @@ const { Tabs } = unlock( privateApis );
 type PluginTabsProps = {
 	pluginSlug: string;
 	isLoading: boolean;
-	sitesWithThisPlugin: Array< unknown >;
-	sitesWithoutThisPlugin: Array< unknown >;
-	plugin: unknown;
+	sitesWithThisPlugin: SiteWithPluginData[];
+	sitesWithoutThisPlugin: Site[];
+	plugin: PluginItem | undefined;
 	pluginName?: string;
-	pluginBySiteId: Map< number, unknown >;
+	pluginBySiteId: Map< number, PluginItem >;
 };
 
 function PluginTabs( {
@@ -53,6 +54,7 @@ function PluginTabs( {
 				<Tabs.TabList>
 					<Tabs.Tab tabId="installed">
 						<SectionHeader
+							level={ 3 }
 							title={ sprintf(
 								// translators: %(count) is the number of sites the plugin is installed on.
 								_n(
@@ -65,7 +67,7 @@ function PluginTabs( {
 						/>
 					</Tabs.Tab>
 					<Tabs.Tab tabId="available">
-						<SectionHeader title={ __( 'Available on' ) } />
+						<SectionHeader level={ 3 } title={ __( 'Available on' ) } />
 					</Tabs.Tab>
 				</Tabs.TabList>
 
@@ -75,9 +77,9 @@ function PluginTabs( {
 							<SitesWithThisPlugin
 								pluginSlug={ pluginSlug }
 								isLoading={ isLoading }
-								plugin={ plugin as never }
-								pluginBySiteId={ pluginBySiteId as never }
-								sitesWithThisPlugin={ sitesWithThisPlugin as never }
+								plugin={ plugin }
+								pluginBySiteId={ pluginBySiteId }
+								sitesWithThisPlugin={ sitesWithThisPlugin }
 							/>
 						</DataViewsCard>
 					</VStack>
@@ -90,7 +92,7 @@ function PluginTabs( {
 								pluginSlug={ pluginSlug }
 								pluginName={ pluginName }
 								isLoading={ isLoading }
-								sitesWithoutThisPlugin={ sitesWithoutThisPlugin as never }
+								sitesWithoutThisPlugin={ sitesWithoutThisPlugin }
 							/>
 						</DataViewsCard>
 					</VStack>
@@ -149,10 +151,10 @@ export default function Plugin() {
 				pluginSlug={ pluginSlug }
 				isLoading={ isLoading }
 				plugin={ plugin }
-				pluginName={ ( plugin as { name?: string } | null | undefined )?.name }
-				pluginBySiteId={ pluginBySiteId as never }
-				sitesWithThisPlugin={ sitesWithThisPlugin as never }
-				sitesWithoutThisPlugin={ sitesWithoutThisPlugin as never }
+				pluginName={ plugin?.name }
+				pluginBySiteId={ pluginBySiteId }
+				sitesWithThisPlugin={ sitesWithThisPlugin }
+				sitesWithoutThisPlugin={ sitesWithoutThisPlugin }
 			/>
 		</PageLayout>
 	);

--- a/client/dashboard/plugins/plugin/index.tsx
+++ b/client/dashboard/plugins/plugin/index.tsx
@@ -1,5 +1,7 @@
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalVStack as VStack, privateApis } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { pluginRoute } from '../../app/router/plugins';
 import { DataViewsCard } from '../../components/dataviews';
@@ -14,9 +16,102 @@ import { usePlugin } from './use-plugin';
 
 import './style.scss';
 
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Tabs } = unlock( privateApis );
+
+type PluginTabsProps = {
+	pluginSlug: string;
+	isLoading: boolean;
+	sitesWithThisPlugin: Array< unknown >;
+	sitesWithoutThisPlugin: Array< unknown >;
+	plugin: unknown;
+	pluginName?: string;
+	pluginBySiteId: Map< number, unknown >;
+};
+
+function PluginTabs( {
+	pluginSlug,
+	isLoading,
+	sitesWithThisPlugin,
+	sitesWithoutThisPlugin,
+	plugin,
+	pluginName,
+	pluginBySiteId,
+}: PluginTabsProps ) {
+	const [ activeTab, setActiveTab ] = useState< 'installed' | 'available' >( 'installed' );
+
+	return (
+		<VStack spacing={ 6 }>
+			<Tabs
+				selectedTabId={ activeTab }
+				onSelect={ ( tabId: 'installed' | 'available' ) => setActiveTab( tabId ) }
+			>
+				<Tabs.TabList>
+					<Tabs.Tab tabId="installed">
+						<SectionHeader
+							title={ sprintf(
+								// translators: %(count) is the number of sites the plugin is installed on.
+								_n(
+									'Installed on %(count)d site',
+									'Installed on %(count)d sites',
+									sitesWithThisPlugin.length
+								),
+								{ count: sitesWithThisPlugin.length }
+							) }
+						/>
+					</Tabs.Tab>
+					<Tabs.Tab tabId="available">
+						<SectionHeader title={ __( 'Available on' ) } />
+					</Tabs.Tab>
+				</Tabs.TabList>
+
+				<Tabs.TabPanel tabId="installed">
+					<VStack spacing={ 6 }>
+						<DataViewsCard>
+							<SitesWithThisPlugin
+								pluginSlug={ pluginSlug }
+								isLoading={ isLoading }
+								plugin={ plugin as never }
+								pluginBySiteId={ pluginBySiteId as never }
+								sitesWithThisPlugin={ sitesWithThisPlugin as never }
+							/>
+						</DataViewsCard>
+					</VStack>
+				</Tabs.TabPanel>
+
+				<Tabs.TabPanel tabId="available">
+					<VStack spacing={ 6 }>
+						<DataViewsCard>
+							<SitesWithoutThisPlugin
+								pluginSlug={ pluginSlug }
+								pluginName={ pluginName }
+								isLoading={ isLoading }
+								sitesWithoutThisPlugin={ sitesWithoutThisPlugin as never }
+							/>
+						</DataViewsCard>
+					</VStack>
+				</Tabs.TabPanel>
+			</Tabs>
+		</VStack>
+	);
+}
+
 export default function Plugin() {
 	const { pluginId: pluginSlug } = pluginRoute.useParams();
-	const { icon, isLoading, sitesWithThisPlugin, plugin } = usePlugin( pluginSlug );
+	const { icon, isLoading, plugin, pluginBySiteId, sitesWithThisPlugin, sitesWithoutThisPlugin } =
+		usePlugin( pluginSlug );
+
+	const decoration = useMemo( () => {
+		if ( icon ) {
+			return <img src={ icon } alt={ plugin?.name } />;
+		} else if ( isLoading ) {
+			return <div className="plugin-icon-placeholder" aria-hidden="true" />;
+		}
+	}, [ icon, isLoading, plugin?.name ] );
 
 	if ( ! isLoading && ! plugin ) {
 		return (
@@ -27,14 +122,6 @@ export default function Plugin() {
 				}
 			/>
 		);
-	}
-
-	let decoration = null;
-
-	if ( icon ) {
-		decoration = <img src={ icon } alt={ plugin?.name } />;
-	} else if ( isLoading ) {
-		decoration = <div className="plugin-icon-placeholder" aria-hidden="true" />;
 	}
 
 	return (
@@ -58,33 +145,15 @@ export default function Plugin() {
 				</VStack>
 			}
 		>
-			<VStack spacing={ 20 }>
-				<VStack spacing={ 6 }>
-					<SectionHeader
-						title={ sprintf(
-							// translators: %(count) is the number of sites the plugin is installed on.
-							_n(
-								'Installed on %(count)d site',
-								'Installed on %(count)d sites',
-								sitesWithThisPlugin.length
-							),
-							{ count: sitesWithThisPlugin.length }
-						) }
-					/>
-
-					<DataViewsCard>
-						<SitesWithThisPlugin pluginSlug={ pluginSlug } />
-					</DataViewsCard>
-				</VStack>
-
-				<VStack spacing={ 6 }>
-					<SectionHeader title={ __( 'Available on' ) } />
-
-					<DataViewsCard>
-						<SitesWithoutThisPlugin pluginSlug={ pluginSlug } />
-					</DataViewsCard>
-				</VStack>
-			</VStack>
+			<PluginTabs
+				pluginSlug={ pluginSlug }
+				isLoading={ isLoading }
+				plugin={ plugin }
+				pluginName={ ( plugin as { name?: string } | null | undefined )?.name }
+				pluginBySiteId={ pluginBySiteId as never }
+				sitesWithThisPlugin={ sitesWithThisPlugin as never }
+				sitesWithoutThisPlugin={ sitesWithoutThisPlugin as never }
+			/>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -163,7 +163,7 @@ export const SitesWithoutThisPlugin = ( {
 								// In some cases the API can return HTTP 200 with an error code
 								// in the response body (e.g., plugin_already_installed). Detect
 								// that case here and treat it like the error path below.
-								// The gets updated by invalidating the plugins cache once more
+								// That gets updated by invalidating the plugins cache once more
 								const responseErrorCode = getPluginInstallErrorCode( response );
 
 								if ( responseErrorCode === 'plugin_already_installed' ) {

--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -163,7 +163,6 @@ export const SitesWithoutThisPlugin = ( {
 								// In some cases the API can return HTTP 200 with an error code
 								// in the response body (e.g., plugin_already_installed). Detect
 								// that case here and treat it like the error path below.
-								// That gets updated by invalidating the plugins cache once more
 								const responseErrorCode = getPluginInstallErrorCode( response );
 
 								if ( responseErrorCode === 'plugin_already_installed' ) {

--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -1,61 +1,299 @@
-import { Site } from '@automattic/api-core';
-import { ExternalLink } from '@wordpress/components';
+import { DotcomFeatures, Site } from '@automattic/api-core';
+import { installPluginMutation, invalidatePlugins } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
+import { Plan } from '../../sites/site-fields';
+import { hasPlanFeature } from '../../utils/site-features';
+import { getSiteDisplayName } from '../../utils/site-name';
+import { getSitePlanDisplayName } from '../../utils/site-plan';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { getSiteDisplayUrl } from '../../utils/site-url';
-import { usePlugin } from './use-plugin';
-import type { Field } from '@wordpress/dataviews';
+import { PluginSiteFieldContent } from './components/plugin-site-field-content';
+import type { Action, Field } from '@wordpress/dataviews';
 
 const defaultView: View = {
 	type: 'table',
-	fields: [ 'link' ],
-	layout: {
-		styles: {
-			link: { align: 'end' },
-		},
-	},
+	fields: [ 'plan' ],
 	sort: { field: 'name', direction: 'asc' },
 	titleField: 'domain',
 };
 
-export const SitesWithoutThisPlugin = ( { pluginSlug }: { pluginSlug: string } ) => {
+type SitesWithoutThisPluginProps = {
+	pluginSlug: string;
+	pluginName?: string;
+	isLoading: boolean;
+	sitesWithoutThisPlugin: Site[];
+};
+
+const getPluginInstallErrorCode = ( source: any ): string | undefined =>
+	source?.code ||
+	source?.data?.code ||
+	source?.error ||
+	source?.body?.error ||
+	source?.body?.data?.code;
+
+const handlePluginAlreadyInstalled = ( {
+	displayPluginName,
+	siteLabel,
+	createSuccessNotice,
+	closeModal,
+}: {
+	displayPluginName: string;
+	siteLabel: string;
+	createSuccessNotice: ( message: string, options?: { type: string } ) => void;
+	closeModal?: () => void;
+} ) => {
+	invalidatePlugins();
+
+	const installingMessage = sprintf(
+		// translators: 1: plugin name, 2: site name.
+		__( '%1$s is installing on %2$s. This may take a little while.' ),
+		displayPluginName,
+		siteLabel
+	);
+	createSuccessNotice( installingMessage, {
+		type: 'snackbar',
+	} );
+	closeModal?.();
+};
+
+export const SitesWithoutThisPlugin = ( {
+	pluginSlug,
+	pluginName,
+	isLoading,
+	sitesWithoutThisPlugin,
+}: SitesWithoutThisPluginProps ) => {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const [ view, setView ] = useState< View >( defaultView );
-	const { isLoading, sitesWithoutThisPlugin } = usePlugin( pluginSlug );
 
 	const fields: Field< Site >[] = useMemo(
 		() => [
 			{
 				id: 'domain',
 				label: __( 'Site' ),
-				getValue: ( { item }: { item: Site } ) => getSiteDisplayUrl( item ),
-				render: ( { field, item } ) => field.getValue( { item } ),
+				getValue: ( { item }: { item: Site } ) => getSiteDisplayName( item ),
+				render: ( { field, item } ) => (
+					<PluginSiteFieldContent
+						site={ item }
+						name={ field.getValue( { item } ) as string }
+						url={ getSiteDisplayUrl( item ) }
+					/>
+				),
 				enableHiding: false,
 				enableSorting: true,
 				enableGlobalSearch: true,
 			},
 			{
-				id: 'link',
-				header: <div />,
-				getValue: ( { item }: { item: Site } ) => item.URL,
-				render: () => (
-					<ExternalLink href={ `https://wordpress.com/plugins/${ pluginSlug }` }>
-						{ __( 'Go to plugin page' ) }
-					</ExternalLink>
+				id: 'plan',
+				label: __( 'Plan' ),
+				getValue: ( { item }: { item: Site } ) => getSitePlanDisplayName( item ) ?? '',
+				render: ( { field, item } ) => (
+					<Plan
+						// Match behaviour of the main sites DataView plan field
+						nag={ item.plan?.expired ? { isExpired: true, site: item } : { isExpired: false } }
+						isSelfHostedJetpackConnected={ isSelfHostedJetpackConnected( item ) }
+						isJetpack={ item.jetpack }
+						value={ field.getValue( { item } ) }
+					/>
 				),
+				enableHiding: true,
+				enableSorting: true,
+				getElements: async () => {
+					const planNames = Array.from(
+						new Set(
+							sitesWithoutThisPlugin
+								.map( ( site ) => getSitePlanDisplayName( site ) ?? '' )
+								.filter( Boolean )
+						)
+					);
+
+					return planNames.map( ( name ) => ( {
+						label: name,
+						value: name,
+					} ) );
+				},
+				filterBy: {
+					operators: [ 'isAny' ],
+				},
+				sort: ( a, b, direction ) => {
+					const planA = getSitePlanDisplayName( a ) ?? '';
+					const planB = getSitePlanDisplayName( b ) ?? '';
+
+					return direction === 'asc' ? planA.localeCompare( planB ) : planB.localeCompare( planA );
+				},
 			},
 		],
-		[ pluginSlug ]
+		[ sitesWithoutThisPlugin ]
+	);
+
+	const actions: Action< Site >[] = useMemo(
+		() => [
+			{
+				id: 'install-plugin',
+				label: __( 'Install plugin' ),
+				isPrimary: true,
+				modalHeader: __( 'Install plugin' ),
+				RenderModal: ( { items, closeModal } ) => {
+					const { mutateAsync: installPluginMutate, isPending: isInstalling } = useMutation(
+						installPluginMutation()
+					);
+					const site = items[ 0 ];
+					const siteName = getSiteDisplayName( site );
+					const siteUrl = getSiteDisplayUrl( site );
+					const siteLabel = `${ siteName } (${ siteUrl })`;
+					const displayPluginName = pluginName || pluginSlug;
+
+					const handleConfirm = () => {
+						if ( isInstalling ) {
+							return;
+						}
+
+						installPluginMutate( { siteId: site.ID, slug: pluginSlug } )
+							.then( ( response: any ) => {
+								// In some cases the API can return HTTP 200 with an error code
+								// in the response body (e.g., plugin_already_installed). Detect
+								// that case here and treat it like the error path below.
+								// The gets updated by invalidating the plugins cache once more
+								const responseErrorCode = getPluginInstallErrorCode( response );
+
+								if ( responseErrorCode === 'plugin_already_installed' ) {
+									handlePluginAlreadyInstalled( {
+										displayPluginName,
+										siteLabel,
+										createSuccessNotice,
+										closeModal,
+									} );
+									return;
+								}
+
+								const successMessage = sprintf(
+									// translators: 1: plugin name, 2: site name.
+									__( '%1$s was installed successfully on %2$s.' ),
+									displayPluginName,
+									siteLabel
+								);
+								createSuccessNotice( successMessage, {
+									type: 'snackbar',
+								} );
+								closeModal?.();
+
+								// Invalidate the cache once more to trigger a delayed check to avoid inconsistent states.
+								setTimeout( () => invalidatePlugins(), 2000 );
+							} )
+							.catch( ( error: any ) => {
+								const errorCode = getPluginInstallErrorCode( error );
+
+								if ( errorCode === 'plugin_already_installed' ) {
+									// The backend reports the plugin as already installed.
+									// Invalidate the plugins cache and let the user know
+									// that the installation is in progress.
+									handlePluginAlreadyInstalled( {
+										displayPluginName,
+										siteLabel,
+										createSuccessNotice,
+										closeModal,
+									} );
+									return;
+								}
+
+								const errorMessage = sprintf(
+									// translators: 1: plugin name, 2: site name.
+									__( 'There was a problem installing %1$s on %2$s. Please try again.' ),
+									displayPluginName,
+									siteLabel
+								);
+								createErrorNotice( errorMessage, {
+									type: 'snackbar',
+								} );
+							} );
+					};
+
+					return (
+						<VStack spacing={ 4 }>
+							<Text>
+								{ sprintf(
+									// translators: 1: plugin name, 2: site name.
+									__( 'You are about to install %1$s on %2$s. Do you want to continue?' ),
+									displayPluginName,
+									siteLabel
+								) }
+							</Text>
+							<HStack spacing={ 2 } justify="right">
+								<Button variant="tertiary" onClick={ () => closeModal?.() }>
+									{ __( 'Cancel' ) }
+								</Button>
+								<Button
+									variant="primary"
+									onClick={ handleConfirm }
+									isBusy={ isInstalling }
+									disabled={ isInstalling }
+								>
+									{ __( 'Install plugin' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					);
+				},
+				supportsBulk: false,
+				isEligible: ( item: Site ) => hasPlanFeature( item, DotcomFeatures.INSTALL_PLUGINS ),
+			},
+			{
+				id: 'upgrade-to-install',
+				label: __( 'Upgrade to install' ),
+				isPrimary: true,
+				callback: ( items: Site[] ) => {
+					const site = items[ 0 ];
+
+					if ( ! site ) {
+						return;
+					}
+
+					if ( site.slug ) {
+						window.open( `https://wordpress.com/plans/${ site.slug }`, '_blank' );
+					}
+				},
+				isEligible: ( item: Site ) => ! hasPlanFeature( item, DotcomFeatures.INSTALL_PLUGINS ),
+			},
+			{
+				id: 'wp-admin',
+				label: __( 'WP Admin ↗' ),
+				callback: ( items: Site[] ) => {
+					const [ site ] = items;
+
+					if ( ! site?.URL ) {
+						return;
+					}
+
+					const baseUrl = site.URL.replace( /\/$/, '' );
+					window.open( `${ baseUrl }/wp-admin/plugins.php`, '_blank' );
+				},
+				isEligible: ( item: Site ) => !! item.URL,
+				supportsBulk: false,
+				isPrimary: true,
+			},
+		],
+		[ createErrorNotice, createSuccessNotice, pluginName, pluginSlug ]
 	);
 
 	const { data, paginationInfo } = filterSortAndPaginate( sitesWithoutThisPlugin, view, fields );
 
 	return (
 		<DataViews
-			search={ false }
+			search
 			isLoading={ isLoading }
 			data={ data }
 			fields={ fields }
+			actions={ actions }
 			view={ view }
 			onChangeView={ setView }
 			defaultLayouts={ { table: {} } }

--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -228,7 +228,12 @@ export const SitesWithoutThisPlugin = ( {
 								) }
 							</Text>
 							<HStack spacing={ 2 } justify="right">
-								<Button variant="tertiary" onClick={ () => closeModal?.() }>
+								<Button
+									variant="tertiary"
+									onClick={ () => closeModal?.() }
+									isBusy={ isInstalling }
+									disabled={ isInstalling }
+								>
 									{ __( 'Cancel' ) }
 								</Button>
 								<Button

--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -106,25 +106,7 @@ export const SitesWithoutThisPlugin = ( {
 						value={ field.getValue( { item } ) }
 					/>
 				),
-				enableHiding: true,
 				enableSorting: true,
-				getElements: async () => {
-					const planNames = Array.from(
-						new Set(
-							sitesWithoutThisPlugin
-								.map( ( site ) => getSitePlanDisplayName( site ) ?? '' )
-								.filter( Boolean )
-						)
-					);
-
-					return planNames.map( ( name ) => ( {
-						label: name,
-						value: name,
-					} ) );
-				},
-				filterBy: {
-					operators: [ 'isAny' ],
-				},
 				sort: ( a, b, direction ) => {
 					const planA = getSitePlanDisplayName( a ) ?? '';
 					const planB = getSitePlanDisplayName( b ) ?? '';
@@ -133,7 +115,7 @@ export const SitesWithoutThisPlugin = ( {
 				},
 			},
 		],
-		[ sitesWithoutThisPlugin ]
+		[]
 	);
 
 	const actions: Action< Site >[] = useMemo(

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -125,6 +125,7 @@ export const DotcomFeatures = {
 	ATOMIC: 'atomic',
 	BACKUPS: 'backups',
 	DOMAIN_MAPPING: 'domain-mapping',
+	INSTALL_PLUGINS: 'install-plugins',
 	SUBSCRIPTION_GIFTING: 'subscription-gifting',
 	COPY_SITE: 'copy-site',
 	FULL_ACTIVITY_LOG: 'full-activity-log',

--- a/packages/api-core/src/plugins/index.ts
+++ b/packages/api-core/src/plugins/index.ts
@@ -1,2 +1,3 @@
 export * from './fetchers';
 export * from './types';
+export * from './mutators';

--- a/packages/api-core/src/plugins/mutators.ts
+++ b/packages/api-core/src/plugins/mutators.ts
@@ -1,0 +1,23 @@
+import { wpcom } from '../wpcom-fetcher';
+
+/**
+ * Install a plugin on the given site via the public WordPress.com API.
+ *
+ * This maps to:
+ *   https://public-api.wordpress.com/rest/v1.1/sites/:site/plugins/install?http_envelope=1
+ *
+ * The `site` must be provided by the caller and is passed through to the
+ * underlying REST endpoint. The plugin `slug` is supplied by the caller
+ * and sent in the request body.
+ */
+export function installPlugin( site: number | string, slug: string ): Promise< unknown > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ encodeURIComponent( String( site ) ) }/plugins/install`,
+			apiVersion: '1.1',
+		},
+		{
+			slug,
+		}
+	);
+}

--- a/packages/api-core/src/plugins/mutators.ts
+++ b/packages/api-core/src/plugins/mutators.ts
@@ -10,10 +10,10 @@ import { wpcom } from '../wpcom-fetcher';
  * underlying REST endpoint. The plugin `slug` is supplied by the caller
  * and sent in the request body.
  */
-export function installPlugin( site: number | string, slug: string ): Promise< unknown > {
+export function installPlugin( siteId: number, slug: string ): Promise< unknown > {
 	return wpcom.req.post(
 		{
-			path: `/sites/${ encodeURIComponent( String( site ) ) }/plugins/install`,
+			path: `/sites/${ encodeURIComponent( String( siteId ) ) }/plugins/install`,
 			apiVersion: '1.1',
 		},
 		{

--- a/packages/api-queries/src/plugin.ts
+++ b/packages/api-queries/src/plugin.ts
@@ -27,15 +27,13 @@ export const wpOrgPluginQuery = ( slug: string, locale: string ) =>
 
 export const installPluginMutation = () =>
 	mutationOptions( {
-		mutationFn: ( vars: { siteId: number | string; slug: string } ) =>
+		mutationFn: ( vars: { siteId: number; slug: string } ) =>
 			installPlugin( vars.siteId, vars.slug ),
 		onSuccess: ( _data, vars ) => {
 			// Refresh the plugin data so usePlugin sees the newly installed plugin.
 			// We invalidate both the per-site plugins list and the aggregated plugins
 			// query that `usePlugin` relies on to compute sitesWith/WithoutThisPlugin.
-			if ( typeof vars.siteId === 'number' ) {
-				invalidateSitePlugins( vars.siteId );
-			}
+			invalidateSitePlugins( vars.siteId );
 			invalidatePlugins();
 		},
 	} );

--- a/packages/api-queries/src/plugin.ts
+++ b/packages/api-queries/src/plugin.ts
@@ -2,8 +2,10 @@ import {
 	fetchWpOrgPlugin,
 	fetchMarketplacePlugin,
 	fetchMarketplacePlugins,
+	installPlugin,
 } from '@automattic/api-core';
-import { queryOptions } from '@tanstack/react-query';
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import { invalidatePlugins, invalidateSitePlugins } from './site-plugins';
 
 export const marketplacePluginQuery = ( slug: string ) =>
 	queryOptions( {
@@ -21,4 +23,19 @@ export const wpOrgPluginQuery = ( slug: string, locale: string ) =>
 	queryOptions( {
 		queryKey: [ 'wp-org-plugin', slug, locale ],
 		queryFn: () => fetchWpOrgPlugin( slug, locale ),
+	} );
+
+export const installPluginMutation = () =>
+	mutationOptions( {
+		mutationFn: ( vars: { siteId: number | string; slug: string } ) =>
+			installPlugin( vars.siteId, vars.slug ),
+		onSuccess: ( _data, vars ) => {
+			// Refresh the plugin data so usePlugin sees the newly installed plugin.
+			// We invalidate both the per-site plugins list and the aggregated plugins
+			// query that `usePlugin` relies on to compute sitesWith/WithoutThisPlugin.
+			if ( typeof vars.siteId === 'number' ) {
+				invalidateSitePlugins( vars.siteId );
+			}
+			invalidatePlugins();
+		},
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of
- https://linear.app/a8c/issue/DES-277/rethink-the-available-on-section

## Proposed Changes

* Complete overhaul of the Available on section. Now, instead of being a separate list without any real utility, it's presented as a tab from where users can install plugins on their sites and visit a site's WP-Admin interface.

| Before | After |
|--------|--------|
|<img width="1518" height="1290" alt="Screenshot 2025-12-09 at 17 49 42" src="https://github.com/user-attachments/assets/2cbdbd6b-4f57-4e16-b775-b939e36e3e04" />|<img width="1530" height="1285" alt="Screenshot 2025-12-09 at 17 50 04" src="https://github.com/user-attachments/assets/cd6a06fa-1250-4513-9dbb-9c0007934a04" />| 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our MSD Plugins i2 effort

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Navigate to `/v2/plugins`
* Select a plugin
* You should see the new tab navigation
* The new section where you can install the plugin on your sites should work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
