### PR TITLE
Update "Add to cart" CTA to sentense case

### DIFF
--- a/packages/domain-search/src/components/featured-search-results/test/item.tsx
+++ b/packages/domain-search/src/components/featured-search-results/test/item.tsx
@@ -593,11 +593,11 @@ describe( 'FeaturedSearchResultsItem', () => {
 
 			await waitFor( () => screen.getByTitle( 'test-add-to-cart.com' ) );
 
-			const cta = screen.getByRole( 'button', { name: 'Add to Cart' } );
+			const cta = screen.getByRole( 'button', { name: 'Add to cart' } );
 
 			expect( cta ).toBeInTheDocument();
 			expect( cta ).toHaveClass( 'is-primary' );
-			expect( cta ).toHaveTextContent( 'Add to Cart' );
+			expect( cta ).toHaveTextContent( 'Add to cart' );
 		} );
 
 		it( 'renders continue cta with text', async () => {

--- a/packages/domain-search/src/components/search-results/test/item.tsx
+++ b/packages/domain-search/src/components/search-results/test/item.tsx
@@ -194,7 +194,7 @@ describe( 'SearchResultsItem', () => {
 
 			await waitFor( () => screen.getByTitle( 'test-add-to-cart.com' ) );
 
-			const cta = screen.getByRole( 'button', { name: 'Add to Cart' } );
+			const cta = screen.getByRole( 'button', { name: 'Add to cart' } );
 
 			expect( cta ).toBeInTheDocument();
 			expect( cta ).toHaveClass( 'is-secondary' );

--- a/packages/domain-search/src/components/suggestion-cta/test/index.tsx
+++ b/packages/domain-search/src/components/suggestion-cta/test/index.tsx
@@ -13,7 +13,7 @@ import { TestDomainSearchWithSuggestions } from '../../../test-helpers/renderer'
 import { DomainSuggestionsList } from '../../../ui';
 
 describe( 'DomainSuggestionCTA', () => {
-	describe( 'add to cart cta', () => {
+	describe( 'Add to cart cta', () => {
 		it( 'allows adding a domain to the cart', async () => {
 			const user = userEvent.setup();
 
@@ -54,7 +54,7 @@ describe( 'DomainSuggestionCTA', () => {
 				</TestDomainSearchWithSuggestions>
 			);
 
-			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to Cart' } );
+			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to cart' } );
 
 			expect( addToCartCta ).toBeInTheDocument();
 
@@ -127,7 +127,7 @@ describe( 'DomainSuggestionCTA', () => {
 				</TestDomainSearchWithSuggestions>
 			);
 
-			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to Cart' } );
+			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to cart' } );
 
 			expect( addToCartCta ).toBeInTheDocument();
 
@@ -193,7 +193,7 @@ describe( 'DomainSuggestionCTA', () => {
 				</TestDomainSearchWithSuggestions>
 			);
 
-			const [ dotCom, dotNet ] = await screen.findAllByRole( 'button', { name: 'Add to Cart' } );
+			const [ dotCom, dotNet ] = await screen.findAllByRole( 'button', { name: 'Add to cart' } );
 
 			await user.click( dotCom );
 
@@ -243,7 +243,7 @@ describe( 'DomainSuggestionCTA', () => {
 				</TestDomainSearchWithSuggestions>
 			);
 
-			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to Cart' } );
+			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to cart' } );
 
 			await user.click( addToCartCta );
 
@@ -294,7 +294,7 @@ describe( 'DomainSuggestionCTA', () => {
 				</TestDomainSearchWithSuggestions>
 			);
 
-			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to Cart' } );
+			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to cart' } );
 
 			await user.click( addToCartCta );
 
@@ -361,7 +361,7 @@ describe( 'DomainSuggestionCTA', () => {
 				</TestDomainSearchWithSuggestions>
 			);
 
-			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to Cart' } );
+			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to cart' } );
 
 			await user.click( addToCartCta );
 
@@ -457,7 +457,7 @@ describe( 'DomainSuggestionCTA', () => {
 			expect( continueCta ).toBeInTheDocument();
 			expect( continueCta ).toBeEnabled();
 
-			const addToCartCta = screen.getByRole( 'button', { name: 'Add to Cart' } );
+			const addToCartCta = screen.getByRole( 'button', { name: 'Add to cart' } );
 
 			expect( addToCartCta ).toBeInTheDocument();
 			expect( addToCartCta ).toBeEnabled();
@@ -496,19 +496,19 @@ describe( 'DomainSuggestionCTA', () => {
 				</TestDomainSearchWithSuggestions>
 			);
 
-			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to Cart' } );
+			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to cart' } );
 
 			expect( addToCartCta ).toBeInTheDocument();
 
 			await user.click( addToCartCta );
 
 			await waitFor( () => {
-				expect( screen.getByRole( 'button', { name: 'Add to Cart' } ) ).toHaveClass(
+				expect( screen.getByRole( 'button', { name: 'Add to cart' } ) ).toHaveClass(
 					'is-destructive'
 				);
 			} );
 
-			await user.hover( screen.getByRole( 'button', { name: 'Add to Cart' } ) );
+			await user.hover( screen.getByRole( 'button', { name: 'Add to cart' } ) );
 
 			await waitFor( () => {
 				expect( screen.getByText( 'Failed to fetch the availability' ) ).toBeInTheDocument();
@@ -536,14 +536,14 @@ describe( 'DomainSuggestionCTA', () => {
 				</TestDomainSearchWithSuggestions>
 			);
 
-			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to Cart' } );
+			const addToCartCta = await screen.findByRole( 'button', { name: 'Add to cart' } );
 
 			expect( addToCartCta ).toBeInTheDocument();
 
 			await user.click( addToCartCta );
 
 			await waitFor( () => {
-				expect( screen.getByRole( 'button', { name: 'Add to Cart' } ) ).toHaveClass(
+				expect( screen.getByRole( 'button', { name: 'Add to cart' } ) ).toHaveClass(
 					'is-destructive'
 				);
 			} );
@@ -556,7 +556,7 @@ describe( 'DomainSuggestionCTA', () => {
 				} ),
 			} );
 
-			await user.click( screen.getByRole( 'button', { name: 'Add to Cart' } ) );
+			await user.click( screen.getByRole( 'button', { name: 'Add to cart' } ) );
 
 			await waitFor( () => {
 				expect( screen.getByRole( 'button', { name: 'Continue' } ) ).toBeInTheDocument();
@@ -597,7 +597,7 @@ describe( 'DomainSuggestionCTA', () => {
 			);
 
 			const [ errorCta, successCta ] = await screen.findAllByRole( 'button', {
-				name: 'Add to Cart',
+				name: 'Add to cart',
 			} );
 
 			expect( errorCta ).toBeInTheDocument();
@@ -607,7 +607,7 @@ describe( 'DomainSuggestionCTA', () => {
 
 			await waitFor( () => {
 				const [ errorCta, successCta ] = screen.getAllByRole( 'button', {
-					name: 'Add to Cart',
+					name: 'Add to cart',
 				} );
 
 				expect( errorCta ).toHaveClass( 'is-destructive' );

--- a/packages/domain-search/src/ui/domain-suggestion-cta/error.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion-cta/error.tsx
@@ -33,11 +33,11 @@ export const DomainSuggestionErrorCTA = ( {
 					isDestructive
 					variant="primary"
 					__next40pxDefaultSize
-					label={ __( 'Add to Cart' ) }
+					label={ __( 'Add to cart' ) }
 					onClick={ callback }
 					icon={ warning }
 				>
-					{ listContext.isFeatured ? __( 'Add to Cart' ) : undefined }
+					{ listContext.isFeatured ? __( 'Add to cart' ) : undefined }
 				</Button>
 			</Tooltip>
 		</div>

--- a/packages/domain-search/src/ui/domain-suggestion-cta/primary.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion-cta/primary.tsx
@@ -37,11 +37,11 @@ export const DomainSuggestionPrimaryCTA = ( {
 			icon={ icon ?? shoppingCartIcon }
 			onClick={ onClick }
 			href={ href }
-			label={ label ?? __( 'Add to Cart' ) }
+			label={ label ?? __( 'Add to cart' ) }
 			disabled={ disabled }
 			isBusy={ isBusy }
 		>
-			{ listContext.isFeatured ? children ?? __( 'Add to Cart' ) : undefined }
+			{ listContext.isFeatured ? children ?? __( 'Add to cart' ) : undefined }
 		</Button>
 	);
 };

--- a/packages/domain-search/src/ui/domain-suggestion/featured.stories.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion/featured.stories.tsx
@@ -33,7 +33,7 @@ export const Default = () => {
 				domain="example"
 				tld="com"
 				price={ <DomainSuggestionPrice salePrice="$97" price="$22" /> }
-				cta={ <DomainSuggestionPrimaryCTA>Add to Cart</DomainSuggestionPrimaryCTA> }
+				cta={ <DomainSuggestionPrimaryCTA>Add to cart</DomainSuggestionPrimaryCTA> }
 			/>
 		</StoryWrapper>
 	);
@@ -57,7 +57,7 @@ export const Highlighted = () => {
 				isHighlighted
 				matchReasons={ [ 'Exact match', '.com is the most common extension' ] }
 				price={ <DomainSuggestionPrice salePrice="$97" price="$22" /> }
-				cta={ <DomainSuggestionPrimaryCTA>Add to Cart</DomainSuggestionPrimaryCTA> }
+				cta={ <DomainSuggestionPrimaryCTA>Add to cart</DomainSuggestionPrimaryCTA> }
 			/>
 		</StoryWrapper>
 	);

--- a/packages/domain-search/src/ui/domain-suggestions-list/index.stories.tsx
+++ b/packages/domain-search/src/ui/domain-suggestions-list/index.stories.tsx
@@ -45,7 +45,7 @@ export const Default = () => {
 								<DomainSuggestionBadge variation="warning">Sale</DomainSuggestionBadge>
 							</>
 						}
-						cta={ <DomainSuggestionPrimaryCTA>Add to Cart</DomainSuggestionPrimaryCTA> }
+						cta={ <DomainSuggestionPrimaryCTA>Add to cart</DomainSuggestionPrimaryCTA> }
 					/>
 				) ) }
 			</DomainSuggestionsList>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTOBRD-362

## Proposed Changes

* We're updating the "Add to Cart" CTA to "Add to cart" (sentence case)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Product consistency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Domain search and make sure all "Add to cart" CTAs are sentence case.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
