### PR TITLE
A4A > Exclusive offers: Remove incorrect article from WooPayments offer title

### DIFF
--- a/client/a8c-for-agencies/sections/exclusive-offers/overview-content/constants.tsx
+++ b/client/a8c-for-agencies/sections/exclusive-offers/overview-content/constants.tsx
@@ -239,7 +239,7 @@ export const partnerOffers: PartnerOffer[] = [
 		logo: (
 			<img src={ WooPaymentsLogo } alt="WooPayments" style={ { width: 'auto', height: '16px' } } />
 		),
-		title: __( 'Earn up to a 5 bps on all TPV' ),
+		title: __( 'Earn up to 5 bps on all TPV' ),
 		description: __(
 			'Earn up to a 5 basis points (bps) revenue share on all Total Payments Volume (TPV) processed on client stores you onboard or migrate to WooPayments.'
 		),


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1916/exclusive-offers-remove-incorrect-article-from-woopayments-offer-title

## Proposed Changes

This PR fixes the title for the WooPayments offer card.

## Why are these changes being made?

* Remove "a" from "Earn up to a 5 bps" since "bps" (basis points) is plural. The correct form is "Earn up to 5 bps" without the indefinite article.

## Testing Instructions

* Open the A4A live link
* Go to "Exclusive offers" > Scroll to the last card > Verify the title now says "Earn up to 5 bps on all TPV".

<img width="387" height="242" alt="Screenshot 2025-12-11 at 2 30 01 PM" src="https://github.com/user-attachments/assets/45117c60-9c52-486a-8b16-12bf31409844" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
