### PR TITLE
MSD: Link whois privacy card on domain overview to privacy view.

### DIFF
--- a/client/dashboard/domains/domain-overview/featured-card-privacy.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-privacy.tsx
@@ -14,12 +14,17 @@ export default function FeaturedCardPrivacy( { domain }: Props ) {
 		'Privacy protection is not available due to the registry’s policies.'
 	);
 	const privacyProtectionNote = domain.private_domain ? __( 'Enabled' ) : __( 'Disabled' );
+	const contactInfoLink =
+		domain.current_user_can_manage && domain.privacy_available
+			? `/domains/${ domain.domain }/contact-info`
+			: undefined;
 
 	return (
 		<OverviewCard
 			title={ __( 'Privacy' ) }
 			heading={ __( 'WHOIS Privacy' ) }
 			icon={ <Icon icon={ domain.private_domain ? unseen : seen } /> }
+			link={ contactInfoLink }
 			externalLink={ ! domain.privacy_available ? PRIVACY_PROTECTION : undefined }
 			description={ ! domain.privacy_available ? privacyWarning : privacyProtectionNote }
 			intent={ domain.private_domain ? 'success' : 'warning' }


### PR DESCRIPTION
## Proposed Changes

Link the WHOIS card to `/contact-info` so users can update the value.


### Screenshots

| Before | After |
|--------|--------|
| <img width="689" height="789" alt="Screenshot 2025-12-12 at 11 37 48 AM" src="https://github.com/user-attachments/assets/05d9de64-579f-412a-8ca0-1d2d3fe28ed3" /> | <img width="690" height="808" alt="Screenshot 2025-12-12 at 11 38 04 AM" src="https://github.com/user-attachments/assets/b2c2d6c9-c2e1-4571-b9b9-4056e183b426" /> | 

## Why are these changes being made?

It wasn't clear why I could click all the cards but this one nor was it easy and quick to find where that setting was. We use the language "WHOIS" as the largest landmark for the card, but below in the settings its "Privacy settings". 

## Testing Instructions

- Visit a domain overview.
- Click on the WHOIS privacy card
- Expect to be on `/contact-info`
- Switch the toggle for privacy
- Go back to the overview
- Expect the value to be correct
- Click on card
- Expect to be back on `/contact-info`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
