### PR TITLE
Remove /go/ from nav and footer

### DIFF
--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -213,11 +213,6 @@ export const PureUniversalNavbarFooter = ( {
 									</a>
 								</li>
 								<li>
-									<a href={ localizeUrl( 'https://wordpress.com/go/' ) } target="_self">
-										{ __( 'Website Building Tips', __i18n_text_domain__ ) }
-									</a>
-								</li>
-								<li>
 									<a
 										href={ localizeUrl( 'https://wordpress.com/business-name-generator/' ) }
 										target="_self"
@@ -231,17 +226,17 @@ export const PureUniversalNavbarFooter = ( {
 									</a>
 								</li>
 								<li>
-									<a href={ localizeUrl( 'https://wordpress.com/discover/' ) } target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/discover' ) } target="_self">
 										{ __( 'Discover New Posts', __i18n_text_domain__ ) }
 									</a>
 								</li>
 								<li>
-									<a href={ localizeUrl( 'https://wordpress.com/tags/' ) } target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/tags' ) } target="_self">
 										{ __( 'Popular Tags', __i18n_text_domain__ ) }
 									</a>
 								</li>
 								<li>
-									<a href={ localizeUrl( 'https://wordpress.com/reader/search/' ) } target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/reader/search' ) } target="_self">
 										{ __( 'Blog Search', __i18n_text_domain__ ) }
 									</a>
 								</li>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -331,13 +331,6 @@ const UniversalNavbarHeader = ( {
 														/>
 														<ClickableItem
 															titleValue=""
-															content={ __( 'Website Building Tips', __i18n_text_domain__ ) }
-															urlValue={ localizeUrl( '//wordpress.com/go/' ) }
-															type="dropdown"
-															target="_self"
-														/>
-														<ClickableItem
-															titleValue=""
 															content={ __( 'Business Name Generator', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl( '//wordpress.com/business-name-generator/' ) }
 															type="dropdown"
@@ -679,13 +672,6 @@ const UniversalNavbarHeader = ( {
 												titleValue=""
 												content={ __( 'News', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/blog/' ) }
-												type="menu"
-												tabIndex={ mobileMenuTabIndex }
-											/>
-											<ClickableItem
-												titleValue=""
-												content={ __( 'Website Building Tips', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl( '//wordpress.com/go/' ) }
 												type="menu"
 												tabIndex={ mobileMenuTabIndex }
 											/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1481

## Proposed Changes

* Removed "Website Building Tips" link (wordpress.com/go/) from both the universal header and footer navigation
  * Removed from desktop dropdown menu in header
  * Removed from mobile menu in header
  * Removed from Resources section in footer
* Cleaned up trailing slashes in footer navigation URLs:
  * wordpress.com/discover/ → wordpress.com/discover
  * wordpress.com/tags/ → wordpress.com/tags
  * wordpress.com/reader/search/ → wordpress.com/reader/search

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Updating the nav and footer per request in M4R73CH-1481

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Use the live testing link, or visit http://calypso.localhost:3000/plugins while logged out
* Verify that the links to `Website Building Tips` have been removed from the Resources section within the nav and footer
* Verify that the trailing slashes have been removed from the links for:
  * https://wordpress.com/discover
  * https://wordpress.com/tags
  * https://wordpress.com/reader/search

**Before:**
<img width="1031" height="354" alt="Screenshot 2025-12-11 at 4 59 22 PM" src="https://github.com/user-attachments/assets/21c31592-b9c0-46e0-9783-9116c271b522" />
<img width="473" height="412" alt="Screenshot 2025-12-11 at 5 00 06 PM" src="https://github.com/user-attachments/assets/44632a71-9008-4ed6-8a21-1da5a9659225" />


**After:**
<img width="1165" height="333" alt="Screenshot 2025-12-11 at 5 01 13 PM" src="https://github.com/user-attachments/assets/df3d52ab-391e-4c11-a0c1-23cd95c9fbbf" />
<img width="459" height="349" alt="Screenshot 2025-12-11 at 5 01 30 PM" src="https://github.com/user-attachments/assets/4db631c1-d503-49f2-a5ad-b4954e3bfbe8" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
