### PR TITLE
Update "Add to cart" CTA to sentence case outside domain search

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -217,7 +217,7 @@ export default function CartFreeUserPlanUpsell( { addItemToCart }: CartFreeUserP
 						firstDomain={ firstDomainInCart }
 					/>
 				</p>
-				<Button onClick={ addPlanToCart }>{ translate( 'Add to Cart' ) }</Button>
+				<Button onClick={ addPlanToCart }>{ translate( 'Add to cart' ) }</Button>
 			</div>
 			<TrackComponentView eventName="calypso_non_dwpo_checkout_plan_upsell_impression" />
 		</div>

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -154,7 +154,7 @@ const UpcomingRenewalsReminder: FunctionComponent< Props > = ( { cart, addItemTo
 						onConfirm={ onConfirm }
 						onClose={ onClose }
 						showManagePurchaseLinks={ false }
-						submitButtonText={ translate( 'Add to Cart' ) }
+						submitButtonText={ translate( 'Add to cart' ) }
 					/>
 					<SectionHeader
 						className="cart__header cart__upsell-header"
@@ -216,7 +216,7 @@ function getMessages( {
 	}
 
 	const purchase = renewablePurchasesNotAlreadyInCart[ 0 ];
-	const buttonLabel = translate( 'Add to Cart' );
+	const buttonLabel = translate( 'Add to cart' );
 	let message: TranslateResult = '';
 	const translateOptions = {
 		comment:

--- a/client/my-sites/checkout/src/components/test/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/src/components/test/secondary-cart-promotions.tsx
@@ -164,10 +164,10 @@ describe( 'SecondaryCartPromotions', () => {
 					</TestWrapper>
 				);
 				expect( await screen.findByText( 'Upgrade and save' ) ).toBeInTheDocument();
-				expect( await screen.findByText( 'Add to Cart' ) ).toBeInTheDocument();
+				expect( await screen.findByText( 'Add to cart' ) ).toBeInTheDocument();
 			} );
 
-			test( 'adds the plan to the cart when "Add to Cart" is clicked', async () => {
+			test( 'adds the plan to the cart when "Add to cart" is clicked', async () => {
 				const mockAddItemToCart = jest.fn();
 				render(
 					<TestWrapper initialCart={ responseCartWithRenewal }>
@@ -177,7 +177,7 @@ describe( 'SecondaryCartPromotions', () => {
 						/>
 					</TestWrapper>
 				);
-				await userEvent.click( await screen.findByText( 'Add to Cart' ) );
+				await userEvent.click( await screen.findByText( 'Add to cart' ) );
 				expect( mockAddItemToCart ).toHaveBeenCalledTimes( 1 );
 				expect( mockAddItemToCart ).toHaveBeenCalledWith( {
 					product_slug: 'personal-bundle',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTOBRD-362

## Proposed Changes

* We're updating the "Add to Cart" CTA to "Add to cart" (sentence case) outside domain search components

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Product consistency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the checkout has proper sentence case "Add to cart".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
