### PR TITLE
A4A: Hide the legacy billing pages banners and handle redirection

### DIFF
--- a/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
+++ b/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -12,6 +13,7 @@ import './style.scss';
 // const PENDING_PAYMENT_NOTIFICATION_DISMISS_PREFERENCE = 'pending-payment-notification-dismissed';
 
 export default function PendingPaymentNotification( { isFullWidth }: { isFullWidth?: boolean } ) {
+	const isBdCheckoutEnabled = isEnabled( 'a4a-bd-checkout' );
 	const invoices = useFetchInvoices( { starting_after: '', ending_before: '' }, undefined, 'open' );
 
 	const translate = useTranslate();
@@ -26,6 +28,11 @@ export default function PendingPaymentNotification( { isFullWidth }: { isFullWid
 		return Math.floor( differenceInSeconds / ( 60 * 60 * 24 ) ); // Convert seconds to days
 	}, [ invoices ] );
 	const daysLeft = 28 - daysDue;
+
+	if ( isBdCheckoutEnabled ) {
+		// In Billing Dragon (BD) context, this payment notification should not be shown.
+		return null;
+	}
 
 	if ( ! invoices?.isSuccess || ! invoices?.data?.items?.length || daysDue < 7 ) {
 		return null;

--- a/client/a8c-for-agencies/sections/purchases/controller.tsx
+++ b/client/a8c-for-agencies/sections/purchases/controller.tsx
@@ -1,6 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
+import {
+	EXTERNAL_WPCOM_PAYMENT_METHODS_URL,
+	EXTERNAL_WPCOM_BILLING_HISTORY_URL,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import PurchasesSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/purchases';
 import {
 	publicToInternalLicenseFilter,
@@ -55,6 +60,9 @@ export const licensesContext: Callback = ( context, next ) => {
 };
 
 export const billingContext: Callback = ( context, next ) => {
+	if ( isEnabled( 'a4a-bd-checkout' ) ) {
+		window.location.href = EXTERNAL_WPCOM_BILLING_HISTORY_URL;
+	}
 	context.secondary = <PurchasesSidebar path={ context.path } />;
 	context.primary = (
 		<>
@@ -67,6 +75,9 @@ export const billingContext: Callback = ( context, next ) => {
 };
 
 export const invoicesContext: Callback = ( context, next ) => {
+	if ( isEnabled( 'a4a-bd-checkout' ) ) {
+		window.location.href = EXTERNAL_WPCOM_BILLING_HISTORY_URL;
+	}
 	context.secondary = <PurchasesSidebar path={ context.path } />;
 	context.primary = (
 		<>
@@ -79,6 +90,9 @@ export const invoicesContext: Callback = ( context, next ) => {
 };
 
 export const paymentMethodsContext: Callback = ( context, next ) => {
+	if ( isEnabled( 'a4a-bd-checkout' ) ) {
+		window.location.href = EXTERNAL_WPCOM_PAYMENT_METHODS_URL;
+	}
 	context.secondary = <PurchasesSidebar path={ context.path } />;
 	context.primary = (
 		<>
@@ -91,6 +105,10 @@ export const paymentMethodsContext: Callback = ( context, next ) => {
 };
 
 export const paymentMethodsAddContext: Callback = ( context, next ) => {
+	if ( isEnabled( 'a4a-bd-checkout' ) ) {
+		page.redirect( EXTERNAL_WPCOM_PAYMENT_METHODS_URL );
+		return;
+	}
 	context.secondary = <PurchasesSidebar path={ context.path } />;
 	context.primary = (
 		<>

--- a/client/a8c-for-agencies/sections/purchases/controller.tsx
+++ b/client/a8c-for-agencies/sections/purchases/controller.tsx
@@ -61,7 +61,8 @@ export const licensesContext: Callback = ( context, next ) => {
 
 export const billingContext: Callback = ( context, next ) => {
 	if ( isEnabled( 'a4a-bd-checkout' ) ) {
-		window.location.href = EXTERNAL_WPCOM_BILLING_HISTORY_URL;
+		window.location.replace( EXTERNAL_WPCOM_BILLING_HISTORY_URL );
+		return;
 	}
 	context.secondary = <PurchasesSidebar path={ context.path } />;
 	context.primary = (
@@ -76,7 +77,8 @@ export const billingContext: Callback = ( context, next ) => {
 
 export const invoicesContext: Callback = ( context, next ) => {
 	if ( isEnabled( 'a4a-bd-checkout' ) ) {
-		window.location.href = EXTERNAL_WPCOM_BILLING_HISTORY_URL;
+		window.location.replace( EXTERNAL_WPCOM_BILLING_HISTORY_URL );
+		return;
 	}
 	context.secondary = <PurchasesSidebar path={ context.path } />;
 	context.primary = (
@@ -91,7 +93,8 @@ export const invoicesContext: Callback = ( context, next ) => {
 
 export const paymentMethodsContext: Callback = ( context, next ) => {
 	if ( isEnabled( 'a4a-bd-checkout' ) ) {
-		window.location.href = EXTERNAL_WPCOM_PAYMENT_METHODS_URL;
+		window.location.replace( EXTERNAL_WPCOM_PAYMENT_METHODS_URL );
+		return;
 	}
 	context.secondary = <PurchasesSidebar path={ context.path } />;
 	context.primary = (
@@ -106,7 +109,7 @@ export const paymentMethodsContext: Callback = ( context, next ) => {
 
 export const paymentMethodsAddContext: Callback = ( context, next ) => {
 	if ( isEnabled( 'a4a-bd-checkout' ) ) {
-		page.redirect( EXTERNAL_WPCOM_PAYMENT_METHODS_URL );
+		window.location.replace( EXTERNAL_WPCOM_PAYMENT_METHODS_URL );
 		return;
 	}
 	context.secondary = <PurchasesSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/purchases/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/index.tsx
@@ -1,9 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import {
-	EXTERNAL_WPCOM_PAYMENT_METHODS_URL,
-	EXTERNAL_WPCOM_BILLING_HISTORY_URL,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
@@ -17,8 +12,6 @@ import {
 } from './controller';
 
 export default function () {
-	const isBillingDragonCheckoutEnabled = isEnabled( 'a4a-bd-checkout' );
-
 	// Purchases
 	page( '/purchases', requireAccessContext, purchasesContext, makeLayout, clientRender );
 
@@ -33,39 +26,27 @@ export default function () {
 
 	page( '/purchases/licenses/*', '/purchases/licenses' ); // Redirect invalid license list filters back to the main portal page.
 
-	if ( isBillingDragonCheckoutEnabled ) {
-		const redirectToWpcomPaymentMethods = () => page.redirect( EXTERNAL_WPCOM_PAYMENT_METHODS_URL );
-		const redirectToWpcomInvoices = () => page.redirect( EXTERNAL_WPCOM_BILLING_HISTORY_URL );
+	// Billing
+	page( '/purchases/billing', requireAccessContext, billingContext, makeLayout, clientRender );
 
-		// Payment methods (redirect to WPCOM)
-		page( '/purchases/payment-methods', requireAccessContext, redirectToWpcomPaymentMethods );
-		page( '/purchases/payment-methods/add', requireAccessContext, redirectToWpcomPaymentMethods );
+	// Payment methods
+	page(
+		'/purchases/payment-methods',
+		requireAccessContext,
+		paymentMethodsContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/purchases/payment-methods/add',
+		requireAccessContext,
+		paymentMethodsAddContext,
+		makeLayout,
+		clientRender
+	);
 
-		// Invoices (redirect to WPCOM)
-		page( '/purchases/invoices', requireAccessContext, redirectToWpcomInvoices );
-	} else {
-		// Billing
-		page( '/purchases/billing', requireAccessContext, billingContext, makeLayout, clientRender );
-
-		// Payment methods
-		page(
-			'/purchases/payment-methods',
-			requireAccessContext,
-			paymentMethodsContext,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/purchases/payment-methods/add',
-			requireAccessContext,
-			paymentMethodsAddContext,
-			makeLayout,
-			clientRender
-		);
-
-		// Invoices
-		page( '/purchases/invoices', requireAccessContext, invoicesContext, makeLayout, clientRender );
-	}
+	// Invoices
+	page( '/purchases/invoices', requireAccessContext, invoicesContext, makeLayout, clientRender );
 
 	// CRM Downloads
 	page(


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

This change prevents the legacy billing pages banners from appearing, and also handles the URL redirection to WPCOM billing correctly.

- `/purchases/payment-methods` => `https://wordpress.com/me/purchases/payment-methods`
- `/purchases/payment-methods/add` => `https://wordpress.com/me/purchases/payment-methods`
- `/purchases/invoices` => `https://wordpress.com/me/purchases/billing`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Ensure that you get the redirection to the WPCOM dashboard (you can switch between feature flags adding this to the URL: `?flags=a4a-bd-checkout` or `?flags=-a4a-bd-checkout`
  - `/purchases/payment-methods` => `https://wordpress.com/me/purchases/payment-methods`
  - `/purchases/payment-methods/add` => `https://wordpress.com/me/purchases/payment-methods`
  - `/purchases/invoices` => `https://wordpress.com/me/purchases/billing`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
