### PR TITLE
MSD: Update domain delete to use DataForms.

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
@@ -56,7 +56,7 @@ export default function DomainRemovalConfirmationStep( {
 	return (
 		<VStack spacing={ 4 }>
 			<VStack spacing={ 4 }>
-				<SectionHeader title={ __( 'Confirm your decision' ) } level={ 2 } />
+				<SectionHeader title={ __( 'Confirm your decision' ) } level={ 3 } />
 
 				<Text>
 					{ createInterpolateElement(

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
@@ -1,15 +1,13 @@
-import {
-	Button,
-	__experimentalInputControl as InputControl,
-	__experimentalVStack as VStack,
-	__experimentalHeading as Heading,
-} from '@wordpress/components';
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { useState, useCallback } from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
 import { ButtonStack } from '../../../components/button-stack';
+import { SectionHeader } from '../../../components/section-header';
 import { Text } from '../../../components/text';
 import type { Purchase } from '@automattic/api-core';
+import type { Field } from '@wordpress/dataviews';
 
 import './style.scss';
 
@@ -20,6 +18,10 @@ interface DomainRemovalConfirmationStepProps {
 	isLoading?: boolean;
 }
 
+interface DomainRemovalFormData {
+	domain: string;
+}
+
 export default function DomainRemovalConfirmationStep( {
 	purchase,
 	onConfirm,
@@ -27,22 +29,34 @@ export default function DomainRemovalConfirmationStep( {
 	isLoading = false,
 }: DomainRemovalConfirmationStepProps ) {
 	const domainName = purchase.meta || purchase.product_name;
-	const [ inputValue, setInputValue ] = useState( '' );
-	const [ domainConfirmed, setDomainConfirmed ] = useState( false );
+	const [ formData, setFormData ] = useState< DomainRemovalFormData >( {
+		domain: '',
+	} );
 
-	const handleInputChange = useCallback(
-		( value: string | undefined ) => {
-			const newValue = value || '';
-			setInputValue( newValue );
-			setDomainConfirmed( newValue === domainName );
+	const fields: Field< DomainRemovalFormData >[] = [
+		{
+			id: 'domain',
+			label: __( 'Type your domain name to proceed' ),
+			type: 'text' as const,
+			description: sprintf(
+				/* translators: %s is the domain name */
+				__( 'The domain name is: %s' ),
+				domainName
+			),
 		},
-		[ domainName ]
-	);
+	];
+
+	const form = {
+		layout: { type: 'regular' as const },
+		fields: [ 'domain' ],
+	};
+
+	const isDomainConfirmed = formData.domain === domainName;
 
 	return (
-		<VStack spacing={ 8 }>
-			<VStack spacing={ 3 }>
-				<Heading level={ 3 }>{ __( 'Confirm your decision' ) }</Heading>
+		<VStack spacing={ 4 }>
+			<VStack spacing={ 4 }>
+				<SectionHeader title={ __( 'Confirm your decision' ) } level={ 2 } />
 
 				<Text>
 					{ createInterpolateElement(
@@ -55,14 +69,13 @@ export default function DomainRemovalConfirmationStep( {
 						}
 					) }
 				</Text>
-
-				<InputControl
-					__next40pxDefaultSize
-					label={ __( 'Type your domain name to proceed' ) }
-					value={ inputValue }
-					onChange={ handleInputChange }
-					disabled={ isLoading }
-					placeholder={ domainName }
+				<DataForm< DomainRemovalFormData >
+					data={ formData }
+					fields={ fields }
+					form={ form }
+					onChange={ ( edits: Partial< DomainRemovalFormData > ) => {
+						setFormData( ( data ) => ( { ...data, ...edits } ) );
+					} }
 				/>
 			</VStack>
 
@@ -80,7 +93,8 @@ export default function DomainRemovalConfirmationStep( {
 					variant="primary"
 					isDestructive
 					onClick={ onConfirm }
-					disabled={ ! domainConfirmed || isLoading }
+					disabled={ ! isDomainConfirmed || isLoading }
+					isBusy={ isLoading }
 				>
 					{ __( 'Delete this domain' ) }
 				</Button>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
@@ -55,30 +55,27 @@ export default function DomainRemovalConfirmationStep( {
 
 	return (
 		<VStack spacing={ 4 }>
-			<VStack spacing={ 4 }>
-				<SectionHeader title={ __( 'Confirm your decision' ) } level={ 3 } />
+			<SectionHeader title={ __( 'Confirm your decision' ) } level={ 3 } />
 
-				<Text>
-					{ createInterpolateElement(
-						/* translators: <domainName /> is the domain name */
-						__(
-							'<domainName /> will be deleted. Any services related to it will stop working. Are you sure you want to proceed?'
-						),
-						{
-							domainName: <strong>{ domainName }</strong>,
-						}
-					) }
-				</Text>
-				<DataForm< DomainRemovalFormData >
-					data={ formData }
-					fields={ fields }
-					form={ form }
-					onChange={ ( edits: Partial< DomainRemovalFormData > ) => {
-						setFormData( ( data ) => ( { ...data, ...edits } ) );
-					} }
-				/>
-			</VStack>
-
+			<Text>
+				{ createInterpolateElement(
+					/* translators: <domainName /> is the domain name */
+					__(
+						'<domainName /> will be deleted. Any services related to it will stop working. Are you sure you want to proceed?'
+					),
+					{
+						domainName: <strong>{ domainName }</strong>,
+					}
+				) }
+			</Text>
+			<DataForm< DomainRemovalFormData >
+				data={ formData }
+				fields={ fields }
+				form={ form }
+				onChange={ ( edits: Partial< DomainRemovalFormData > ) => {
+					setFormData( ( data ) => ( { ...data, ...edits } ) );
+				} }
+			/>
 			<ButtonStack justify="flex-end">
 				<Button
 					__next40pxDefaultSize


### PR DESCRIPTION
Related to: #107600

## Proposed Changes

Update the delete domain view to use DataForms, spacing and `isBusy` on the button while we are deleting the domain to make it follow other similar states:
- [Deleting a site](https://github.com/Automattic/wp-calypso/blob/trunk/client/dashboard/sites/site-delete-modal/index.tsx)
- [Resetting a site](https://github.com/Automattic/wp-calypso/blob/trunk/client/dashboard/sites/site-reset-modal/index.tsx)

## Screenshots

| State | Before | After |
|--------|--------|--------|
| Default | <img width="704" height="305" alt="Screenshot 2025-12-11 at 9 26 06 AM" src="https://github.com/user-attachments/assets/66a19d87-d021-46dc-9ee8-d5daec1c46fc" /> | <img width="730" height="367" alt="Screenshot 2025-12-11 at 9 26 42 AM" src="https://github.com/user-attachments/assets/da3b339c-e9ea-40f3-a610-5823f333587a" /> | 
| isPending | <img width="740" height="352" alt="Screenshot 2025-12-11 at 9 28 09 AM" src="https://github.com/user-attachments/assets/de05359d-072a-48ef-aaf5-f18b7decc66d" /> | <img width="715" height="366" alt="Screenshot 2025-12-11 at 9 27 29 AM" src="https://github.com/user-attachments/assets/0ff5255e-2690-402a-942c-37b0cc9b60ae" /> | 





## Why are these changes being made?

Consistency.

## Testing Instructions

1. Visit you active upgrades.
2. Click on your domain in the active updates list.
3. Click "Downgrade or cancel".
4. Confirm that you want to delete.
5. Verify you see the changes mentioned above.
6. Delete you domain
7. Expect it to be deleted.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
