### PR TITLE
Fix the "Transfer to another user" screen in the hosting dashboard

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -18,6 +18,7 @@ import {
 	domainAvailabilityQuery,
 	domainInboundTransferStatusQuery,
 	purchaseQuery,
+	siteUsersWpcomQuery,
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import {
@@ -633,6 +634,7 @@ export const domainTransferToOtherUserRoute = createRoute( {
 	loader: async ( { params: { domainName } } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
 		await queryClient.ensureQueryData( domainTransferRequestQuery( domainName, domain.site_slug ) );
+		await queryClient.ensureQueryData( siteUsersWpcomQuery( domain.blog_id, 'administrator' ) );
 	},
 } ).lazy( () =>
 	import( '../../domains/domain-transfer/transfer-domain-to-other-user' ).then( ( d ) =>

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -633,8 +633,10 @@ export const domainTransferToOtherUserRoute = createRoute( {
 	path: 'other-user',
 	loader: async ( { params: { domainName } } ) => {
 		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
-		await queryClient.ensureQueryData( domainTransferRequestQuery( domainName, domain.site_slug ) );
-		await queryClient.ensureQueryData( siteUsersWpcomQuery( domain.blog_id, 'administrator' ) );
+		await Promise.all( [
+			queryClient.ensureQueryData( domainTransferRequestQuery( domainName, domain.site_slug ) ),
+			queryClient.ensureQueryData( siteUsersWpcomQuery( domain.blog_id, 'administrator' ) ),
+		] );
 	},
 } ).lazy( () =>
 	import( '../../domains/domain-transfer/transfer-domain-to-other-user' ).then( ( d ) =>

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -94,6 +94,14 @@ export default function TransferDomainToOtherUser() {
 	const fields = useMemo( () => {
 		return createFields( availableUsers );
 	}, [ availableUsers ] );
+	const selectedUser = useMemo( () => {
+		if ( ! formData.user ) {
+			return undefined;
+		}
+		return availableUsers.find(
+			( user ) => getWpcomUserId( user ) === parseInt( formData.user, 10 )
+		);
+	}, [ availableUsers, formData.user ] );
 
 	const isMapping = domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION;
 
@@ -103,9 +111,6 @@ export default function TransferDomainToOtherUser() {
 	};
 
 	const onConfirm = () => {
-		const selectedUser = availableUsers.find(
-			( user ) => getWpcomUserId( user ) === parseInt( formData.user )
-		);
 		domainTransferToOtherUser( formData.user, {
 			onSuccess: () => {
 				createSuccessNotice(
@@ -208,10 +213,6 @@ export default function TransferDomainToOtherUser() {
 	};
 
 	const renderConfirmationDialog = () => {
-		const selectedUser = availableUsers.find(
-			( user ) => getWpcomUserId( user ) === parseInt( formData.user )
-		);
-
 		return (
 			<Modal title={ __( 'Confirm transfer' ) } onRequestClose={ () => setIsDialogOpen( false ) }>
 				<VStack spacing={ 6 }>

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -1,5 +1,9 @@
-import { DomainSubtype, type SiteUser } from '@automattic/api-core';
-import { domainQuery, domainTransferToUserMutation, siteUsersQuery } from '@automattic/api-queries';
+import { DomainSubtype, type WpcomSiteUser } from '@automattic/api-core';
+import {
+	domainQuery,
+	domainTransferToUserMutation,
+	siteUsersWpcomQuery,
+} from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -33,7 +37,14 @@ export type TransferFormData = {
 	user: string;
 };
 
-const createFields = ( users: SiteUser[] ): Field< TransferFormData >[] => [
+const getWpcomUserId = ( user: WpcomSiteUser ) => user.linked_user_ID ?? user.ID;
+
+const getUserDisplayName = ( user: WpcomSiteUser ) => {
+	const { first_name, last_name, nice_name } = user;
+	return first_name && last_name ? `${ first_name } ${ last_name } (${ nice_name })` : nice_name;
+};
+
+const createFields = ( users: WpcomSiteUser[] ): Field< TransferFormData >[] => [
 	{
 		id: 'user',
 		label: __( 'New owner' ),
@@ -42,8 +53,8 @@ const createFields = ( users: SiteUser[] ): Field< TransferFormData >[] => [
 				? [
 						{ value: '', label: __( 'Choose an administrator on this site' ) },
 						...users.map( ( user ) => ( {
-							value: user.id,
-							label: user.name,
+							value: getWpcomUserId( user ),
+							label: getUserDisplayName( user ),
 						} ) ),
 				  ]
 				: [ { value: '', label: '--' + __( 'Site has no other administrators' ) + '--' } ],
@@ -61,7 +72,9 @@ const form = {
 export default function TransferDomainToOtherUser() {
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: users } = useSuspenseQuery( siteUsersQuery( domain.blog_id ) );
+	const { data: usersResponse } = useSuspenseQuery(
+		siteUsersWpcomQuery( domain.blog_id, 'administrator' )
+	);
 	const { user: currentUser } = useAuth();
 	const { mutate: domainTransferToOtherUser, isPending: isDomainTransferringToOtherUser } =
 		useMutation( domainTransferToUserMutation( domainName, domain.blog_id ) );
@@ -73,10 +86,10 @@ export default function TransferDomainToOtherUser() {
 	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
 
 	const availableUsers = useMemo( () => {
-		return users.filter( ( user: SiteUser ) => {
-			return user.id !== currentUser.ID;
+		return usersResponse.users.filter( ( user: WpcomSiteUser ) => {
+			return getWpcomUserId( user ) !== currentUser.ID;
 		} );
-	}, [ users, currentUser.ID ] );
+	}, [ usersResponse.users, currentUser.ID ] );
 	const fields = useMemo( () => {
 		return createFields( availableUsers );
 	}, [ availableUsers ] );
@@ -90,7 +103,7 @@ export default function TransferDomainToOtherUser() {
 
 	const onConfirm = () => {
 		const selectedUser = availableUsers.find(
-			( user ) => ( user.id as unknown as string ) === formData.user
+			( user ) => String( getWpcomUserId( user ) ) === formData.user
 		);
 		domainTransferToOtherUser( formData.user, {
 			onSuccess: () => {
@@ -98,7 +111,12 @@ export default function TransferDomainToOtherUser() {
 					sprintf(
 						/* Translators: %s: domainName is the domain name, %s: selectedUserDisplay is the selected user display */
 						__( '%(selectedDomainName)s has been transferred to %(selectedUserDisplay)s' ),
-						{ args: { selectedDomainName: domainName, selectedUserDisplay: selectedUser?.name } }
+						{
+							args: {
+								selectedDomainName: domainName,
+								selectedUserDisplay: selectedUser ? getUserDisplayName( selectedUser ) : '',
+							},
+						}
 					)
 				);
 				setIsDialogOpen( false );
@@ -189,7 +207,9 @@ export default function TransferDomainToOtherUser() {
 	};
 
 	const renderConfirmationDialog = () => {
-		const selectedUser = availableUsers.find( ( user ) => user.id.toString() === formData.user );
+		const selectedUser = availableUsers.find(
+			( user ) => String( getWpcomUserId( user ) ) === formData.user
+		);
 
 		return (
 			<Modal title={ __( 'Confirm transfer' ) } onRequestClose={ () => setIsDialogOpen( false ) }>
@@ -205,7 +225,9 @@ export default function TransferDomainToOtherUser() {
 								  ),
 							{
 								domainName: <strong>{ domainName }</strong>,
-								selectedUserDisplay: <strong>{ selectedUser?.name }</strong>,
+								selectedUserDisplay: (
+									<strong>{ selectedUser ? getUserDisplayName( selectedUser ) : '' }</strong>
+								),
 							}
 						) }
 					</Text>

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -40,8 +40,9 @@ export type TransferFormData = {
 const getWpcomUserId = ( user: WpcomSiteUser ) => user.linked_user_ID ?? user.ID;
 
 const getUserDisplayName = ( user: WpcomSiteUser ) => {
-	const { first_name, last_name, nice_name } = user;
-	return first_name && last_name ? `${ first_name } ${ last_name } (${ nice_name })` : nice_name;
+	const { name, nice_name, email } = user;
+
+	return name || nice_name || email;
 };
 
 const createFields = ( users: WpcomSiteUser[] ): Field< TransferFormData >[] => [

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -104,7 +104,7 @@ export default function TransferDomainToOtherUser() {
 
 	const onConfirm = () => {
 		const selectedUser = availableUsers.find(
-			( user ) => String( getWpcomUserId( user ) ) === formData.user
+			( user ) => getWpcomUserId( user ) === parseInt( formData.user )
 		);
 		domainTransferToOtherUser( formData.user, {
 			onSuccess: () => {
@@ -209,7 +209,7 @@ export default function TransferDomainToOtherUser() {
 
 	const renderConfirmationDialog = () => {
 		const selectedUser = availableUsers.find(
-			( user ) => String( getWpcomUserId( user ) ) === formData.user
+			( user ) => getWpcomUserId( user ) === parseInt( formData.user )
 		);
 
 		return (

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -73,7 +73,7 @@ const form = {
 export default function TransferDomainToOtherUser() {
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: usersResponse } = useSuspenseQuery(
+	const { data: users } = useSuspenseQuery(
 		siteUsersWpcomQuery( domain.blog_id, 'administrator' )
 	);
 	const { user: currentUser } = useAuth();
@@ -87,10 +87,10 @@ export default function TransferDomainToOtherUser() {
 	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
 
 	const availableUsers = useMemo( () => {
-		return usersResponse.users.filter( ( user: WpcomSiteUser ) => {
+		return users.filter( ( user: WpcomSiteUser ) => {
 			return getWpcomUserId( user ) !== currentUser.ID;
 		} );
-	}, [ usersResponse.users, currentUser.ID ] );
+	}, [ users, currentUser.ID ] );
 	const fields = useMemo( () => {
 		return createFields( availableUsers );
 	}, [ availableUsers ] );

--- a/packages/api-core/src/site-users/fetchers.ts
+++ b/packages/api-core/src/site-users/fetchers.ts
@@ -1,5 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { SiteUser, WpcomSiteUsersResponse } from './types';
+import type { SiteUser, WpcomSiteUser, WpcomSiteUsersResponse } from './types';
 
 export async function fetchCurrentSiteUser( siteId: number ): Promise< SiteUser > {
 	return wpcom.req.get( {
@@ -18,8 +18,8 @@ export async function fetchSiteUsers( siteId: number ): Promise< SiteUser[] > {
 export async function fetchWpcomSiteUsers(
 	siteId: number,
 	options?: { role?: string }
-): Promise< WpcomSiteUsersResponse > {
-	return wpcom.req.get( {
+): Promise< WpcomSiteUser[] > {
+	const response: WpcomSiteUsersResponse = await wpcom.req.get( {
 		path: `/sites/${ siteId }/users`,
 		apiVersion: '1.1',
 		query: {
@@ -27,4 +27,5 @@ export async function fetchWpcomSiteUsers(
 			...options,
 		},
 	} );
+	return response.users;
 }

--- a/packages/api-core/src/site-users/fetchers.ts
+++ b/packages/api-core/src/site-users/fetchers.ts
@@ -15,7 +15,7 @@ export async function fetchSiteUsers( siteId: number ): Promise< SiteUser[] > {
 	} );
 }
 
-export async function fetchSiteUsersWpcom(
+export async function fetchWpcomSiteUsers(
 	siteId: number,
 	role?: string
 ): Promise< WpcomSiteUsersResponse > {

--- a/packages/api-core/src/site-users/fetchers.ts
+++ b/packages/api-core/src/site-users/fetchers.ts
@@ -1,5 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { SiteUser } from './types';
+import type { SiteUser, WpcomSiteUsersResponse } from './types';
 
 export async function fetchCurrentSiteUser( siteId: number ): Promise< SiteUser > {
 	return wpcom.req.get( {
@@ -12,5 +12,19 @@ export async function fetchSiteUsers( siteId: number ): Promise< SiteUser[] > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/users`,
 		apiNamespace: 'wp/v2',
+	} );
+}
+
+export async function fetchSiteUsersWpcom(
+	siteId: number,
+	role?: string
+): Promise< WpcomSiteUsersResponse > {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/users`,
+		apiVersion: '1.1',
+		query: {
+			force: 'wpcom',
+			...( role && { role } ),
+		},
 	} );
 }

--- a/packages/api-core/src/site-users/fetchers.ts
+++ b/packages/api-core/src/site-users/fetchers.ts
@@ -17,14 +17,14 @@ export async function fetchSiteUsers( siteId: number ): Promise< SiteUser[] > {
 
 export async function fetchWpcomSiteUsers(
 	siteId: number,
-	role?: string
+	options?: { role?: string }
 ): Promise< WpcomSiteUsersResponse > {
 	return wpcom.req.get( {
 		path: `/sites/${ siteId }/users`,
 		apiVersion: '1.1',
 		query: {
 			force: 'wpcom',
-			...( role && { role } ),
+			...options,
 		},
 	} );
 }

--- a/packages/api-core/src/site-users/types.ts
+++ b/packages/api-core/src/site-users/types.ts
@@ -3,3 +3,25 @@ export interface SiteUser {
 	name: string;
 	slug: string;
 }
+
+export interface WpcomSiteUser {
+	ID: number;
+	linked_user_ID?: number;
+	login: string;
+	email: string;
+	name: string;
+	first_name: string;
+	last_name: string;
+	nice_name: string;
+	URL: string;
+	avatar_URL: string;
+	profile_URL: string;
+	site_ID: number;
+	roles: string[];
+	is_super_admin: boolean;
+}
+
+export interface WpcomSiteUsersResponse {
+	found: number;
+	users: WpcomSiteUser[];
+}

--- a/packages/api-queries/src/site-users.ts
+++ b/packages/api-queries/src/site-users.ts
@@ -33,5 +33,5 @@ export const siteUsersQuery = ( siteId: number ) =>
 export const siteUsersWpcomQuery = ( siteId: number, role?: string ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'wpcom-users', role ],
-		queryFn: () => fetchWpcomSiteUsers( siteId, role ),
+		queryFn: () => fetchWpcomSiteUsers( siteId, { role } ),
 	} );

--- a/packages/api-queries/src/site-users.ts
+++ b/packages/api-queries/src/site-users.ts
@@ -32,6 +32,6 @@ export const siteUsersQuery = ( siteId: number ) =>
 
 export const siteUsersWpcomQuery = ( siteId: number, role?: string ) =>
 	queryOptions( {
-		queryKey: [ 'site', siteId, 'wpcom-users', 'wpcom', role ],
+		queryKey: [ 'site', siteId, 'wpcom-users', role ],
 		queryFn: () => fetchWpcomSiteUsers( siteId, role ),
 	} );

--- a/packages/api-queries/src/site-users.ts
+++ b/packages/api-queries/src/site-users.ts
@@ -1,4 +1,9 @@
-import { fetchCurrentSiteUser, deleteSiteUser, fetchSiteUsers } from '@automattic/api-core';
+import {
+	fetchCurrentSiteUser,
+	deleteSiteUser,
+	fetchSiteUsers,
+	fetchSiteUsersWpcom,
+} from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
@@ -23,4 +28,10 @@ export const siteUsersQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'users', 'list' ],
 		queryFn: () => fetchSiteUsers( siteId ),
+	} );
+
+export const siteUsersWpcomQuery = ( siteId: number, role?: string ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'users', 'wpcom', role ],
+		queryFn: () => fetchSiteUsersWpcom( siteId, role ),
 	} );

--- a/packages/api-queries/src/site-users.ts
+++ b/packages/api-queries/src/site-users.ts
@@ -32,6 +32,6 @@ export const siteUsersQuery = ( siteId: number ) =>
 
 export const siteUsersWpcomQuery = ( siteId: number, role?: string ) =>
 	queryOptions( {
-		queryKey: [ 'site', siteId, 'users', 'wpcom', role ],
+		queryKey: [ 'site', siteId, 'wpcom-users', 'wpcom', role ],
 		queryFn: () => fetchSiteUsersWpcom( siteId, role ),
 	} );

--- a/packages/api-queries/src/site-users.ts
+++ b/packages/api-queries/src/site-users.ts
@@ -2,7 +2,7 @@ import {
 	fetchCurrentSiteUser,
 	deleteSiteUser,
 	fetchSiteUsers,
-	fetchSiteUsersWpcom,
+	fetchWpcomSiteUsers,
 } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
@@ -33,5 +33,5 @@ export const siteUsersQuery = ( siteId: number ) =>
 export const siteUsersWpcomQuery = ( siteId: number, role?: string ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'wpcom-users', 'wpcom', role ],
-		queryFn: () => fetchSiteUsersWpcom( siteId, role ),
+		queryFn: () => fetchWpcomSiteUsers( siteId, role ),
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes ARC-1294

## Proposed Changes

**Scenario 1**
A CIAB user is attempting to transfer a domain mapping to another user on the same CIAB site. In this case, we only see a "-" since no display name is available and the user id is directly from the CIAB site and is not a WPCOM user id.

<img width="1612" height="1292" alt="image" src="https://github.com/user-attachments/assets/05b9026a-3990-4771-8563-74f72522956c" />

**Scenario 2**
A WPCOM user (with a WoA) site is attempting to transfer a domain mapping to another user on the site. The other user was manually created on the site, then attached to a WPCOM account later. In this case, we see the correct display name for the other user but the user id is still directly from the site and is not a WPCOM user id.

**The fix**
Previously, we called `/wp/v2/:siteId/users` to populate the "New Owner" pulldown. This (generally) went directly to the remote site.

Now we call the `/rest/v1.1/sites/:siteId/users?force=wpcom` endpoint. This ensures that we always get the correct WPCOM user data, even in cases like CIAB.

<img width="759" height="654" alt="image" src="https://github.com/user-attachments/assets/5a1e44d3-efba-4837-9614-3bdbef9d80cf" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new CIAB site and invite another user to the site.
* Attach an external domain to the site (no need to setup DNS).
* Run this locally or use the calypso.live url and visit `/ciab/domains/the.external-domain.com/transfer/other-user`.
* Verify that the pulldown contains the correct display name and user id for the other user.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
