### PR TITLE
Add a Back button snackbar when visiting a domain from the site domains list

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -1,9 +1,13 @@
 import { DomainSubtype } from '@automattic/api-core';
 import config from '@automattic/calypso-config';
-import { Link } from '@tanstack/react-router';
+import { Link, useLocation, useMatches } from '@tanstack/react-router';
 import { Tooltip, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { domainOverviewRoute, domainTransferRoute } from '../../app/router/domains';
+import {
+	domainsIndexRoute,
+	domainOverviewRoute,
+	domainTransferRoute,
+} from '../../app/router/domains';
 import { Text } from '../../components/text';
 import { textOverflowStyles } from './utils';
 import type { DomainSummary, Site } from '@automattic/api-core';
@@ -19,6 +23,9 @@ export const DomainNameField = ( {
 	value: string;
 	showPrimaryDomainBadge?: boolean;
 } ) => {
+	const location = useLocation();
+	const matches = useMatches();
+
 	const siteSlug = site?.slug ?? domain.site_slug;
 
 	const href =
@@ -57,8 +64,13 @@ export const DomainNameField = ( {
 		return content;
 	}
 
+	const currentRoute = matches[ matches.length - 1 ];
+
+	const searchParams =
+		currentRoute.fullPath !== domainsIndexRoute.fullPath ? { from: location.pathname } : undefined;
+
 	return (
-		<Link to={ href } params={ { siteSlug, domainName: domain.domain } }>
+		<Link to={ href } params={ { siteSlug, domainName: domain.domain } } search={ searchParams }>
 			{ content }
 		</Link>
 	);

--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -1,13 +1,10 @@
 import { DomainSubtype } from '@automattic/api-core';
 import config from '@automattic/calypso-config';
-import { Link, useLocation, useMatches } from '@tanstack/react-router';
+import { Link, useMatches } from '@tanstack/react-router';
 import { Tooltip, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	domainsIndexRoute,
-	domainOverviewRoute,
-	domainTransferRoute,
-} from '../../app/router/domains';
+import { domainOverviewRoute, domainTransferRoute } from '../../app/router/domains';
+import { siteDomainsRoute, siteOverviewRoute } from '../../app/router/sites';
 import { Text } from '../../components/text';
 import { textOverflowStyles } from './utils';
 import type { DomainSummary, Site } from '@automattic/api-core';
@@ -23,7 +20,6 @@ export const DomainNameField = ( {
 	value: string;
 	showPrimaryDomainBadge?: boolean;
 } ) => {
-	const location = useLocation();
 	const matches = useMatches();
 
 	const siteSlug = site?.slug ?? domain.site_slug;
@@ -66,11 +62,18 @@ export const DomainNameField = ( {
 
 	const currentRoute = matches[ matches.length - 1 ];
 
-	const searchParams =
-		currentRoute.fullPath !== domainsIndexRoute.fullPath ? { from: location.pathname } : undefined;
+	const searchParams = () => {
+		if ( currentRoute.fullPath === siteDomainsRoute.fullPath ) {
+			return { back_to: 'site-domains' };
+		}
+		if ( currentRoute.fullPath === siteOverviewRoute.fullPath ) {
+			return { back_to: 'site-overview' };
+		}
+		return undefined;
+	};
 
 	return (
-		<Link to={ href } params={ { siteSlug, domainName: domain.domain } } search={ searchParams }>
+		<Link to={ href } params={ { siteSlug, domainName: domain.domain } } search={ searchParams() }>
 			{ content }
 		</Link>
 	);

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -3,15 +3,15 @@ import { domainQuery, purchaseQuery } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useNavigate, useSearch } from '@tanstack/react-router';
-import { Button, Snackbar, __experimentalHStack as HStack } from '@wordpress/components';
+import { useSearch } from '@tanstack/react-router';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { keyboardReturn, Icon } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { useLocale } from '../../app/locale';
 import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import SnackbarBackButton from '../../components/snackbar-back-button';
 import { formatDate } from '../../utils/datetime';
 import { getDomainRenewalUrl } from '../../utils/domain';
 import Actions from './actions';
@@ -44,8 +44,16 @@ export default function DomainOverview() {
 		dateStyle: 'long',
 	} );
 
-	const navigate = useNavigate();
-	const { from: domainsBackLink } = useSearch( { from: domainRoute.fullPath } );
+	const { back_to: domainsBackTo } = useSearch( { from: domainRoute.fullPath } );
+	let backButton = null;
+	switch ( domainsBackTo ) {
+		case 'site-domains':
+			backButton = <SnackbarBackButton>{ __( 'Back to Site Domain Names' ) }</SnackbarBackButton>;
+			break;
+		case 'site-overview':
+			backButton = <SnackbarBackButton>{ __( 'Back to Site Overview' ) }</SnackbarBackButton>;
+			break;
+	}
 
 	return (
 		<>
@@ -115,23 +123,7 @@ export default function DomainOverview() {
 				) }
 				<Actions />
 			</PageLayout>
-			{ domainsBackLink !== undefined && (
-				<HStack className="dashboard-snackbars">
-					<Snackbar
-						icon={ <Icon icon={ keyboardReturn } style={ { fill: 'currentcolor' } } /> }
-						actions={ [
-							{
-								label: __( 'Navigate' ),
-								onClick: () => {
-									navigate( { to: domainsBackLink } );
-								},
-							},
-						] }
-					>
-						{ __( 'Back to Site Domains' ) }
-					</Snackbar>
-				</HStack>
-			) }
+			{ backButton }
 		</>
 	);
 }

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -3,8 +3,10 @@ import { domainQuery, purchaseQuery } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { useNavigate, useSearch } from '@tanstack/react-router';
+import { Button, Snackbar, __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { keyboardReturn, Icon } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { useLocale } from '../../app/locale';
 import { domainRoute } from '../../app/router/domains';
@@ -42,72 +44,94 @@ export default function DomainOverview() {
 		dateStyle: 'long',
 	} );
 
+	const navigate = useNavigate();
+	const { from: domainsBackLink } = useSearch( { from: domainRoute.fullPath } );
+
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader
-					title={ wrappableDomainName }
-					description={
-						<HStack spacing={ 2 } alignment="center" justify="flex-start">
-							{ domain.subtype.id !== DomainSubtype.DOMAIN_REGISTRATION &&
-								domain.subtype?.label && <Badge>{ domain.subtype.label }</Badge> }
-							<span>
-								{ ( () => {
-									switch ( domain.subtype.id ) {
-										case DomainSubtype.DOMAIN_CONNECTION:
-											// translators: date is the date the domain was connected.
-											return sprintf( __( 'Connected on %(date)s' ), {
-												date: formattedRegistrationDate,
-											} );
-										case DomainSubtype.DOMAIN_REGISTRATION:
-											// translators: date is the date the domain was registered.
-											return sprintf( __( 'Registered on %(date)s' ), {
-												date: formattedRegistrationDate,
-											} );
-										default:
-											return null;
+		<>
+			<PageLayout
+				size="small"
+				header={
+					<PageHeader
+						title={ wrappableDomainName }
+						description={
+							<HStack spacing={ 2 } alignment="center" justify="flex-start">
+								{ domain.subtype.id !== DomainSubtype.DOMAIN_REGISTRATION &&
+									domain.subtype?.label && <Badge>{ domain.subtype.label }</Badge> }
+								<span>
+									{ ( () => {
+										switch ( domain.subtype.id ) {
+											case DomainSubtype.DOMAIN_CONNECTION:
+												// translators: date is the date the domain was connected.
+												return sprintf( __( 'Connected on %(date)s' ), {
+													date: formattedRegistrationDate,
+												} );
+											case DomainSubtype.DOMAIN_REGISTRATION:
+												// translators: date is the date the domain was registered.
+												return sprintf( __( 'Registered on %(date)s' ), {
+													date: formattedRegistrationDate,
+												} );
+											default:
+												return null;
+										}
+									} )() }
+								</span>
+							</HStack>
+						}
+						actions={
+							purchase?.can_explicit_renew &&
+							domain.current_user_is_owner && (
+								<Button
+									variant="primary"
+									__next40pxDefaultSize
+									href={ getDomainRenewalUrl( domain, purchase ) }
+								>
+									{
+										// translators: price is the price of the domain renewal.
+										sprintf( __( 'Renew now for %(price)s' ), {
+											price: formatCurrency( purchase.price_integer, purchase.currency_code, {
+												isSmallestUnit: true,
+												stripZeros: true,
+											} ),
+										} )
 									}
-								} )() }
-							</span>
-						</HStack>
-					}
-					actions={
-						purchase?.can_explicit_renew &&
-						domain.current_user_is_owner && (
-							<Button
-								variant="primary"
-								__next40pxDefaultSize
-								href={ getDomainRenewalUrl( domain, purchase ) }
-							>
-								{
-									// translators: price is the price of the domain renewal.
-									sprintf( __( 'Renew now for %(price)s' ), {
-										price: formatCurrency( purchase.price_integer, purchase.currency_code, {
-											isSmallestUnit: true,
-											stripZeros: true,
-										} ),
-									} )
-								}
-							</Button>
-						)
-					}
-				/>
-			}
-		>
-			{ domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER && (
-				<TransferredDomainDetails domain={ domain } />
+								</Button>
+							)
+						}
+					/>
+				}
+			>
+				{ domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER && (
+					<TransferredDomainDetails domain={ domain } />
+				) }
+				{ domain.is_pending_icann_verification && (
+					<IcannSuspensionNotice domainName={ domain.domain } />
+				) }
+				{ domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER && (
+					<>
+						<FeaturedCards />
+						<DomainOverviewSettings domain={ domain } />
+					</>
+				) }
+				<Actions />
+			</PageLayout>
+			{ domainsBackLink !== undefined && (
+				<HStack className="dashboard-snackbars">
+					<Snackbar
+						icon={ <Icon icon={ keyboardReturn } style={ { fill: 'currentcolor' } } /> }
+						actions={ [
+							{
+								label: __( 'Navigate' ),
+								onClick: () => {
+									navigate( { to: domainsBackLink } );
+								},
+							},
+						] }
+					>
+						{ __( 'Back to Site Domains' ) }
+					</Snackbar>
+				</HStack>
 			) }
-			{ domain.is_pending_icann_verification && (
-				<IcannSuspensionNotice domainName={ domain.domain } />
-			) }
-			{ domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER && (
-				<>
-					<FeaturedCards />
-					<DomainOverviewSettings domain={ domain } />
-				</>
-			) }
-			<Actions />
-		</PageLayout>
+		</>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

It looks like this:

<img width="265" height="83" alt="Screenshot 2025-12-16 at 20 13 08" src="https://github.com/user-attachments/assets/78e6e61a-5e32-4f5f-beae-bfa9f79b3982" />

<img width="298" height="76" alt="Screenshot 2025-12-16 at 20 13 00" src="https://github.com/user-attachments/assets/86cd52e4-8025-4e6c-9740-d9f1a55758e1" />

Part of [DOMAINS-1861: Add "Back to site domain names" snackbar in the site Overview screen](https://linear.app/a8c/issue/DOMAINS-1861/add-back-to-site-domain-names-snackbar-in-the-site-overview-screen)

## Proposed Changes

* Add a Back button snackbar when coming to the domain overview screen from the site domains list or the site overview screen

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the navigation between sites and domains

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a site and click on the domains section. Then click on a domain and verify that you see the "Back to Site Domain Names" or "Back to Site Overview" snackbar at the bottom left

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
