### PR TITLE
Do not preserve search query in Help Center when navigating to chat

### DIFF
--- a/packages/help-center/src/components/help-center-footer.tsx
+++ b/packages/help-center/src/components/help-center-footer.tsx
@@ -1,9 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { HelpCenterSelect } from '@automattic/data-stores';
 import { Button, CardFooter } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useStillNeedHelpURL } from '../hooks';
+import { HELP_CENTER_STORE } from '../stores';
 
 import './help-center-footer.scss';
 
@@ -11,8 +14,12 @@ export const HelpCenterContactButton = () => {
 	const { __ } = useI18n();
 	const { url } = useStillNeedHelpURL();
 	const { sectionName } = useHelpCenterContext();
-	const redirectToWpcom = url === 'https://wordpress.com/help/contact';
 	const navigate = useNavigate();
+	const { setMessage } = useDispatch( HELP_CENTER_STORE );
+	const searchQuery = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getMessage(),
+		[]
+	);
 
 	const handleClick = () => {
 		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
@@ -22,7 +29,11 @@ export const HelpCenterContactButton = () => {
 			button_type: 'Still need help?',
 		} );
 
-		navigate( redirectToWpcom ? { pathname: url } : url );
+		navigate(
+			url === '/odie' && searchQuery ? `/odie?query=${ encodeURIComponent( searchQuery ) }` : url
+		);
+
+		setMessage( '' );
 	};
 
 	return (

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -383,7 +383,9 @@ function HelpSearchResults( {
 					</p>
 					<Button
 						variant="secondary"
-						onClick={ () => setNavigateToRoute( '/odie' ) }
+						onClick={ () =>
+							setNavigateToRoute( `/odie?query=${ encodeURIComponent( searchQuery ) }` )
+						}
 						className="show-more-button"
 					>
 						{ __( 'Ask AI assistant', __i18n_text_domain__ ) }

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -1,11 +1,9 @@
 import '@automattic/agenttic-ui/index.css';
 import { useInput } from '@automattic/agenttic-ui';
-import { HelpCenterSelect } from '@automattic/data-stores';
 import { EmailFallbackNotice } from '@automattic/help-center/src/components/notices';
-import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
-import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useSearchParams } from 'react-router-dom';
 import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
@@ -37,11 +35,9 @@ export const OdieSendMessageButton = () => {
 	const isChatBusy = chat.status === 'loading' || chat.status === 'sending';
 	const isInitialLoading = chat.status === 'loading';
 	const isLiveChat = chat.provider?.startsWith( 'zendesk' );
-	const searchQuery = useSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getMessage(),
-		[]
-	);
-	const [ inputValue, setInputValue ] = useState( searchQuery || '' );
+	const [ searchParams ] = useSearchParams();
+	const initialQuery = searchParams.get( 'query' ) || '';
+	const [ inputValue, setInputValue ] = useState( initialQuery );
 	const messageSizeNotice = useMessageSizeErrorNotice( inputValue.trim().length );
 	const connectionNotice = useConnectionStatusNotice( isLiveChat );
 


### PR DESCRIPTION
Modified the logic from this PR https://github.com/Automattic/wp-calypso/pull/107561, as it was relying on `message` from the store and it was preserved between sessions.

