### PR TITLE
Update Charts package

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -1,10 +1,4 @@
-import {
-	LineChart,
-	ThemeProvider,
-	jetpackTheme,
-	type EventHandlerParams,
-	type DataPointDate,
-} from '@automattic/charts';
+import { LineChart, type EventHandlerParams, type DataPointDate } from '@automattic/charts';
 import { formatNumber } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
@@ -196,40 +190,38 @@ function StatsLineChart( {
 		<div className={ clsx( 'stats-line-chart', className ) }>
 			{ isEmpty && emptyState }
 			{ ! isEmpty && (
-				<ThemeProvider theme={ jetpackTheme }>
-					<LineChart
-						data={ chartData }
-						withTooltips
-						withGradientFill
-						height={ height }
-						curveType={ curveType }
-						onPointerUp={ onPointerUp }
-						margin={ {
-							left: 20,
-							top: 20,
-							bottom: 20,
-							right: Math.max( formatValue( maxValue ).length * 10, 40 ), //TODO: we should support this from the lib.
-						} }
-						options={ {
-							yScale: {
-								type: yScaleType,
-								...( fixedDomain && { domain: [ 0, maxValue ] } ),
-								zero: zeroBaseline,
+				<LineChart
+					data={ chartData }
+					withTooltips
+					withGradientFill
+					height={ height }
+					curveType={ curveType }
+					onPointerUp={ onPointerUp }
+					margin={ {
+						left: 20,
+						top: 20,
+						bottom: 20,
+						right: Math.max( formatValue( maxValue ).length * 10, 40 ), //TODO: we should support this from the lib.
+					} }
+					options={ {
+						yScale: {
+							type: yScaleType,
+							...( fixedDomain && { domain: [ 0, maxValue ] } ),
+							zero: zeroBaseline,
+						},
+						axis: {
+							x: {
+								tickFormat: formatTime,
 							},
-							axis: {
-								x: {
-									tickFormat: formatTime,
-								},
-								y: {
-									orientation: 'right',
-									tickFormat: formatValue,
-									numTicks: yNumTicks,
-								},
+							y: {
+								orientation: 'right',
+								tickFormat: formatValue,
+								numTicks: yNumTicks,
 							},
-						} }
-						renderTooltip={ renderTooltip }
-					/>
-				</ThemeProvider>
+						},
+					} }
+					renderTooltip={ renderTooltip }
+				/>
 			) }
 		</div>
 	);

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -1,4 +1,4 @@
-import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
+import { LineChart } from '@automattic/charts';
 import clsx from 'clsx';
 import moment from 'moment';
 import { useEffect, useState, useMemo } from 'react';
@@ -135,32 +135,30 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 
 	return (
 		<div className={ clsx( 'stats-line-chart', 'stats-realtime-chart' ) }>
-			<ThemeProvider theme={ jetpackTheme }>
-				<LineChart
-					data={ chartDataSeries }
-					withTooltips
-					withGradientFill
-					height={ 425 }
-					margin={ { left: 15, top: 20, bottom: 20 } }
-					options={ {
-						yScale: {
-							type: 'linear',
-							domain: [ 0, maxViews ],
-							zero: false,
+			<LineChart
+				data={ chartDataSeries }
+				withTooltips
+				withGradientFill
+				height={ 425 }
+				margin={ { left: 15, top: 20, bottom: 20 } }
+				options={ {
+					yScale: {
+						type: 'linear',
+						domain: [ 0, maxViews ],
+						zero: false,
+					},
+					axis: {
+						x: {
+							tickFormat: formatTimeTick,
 						},
-						axis: {
-							x: {
-								tickFormat: formatTimeTick,
-							},
-							y: {
-								orientation: 'right',
-								tickFormat: formatViews,
-								numTicks: maxViews > 4 ? 4 : 1,
-							},
+						y: {
+							orientation: 'right',
+							tickFormat: formatViews,
+							numTicks: maxViews > 4 ? 4 : 1,
 						},
-					} }
-				/>
-			</ThemeProvider>
+					},
+				} }
+			/>
 		</div>
 	);
 };

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-razorpay": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/charts": "^0.46.1",
+		"@automattic/charts": "^0.50.0",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,6 +921,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@automattic/charts@npm:^0.50.0":
+  version: 0.50.2
+  resolution: "@automattic/charts@npm:0.50.2"
+  dependencies:
+    "@automattic/number-formatters": "npm:^1.0.15"
+    "@babel/runtime": "npm:7.28.4"
+    "@react-spring/web": "npm:9.7.5"
+    "@visx/annotation": "npm:^3.12.0"
+    "@visx/axis": "npm:^3.12.0"
+    "@visx/curve": "npm:^3.12.0"
+    "@visx/event": "npm:^3.12.0"
+    "@visx/gradient": "npm:^3.12.0"
+    "@visx/grid": "npm:^3.12.0"
+    "@visx/group": "npm:^3.12.0"
+    "@visx/legend": "npm:^3.12.0"
+    "@visx/pattern": "npm:^3.12.0"
+    "@visx/responsive": "npm:^3.12.0"
+    "@visx/scale": "npm:^3.12.0"
+    "@visx/shape": "npm:^3.12.0"
+    "@visx/text": "npm:^3.12.0"
+    "@visx/tooltip": "npm:^3.12.0"
+    "@visx/xychart": "npm:^3.12.0"
+    "@wordpress/i18n": "npm:^6.0.0"
+    clsx: "npm:2.1.1"
+    date-fns: "npm:^4.1.0"
+    deepmerge: "npm:4.3.1"
+    fast-deep-equal: "npm:3.1.3"
+    gridicons: "npm:3.4.2"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: e0bdce896e10910973c422eb9626e86375731abd53223f06f77daa717da30fb04457d5ed71d54d51c323a037518c722d947d8b50b869cc65a3bcd4c0c690d76d
+  languageName: node
+  linkType: hard
+
 "@automattic/color-studio@npm:^4.1.0":
   version: 4.1.0
   resolution: "@automattic/color-studio@npm:4.1.0"
@@ -1808,6 +1844,17 @@ __metadata:
     debug: "npm:^4.4.0"
     tslib: "npm:^2.5.0"
   checksum: 271214c5a2b5363a5e85b12f4773ec02d52fcd214d41e6877f780287684f279e8c194128c7f4a57e66fde51f37f4243579666216ef437a4ed4b69e2229abfe8b
+  languageName: node
+  linkType: hard
+
+"@automattic/number-formatters@npm:^1.0.15":
+  version: 1.0.15
+  resolution: "@automattic/number-formatters@npm:1.0.15"
+  dependencies:
+    "@wordpress/date": "npm:^5.19.0"
+    debug: "npm:^4.4.0"
+    tslib: "npm:^2.5.0"
+  checksum: 033aee63dbb320d3ab6e34eec73453bf434911123371501014027fed5251793bedf96047d7158ef326cfc35fe75175dbe48a6c53f2343ec91004d43c007ea022
   languageName: node
   linkType: hard
 
@@ -38491,7 +38538,7 @@ __metadata:
     "@automattic/calypso-razorpay": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/charts": "npm:^0.46.1"
+    "@automattic/charts": "npm:^0.50.0"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,43 +885,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/charts@npm:>=0.14.0 <1.0.0, @automattic/charts@npm:^0.46.1":
-  version: 0.46.1
-  resolution: "@automattic/charts@npm:0.46.1"
-  dependencies:
-    "@automattic/number-formatters": "npm:^1.0.14"
-    "@babel/runtime": "npm:7.28.4"
-    "@react-spring/web": "npm:9.7.5"
-    "@visx/annotation": "npm:^3.12.0"
-    "@visx/axis": "npm:^3.12.0"
-    "@visx/curve": "npm:^3.12.0"
-    "@visx/event": "npm:^3.12.0"
-    "@visx/gradient": "npm:^3.12.0"
-    "@visx/grid": "npm:^3.12.0"
-    "@visx/group": "npm:^3.12.0"
-    "@visx/legend": "npm:^3.12.0"
-    "@visx/pattern": "npm:^3.12.0"
-    "@visx/responsive": "npm:^3.12.0"
-    "@visx/scale": "npm:^3.12.0"
-    "@visx/shape": "npm:^3.12.0"
-    "@visx/text": "npm:^3.12.0"
-    "@visx/tooltip": "npm:^3.12.0"
-    "@visx/xychart": "npm:^3.12.0"
-    "@wordpress/i18n": "npm:^6.0.0"
-    clsx: "npm:2.1.1"
-    date-fns: "npm:^4.1.0"
-    deepmerge: "npm:4.3.1"
-    fast-deep-equal: "npm:3.1.3"
-    gridicons: "npm:3.4.2"
-    tslib: "npm:2.8.1"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-  checksum: 0c986843d1ce366fe6bd0556f097ed278b39f6bdd1bd5e70ac665aac4ef4c3b5a5823f4ba9ecab6c277fe0e4ba5a6e6179664e05d933eb517fa91d24000f66bd
-  languageName: node
-  linkType: hard
-
-"@automattic/charts@npm:^0.50.0":
+"@automattic/charts@npm:>=0.14.0 <1.0.0, @automattic/charts@npm:^0.50.0":
   version: 0.50.2
   resolution: "@automattic/charts@npm:0.50.2"
   dependencies:
@@ -954,6 +918,42 @@ __metadata:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
   checksum: e0bdce896e10910973c422eb9626e86375731abd53223f06f77daa717da30fb04457d5ed71d54d51c323a037518c722d947d8b50b869cc65a3bcd4c0c690d76d
+  languageName: node
+  linkType: hard
+
+"@automattic/charts@npm:^0.46.1":
+  version: 0.46.1
+  resolution: "@automattic/charts@npm:0.46.1"
+  dependencies:
+    "@automattic/number-formatters": "npm:^1.0.14"
+    "@babel/runtime": "npm:7.28.4"
+    "@react-spring/web": "npm:9.7.5"
+    "@visx/annotation": "npm:^3.12.0"
+    "@visx/axis": "npm:^3.12.0"
+    "@visx/curve": "npm:^3.12.0"
+    "@visx/event": "npm:^3.12.0"
+    "@visx/gradient": "npm:^3.12.0"
+    "@visx/grid": "npm:^3.12.0"
+    "@visx/group": "npm:^3.12.0"
+    "@visx/legend": "npm:^3.12.0"
+    "@visx/pattern": "npm:^3.12.0"
+    "@visx/responsive": "npm:^3.12.0"
+    "@visx/scale": "npm:^3.12.0"
+    "@visx/shape": "npm:^3.12.0"
+    "@visx/text": "npm:^3.12.0"
+    "@visx/tooltip": "npm:^3.12.0"
+    "@visx/xychart": "npm:^3.12.0"
+    "@wordpress/i18n": "npm:^6.0.0"
+    clsx: "npm:2.1.1"
+    date-fns: "npm:^4.1.0"
+    deepmerge: "npm:4.3.1"
+    fast-deep-equal: "npm:3.1.3"
+    gridicons: "npm:3.4.2"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: 0c986843d1ce366fe6bd0556f097ed278b39f6bdd1bd5e70ac665aac4ef4c3b5a5823f4ba9ecab6c277fe0e4ba5a6e6179664e05d933eb517fa91d24000f66bd
   languageName: node
   linkType: hard
 
@@ -1836,18 +1836,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.0.1, @automattic/number-formatters@npm:^1.0.14":
-  version: 1.0.14
-  resolution: "@automattic/number-formatters@npm:1.0.14"
-  dependencies:
-    "@wordpress/date": "npm:^5.19.0"
-    debug: "npm:^4.4.0"
-    tslib: "npm:^2.5.0"
-  checksum: 271214c5a2b5363a5e85b12f4773ec02d52fcd214d41e6877f780287684f279e8c194128c7f4a57e66fde51f37f4243579666216ef437a4ed4b69e2229abfe8b
-  languageName: node
-  linkType: hard
-
-"@automattic/number-formatters@npm:^1.0.15":
+"@automattic/number-formatters@npm:^1.0.1, @automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15":
   version: 1.0.15
   resolution: "@automattic/number-formatters@npm:1.0.15"
   dependencies:


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

See [CHARTS-141: Remove consumer product themes](https://linear.app/a8c/issue/CHARTS-141/remove-consumer-product-themes)

## Proposed Changes

* Updates Charts dependency to 0.50.0 and removes usage of deprecated Jetpack theme

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Consumer themes for Automattic charts are no longer being included in the package so we need to remove usage. The default theme that is included is practically identical to the Jetpack theme (except for some colors for the leaderboard chart which is not used here), so there is no functional change caused by switching to it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Regression test usages Charts: LineChart in Jetpack stats (eg. http://calypso.localhost:3000/stats/month/pixelantics8.wpcomstaging.com) and LineChart and PieChart in multi site dashboard v2 (eg. http://calypso.localhost:3000/v2/sites/pixelantics8.wpcomstaging.com/monitoring?flags=dashboard/v2)
* Check display of charts; colors of lines and grids, other theme configuration
* Check console for errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
