### PR TITLE
MSD: only reset scrolling after pagination data loads

### DIFF
--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -156,6 +156,7 @@ export function usePersistentView( {
 				} else if ( ! fastDeepEqual( newTransientProperties, transientProperties ) ) {
 					navigate( {
 						search: mergeQueryParamsWithTransientProperties( queryParams, newTransientProperties ),
+						resetScroll: false,
 					} );
 				}
 			}

--- a/client/dashboard/components/dataviews/dataviews.tsx
+++ b/client/dashboard/components/dataviews/dataviews.tsx
@@ -1,17 +1,20 @@
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { DataViews as WPDataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { useEffect, useRef } from 'react';
 import { sanitizeView } from './sanitize-view';
 import type { ComponentProps } from 'react';
 
 type WPDataViewsProps< Item > = ComponentProps< typeof WPDataViews< Item > >;
 
 export type DataViewsProps< Item > = WPDataViewsProps< Item > & {
+	isPlaceholderData?: boolean;
 	onResetView?: () => void;
 };
 
 export function DataViews< Item >( {
 	view,
+	isPlaceholderData,
 	onResetView,
 	header,
 	search = true,
@@ -19,6 +22,19 @@ export function DataViews< Item >( {
 	children,
 	...props
 }: DataViewsProps< Item > ) {
+	const previousPage = useRef( view.page );
+
+	// Scroll to top only after pagination data loads.
+	useEffect( () => {
+		if ( isPlaceholderData ) {
+			return;
+		}
+		if ( previousPage.current !== view.page ) {
+			window.scrollTo( { top: 0, behavior: 'instant' } );
+			previousPage.current = view.page;
+		}
+	}, [ view.page, isPlaceholderData ] );
+
 	const sanitizedView = sanitizeView( view, props.fields );
 
 	const resetViewAction = onResetView && (

--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -11,6 +11,7 @@ export function SitesDataViews< SiteType >( {
 	fields,
 	actions,
 	isLoading,
+	isPlaceholderData,
 	empty,
 	paginationInfo,
 	renderItemLink,
@@ -23,6 +24,7 @@ export function SitesDataViews< SiteType >( {
 	fields: Field< SiteType >[];
 	actions?: Action< SiteType >[];
 	isLoading: boolean;
+	isPlaceholderData?: boolean;
 	empty: ReactNode;
 	paginationInfo: ComponentProps< typeof DataViews< SiteType > >[ 'paginationInfo' ];
 	renderItemLink: ComponentProps< typeof DataViews< SiteType > >[ 'renderItemLink' ];
@@ -41,6 +43,7 @@ export function SitesDataViews< SiteType >( {
 					actions={ actions }
 					view={ view }
 					isLoading={ isLoading }
+					isPlaceholderData={ isPlaceholderData }
 					onChangeView={ onChangeView }
 					onResetView={ onResetView }
 					defaultLayouts={ DEFAULT_LAYOUTS }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -400,6 +400,7 @@ export default function Sites() {
 						fields={ fields__ES }
 						// TODO: actions={ actions }
 						isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
+						isPlaceholderData={ isPlaceholderData }
 						empty={ emptyState }
 						paginationInfo={ paginationInfo__ES }
 						renderItemLink={ ( { item, ...props } ) => (
@@ -420,6 +421,7 @@ export default function Sites() {
 						fields={ fields }
 						actions={ actions }
 						isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
+						isPlaceholderData={ isPlaceholderData }
 						empty={ emptyState }
 						paginationInfo={ paginationInfo }
 						onChangeView={ handleViewChange }


### PR DESCRIPTION
## Proposed Changes

In ES-powered Site List, when we click next page button, we scroll to the top while the request to get the next page is still ongoing, resulting in a flash of previous data:


https://github.com/user-attachments/assets/c41d020c-f354-45da-af12-e52c2266a646

Why is this happening? This is because we set TanStack Router's [scrollRestoration: true](https://github.com/Automattic/wp-calypso/blob/465341eefd27b0a617fee336095eb754e37e1220/client/dashboard/app/router/index.tsx#L89). When we navigate, we append the `page` query param to the URL, which counts as navigation, so TanStack will trigger the scroll restoration to the top.

This PR fixes that behavior by:

- When appending the `page` param, don't modify the scrolling (using `resetScroll: false` option when calling `navigate()`).
- Manually scroll the page after the new page is fully loaded.

### After fix


https://github.com/user-attachments/assets/4d482eae-92f7-4fe1-8a5a-ae1f769f6c57



## Why are these changes being made?

Fit 'n finish ES site list

## Testing Instructions

1. Go to `/v2/sites?flags=dashboard/v2/es-site-list`
2. Go to next page
3. Verify it only scrolls when the page has fully loaded
4. Go to normal `/v2/sites` and verify no regression when navigating pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?