### PR TITLE
MSD: Update layout to use components and equalize spacing.

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
@@ -71,7 +71,6 @@ export default function CancelButton( {
 
 	return (
 		<Button
-			className="cancel-purchase__button"
 			disabled={ isDisabled }
 			isBusy={ isBusy ?? state.isLoading ?? false }
 			onClick={ onClick }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -1,3 +1,4 @@
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { isAkismetProduct, isGSuiteOrGoogleWorkspaceProductSlug } from '../../../utils/purchase';
 import BackupRetentionOptionOnCancelPurchase from './backup-retention-management/retention-option-on-cancel-purchase';
@@ -108,7 +109,7 @@ export default function CancellationMainContent( {
 		! willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase );
 
 	return (
-		<>
+		<VStack spacing={ 4 }>
 			{ shouldShowDomainOptionsInline && (
 				<CancelPurchaseDomainOptions
 					includedDomainPurchase={ includedDomainPurchase }
@@ -153,6 +154,6 @@ export default function CancellationMainContent( {
 				onKeepSubscriptionClick={ onKeepSubscriptionClick }
 				onCancelClick={ onCancelClick }
 			/>
-		</>
+		</VStack>
 	);
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -1,6 +1,7 @@
-import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { SectionHeader } from '../../../components/section-header';
+import { Text } from '../../../components/text';
 import CancellationMainContent from './cancellation-main-content';
 import DomainOptionsContent from './domain-options-content';
 import type { CancelPurchaseState } from './types';

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -55,7 +55,7 @@ export default function CancellationPreSurveyContent( {
 						purchaseName: purchase.is_domain ? purchase.meta : purchase.product_name,
 					}
 				) }
-				level={ 2 }
+				level={ 3 }
 			/>
 
 			<Text>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -1,5 +1,6 @@
-import { __experimentalHeading as Heading } from '@wordpress/components';
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { SectionHeader } from '../../../components/section-header';
 import CancellationMainContent from './cancellation-main-content';
 import DomainOptionsContent from './domain-options-content';
 import type { CancelPurchaseState } from './types';
@@ -44,17 +45,19 @@ export default function CancellationPreSurveyContent( {
 	showMarketplaceDialog,
 }: CancellationPreSurveyContentProps ) {
 	return (
-		<>
-			<Heading level={ 4 }>
-				{
+		<VStack>
+			<SectionHeader
+				title={ sprintf(
 					/* translators: %(purchaseName)s is the name of the product which was purchased */
-					sprintf( __( 'Manage %(purchaseName)s' ), {
+					__( 'Manage %(purchaseName)s' ),
+					{
 						purchaseName: purchase.is_domain ? purchase.meta : purchase.product_name,
-					} )
-				}
-			</Heading>
+					}
+				) }
+				level={ 2 }
+			/>
 
-			<p className="cancel-purchase__left">
+			<Text>
 				{ state.showDomainOptionsStep ? (
 					<DomainOptionsContent
 						purchase={ purchase }
@@ -82,7 +85,7 @@ export default function CancellationPreSurveyContent( {
 						}
 					/>
 				) }
-			</p>
-		</>
+			</Text>
+		</VStack>
 	);
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
@@ -1,12 +1,12 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	CheckboxControl,
-	__experimentalText as Text,
 	__experimentalDivider as Divider,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Text } from '../../../components/text';
 import type { CancelPurchaseState } from './types';
 import type { Purchase, AtomicTransfer } from '@automattic/api-core';
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
@@ -29,7 +29,7 @@ export default function ConfirmCheckbox( {
 
 	return (
 		<VStack spacing={ 4 }>
-			<Text as="b">{ __( 'Have a question before cancelling?' ) }</Text>
+			<Text weight="bold">{ __( 'Have a question before cancelling?' ) }</Text>
 			<Text>
 				{ createInterpolateElement(
 					__( 'Our support team is here for you. <contactLink>Contact us</contactLink>' ),

--- a/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/confirm-checkbox.tsx
@@ -1,5 +1,10 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { CheckboxControl } from '@wordpress/components';
+import {
+	CheckboxControl,
+	__experimentalText as Text,
+	__experimentalDivider as Divider,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import type { CancelPurchaseState } from './types';
@@ -23,30 +28,28 @@ export default function ConfirmCheckbox( {
 	const isDomainRegistrationPurchase = purchase && purchase.is_domain_registration;
 
 	return (
-		<>
-			<b>{ __( 'Have a question before cancelling?' ) }</b>
-			<p>
+		<VStack spacing={ 4 }>
+			<Text as="b">{ __( 'Have a question before cancelling?' ) }</Text>
+			<Text>
 				{ createInterpolateElement(
 					__( 'Our support team is here for you. <contactLink>Contact us</contactLink>' ),
 					{
 						contactLink: <a href={ localizeUrl( 'https://wordpress.com/support' ) } />,
 					}
 				) }
-			</p>
+			</Text>
 
-			<hr />
+			<Divider />
 
-			{ isDomainRegistrationPurchase && ! state.surveyShown && (
-				<div>
+			<div>
+				{ isDomainRegistrationPurchase && ! state.surveyShown && (
 					<CheckboxControl
 						label={ __( 'I understand that canceling means that I may lose this domain forever.' ) }
 						checked={ state.domainConfirmationConfirmed }
 						onChange={ onDomainConfirmationChange }
 					/>
-				</div>
-			) }
+				) }
 
-			<div>
 				<CheckboxControl
 					label={ __( 'I understand my site will change when my plan expires.' ) }
 					checked={ state.customerConfirmedUnderstanding }
@@ -60,6 +63,6 @@ export default function ConfirmCheckbox( {
 					} }
 				/>
 			</div>
-		</>
+		</VStack>
 	);
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,9 @@
-import { Icon } from '@wordpress/components';
+import {
+	Icon,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { close, info } from '@wordpress/icons';
 import { intlFormat } from 'date-fns';
@@ -25,55 +30,49 @@ const CancelPurchaseFeatureList = ( {
 	const { expiry_date: expiryDate } = purchase;
 	const expirationDate = intlFormat( expiryDate, { dateStyle: 'medium' }, { locale: 'en-US' } );
 	return (
-		<>
-			<div className="cancel-purchase__features">
-				<p>
-					{ sprintf(
-						/* translators: %(expire)s is the date the product will expire */
-						__( "Your plan will expire on %(expiry)s and you'll lose access to:" ),
-						{
-							expiry: expirationDate,
-						}
-					) }
-				</p>
-				<ul className="cancel-purchase__features-list">
-					{ cancellationFeatures.map( ( feature ) => {
-						if ( ! feature ) {
-							return null;
-						}
-						return (
-							<li key={ feature.feature_id }>
-								<Icon
-									className="cancel-purchase__refund-information--item-cross-small"
-									size={ 24 }
-									icon={ close }
-								/>
+		<VStack spacing={ 4 }>
+			<Text as="p">
+				{ sprintf(
+					/* translators: %(expire)s is the date the product will expire */
+					__( "Your plan will expire on %(expiry)s and you'll lose access to:" ),
+					{
+						expiry: expirationDate,
+					}
+				) }
+			</Text>
+			<VStack as="ul" spacing={ 1 } style={ { listStyle: 'none', padding: 0, margin: 0 } }>
+				{ cancellationFeatures.map( ( feature ) => {
+					if ( ! feature ) {
+						return null;
+					}
+					return (
+						<li key={ feature.feature_id }>
+							<HStack alignment="topLeft">
+								<Icon size={ 20 } icon={ close } style={ { flexShrink: 0 } } />
 								<span>{ feature.title }</span>
-							</li>
-						);
-					} ) }
-				</ul>
-			</div>
+							</HStack>
+						</li>
+					);
+				} ) }
+			</VStack>
 			{ cancellationChanges.length > 0 && (
-				<div className="cancel-purchase__changes">
-					<p>{ __( 'We will also make these changes to your site:' ) }</p>
-					<ul className="cancel-purchase__changes-list">
+				<>
+					<Text as="p">{ __( 'We will also make these changes to your site:' ) }</Text>
+					<VStack as="ul" spacing={ 1 } style={ { listStyle: 'none', padding: 0, margin: 0 } }>
 						{ cancellationChanges.map( ( change ) => {
 							return (
 								<li key={ change.getSlug() }>
-									<Icon
-										className="cancel-purchase__refund-information--item-notice-outline"
-										size={ 24 }
-										icon={ info }
-									/>
-									<span>{ change.getTitle() }</span>
+									<HStack alignment="topLeft">
+										<Icon size={ 20 } icon={ info } style={ { flexShrink: 0 } } />
+										<span>{ change.getTitle() }</span>
+									</HStack>
 								</li>
 							);
 						} ) }
-					</ul>
-				</div>
+					</VStack>
+				</>
 			) }
-		</>
+		</VStack>
 	);
 };
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -34,7 +34,7 @@ const CancelPurchaseFeatureList = ( {
 			<Text as="p">
 				{ sprintf(
 					/* translators: %(expire)s is the date the product will expire */
-					__( "Your plan will expire on %(expiry)s and you'll lose access to:" ),
+					__( 'Your plan will expire on %(expiry)s and you’ll lose access to:' ),
 					{
 						expiry: expirationDate,
 					}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,12 +1,12 @@
 import {
 	Icon,
 	__experimentalHStack as HStack,
-	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { close, info } from '@wordpress/icons';
 import { intlFormat } from 'date-fns';
+import { Text } from '../../../components/text';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1198,10 +1198,9 @@ export default function CancelPurchase() {
 					) }
 				/>
 			}
+			notices={ ! state.surveyShown && <TimeRemainingNotice purchase={ purchase } /> }
 		>
 			<VStack>
-				{ ! state.surveyShown && <TimeRemainingNotice purchase={ purchase } /> }
-
 				<Card>
 					<CardBody>
 						<CancelPurchaseForm

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -33,7 +33,7 @@ import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { useLocale } from '../../../app/locale';
 import { cancelPurchaseRoute, purchaseSettingsRoute, purchasesRoute } from '../../../app/router/me';
-import { Card } from '../../../components/card';
+import { Card, CardBody } from '../../../components/card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { shuffleArray } from '../../../utils/collection';
@@ -1177,8 +1177,10 @@ export default function CancelPurchase() {
 					/>
 				}
 			>
-				<Card className="cancel-purchase__wrapper-card">
-					<DomainRemovalFlow purchase={ purchase } onCancel={ redirectBack } />
+				<Card>
+					<CardBody>
+						<DomainRemovalFlow purchase={ purchase } onCancel={ redirectBack } />
+					</CardBody>
 				</Card>
 			</PageLayout>
 		);
@@ -1200,96 +1202,98 @@ export default function CancelPurchase() {
 			<VStack>
 				{ ! state.surveyShown && <TimeRemainingNotice purchase={ purchase } /> }
 
-				<Card className="cancel-purchase__wrapper-card">
-					<CancelPurchaseForm
-						atomicRevertCheckOne={ state.atomicRevertCheckOne }
-						atomicRevertCheckTwo={ state.atomicRevertCheckTwo }
-						atomicRevertOnClickCheckOne={ atomicRevertOnClickCheckOne }
-						atomicRevertOnClickCheckTwo={ atomicRevertOnClickCheckTwo }
-						atomicTransfer={ atomicTransfer }
-						cancelBundledDomain={ state.cancelBundledDomain }
-						cancellationInProgress={ state.isLoading }
-						cancellationOffer={ cancellationOffer }
-						clickNext={ clickNext }
-						closeDialog={ closeDialog }
-						disableButtons={ state.isLoading }
-						downgradeClick={ downgradeClick }
-						downgradePlan={ downgradePlan }
-						flowType={ flowType }
-						freeMonthOfferClick={ freeMonthOfferClick }
-						getAllSurveySteps={ getAllSurveySteps }
-						hasBackupsFeature={ hasBackupsFeature }
-						importQuestionRadio={ state.importQuestionRadio }
-						includedDomainPurchase={ includedDomainPurchase }
-						isAkismet={ isAkismet }
-						isApplyingOffer={ isApplyingOffer }
-						isImport={ isImport }
-						isNextAdventureValid={ state.isNextAdventureValid }
-						isShowing={ state.isShowingMarketplaceSubscriptionsDialog }
-						isSubmitting={ state.isSubmitting }
-						isVisible={ state.surveyShown }
-						offerDiscountBasedFromPurchasePrice={ offerDiscountBasedFromPurchasePrice }
-						onClickAcceptForCancellationOffer={ onClickAcceptForCancellationOffer }
-						onGetCancellationOffer={ onGetCancellationOffer }
-						onImportRadioChange={ onImportRadioChange }
-						onNextAdventureValidationChange={ onNextAdventureValidationChange }
-						onRadioOneChange={ onRadioOneChange }
-						onRadioTwoChange={ onRadioTwoChange }
-						onSubmit={ onSubmit }
-						onSurveyComplete={ onSurveyComplete }
-						onTextOneChange={ onTextOneChange }
-						onTextThreeChange={ onTextThreeChange }
-						onTextTwoChange={ onTextTwoChange }
-						plans={ plans }
-						purchase={ purchase }
-						questionOneOrder={ state.questionOneOrder }
-						questionOneRadio={ state.questionOneRadio }
-						questionOneText={ state.questionOneText }
-						questionTwoOrder={ state.questionTwoOrder }
-						questionTwoRadio={ state.questionTwoRadio }
-						questionTwoText={ state.questionTwoText }
-						refundAmount={ purchase.total_refund_amount }
-						siteSlug={ siteSlug }
-						solution={ state.solution }
-						surveyStep={ state.surveyStep }
-						upsell={ state.upsell }
-					/>
-					{ ! state.surveyShown && (
-						<CancellationPreSurveyContent
-							purchase={ purchase }
-							includedDomainPurchase={ includedDomainPurchase }
+				<Card>
+					<CardBody>
+						<CancelPurchaseForm
+							atomicRevertCheckOne={ state.atomicRevertCheckOne }
+							atomicRevertCheckTwo={ state.atomicRevertCheckTwo }
+							atomicRevertOnClickCheckOne={ atomicRevertOnClickCheckOne }
+							atomicRevertOnClickCheckTwo={ atomicRevertOnClickCheckTwo }
 							atomicTransfer={ atomicTransfer }
-							selectedDomain={ selectedDomain }
-							state={ state }
-							purchaseCancelFeatures={ purchaseCancelFeatures }
-							onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
-							onDomainConfirmationChange={ onDomainConfirmationChange }
-							onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
-							onKeepSubscriptionClick={ onKeepSubscriptionClick }
-							onCancellationComplete={ onCancellationComplete }
-							onCancellationStart={ onCancellationStart }
-							shouldHandleMarketplaceSubscriptions={ shouldHandleMarketplaceSubscriptions }
-							showMarketplaceDialog={ showMarketplaceDialog }
+							cancelBundledDomain={ state.cancelBundledDomain }
+							cancellationInProgress={ state.isLoading }
+							cancellationOffer={ cancellationOffer }
+							clickNext={ clickNext }
+							closeDialog={ closeDialog }
+							disableButtons={ state.isLoading }
+							downgradeClick={ downgradeClick }
+							downgradePlan={ downgradePlan }
+							flowType={ flowType }
+							freeMonthOfferClick={ freeMonthOfferClick }
+							getAllSurveySteps={ getAllSurveySteps }
+							hasBackupsFeature={ hasBackupsFeature }
+							importQuestionRadio={ state.importQuestionRadio }
+							includedDomainPurchase={ includedDomainPurchase }
+							isAkismet={ isAkismet }
+							isApplyingOffer={ isApplyingOffer }
+							isImport={ isImport }
+							isNextAdventureValid={ state.isNextAdventureValid }
+							isShowing={ state.isShowingMarketplaceSubscriptionsDialog }
+							isSubmitting={ state.isSubmitting }
+							isVisible={ state.surveyShown }
+							offerDiscountBasedFromPurchasePrice={ offerDiscountBasedFromPurchasePrice }
+							onClickAcceptForCancellationOffer={ onClickAcceptForCancellationOffer }
+							onGetCancellationOffer={ onGetCancellationOffer }
+							onImportRadioChange={ onImportRadioChange }
+							onNextAdventureValidationChange={ onNextAdventureValidationChange }
+							onRadioOneChange={ onRadioOneChange }
+							onRadioTwoChange={ onRadioTwoChange }
+							onSubmit={ onSubmit }
+							onSurveyComplete={ onSurveyComplete }
+							onTextOneChange={ onTextOneChange }
+							onTextThreeChange={ onTextThreeChange }
+							onTextTwoChange={ onTextTwoChange }
+							plans={ plans }
+							purchase={ purchase }
+							questionOneOrder={ state.questionOneOrder }
+							questionOneRadio={ state.questionOneRadio }
+							questionOneText={ state.questionOneText }
+							questionTwoOrder={ state.questionTwoOrder }
+							questionTwoRadio={ state.questionTwoRadio }
+							questionTwoText={ state.questionTwoText }
+							refundAmount={ purchase.total_refund_amount }
+							siteSlug={ siteSlug }
+							solution={ state.solution }
+							surveyStep={ state.surveyStep }
+							upsell={ state.upsell }
 						/>
-					) }
-					{ shouldHandleMarketplaceSubscriptions() && (
-						<MarketPlaceSubscriptionsDialog
-							activeSubscriptions={ activeSubscriptions }
-							bodyParagraphText={ _n(
-								'This subscription will be cancelled. It will be removed when it expires.',
-								'These subscriptions will be cancelled. They will be removed when they expire.',
-								activeSubscriptions.length
-							) }
-							closeDialog={ closeMarketplaceSubscriptionsDialog }
-							isDialogVisible
-							planName={ planName ?? '' }
-							/* Translators: This button cancels the active plan and all active Marketplace subscriptions on the site */
-							primaryButtonText={ __( 'Continue' ) }
-							removePlan={ handleMarketplaceDialogContinue }
-							/* Translators: %(plan)s is the name of the plan being cancelled */
-							sectionHeadingText={ sprintf( __( 'Cancel %(plan)s' ), { plan: planName } ) }
-						/>
-					) }
+						{ ! state.surveyShown && (
+							<CancellationPreSurveyContent
+								purchase={ purchase }
+								includedDomainPurchase={ includedDomainPurchase }
+								atomicTransfer={ atomicTransfer }
+								selectedDomain={ selectedDomain }
+								state={ state }
+								purchaseCancelFeatures={ purchaseCancelFeatures }
+								onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
+								onDomainConfirmationChange={ onDomainConfirmationChange }
+								onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
+								onKeepSubscriptionClick={ onKeepSubscriptionClick }
+								onCancellationComplete={ onCancellationComplete }
+								onCancellationStart={ onCancellationStart }
+								shouldHandleMarketplaceSubscriptions={ shouldHandleMarketplaceSubscriptions }
+								showMarketplaceDialog={ showMarketplaceDialog }
+							/>
+						) }
+						{ shouldHandleMarketplaceSubscriptions() && (
+							<MarketPlaceSubscriptionsDialog
+								activeSubscriptions={ activeSubscriptions }
+								bodyParagraphText={ _n(
+									'This subscription will be cancelled. It will be removed when it expires.',
+									'These subscriptions will be cancelled. They will be removed when they expire.',
+									activeSubscriptions.length
+								) }
+								closeDialog={ closeMarketplaceSubscriptionsDialog }
+								isDialogVisible
+								planName={ planName ?? '' }
+								/* Translators: This button cancels the active plan and all active Marketplace subscriptions on the site */
+								primaryButtonText={ __( 'Continue' ) }
+								removePlan={ handleMarketplaceDialogContinue }
+								/* Translators: %(plan)s is the name of the plan being cancelled */
+								sectionHeadingText={ sprintf( __( 'Cancel %(plan)s' ), { plan: planName } ) }
+							/>
+						) }
+					</CardBody>
 				</Card>
 			</VStack>
 		</PageLayout>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
@@ -1,3 +1,4 @@
+import { __experimentalVStack as VStack, __experimentalText as Text } from '@wordpress/components';
 import { ButtonStack } from '../../../components/button-stack';
 import CancelButton from './cancel-button';
 import CancellationFullText from './cancellation-full-text';
@@ -28,15 +29,15 @@ export default function PlanProductRevertContent( {
 	onCancelClick,
 }: PlanProductRevertContentProps ) {
 	return (
-		<>
+		<VStack spacing={ 4 }>
 			{ ! includedDomainPurchase && (
-				<p>
+				<Text>
 					<CancellationFullText
 						purchase={ purchase }
 						cancelBundledDomain={ state.cancelBundledDomain ?? false }
 						includedDomainPurchase={ includedDomainPurchase }
 					/>
-				</p>
+				</Text>
 			) }
 
 			{ ! state.surveyShown && (
@@ -62,6 +63,6 @@ export default function PlanProductRevertContent( {
 					onKeepSubscriptionClick={ onKeepSubscriptionClick }
 				/>
 			</ButtonStack>
-		</>
+		</VStack>
 	);
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
@@ -1,5 +1,6 @@
-import { __experimentalVStack as VStack, __experimentalText as Text } from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { ButtonStack } from '../../../components/button-stack';
+import { Text } from '../../../components/text';
 import CancelButton from './cancel-button';
 import CancellationFullText from './cancellation-full-text';
 import ConfirmCheckbox from './confirm-checkbox';

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { hasAmountAvailableToRefund, isOneTimePurchase } from '../../../utils/purchase';
 import type { Purchase, Domain } from '@automattic/api-core';
@@ -125,20 +126,17 @@ const CancelPurchaseRefundInformation = ( {
 	}
 
 	return (
-		<div className="cancel-purchase__info">
+		<VStack>
 			{ Array.isArray( text ) ? (
 				text.map( ( paragraph, index ) => (
-					<p
-						key={ purchase?.ID + '_refund_p_' + index }
-						className="cancel-purchase__refund-details"
-					>
+					<Text as="p" key={ purchase?.ID + '_refund_p_' + index }>
 						{ paragraph }
-					</p>
+					</Text>
 				) )
 			) : (
-				<p className="cancel-purchase__refund-details">{ text }</p>
+				<Text as="p">{ text }</Text>
 			) }
-		</div>
+		</VStack>
 	);
 };
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
-import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { Text } from '../../../components/text';
 import { hasAmountAvailableToRefund, isOneTimePurchase } from '../../../utils/purchase';
 import type { Purchase, Domain } from '@automattic/api-core';
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
@@ -1,30 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.cancel-purchase__domain-options {
-	.card {
-		margin: 16px 0;
-	}
-
-	.cancel-purchase__refund-domain-info {
-		color: var(--color-text-subtle);
-		display: inline-block;
-		font-size: $font-body-extra-small;
-		line-height: 1.4;
-		margin-top: 4px;
-	}
-
-	.cancel-purchase__domain-warning {
-		display: inline-block;
-		font-size: $font-body-small;
-		line-height: 1.4;
-
-		.form-label {
-			margin: 1.5em 0;
-		}
-	}
-}
-
 .confirm-cancel-domain__formatted-header.formatted-header {
 	margin: 16px 0 8px;
 }
@@ -37,18 +13,6 @@
 .cancel-purchase__warning-string {
 	color: var(--color-error);
 	font-weight: 600;
-}
-
-.cancel-purchase__confirm-buttons {
-	display: flex;
-
-	.form-button {
-		margin-inline-start: 8px;
-	}
-
-	button.cancel-purchase__button {
-		background-color: #F00;
-	}
 }
 
 .cancel-purchase__refund-information {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
@@ -18,9 +18,3 @@
 .cancel-purchase__refund-information {
 	font-size: $font-body-small;
 }
-
-.cancel-purchase__button {
-	@include breakpoint-deprecated( "<660px" ) {
-		width: 100%;
-	}
-}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/style.scss
@@ -1,11 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.cancel-purchase__wrapper-card {
-	padding: 32px;
-	margin-top: 12px;
-}
-
 .cancel-purchase__domain-options {
 	.card {
 		margin: 16px 0;
@@ -32,40 +27,6 @@
 
 .confirm-cancel-domain__formatted-header.formatted-header {
 	margin: 16px 0 8px;
-}
-
-.cancel-purchase__features {
-	line-height: 1.4;
-
-	p {
-		margin: 16px 0 8px 0;
-		font-size: $font-body-small;
-		line-height: 1.4;
-	}
-
-	ul.cancel-purchase__features-list {
-		list-style: none;
-		margin: 0 0 1.5em;
-		padding: 0;
-
-		li {
-			list-style: none;
-			display: flex;
-			font-size: $font-body-small;
-
-			span {
-				margin: auto 0;
-				flex: 1;
-			}
-
-			.gridicon {
-				flex-shrink: 0;
-				margin-inline-end: 8px;
-				margin-top: 2px;
-				color: var(--color-error-40);
-			}
-		}
-	}
 }
 
 .cancel-purchase__refund-string {
@@ -97,31 +58,5 @@
 .cancel-purchase__button {
 	@include breakpoint-deprecated( "<660px" ) {
 		width: 100%;
-	}
-}
-
-.cancel-purchase__changes {
-	ul.cancel-purchase__changes-list {
-		list-style: none;
-		margin: 0 0 1.5em;
-		padding: 0;
-
-		li {
-			list-style: none;
-			display: flex;
-			font-size: $font-body-small;
-
-			span {
-				margin: auto 0;
-				flex: 1;
-			}
-
-			.gridicon {
-				flex-shrink: 0;
-				margin-inline-end: 8px;
-				margin-top: 2px;
-				color: var(--color-warning);
-			}
-		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Update billing downgrade flow layout, removing custom styles and using wordpress/components where applicable.

| Before | After |
|--------|--------|
| <img width="650" height="886" alt="Screenshot 2025-12-10 at 2 24 05 PM" src="https://github.com/user-attachments/assets/4ee77a32-a10d-4c09-8c88-fb4cbf9e9b5f" /> | <img width="634" height="848" alt="Screenshot 2025-12-10 at 2 31 39 PM" src="https://github.com/user-attachments/assets/5d5b2c63-2aec-4ed6-8353-569daf66b9ef" /> |
| <img width="731" height="724" alt="Screenshot 2025-12-10 at 2 21 33 PM" src="https://github.com/user-attachments/assets/7f270b0f-6d6e-44f8-9923-a94d7adc28fd" /> | <img width="648" height="637" alt="Screenshot 2025-12-10 at 2 31 53 PM" src="https://github.com/user-attachments/assets/d8d46d2d-9cf2-4433-9ce5-45fbabf79fb7" /> | 


## Why are these changes being made?

We want the layout to be consistent, use wordpress/components and not use custom styles.


## Testing Instructions

Start on `me/billing/purchases`

Try downgrading the following:
- Hosting plan
- Domain
- Mailbox

Expect the layout to look consistent in those circumstances.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
