### PR TITLE
MSD: Add a support link in SSL card, when the certificate can not be provisioned

### DIFF
--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -75,8 +75,22 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 		}
 
 		if ( hasFailureReasons ) {
-			return __(
-				'There are one or more problems with your DNS configuration that prevent an SSL certificate from being issued.'
+			return createInterpolateElement(
+				__(
+					'There are one or more problems with your DNS configuration that prevent an SSL certificate from being issued. <learnMoreLink />'
+				),
+				{
+					learnMoreLink: (
+						<InlineSupportLink
+							supportContext="https-ssl"
+							onClick={ () => {
+								recordTracksEvent( 'calypso_dashboard_domain_security_learn_more_click', {
+									domain: domainName,
+								} );
+							} }
+						/>
+					),
+				}
 			);
 		}
 


### PR DESCRIPTION
Closes [DOMAINS-1850](https://linear.app/a8c/issue/DOMAINS-1850/we-shouldnt-allow-users-to-try-to-provision-a-certificate-for-not)

## Proposed Changes
Add a support link in the SSL card when the SSL certificate can't be provisioned.

![Screenshot 2025-12-11 alle 09 38 55](https://github.com/user-attachments/assets/df11dd3e-16ff-4c0e-8969-229c03012929)

## Why are these changes being made?
It can be helpful for uses have a quick access to SSL guide in our support docs.

## Testing Instructions
Open the SSL card for a domain with SSL issues and verify that the "Learn more" link is rendered and opens the support docs SSL guide.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
