### PR TITLE
SSH Migration: Update the migration status when landing on the SSH Migration step

### DIFF
--- a/client/data/site-migration/landing/types.ts
+++ b/client/data/site-migration/landing/types.ts
@@ -5,4 +5,6 @@ export enum MigrationStatus {
 	// Do it yourself
 	PENDING_DIY = 'migration-pending-diy',
 	STARTED_DIY = 'migration-started-diy',
+	// SSH
+	PENDING_SSH = 'migration-pending-ssh',
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-setup-ssh-migration.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-setup-ssh-migration.ts
@@ -1,0 +1,50 @@
+import { useMutation } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface SetupSSHMigrationParams {
+	siteId: number;
+	migrationSourceSiteDomain: string;
+}
+
+interface SetupSSHMigrationResponse {
+	success: boolean;
+	migration_source_site_domain: string;
+	message: string;
+}
+
+/**
+ * Sets up site migration by registering the source domain
+ * @param params - Migration parameters including site ID and source domain
+ * @returns Promise with migration setup response
+ */
+const setupSSHMigration = async (
+	params: SetupSSHMigrationParams
+): Promise< SetupSSHMigrationResponse > => {
+	try {
+		const response = await wpcom.req.post( {
+			path: `/sites/${ params.siteId }/ssh-migration`,
+			apiNamespace: 'wpcom/v2',
+			body: {
+				migration_source_site_domain: params.migrationSourceSiteDomain,
+			},
+		} );
+
+		if ( ! response.success ) {
+			throw new Error( response.message || 'Failed to setup site migration' );
+		}
+
+		return response;
+	} catch ( error ) {
+		throw new Error( error instanceof Error ? error.message : 'Failed to setup site migration' );
+	}
+};
+
+/**
+ * Hook to setup site migration
+ * @returns Mutation object with setup function and status
+ */
+export const useSetupSSHMigration = () => {
+	return useMutation< SetupSSHMigrationResponse, Error, SetupSSHMigrationParams >( {
+		mutationFn: setupSSHMigration,
+	} );
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -6,6 +6,8 @@ import emailValidator from 'email-validator';
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { MigrationStatus } from 'calypso/data/site-migration/landing/types';
+import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/use-update-migration-status';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -87,6 +89,7 @@ const SiteMigrationSshShareAccess: StepType< {
 	const locale = useLocale();
 	const siteSlug = useSiteSlugParam() ?? '';
 	const { sendTicketAsync, isPending: isSubmittingTicket } = useSubmitMigrationTicket();
+	const { mutateAsync: updateMigrationStatus } = useUpdateMigrationStatus( siteId );
 
 	// Redirect back to verification step if transferId is missing
 	useEffect( () => {
@@ -94,6 +97,21 @@ const SiteMigrationSshShareAccess: StepType< {
 			navigation.submit?.( { destination: 'back-to-verification' } );
 		}
 	}, [ transferId, navigation ] );
+
+	// Update migration status to pending SSH when the user reaches this step
+	useEffect( () => {
+		const currentStatus = site?.site_migration?.migration_status;
+
+		// Only update if status is not already set to a migration status
+		if ( siteId && currentStatus !== MigrationStatus.PENDING_SSH ) {
+			updateMigrationStatus( { status: MigrationStatus.PENDING_SSH } ).catch( ( error: Error ) => {
+				// Log error but don't block the user from continuing
+				recordTracksEvent( 'calypso_site_migration_ssh_status_update_error', {
+					error: error instanceof Error ? error.message : 'Unknown error',
+				} );
+			} );
+		}
+	}, [ siteId, site?.site_migration?.migration_status, updateMigrationStatus ] );
 
 	const handleNoSSHAccess = useCallback( async () => {
 		setIsProcessingNoSSH( true );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -6,8 +6,6 @@ import emailValidator from 'email-validator';
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { MigrationStatus } from 'calypso/data/site-migration/landing/types';
-import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/use-update-migration-status';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -26,6 +24,7 @@ import { Accordion } from './components/accordion';
 import { SshMigrationContainer } from './components/ssh-migration-container';
 import { usePollSSHMigrationAtomicTransfer } from './hooks/use-poll-ssh-migration-atomic-transfer';
 import { useRotatingLoadingMessages } from './hooks/use-rotating-loading-messages';
+import { useSetupSSHMigration } from './hooks/use-setup-ssh-migration';
 import { useStartSSHMigration } from './hooks/use-start-ssh-migration';
 import { getSSHHostDisplayName } from './steps/ssh-host-support-urls';
 import { useSteps } from './steps/use-steps';
@@ -89,7 +88,7 @@ const SiteMigrationSshShareAccess: StepType< {
 	const locale = useLocale();
 	const siteSlug = useSiteSlugParam() ?? '';
 	const { sendTicketAsync, isPending: isSubmittingTicket } = useSubmitMigrationTicket();
-	const { mutateAsync: updateMigrationStatus } = useUpdateMigrationStatus( siteId );
+	const { mutateAsync: setupSSHMigration } = useSetupSSHMigration();
 
 	// Redirect back to verification step if transferId is missing
 	useEffect( () => {
@@ -98,20 +97,25 @@ const SiteMigrationSshShareAccess: StepType< {
 		}
 	}, [ transferId, navigation ] );
 
-	// Update migration status to pending SSH when the user reaches this step
+	// Setup site migration when the user reaches this step
 	useEffect( () => {
-		const currentStatus = site?.site_migration?.migration_status;
+		const migrationSourceSiteDomain = urlToDomain( fromUrl );
+		const storedSourceSite = site?.options?.migration_source_site_domain;
 
-		// Only update if status is not already set to a migration status
-		if ( siteId && currentStatus !== MigrationStatus.PENDING_SSH ) {
-			updateMigrationStatus( { status: MigrationStatus.PENDING_SSH } ).catch( ( error: Error ) => {
+		// Only setup if we have all required data and migration is not already configured
+		if (
+			siteId &&
+			migrationSourceSiteDomain &&
+			( ! storedSourceSite || migrationSourceSiteDomain !== storedSourceSite )
+		) {
+			setupSSHMigration( { siteId, migrationSourceSiteDomain } ).catch( ( error: Error ) => {
 				// Log error but don't block the user from continuing
-				recordTracksEvent( 'calypso_site_migration_ssh_status_update_error', {
+				recordTracksEvent( 'calypso_site_migration_ssh_setup_error', {
 					error: error instanceof Error ? error.message : 'Unknown error',
 				} );
 			} );
 		}
-	}, [ siteId, site?.site_migration?.migration_status, updateMigrationStatus ] );
+	}, [ siteId, fromUrl, site?.options?.migration_source_site_domain, setupSSHMigration ] );
 
 	const handleNoSSHAccess = useCallback( async () => {
 		setIsProcessingNoSSH( true );


### PR DESCRIPTION


<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCOM-15176

## Proposed Changes

* Ensures that the user can return to the SSH Migration flow.
* We now update the tracking sticker when the user lands on the `Securely share your access` step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The users didn't have a clear way to return to the SSH Migration flow if they left it in the middle of the flow. This PR aims to address this, like we do in other migration flows.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso live or apply this PR to your local environment
* Navigate to `/setup/site-migration` and ensure you input an site that allows the SSH migration.
* Go through the flow until you reach the `Securely share your acesss`
* Now navigate to `/sites` and look for the site you just started the migration. You should see the `Migration Pending` label.
* If you click on the site, you should see the `Your WordPress site is ready to be migrated` screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
