### PR TITLE
Add login E2E coverage for localized hydration

### DIFF
--- a/test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts
+++ b/test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts
@@ -1,0 +1,44 @@
+import { DataHelper } from '@automattic/calypso-e2e';
+import { tags, test, expect } from '../../lib/pw-base';
+
+test.describe(
+	'Authentication: Login SSR + hydration (localized)',
+	{ tag: [ tags.AUTHENTICATION ] },
+	() => {
+		test( 'Default locale: headings SSR and controls interactive', async ( { page } ) => {
+			await page.goto( DataHelper.getCalypsoURL( 'log-in' ), {
+				waitUntil: 'domcontentloaded',
+			} );
+
+			const heading = page.locator( 'h1' ).first();
+			const initialHeading = ( await heading.textContent() )?.trim() ?? '';
+			expect( initialHeading.length ).toBeGreaterThan( 0 );
+
+			const usernameInput = page.getByRole( 'textbox', {
+				name: /email address|username/i,
+			} );
+			await expect( usernameInput ).toBeEnabled( { timeout: 15_000 } );
+
+			const continueButton = page.getByRole( 'button', { name: /continue/i } );
+			await expect( continueButton ).toBeEnabled( { timeout: 15_000 } );
+		} );
+
+		test( 'Dutch locale: headings SSR and controls interactive', async ( { page } ) => {
+			await page.goto( DataHelper.getCalypsoURL( 'log-in/nl' ), {
+				waitUntil: 'domcontentloaded',
+			} );
+
+			const heading = page.locator( 'h1' ).first();
+			const initialHeading = ( await heading.textContent() )?.trim() ?? '';
+			expect( initialHeading.length ).toBeGreaterThan( 0 );
+
+			const usernameInput = page.getByRole( 'textbox', {
+				name: /e-mailadres|gebruikersnaam/i,
+			} );
+			await expect( usernameInput ).toBeEnabled( { timeout: 15_000 } );
+
+			const continueButton = page.getByRole( 'button', { name: /doorgaan/i } );
+			await expect( continueButton ).toBeEnabled( { timeout: 15_000 } );
+		} );
+	}
+);

--- a/test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts
+++ b/test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts
@@ -19,7 +19,7 @@ test.describe(
 			} );
 			await expect( usernameInput ).toBeEnabled( { timeout: 15_000 } );
 
-			const continueButton = page.getByRole( 'button', { name: /continue/i } );
+			const continueButton = page.getByRole( 'button', { name: /^continue$/i } );
 			await expect( continueButton ).toBeEnabled( { timeout: 15_000 } );
 		} );
 
@@ -37,7 +37,7 @@ test.describe(
 			} );
 			await expect( usernameInput ).toBeEnabled( { timeout: 15_000 } );
 
-			const continueButton = page.getByRole( 'button', { name: /doorgaan/i } );
+			const continueButton = page.getByRole( 'button', { name: /^doorgaan$/i } );
 			await expect( continueButton ).toBeEnabled( { timeout: 15_000 } );
 		} );
 	}

--- a/test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts
+++ b/test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts
@@ -3,7 +3,7 @@ import { tags, test, expect } from '../../lib/pw-base';
 
 test.describe(
 	'Authentication: Login SSR + hydration (localized)',
-	{ tag: [ tags.AUTHENTICATION ] },
+	{ tag: [ tags.AUTHENTICATION, tags.CALYPSO_RELEASE ] },
 	() => {
 		test( 'Default locale: headings SSR and controls interactive', async ( { page } ) => {
 			await page.goto( DataHelper.getCalypsoURL( 'log-in' ), {


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/HAP-2389/localized-login-page-log-innl-loads-but-never-becomes-interactive
Related: original PR #107329 (heading seeding) and follow-up fix #107517

## Proposed Changes
* Add an authentication E2E spec that covers `/log-in` (default locale) and `/log-in/nl` to assert:
  - Headings/subheadings are present on first paint (SSR, no snap).
  - Username input and primary CTA become enabled (hydration completes, page is interactive).

## Why are these changes being made?
* The localized login regression introduced by the earlier heading-seeding work (#107329, later fixed in #107517) caused localized pages to load but stay non-interactive. It went unnoticed in CI/local because we didn't exercise localized login hydration. This adds targeted E2E checks to prevent a similar escalation.

## Testing Instructions

### Prerequisites
- Branch: `fix/login-e2e-localized`
- Access to `E2E_SECRETS_KEY`

`E2E_SECRETS_KEY` is the passphrase used to decrypt the encrypted E2E secrets bundle in `packages/calypso-e2e/src/secrets/encrypted.enc`. It’s not in the repo; you need to get it from the Calypso E2E secrets source. Search for `Calypso E2E Config decode key`.

### Setup
1. yarn install
2. Export secrets key: `export E2E_SECRETS_KEY="your-passphrase"`
3. Decrypt and build e2e workspace
   `yarn workspace @automattic/calypso-e2e decrypt-secrets`
   `yarn workspace @automattic/calypso-e2e build`

### Run Calypso locally and the login hydration tests
- `yarn start`
- Option A (from repo root):
  
```
CALYPSO_BASE_URL=http://calypso.localhost:3000 \
yarn workspace wp-e2e-tests playwright test \
  --project=authentication \
  specs/authentication/authentication__login-localized-hydration.spec.ts
```

- Option B (cd into test/e2e):

```
cd test/e2e
CALYPSO_BASE_URL=http://calypso.localhost:3000 \
yarn playwright test --project=authentication \
  specs/authentication/authentication__login-localized-hydration.spec.ts
```

### What the tests cover
- `/log-in` and `/log-in/nl`:
  - Headings/subheadings present on first paint (no snap)
  - Username input enabled after hydration
  - Primary CTA enabled (“Continue” / “Doorgaan”)

## Pre-merge Checklist
- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing docs
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
