### PR TITLE
A4A > Exclusive offers: Fix the toggle refer mode

### DIFF
--- a/client/a8c-for-agencies/sections/exclusive-offers/overview-content/constants.tsx
+++ b/client/a8c-for-agencies/sections/exclusive-offers/overview-content/constants.tsx
@@ -13,6 +13,10 @@ import {
 	PRODUCT_BRAND_FILTER_JETPACK,
 	PRODUCT_BRAND_FILTER_WOOCOMMERCE,
 } from 'calypso/a8c-for-agencies/sections/marketplace/constants';
+import {
+	MARKETPLACE_TYPE_REFERRAL,
+	MARKETPLACE_TYPE_REGULAR,
+} from 'calypso/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type';
 import JetpackLogo from './images/jetpack.svg';
 import PressableLogo from './images/pressable.svg';
 import VIPLogo from './images/vip.svg';
@@ -57,9 +61,8 @@ export const partnerOffers: PartnerOffer[] = [
 		),
 		cta: {
 			label: __( 'Refer WordPress.com' ),
-			url: addQueryArgs( A4A_MARKETPLACE_HOSTING_WPCOM_LINK, {
-				purchase_type: 'referral',
-			} ),
+			url: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+			purchase_type: MARKETPLACE_TYPE_REFERRAL,
 		},
 	},
 	{
@@ -74,9 +77,8 @@ export const partnerOffers: PartnerOffer[] = [
 		),
 		cta: {
 			label: __( 'Refer Pressable' ),
-			url: addQueryArgs( A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK, {
-				purchase_type: 'referral',
-			} ),
+			url: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+			purchase_type: MARKETPLACE_TYPE_REFERRAL,
 		},
 	},
 	{
@@ -135,8 +137,8 @@ export const partnerOffers: PartnerOffer[] = [
 			label: __( 'Refer Woo' ),
 			url: addQueryArgs( A4A_MARKETPLACE_PRODUCTS_LINK, {
 				category: PRODUCT_BRAND_FILTER_WOOCOMMERCE,
-				purchase_type: 'referral',
 			} ),
+			purchase_type: MARKETPLACE_TYPE_REFERRAL,
 		},
 	},
 	{
@@ -152,8 +154,8 @@ export const partnerOffers: PartnerOffer[] = [
 			label: __( 'Refer Jetpack' ),
 			url: addQueryArgs( A4A_MARKETPLACE_PRODUCTS_LINK, {
 				category: PRODUCT_BRAND_FILTER_JETPACK,
-				purchase_type: 'referral',
 			} ),
+			purchase_type: MARKETPLACE_TYPE_REFERRAL,
 		},
 	},
 	{
@@ -174,9 +176,8 @@ export const partnerOffers: PartnerOffer[] = [
 		),
 		cta: {
 			label: __( 'Save on WordPress.com' ),
-			url: addQueryArgs( A4A_MARKETPLACE_HOSTING_WPCOM_LINK, {
-				purchase_type: 'regular',
-			} ),
+			url: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+			purchase_type: MARKETPLACE_TYPE_REGULAR,
 		},
 	},
 	{
@@ -191,9 +192,8 @@ export const partnerOffers: PartnerOffer[] = [
 		),
 		cta: {
 			label: __( 'Save on Pressable' ),
-			url: addQueryArgs( A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK, {
-				purchase_type: 'regular',
-			} ),
+			url: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+			purchase_type: MARKETPLACE_TYPE_REGULAR,
 		},
 	},
 	{
@@ -210,8 +210,8 @@ export const partnerOffers: PartnerOffer[] = [
 			label: __( 'Save on Woo' ),
 			url: addQueryArgs( A4A_MARKETPLACE_PRODUCTS_LINK, {
 				category: PRODUCT_BRAND_FILTER_WOOCOMMERCE,
-				purchase_type: 'regular',
 			} ),
+			purchase_type: MARKETPLACE_TYPE_REGULAR,
 		},
 	},
 	{
@@ -227,8 +227,8 @@ export const partnerOffers: PartnerOffer[] = [
 			label: __( 'Save on Jetpack' ),
 			url: addQueryArgs( A4A_MARKETPLACE_PRODUCTS_LINK, {
 				category: PRODUCT_BRAND_FILTER_JETPACK,
-				purchase_type: 'regular',
 			} ),
+			purchase_type: MARKETPLACE_TYPE_REGULAR,
 		},
 	},
 	{

--- a/client/a8c-for-agencies/sections/exclusive-offers/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/exclusive-offers/overview-content/index.tsx
@@ -11,6 +11,7 @@ import {
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { MARKETPLACE_TYPE_SESSION_STORAGE_KEY } from 'calypso/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type';
 import { ButtonStack } from 'calypso/dashboard/components/button-stack';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -35,6 +36,9 @@ function PartnerOfferCard( { item }: { item: PartnerOffer } ) {
 	const offerType = filterOptions.offerTypes.find( ( option ) => option.value === item.offerType );
 
 	const handleCTAClick = () => {
+		if ( item.cta.purchase_type ) {
+			sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, item.cta.purchase_type );
+		}
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_exclusive_offers_cta_click', {
 				offer_id: item.id,

--- a/client/a8c-for-agencies/sections/exclusive-offers/overview-content/types.ts
+++ b/client/a8c-for-agencies/sections/exclusive-offers/overview-content/types.ts
@@ -10,5 +10,6 @@ export type PartnerOffer = {
 	cta: {
 		label: string;
 		url: string;
+		purchase_type?: string;
 	};
 };


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1915/exclusive-offers-fix-the-toggle-for-refer-mode-when-clicking-offers-on

## Proposed Changes

This PR fixes the toggle for refer mode when clicking offers on the Exclusive Offers page. 

## Why are these changes being made?

* To be able to refer products/hosting without any issue.

## Testing Instructions

* Open the A4A live link
* Go to "Exclusive offers" > Click the "Refer WordPress.com" button on the first card > Verify the referral toggle is on > Click the "Add to referral" button > Go to checkout and verify the product is visible. Currently, there is a bug that hides the products in the cart > Go ahead and make the referral > Verify it works as expected
* Go back to "Exclusive offers" > Click the "Save on WordPress.com" button > Verify the referral toggle is off > Purchase the products and verify it works as expected.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
