### PR TITLE
MSD Domains: Bulk update progress notice

### DIFF
--- a/client/dashboard/components/notice/index.tsx
+++ b/client/dashboard/components/notice/index.tsx
@@ -62,7 +62,7 @@ function UnforwardedNotice(
 					<VStack className="dashboard-notice__content" spacing={ 3 }>
 						<VStack className="dashboard-notice__heading" spacing={ 1 }>
 							{ title && <span className="dashboard-notice__title">{ title }</span> }
-							{ children && <span className="dashboard-notice__description">{ children }</span> }
+							{ children && <div className="dashboard-notice__description">{ children }</div> }
 						</VStack>
 						{ actions && (
 							<ButtonStack className="dashboard-notice__actions" justify="flex-start">

--- a/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
+++ b/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
@@ -1,7 +1,7 @@
 import { bulkDomainUpdateStatusQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useLayoutEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Notice } from '../../components/notice';
 import type { BulkDomainUpdateStatusQueryFnData } from '@automattic/api-core';
 
@@ -32,22 +32,23 @@ export const BulkActionsProgressNotice = () => {
 		select: ( data ) => getLastJob( data ),
 	} );
 
-	useLayoutEffect( () => {
+	useEffect( () => {
 		if ( ! data ) {
 			return;
 		}
 
-		if ( ! lastId ) {
-			setLastId( data.id );
-			return;
-		}
+		setLastId( ( prevId ) => {
+			if ( ! prevId ) {
+				return data.id;
+			}
 
-		if ( lastId !== data.id ) {
-			setShouldShowCompleteNotice( true );
-		}
+			if ( prevId !== data.id ) {
+				setShouldShowCompleteNotice( true );
+			}
 
-		setLastId( data.id );
-	}, [ data, lastId ] );
+			return data.id;
+		} );
+	}, [ data ] );
 
 	if ( ! data ) {
 		return null;

--- a/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
+++ b/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
@@ -1,6 +1,6 @@
 import { bulkDomainUpdateStatusQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useLayoutEffect, useState } from 'react';
 import { Notice } from '../../components/notice';
 import type { BulkDomainUpdateStatusQueryFnData } from '@automattic/api-core';
@@ -87,6 +87,13 @@ export const BulkActionsProgressNotice = () => {
 	const someUpdatesFailed = data.failed.length > 0;
 
 	if ( someUpdatesFailed ) {
+		// translators: %(domains)s is the list of failed domains
+		const title = _n(
+			'The following domain was not updated: %(domains)s',
+			'The following domains were not updated: %(domains)s',
+			data.failed.length
+		);
+
 		return (
 			<Notice
 				onClose={ closeNotice }
@@ -94,9 +101,7 @@ export const BulkActionsProgressNotice = () => {
 				title={ __( 'Some domain updates were not successful' ) }
 			>
 				<p>{ __( 'Please try again. If the problem persists, contact support.' ) }</p>
-				<p>
-					{ __( 'The following domains were not updated:' ) } { data.failed.join( ', ' ) }
-				</p>
+				<p>{ sprintf( title, { domains: data.failed.join( ', ' ) } ) }</p>
 			</Notice>
 		);
 	}

--- a/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
+++ b/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
@@ -25,7 +25,7 @@ export const BulkActionsProgressNotice = () => {
 		refetchInterval: ( query ) => {
 			const lastJob = getLastJob( query.state.data );
 
-			return lastJob?.complete ? -1 : 1_000;
+			return lastJob?.complete ? false : 1_000;
 		},
 		meta: { persist: false },
 		staleTime: 0,

--- a/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
+++ b/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
@@ -62,7 +62,7 @@ export const BulkActionsProgressNotice = () => {
 
 		return (
 			<Notice variant="warning" title={ title }>
-				<p>{ __( "This may take a few minutes. This page will refresh once it's complete." ) }</p>
+				{ __( "This may take a few minutes. This page will refresh once it's complete." ) }
 			</Notice>
 		);
 	}
@@ -80,7 +80,7 @@ export const BulkActionsProgressNotice = () => {
 	if ( allUpdatesFailed ) {
 		return (
 			<Notice onClose={ closeNotice } variant="error" title={ __( 'Domain updates failed' ) }>
-				<p>{ __( 'Please try again. If the problem persists, contact support.' ) }</p>
+				{ __( 'Please try again. If the problem persists, contact support.' ) }
 			</Notice>
 		);
 	}
@@ -102,7 +102,7 @@ export const BulkActionsProgressNotice = () => {
 				title={ __( 'Some domain updates were not successful' ) }
 			>
 				<p>{ __( 'Please try again. If the problem persists, contact support.' ) }</p>
-				<p>{ sprintf( title, { domains: data.failed.join( ', ' ) } ) }</p>
+				<span>{ sprintf( title, { domains: data.failed.join( ', ' ) } ) }</span>
 			</Notice>
 		);
 	}
@@ -114,7 +114,7 @@ export const BulkActionsProgressNotice = () => {
 
 	return (
 		<Notice onClose={ closeNotice } variant="success" title={ __( 'All updates complete' ) }>
-			<p>{ content }</p>
+			{ content }
 		</Notice>
 	);
 };

--- a/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
+++ b/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
@@ -1,0 +1,114 @@
+import { bulkDomainUpdateStatusQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { useLayoutEffect, useState } from 'react';
+import { Notice } from '../../components/notice';
+import type { BulkDomainUpdateStatusQueryFnData } from '@automattic/api-core';
+
+const getLastJob = ( data: BulkDomainUpdateStatusQueryFnData | undefined ) => {
+	if ( ! data ) {
+		return undefined;
+	}
+
+	return bulkDomainUpdateStatusQuery()
+		.select?.( data )
+		.allJobs.sort( ( a, b ) => b.created_at - a.created_at )
+		.at( 0 );
+};
+
+export const BulkActionsProgressNotice = () => {
+	const [ lastId, setLastId ] = useState( '' );
+	const [ shouldShowCompleteNotice, setShouldShowCompleteNotice ] = useState( false );
+
+	const { data } = useQuery( {
+		...bulkDomainUpdateStatusQuery(),
+		refetchInterval: ( query ) => {
+			const lastJob = getLastJob( query.state.data );
+
+			return lastJob?.complete ? -1 : 1_000;
+		},
+		meta: { persist: false },
+		staleTime: 0,
+		select: ( data ) => getLastJob( data ),
+	} );
+
+	useLayoutEffect( () => {
+		if ( ! data ) {
+			return;
+		}
+
+		if ( ! lastId ) {
+			setLastId( data.id );
+			return;
+		}
+
+		if ( lastId !== data.id ) {
+			setShouldShowCompleteNotice( true );
+		}
+
+		setLastId( data.id );
+	}, [ data, lastId ] );
+
+	if ( ! data ) {
+		return null;
+	}
+
+	if ( ! data.complete ) {
+		const title =
+			data.action === 'set_auto_renew'
+				? __( 'Updating auto-renewal settings' )
+				: __( 'Updating your contact information' );
+
+		return (
+			<Notice variant="warning" title={ title }>
+				<p>{ __( "This may take a few minutes. This page will refresh once it's complete." ) }</p>
+			</Notice>
+		);
+	}
+
+	if ( ! lastId || ! shouldShowCompleteNotice ) {
+		return null;
+	}
+
+	const closeNotice = () => {
+		setShouldShowCompleteNotice( false );
+	};
+
+	const allUpdatesFailed = data.success.length === 0;
+
+	if ( allUpdatesFailed ) {
+		return (
+			<Notice onClose={ closeNotice } variant="error" title={ __( 'Domain updates failed' ) }>
+				<p>{ __( 'Please try again. If the problem persists, contact support.' ) }</p>
+			</Notice>
+		);
+	}
+
+	const someUpdatesFailed = data.failed.length > 0;
+
+	if ( someUpdatesFailed ) {
+		return (
+			<Notice
+				onClose={ closeNotice }
+				variant="warning"
+				title={ __( 'Some domain updates were not successful' ) }
+			>
+				<p>{ __( 'Please try again. If the problem persists, contact support.' ) }</p>
+				<p>
+					{ __( 'The following domains were not updated:' ) } { data.failed.join( ', ' ) }
+				</p>
+			</Notice>
+		);
+	}
+
+	const content =
+		data.action === 'set_auto_renew'
+			? __( 'Your auto-renewal settings have been updated across all selected domain names.' )
+			: __( 'Your contact information has been updated across all selected domain names.' );
+
+	return (
+		<Notice onClose={ closeNotice } variant="success" title={ __( 'All updates complete' ) }>
+			<p>{ content }</p>
+		</Notice>
+	);
+};

--- a/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
+++ b/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
@@ -1,5 +1,5 @@
-import { bulkDomainUpdateStatusQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
+import { bulkDomainUpdateStatusQuery, domainsQuery } from '@automattic/api-queries';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import { Notice } from '../../components/notice';
@@ -18,6 +18,7 @@ const getLastJob = ( data: BulkDomainUpdateStatusQueryFnData | undefined ) => {
 
 export const BulkActionsProgressNotice = () => {
 	const [ lastId, setLastId ] = useState( '' );
+	const queryClient = useQueryClient();
 	const [ shouldShowCompleteNotice, setShouldShowCompleteNotice ] = useState( false );
 
 	const { data } = useQuery( {
@@ -49,6 +50,14 @@ export const BulkActionsProgressNotice = () => {
 			return data.id;
 		} );
 	}, [ data ] );
+
+	const shouldRefetchAllDomainsQuery = data?.complete && shouldShowCompleteNotice;
+
+	useEffect( () => {
+		if ( shouldRefetchAllDomainsQuery ) {
+			queryClient.refetchQueries( domainsQuery() );
+		}
+	}, [ shouldRefetchAllDomainsQuery, queryClient ] );
 
 	if ( ! data ) {
 		return null;

--- a/client/dashboard/domains/dataviews/index.tsx
+++ b/client/dashboard/domains/dataviews/index.tsx
@@ -1,3 +1,4 @@
 export * from './actions';
 export * from './fields';
 export * from './views';
+export * from './bulk-actions-progress-notice';

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -12,7 +12,13 @@ import { OptInWelcome } from '../components/opt-in-welcome';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import { AddDomainButton } from './add-domain-button';
-import { useActions, useFields, DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews';
+import {
+	BulkActionsProgressNotice,
+	useActions,
+	useFields,
+	DEFAULT_VIEW,
+	DEFAULT_LAYOUTS,
+} from './dataviews';
 import type { DomainSummary } from '@automattic/api-core';
 
 export function getDomainId( domain: DomainSummary ): string {
@@ -60,7 +66,12 @@ function Domains() {
 	return (
 		<PageLayout
 			header={ <PageHeader title={ __( 'Domains' ) } actions={ <AddDomainButton /> } /> }
-			notices={ <OptInWelcome tracksContext="domains" /> }
+			notices={
+				<>
+					<OptInWelcome tracksContext="domains" />
+					<BulkActionsProgressNotice />
+				</>
+			}
 		>
 			<DataViewsCard>
 				<DataViews< DomainSummary >

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -14,7 +14,13 @@ import { Notice } from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { AddDomainButton } from '../../domains/add-domain-button';
-import { useActions, useFields, DEFAULT_LAYOUTS, SITE_CONTEXT_VIEW } from '../../domains/dataviews';
+import {
+	useActions,
+	useFields,
+	DEFAULT_LAYOUTS,
+	SITE_CONTEXT_VIEW,
+	BulkActionsProgressNotice,
+} from '../../domains/dataviews';
 import PrimaryDomainSelector from './primary-domain-selector';
 import type { DomainSummary } from '@automattic/api-core';
 
@@ -32,6 +38,7 @@ function SiteDomains() {
 			return data.filter( ( domain ) => domain.blog_id === site.ID );
 		},
 	} );
+
 	const { data: redirect, isLoading: isRedirectLoading } = useQuery( siteRedirectQuery( site.ID ) );
 	const hasRedirect = redirect && Object.keys( redirect ).length > 0;
 
@@ -85,6 +92,7 @@ function SiteDomains() {
 					}
 				/>
 			}
+			notices={ <BulkActionsProgressNotice /> }
 		>
 			{ ! isLoading && ! isRedirectLoading && siteDomains && ! hasRedirect && (
 				<PrimaryDomainSelector domains={ siteDomains } site={ site } user={ user } />

--- a/client/my-sites/backup/backup-date-picker/test/index.jsx
+++ b/client/my-sites/backup/backup-date-picker/test/index.jsx
@@ -16,6 +16,7 @@ jest.mock( 'i18n-calypso', () => ( {
 	useTranslate: jest.fn(),
 } ) );
 jest.mock( '@tanstack/react-query', () => ( {
+	...jest.requireActual( '@tanstack/react-query' ),
 	useQuery: jest.fn(),
 } ) );
 jest.mock( 'react-redux', () => ( {

--- a/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-field.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-field.tsx
@@ -1,8 +1,9 @@
-import { JobStatus, PartialDomainData } from '@automattic/data-stores';
 import { PrimaryDomainLabel } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useDomainsDataViewsContext } from '../use-context';
+import type { JobStatus } from '@automattic/api-core';
+import type { PartialDomainData } from '@automattic/data-stores';
 
 interface Props {
 	domain: PartialDomainData;

--- a/client/my-sites/domains/domain-management/dataviews/types.ts
+++ b/client/my-sites/domains/domain-management/dataviews/types.ts
@@ -1,15 +1,14 @@
-import {
-	DomainUpdateStatus,
-	JobStatus,
-	BulkUpdateVariables,
-	BulkDomainUpdateStatusQueryFnData,
-	PartialDomainData,
-} from '@automattic/data-stores';
 import { SiteDomainsQueryFnData } from '@automattic/data-stores/src/queries/use-site-domains-query';
 import { DomainStatusPurchaseActions, ResponseDomain } from '@automattic/domains-table';
 import { DomainAction } from '@automattic/domains-table/src/domains-table/domains-table-row-actions';
 import { SiteExcerptData } from '@automattic/sites';
 import { QueryParams } from './query-params';
+import type {
+	DomainUpdateStatus,
+	JobStatus,
+	BulkDomainUpdateStatusQueryFnData,
+} from '@automattic/api-core';
+import type { BulkUpdateVariables, PartialDomainData } from '@automattic/data-stores';
 
 /**
  * Utility type for domain action descriptions.

--- a/client/my-sites/domains/domain-management/dataviews/use-bulk-action-notice.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-bulk-action-notice.tsx
@@ -1,4 +1,3 @@
-import { JobStatus } from '@automattic/data-stores';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { translate, useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -6,6 +5,7 @@ import { useDispatch } from 'react-redux';
 import wpcomRequest from 'wpcom-proxy-request';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { useDomainsDataViewsContext } from './use-context';
+import type { JobStatus } from '@automattic/api-core';
 
 type TranslateFunction = typeof translate;
 type HasTranslation = ( single: string, context?: string, domain?: string ) => boolean;

--- a/client/my-sites/domains/domain-management/domains-table-fetch-functions.ts
+++ b/client/my-sites/domains/domain-management/domains-table-fetch-functions.ts
@@ -1,9 +1,9 @@
 import { addQueryArgs } from '@wordpress/url';
 import wp from 'calypso/lib/wp';
+import type { BulkDomainUpdateStatusQueryFnData } from '@automattic/api-core';
 import type {
 	AllDomainsQueryArgs,
 	AllDomainsQueryFnData,
-	BulkDomainUpdateStatusQueryFnData,
 	BulkUpdateVariables,
 	SiteDetails,
 	SiteDomainsQueryFnData,

--- a/packages/api-core/src/domains/fetchers.ts
+++ b/packages/api-core/src/domains/fetchers.ts
@@ -1,7 +1,14 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { DomainSummary } from './types';
+import type { BulkDomainUpdateStatusQueryFnData, DomainSummary } from './types';
 
 export async function fetchDomains(): Promise< DomainSummary[] > {
 	const { domains } = await wpcom.req.get( { path: '/all-domains', apiVersion: '1.2' } );
 	return domains;
+}
+
+export async function fetchBulkDomainUpdateStatus(): Promise< BulkDomainUpdateStatusQueryFnData > {
+	return wpcom.req.get( {
+		path: '/domains/bulk-actions',
+		apiNamespace: 'wpcom/v2',
+	} );
 }

--- a/packages/api-core/src/domains/types.ts
+++ b/packages/api-core/src/domains/types.ts
@@ -93,3 +93,56 @@ export type BulkDomainsAction =
 			transfer_lock: boolean;
 			whois: Record< string, string | undefined >;
 	  };
+
+export interface BulkDomainUpdateStatus {
+	results: {
+		[ key: string ]: '' | 'success' | 'failed';
+	};
+	action: 'set_auto_renew' | 'update_contact_info';
+	created_at: number;
+	auto_renew?: boolean;
+	whois?: unknown;
+	transfer_lock?: boolean;
+}
+
+export interface BulkDomainUpdateStatusQueryFnData {
+	[ key: string ]: BulkDomainUpdateStatus;
+}
+
+export interface JobStatus {
+	id: string;
+	action: 'set_auto_renew' | 'update_contact_info';
+	created_at: number;
+	success: string[];
+	failed: string[];
+	pending: string[];
+	complete: boolean;
+	params: {
+		auto_renew?: boolean;
+		whois?: unknown;
+		transfer_lock?: boolean;
+	};
+}
+
+interface DomainUpdateRemoteStatus {
+	status: '' | 'success' | 'failed';
+	action: 'set_auto_renew' | 'update_contact_info';
+	created_at: number;
+	auto_renew?: boolean;
+	whois?: unknown;
+	transfer_lock?: boolean;
+}
+
+interface DomainUpdateDerivedStatus {
+	status: '';
+	message: string;
+	created_at: number;
+}
+
+export type DomainUpdateStatus = DomainUpdateRemoteStatus | DomainUpdateDerivedStatus;
+
+export interface BulkDomainUpdateStatusResult {
+	domainResults: Map< string, DomainUpdateStatus[] >;
+	completedJobs: JobStatus[];
+	allJobs: JobStatus[];
+}

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -110,10 +110,5 @@ export const bulkDomainsActionMutation = () =>
 		mutationFn: ( action: BulkDomainsAction ) => bulkDomainsAction( action ),
 		onSuccess: () => {
 			queryClient.refetchQueries( bulkDomainUpdateStatusQuery() );
-
-			queryClient.invalidateQueries( {
-				queryKey: domainsQuery().queryKey,
-				exact: true,
-			} );
 		},
 	} );

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -1,9 +1,14 @@
 import {
 	type BulkDomainsAction,
 	bulkDomainsAction,
+	BulkDomainUpdateStatus,
+	BulkDomainUpdateStatusResult,
+	DomainUpdateStatus,
 	fetchAvailableTlds,
+	fetchBulkDomainUpdateStatus,
 	fetchDomainSuggestions,
 	fetchFreeDomainSuggestion,
+	type JobStatus,
 	type DomainSuggestionQuery,
 } from '@automattic/api-core';
 import { fetchDomains } from '@automattic/api-core';
@@ -41,10 +46,71 @@ export const availableTldsQuery = ( query?: string, vendor?: string ) =>
 		queryFn: () => fetchAvailableTlds( query, vendor ),
 	} );
 
+export const bulkDomainUpdateStatusQuery = () =>
+	queryOptions( {
+		queryKey: [ 'domains', 'bulk-actions' ],
+		queryFn: fetchBulkDomainUpdateStatus,
+		select: ( data ): BulkDomainUpdateStatusResult => {
+			// get top-level info about recent jobs
+			const allJobs: JobStatus[] = Object.keys( data ).map( ( jobId ) => {
+				const { action, created_at, results, ...rest } = data[ jobId ];
+				const success: string[] = [];
+				const failed: string[] = [];
+				const pending: string[] = [];
+
+				Object.entries( results ).forEach( ( entry ) => {
+					if ( entry[ 1 ] === 'success' ) {
+						success.push( entry[ 0 ] );
+					} else if ( entry[ 1 ] === 'failed' ) {
+						failed.push( entry[ 0 ] );
+					} else {
+						pending.push( entry[ 0 ] );
+					}
+				} );
+
+				return {
+					id: jobId,
+					action: action,
+					created_at: created_at,
+					success,
+					failed,
+					pending,
+					complete: pending.length === 0,
+					params: rest,
+				};
+			} );
+
+			// get domain-level updates that can be shown inline in the table rows
+			const domainResults = new Map< string, DomainUpdateStatus[] >();
+
+			Object.keys( data ).forEach( ( jobId ) => {
+				// only create domain-level results for jobs that
+				// are still running
+				if ( ! allJobs.find( ( job ) => job.id === jobId )?.complete ) {
+					const entry = data[ jobId ] as BulkDomainUpdateStatus;
+					const { results, ...rest } = entry;
+					Object.keys( results ).forEach( ( domain ) => {
+						if ( ! domainResults.has( domain ) ) {
+							domainResults.set( domain, [] );
+						}
+						const status = results[ domain ];
+						domainResults.get( domain )?.push( { ...rest, status } );
+					} );
+				}
+			} );
+
+			const completedJobs = allJobs.filter( ( job ) => job.complete );
+
+			return { domainResults, completedJobs, allJobs };
+		},
+	} );
+
 export const bulkDomainsActionMutation = () =>
 	mutationOptions( {
 		mutationFn: ( action: BulkDomainsAction ) => bulkDomainsAction( action ),
 		onSuccess: () => {
+			queryClient.refetchQueries( bulkDomainUpdateStatusQuery() );
+
 			queryClient.invalidateQueries( {
 				queryKey: domainsQuery().queryKey,
 				exact: true,

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -44,6 +44,7 @@
 	},
 	"dependencies": {
 		"@automattic/api-core": "workspace:^",
+		"@automattic/api-queries": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",

--- a/packages/data-stores/src/queries/use-bulk-domain-update-status-query.ts
+++ b/packages/data-stores/src/queries/use-bulk-domain-update-status-query.ts
@@ -1,130 +1,29 @@
+import {
+	type BulkDomainUpdateStatusQueryFnData,
+	type BulkDomainUpdateStatusResult,
+} from '@automattic/api-core';
+import { bulkDomainUpdateStatusQuery } from '@automattic/api-queries';
 import { type UseQueryOptions, useQuery } from '@tanstack/react-query';
-import wpcomRequest from 'wpcom-proxy-request';
-
-export interface BulkDomainUpdateStatus {
-	results: {
-		[ key: string ]: '' | 'success' | 'failed';
-	};
-	action: 'set_auto_renew' | 'update_contact_info';
-	created_at: number;
-	auto_renew?: boolean;
-	whois?: unknown;
-	transfer_lock?: boolean;
-}
-
-export interface BulkDomainUpdateStatusQueryFnData {
-	[ key: string ]: BulkDomainUpdateStatus;
-}
-
-export interface JobStatus {
-	id: string;
-	action: 'set_auto_renew' | 'update_contact_info';
-	created_at: number;
-	success: string[];
-	failed: string[];
-	pending: string[];
-	complete: boolean;
-	params: {
-		auto_renew?: boolean;
-		whois?: unknown;
-		transfer_lock?: boolean;
-	};
-}
-
-interface DomainUpdateRemoteStatus {
-	status: '' | 'success' | 'failed';
-	action: 'set_auto_renew' | 'update_contact_info';
-	created_at: number;
-	auto_renew?: boolean;
-	whois?: unknown;
-	transfer_lock?: boolean;
-}
-
-interface DomainUpdateDerivedStatus {
-	status: '';
-	message: string;
-	created_at: number;
-}
-
-export type DomainUpdateStatus = DomainUpdateRemoteStatus | DomainUpdateDerivedStatus;
 
 export const getBulkDomainUpdateStatusQueryKey = () => {
-	return [ 'domains', 'bulk-actions' ];
+	return bulkDomainUpdateStatusQuery().queryKey;
 };
 
-export interface BulkDomainUpdateStatusResult {
-	domainResults: Map< string, DomainUpdateStatus[] >;
-	completedJobs: JobStatus[];
-}
-
-export function useBulkDomainUpdateStatusQuery< TError = unknown >(
+export function useBulkDomainUpdateStatusQuery(
 	pollingInterval: number,
 	options: Omit<
-		UseQueryOptions< BulkDomainUpdateStatusQueryFnData, TError, BulkDomainUpdateStatusResult >,
+		UseQueryOptions<
+			BulkDomainUpdateStatusQueryFnData,
+			Error,
+			BulkDomainUpdateStatusResult,
+			string[]
+		>,
 		'queryKey'
 	> = {}
 ) {
 	return useQuery( {
-		queryFn: () =>
-			wpcomRequest< BulkDomainUpdateStatusQueryFnData >( {
-				path: '/domains/bulk-actions',
-				apiNamespace: 'wpcom/v2',
-			} ),
-		select: ( data ): BulkDomainUpdateStatusResult => {
-			// get top-level info about recent jobs
-			const allJobs: JobStatus[] = Object.keys( data ).map( ( jobId ) => {
-				const { action, created_at, results, ...rest } = data[ jobId ];
-				const success: string[] = [];
-				const failed: string[] = [];
-				const pending: string[] = [];
-
-				Object.entries( results ).forEach( ( entry ) => {
-					if ( entry[ 1 ] === 'success' ) {
-						success.push( entry[ 0 ] );
-					} else if ( entry[ 1 ] === 'failed' ) {
-						failed.push( entry[ 0 ] );
-					} else {
-						pending.push( entry[ 0 ] );
-					}
-				} );
-
-				return {
-					id: jobId,
-					action: action,
-					created_at: created_at,
-					success,
-					failed,
-					pending,
-					complete: pending.length === 0,
-					params: rest,
-				};
-			} );
-
-			// get domain-level updates that can be shown inline in the table rows
-			const domainResults = new Map< string, DomainUpdateStatus[] >();
-
-			Object.keys( data ).forEach( ( jobId ) => {
-				// only create domain-level results for jobs that
-				// are still running
-				if ( ! allJobs.find( ( job ) => job.id === jobId )?.complete ) {
-					const entry = data[ jobId ] as BulkDomainUpdateStatus;
-					const { results, ...rest } = entry;
-					Object.keys( results ).forEach( ( domain ) => {
-						if ( ! domainResults.has( domain ) ) {
-							domainResults.set( domain, [] );
-						}
-						const status = results[ domain ];
-						domainResults.get( domain )?.push( { ...rest, status } );
-					} );
-				}
-			} );
-
-			const completedJobs = allJobs.filter( ( job ) => job.complete );
-
-			return { domainResults, completedJobs };
-		},
+		...bulkDomainUpdateStatusQuery(),
 		refetchInterval: pollingInterval,
 		...options,
-		queryKey: getBulkDomainUpdateStatusQueryKey(),
 	} );
 }

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -12,6 +12,7 @@
 		{ "path": "../calypso-products" },
 		{ "path": "../calypso-config" },
 		{ "path": "../api-core" },
+		{ "path": "../api-queries" },
 		{ "path": "../global-styles" },
 		{ "path": "../i18n-utils" },
 		{ "path": "../shopping-cart" },

--- a/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
@@ -1,10 +1,10 @@
 import { Spinner } from '@automattic/components';
-import { DomainUpdateStatus } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { StatusPopover } from '../status-popover';
 import { ResolveDomainStatusReturn } from '../utils/resolve-domain-status';
+import type { DomainUpdateStatus } from '@automattic/api-core';
 
 interface DomainsTableStatusCellProps {
 	domainStatus: ResolveDomainStatusReturn | null;

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -6,11 +6,8 @@ import {
 	SiteDetails,
 	SiteDomainsQueryFnData,
 	useDomainsBulkActionsMutation,
-	DomainUpdateStatus,
-	JobStatus,
 	BulkUpdateVariables,
 	AllDomainsQueryFnData,
-	BulkDomainUpdateStatusQueryFnData,
 	AllDomainsQueryArgs,
 } from '@automattic/data-stores';
 import { useFuzzySearch } from '@automattic/search';
@@ -35,6 +32,11 @@ import { canBulkUpdate } from '../utils/can-bulk-update';
 import { DomainStatusPurchaseActions } from '../utils/resolve-domain-status';
 import { ResponseDomain } from '../utils/types';
 import { DomainAction } from './domains-table-row-actions';
+import type {
+	BulkDomainUpdateStatusQueryFnData,
+	JobStatus,
+	DomainUpdateStatus,
+} from '@automattic/api-core';
 
 type DomainActionDescription = {
 	message?: string;

--- a/packages/domains-table/src/use-domain-bulk-update-status.ts
+++ b/packages/domains-table/src/use-domain-bulk-update-status.ts
@@ -1,11 +1,10 @@
 import {
-	DomainUpdateStatus,
 	useBulkDomainUpdateStatusQuery,
 	getBulkDomainUpdateStatusQueryKey,
-	BulkDomainUpdateStatusQueryFnData,
 } from '@automattic/data-stores';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import type { BulkDomainUpdateStatusQueryFnData, DomainUpdateStatus } from '@automattic/api-core';
 
 const defaultResult = {
 	completedJobs: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,6 +1131,7 @@ __metadata:
   resolution: "@automattic/data-stores@workspace:packages/data-stores"
   dependencies:
     "@automattic/api-core": "workspace:^"
+    "@automattic/api-queries": "workspace:^"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-products": "workspace:^"


### PR DESCRIPTION
Addresses p1764621573932439-slack-C04H4NY6STW.

## Proposed Changes

Adds a notice indicating the progress of a bulk update operation in both `/v2/sites/%s/domains` and `/v2/domains`:


https://github.com/user-attachments/assets/1b775def-fec3-4917-bcec-b1123f8cdb13


## Testing Instructions

Select some domains and toggle the auto-renew at the dataviews footer. You should see a notice indicating that the operation is in progress, and it should be replaced with a success/failure one.

Close the notice and retry the operation - the UI should repeat the process.