### PR TITLE
Checkout: Hide payment methods while loading Wallet methods

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -807,6 +807,7 @@ export default function CheckoutMainContent( {
 						validatingButtonText={ validatingButtonText }
 						validatingButtonAriaLabel={ validatingButtonText }
 						onPageLoadError={ onPageLoadError }
+						waitForPaymentMethodIds={ [ 'apple-pay', 'google-pay' ] }
 						isCompleteCallback={ () => {
 							// We want to consider this step complete only if there is a
 							// payment method selected and it does not have required fields.

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -543,11 +543,11 @@ export default function useCreatePaymentMethods( {
 	if ( currentTaxCountryCode?.toUpperCase() === 'DE' ) {
 		paymentMethods = [
 			...existingCardMethods,
+			applePayMethod,
+			googlePayMethod,
 			paypalExpressMethod,
 			paypalPPCPMethod,
 			stripeMethod,
-			applePayMethod,
-			googlePayMethod,
 			freePaymentMethod,
 			idealMethod,
 			sofortMethod,

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -520,9 +520,9 @@ export default function useCreatePaymentMethods( {
 	// `filterAppropriatePaymentMethods()`.
 	let paymentMethods = [
 		...existingCardMethods,
-		stripeMethod,
 		applePayMethod,
 		googlePayMethod,
+		stripeMethod,
 		freePaymentMethod,
 		paypalExpressMethod,
 		paypalPPCPMethod,

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -22,8 +22,10 @@ import type { ReactNode } from 'react';
 
 const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
 
-const CheckoutPaymentMethodsWrapper = styled.div`
+const CheckoutPaymentMethodsWrapper = styled.div< { isLoading: boolean } >`
+	position: relative;
 	padding-top: 4px;
+	pointer-events: ${ ( props ) => ( props.isLoading ? 'none' : 'auto' ) };
 	> div > div:not( [disabled] ):has( + div:hover )::before,
 	> div > div[disabled]:has( + div.is-checked[disabled] )::before {
 		border-bottom: none;
@@ -40,7 +42,8 @@ const LoadingOverlay = styled.div`
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	z-index: 10;
+	z-index: 999;
+	cursor: not-allowed;
 `;
 
 const LoadingSpinner = styled.div`
@@ -65,7 +68,6 @@ const PaymentMethodsContainer = styled.div< { isLoading: boolean } >`
 	position: relative;
 	min-height: 100px;
 	opacity: ${ ( props ) => ( props.isLoading ? 0.3 : 1 ) };
-	pointer-events: ${ ( props ) => ( props.isLoading ? 'none' : 'auto' ) };
 `;
 
 export default function CheckoutPaymentMethods( {
@@ -103,6 +105,7 @@ export default function CheckoutPaymentMethods( {
 		return (
 			<CheckoutPaymentMethodsWrapper
 				className={ joinClasses( [ className, 'checkout-payment-methods' ] ) }
+				isLoading={ false }
 			>
 				<CheckoutErrorBoundary
 					errorMessage={ __( 'There was a problem with this payment method.' ) }
@@ -136,13 +139,14 @@ export default function CheckoutPaymentMethods( {
 	return (
 		<CheckoutPaymentMethodsWrapper
 			className={ joinClasses( [ className, 'checkout-payment-methods' ] ) }
+			isLoading={ arePaymentMethodsLoading }
 		>
+			{ arePaymentMethodsLoading && (
+				<LoadingOverlay>
+					<LoadingSpinner />
+				</LoadingOverlay>
+			) }
 			<PaymentMethodsContainer isLoading={ arePaymentMethodsLoading }>
-				{ arePaymentMethodsLoading && (
-					<LoadingOverlay>
-						<LoadingSpinner />
-					</LoadingOverlay>
-				) }
 				<div>
 					{ paymentMethods.map( ( method ) => (
 						<CheckoutErrorBoundary

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -13,6 +13,7 @@ import {
 	useIsStepActive,
 	useIsStepComplete,
 	useFormStatus,
+	useArePaymentMethodsLoading,
 } from '../public-api';
 import { CheckoutPageErrorCallback, FormStatus } from '../types';
 import CheckoutErrorBoundary from './checkout-error-boundary';
@@ -29,16 +30,56 @@ const CheckoutPaymentMethodsWrapper = styled.div`
 	}
 `;
 
+const LoadingOverlay = styled.div`
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: rgba( 255, 255, 255, 0.9 );
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 10;
+`;
+
+const LoadingSpinner = styled.div`
+	border: 3px solid #f3f3f3;
+	border-top: 3px solid #3498db;
+	border-radius: 50%;
+	width: 40px;
+	height: 40px;
+	animation: spin 1s linear infinite;
+
+	@keyframes spin {
+		0% {
+			transform: rotate( 0deg );
+		}
+		100% {
+			transform: rotate( 360deg );
+		}
+	}
+`;
+
+const PaymentMethodsContainer = styled.div< { isLoading: boolean } >`
+	position: relative;
+	min-height: 100px;
+	opacity: ${ ( props ) => ( props.isLoading ? 0.3 : 1 ) };
+	pointer-events: ${ ( props ) => ( props.isLoading ? 'none' : 'auto' ) };
+`;
+
 export default function CheckoutPaymentMethods( {
 	summary,
 	isComplete,
 	className,
 	onPageLoadError,
+	waitForPaymentMethodIds = [],
 }: {
 	summary?: boolean;
 	isComplete: boolean;
 	className?: string;
 	onPageLoadError?: CheckoutPageErrorCallback;
+	waitForPaymentMethodIds?: string[];
 } ) {
 	const { __ } = useI18n();
 	const { onPaymentMethodChanged } = useContext( PaymentMethodProviderContext );
@@ -55,6 +96,7 @@ export default function CheckoutPaymentMethods( {
 		setPaymentMethod( newMethod );
 	};
 	const paymentMethods = useAllPaymentMethods();
+	const arePaymentMethodsLoading = useArePaymentMethodsLoading( waitForPaymentMethodIds );
 
 	if ( summary && isComplete && paymentMethod ) {
 		debug( 'rendering selected paymentMethod', paymentMethod );
@@ -95,29 +137,36 @@ export default function CheckoutPaymentMethods( {
 		<CheckoutPaymentMethodsWrapper
 			className={ joinClasses( [ className, 'checkout-payment-methods' ] ) }
 		>
-			<div>
-				{ paymentMethods.map( ( method ) => (
-					<CheckoutErrorBoundary
-						key={ method.id }
-						errorMessage={ sprintf(
-							/* translators: %s is the payment method name that has an error, like "PayPal" */
-							__( 'There was a problem with the payment method: %s' ),
-							method.id
-						) }
-						onError={ onError }
-					>
-						<PaymentMethod
-							id={ method.id }
-							label={ method.label }
-							activeContent={ method.activeContent }
-							inactiveContent={ method.inactiveContent }
-							checked={ paymentMethod?.id === method.id }
-							onClick={ onClickPaymentMethod }
-							ariaLabel={ method.getAriaLabel( __ as ( text: string ) => string ) }
-						/>
-					</CheckoutErrorBoundary>
-				) ) }
-			</div>
+			<PaymentMethodsContainer isLoading={ arePaymentMethodsLoading }>
+				{ arePaymentMethodsLoading && (
+					<LoadingOverlay>
+						<LoadingSpinner />
+					</LoadingOverlay>
+				) }
+				<div>
+					{ paymentMethods.map( ( method ) => (
+						<CheckoutErrorBoundary
+							key={ method.id }
+							errorMessage={ sprintf(
+								/* translators: %s is the payment method name that has an error, like "PayPal" */
+								__( 'There was a problem with the payment method: %s' ),
+								method.id
+							) }
+							onError={ onError }
+						>
+							<PaymentMethod
+								id={ method.id }
+								label={ method.label }
+								activeContent={ method.activeContent }
+								inactiveContent={ method.inactiveContent }
+								checked={ paymentMethod?.id === method.id }
+								onClick={ onClickPaymentMethod }
+								ariaLabel={ method.getAriaLabel( __ as ( text: string ) => string ) }
+							/>
+						</CheckoutErrorBoundary>
+					) ) }
+				</div>
+			</PaymentMethodsContainer>
 		</CheckoutPaymentMethodsWrapper>
 	);
 }

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -1168,13 +1168,16 @@ export function CheckoutStepGroup( {
 	);
 }
 
-export function PaymentMethodStep( props: Partial< CheckoutStepProps > ) {
+export function PaymentMethodStep(
+	props: Partial< CheckoutStepProps > & { waitForPaymentMethodIds?: string[] }
+) {
 	const paymentMethodStepProps = useMemo(
 		() =>
 			getDefaultPaymentMethodStep( {
 				onPageLoadError: props.onPageLoadError,
+				waitForPaymentMethodIds: props.waitForPaymentMethodIds,
 			} ),
-		[ props.onPageLoadError ]
+		[ props.onPageLoadError, props.waitForPaymentMethodIds ]
 	);
 	return <CheckoutStep { ...{ ...paymentMethodStepProps, ...props } } />;
 }

--- a/packages/composite-checkout/src/components/default-steps.tsx
+++ b/packages/composite-checkout/src/components/default-steps.tsx
@@ -3,8 +3,10 @@ import type { CheckoutPageErrorCallback, CheckoutStepProps } from '../types';
 
 export function getDefaultPaymentMethodStep( {
 	onPageLoadError,
+	waitForPaymentMethodIds = [],
 }: {
 	onPageLoadError?: CheckoutPageErrorCallback;
+	waitForPaymentMethodIds?: string[];
 } ): CheckoutStepProps {
 	return {
 		stepId: 'payment-method-step',
@@ -12,7 +14,11 @@ export function getDefaultPaymentMethodStep( {
 		className: 'checkout__payment-method-step',
 		titleContent: <CheckoutPaymentMethodsTitle />,
 		activeStepContent: (
-			<CheckoutPaymentMethods onPageLoadError={ onPageLoadError } isComplete={ false } />
+			<CheckoutPaymentMethods
+				onPageLoadError={ onPageLoadError }
+				isComplete={ false }
+				waitForPaymentMethodIds={ waitForPaymentMethodIds }
+			/>
 		),
 		completeStepContent: <CheckoutPaymentMethods summary isComplete />,
 	};

--- a/packages/composite-checkout/src/components/payment-method-provider.tsx
+++ b/packages/composite-checkout/src/components/payment-method-provider.tsx
@@ -33,6 +33,9 @@ export function PaymentMethodProvider( {
 		.filter( ( method ) => ! disabledPaymentMethodIds.includes( method.id ) )
 		.map( ( method ) => method.id );
 
+	// Keep track of loading payment methods.
+	const [ loadingPaymentMethodIds, setLoadingPaymentMethodIds ] = useState< string[] >( [] );
+
 	// Automatically select first payment method unless explicitly set or disabled.
 	if (
 		selectFirstAvailablePaymentMethod &&
@@ -65,6 +68,8 @@ export function PaymentMethodProvider( {
 			paymentMethodId,
 			setPaymentMethodId,
 			onPaymentMethodChanged,
+			loadingPaymentMethodIds,
+			setLoadingPaymentMethodIds,
 		} ),
 		[
 			paymentMethodId,
@@ -72,6 +77,7 @@ export function PaymentMethodProvider( {
 			disabledPaymentMethodIds,
 			onPaymentMethodChanged,
 			paymentProcessors,
+			loadingPaymentMethodIds,
 		]
 	);
 

--- a/packages/composite-checkout/src/lib/payment-method-provider-context.ts
+++ b/packages/composite-checkout/src/lib/payment-method-provider-context.ts
@@ -11,6 +11,8 @@ const defaultContext: PaymentMethodProviderContextInterface = {
 	setDisabledPaymentMethodIds: noop,
 	paymentMethodId: null,
 	setPaymentMethodId: noop,
+	loadingPaymentMethodIds: [],
+	setLoadingPaymentMethodIds: noop,
 };
 
 export const PaymentMethodProviderContext = createContext( defaultContext );

--- a/packages/composite-checkout/src/lib/payment-methods/index.ts
+++ b/packages/composite-checkout/src/lib/payment-methods/index.ts
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useEffect } from 'react';
 import { PaymentMethodProviderContext } from '../payment-method-provider-context';
 import type { PaymentMethod, TogglePaymentMethod } from '../../types';
 
@@ -80,4 +80,36 @@ export function useTogglePaymentMethod(): TogglePaymentMethod {
 			setDisabledPaymentMethodIds( [ ...disabledPaymentMethodIds, paymentMethodId ] );
 		}
 	};
+}
+
+export function useRegisterPaymentMethodLoading(
+	paymentMethodId: string,
+	isLoading: boolean
+): void {
+	const { loadingPaymentMethodIds, setLoadingPaymentMethodIds } = useContext(
+		PaymentMethodProviderContext
+	);
+
+	useEffect( () => {
+		if ( isLoading && ! loadingPaymentMethodIds.includes( paymentMethodId ) ) {
+			debug( 'Registering loading payment method', paymentMethodId );
+			setLoadingPaymentMethodIds( [ ...loadingPaymentMethodIds, paymentMethodId ] );
+		}
+
+		if ( ! isLoading && loadingPaymentMethodIds.includes( paymentMethodId ) ) {
+			debug( 'Unregistering loading payment method', paymentMethodId );
+			setLoadingPaymentMethodIds(
+				loadingPaymentMethodIds.filter( ( id ) => id !== paymentMethodId )
+			);
+		}
+	}, [ isLoading, paymentMethodId, loadingPaymentMethodIds, setLoadingPaymentMethodIds ] );
+}
+
+export function useArePaymentMethodsLoading( paymentMethodIds: string[] ): boolean {
+	const { loadingPaymentMethodIds } = useContext( PaymentMethodProviderContext );
+	const areMethodsLoading = paymentMethodIds.some( ( id ) =>
+		loadingPaymentMethodIds.includes( id )
+	);
+	debug( 'Checking if payment methods are loading', paymentMethodIds, areMethodsLoading );
+	return areMethodsLoading;
 }

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -24,6 +24,8 @@ import {
 	useAllPaymentMethods,
 	useAvailablePaymentMethodIds,
 	useTogglePaymentMethod,
+	useRegisterPaymentMethodLoading,
+	useArePaymentMethodsLoading,
 } from './lib/payment-methods';
 import {
 	usePaymentProcessor,
@@ -72,4 +74,6 @@ export {
 	useTogglePaymentMethod,
 	useTransactionStatus,
 	useMakeStepActive,
+	useRegisterPaymentMethodLoading,
+	useArePaymentMethodsLoading,
 };

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -94,6 +94,8 @@ export interface PaymentMethodProviderContextInterface {
 	paymentMethodId: string | null | undefined;
 	setPaymentMethodId: ( id: string ) => void;
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;
+	loadingPaymentMethodIds: string[];
+	setLoadingPaymentMethodIds: ( methods: string[] ) => void;
 }
 
 export type ReactStandardAction< T = string, P = unknown > = P extends void

--- a/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
@@ -1,4 +1,7 @@
-import { useTogglePaymentMethod } from '@automattic/composite-checkout';
+import {
+	useTogglePaymentMethod,
+	useRegisterPaymentMethodLoading,
+} from '@automattic/composite-checkout';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import { Fragment, useCallback, useEffect } from 'react';
@@ -89,6 +92,9 @@ export function ApplePaySubmitButton( {
 		stripe,
 	} );
 	debug( 'apple-pay button isLoading', isLoading );
+
+	// Register loading state with the payment methods context
+	useRegisterPaymentMethodLoading( 'apple-pay', isLoading );
 
 	useEffect( () => {
 		if ( ! isLoading ) {

--- a/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
@@ -1,4 +1,7 @@
-import { useTogglePaymentMethod } from '@automattic/composite-checkout';
+import {
+	useTogglePaymentMethod,
+	useRegisterPaymentMethodLoading,
+} from '@automattic/composite-checkout';
 import debugFactory from 'debug';
 import { Fragment, useCallback, useEffect } from 'react';
 import { GooglePayMark } from '../google-pay-mark';
@@ -86,6 +89,9 @@ export function GooglePaySubmitButton( {
 		onSubmit,
 		stripe,
 	} );
+
+	// Register loading state with the payment methods context
+	useRegisterPaymentMethodLoading( 'google-pay', isLoading );
 
 	useEffect( () => {
 		if ( ! isLoading ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-280/checkout-default-to-wallet-methods-when-available

## Proposed Changes

This PR modifies the checkout payment method list so that Wallet payment methods are shown above the "new card" and PayPal options (effectively undoing https://github.com/Automattic/wp-calypso/pull/85571) but also hides all payment methods while the Wallet payment methods are loading to prevent the layout shift that necessitated moving them below cards in the first place.

Here's what the loading overlay looks like:

<img width="367" height="171" alt="Screenshot 2025-12-10 at 2 07 12 PM" src="https://github.com/user-attachments/assets/a3c5ea2c-5731-40fb-9f35-d00505ec19cc" />

In fact, in most (all?) current cases this loading indicator won't even be visible because since https://github.com/Automattic/wp-calypso/pull/83985, https://github.com/Automattic/wp-calypso/pull/85516, and https://github.com/Automattic/wp-calypso/pull/85797 we collapse the payment method step by default, but this is still a good idea in case that ever changes or if there's a rare case where the step is expanded by default.

Before             |  After
:-------------------------:|:-------------------------:
<img width="368" height="533" alt="Screenshot 2025-12-10 at 1 28 23 PM" src="https://github.com/user-attachments/assets/08716694-c9a1-498e-9249-6b393929e2b6" /> | <img width="368" height="364" alt="Screenshot 2025-12-10 at 1 27 44 PM" src="https://github.com/user-attachments/assets/48ec0788-1635-4b7e-aae7-8c7a808eda3d" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In https://github.com/Automattic/wp-calypso/pull/70614 we modified the Wallet payment methods (Google Pay/Apple Pay) so that they will always try to load their payment buttons, since that's the only way we can determine if they are actually available. If they fail to load, they will be hidden. This was further modified by https://github.com/Automattic/wp-calypso/pull/85571 so that they start out hidden and so that they render _after_ the "new credit card" payment method. 

This is because when checkout is loaded, the first payment method is selected by default and expanded. The "new credit card" payment method is rather large when expanded and therefore if the Wallet payment methods appear or disappear above it, there will be a notable layout shift which looks very unpleasant. However, this effectively hides the Wallet payment methods from some users and we'd like to emphasize them instead since they are more efficient and reliable. In order to resolve this situation, The simplest option may be to delay displaying the payment method step in checkout behind a step-specific loading indicator until the payment method list has stabilized.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is difficult to test because loading Apple Pay is basically impossible outside of production (see pbOQVh-10b-p2) and loading Google Pay has two requirements:

1. You must have a saved card in your Google Pay wallet already.
2. Checkout must be accessed over https.

The first requirement is fairly straightforward; just make sure that you are using Google Chrome as your browser and that your browser profile has a saved card in the Wallet.

The second requirement means you cannot test this on localhost; you'll need to use the calypso.live link in the comments below.

To test, visit checkout with a product in your cart and verify that the pre-selected payment method is "Google pay". It will actually look like this when collapsed:

<img width="370" height="265" alt="Screenshot 2025-12-10 at 2 14 42 PM" src="https://github.com/user-attachments/assets/83c237bf-4264-4017-a316-72c015c9d304" />

> [!NOTE]
> We still prioritize saved credit cards over Wallet payment methods in this PR, so if you have saved cards, those will still show up first. You may want to remove any saved cards to test this properly. Alternatively, you can modify the `/me/payment-methods` public.api endpoint on your sandbox to return an empty array, then point `public.api-wordpress.com` to your sandbox.

