### PR TITLE
MSD Domains Bulk Contact Editing: Move warning within the notice

### DIFF
--- a/client/dashboard/components/domain-contact-details-form/contact-form.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form.tsx
@@ -21,6 +21,7 @@ import { RegionAddressFieldsLayout } from './region-address-fieldsets';
 import type { UseMutateAsyncFunction } from '@tanstack/react-query';
 interface ContactFormProps {
 	initialData?: DomainContactDetails;
+	beforeFormCard?: React.ReactNode;
 	beforeForm?: React.ReactNode;
 	isSubmitting: boolean;
 	onSubmit: ( normalizedFormData: DomainContactDetails ) => void;
@@ -30,6 +31,7 @@ interface ContactFormProps {
 export default function ContactForm( {
 	initialData,
 	isSubmitting,
+	beforeFormCard,
 	beforeForm,
 	onSubmit,
 	validate,
@@ -170,11 +172,12 @@ export default function ContactForm( {
 				</VStack>
 			</Notice>
 
-			{ beforeForm }
+			{ beforeFormCard }
 
 			<Card>
 				<CardBody>
 					<VStack spacing={ 4 }>
+						{ beforeForm }
 						<DataForm< DomainContactDetails >
 							data={ normalizedFormData }
 							fields={ fields }

--- a/client/dashboard/domains/domain-contact-details/index.tsx
+++ b/client/dashboard/domains/domain-contact-details/index.tsx
@@ -147,7 +147,7 @@ export default function DomainContactInfo() {
 			<ContactForm
 				isSubmitting={ isSubmitting }
 				onSubmit={ handleSubmit }
-				beforeForm={
+				beforeFormCard={
 					! domain.is_hundred_year_domain && (
 						<Card>
 							<CardBody>

--- a/client/dashboard/domains/domains-contact-details/index.tsx
+++ b/client/dashboard/domains/domains-contact-details/index.tsx
@@ -14,11 +14,13 @@ import { useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { domainsContactInfoRoute, domainsIndexRoute } from '../../app/router/domains';
 import ContactForm from '../../components/domain-contact-details-form/contact-form';
+import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
 import { mostCommonValueInArray } from '../../utils/collection';
 import { omit } from '../../utils/object';
+import './style.scss';
 
 const aggregateWhoisDataWithMostCommonValues = (
 	whoisData: WhoisDataEntry[]
@@ -161,41 +163,39 @@ export default function DomainsContactInfo() {
 				/>
 			}
 		>
-			<div>
-				<Text variant="muted">
-					{ __( 'Note: Changes may take a few minutes to appear on the dashboard' ) }
-				</Text>
-			</div>
-			<div>
-				<span>{ sprintf( editingMessage, { domainCount: selectedDomains.length } ) }</span>
-				<ul>
-					{ selectedDomains.map( ( domain ) => (
-						<li key={ domain }>{ domain }</li>
-					) ) }
-				</ul>
-			</div>
-			{ domainsWithUnmodifiableContactInfo.length > 0 && (
-				<div>
-					<span>
-						<strong>{ __( 'The following domain fields will not be updated:' ) }</strong>
-					</span>
-					<ul>
-						{ domainsWithUnmodifiableContactInfo.map( ( domain ) => (
-							<li key={ domain.domain }>
-								<strong>{ domain.domain }</strong>
-								<ul style={ { listStylePosition: 'inside' } }>
-									{ domain.whois_update_unmodifiable_fields.map( ( field: string ) => (
-										<li key={ field }>{ getFieldMapping( field ) }</li>
-									) ) }
-								</ul>
-							</li>
-						) ) }
-					</ul>
-				</div>
-			) }
 			<ContactForm
 				key={ key }
 				initialData={ initialData }
+				beforeForm={
+					<Notice
+						variant="warning"
+						title={ sprintf( editingMessage, { domainCount: selectedDomains.length } ) }
+					>
+						<ul className="domains-contact-details__list">
+							{ selectedDomains.map( ( domain ) => (
+								<li key={ domain }>{ domain }</li>
+							) ) }
+						</ul>
+						<Text>{ __( 'Updates may take a few minutes to appear.' ) }</Text>
+						{ domainsWithUnmodifiableContactInfo.length > 0 && (
+							<>
+								<Text weight="bold">
+									{ __( 'The following domain fields will not be updated:' ) }
+								</Text>
+								<ul className="domains-contact-details__list">
+									{ domainsWithUnmodifiableContactInfo.map( ( domain ) => (
+										<li key={ domain.domain }>
+											<strong>{ domain.domain }</strong>:
+											{ domain.whois_update_unmodifiable_fields
+												.map( ( field: string ) => getFieldMapping( field ) )
+												.join( ', ' ) }
+										</li>
+									) ) }
+								</ul>
+							</>
+						) }
+					</Notice>
+				}
 				isSubmitting={ isValidatePending || isUpdatePending }
 				onSubmit={ handleSubmit }
 				validate={ validateBulkDomainsAsync }

--- a/client/dashboard/domains/domains-contact-details/index.tsx
+++ b/client/dashboard/domains/domains-contact-details/index.tsx
@@ -20,7 +20,6 @@ import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
 import { mostCommonValueInArray } from '../../utils/collection';
 import { omit } from '../../utils/object';
-import './style.scss';
 
 const aggregateWhoisDataWithMostCommonValues = (
 	whoisData: WhoisDataEntry[]
@@ -171,9 +170,11 @@ export default function DomainsContactInfo() {
 						variant="warning"
 						title={ sprintf( editingMessage, { domainCount: selectedDomains.length } ) }
 					>
-						<ul className="domains-contact-details__list">
+						<ul style={ { paddingLeft: 0 } }>
 							{ selectedDomains.map( ( domain ) => (
-								<li key={ domain }>{ domain }</li>
+								<li key={ domain } style={ { listStylePosition: 'inside' } }>
+									{ domain }
+								</li>
 							) ) }
 						</ul>
 						<Text>{ __( 'Updates may take a few minutes to appear.' ) }</Text>
@@ -182,9 +183,9 @@ export default function DomainsContactInfo() {
 								<Text weight="bold">
 									{ __( 'The following domain fields will not be updated:' ) }
 								</Text>
-								<ul className="domains-contact-details__list">
+								<ul style={ { paddingLeft: 0 } }>
 									{ domainsWithUnmodifiableContactInfo.map( ( domain ) => (
-										<li key={ domain.domain }>
+										<li key={ domain.domain } style={ { listStylePosition: 'inside' } }>
 											<strong>{ domain.domain }</strong>:
 											{ domain.whois_update_unmodifiable_fields
 												.map( ( field: string ) => getFieldMapping( field ) )

--- a/client/dashboard/domains/domains-contact-details/style.scss
+++ b/client/dashboard/domains/domains-contact-details/style.scss
@@ -1,7 +1,0 @@
-.domains-contact-details__list {
-	padding-left: 0;
-
-	li {
-		list-style-position: inside;
-	}
-}

--- a/client/dashboard/domains/domains-contact-details/style.scss
+++ b/client/dashboard/domains/domains-contact-details/style.scss
@@ -1,0 +1,7 @@
+.domains-contact-details__list {
+	padding-left: 0;
+
+	li {
+		list-style-position: inside;
+	}
+}


### PR DESCRIPTION
Addresses p1765334414686929/1764621573.932439-slack-C04H4NY6STW.

## Proposed Changes

| Before | After |
| --- | --- |
| <img width="2382" height="1876" alt="image" src="https://github.com/user-attachments/assets/415649af-e51b-4575-8aca-8e94ac77e0ce" /> | <img width="727" height="569" alt="image" src="https://github.com/user-attachments/assets/bf89b874-f4fa-4241-b7bb-d47139124f57" /> |

## Why are these changes being made?

Design consistency.

## Testing Instructions

Enter `/v2/domains/contact-info?selected=%s` where `%s` is a list of domains that you own, separated by a comma. You should see the notice within the form instead of above it.