### PR TITLE
MSD Emails: improve cache invalidation and dataview loading state

### DIFF
--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -17,7 +17,7 @@ import type { Email } from './types';
 import './style.scss';
 
 function Emails() {
-	const { data: allEmailAccounts, isFetching: isLoadingEmailAccounts } = useQuery(
+	const { data: allEmailAccounts, isLoading: isLoadingEmailAccounts } = useQuery(
 		userMailboxesQuery()
 	);
 	const { domainName: domainNameFilter }: { domainName?: string } = emailsRoute.useSearch();

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -17,7 +17,7 @@ import type { Email } from './types';
 import './style.scss';
 
 function Emails() {
-	const { data: allEmailAccounts, isLoading: isLoadingEmailAccounts } = useQuery(
+	const { data: allEmailAccounts, isFetching: isLoadingEmailAccounts } = useQuery(
 		userMailboxesQuery()
 	);
 	const { domainName: domainNameFilter }: { domainName?: string } = emailsRoute.useSearch();

--- a/packages/api-queries/src/domain-email.ts
+++ b/packages/api-queries/src/domain-email.ts
@@ -43,7 +43,7 @@ export const addEmailForwarderMutation = () =>
 			redirectUrl?: string;
 		} ) => addEmailForwarder( domain, mailbox, destinations, redirectUrl ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'mailboxes' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'me', 'mailboxes' ] } );
 			queryClient.invalidateQueries( {
 				queryKey: [ 'domains' ],
 				predicate: ( query ) =>

--- a/packages/api-queries/src/domain-email.ts
+++ b/packages/api-queries/src/domain-email.ts
@@ -1,5 +1,6 @@
 import { addEmailForwarder, fetchEmailForwarders } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import { userMailboxesQuery } from './me-mailboxes';
 import { queryClient } from './query-client';
 
 type ResponseError = {
@@ -43,7 +44,7 @@ export const addEmailForwarderMutation = () =>
 			redirectUrl?: string;
 		} ) => addEmailForwarder( domain, mailbox, destinations, redirectUrl ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'me', 'mailboxes' ] } );
+			queryClient.resetQueries( userMailboxesQuery() );
 			queryClient.invalidateQueries( {
 				queryKey: [ 'domains' ],
 				predicate: ( query ) =>

--- a/packages/api-queries/src/domain.ts
+++ b/packages/api-queries/src/domain.ts
@@ -6,6 +6,7 @@ import {
 	deleteEmailForward,
 } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import { userMailboxesQuery } from './me-mailboxes';
 import { queryClient } from './query-client';
 
 export const domainQuery = ( domainName: string ) =>
@@ -39,7 +40,7 @@ export const deleteEmailForwardMutation = () => {
 		mutationFn: ( vars: { domainName: string; mailbox: string; destination: string } ) =>
 			deleteEmailForward( vars.domainName, vars.mailbox, vars.destination ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'me', 'mailboxes' ] } );
+			queryClient.resetQueries( userMailboxesQuery() );
 		},
 	} );
 };

--- a/packages/api-queries/src/domain.ts
+++ b/packages/api-queries/src/domain.ts
@@ -39,7 +39,7 @@ export const deleteEmailForwardMutation = () => {
 		mutationFn: ( vars: { domainName: string; mailbox: string; destination: string } ) =>
 			deleteEmailForward( vars.domainName, vars.mailbox, vars.destination ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'mailboxes' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'me', 'mailboxes' ] } );
 		},
 	} );
 };

--- a/packages/api-queries/src/emails.ts
+++ b/packages/api-queries/src/emails.ts
@@ -39,7 +39,7 @@ export const createTitanMailboxMutation = () => {
 				passwordResetEmail: vars.passwordResetEmail,
 			} ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'mailboxes' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'me', 'mailboxes' ] } );
 		},
 	} );
 };
@@ -49,7 +49,7 @@ export const deleteTitanMailboxMutation = () => {
 		mutationFn: ( vars: { domainName: string; mailbox: string } ) =>
 			deleteTitanMailbox( vars.domainName, vars.mailbox ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'mailboxes' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'me', 'mailboxes' ] } );
 		},
 	} );
 };

--- a/packages/api-queries/src/emails.ts
+++ b/packages/api-queries/src/emails.ts
@@ -5,6 +5,7 @@ import {
 	fetchMailboxes,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import { userMailboxesQuery } from './me-mailboxes';
 import { queryClient } from './query-client';
 
 export const mailboxesQuery = ( siteId: number ) =>
@@ -39,7 +40,7 @@ export const createTitanMailboxMutation = () => {
 				passwordResetEmail: vars.passwordResetEmail,
 			} ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'me', 'mailboxes' ] } );
+			queryClient.resetQueries( userMailboxesQuery() );
 		},
 	} );
 };
@@ -49,7 +50,7 @@ export const deleteTitanMailboxMutation = () => {
 		mutationFn: ( vars: { domainName: string; mailbox: string } ) =>
 			deleteTitanMailbox( vars.domainName, vars.mailbox ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'me', 'mailboxes' ] } );
+			queryClient.resetQueries( userMailboxesQuery() );
 		},
 	} );
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTMSD-935/deleting-email-forward-doesnt-clear-it-from-my-list
- https://linear.app/a8c/issue/DOTMSD-937/there-is-a-noticeable-delay-before-my-new-forwardermailbox-is-added-to

## Proposed Changes

* We now invalidate the correct cache key for the mailboxes query.
* The Dataview now relies on the `isFetching` property to indicate the loading state.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our ongoing effort to provide a new Dashboard experience (MSD)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to `/v2/emails`
* Add a forwarder, the Dataview should show the loading state until the request finishes and then the Dataview should show the updated results.
* Delete a forwarder, same result as above is expected.
* Add a mailbox, same result as above is expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
