### PR TITLE
MSD: fix Reader link to point to wp.com

### DIFF
--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -28,6 +28,7 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 import { Suspense, lazy, useCallback, useState } from 'react';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
 import { useExperiment } from 'calypso/lib/explat';
+import { wpcomLink } from '../../utils/link';
 import { useAnalytics } from '../analytics';
 import { useAuth } from '../auth';
 import { useAppContext } from '../context';
@@ -352,7 +353,7 @@ function SecondaryMenu() {
 					icon={ <ReaderIcon /> }
 					label={ __( 'Reader' ) }
 					text={ isDesktop ? __( 'Reader' ) : undefined }
-					href="/reader"
+					href={ wpcomLink( '/reader' ) }
 				/>
 			) }
 			{ supports.help && <Help /> }


### PR DESCRIPTION
Fixes: p1765307561844029/1765292293.160839-slack-C08JZTRS6NA

## Proposed Changes

Fix Reader link in MSD to point to the correct domain (`wordpress.com`).

For now, I'm opening it in the same tab. We can revisit it if there's direction after testing (as noted in the linked Slack thread).

## Testing Instructions

Open /v2/sites, click the Reader link at the top-right, verify it opens Reader.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?