### PR TITLE
Analytics: `is_gift_purchase` property is sometimes null on `calypso_checkout_page_view` events

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -654,7 +654,6 @@ export default function CheckoutMain( {
 		storedCards,
 		productAliasFromUrl,
 		checkoutFlow,
-		isGiftPurchase,
 	} );
 
 	const onPageLoadError: CheckoutPageErrorCallback = useCallback(

--- a/client/my-sites/checkout/src/hooks/use-record-checkout-loaded.ts
+++ b/client/my-sites/checkout/src/hooks/use-record-checkout-loaded.ts
@@ -14,14 +14,12 @@ export default function useRecordCheckoutLoaded( {
 	storedCards,
 	productAliasFromUrl,
 	checkoutFlow,
-	isGiftPurchase,
 }: {
 	isLoading: boolean;
 	responseCart: ResponseCart;
 	storedCards: StoredPaymentMethod[];
 	productAliasFromUrl: string | undefined | null;
 	checkoutFlow: string;
-	isGiftPurchase?: boolean;
 } ): void {
 	const reduxDispatch = useDispatch();
 	const hasRecordedCheckoutLoad = useRef( false );
@@ -32,7 +30,7 @@ export default function useRecordCheckoutLoaded( {
 			recordTracksEvent( 'calypso_checkout_page_view', {
 				saved_cards: storedCards.length,
 				is_renewal: hasRenewalItem( responseCart ),
-				is_gift_purchase: isGiftPurchase,
+				is_gift_purchase: responseCart.is_gift_purchase,
 				product_slug: productAliasFromUrl,
 				is_composite: true,
 				checkout_flow: checkoutFlow,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-313/tracks-is-gift-purchase-property-is-sometimes-null-on-calypso-checkout

## Proposed Changes

The code in Calypso that records checkout page views requires information to be passed in to determine whether or not the checkout is being built for a gift purchase.

It turns out this isn't always being passed in (it looks like the main culprit may be siteless checkout) which results in the `is_gift_purchase` property sometimes being `null` rather than `true` or `false`.  This can cause issues with internal analytics.

This pull request fixes the problem for data going forward (we can't fix historical data) by simply deriving the property from the `responseCart` rather than requiring it to be separately passed in, which should be a more foolproof solution.

## Testing Instructions

Run `localStorage.setItem('debug', 'calypso:analytics*');` in your browser console, then filter the console events to look for `calypso_checkout_page_view`.

Perform the following tests (note the first one needs to be done in production mode rather than store sandbox) and examine the console logging to see how the `is_gift_purchase` property is being recorded:
- Visit one of the `/gift/` URLs from p1764660425751269/1764608681.498159-slack-C0117V2PCAE
  - `is_gift_purchase` should be `true`
- Visit `/checkout/value_bundle` and select a site if needed to enter checkout (regular WordPress.com purchase)
  - `is_gift_purchase` should be `false`
- Visit `/checkout/akismet/ak_pro5h_yearly` (siteless checkout)
  - `is_gift_purchase` should be `false`, but before this pull request it would have been undefined