### PR TITLE
Reimplement unified ai chat to use server side flag.

### DIFF
--- a/apps/help-center/config.js
+++ b/apps/help-center/config.js
@@ -5,7 +5,6 @@ window.configData = {
 	env_id: isProxied ? 'staging' : 'production',
 	features: {
 		'help/gpt-response': true,
-		'unified-agent': false, // Enable to use unified AI agent instead of HelpCenterGPT
 	},
 	wapuu: false,
 	i18n_default_locale_slug: 'en',

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Global type declarations for the Agents Manager package.
+ */
+
+/**
+ * agentsManagerData is set as a global const via wp_add_inline_script
+ * in Jetpack's Agents Manager feature.
+ */
+declare const agentsManagerData:
+	| {
+			agentProviders?: string[];
+			useUnifiedExperience?: boolean;
+	  }
+	| undefined;

--- a/packages/agents-manager/src/index.ts
+++ b/packages/agents-manager/src/index.ts
@@ -4,6 +4,9 @@ export type { UnifiedAIAgentProps } from './components/unified-ai-agent';
 
 export { AGENTS_MANAGER_STORE } from './stores';
 
+// Utility for checking unified experience from inline script data
+export { getUseUnifiedExperienceFromInlineData } from './utils/load-external-providers';
+
 // Extension API types for other plugins to hook into
 export type {
 	Ability,

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -9,8 +9,28 @@ import type { ToolProvider, ContextProvider, Suggestion } from '../types';
 import type { SubmitOptions } from '@automattic/agenttic-client';
 import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 
-// agentsManagerData is set as a global const via wp_add_inline_script
-declare const agentsManagerData: { agentProviders?: string[] } | undefined;
+// agentsManagerData is set as a global const via wp_add_inline_script in Jetpack's Agents Manager
+declare const agentsManagerData:
+	| {
+			agentProviders?: string[];
+			useUnifiedExperience?: boolean;
+	  }
+	| undefined;
+
+/**
+ * Check if the unified experience flag is set via agentsManagerData.
+ *
+ * This is used on wp-admin environments (Atomic, Garden, Simple sites) where
+ * the flag is injected server-side by Jetpack's Agents Manager.
+ *
+ * @returns The useUnifiedExperience value, or undefined if not available.
+ */
+export function getUseUnifiedExperienceFromInlineData(): boolean | undefined {
+	if ( typeof agentsManagerData !== 'undefined' ) {
+		return agentsManagerData?.useUnifiedExperience;
+	}
+	return undefined;
+}
 
 /**
  * Navigation continuation hook type - provided by environments that support

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -9,14 +9,6 @@ import type { ToolProvider, ContextProvider, Suggestion } from '../types';
 import type { SubmitOptions } from '@automattic/agenttic-client';
 import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
 
-// agentsManagerData is set as a global const via wp_add_inline_script in Jetpack's Agents Manager
-declare const agentsManagerData:
-	| {
-			agentProviders?: string[];
-			useUnifiedExperience?: boolean;
-	  }
-	| undefined;
-
 /**
  * Check if the unified experience flag is set via agentsManagerData.
  *

--- a/packages/help-center/src/data/use-unified-ai-chat.ts
+++ b/packages/help-center/src/data/use-unified-ai-chat.ts
@@ -2,8 +2,10 @@ import { getUseUnifiedExperienceFromInlineData } from '@automattic/agents-manage
 import { useQuery } from '@tanstack/react-query';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
-interface MeResponse {
-	unified_ai_chat?: boolean;
+interface CalypsoPreferencesResponse {
+	calypso_preferences?: {
+		unified_ai_chat?: boolean;
+	};
 }
 
 /**
@@ -16,7 +18,7 @@ interface MeResponse {
  *    injected server-side by Jetpack's Agents Manager.
  *
  * 2. **Calypso app** (wordpress.com):
- *    The flag is fetched from the `/me?fields=unified_ai_chat` endpoint.
+ *    The flag is fetched from the `/me/preferences` endpoint.
  *
  * The rollout logic lives in Agents Manager (Jetpack) via the
  * `agents_manager_use_unified_experience` filter.
@@ -31,15 +33,14 @@ export function useUnifiedAiChat( enabled = true ) {
 				return inlineValue;
 			}
 
-			// 2. Fall back to /me endpoint for Calypso app (wordpress.com)
+			// 2. Fall back to /me/preferences endpoint for Calypso app (wordpress.com)
 			if ( canAccessWpcomApis() ) {
-				const response: MeResponse = await wpcomRequest( {
-					path: '/me',
+				const response: CalypsoPreferencesResponse = await wpcomRequest( {
+					path: '/me/preferences',
 					apiVersion: '1.1',
-					query: 'fields=unified_ai_chat',
 				} );
 
-				return response.unified_ai_chat ?? false;
+				return response.calypso_preferences?.unified_ai_chat ?? false;
 			}
 
 			// 3. No data available - default to false

--- a/packages/help-center/src/data/use-unified-ai-chat.ts
+++ b/packages/help-center/src/data/use-unified-ai-chat.ts
@@ -1,3 +1,4 @@
+import { getUseUnifiedExperienceFromInlineData } from '@automattic/agents-manager';
 import { useQuery } from '@tanstack/react-query';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
@@ -6,8 +7,16 @@ interface MeResponse {
 }
 
 /**
- * Fetches the unified_ai_chat field from the /me endpoint.
- * This determines if the user should see the unified AI chat experience.
+ * Determines if the user should see the unified AI chat experience.
+ *
+ * This hook uses a hybrid approach to work across all environments:
+ *
+ * 1. **wp-admin environments** (Atomic, Garden, Simple sites):
+ *    The flag is available via `agentsManagerData.useUnifiedExperience`,
+ *    injected server-side by Jetpack's Agents Manager.
+ *
+ * 2. **Calypso app** (wordpress.com):
+ *    The flag is fetched from the `/me?fields=unified_ai_chat` endpoint.
  *
  * The rollout logic lives in Agents Manager (Jetpack) via the
  * `agents_manager_use_unified_experience` filter.
@@ -16,20 +25,25 @@ export function useUnifiedAiChat( enabled = true ) {
 	return useQuery< boolean, Error >( {
 		queryKey: [ 'unified-ai-chat' ],
 		queryFn: async () => {
-			if ( ! canAccessWpcomApis() ) {
-				// For non-wpcom environments (Atomic/Garden), the filter is checked
-				// server-side by Agents Manager. This API call won't work there.
-				// The Help Center should rely on other signals in those environments.
-				return false;
+			// 1. Check inline script first (available on wp-admin via Jetpack's Agents Manager)
+			const inlineValue = getUseUnifiedExperienceFromInlineData();
+			if ( inlineValue !== undefined ) {
+				return inlineValue;
 			}
 
-			const response: MeResponse = await wpcomRequest( {
-				path: '/me',
-				apiVersion: '1.1',
-				query: 'fields=unified_ai_chat',
-			} );
+			// 2. Fall back to /me endpoint for Calypso app (wordpress.com)
+			if ( canAccessWpcomApis() ) {
+				const response: MeResponse = await wpcomRequest( {
+					path: '/me',
+					apiVersion: '1.1',
+					query: 'fields=unified_ai_chat',
+				} );
 
-			return response.unified_ai_chat ?? false;
+				return response.unified_ai_chat ?? false;
+			}
+
+			// 3. No data available - default to false
+			return false;
 		},
 		enabled,
 		refetchOnWindowFocus: false,

--- a/packages/help-center/src/data/use-unified-ai-chat.ts
+++ b/packages/help-center/src/data/use-unified-ai-chat.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+
+interface MeResponse {
+	unified_ai_chat?: boolean;
+}
+
+/**
+ * Fetches the unified_ai_chat field from the /me endpoint.
+ * This determines if the user should see the unified AI chat experience.
+ *
+ * The rollout logic lives in Agents Manager (Jetpack) via the
+ * `agents_manager_use_unified_experience` filter.
+ */
+export function useUnifiedAiChat( enabled = true ) {
+	return useQuery< boolean, Error >( {
+		queryKey: [ 'unified-ai-chat' ],
+		queryFn: async () => {
+			if ( ! canAccessWpcomApis() ) {
+				// For non-wpcom environments (Atomic/Garden), the filter is checked
+				// server-side by Agents Manager. This API call won't work there.
+				// The Help Center should rely on other signals in those environments.
+				return false;
+			}
+
+			const response: MeResponse = await wpcomRequest( {
+				path: '/me',
+				apiVersion: '1.1',
+				query: 'fields=unified_ai_chat',
+			} );
+
+			return response.unified_ai_chat ?? false;
+		},
+		enabled,
+		refetchOnWindowFocus: false,
+		staleTime: 300000, // 5 minutes
+	} );
+}

--- a/packages/help-center/src/hooks/use-should-use-unified-agent.ts
+++ b/packages/help-center/src/hooks/use-should-use-unified-agent.ts
@@ -1,26 +1,8 @@
 /* eslint-disable no-restricted-imports */
-import config from '@automattic/calypso-config';
-import { useSupportStatus } from '../data/use-support-status';
-
-function isUnifiedAgentFlagSetInURL(): boolean {
-	const currentUrl = window.location.href;
-	const urlParams = new URLSearchParams( new URL( currentUrl ).search );
-	const flags = urlParams.get( 'flags' );
-	return flags?.split( ',' ).includes( 'unified-agent' ) ?? false;
-}
+import { useUnifiedAiChat } from '../data/use-unified-ai-chat';
 
 export const useShouldUseUnifiedAgent = () => {
-	const { data: supportStatus } = useSupportStatus();
+	const { data: isEligibleViaAPI } = useUnifiedAiChat();
 
-	// Check if user is eligible via support status API
-	// Note: This will need to be added to the backend support-status endpoint
-	const isEligibleViaAPI = Boolean( supportStatus?.eligibility?.unified_agent_enabled );
-
-	// Force unified agent via URL flag (for testing)
-	const isFlagSetInURL = isUnifiedAgentFlagSetInURL();
-
-	// Unified agent can be enabled via config
-	const isConfigEnabled = config.isEnabled( 'unified-agent' );
-
-	return isEligibleViaAPI || isFlagSetInURL || isConfigEnabled;
+	return isEligibleViaAPI;
 };


### PR DESCRIPTION
Part of DOTCOM-15279

## Proposed Changes

* Consumes `/me/preferences` endpoint for `unified_ai_chat` property for wpcom. Atomic/Garden relies on agentsManagerData inline JS that is generated by `jetpack-mu-wpcom` consuming `/me/preferences` too.

  | Environment                 | How flag is retrieved                  |
  |-----------------------------|----------------------------------------|
  | Calypso app (wordpress.com) | /me/preferences |
  | Simple site wp-admin        | agentsManagerData.useUnifiedExperience |
  | Atomic site wp-admin        | agentsManagerData.useUnifiedExperience -> /me/preferences |
  | Garden/CIAB wp-admin        | agentsManagerData.useUnifiedExperience  -> /me/preferences |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to stop relying on `flags=unified-agent` query parameter for testing.
* We need automatticians to be able to opt-in to the unified experience (via 197669-ghe-Automattic/wpcom).
* Shortly in the future, we will use this same flag to do the progressive rollout to real users.

## Testing Instructions

This depends on the following PRs. Make sure you have them in place if they haven't been released yet (details below):
* ~197669-ghe-Automattic/wpcom~ **RELEASED**
* ~https://github.com/Automattic/jetpack/pull/46237~ **RELEASED**
* 5210-gh-Automattic/big-sky-plugin

Requirements:
- ~Follow the steps in 197669-ghe-Automattic/wpcom~ Go to https://wordpress.com/wp-admin/profile.php and enable the Unified Chat option (under Automattician Options).
- ~Make sure you have public-api.wordpress.com.~
- ~Checkout 197669-ghe-Automattic/wpcom in your sandbox.~ **RELEASED**
- ~In your sandbox run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/agents-manager-unified-experience-toggle-logic` to get https://github.com/Automattic/jetpack/pull/46237 code in place.~ RELEASED

### Testing calypso:
- Checkout this branch and run `yarn start`.
- Go to http://calypso.localhost:3000/sites 
- [x] Confirm you see the unified ai experience.

⚠️  You must have enabled Unified Chat option as described above in [your WPCOM profile](https://wordpress.com/wp-admin/profile.php).

### Testing simple site:
- Checkout big-sky-plugin to 5210-gh-Automattic/big-sky-plugin and run `WPCOM_USERNAME={YOURUSERNAME} npm run build:wpcom`. (Not needed if PR has been already merged and deployed).
- Go to `/wp-admin/` in a sandboxed simple site.
- [x] Confirm you see the unified ai experience.

### Testing atomic site:
- We need `help-center` app in place:
  - Make sure widgets.wp.com is pointing to your sandbox.
  - `cd apps/help-center`
  - Run `yarn dev --sync`.
  - Issues? If you are an Automattician check PCYsg-OT6-p2
- We also need `agents-manager` (jetpack-mu-wpcom) in place:
  - ⚠️ Stop sandboxing wordpress.com if you are still doing. Or you won't be able to access your dev blog's hosting-config page required in next step.
  - Automattician, you need a woa dev blog for this. To get one follow steps in PCYsg-Osp-p2 ("First time setup" section).
  - ~⚠️ You need to select the "Transfer to WP Cloud dev pool" checkbox. So you can point your Atomic to your sandbox for public-api.wordpress.com.~ 197669-ghe-Automattic/wpcom **RELEASED**

<img width="446" height="108" alt="image" src="https://github.com/user-attachments/assets/dc2250c7-9f7f-4bed-a915-661a67c6563d" />

  - SSH into your and add both constants to your `htdocs/wp-config.php` file.
```
define( 'JETPACK_AUTOLOAD_DEV', true ); // Enabled jetpack autoloading
//define( 'JETPACK__SANDBOX_DOMAIN', '$YOUR_SANDBOX_HOSTNAME' ); // Point to your sandbox USE YOUR SANDBOX – NOT NEEDED AFTER 197669-ghe-Automattic/wpcom HAS BEEN RELEASED
```
  - Then, follow "Testing a PR on WoW": Install [jetpack-beta plugin](https://github.com/Automattic/jetpack-beta/releases). Then go to `/wp-admin/admin.php?page=jetpack-beta&plugin=wpcomsh` and activate the feature branch `add/agents-manager-unified-experience-toggle-logic`.
- We finally need `big-sky-plugin` updated too (minor: to avoid duplicate experience)
- [x] Confirm that you see the unified chat experience in `/wp-admin` and basically everywhere around your atomic site.

### Testing garden site:
- Get your site garden site ready. Automattician? Follow p9lV3a-7yV-p2
  - While doing so, make sure `big-sky-plugin` and `agents-manager` are using: 5210-gh-Automattic/big-sky-plugin and https://github.com/Automattic/jetpack/pull/46237
  - Also, confirm your sandbox contains calypso's help center app (`yarn dev --sync`) ~and 197669-ghe-Automattic/wpcom~ **RELEASED** – ⚠️ you must be sandboxing ~both `public-api.wordpress.com` and~ `widgets.wp.com`.
- Navigate to your ciab site (using jurassic tube) and:
  - [ ] Navigate to `/wp-admin/` and confirm it displays the unified chat experience.
  - [ ] Navigate to `/wp-admin/plugins.php` and confirm it displays the unified chat experience.

## Screenshots

### Simple site (wp-admin)

<img width="1722" height="961" alt="image" src="https://github.com/user-attachments/assets/4aff9740-18e8-44c7-bd97-8050a640a350" />

### Simple site (post editor)

<img width="1914" height="928" alt="image" src="https://github.com/user-attachments/assets/26f09b41-8fd7-478f-8457-60b8605126b1" />

### WoA (wp-admin)

<img width="1727" height="961" alt="image" src="https://github.com/user-attachments/assets/86bb2de4-b7b7-45a3-86f6-679797cd53ec" />

### CIAB (wp-admin + next-admin)

No screenshots.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?