### PR TITLE
Update MSD links to use my.wordpress.com

### DIFF
--- a/client/components/email-verification/index.js
+++ b/client/components/email-verification/index.js
@@ -1,5 +1,6 @@
 import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { sendVerificationSignal } from 'calypso/lib/user/verification-checker';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -45,8 +46,8 @@ export default function emailVerification( context, next ) {
 }
 
 // Helper function to build redirect URL
-function buildV2RedirectUrl( verified, newEmailResult ) {
-	let redirectUrl = '/v2/me/profile';
+function buildDashboardRedirectUrl( verified, newEmailResult ) {
+	let redirectUrl = dashboardLink( '/me/profile' );
 	if ( verified ) {
 		redirectUrl += `?verified=${ verified }`;
 	} else if ( newEmailResult ) {
@@ -89,7 +90,10 @@ function shouldRedirectToV2( context, next, params ) {
 				unsubscribe();
 
 				if ( hasHostingDashboardOptIn( state ) ) {
-					window.location.href = buildV2RedirectUrl( params.verified, params.newEmailResult );
+					window.location.href = buildDashboardRedirectUrl(
+						params.verified,
+						params.newEmailResult
+					);
 				}
 			}
 		} );
@@ -101,7 +105,7 @@ function shouldRedirectToV2( context, next, params ) {
 	}
 
 	if ( hasHostingDashboardOptIn( state ) ) {
-		window.location.href = buildV2RedirectUrl( params.verified, params.newEmailResult );
+		window.location.href = buildDashboardRedirectUrl( params.verified, params.newEmailResult );
 		return true;
 	}
 

--- a/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
@@ -211,6 +211,7 @@ describe( 'StagingSiteDeleteModal', () => {
 			Object.defineProperty( window, 'location', {
 				writable: true,
 				value: {
+					hostname: 'my.localhost',
 					pathname: '/sites/test-site',
 				},
 			} );

--- a/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
@@ -211,7 +211,7 @@ describe( 'StagingSiteDeleteModal', () => {
 			Object.defineProperty( window, 'location', {
 				writable: true,
 				value: {
-					pathname: '/v2/sites/test-site',
+					pathname: '/sites/test-site',
 				},
 			} );
 		} );

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -11,6 +11,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { hasPlanFeature } from 'calypso/dashboard/utils/site-features';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import wpcom from 'calypso/lib/wp';
@@ -90,7 +91,7 @@ const domain: FlowV2< typeof initialize > = {
 		);
 
 		const redirectTo = useQuery().get( 'redirect_to' ) || undefined;
-		const defaultRedirect = `/v2/sites/${ siteSlug }/domains`;
+		const defaultRedirect = dashboardLink( `/sites/${ siteSlug }/domains` );
 
 		const goToCheckout = ( siteSlug: string ) => {
 			// Check if cart contains only one domain product and it's a domain connection
@@ -101,13 +102,13 @@ const domain: FlowV2< typeof initialize > = {
 				domainCartItems && domainCartItems.length === 1 && isDomainMapping( domainCartItems[ 0 ] );
 
 			// Use the redirect_to query param if provided, otherwise fall back to v2 domains
-			let destination = redirectTo || `/v2/sites/${ siteSlug }/domains`;
+			let destination = redirectTo || dashboardLink( `/sites/${ siteSlug }/domains` );
 
 			// But send domain-only connects to domain-connection-setup.
 			if ( ! redirectTo && hasOnlyDomainConnection ) {
 				const domain = domainCartItems[ 0 ].meta;
 				if ( domain ) {
-					destination = `/v2/domains/${ domain }/domain-connection-setup`;
+					destination = dashboardLink( `/domains/${ domain }/domain-connection-setup` );
 				}
 			}
 
@@ -285,7 +286,7 @@ const domain: FlowV2< typeof initialize > = {
 					if ( providedDependencies.newExistingSiteChoice === 'domain' ) {
 						return window.location.assign(
 							addQueryArgs( '/checkout/no-site', {
-								redirect_to: '/v2/domains',
+								redirect_to: dashboardLink( '/domains' ),
 								signup: 0,
 								isDomainOnly: 1,
 								cancel_to: new URL(
@@ -329,7 +330,7 @@ const domain: FlowV2< typeof initialize > = {
 								);
 
 								return {
-									redirectTo: `/v2/domains/${ domain }/domain-connection-setup`,
+									redirectTo: dashboardLink( `/domains/${ domain }/domain-connection-setup` ),
 								};
 							}
 
@@ -405,7 +406,9 @@ const domain: FlowV2< typeof initialize > = {
 							return window.location.replace( providedDependencies.redirectTo );
 						}
 
-						const destination = `/v2/sites/${ providedDependencies.siteSlug }/domains`;
+						const destination = dashboardLink(
+							`/sites/${ providedDependencies.siteSlug }/domains`
+						);
 
 						persistSignupDestination( destination );
 						setSignupCompleteFlowName( this.name );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -5,6 +5,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { addSurvicate } from 'calypso/lib/analytics/survicate';
@@ -110,7 +111,9 @@ const onboarding: FlowV2< typeof initialize > = {
 			 */
 			if ( isEnabled( 'dashboard/v2/onboarding' ) ) {
 				return [
-					addQueryArgs( `/v2/sites/${ providedDependencies.siteSlug }`, { ref: flowName } ),
+					addQueryArgs( dashboardLink( `/sites/${ providedDependencies.siteSlug }` ), {
+						ref: flowName,
+					} ),
 					addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
 						siteSlug: providedDependencies.siteSlug,
 					} ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -21,6 +21,7 @@ import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain
 import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { useWPCOMDomainSearchEvents } from 'calypso/components/domains/wpcom-domain-search/use-wpcom-domain-search-events';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -318,7 +319,7 @@ const DomainSearchStep: StepType< {
 	const [ sitesBackLabelText, defaultBackUrl ] =
 		userSiteCount === 1
 			? [ __( 'Back to My Home' ), '/home' ]
-			: [ __( 'Back to sites' ), hostingDashboardOptIn ? '/v2/sites' : '/sites' ];
+			: [ __( 'Back to sites' ), hostingDashboardOptIn ? dashboardLink( '/sites' ) : '/sites' ];
 
 	if ( isHundredYearDomainFlow( flow ) || isHundredYearPlanFlow( flow ) ) {
 		return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -23,6 +23,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import FormattedHeader from 'calypso/components/formatted-header';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
@@ -246,7 +247,7 @@ function UnifiedPlansStep( {
 			return null;
 		}
 
-		return hostingDashboardOptIn ? '/v2/sites' : '/sites/';
+		return hostingDashboardOptIn ? dashboardLink( '/sites' ) : '/sites/';
 	} );
 
 	useSiteGlobalStylesOnPersonal();

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
@@ -234,7 +235,7 @@ class MasterbarLoggedIn extends Component {
 			? domainManagementList( siteSlug, currentRoute, true )
 			: '/sites';
 		if ( hostingDashboardOptIn ) {
-			mySitesUrl = domainOnlySite ? '/v2/domains' : '/v2/sites';
+			mySitesUrl = domainOnlySite ? dashboardLink( '/domains' ) : dashboardLink( '/sites' );
 		}
 		const icon = this.wordpressIcon();
 
@@ -249,11 +250,11 @@ class MasterbarLoggedIn extends Component {
 					[
 						{
 							label: translate( 'Sites' ),
-							url: hostingDashboardOptIn ? '/v2/sites' : '/sites',
+							url: hostingDashboardOptIn ? dashboardLink( '/sites' ) : '/sites',
 						},
 						{
 							label: translate( 'Domains' ),
-							url: hostingDashboardOptIn ? '/v2/domains' : '/domains/manage',
+							url: hostingDashboardOptIn ? dashboardLink( '/domains' ) : '/domains/manage',
 						},
 					],
 					...( this.props.isSimpleSite

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -14,6 +14,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import ResurrectedWelcomeModalGate from 'calypso/components/resurrected-welcome-modal';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import useDomainDiagnosticsQuery from 'calypso/data/domains/diagnostics/use-domain-diagnostics-query';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery, { getCacheKey } from 'calypso/data/home/use-home-layout-query';
@@ -188,7 +189,11 @@ const HomeContent = ( {
 			{ isAdmin && ! isP2 && (
 				<Button
 					primary
-					href={ hostingDashboardOptIn ? `/v2/sites/${ site.slug }` : `/overview/${ site.slug }` }
+					href={
+						hostingDashboardOptIn
+							? dashboardLink( `/sites/${ site.slug }` )
+							: `/overview/${ site.slug }`
+					}
 				>
 					{ hostingDashboardOptIn
 						? translate( 'Hosting Dashboard' )

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -14,6 +14,7 @@ import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
 import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
@@ -307,7 +308,7 @@ const DomainSearchUI = (
 		const [ sitesBackLabelText, defaultBackUrl ] =
 			userSiteCount && userSiteCount === 1
 				? [ __( 'Back to My Home' ), '/home' ]
-				: [ __( 'Back to sites' ), hostingDashboardOptIn ? '/v2/sites' : '/sites' ];
+				: [ __( 'Back to sites' ), hostingDashboardOptIn ? dashboardLink( '/sites' ) : '/sites' ];
 
 		if ( isDomainForGravatarFlow( flowName ) ) {
 			backUrl = null;


### PR DESCRIPTION
Fixes DOTMSD-942

## Proposed Changes

Deprecate /v2 in favor of my.wordpress.com.

>[!NOTE]
> E2E tests will be addressed separately. 
> https://github.com/Automattic/wp-calypso/blob/ebcd6562efb609489ea3ef1d0a9e43e28adc2235/packages/calypso-e2e/src/lib/pages/dashboard-page.ts#L49

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

As the changes affect many flows, I've left instructions as comments.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
