### PR TITLE
MSD Emails: Fix empty state button links

### DIFF
--- a/client/dashboard/emails/components/no-emails-available-empty-state.tsx
+++ b/client/dashboard/emails/components/no-emails-available-empty-state.tsx
@@ -1,9 +1,13 @@
+import { useNavigate } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { chooseDomainRoute, addEmailForwarderRoute } from '../../app/router/emails';
 import { DataViewsEmptyState } from '../../components/dataviews';
 import EmailEmptyIllustration from '../resources/email-empty-illustration';
 
 const NoEmailsAvailableEmptyState = () => {
+	const navigate = useNavigate();
+
 	return (
 		<DataViewsEmptyState
 			title={ __( 'Stand out with professional email' ) }
@@ -13,8 +17,19 @@ const NoEmailsAvailableEmptyState = () => {
 			illustration={ <EmailEmptyIllustration /> }
 			actions={
 				<>
-					<Button variant="primary">{ __( 'Add mailbox' ) }</Button>
-					<Button className="emails__add-email-forwarder" variant="secondary">
+					<Button
+						variant="primary"
+						__next40pxDefaultSize
+						onClick={ () => navigate( { to: chooseDomainRoute.to } ) }
+					>
+						{ __( 'Add mailbox' ) }
+					</Button>
+					<Button
+						className="emails__add-email-forwarder"
+						variant="secondary"
+						__next40pxDefaultSize
+						onClick={ () => navigate( { to: addEmailForwarderRoute.to } ) }
+					>
 						{ __( 'Add email forwarder' ) }
 					</Button>
 				</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
https://linear.app/a8c/issue/DOTMSD-938/the-email-empty-state-buttons-dont-work

## Proposed Changes

* Added links to the empty state buttons.


https://github.com/user-attachments/assets/c100b116-c6c2-47ed-a408-95c123ceb017



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing MSD effort

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Navigate to `/v2/emails`
* Make sure you see the empty state (no emails added yet)
* Click on the buttons shown
* They should initiate the flows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
