### PR TITLE
MSD: Update back URLs

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -60,7 +60,7 @@ import SiteIcon from '../../../components/site-icon';
 import SiteBandwidthStat from '../../../sites/overview-plan-card/site-bandwidth-stat';
 import SiteStorageStat from '../../../sites/overview-plan-card/site-storage-stat';
 import { formatDate } from '../../../utils/datetime';
-import { dashboardLink, wpcomLink } from '../../../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../../../utils/link';
 import {
 	getBillPeriodLabel,
 	getTitleForDisplay,
@@ -149,7 +149,7 @@ function getExpiredNewPlanUrl( purchase: Purchase ): string {
 }
 
 function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
-	const backUrl = dashboardLink( window.location.href.replace( window.location.origin, '' ) );
+	const backUrl = redirectToDashboardLink();
 	return addQueryArgs( wpcomLink( '/setup/plan-upgrade' ), {
 		...( siteSlug && { siteSlug } ),
 		cancel_to: backUrl,

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -60,7 +60,7 @@ import SiteIcon from '../../../components/site-icon';
 import SiteBandwidthStat from '../../../sites/overview-plan-card/site-bandwidth-stat';
 import SiteStorageStat from '../../../sites/overview-plan-card/site-storage-stat';
 import { formatDate } from '../../../utils/datetime';
-import { wpcomLink } from '../../../utils/link';
+import { dashboardLink, wpcomLink } from '../../../utils/link';
 import {
 	getBillPeriodLabel,
 	getTitleForDisplay,
@@ -149,7 +149,7 @@ function getExpiredNewPlanUrl( purchase: Purchase ): string {
 }
 
 function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
-	const backUrl = window.location.href.replace( window.location.origin, '' );
+	const backUrl = dashboardLink( window.location.href.replace( window.location.origin, '' ) );
 	return addQueryArgs( wpcomLink( '/setup/plan-upgrade' ), {
 		...( siteSlug && { siteSlug } ),
 		cancel_to: backUrl,

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx
@@ -6,7 +6,7 @@ import { useAnalytics } from '../../app/analytics';
 import { Callout } from '../../components/callout';
 import { CalloutOverlay } from '../../components/callout-overlay';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
-import { dashboardLink, wpcomLink } from '../../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import HostingFeatureActivationModal from '../hosting-feature-activation-modal';
 import HostingFeatureList from '../hosting-feature-list';
 import illustrationUrl from './upsell-illustration.svg';
@@ -54,7 +54,7 @@ export default function ActivationCallout( {
 			feature,
 			initiate_transfer_context: 'hosting',
 			initiate_transfer_geo_affinity: options.geo_affinity || '',
-			redirect_to: dashboardLink( window.location.href.replace( window.location.origin, '' ) ),
+			redirect_to: redirectToDashboardLink(),
 		} );
 	};
 

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx
@@ -6,7 +6,7 @@ import { useAnalytics } from '../../app/analytics';
 import { Callout } from '../../components/callout';
 import { CalloutOverlay } from '../../components/callout-overlay';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
-import { wpcomLink } from '../../utils/link';
+import { dashboardLink, wpcomLink } from '../../utils/link';
 import HostingFeatureActivationModal from '../hosting-feature-activation-modal';
 import HostingFeatureList from '../hosting-feature-list';
 import illustrationUrl from './upsell-illustration.svg';
@@ -54,7 +54,7 @@ export default function ActivationCallout( {
 			feature,
 			initiate_transfer_context: 'hosting',
 			initiate_transfer_geo_affinity: options.geo_affinity || '',
-			redirect_to: window.location.href.replace( window.location.origin, '' ),
+			redirect_to: dashboardLink( window.location.href.replace( window.location.origin, '' ) ),
 		} );
 	};
 

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -6,7 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import React from 'react';
 import { Callout } from '../../components/callout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
-import { wpcomLink } from '../../utils/link';
+import { dashboardLink, wpcomLink } from '../../utils/link';
 import illustrationUrl from './upsell-illustration.svg';
 import type { CalloutProps } from '../../components/callout/types';
 import type { HostingFeatureSlug, Site } from '@automattic/api-core';
@@ -37,7 +37,7 @@ export default function UpsellCallout( {
 	feature,
 }: UpsellCalloutProps ) {
 	const handleUpsellClick = () => {
-		const backUrl = window.location.href.replace( window.location.origin, '' );
+		const backUrl = dashboardLink( window.location.href.replace( window.location.origin, '' ) );
 
 		window.location.href = addQueryArgs( wpcomLink( '/setup/plan-upgrade/' ), {
 			siteSlug: site.slug,

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/upsell.tsx
@@ -6,7 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import React from 'react';
 import { Callout } from '../../components/callout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
-import { dashboardLink, wpcomLink } from '../../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import illustrationUrl from './upsell-illustration.svg';
 import type { CalloutProps } from '../../components/callout/types';
 import type { HostingFeatureSlug, Site } from '@automattic/api-core';
@@ -37,7 +37,7 @@ export default function UpsellCallout( {
 	feature,
 }: UpsellCalloutProps ) {
 	const handleUpsellClick = () => {
-		const backUrl = dashboardLink( window.location.href.replace( window.location.origin, '' ) );
+		const backUrl = redirectToDashboardLink();
 
 		window.location.href = addQueryArgs( wpcomLink( '/setup/plan-upgrade/' ), {
 			siteSlug: site.slug,

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -10,7 +10,7 @@ import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import { Callout } from '../../components/callout';
 import { TextBlur } from '../../components/text-blur';
 import UpsellCTAButton from '../../components/upsell-cta-button';
-import { dashboardLinkWithBackport, wpcomLink } from '../../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { DomainUpsellIllustraction } from './upsell-illustration';
 import type { Site } from '@automattic/api-core';
 
@@ -52,10 +52,7 @@ const DomainUpsellCardContent = ( {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const { search, suggestedDomain } = useDomainSuggestion( site );
 
-	const backUrl = dashboardLinkWithBackport(
-		window.location.href.replace( window.location.origin, '' )
-	);
-
+	const backUrl = redirectToDashboardLink( { supportBackport: true } );
 	const handleUpsell = async () => {
 		if ( suggestedDomain ) {
 			setIsSubmitting( true );

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -10,7 +10,7 @@ import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains';
 import { Callout } from '../../components/callout';
 import { TextBlur } from '../../components/text-blur';
 import UpsellCTAButton from '../../components/upsell-cta-button';
-import { wpcomLink } from '../../utils/link';
+import { dashboardLinkWithBackport, wpcomLink } from '../../utils/link';
 import { DomainUpsellIllustraction } from './upsell-illustration';
 import type { Site } from '@automattic/api-core';
 
@@ -52,7 +52,9 @@ const DomainUpsellCardContent = ( {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const { search, suggestedDomain } = useDomainSuggestion( site );
 
-	const backUrl = window.location.href.replace( window.location.origin, '' );
+	const backUrl = dashboardLinkWithBackport(
+		window.location.href.replace( window.location.origin, '' )
+	);
 
 	const handleUpsell = async () => {
 		if ( suggestedDomain ) {

--- a/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
+++ b/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
@@ -8,7 +8,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 import { Card, CardBody } from '../../components/card';
 import { Notice } from '../../components/notice';
-import { dashboardLinkWithBackport, wpcomLink } from '../../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import SiteRedirectForm, { SiteRedirectFormData } from './site-redirect-form';
 
 export default function CreateSiteRedirect( {
@@ -38,10 +38,8 @@ export default function CreateSiteRedirect( {
 
 	const handleSubmit = async ( formData: SiteRedirectFormData ) => {
 		setIsSubmitting( true );
-		const backUrl = dashboardLinkWithBackport(
-			window.location.href.replace( window.location.origin, '' )
-		);
 
+		const backUrl = redirectToDashboardLink( { supportBackport: true } );
 		const { shoppingCartManagerClient } = await import(
 			/* webpackChunkName: "async-load-shopping-cart" */ '../../app/shopping-cart'
 		);

--- a/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
+++ b/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
@@ -8,7 +8,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 import { Card, CardBody } from '../../components/card';
 import { Notice } from '../../components/notice';
-import { wpcomLink } from '../../utils/link';
+import { dashboardLinkWithBackport, wpcomLink } from '../../utils/link';
 import SiteRedirectForm, { SiteRedirectFormData } from './site-redirect-form';
 
 export default function CreateSiteRedirect( {
@@ -38,7 +38,10 @@ export default function CreateSiteRedirect( {
 
 	const handleSubmit = async ( formData: SiteRedirectFormData ) => {
 		setIsSubmitting( true );
-		const backUrl = window.location.href.replace( window.location.origin, '' );
+		const backUrl = dashboardLinkWithBackport(
+			window.location.href.replace( window.location.origin, '' )
+		);
+
 		const { shoppingCartManagerClient } = await import(
 			/* webpackChunkName: "async-load-shopping-cart" */ '../../app/shopping-cart'
 		);

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
-import { wpcomLink } from '../../utils/link';
+import { dashboardLinkWithBackport, wpcomLink } from '../../utils/link';
 import {
 	isSitePlanLaunchable as getIsSitePlanLaunchable,
 	isSitePlanBigSkyTrial,
@@ -67,7 +67,9 @@ export function SiteLaunchButton( { site, tracksContext }: { site: Site; tracksC
 			siteSlug: site.slug,
 			new: site.name,
 			hide_initial_query: 'yes',
-			back_to: window.location.href.replace( window.location.origin, '' ),
+			back_to: dashboardLinkWithBackport(
+				window.location.href.replace( window.location.origin, '' )
+			),
 		} );
 	};
 

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
-import { dashboardLinkWithBackport, wpcomLink } from '../../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import {
 	isSitePlanLaunchable as getIsSitePlanLaunchable,
 	isSitePlanBigSkyTrial,
@@ -67,9 +67,7 @@ export function SiteLaunchButton( { site, tracksContext }: { site: Site; tracksC
 			siteSlug: site.slug,
 			new: site.name,
 			hide_initial_query: 'yes',
-			back_to: dashboardLinkWithBackport(
-				window.location.href.replace( window.location.origin, '' )
-			),
+			back_to: redirectToDashboardLink( { supportBackport: true } ),
 		} );
 	};
 

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -13,7 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import filesize from 'filesize';
 import { useState } from 'react';
-import { wpcomLink } from '../../utils/link';
+import { dashboardLinkWithBackport, wpcomLink } from '../../utils/link';
 import { StorageCapacityStat } from './storage-capacity-stat';
 import {
 	getStorageAddOnProduct,
@@ -120,7 +120,10 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 			return;
 		}
 
-		const backUrl = window.location.href.replace( window.location.origin, '' );
+		const backUrl = dashboardLinkWithBackport(
+			window.location.href.replace( window.location.origin, '' )
+		);
+
 		const checkoutUrl = addQueryArgs(
 			wpcomLink(
 				`/checkout/${ site.slug }/${ storageProduct.product_slug }:-q-${ selectedTier.quantity }`

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -13,7 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import filesize from 'filesize';
 import { useState } from 'react';
-import { dashboardLinkWithBackport, wpcomLink } from '../../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { StorageCapacityStat } from './storage-capacity-stat';
 import {
 	getStorageAddOnProduct,
@@ -120,10 +120,7 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 			return;
 		}
 
-		const backUrl = dashboardLinkWithBackport(
-			window.location.href.replace( window.location.origin, '' )
-		);
-
+		const backUrl = redirectToDashboardLink( { supportBackport: true } );
 		const checkoutUrl = addQueryArgs(
 			wpcomLink(
 				`/checkout/${ site.slug }/${ storageProduct.product_slug }:-q-${ selectedTier.quantity }`

--- a/client/dashboard/sites/trial-ended/index.tsx
+++ b/client/dashboard/sites/trial-ended/index.tsx
@@ -16,7 +16,7 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
-import { dashboardLink, wpcomLink } from '../../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { wasEcommerceTrial } from '../../utils/site-trial';
 import SiteDeleteModal from '../site-delete-modal';
 import type { Site } from '@automattic/api-core';
@@ -53,7 +53,7 @@ const SiteTrialEnded = ( { siteSlug }: { siteSlug: string } ) => {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const product = getProduct( site );
 	const { data: plan } = useQuery( sitePlanBySlugQuery( site.ID, product.slug ) );
-	const backUrl = dashboardLink( window.location.href.replace( window.location.origin, '' ) );
+	const backUrl = redirectToDashboardLink();
 
 	if ( ! plan ) {
 		return null;

--- a/client/dashboard/sites/trial-ended/index.tsx
+++ b/client/dashboard/sites/trial-ended/index.tsx
@@ -16,7 +16,7 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
-import { wpcomLink } from '../../utils/link';
+import { dashboardLink, wpcomLink } from '../../utils/link';
 import { wasEcommerceTrial } from '../../utils/site-trial';
 import SiteDeleteModal from '../site-delete-modal';
 import type { Site } from '@automattic/api-core';
@@ -53,7 +53,7 @@ const SiteTrialEnded = ( { siteSlug }: { siteSlug: string } ) => {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const product = getProduct( site );
 	const { data: plan } = useQuery( sitePlanBySlugQuery( site.ID, product.slug ) );
-	const backUrl = window.location.href.replace( window.location.origin, '' );
+	const backUrl = dashboardLink( window.location.href.replace( window.location.origin, '' ) );
 
 	if ( ! plan ) {
 		return null;

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -43,7 +43,7 @@ export function redirectToDashboardLink( {
 }: {
 	backUrl?: string;
 	supportBackport?: boolean;
-} ) {
+} = {} ) {
 	const url = backUrl ? backUrl : window.location.href.replace( window.location.origin, '' );
 	return supportBackport ? dashboardLinkWithBackport( url ) : dashboardLink( url );
 }

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { isDashboardBackport } from './is-dashboard-backport';
 
 /**
  * This function essentially returns `https://wordpress.com${ path }`.
@@ -20,6 +21,17 @@ export function dashboardLink( path: string = '' ) {
 	return config( 'env' ) === 'development'
 		? `http://my.localhost:3000${ path }`
 		: `https://my.wordpress.com${ path }`;
+}
+
+/**
+ * This function returns the link to the dashboard, with backport support.
+ */
+export function dashboardLinkWithBackport( path: string = '' ) {
+	if ( isDashboardBackport() ) {
+		return path;
+	}
+
+	return dashboardLink( path );
 }
 
 /**

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -2,6 +2,13 @@ import config from '@automattic/calypso-config';
 import { isDashboardBackport } from './is-dashboard-backport';
 
 /**
+ * This function returns all the origins for the dashboard.
+ */
+export function dashboardOrigins(): string[] {
+	return [ 'http://my.localhost:3000', 'https://my.wordpress.com' ];
+}
+
+/**
  * This function essentially returns `https://wordpress.com${ path }`.
  *
  * However, the hostname is configurable in the `wpcom_url` key, so that

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -35,6 +35,20 @@ export function dashboardLinkWithBackport( path: string = '' ) {
 }
 
 /**
+ * This function returns the redirect link back to the dashboard.
+ */
+export function redirectToDashboardLink( {
+	backUrl,
+	supportBackport,
+}: {
+	backUrl?: string;
+	supportBackport?: boolean;
+} ) {
+	const url = backUrl ? backUrl : window.location.href.replace( window.location.origin, '' );
+	return supportBackport ? dashboardLinkWithBackport( url ) : dashboardLink( url );
+}
+
+/**
  * This function returns the link to the reauth page.
  *
  * Currently, the dashboard run in either Calypso or Dashboard environment. When it comes to the redirect URL:

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -66,7 +66,7 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 		const selectedFeature = query.get( 'feature' ) ?? undefined;
 		const backTo = query.get( 'back_to' ) ?? query.get( 'cancel_to' ) ?? undefined;
 
-		// Validate back_to to prevent open redirect - must not be external
+		// Validate back_to to prevent open redirect - must not be external (expect for allowed origins).
 		const isValidBackTo = dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
 		const safeBackTo = backTo && ( ! isExternal( backTo ) || isValidBackTo ) ? backTo : '/sites';
 

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -2,6 +2,7 @@ import { PLAN_UPGRADE_FLOW } from '@automattic/onboarding';
 import { resolveSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { dashboardOrigins } from 'calypso/dashboard/utils/link';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
 import { FlowV2, SubmitHandler } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -66,7 +67,8 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 		const backTo = query.get( 'back_to' ) ?? query.get( 'cancel_to' ) ?? undefined;
 
 		// Validate back_to to prevent open redirect - must not be external
-		const safeBackTo = backTo && ! isExternal( backTo ) ? backTo : '/sites';
+		const isValidBackTo = dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
+		const safeBackTo = backTo && ( ! isExternal( backTo ) || isValidBackTo ) ? backTo : '/sites';
 
 		return {
 			[ STEPS.UNIFIED_PLANS.slug ]: {


### PR DESCRIPTION
Part of DOTMSD-951

## Proposed Changes

Pass my.wordpress.com absolute URLs for flows external to the MSD.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure that after these flows, you're back to my.wordpress.com.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
