### PR TITLE
MSD: Refactors the "is enabled" check to consider "existing" users

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -48,6 +48,7 @@ import canDisplayCommunityTranslator from 'calypso/state/selectors/can-display-c
 import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import isRequestingMissingSites from 'calypso/state/selectors/is-requesting-missing-sites';
+import { isMultiSiteDashboardEnabled } from 'calypso/state/sites/selectors/is-multi-site-dashboard-enabled';
 import { isA8cTeamMember } from 'calypso/state/teams/selectors';
 import {
 	clearUnsavedUserSettings,
@@ -883,7 +884,7 @@ class Account extends Component {
 	};
 
 	render() {
-		const { isFetching, markChanged, translate } = this.props;
+		const { isFetching, markChanged, translate, isMSDEnabled } = this.props;
 		// Is a username change in progress?
 		const renderUsernameForm = this.hasUnsavedUserSetting( 'user_login' );
 		return (
@@ -1026,7 +1027,7 @@ class Account extends Component {
 					</form>
 				</Card>
 
-				{ config.isEnabled( 'dashboard/v2' ) && <HostingDashboardOptInForm /> }
+				{ isMSDEnabled && <HostingDashboardOptInForm /> }
 
 				{ config.isEnabled( 'me/account-close' ) && <AccountSettingsCloseLink /> }
 			</Main>
@@ -1053,6 +1054,7 @@ export default compose(
 			visibleSiteCount: getCurrentUserVisibleSiteCount( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			isAutomattician: isA8cTeamMember( state ),
+			isMSDEnabled: isMultiSiteDashboardEnabled( state ),
 		} ),
 		{
 			clearUnsavedUserSettings,

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -9,6 +9,7 @@ import MySitesSidebarUnifiedBody from 'calypso/my-sites/sidebar/body';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { isMultiSiteDashboardEnabled } from 'calypso/state/sites/selectors/is-multi-site-dashboard-enabled';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 class MySitesNavigation extends Component {
@@ -52,7 +53,7 @@ class MySitesNavigation extends Component {
 			<GlobalSidebar
 				path={ this.props.path }
 				footer={
-					config.isEnabled( 'dashboard/v2' ) &&
+					this.props.isMultiSiteDashboardEnabled &&
 					! this.props.isGlobalSidebarCollapsed && <HostingDashboardOptInBanner />
 				}
 			>
@@ -93,6 +94,7 @@ export default withCurrentRoute(
 				isGlobalSidebarVisible: shouldShowGlobalSidebar,
 				isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar,
 				isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar,
+				isMultiSiteDashboardEnabled: isMultiSiteDashboardEnabled( state ),
 			};
 		},
 		{

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -12,6 +12,7 @@ import SidebarMenu from 'calypso/layout/sidebar/menu';
 import HostingDashboardOptInBanner from 'calypso/my-sites/hosting-dashboard-opt-in-banner';
 import { getShouldShowCollapsedGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
 import { hasHostingDashboardOptIn } from 'calypso/state/sites/selectors/has-hosting-dashboard-opt-in';
+import { isMultiSiteDashboardEnabled } from 'calypso/state/sites/selectors/is-multi-site-dashboard-enabled';
 import { AppState } from 'calypso/types';
 import { SidebarIconPlugins } from '../../sidebar/static-data/global-sidebar-menu';
 import { SidebarIconCalendar } from './icons';
@@ -21,10 +22,11 @@ interface Props {
 	path: string;
 	isCollapsed: boolean;
 	hasOptIn: boolean;
+	isMultiSiteDashboardEnabled: boolean;
 }
 const managePluginsPattern = /^\/plugins\/(manage|active|inactive|updates)/;
 
-const PluginsSidebar = ( { path, isCollapsed, hasOptIn }: Props ) => {
+const PluginsSidebar = ( { path, isCollapsed, hasOptIn, isMultiSiteDashboardEnabled }: Props ) => {
 	const translate = useTranslate();
 
 	const [ previousPath, setPreviousPath ] = useState( path );
@@ -46,7 +48,7 @@ const PluginsSidebar = ( { path, isCollapsed, hasOptIn }: Props ) => {
 					"Enhance your site's features with plugins, or schedule updates to fit your needs."
 				)
 			}
-			footer={ isEnabled( 'dashboard/v2' ) && ! isCollapsed && <HostingDashboardOptInBanner /> }
+			footer={ isMultiSiteDashboardEnabled && ! isCollapsed && <HostingDashboardOptInBanner /> }
 		>
 			<SidebarMenu>
 				{ ! ( isEnabled( 'plugins/universal-header' ) && hasOptIn ) && (
@@ -119,6 +121,7 @@ export default withCurrentRoute(
 		return {
 			isCollapsed: shouldShowCollapsedGlobalSidebar,
 			hasOptIn: hasHostingDashboardOptIn( state ),
+			isMultiSiteDashboardEnabled: isMultiSiteDashboardEnabled( state ),
 		};
 	} )( PluginsSidebar )
 );

--- a/client/sites/components/sites-dashboard-banners/use-dashboard-opt-in-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-dashboard-opt-in-banner.tsx
@@ -1,15 +1,17 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { useSelector } from 'react-redux';
 import HostingDashboardOptInBanner from 'calypso/my-sites/hosting-dashboard-opt-in-banner';
+import { isMultiSiteDashboardEnabled } from 'calypso/state/sites/selectors/is-multi-site-dashboard-enabled';
 
 export function useDashboardOptInBanner() {
 	const id = 'dashboard-opt-in';
 	const isDesktop = useBreakpoint( '>=782px' );
+	const isMSDEnabled = useSelector( isMultiSiteDashboardEnabled );
 
 	return {
 		id,
 		shouldShow() {
-			return ! isDesktop && isEnabled( 'dashboard/v2' );
+			return ! isDesktop && isMSDEnabled;
 		},
 		render() {
 			return <HostingDashboardOptInBanner isMobile />;

--- a/client/state/sites/selectors/has-hosting-dashboard-opt-in.ts
+++ b/client/state/sites/selectors/has-hosting-dashboard-opt-in.ts
@@ -1,10 +1,10 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import { isMultiSiteDashboardEnabled } from 'calypso/state/sites/selectors/is-multi-site-dashboard-enabled';
 import type { HostingDashboardOptIn } from '@automattic/api-core';
 import type { AppState } from 'calypso/types';
 
 export const hasHostingDashboardOptIn = ( state: AppState ): boolean => {
-	if ( ! isEnabled( 'dashboard/v2' ) ) {
+	if ( ! isMultiSiteDashboardEnabled( state ) ) {
 		return false;
 	}
 

--- a/client/state/sites/selectors/is-multi-site-dashboard-enabled.ts
+++ b/client/state/sites/selectors/is-multi-site-dashboard-enabled.ts
@@ -1,0 +1,19 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import type { AppState } from 'calypso/types';
+
+// TODO: Set to a specific user when feature is rolled out to a limited audience.
+export const OLDEST_ELIGIBLE_USER = Infinity;
+
+export const isMultiSiteDashboardEnabled = ( state: AppState ): boolean => {
+	if ( ! isEnabled( 'dashboard/v2' ) ) {
+		return false;
+	}
+
+	const user = getCurrentUser( state ); // Ensure current user is loaded.
+	if ( ! user || user.ID > OLDEST_ELIGIBLE_USER ) {
+		return false;
+	}
+
+	return true;
+};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Refactored so that when the `dashboard/v2` feature flag goes away we instead can enable the feature based on whether the user is considered an "existing" user.

Some of the `dashboard/v2` checks are left unchanged. These are mainly to do with routing. I think when the rollout happens, the MSD routes will become available, regardless of whether a user is "existing" or has opt-in or not. The simplest approach is to simply not hide them. It's possible to hide them, but will involve loading the the user data during server side rendering, which we don't always do. So it'd be a bit more complicated to achieve that.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Preparing for the rollout strategy for existing users pgz0xU-sd-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Nothing should be different 🤞 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?