### PR TITLE
A4A: Ensure Reports page table height is 100%.

### DIFF
--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/style.scss
@@ -57,6 +57,10 @@
 		flex-direction: column;
 		height: calc(100vh - 32px);
 	}
+
+	.hosting-dashboard-layout-with-columns__container.hosting-dashboard-layout-with-columns__container.hosting-dashboard-layout-with-columns__container {
+		height: 100%;
+	}
 }
 
 .reports-dashboard__actions {


### PR DESCRIPTION
Context: p1765555433721239-slack-C047ACYM8UQ 

## Proposed Changes

* Add a specific 100% height for the table container.

| Before | After |
|--------|--------|
| <img width="1728" height="963" alt="Screenshot 2025-12-13 at 12 02 23 AM" src="https://github.com/user-attachments/assets/229b55bd-ac02-49ee-ba2c-69cac377e1dd" /> | <img width="1728" height="959" alt="Screenshot 2025-12-13 at 12 19 50 AM" src="https://github.com/user-attachments/assets/7ade79c2-d50c-4804-8e70-185bbdd32907" /> | 

## Why are these changes being made?

* Make our UI polished.

## Testing Instructions

* Use the A4A live link and navigate to `/plugins/manage/sites` page.
* Then navigate to the Reports dashboard page.
* Confirm the height looks good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?