### PR TITLE
Dashboard ES Site List: render site link correctly

### DIFF
--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -2,29 +2,44 @@ import { DotcomFeatures, HostingFeatures } from '@automattic/api-core';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
 import { hasHostingFeature, hasPlanFeature } from '../utils/site-features';
 import { isSiteMigrationInProgress } from '../utils/site-status';
-import { isSelfHostedJetpackConnected, isP2 } from '../utils/site-types';
-import type { Site, User } from '@automattic/api-core';
+import {
+	isSelfHostedJetpackConnected,
+	isSelfHostedJetpackConnected__ES,
+	isP2,
+} from '../utils/site-types';
+import type { DashboardSiteListSite, Site, User } from '@automattic/api-core';
 
 export function canManageSite( site: Site ) {
 	if ( site.is_deleted || ! site.capabilities?.manage_options ) {
 		return false;
 	}
 
-	// P2 sites are not supported.
-	if ( isP2( site ) ) {
+	// Unsupported site types
+	if ( isP2( site ) || site.is_vip ) {
 		return false;
 	}
 
-	// VIP sites are not supported, yet.
-	if ( site.is_vip ) {
+	// Self-hosted Jetpack-connected sites are not supported in the dashboard backport.
+	if ( isSelfHostedJetpackConnected( site ) ) {
+		return ! isDashboardBackport();
+	}
+
+	return true;
+}
+
+export function canManageSite__ES( site: DashboardSiteListSite ) {
+	if ( site.deleted || ! site.capabilities?.manage_options ) {
 		return false;
 	}
 
-	// Self-hosted Jetpack-connected sites are not supported, yet. But disable this
-	// check on the Multi-site Dashboard for development purposes, since it is not
-	// yet user-facing.
-	if ( isSelfHostedJetpackConnected( site ) && isDashboardBackport() ) {
+	// Unsupported site types
+	if ( site.is_p2 || site.is_vip ) {
 		return false;
+	}
+
+	// Self-hosted Jetpack-connected sites are not supported in the dashboard backport.
+	if ( isSelfHostedJetpackConnected__ES( site ) ) {
+		return ! isDashboardBackport();
 	}
 
 	return true;

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -100,10 +100,12 @@ function getFetchSiteListParams(
 		'blog_id',
 		'slug',
 		'deleted',
+		'capabilities',
 		'is_a8c',
 		'is_atomic',
 		'is_garden',
 		'is_jetpack',
+		'is_p2',
 		'is_vip',
 	];
 

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -32,11 +32,11 @@ import { hasHostingFeature, hasJetpackModule, hasPlanFeature } from '../../utils
 import { getSiteStatus, getSiteStatusLabel } from '../../utils/site-status';
 import { isP2 } from '../../utils/site-types';
 import { getSiteFormattedUrl } from '../../utils/site-url';
-import { canManageSite } from '../features';
+import { canManageSite, canManageSite__ES } from '../features';
 import { isSitePlanTrial } from '../plans';
 import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
-import type { AtomicTransferStatus, Site, DashboardSiteListSite } from '@automattic/api-core';
+import type { AtomicTransferStatus, DashboardSiteListSite, Site } from '@automattic/api-core';
 import type { ComponentProps } from 'react';
 
 function IneligibleIndicator() {
@@ -47,7 +47,7 @@ function LoadingIndicator( { label }: { label: string } ) {
 	return <TextBlur>{ label }</TextBlur>;
 }
 
-export function getSiteManagementUrl( site: Site ) {
+function getSiteManagementUrl( site: Site ) {
 	if ( canManageSite( site ) ) {
 		const path = `/sites/${ site.slug }`;
 
@@ -58,6 +58,19 @@ export function getSiteManagementUrl( site: Site ) {
 		return path;
 	}
 	return site.options?.admin_url;
+}
+
+function getSiteManagementUrl__ES( site: DashboardSiteListSite ) {
+	if ( canManageSite__ES( site ) ) {
+		const path = `/sites/${ site.slug }`;
+
+		if ( isDashboardBackport() ) {
+			return addTransientViewPropertiesToQueryParams( path );
+		}
+
+		return path;
+	}
+	return `${ site.url?.with_scheme }/wp-admin`;
 }
 
 export const titleFieldTextOverflowStyles = {
@@ -85,7 +98,7 @@ export function SiteLink__ES( {
 	return (
 		<Link
 			{ ...props }
-			to={ `/sites/${ site.slug }` }
+			to={ getSiteManagementUrl__ES( site ) }
 			disabled={ site.deleted }
 			preload="viewport"
 			style={ { width: 'auto', minWidth: 'unset', textDecoration: 'none', ...props.style } }

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -26,6 +26,7 @@ export interface DashboardSiteListSite {
 	is_atomic?: boolean;
 	is_garden?: boolean;
 	is_jetpack?: boolean;
+	is_p2?: boolean;
 	is_vip?: boolean;
 	owner_id?: number;
 	slug: string; // Slug is always fetched


### PR DESCRIPTION
Fixes DOTMSD-920

## Proposed Changes

This PR correctly set the individual site row link in the Dashboard Site List when the ES Site Profiles flag is on, based on various criteria.


## Testing Instructions

1. Go to `/v2/sites?flags=dashboard/es-site-list`
2. Check that the individual site row points to wp-admin if it's P2, or sites that you can't administer, etc.

> [!IMPORTANT]  
> Initially, I want to add a new computed field in the backend (`is_manageable`). However, I now believe it's better to have the check in Calypso. It's because `canManageSite()` and `canManage__ES()` **MUST** have the same logic, so I think it's better if they are co-located together.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
