### PR TITLE
Add message and escalation option on error

### DIFF
--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -13,6 +13,7 @@ import {
 	interactionHasZendeskEvent,
 	getIsRequestingHumanSupport,
 	getIsLastBotMessage,
+	getIsErrorMessage,
 } from '../../utils';
 import getMostRecentOpenLiveInteraction from '../notices/get-most-recent-open-live-interaction';
 import BotMessageActions from './bot-message-actions';
@@ -79,9 +80,12 @@ export const UserMessage = ( {
 	const isRequestingHumanSupport = getIsRequestingHumanSupport( message );
 	const isLastBotMessage = getIsLastBotMessage( chat, message );
 	const hasRecentOpenConversation = getMostRecentOpenLiveInteraction();
-
+	const isErrorMessage = getIsErrorMessage( message );
 	const isMessageShowingDisclaimer =
 		message.context?.question_tags?.inquiry_type !== 'request-for-human-support';
+
+	const showGetSupport = isLastBotMessage && ( isRequestingHumanSupport || isErrorMessage );
+	const showActionButtons = ! isRequestingHumanSupport && ! isErrorMessage;
 
 	const shouldOverrideWithForwardMessage = isRequestingHumanSupport && chat.provider !== 'zendesk';
 
@@ -111,7 +115,7 @@ export const UserMessage = ( {
 			</div>
 			{ isMessageWithEscalationOption && (
 				<>
-					{ isRequestingHumanSupport && isLastBotMessage && (
+					{ showGetSupport && (
 						<GetSupport
 							onClickAdditionalEvent={ ( destination ) => {
 								trackEvent( 'chat_get_support', {
@@ -121,7 +125,7 @@ export const UserMessage = ( {
 							} }
 						/>
 					) }{ ' ' }
-					{ ! isRequestingHumanSupport && (
+					{ showActionButtons && (
 						<>
 							{ ! interactionHasZendeskEvent( currentSupportInteraction ) && (
 								<BotMessageActions message={ message } />

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -274,6 +274,10 @@ export const getErrorMessageUnknownError = (): Message => {
 			flags: {
 				show_ai_avatar: true,
 				is_error_message: true,
+				forward_to_human_support: false,
+			},
+			question_tags: {
+				inquiry_type: 'request-for-human-support',
 			},
 		},
 	};

--- a/packages/odie-client/src/utils/index.ts
+++ b/packages/odie-client/src/utils/index.ts
@@ -15,6 +15,10 @@ export const getIsRequestingHumanSupport = ( message: Message ) => {
 	return message.context?.flags?.forward_to_human_support ?? false;
 };
 
+export const getIsErrorMessage = ( message: Message ) => {
+	return message.context?.flags?.is_error_message ?? false;
+};
+
 export const getIsLastBotMessage = ( chat: Chat, message: Message ) => {
 	return (
 		chat?.messages?.length > 0 &&


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

| Error and Zendesk not Available  | Error and Zendesk is Available |
| ------------- | ------------- |
| <img width="430" height="775" alt="Screenshot 2025-12-11 at 18 10 04" src="https://github.com/user-attachments/assets/8ae08404-40e7-4e4d-b8e5-cfd31f3c318f" />  | <img width="444" height="769" alt="Screenshot 2025-12-11 at 18 10 14" src="https://github.com/user-attachments/assets/0fc07eda-c316-4e64-a517-b18d4b7fde64" /> |

Part of #DOTSUP-378

## Proposed Changes

* Show message and GetSupport buttons on error

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Provide options to reach support on error

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Force the backend to return error:
```
	public function send_chat_message( $request ) {
		return new WP_Error( 'test', 'Something wrong happened', [ 'status' => 403 ] );
```
* Open the help center
* Send a message to odie
* The message should show along with the available support buttons
* To test messaging not being initalized add a long delay before smooch is initialized

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
