### PR TITLE
Update e2e test for domain connection (setup/domain flow)

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -86,51 +86,6 @@ export class DomainSearchComponent {
 	}
 
 	/**
-	 * Fills the "Use a domain I own" input and waits for the `is-available` response
-	 *
-	 * @param domainName Domain name to fill in the input
-	 */
-	async fillUseDomainIOwnInput( domainName: string ): Promise< void > {
-		const searchAndPressEnter = async () => {
-			const input = this.page.locator( '.use-my-domain__domain-input input' );
-			await input.fill( domainName );
-			await input.press( 'Enter' );
-		};
-
-		const [ response ] = await Promise.all( [
-			this.page.waitForResponse( /is-available\?/ ),
-			searchAndPressEnter(),
-		] );
-
-		if ( ! response ) {
-			const errorText = await this.page.getByRole( 'status', { name: 'Notice' } ).innerText();
-			throw new Error(
-				`Encountered error while trying to check availability of domain.\nOriginal error: ${ errorText }`
-			);
-		}
-	}
-
-	/**
-	 * Click on the "Transfer your domain" option in the "Transfer or Connect" page
-	 */
-	async selectTransferYourDomain(): Promise< void > {
-		const button = this.getContainer()
-			.locator( '.domain-transfer-or-connect__content button' )
-			.nth( 0 );
-		await button.waitFor();
-		await button.click();
-	}
-
-	/**
-	 * Click on the "Connect your domain" option in the "Transfer or Connect" page
-	 */
-	async selectConnectYourDomain(): Promise< void > {
-		const button = await this.getContainer().getByRole( 'button', { name: 'Select' } ).nth( 1 );
-		await button.waitFor();
-		await button.click();
-	}
-
-	/**
 	 * Click on the "Just buy a domain" option in the "Choose how to use your domain" page
 	 */
 	async selectJustBuyADomain(): Promise< void > {

--- a/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
@@ -3,8 +3,8 @@ import { Page } from 'playwright';
 const selectors = {
 	ownedDomainInput: '.use-my-domain__domain-input-fieldset input',
 	continueButton: 'button:text("Continue")',
-	connectDomainButton: '.domain-transfer-or-connect__content button:nth-child(2)',
-	transferDomainButton: '.domain-transfer-or-connect__content button:nth-child(1)',
+	connectDomainButton: 'button span:text("Connect your site address")',
+	transferDomainButton: 'button span:text("Transfer your domain name")',
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Locator, Page } from 'playwright';
 
 const selectors = {
 	ownedDomainInput: '.use-my-domain__domain-input-fieldset input',
@@ -12,14 +12,26 @@ const selectors = {
  */
 export class UseADomainIOwnPage {
 	private page: Page;
+	private container?: Locator;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
+	 * @param {Locator} container The container locator.
 	 */
-	constructor( page: Page ) {
+	constructor( page: Page, container?: Locator ) {
 		this.page = page;
+		this.container = container;
+	}
+
+	/**
+	 * Gets the container locator.
+	 *
+	 * @returns {Locator} The container locator.
+	 */
+	private getContainer(): Page | Locator {
+		return this.container ?? this.page;
 	}
 
 	/**
@@ -67,5 +79,50 @@ export class UseADomainIOwnPage {
 	 */
 	async clickButtonToTransferDomain(): Promise< void > {
 		await this.page.click( selectors.transferDomainButton );
+	}
+
+	/**
+	 * Fills the "Use a domain I own" input and waits for the `is-available` response
+	 *
+	 * @param domainName Domain name to fill in the input
+	 */
+	async fillUseDomainIOwnInput( domainName: string ): Promise< void > {
+		const searchAndPressEnter = async () => {
+			const input = this.getContainer().locator( '.use-my-domain__domain-input input' );
+			await input.fill( domainName );
+			await input.press( 'Enter' );
+		};
+
+		const [ response ] = await Promise.all( [
+			this.page.waitForResponse( /is-available\?/ ),
+			searchAndPressEnter(),
+		] );
+
+		if ( ! response ) {
+			const errorText = await this.page.getByRole( 'status', { name: 'Notice' } ).innerText();
+			throw new Error(
+				`Encountered error while trying to check availability of domain.\nOriginal error: ${ errorText }`
+			);
+		}
+	}
+
+	/**
+	 * Click on the "Transfer your domain" option in the "Transfer or Connect" page
+	 */
+	async selectTransferYourDomain(): Promise< void > {
+		const button = this.getContainer()
+			.locator( '.domain-transfer-or-connect__content button' )
+			.nth( 0 );
+		await button.waitFor();
+		await button.click();
+	}
+
+	/**
+	 * Click on the "Connect your domain" option in the "Transfer or Connect" page
+	 */
+	async selectConnectYourDomain(): Promise< void > {
+		const button = this.getContainer().getByRole( 'button', { name: 'Select' } ).nth( 1 );
+		await button.waitFor();
+		await button.click();
 	}
 }

--- a/test/e2e/specs/flows/setup-onboarding__use-a-domain-i-own-transfer-domain.ts
+++ b/test/e2e/specs/flows/setup-onboarding__use-a-domain-i-own-transfer-domain.ts
@@ -5,6 +5,7 @@
 import {
 	DataHelper,
 	DomainSearchComponent,
+	UseADomainIOwnPage,
 	SignupPickPlanPage,
 	CartCheckoutPage,
 	UserSignupPage,
@@ -53,13 +54,13 @@ describe(
 		} );
 
 		it( 'Fill the "Use a odmain I own" input', async function () {
-			const domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.fillUseDomainIOwnInput( domain );
+			const useADomainIOwnPage = new UseADomainIOwnPage( page );
+			await useADomainIOwnPage.fillUseDomainIOwnInput( domain );
 		} );
 
 		it( 'Select the "Transfer your domain" option', async function () {
-			const domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.selectTransferYourDomain();
+			const useADomainIOwnPage = new UseADomainIOwnPage( page );
+			await useADomainIOwnPage.selectTransferYourDomain();
 		} );
 
 		it( `Select ${ planName } plan`, async function () {


### PR DESCRIPTION
Closes [DOMAINS-1886](https://linear.app/a8c/issue/DOMAINS-1886/create-an-e2e-test-for-the-happy-path)

## Proposed Changes
* Move `fillUseDomainIOwnInput`, `selectTransferYourDomain`, and `selectConnectYourDomain` methods from `DomainSearchComponent` to `UseADomainIOwnPage`
* Add container pattern support to `UseADomainIOwnPage` class (similar to `DomainSearchComponent`) to enable scoped element searches
* Update moved methods to use `getContainer()` for consistency and proper scoping

## Why are these changes being made?
This refactoring improves code organization by moving domain-specific methods to the appropriate page object class. The three methods (`fillUseDomainIOwnInput`, `selectTransferYourDomain`, and `selectConnectYourDomain`) are specifically related to the "Use a domain I own" flow and logically belong in `UseADomainIOwnPage` rather than the more generic `DomainSearchComponent`.

Additionally, adding container pattern support to `UseADomainIOwnPage` provides flexibility for future use cases where the component might appear within a specific container scope, and ensures consistency with the pattern already established in `DomainSearchComponent`.

## Testing Instructions

Run this e2e tests against wpcalypso:
```
CALYPSO_BASE_URL=https://wpcalypso.wordpress.com yarn workspace wp-e2e-tests test -- test/e2e/specs/flows/setup-domain__transfer-domain.ts
CALYPSO_BASE_URL=https://wpcalypso.wordpress.com yarn workspace wp-e2e-tests test -- test/e2e/specs/flows/setup-onboarding__use-a-domain-i-own-transfer-domain.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
