### PR TITLE
MSD Opt-in: Links in wp-admin will eventually redirect to MSD if that is the user's preference

### DIFF
--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -1,8 +1,17 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
+import { maybeRedirectToMultiSiteDashboard } from '../controller';
 import { account } from './controller';
 
 export default function () {
-	page( '/me/account', sidebar, setSelectedSiteIdByOrigin, account, makeLayout, clientRender );
+	page(
+		'/me/account',
+		maybeRedirectToMultiSiteDashboard,
+		sidebar,
+		setSelectedSiteIdByOrigin,
+		account,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -1,13 +1,13 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
-import { maybeRedirectToMultiSiteDashboard } from '../controller';
+import { maybeRedirectToDashboard } from '../controller';
 import { account } from './controller';
 
 export default function () {
 	page(
 		'/me/account',
-		maybeRedirectToMultiSiteDashboard,
+		maybeRedirectToDashboard,
 		sidebar,
 		setSelectedSiteIdByOrigin,
 		account,

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -121,7 +121,7 @@ export const maybeRedirectToDashboard = ( context, next ) => {
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasHostingDashboardOptIn( getState() ) ) {
-			window.location.href = dashboardLink( '/me/profile' );
+			window.location.replace( dashboardLink( '/me/profile' ) );
 			return;
 		}
 		context.page.replace( removeQueryArgs( context.canonicalPath, 'origin_admin_bar' ) );

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -111,11 +111,10 @@ const waitForPrefs = () => async ( dispatch, getState ) => {
 // preference into account (without the query param, users can still navigate to
 // `/me` or `/me/account` manually, meaning the old dashboard is still accessible
 // when the user is specifically trying to go there).
-export const maybeRedirectToMultiSiteDashboard = ( context, next ) => {
+export const maybeRedirectToDashboard = ( context, next ) => {
 	const originAdminBar = context.query.origin_admin_bar;
 	if ( originAdminBar !== 'wpcom' ) {
-		next();
-		return;
+		return next();
 	}
 
 	const { dispatch, getState } = context.store;

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -1,12 +1,17 @@
 import page from '@automattic/calypso-router';
+import { removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { createElement } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import AppsComponent from 'calypso/me/get-apps';
 import McpComponent from 'calypso/me/mcp/main';
 import McpSetupComponent from 'calypso/me/mcp/setup';
 import SidebarComponent from 'calypso/me/sidebar';
+import { fetchPreferences } from 'calypso/state/preferences/actions';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 
 export function sidebar( context, next ) {
 	context.secondary = createElement( SidebarComponent, {
@@ -86,3 +91,41 @@ export function mcpSetup( context, next ) {
 	);
 	next();
 }
+
+// Helper thunk that ensures that the user preferences has been fetched into Redux state before we
+// continue working with it.
+const waitForPrefs = () => async ( dispatch, getState ) => {
+	if ( hasReceivedRemotePreferences( getState() ) ) {
+		return;
+	}
+
+	try {
+		await dispatch( fetchPreferences() );
+	} catch {
+		// if the fetching of preferences fails, return gracefully and proceed to the next landing page candidate
+	}
+};
+
+// The wp-admin admin bar does not know about user preferences and so may use the
+// origin_admin_bar query param to indicate that Calypso should take the user's
+// preference into account (without the query param, users can still navigate to
+// `/me` or `/me/account` manually, meaning the old dashboard is still accessible
+// when the user is specifically trying to go there).
+export const maybeRedirectToMultiSiteDashboard = ( context, next ) => {
+	const originAdminBar = context.query.origin_admin_bar;
+	if ( originAdminBar !== 'wpcom' ) {
+		next();
+		return;
+	}
+
+	const { dispatch, getState } = context.store;
+
+	dispatch( waitForPrefs() ).finally( () => {
+		if ( hasHostingDashboardOptIn( getState() ) ) {
+			window.location.href = dashboardLink( '/me/profile' );
+			return;
+		}
+		context.page.replace( removeQueryArgs( context.canonicalPath, 'origin_admin_bar' ) );
+		next();
+	} );
+};

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -7,6 +7,7 @@ import './style.scss';
 export default function () {
 	page(
 		'/me',
+		controller.maybeRedirectToMultiSiteDashboard,
 		controller.sidebar,
 		setSelectedSiteIdByOrigin,
 		controller.profile,

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -7,7 +7,7 @@ import './style.scss';
 export default function () {
 	page(
 		'/me',
-		controller.maybeRedirectToMultiSiteDashboard,
+		controller.maybeRedirectToDashboard,
 		controller.sidebar,
 		setSelectedSiteIdByOrigin,
 		controller.profile,

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -367,11 +367,10 @@ const waitForPrefs = () => async ( dispatch, getState ) => {
 // preference into account (without the query param, users can still navigate to
 // `/domains/manage` manually, meaning the old dashboard is still accessible when
 // the user is specifically trying to go there).
-const maybeRedirectToMultiSiteDashboard = ( context, next ) => {
+const maybeRedirectToDashboard = ( context, next ) => {
 	const originAdminBar = context.query.origin_admin_bar;
 	if ( originAdminBar !== 'wpcom' ) {
-		next();
-		return;
+		return next();
 	}
 
 	const { dispatch, getState } = context.store;
@@ -402,5 +401,5 @@ export default {
 	transferDomainPrecheck,
 	useMyDomain,
 	redirectDomainToSite,
-	maybeRedirectToMultiSiteDashboard,
+	maybeRedirectToDashboard,
 };

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { removeQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { get, includes, map } from 'lodash';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -9,6 +10,7 @@ import { connectDomainAction } from 'calypso/components/domains/use-my-domain/ut
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { sectionify } from 'calypso/lib/route';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -23,9 +25,12 @@ import {
 } from 'calypso/my-sites/domains/paths';
 import TransferDomain from 'calypso/my-sites/domains/transfer-domain';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { fetchPreferences } from 'calypso/state/preferences/actions';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite, isWpcomFlexSite } from 'calypso/state/sites/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import {
 	getSelectedSiteId,
 	getSelectedSite,
@@ -342,6 +347,44 @@ const redirectDomainToSite = ( context, next ) => {
 	context.primary = <RedirectComponent domainName={ context.params.domain } />;
 	next();
 };
+//
+// Helper thunk that ensures that the user preferences has been fetched into Redux state before we
+// continue working with it.
+const waitForPrefs = () => async ( dispatch, getState ) => {
+	if ( hasReceivedRemotePreferences( getState() ) ) {
+		return;
+	}
+
+	try {
+		await dispatch( fetchPreferences() );
+	} catch {
+		// if the fetching of preferences fails, return gracefully and proceed to the next landing page candidate
+	}
+};
+
+// The wp-admin admin bar does not know about user preferences and so may use the
+// origin_admin_bar query param to indicate that Calypso should take the user's
+// preference into account (without the query param, users can still navigate to
+// `/domains/manage` manually, meaning the old dashboard is still accessible when
+// the user is specifically trying to go there).
+const maybeRedirectToMultiSiteDashboard = ( context, next ) => {
+	const originAdminBar = context.query.origin_admin_bar;
+	if ( originAdminBar !== 'wpcom' ) {
+		next();
+		return;
+	}
+
+	const { dispatch, getState } = context.store;
+
+	dispatch( waitForPrefs() ).finally( () => {
+		if ( hasHostingDashboardOptIn( getState() ) ) {
+			window.location.href = dashboardLink( '/domains' );
+			return;
+		}
+		context.page.replace( removeQueryArgs( context.canonicalPath, 'origin_admin_bar' ) );
+		next();
+	} );
+};
 
 export default {
 	domainsAddHeader,
@@ -359,4 +402,5 @@ export default {
 	transferDomainPrecheck,
 	useMyDomain,
 	redirectDomainToSite,
+	maybeRedirectToMultiSiteDashboard,
 };

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -347,7 +347,7 @@ const redirectDomainToSite = ( context, next ) => {
 	context.primary = <RedirectComponent domainName={ context.params.domain } />;
 	next();
 };
-//
+
 // Helper thunk that ensures that the user preferences has been fetched into Redux state before we
 // continue working with it.
 const waitForPrefs = () => async ( dispatch, getState ) => {
@@ -377,7 +377,7 @@ const maybeRedirectToDashboard = ( context, next ) => {
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasHostingDashboardOptIn( getState() ) ) {
-			window.location.href = dashboardLink( '/domains' );
+			window.location.replace( dashboardLink( '/domains' ) );
 			return;
 		}
 		context.page.replace( removeQueryArgs( context.canonicalPath, 'origin_admin_bar' ) );

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -194,6 +194,7 @@ export default function () {
 
 	page(
 		paths.domainManagementRoot(),
+		domainsController.maybeRedirectToMultiSiteDashboard,
 		noSite,
 		...getCommonHandlers( { noSitePath: false, noSiteSelection: true } ),
 		domainManagementController.domainManagementListAllSites,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -194,7 +194,7 @@ export default function () {
 
 	page(
 		paths.domainManagementRoot(),
-		domainsController.maybeRedirectToMultiSiteDashboard,
+		domainsController.maybeRedirectToDashboard,
 		noSite,
 		...getCommonHandlers( { noSitePath: false, noSiteSelection: true } ),
 		domainManagementController.domainManagementListAllSites,

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -171,9 +171,8 @@ const waitForPrefs = () => async ( dispatch: CalypsoDispatch, getState: () => IA
 // The wp-admin admin bar does not know about user preferences and so may use the
 // origin_admin_bar query param to indicate that Calypso should take the user's
 // preference into account (without the query param, users can still navigate to
-// `/sites` manually allowing, meaning `/sites
-// navigate to `/sites`
-// user's preferenc
+// `/sites` manually, meaning the old dashboard is still accessible when the user
+// is specifically trying to go there).
 export const maybeRedirectToMultiSiteDashboard = ( context: PageJSContext, next: () => void ) => {
 	const originAdminBar = context.query[ 'origin_admin_bar' ];
 	if ( originAdminBar !== 'wpcom' ) {

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -5,13 +5,18 @@ import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import ResurrectedWelcomeModalGate from 'calypso/components/resurrected-welcome-modal';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { fetchPreferences } from 'calypso/state/preferences/actions';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import SitesDashboard from './components/sites-dashboard';
 import { areHostingFeaturesSupported } from './hosting/features';
 import type { Context, Context as PageJSContext } from '@automattic/calypso-router';
+import type { CalypsoDispatch, IAppState } from 'calypso/state/types';
 
 const getStatusFilterValue = ( status?: string ) => {
 	return siteLaunchStatusGroupValues.find( ( value ) => value === status );
@@ -148,6 +153,45 @@ export function maybeRemoveCheckoutSuccessNotice( context: PageJSContext, next: 
 	}
 	next();
 }
+
+// Helper thunk that ensures that the user preferences has been fetched into Redux state before we
+// continue working with it.
+const waitForPrefs = () => async ( dispatch: CalypsoDispatch, getState: () => IAppState ) => {
+	if ( hasReceivedRemotePreferences( getState() ) ) {
+		return;
+	}
+
+	try {
+		await dispatch( fetchPreferences() );
+	} catch {
+		// if the fetching of preferences fails, return gracefully and proceed to the next landing page candidate
+	}
+};
+
+// The wp-admin admin bar does not know about user preferences and so may use the
+// origin_admin_bar query param to indicate that Calypso should take the user's
+// preference into account (without the query param, users can still navigate to
+// `/sites` manually allowing, meaning `/sites
+// navigate to `/sites`
+// user's preferenc
+export const maybeRedirectToMultiSiteDashboard = ( context: PageJSContext, next: () => void ) => {
+	const originAdminBar = context.query[ 'origin_admin_bar' ];
+	if ( originAdminBar !== 'wpcom' ) {
+		next();
+		return;
+	}
+
+	const { dispatch, getState } = context.store;
+
+	dispatch( waitForPrefs() ).finally( () => {
+		if ( hasHostingDashboardOptIn( getState() ) ) {
+			window.location.href = dashboardLink( '/sites' );
+			return;
+		}
+		context.page.replace( removeQueryArgs( context.canonicalPath, 'origin_admin_bar' ) );
+		next();
+	} );
+};
 
 export function redirectToHostingFeaturesIfNotAtomic( context: PageJSContext, next: () => void ) {
 	const state = context.store.getState();

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -173,11 +173,10 @@ const waitForPrefs = () => async ( dispatch: CalypsoDispatch, getState: () => IA
 // preference into account (without the query param, users can still navigate to
 // `/sites` manually, meaning the old dashboard is still accessible when the user
 // is specifically trying to go there).
-export const maybeRedirectToMultiSiteDashboard = ( context: PageJSContext, next: () => void ) => {
+export const maybeRedirectToDashboard = ( context: PageJSContext, next: () => void ) => {
 	const originAdminBar = context.query[ 'origin_admin_bar' ];
 	if ( originAdminBar !== 'wpcom' ) {
-		next();
-		return;
+		return next();
 	}
 
 	const { dispatch, getState } = context.store;

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -183,7 +183,7 @@ export const maybeRedirectToDashboard = ( context: PageJSContext, next: () => vo
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasHostingDashboardOptIn( getState() ) ) {
-			window.location.href = dashboardLink( '/sites' );
+			window.location.replace( dashboardLink( '/sites' ) );
 			return;
 		}
 		context.page.replace( removeQueryArgs( context.canonicalPath, 'origin_admin_bar' ) );

--- a/client/sites/index.tsx
+++ b/client/sites/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
 import { siteSelection, navigation } from 'calypso/my-sites/controller';
-import { maybeRedirectToMultiSiteDashboard, siteDashboard } from 'calypso/sites/controller';
+import { maybeRedirectToDashboard, siteDashboard } from 'calypso/sites/controller';
 import { OVERVIEW, SETTINGS_SITE } from './components/site-preview-pane/constants';
 import {
 	maybeRemoveCheckoutSuccessNotice,
@@ -49,7 +49,7 @@ export default function () {
 	page(
 		'/sites',
 		maybeRemoveCheckoutSuccessNotice,
-		maybeRedirectToMultiSiteDashboard,
+		maybeRedirectToDashboard,
 		sanitizeQueryParameters,
 		navigation,
 		setSelectedSiteIdByOrigin,

--- a/client/sites/index.tsx
+++ b/client/sites/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
 import { siteSelection, navigation } from 'calypso/my-sites/controller';
-import { siteDashboard } from 'calypso/sites/controller';
+import { maybeRedirectToMultiSiteDashboard, siteDashboard } from 'calypso/sites/controller';
 import { OVERVIEW, SETTINGS_SITE } from './components/site-preview-pane/constants';
 import {
 	maybeRemoveCheckoutSuccessNotice,
@@ -49,6 +49,7 @@ export default function () {
 	page(
 		'/sites',
 		maybeRemoveCheckoutSuccessNotice,
+		maybeRedirectToMultiSiteDashboard,
 		sanitizeQueryParameters,
 		navigation,
 		setSelectedSiteIdByOrigin,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-934

## Proposed Changes

Following on from https://github.com/Automattic/jetpack/pull/46193, which added a `?origin_admin_bar=wpcom` query param to links in the wp-admin admin bar that could either go to Calypso v1 or MSD v2. The remote site doesn't have the user preference and so it doesn't know where those users should be linked to. It attaches the query param to signal intent to Calypso and allows Calypso to deal with the user preference.

- `/sites` -> `/sites`
- `/me` -> `/me/profile`
- `/me/account` -> `/me/profile`
  - Both of the account links go to the same place, this new page seems like the equivalent to both the `/me` and `/me/account` pages in Calypso.
- `/domains/manage` -> `/domains`
  - There seems to be an issue with the v2 `/domains` link when developing locally. It takes the user to the domain onboarding flow, even though if you were to click the link in the MSD UI it doesn't do that.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To give affect to the opt-in

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Manually append `?origin_admin_bar=wpcom` to the Calypso URL you are testing.
* Test either
  * opt-in (in which case the user should be redirected to v2)
  * opt-out (the query param should be stripped from the URL)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
