### PR TITLE
Setup help center customizer

### DIFF
--- a/apps/help-center/help-center-customizer.js
+++ b/apps/help-center/help-center-customizer.js
@@ -1,0 +1,108 @@
+/* global helpCenterData */
+import './config';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import HelpCenter from '@automattic/help-center';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useCallback } from '@wordpress/element';
+import { createRoot } from 'react-dom/client';
+
+import './help-center.scss';
+
+const queryClient = new QueryClient();
+
+function CustomizerHelpCenterContent() {
+	const { setShowHelpCenter } = useDataStoreDispatch( 'automattic/help-center' );
+	const { isShown, unreadCount } = useSelect(
+		( select ) => ( {
+			isShown: select( 'automattic/help-center' ).isHelpCenterShown(),
+			unreadCount: select( 'automattic/help-center' ).getUnreadCount(),
+		} ),
+		[]
+	);
+
+	const button = document.querySelector( '.customize-help-toggle' );
+
+	useEffect( () => {
+		if ( isShown ) {
+			button.classList.add( 'active' );
+		} else {
+			button.classList.remove( 'active' );
+		}
+	}, [ isShown, button ] );
+
+	useEffect( () => {
+		if ( unreadCount > 0 ) {
+			button.classList.add( 'has-unread' );
+		} else {
+			button.classList.remove( 'has-unread' );
+		}
+	}, [ unreadCount, button ] );
+
+	const closeCallback = useCallback(
+		() => setShowHelpCenter( false, undefined, true ),
+		[ setShowHelpCenter ]
+	);
+
+	const trackIconInteraction = useCallback( () => {
+		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
+			is_help_center_visible: isShown ?? false,
+			section: helpCenterData.sectionName || 'wp-customizer',
+			is_menu_panel_enabled: false,
+		} );
+	}, [ isShown ] );
+
+	const handleToggleHelpCenter = useCallback( () => {
+		trackIconInteraction();
+		recordTracksEvent( `calypso_inlinehelp_${ isShown ? 'close' : 'show' }`, {
+			force_site_id: true,
+			location: 'help-center',
+			section: helpCenterData.sectionName || 'wp-admin',
+		} );
+
+		setShowHelpCenter( ! isShown );
+	}, [ isShown, setShowHelpCenter, trackIconInteraction ] );
+
+	useEffect( () => {
+		if ( ! button ) {
+			return;
+		}
+
+		const handler = ( event ) => {
+			event.stopImmediatePropagation();
+			event.preventDefault();
+			handleToggleHelpCenter();
+		};
+
+		button.addEventListener( 'click', handler, { capture: true } );
+
+		return () => {
+			button.removeEventListener( 'click', handler, { capture: true } );
+		};
+	}, [ button, handleToggleHelpCenter ] );
+
+	return (
+		<HelpCenter
+			locale={ helpCenterData.locale }
+			sectionName={ helpCenterData.sectionName || 'wp-customizer' }
+			currentUser={ helpCenterData.currentUser }
+			site={ helpCenterData.site }
+			hasPurchases={ false }
+			onboardingUrl="https://wordpress.com/start"
+			handleClose={ closeCallback }
+			isCommerceGarden={ helpCenterData.isCommerceGarden }
+		/>
+	);
+}
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	const target = document.getElementById( 'help-center-customizer' );
+
+	if ( target ) {
+		createRoot( target ).render(
+			<QueryClientProvider client={ queryClient }>
+				<CustomizerHelpCenterContent />
+			</QueryClientProvider>
+		);
+	}
+} );

--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -82,6 +82,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 	return [
 		getIndividualConfig( { env, argv, name: 'help-center-gutenberg' } ),
 		getIndividualConfig( { env, argv, name: 'help-center-wp-admin' } ),
+		getIndividualConfig( { env, argv, name: 'help-center-customizer' } ),
 		getIndividualConfig( { env, argv, name: 'help-center-gutenberg-disconnected' } ),
 		getIndividualConfig( {
 			env,

--- a/packages/help-center/src/components/_variables.scss
+++ b/packages/help-center/src/components/_variables.scss
@@ -1,5 +1,5 @@
 $head-foot-height: 56px;
-$help-center-z-index: 100000;
+$help-center-z-index: 500000;
 $help-center-blue: #3858e9;
 $help-center-notice-background: #FDF7E9;
 $help-center-notice-color: #644B1C;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

<img width="781" height="839" alt="Screenshot 2025-12-12 at 11 00 51" src="https://github.com/user-attachments/assets/73e4a0db-11b0-44e3-be92-5ba116f2eba1" />

Part of #DOTSUP-379

## Proposed Changes

* Initial setup for the help center

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The help center is not available in the customizer

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Sync this PR https://github.com/Automattic/jetpack/pull/46278
* Checkout this branch
* cd to apps/help-center and run `yarn dev --sync`
* Open the customizer for a simple site
* Clicking the help button in the left side panel should open the help center

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
