### PR TITLE
Improve DNS connection setup/verification tables for subdomain hostnames

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table-style.scss
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table-style.scss
@@ -1,5 +1,16 @@
-/* The Type and Name columns should be narrow */
-.dns-records-table .dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper {
-	min-width: initial;
-	white-space: normal;
+/* Prevent horizontal overflow and allow text wrapping */
+.dns-records-table {
+		.dataviews-view-table__cell-content-wrapper {
+			min-width: initial;
+			white-space: normal;
+			word-break: break-word;
+			overflow-wrap: break-word;
+			max-width: 100%;
+
+			// Ensure Text components wrap properly
+			> * {
+				word-break: break-word;
+				overflow-wrap: break-word;
+			}
+	}
 }

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -13,17 +13,26 @@ import type { Field, ViewTable } from '@wordpress/dataviews';
 
 import './dns-records-table-style.scss';
 
-const viewSuggested: ViewTable = {
+const baseSuggestedView: ViewTable = {
 	type: 'table',
 	page: 1,
-	fields: [ 'currentValue', 'expectedValue', 'status' ],
+	fields: [],
 	layout: {
 		enableMoving: false,
 	},
 };
 
+const getSuggestedView = ( includeName: boolean ): ViewTable => {
+	return {
+		...baseSuggestedView,
+		fields: includeName
+			? [ 'name', 'currentValue', 'expectedValue', 'status' ]
+			: [ 'currentValue', 'expectedValue', 'status' ],
+	};
+};
+
 const viewAdvanced: ViewTable = {
-	...viewSuggested,
+	...baseSuggestedView,
 	fields: [ 'type', 'name', 'currentValue', 'expectedValue', 'status' ],
 };
 
@@ -94,26 +103,35 @@ const fields: Field< DnsRecordVerification >[] = [
 	},
 ];
 
-const aRecordData = ( currentValue: string | null, expectedValue: string | null ) => {
+const aRecordData = ( currentValue: string | null, expectedValue: string | null, name: string ) => {
 	return {
 		type: 'A',
-		name: '@',
+		name,
 		currentValue: currentValue,
 		expectedValue: expectedValue,
 	};
 };
 
-const wwwCnameRecordData = ( currentValue: string | null, expectedValue: string | null ) => {
+const wwwCnameRecordData = (
+	currentValue: string | null,
+	expectedValue: string | null,
+	name: string
+) => {
 	return {
 		type: 'CNAME',
-		name: 'www',
+		name,
 		currentValue: currentValue,
 		expectedValue: expectedValue,
 	};
 };
 
-const nameServerRecordData = ( currentValue: string | null, expectedValue: string | null ) => {
+const nameServerRecordData = (
+	currentValue: string | null,
+	expectedValue: string | null,
+	name?: string
+) => {
 	return {
+		name,
 		currentValue: currentValue,
 		expectedValue: expectedValue,
 	};
@@ -131,6 +149,31 @@ export default function DnsRecordsTable( {
 	domainConnectionSetupInfo,
 }: DnsRecordVerificationProps ) {
 	const isSuggestedMode = domainConnectionStatus.mode === DomainConnectionSetupMode.SUGGESTED;
+	const isSubdomain = domainConnectionSetupInfo.is_subdomain;
+
+	const recordName = useMemo( () => {
+		if ( isSubdomain && domainConnectionSetupInfo.root_domain ) {
+			const rootDomain = domainConnectionSetupInfo.root_domain;
+			const suffix = `.${ rootDomain }`;
+
+			if ( domainName.endsWith( suffix ) ) {
+				const subdomain = domainName.slice( 0, -suffix.length );
+				return subdomain || domainName;
+			}
+
+			return domainName;
+		}
+
+		return '@';
+	}, [ domainName, domainConnectionSetupInfo.root_domain, isSubdomain ] );
+
+	const cnameRecordName = useMemo( () => {
+		if ( recordName === '@' ) {
+			return 'www';
+		}
+
+		return `www.${ recordName }`;
+	}, [ recordName ] );
 
 	const dnsRecords = useMemo( () => {
 		const data: DnsRecordVerification[] = [];
@@ -141,7 +184,13 @@ export default function DnsRecordsTable( {
 			const longestLength = Math.max( currentNameServers.length, expectedNameServers.length );
 
 			for ( let i = 0; i < longestLength; i++ ) {
-				data.push( nameServerRecordData( currentNameServers[ i ], expectedNameServers[ i ] ) );
+				data.push(
+					nameServerRecordData(
+						currentNameServers[ i ],
+						expectedNameServers[ i ],
+						isSubdomain ? recordName : undefined
+					)
+				);
 			}
 		} else {
 			const currentIpAddresses = ( domainConnectionStatus?.host_ip_addresses || [] ).sort();
@@ -149,22 +198,30 @@ export default function DnsRecordsTable( {
 			const longestLength = Math.max( currentIpAddresses.length, expectedIpAddresses.length );
 
 			for ( let i = 0; i < longestLength; i++ ) {
-				data.push( aRecordData( currentIpAddresses[ i ], expectedIpAddresses[ i ] ) );
+				data.push( aRecordData( currentIpAddresses[ i ], expectedIpAddresses[ i ], recordName ) );
 			}
 
 			const wwwCnameRecordTarget = domainConnectionStatus.www_cname_record_target;
-			data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainName ) );
+			data.push( wwwCnameRecordData( wwwCnameRecordTarget, domainName, cnameRecordName ) );
 		}
 
 		return data;
-	}, [ domainName, domainConnectionStatus, domainConnectionSetupInfo, isSuggestedMode ] );
+	}, [
+		domainName,
+		domainConnectionStatus,
+		domainConnectionSetupInfo,
+		isSuggestedMode,
+		isSubdomain,
+		recordName,
+		cnameRecordName,
+	] );
 
 	return (
 		<DataViewsCard className="dns-records-table">
 			<DataViews< DnsRecordVerification >
 				data={ dnsRecords }
 				fields={ fields }
-				view={ isSuggestedMode ? viewSuggested : viewAdvanced }
+				view={ isSuggestedMode ? getSuggestedView( isSubdomain ) : viewAdvanced }
 				defaultLayouts={ { table: {} } }
 				paginationInfo={ { totalItems: dnsRecords.length, totalPages: 1 } }
 				onChangeView={ () => {} }

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -9,6 +9,7 @@ import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { DataViewsCard } from '../../../components/dataviews';
+import { useDnsRecordNames } from '../hooks/use-dns-record-names';
 import type { Field, ViewTable } from '@wordpress/dataviews';
 
 import './dns-records-table-style.scss';
@@ -151,29 +152,11 @@ export default function DnsRecordsTable( {
 	const isSuggestedMode = domainConnectionStatus.mode === DomainConnectionSetupMode.SUGGESTED;
 	const isSubdomain = domainConnectionSetupInfo.is_subdomain;
 
-	const recordName = useMemo( () => {
-		if ( isSubdomain && domainConnectionSetupInfo.root_domain ) {
-			const rootDomain = domainConnectionSetupInfo.root_domain;
-			const suffix = `.${ rootDomain }`;
-
-			if ( domainName.endsWith( suffix ) ) {
-				const subdomain = domainName.slice( 0, -suffix.length );
-				return subdomain || domainName;
-			}
-
-			return domainName;
-		}
-
-		return '@';
-	}, [ domainName, domainConnectionSetupInfo.root_domain, isSubdomain ] );
-
-	const cnameRecordName = useMemo( () => {
-		if ( recordName === '@' ) {
-			return 'www';
-		}
-
-		return `www.${ recordName }`;
-	}, [ recordName ] );
+	const { recordName, cnameRecordName } = useDnsRecordNames( {
+		domainName,
+		isSubdomain,
+		rootDomain: domainConnectionSetupInfo.root_domain,
+	} );
 
 	const dnsRecords = useMemo( () => {
 		const data: DnsRecordVerification[] = [];

--- a/client/dashboard/domains/domain-connection-setup/dns-records-dataview.tsx
+++ b/client/dashboard/domains/domain-connection-setup/dns-records-dataview.tsx
@@ -13,15 +13,23 @@ import { matchCurrentToTargetValues } from './utils/match-records';
 
 import './components/dns-records-table-style.scss';
 
-const viewSuggested: ViewTable = {
+const baseSuggestedView: Pick< ViewTable, 'type' | 'page' | 'perPage' > = {
 	type: 'table',
 	page: 1,
 	perPage: 10,
-	fields: [ 'currentValue', 'arrow', 'updateTo' ],
+};
+
+const getSuggestedView = ( includeName: boolean ): ViewTable => {
+	return {
+		...baseSuggestedView,
+		fields: includeName
+			? [ 'name', 'currentValue', 'arrow', 'updateTo' ]
+			: [ 'currentValue', 'arrow', 'updateTo' ],
+	};
 };
 
 const viewAdvanced: ViewTable = {
-	...viewSuggested,
+	...baseSuggestedView,
 	fields: [ 'type', 'name', 'currentValue', 'arrow', 'updateTo' ],
 };
 
@@ -47,6 +55,31 @@ export default function DNSRecordsDataView( {
 	mode,
 }: DNSRecordsDataViewProps ) {
 	const isSuggestedMode = mode === DomainConnectionSetupMode.SUGGESTED;
+	const isSubdomain = domainConnectionSetupInfo.is_subdomain;
+
+	const recordName = useMemo( () => {
+		if ( isSubdomain && domainConnectionSetupInfo.root_domain ) {
+			const rootDomain = domainConnectionSetupInfo.root_domain;
+			const suffix = `.${ rootDomain }`;
+
+			if ( domainName.endsWith( suffix ) ) {
+				const subdomain = domainName.slice( 0, -suffix.length );
+				return subdomain || domainName;
+			}
+
+			return domainName;
+		}
+
+		return '@';
+	}, [ isSubdomain, domainConnectionSetupInfo.root_domain, domainName ] );
+
+	const cnameRecordName = useMemo( () => {
+		if ( recordName === '@' ) {
+			return 'www';
+		}
+
+		return `www.${ recordName }`;
+	}, [ recordName ] );
 
 	// Build the DNS records data
 	const records = useMemo( () => {
@@ -62,6 +95,7 @@ export default function DNSRecordsDataView( {
 			matchedRecords.forEach( ( record, index ) => {
 				dnsRecords.push( {
 					id: `ns-record-${ index }`,
+					name: recordName,
 					...record,
 				} );
 			} );
@@ -76,7 +110,7 @@ export default function DNSRecordsDataView( {
 				dnsRecords.push( {
 					id: `a-record-${ index }`,
 					type: 'A',
-					name: '@',
+					name: recordName,
 					...record,
 				} );
 			} );
@@ -87,14 +121,21 @@ export default function DNSRecordsDataView( {
 			dnsRecords.push( {
 				id: 'cname-record',
 				type: 'CNAME',
-				name: 'www',
+				name: cnameRecordName,
 				currentValue: currentCname || '-',
 				updateTo: domainName,
 			} );
 		}
 
 		return dnsRecords;
-	}, [ domainName, domainMappingStatus, domainConnectionSetupInfo, isSuggestedMode ] );
+	}, [
+		domainName,
+		domainMappingStatus,
+		domainConnectionSetupInfo,
+		isSuggestedMode,
+		recordName,
+		cnameRecordName,
+	] );
 
 	const fields = useMemo< Field< DNSRecord >[] >(
 		() => [
@@ -153,7 +194,7 @@ export default function DNSRecordsDataView( {
 			<DataViews< DNSRecord >
 				data={ records }
 				fields={ fields }
-				view={ isSuggestedMode ? viewSuggested : viewAdvanced }
+				view={ isSuggestedMode ? getSuggestedView( isSubdomain ) : viewAdvanced }
 				onChangeView={ () => {} }
 				defaultLayouts={ { table: {} } }
 				paginationInfo={ { totalItems: records.length, totalPages: 1 } }

--- a/client/dashboard/domains/domain-connection-setup/dns-records-dataview.tsx
+++ b/client/dashboard/domains/domain-connection-setup/dns-records-dataview.tsx
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, arrowRight } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { DataViewsCard } from '../../components/dataviews';
+import { useDnsRecordNames } from './hooks/use-dns-record-names';
 import { matchCurrentToTargetValues } from './utils/match-records';
 
 import './components/dns-records-table-style.scss';
@@ -57,29 +58,11 @@ export default function DNSRecordsDataView( {
 	const isSuggestedMode = mode === DomainConnectionSetupMode.SUGGESTED;
 	const isSubdomain = domainConnectionSetupInfo.is_subdomain;
 
-	const recordName = useMemo( () => {
-		if ( isSubdomain && domainConnectionSetupInfo.root_domain ) {
-			const rootDomain = domainConnectionSetupInfo.root_domain;
-			const suffix = `.${ rootDomain }`;
-
-			if ( domainName.endsWith( suffix ) ) {
-				const subdomain = domainName.slice( 0, -suffix.length );
-				return subdomain || domainName;
-			}
-
-			return domainName;
-		}
-
-		return '@';
-	}, [ isSubdomain, domainConnectionSetupInfo.root_domain, domainName ] );
-
-	const cnameRecordName = useMemo( () => {
-		if ( recordName === '@' ) {
-			return 'www';
-		}
-
-		return `www.${ recordName }`;
-	}, [ recordName ] );
+	const { recordName, cnameRecordName } = useDnsRecordNames( {
+		domainName,
+		isSubdomain,
+		rootDomain: domainConnectionSetupInfo.root_domain,
+	} );
 
 	// Build the DNS records data
 	const records = useMemo( () => {

--- a/client/dashboard/domains/domain-connection-setup/hooks/use-dns-record-names.ts
+++ b/client/dashboard/domains/domain-connection-setup/hooks/use-dns-record-names.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+
+interface UseDnsRecordNamesParams {
+	domainName: string;
+	isSubdomain: boolean;
+	rootDomain?: string;
+}
+
+interface UseDnsRecordNamesReturn {
+	recordName: string;
+	cnameRecordName: string;
+}
+
+/**
+ * Custom hook to calculate DNS record names based on domain configuration.
+ */
+export function useDnsRecordNames( {
+	domainName,
+	isSubdomain,
+	rootDomain,
+}: UseDnsRecordNamesParams ): UseDnsRecordNamesReturn {
+	const recordName = useMemo( () => {
+		if ( isSubdomain && rootDomain ) {
+			const suffix = `.${ rootDomain }`;
+
+			if ( domainName.endsWith( suffix ) ) {
+				const subdomain = domainName.slice( 0, -suffix.length );
+				return subdomain || domainName;
+			}
+
+			return domainName;
+		}
+
+		return '@';
+	}, [ isSubdomain, rootDomain, domainName ] );
+
+	const cnameRecordName = useMemo( () => {
+		if ( recordName === '@' ) {
+			return 'www';
+		}
+
+		return `www.${ recordName }`;
+	}, [ recordName ] );
+
+	return {
+		recordName,
+		cnameRecordName,
+	};
+}


### PR DESCRIPTION
Closes [DOMAINS-1948](https://linear.app/a8c/issue/DOMAINS-1948/show-name-column-when-showing-subdomain-ns-table)

## Proposed Changes
- Show subdomain-aware names in DNS connection tables and dataview (A records use subdomain label; CNAME uses `www.<subdomain>`; root domains remain `@`/`www`).
- Conditionally display the Name column in simple mode only for subdomains; keep root domains with the simpler view.
- Align verification tables and dataviews so subdomain connection guidance matches actual DNS values.

### Screenshots
|![Screenshot 2025-12-10 alle 10 22 52](https://github.com/user-attachments/assets/652044c4-5267-477d-b123-ce10058bdcc8)|![Screenshot 2025-12-10 alle 10 22 41](https://github.com/user-attachments/assets/7ca14a5d-0f40-42b5-8fa7-c9f67bff7212)|![Screenshot 2025-12-10 alle 10 23 28](https://github.com/user-attachments/assets/a6063dc9-49ff-4685-8be6-2837804c62d2)|![Screenshot 2025-12-10 alle 10 23 09](https://github.com/user-attachments/assets/4e269c74-ff85-42a5-8585-f4f579866945)|
|:---:|:---:|:---:|:---:|
|**Subdomain connection setup (simple mode)**|**Subdomain connection setup (advanced mode)**|**Subdomain connection verification (simple mode)**|**Subdomain connection verification (advanced mode)**|

## Why are these changes being made?
- Users connecting subdomains need explicit hostnames; showing `@`/`www` was incorrect and confusing. These changes surface the correct subdomain labels across both setup views and verification tables.

## Testing Instructions
- `yarn test-client client/dashboard/domains/domain-connection-setup/test/dns-records-dataview.test.tsx`
- Manually verify suggested vs advanced flows:
  - Root domain: suggested view hides Name column; names remain `@`/`www`.
  - Subdomain: suggested/advanced views show Name column; A records show subdomain label; CNAME shows `www.<subdomain>`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
