### PR TITLE
Help center: also use height in sidebar calculation

### DIFF
--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -1,8 +1,10 @@
+import { useWindowDimensions } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
 import {
 	createPortal,
 	useCallback,
+	useEffect,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -48,8 +50,21 @@ export default function useAgentLayoutManager( {
 	const portalRef = useRef< HTMLDivElement >();
 	const [ isPortalReady, setIsPortalReady ] = useState( false );
 	const isDesktop = useMediaQuery( desktopMediaQuery );
+	const { height } = useWindowDimensions();
 	const [ isDocked, setIsDocked ] = useState< boolean | null >( null );
-	const shouldRenderSidebar = isDesktop && isDocked;
+	const [ adminMenuHeight, setAdminMenuHeight ] = useState( 0 );
+
+	useEffect( () => {
+		const adminMenu = document.getElementById( 'adminmenu' );
+		if ( adminMenu ) {
+			const menuHeight = adminMenu.offsetHeight;
+			const menuTopOffset = adminMenu.getBoundingClientRect().top + window.scrollY;
+			setAdminMenuHeight( menuHeight + menuTopOffset + 20 );
+		}
+	}, [ height ] );
+
+	const hasEnoughHeight = height >= adminMenuHeight;
+	const shouldRenderSidebar = isDesktop && hasEnoughHeight && isDocked;
 	const openSidebarTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
 
 	// Store default state refs to avoid stale closures and prevent unnecessary re-renders

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -129,7 +129,6 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open {
 		border-left: 1px solid $border-color;
 		border-bottom: 1px solid $border-color;
 		border-bottom-left-radius: $main-border-radius;
-		overflow: scroll;
 	}
 
 	#wpcontent {


### PR DESCRIPTION
In the new unified sidebar, if the screen height is smaller than height of the wp admin sidebar we are unable to scroll the WP sidebar unless an `overflow: scroll` is applied (this is caused by the main content becoming `position: fixed`).

Applying `overflow: scroll` to the sidebar breaks the popout menus, as these are defined inside the menu itself.

I've not found a neat way of fixing this using CSS. Maybe a more substantial alteration to how the enclosing sidebar works could resolve this, but that quickly starts to become a bigger project.

Instead, this PR adjusts the responsive calculation to trigger when the height is too small. It already does this if the width is too small, so applying it for the height seems reasonable. This means the sidebar becomes undocked, and the problem of the sidebar scrolling/popout menus disappears.

Fixes DOTCOM-15493

Note this does have the effect of maybe making the undocked sidebar appear earlier than previously on small size screens.

## Proposed Changes

* Use height as part of the calculation for docked/undocked mode


## Testing Instructions

* `cd apps/help-center`
* `yarn dev --sync`
* Sandbox `widgets.wp.com`
* Open a wp-admin page with `?flags=unified-agent` and make sure in docked mode
* Shrink the height of the browser below that of the WP sidebar height and confirm it switches to undocked mode. The WP sidebar should still be available in all heights

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
