### PR TITLE
Try to move orchestrator logic to its own component

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -84,7 +84,7 @@ export default function AgentDock( {
 		const newChatMenuItem = {
 			icon: comment,
 			title: __( 'New chat', '__i18n_text_domain__' ),
-			onClick: () => navigate( '/' ),
+			onClick: () => navigate( '/chat' ),
 		};
 		const undockMenuItem = {
 			icon: login,

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -1,93 +1,78 @@
-import {
-	getAgentManager,
-	useAgentChat,
-	type UseAgentChatConfig,
-	type SubmitOptions,
-} from '@automattic/agenttic-client';
-import {
-	type MarkdownComponents,
-	type MarkdownExtensions,
-	type Suggestion,
-} from '@automattic/agenttic-ui';
+import { type AuthProvider } from '@automattic/agenttic-client';
 import { useManagedOdieChat } from '@automattic/odie-client';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useEffect, useState, useRef, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { comment, drawerRight, login } from '@wordpress/icons';
-import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { createCalypsoAuthProvider } from '../../auth/calypso-auth-provider';
 import useAgentLayoutManager from '../../hooks/use-agent-layout-manager';
-import useConversation from '../../hooks/use-conversation';
 import { AGENTS_MANAGER_STORE } from '../../stores';
-import { setSessionId, clearSessionId } from '../../utils/agent-session';
+import { loadExternalProviders, type LoadedProviders } from '../../utils/load-external-providers';
 import AgentChat from '../agent-chat';
 import AgentHistory from '../agent-history';
 import { type Options as ChatHeaderOptions } from '../chat-header';
+import OrchestratorAgentChat from '../orchestrator-agent-chat';
 import SupportGuide from '../support-guide';
 import SupportGuides from '../support-guides';
 import type { AgentsManagerSelect, HelpCenterSite } from '@automattic/data-stores';
 
-/**
- * Navigation continuation hook type
- */
-type NavigationContinuationHook = ( props: {
-	isProcessing: boolean;
-	onSubmit: ( message: string, options?: SubmitOptions ) => Promise< void >;
-	sessionId: string;
-	agentId: string;
-} ) => void;
-
 interface AgentDockProps {
 	/** The selected site object. */
 	site?: HelpCenterSite | null;
+	/** The current route path. */
+	currentRoute?: string;
 	/** The name of the current section (e.g., 'posts', 'pages'). */
 	sectionName: string;
 	/** Indicates if the user is eligible for chat. */
 	isEligibleForChat: boolean;
-	/** Agent configuration for the chat client. */
-	agentConfig: UseAgentChatConfig;
-	/** Suggestions displayed when the chat is empty. */
-	emptyViewSuggestions?: Suggestion[];
-	/** Custom components for rendering markdown. */
-	markdownComponents?: MarkdownComponents;
-	/** Custom markdown extensions. */
-	markdownExtensions?: MarkdownExtensions;
-	/** Navigation continuation hook for post-navigation conversation resumption. */
-	useNavigationContinuation?: NavigationContinuationHook;
 }
 
 export default function AgentDock( {
-	agentConfig,
 	site,
+	currentRoute,
 	sectionName,
 	isEligibleForChat,
-	emptyViewSuggestions = [],
-	markdownComponents = {},
-	markdownExtensions = {},
-	useNavigationContinuation,
 }: AgentDockProps ) {
+	const navigate = useNavigate();
+	const providersLoadedRef = useRef( false );
+	const [ loadedProviders, setLoadedProviders ] = useState< LoadedProviders >( {} );
+
 	const { setIsOpen } = useDispatch( AGENTS_MANAGER_STORE );
 	const { hasLoaded: isStoreReady, isOpen = false } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
 		return store.getAgentsManagerState();
 	}, [] );
-	const { pathname } = useLocation();
-	const navigate = useNavigate();
-
-	const sessionId = agentConfig.sessionId;
-	const agentId = agentConfig.agentId;
 
 	const { isDocked, isDesktop, dock, undock, closeSidebar, createAgentPortal } =
 		useAgentLayoutManager();
 
-	const {
-		messages,
-		suggestions,
-		isProcessing,
-		error,
-		loadMessages,
-		onSubmit,
-		abortCurrentRequest,
-	} = useAgentChat( agentConfig );
+	const authProvider: AuthProvider = useMemo(
+		() => createCalypsoAuthProvider( site?.ID ),
+		[ site?.ID ]
+	);
+
+	// Default suggestions - can be overridden by loaded providers
+	const defaultSuggestions = useMemo(
+		() => [
+			{
+				id: 'getting-started',
+				label: 'Getting started with WordPress',
+				prompt: 'How do I get started with WordPress?',
+			},
+			{
+				id: 'create-post',
+				label: 'Create a blog post',
+				prompt: 'How do I create a blog post?',
+			},
+			{
+				id: 'customize-site',
+				label: 'Customize my site',
+				prompt: 'How can I customize my site?',
+			},
+		],
+		[]
+	);
 
 	const {
 		messages: odieMessages,
@@ -95,66 +80,11 @@ export default function AgentDock( {
 		sendMessage: sendOdieMessage,
 	} = useManagedOdieChat();
 
-	const { isLoading: isLoadingConversation } = useConversation( {
-		agentId,
-		sessionId,
-		authProvider: agentConfig.authProvider,
-		onSuccess: ( messages, serverSessionId ) => {
-			// Update the UI with the loaded messages
-			loadMessages( messages );
-			// Make sure future messages go to the right session
-			getAgentManager().updateSessionId( agentId, serverSessionId );
-
-			// Sync local session ID with the server's
-			if ( sessionId !== serverSessionId ) {
-				setSessionId( serverSessionId );
-				navigate( '/chat', { state: { sessionId: serverSessionId }, replace: true } );
-			}
-		},
-	} );
-
-	// Handle navigation continuation if hook is provided
-	// This allows to resume conversations after full page navigation
-	useNavigationContinuation?.( {
-		isProcessing,
-		onSubmit,
-		sessionId,
-		agentId,
-	} );
-
-	const handleNewChat = useCallback( async () => {
-		const agentManager = getAgentManager();
-
-		if ( agentManager.hasAgent( agentId ) ) {
-			abortCurrentRequest();
-			await loadMessages( [] );
-
-			// Start a new session by removing and recreating the agent with an empty session ID
-			// The server will assign a new session ID once the user sends a message
-			agentManager.removeAgent( agentId );
-			await agentManager.createAgent( agentId, { ...agentConfig, sessionId: '' } );
-		}
-
-		clearSessionId();
-
-		// Navigate to the chat view if not already there
-		if ( pathname !== '/' ) {
-			navigate( '/' );
-		}
-	}, [ abortCurrentRequest, agentConfig, agentId, loadMessages, navigate, pathname ] );
-
-	const handleSelectConversation = ( sessionId: string ) => {
-		abortCurrentRequest();
-		setSessionId( sessionId );
-		navigate( '/chat', { state: { sessionId } } );
-	};
-
 	const getChatHeaderOptions = (): ChatHeaderOptions => {
 		const newChatMenuItem = {
 			icon: comment,
 			title: __( 'New chat', '__i18n_text_domain__' ),
-			isDisabled: pathname !== '/history' && ! messages.length,
-			onClick: handleNewChat,
+			onClick: () => navigate( '/' ),
 		};
 		const undockMenuItem = {
 			icon: login,
@@ -187,23 +117,27 @@ export default function AgentDock( {
 		return options;
 	};
 
-	const Chat = (
-		<AgentChat
-			messages={ messages }
-			suggestions={ suggestions }
-			isProcessing={ isProcessing }
-			error={ error }
-			onSubmit={ onSubmit }
-			onAbort={ abortCurrentRequest }
-			isLoadingConversation={ isLoadingConversation }
+	useEffect( () => {
+		const loadProviders = async () => {
+			if ( ! providersLoadedRef.current ) {
+				const providers = await loadExternalProviders();
+				providersLoadedRef.current = true;
+				setLoadedProviders( providers );
+			}
+		};
+
+		loadProviders();
+	}, [] );
+
+	const OrchestratorChat = (
+		<OrchestratorAgentChat
+			authProvider={ authProvider }
+			currentRoute={ currentRoute }
 			isDocked={ isDocked }
-			isOpen={ isOpen }
-			onClose={ isDocked ? closeSidebar : () => setIsOpen( false ) }
-			onExpand={ () => setIsOpen( true ) }
+			closeSidebar={ closeSidebar }
 			chatHeaderOptions={ getChatHeaderOptions() }
-			markdownComponents={ markdownComponents }
-			markdownExtensions={ markdownExtensions }
-			emptyViewSuggestions={ emptyViewSuggestions }
+			defaultSuggestions={ defaultSuggestions }
+			loadedProviders={ loadedProviders }
 		/>
 	);
 
@@ -215,38 +149,32 @@ export default function AgentDock( {
 			error={ null }
 			onSubmit={ sendOdieMessage }
 			onAbort={ () => {} }
-			isLoadingConversation={ isLoadingConversation }
+			isLoadingConversation={ false }
 			isDocked={ isDocked }
 			isOpen={ isOpen }
 			onClose={ isDocked ? closeSidebar : () => setIsOpen( false ) }
 			onExpand={ () => setIsOpen( true ) }
 			chatHeaderOptions={ getChatHeaderOptions() }
-			markdownComponents={ markdownComponents }
-			markdownExtensions={ markdownExtensions }
-			emptyViewSuggestions={ emptyViewSuggestions }
+			markdownComponents={ loadedProviders.markdownComponents }
+			markdownExtensions={ loadedProviders.markdownExtensions }
+			emptyViewSuggestions={ loadedProviders.suggestions || defaultSuggestions }
 		/>
 	);
 
 	const History = (
 		<AgentHistory
-			agentId={ agentId }
-			authProvider={ agentConfig.authProvider }
+			authProvider={ authProvider }
 			chatHeaderOptions={ getChatHeaderOptions() }
 			isDocked={ isDocked }
 			isOpen={ isOpen }
-			onSubmit={ onSubmit }
-			onAbort={ abortCurrentRequest }
 			onClose={ isDocked ? closeSidebar : () => setIsOpen( false ) }
 			onExpand={ () => setIsOpen( true ) }
-			onSelectConversation={ handleSelectConversation }
-			onNewChat={ handleNewChat }
 		/>
 	);
 
 	const SupportGuideRoute = (
 		<SupportGuide
 			isEligibleForChat={ isEligibleForChat }
-			onAbort={ abortCurrentRequest }
 			onClose={ closeSidebar }
 			isOpen={ isOpen }
 			sectionName={ sectionName }
@@ -258,7 +186,6 @@ export default function AgentDock( {
 
 	const SupportGuidesRoute = (
 		<SupportGuides
-			onAbort={ abortCurrentRequest }
 			onClose={ closeSidebar }
 			isOpen={ isOpen }
 			chatHeaderOptions={ getChatHeaderOptions() }
@@ -272,14 +199,12 @@ export default function AgentDock( {
 
 	return createAgentPortal(
 		<Routes>
-			<Route path="/" element={ Chat } />
-			<Route path="/odie" element={ OdieChat } />
-			{ /* NOTE: Use route state for session ID so it can be accessed throughout the app. */ }
-			<Route path="/chat" element={ Chat } />
+			<Route path="/chat/:sessionId?" element={ OrchestratorChat } />
+			<Route path="/odie/:sessionId?" element={ OdieChat } />
 			<Route path="/post" element={ SupportGuideRoute } />
 			<Route path="/support-guides" element={ SupportGuidesRoute } />
 			<Route path="/history" element={ History } />
-			<Route path="*" element={ <Navigate to="/" replace /> } />
+			<Route path="*" element={ <Navigate to="/chat" replace /> } />
 		</Routes>
 	);
 }

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -54,7 +54,7 @@ export default function AgentHistory( {
 					botId={ createOdieBotId( ORCHESTRATOR_AGENT_ID ) }
 					authProvider={ authProvider }
 					onSelectConversation={ ( sessionId ) => navigate( `/chat/${ sessionId }` ) }
-					onNewChat={ () => navigate( '/' ) }
+					onNewChat={ () => navigate( '/chat' ) }
 				/>
 			</AgentUI.ConversationView>
 		</AgentUI.Container>

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -1,12 +1,12 @@
 import { createOdieBotId, type UseAgentChatConfig } from '@automattic/agenttic-client';
 import { AgentUI } from '@automattic/agenttic-ui';
 import { __ } from '@wordpress/i18n';
+import { useNavigate } from 'react-router-dom';
+import { ORCHESTRATOR_AGENT_ID } from '../../constants';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import ConversationHistoryView from '../conversation-history-view';
 
 interface AgentHistoryProps {
-	/** Agent ID for fetching conversation history. */
-	agentId: string;
 	/** Authentication provider for API requests. */
 	authProvider: UseAgentChatConfig[ 'authProvider' ];
 	/** Chat header menu options. */
@@ -15,45 +15,33 @@ interface AgentHistoryProps {
 	isDocked: boolean;
 	/** Indicates if the chat is expanded (floating mode). */
 	isOpen: boolean;
-	/** Called when the user submits a message. */
-	onSubmit: ( message: string ) => void;
-	/** Called when the user aborts the current request. */
-	onAbort: () => void;
 	/** Called when the chat is closed. */
 	onClose: () => void;
 	/** Called when the chat is expanded (floating mode). */
 	onExpand: () => void;
-	/** Called when a conversation is selected. */
-	onSelectConversation: ( sessionId: string ) => void;
-	/** Called when the user starts a new chat. */
-	onNewChat: () => void;
 }
 
 export default function AgentHistory( {
-	agentId,
 	authProvider,
 	chatHeaderOptions,
 	isDocked,
 	isOpen,
-	onSubmit,
-	onAbort,
 	onClose,
 	onExpand,
-	onSelectConversation,
-	onNewChat,
 }: AgentHistoryProps ) {
+	const navigate = useNavigate();
+
 	return (
 		<AgentUI.Container
 			className="agenttic"
 			messages={ [] }
 			isProcessing={ false }
 			error={ null }
-			onSubmit={ onSubmit }
+			onSubmit={ () => null }
 			variant={ isDocked ? 'embedded' : 'floating' }
 			floatingChatState={ isOpen ? 'expanded' : 'collapsed' }
 			onClose={ onClose }
 			onExpand={ onExpand }
-			onStop={ onAbort }
 		>
 			<AgentUI.ConversationView>
 				<ChatHeader
@@ -63,10 +51,10 @@ export default function AgentHistory( {
 					title={ __( 'Past chats', '__i18n_text_domain__' ) }
 				/>
 				<ConversationHistoryView
-					botId={ createOdieBotId( agentId ) }
+					botId={ createOdieBotId( ORCHESTRATOR_AGENT_ID ) }
 					authProvider={ authProvider }
-					onSelectConversation={ onSelectConversation }
-					onNewChat={ onNewChat }
+					onSelectConversation={ ( sessionId ) => navigate( `/chat/${ sessionId }` ) }
+					onNewChat={ () => navigate( '/' ) }
 				/>
 			</AgentUI.ConversationView>
 		</AgentUI.Container>

--- a/packages/agents-manager/src/components/orchestrator-agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-agent-chat/index.tsx
@@ -1,0 +1,259 @@
+import {
+	getAgentManager,
+	useAgentChat,
+	type UseAgentChatConfig,
+	type AuthProvider,
+	type Ability as AgenticAbility,
+} from '@automattic/agenttic-client';
+import { type Suggestion } from '@automattic/agenttic-ui';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { useParams, useNavigate } from 'react-router-dom';
+import { ORCHESTRATOR_AGENT_ID, ORCHESTRATOR_AGENT_URL } from '../../constants';
+import useConversation from '../../hooks/use-conversation';
+import { AGENTS_MANAGER_STORE } from '../../stores';
+import { getSessionId, SESSION_STORAGE_KEY } from '../../utils/agent-session';
+import { type LoadedProviders } from '../../utils/load-external-providers';
+import AgentChat from '../agent-chat';
+import { type Options as ChatHeaderOptions } from '../chat-header';
+import type { ContextEntry } from '../../extension-types';
+import type { AgentsManagerSelect } from '@automattic/data-stores';
+
+/**
+ * Resolve context entries by calling `getData()` closures
+ *
+ * Takes context entries with optional `getData()` closures and resolves them
+ * by calling `getData()` to populate the `data` field. The `getData` function is
+ * removed from the resolved entries.
+ *
+ * This allows us to fetch live data as needed.
+ */
+function resolveContextEntries( entries: ContextEntry[] ): ContextEntry[] {
+	return entries.map( ( entry ) => {
+		if ( entry.getData ) {
+			try {
+				const data = entry.getData();
+				// Remove getData and add resolved data
+				const { getData: _, ...resolvedEntry } = entry;
+				return {
+					...resolvedEntry,
+					data,
+				};
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					`[OrchestratorAgentChat] Failed to resolve context entry "${ entry.id }":`,
+					error
+				);
+				// Return entry without data if resolution fails
+				const { getData: _, ...entryWithoutGetData } = entry;
+				return entryWithoutGetData;
+			}
+		}
+		// Entry already has data or doesn't need resolution
+		return entry;
+	} );
+}
+
+interface OrchestratorAgentChatProps {
+	/** Authentication provider for the chat client. */
+	authProvider: AuthProvider;
+	/** The current route path. */
+	currentRoute?: string;
+	/** Indicates if the chat is docked in the sidebar. */
+	isDocked: boolean;
+	/** Function to close the sidebar. */
+	closeSidebar: () => void;
+	/** Chat header menu options. */
+	chatHeaderOptions: ChatHeaderOptions;
+	/** Suggestions displayed when the chat is empty. */
+	defaultSuggestions?: Suggestion[];
+	/** Loaded external providers. */
+	loadedProviders: LoadedProviders;
+}
+
+export default function OrchestratorAgentChat( {
+	authProvider,
+	currentRoute,
+	isDocked,
+	closeSidebar,
+	chatHeaderOptions,
+	defaultSuggestions = [],
+	loadedProviders,
+}: OrchestratorAgentChatProps ) {
+	const navigate = useNavigate();
+	const { sessionId = '' } = useParams< { sessionId?: string } >();
+	const { useNavigationContinuation } = loadedProviders;
+	const agentId = ORCHESTRATOR_AGENT_ID;
+	const localStorageSessionId = getSessionId();
+
+	const { setIsOpen } = useDispatch( AGENTS_MANAGER_STORE );
+	const { hasLoaded: isStoreReady, isOpen = false } = useSelect( ( select ) => {
+		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
+		return store.getAgentsManagerState();
+	}, [] );
+
+	// Create a minimal default config immediately so hooks can always be called
+	const [ agentConfig, setAgentConfig ] = useState< UseAgentChatConfig >( () => ( {
+		agentId,
+		agentUrl: ORCHESTRATOR_AGENT_URL,
+		sessionId,
+		sessionIdStorageKey: SESSION_STORAGE_KEY,
+		authProvider,
+		enableStreaming: true,
+		contextProvider: {
+			getClientContext: () => ( {
+				url: window.location.href,
+				pathname: currentRoute || window.location.pathname,
+				search: window.location.search,
+				environment: 'calypso',
+			} ),
+		},
+	} ) );
+
+	const {
+		messages,
+		suggestions,
+		isProcessing,
+		error,
+		loadMessages,
+		onSubmit,
+		abortCurrentRequest,
+	} = useAgentChat( agentConfig );
+
+	const { isLoading: isLoadingConversation } = useConversation( {
+		agentId,
+		sessionId,
+		authProvider: agentConfig.authProvider,
+		onSuccess: ( messages, serverSessionId ) => {
+			// Update the UI with the loaded messages
+			loadMessages( messages );
+			// Make sure future messages go to the right session
+			getAgentManager().updateSessionId( agentId, serverSessionId );
+
+			// Sync local session ID with the server's
+			if ( sessionId !== serverSessionId ) {
+				navigate( `/chat/${ serverSessionId }`, { replace: true } );
+			}
+		},
+	} );
+
+	// Handle navigation continuation if hook is provided
+	// This allows to resume conversations after full page navigation
+	useNavigationContinuation?.( {
+		isProcessing,
+		onSubmit,
+		sessionId,
+		agentId,
+	} );
+
+	useEffect( () => {
+		const initializeAgent = () => {
+			const { toolProvider, contextProvider } = loadedProviders;
+
+			// Create the agent configuration
+			const config: UseAgentChatConfig = {
+				agentId,
+				agentUrl: ORCHESTRATOR_AGENT_URL,
+				sessionId,
+				sessionIdStorageKey: SESSION_STORAGE_KEY,
+				authProvider,
+				enableStreaming: true,
+			};
+
+			// Add tool provider if provided by plugin
+			if ( toolProvider ) {
+				// Wrap `toolProvider` to filter out `null` annotation values
+				// WordPress Abilities API uses `null`, but `agenttic-client` expects `undefined`
+				config.toolProvider = {
+					...toolProvider,
+					getAbilities: async (): Promise< AgenticAbility[] > => {
+						const abilities = await toolProvider.getAbilities();
+						return abilities.map( ( ability ) => ( {
+							...ability,
+							meta: ability.meta?.annotations
+								? {
+										...ability.meta,
+										annotations: Object.fromEntries(
+											Object.entries( ability.meta.annotations ).filter(
+												( [ , value ] ) => value !== null
+											)
+										),
+								  }
+								: ability.meta,
+						} ) ) as AgenticAbility[];
+					},
+				};
+			}
+
+			// Add context provider - use plugin's or create default Calypso context
+			if ( contextProvider ) {
+				// Wrap plugin's context provider to resolve contextEntries
+				config.contextProvider = {
+					getClientContext: () => {
+						const pluginContext = contextProvider.getClientContext();
+
+						// Resolve `contextEntries` if present
+						if ( pluginContext.contextEntries && pluginContext.contextEntries.length ) {
+							return {
+								...pluginContext,
+								contextEntries: resolveContextEntries( pluginContext.contextEntries ),
+							};
+						}
+
+						return pluginContext;
+					},
+				};
+			} else {
+				// Create default Calypso context
+				config.contextProvider = {
+					getClientContext: () => ( {
+						url: window.location.href,
+						pathname: currentRoute || window.location.pathname,
+						search: window.location.search,
+						environment: 'calypso',
+					} ),
+				};
+			}
+
+			setAgentConfig( config );
+		};
+
+		initializeAgent();
+	}, [ agentId, authProvider, currentRoute, loadedProviders, sessionId ] );
+
+	useEffect( () => {
+		// This should mean the user was in a new chat and received messages from the server
+		// Move the user to the correct chat URL
+		// Know issue: Because the received messages are not in the ReactQuery cache,
+		// We are triggering a reload after moving to the correct URL.
+		// We could try setting the ReactQuery cache before navigating to avoid that.
+		if ( sessionId === '' && localStorageSessionId && messages.length ) {
+			navigate( `/chat/${ localStorageSessionId }`, { replace: true } );
+		}
+	}, [ localStorageSessionId, messages.length, navigate, sessionId ] );
+
+	if ( ! isStoreReady ) {
+		return null;
+	}
+
+	return (
+		<AgentChat
+			messages={ messages }
+			suggestions={ suggestions }
+			isProcessing={ isProcessing }
+			error={ error }
+			onSubmit={ onSubmit }
+			onAbort={ abortCurrentRequest }
+			isLoadingConversation={ isLoadingConversation }
+			isDocked={ isDocked }
+			isOpen={ isOpen }
+			onClose={ isDocked ? closeSidebar : () => setIsOpen( false ) }
+			onExpand={ () => setIsOpen( true ) }
+			chatHeaderOptions={ chatHeaderOptions }
+			markdownComponents={ loadedProviders.markdownComponents }
+			markdownExtensions={ loadedProviders.markdownExtensions }
+			emptyViewSuggestions={ loadedProviders.suggestions || defaultSuggestions }
+		/>
+	);
+}

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -10,7 +10,6 @@ export default function SupportGuide( {
 	isOpen,
 	chatHeaderOptions,
 	isChatDocked,
-	onAbort,
 	onClose,
 	currentSiteDomain,
 	sectionName,
@@ -19,7 +18,6 @@ export default function SupportGuide( {
 	chatHeaderOptions: Options;
 	isChatDocked: boolean;
 	isOpen: boolean;
-	onAbort: () => void;
 	onClose: () => void;
 	currentSiteDomain?: string;
 	sectionName: string;
@@ -45,7 +43,6 @@ export default function SupportGuide( {
 			variant={ isChatDocked ? 'embedded' : 'floating' }
 			floatingChatState={ isOpen ? 'expanded' : 'collapsed' }
 			onClose={ onClose }
-			onStop={ onAbort }
 		>
 			<AgentUI.ConversationView>
 				<ChatHeader

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -47,13 +47,11 @@ export default function SupportGuides( {
 	isOpen,
 	chatHeaderOptions,
 	isChatDocked,
-	onAbort,
 	onClose,
 }: {
 	chatHeaderOptions: Options;
 	isChatDocked: boolean;
 	isOpen: boolean;
-	onAbort: () => void;
 	onClose: () => void;
 } ) {
 	const [ searchInput, setSearchInput ] = useState( '' );
@@ -73,7 +71,6 @@ export default function SupportGuides( {
 			variant={ isChatDocked ? 'embedded' : 'floating' }
 			floatingChatState={ isOpen ? 'expanded' : 'collapsed' }
 			onClose={ onClose }
-			onStop={ onAbort }
 		>
 			<AgentUI.ConversationView>
 				<ChatHeader

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -1,14 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useMemo, useEffect, useState, useRef } from '@wordpress/element';
-import { useLocation } from 'react-router-dom';
-import { createCalypsoAuthProvider } from '../../auth/calypso-auth-provider';
-import { ORCHESTRATOR_AGENT_ID, ORCHESTRATOR_AGENT_URL } from '../../constants';
-import { SESSION_STORAGE_KEY, getSessionId } from '../../utils/agent-session';
-import { loadExternalProviders, type LoadedProviders } from '../../utils/load-external-providers';
 import AgentDock from '../agent-dock';
 import { PersistentRouter } from '../persistent-router';
-import type { ContextEntry } from '../../extension-types';
-import type { UseAgentChatConfig, Ability as AgenticAbility } from '@automattic/agenttic-client';
 import type { HelpCenterSite, CurrentUser } from '@automattic/data-stores';
 
 export interface UnifiedAIAgentProps {
@@ -24,39 +16,6 @@ export interface UnifiedAIAgentProps {
 	currentUser?: CurrentUser;
 	/** Called when the agent is closed. */
 	handleClose?: () => void;
-}
-
-/**
- * Resolve context entries by calling `getData()` closures
- *
- * Takes context entries with optional `getData()` closures and resolves them
- * by calling `getData()` to populate the `data` field. The `getData` function is
- * removed from the resolved entries.
- *
- * This allows us to fetch live data as needed.
- */
-function resolveContextEntries( entries: ContextEntry[] ): ContextEntry[] {
-	return entries.map( ( entry ) => {
-		if ( entry.getData ) {
-			try {
-				const data = entry.getData();
-				// Remove getData and add resolved data
-				const { getData: _, ...resolvedEntry } = entry;
-				return {
-					...resolvedEntry,
-					data,
-				};
-			} catch ( error ) {
-				// eslint-disable-next-line no-console
-				console.warn( `[UnifiedAIAgent] Failed to resolve context entry "${ entry.id }":`, error );
-				// Return entry without data if resolution fails
-				const { getData: _, ...entryWithoutGetData } = entry;
-				return entryWithoutGetData;
-			}
-		}
-		// Entry already has data or doesn't need resolution
-		return entry;
-	} );
 }
 
 const queryClient = new QueryClient();
@@ -78,134 +37,12 @@ function AgentSetup( {
 	sectionName,
 	isEligibleForChat,
 }: UnifiedAIAgentProps ) {
-	const [ agentConfig, setAgentConfig ] = useState< UseAgentChatConfig | null >( null );
-	const [ loadedProviders, setLoadedProviders ] = useState< LoadedProviders >( {} );
-	const providersLoadedRef = useRef( false );
-	const { state } = useLocation();
-	// Prefer route state `sessionId`, fall back to stored `sessionId` (server-generated via Agenttic UI)
-	const sessionId = state?.sessionId || getSessionId();
-
-	// Load external providers and initialize agent config
-	useEffect( () => {
-		const initializeAgent = async () => {
-			// Load external providers (only once)
-			let providers = loadedProviders;
-			if ( ! providersLoadedRef.current ) {
-				providers = await loadExternalProviders();
-				providersLoadedRef.current = true;
-				setLoadedProviders( providers );
-			}
-
-			const { toolProvider, contextProvider } = providers;
-
-			// Create the agent configuration
-			const config: UseAgentChatConfig = {
-				agentId: ORCHESTRATOR_AGENT_ID,
-				agentUrl: ORCHESTRATOR_AGENT_URL,
-				sessionId,
-				sessionIdStorageKey: SESSION_STORAGE_KEY,
-				authProvider: createCalypsoAuthProvider( site?.ID ),
-				enableStreaming: true,
-			};
-
-			// Add tool provider if provided by plugin
-			if ( toolProvider ) {
-				// Wrap `toolProvider` to filter out `null` annotation values
-				// WordPress Abilities API uses `null`, but `agenttic-client` expects `undefined`
-				config.toolProvider = {
-					...toolProvider,
-					getAbilities: async (): Promise< AgenticAbility[] > => {
-						const abilities = await toolProvider.getAbilities();
-						return abilities.map( ( ability ) => ( {
-							...ability,
-							meta: ability.meta?.annotations
-								? {
-										...ability.meta,
-										annotations: Object.fromEntries(
-											Object.entries( ability.meta.annotations ).filter(
-												( [ , value ] ) => value !== null
-											)
-										),
-								  }
-								: ability.meta,
-						} ) ) as AgenticAbility[];
-					},
-				};
-			}
-
-			// Add context provider - use plugin's or create default Calypso context
-			if ( contextProvider ) {
-				// Wrap plugin's context provider to resolve contextEntries
-				config.contextProvider = {
-					getClientContext: () => {
-						const pluginContext = contextProvider.getClientContext();
-
-						// Resolve `contextEntries` if present
-						if ( pluginContext.contextEntries && pluginContext.contextEntries.length ) {
-							return {
-								...pluginContext,
-								contextEntries: resolveContextEntries( pluginContext.contextEntries ),
-							};
-						}
-
-						return pluginContext;
-					},
-				};
-			} else {
-				// Create default Calypso context
-				config.contextProvider = {
-					getClientContext: () => ( {
-						url: window.location.href,
-						pathname: currentRoute || window.location.pathname,
-						search: window.location.search,
-						environment: 'calypso',
-					} ),
-				};
-			}
-
-			setAgentConfig( config );
-		};
-
-		initializeAgent();
-	}, [ currentRoute, loadedProviders, sessionId, site?.ID ] );
-
-	// Default suggestions - can be overridden by loaded providers
-	const defaultSuggestions = useMemo(
-		() => [
-			{
-				id: 'getting-started',
-				label: 'Getting started with WordPress',
-				prompt: 'How do I get started with WordPress?',
-			},
-			{
-				id: 'create-post',
-				label: 'Create a blog post',
-				prompt: 'How do I create a blog post?',
-			},
-			{
-				id: 'customize-site',
-				label: 'Customize my site',
-				prompt: 'How can I customize my site?',
-			},
-		],
-		[]
-	);
-
-	// Don't render until agent configuration is initialized
-	if ( ! agentConfig ) {
-		return null;
-	}
-
 	return (
 		<AgentDock
-			agentConfig={ agentConfig }
-			isEligibleForChat={ isEligibleForChat }
 			site={ site }
+			currentRoute={ currentRoute }
+			isEligibleForChat={ isEligibleForChat }
 			sectionName={ sectionName }
-			emptyViewSuggestions={ loadedProviders.suggestions || defaultSuggestions }
-			markdownComponents={ loadedProviders.markdownComponents || {} }
-			markdownExtensions={ loadedProviders.markdownExtensions || {} }
-			useNavigationContinuation={ loadedProviders.useNavigationContinuation }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
