### PR TITLE
A4A: Address Help center contact form label and button text.

### DIFF
--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -62,7 +62,7 @@ const fields: Field< FormData >[] = [
 	},
 	{
 		id: 'product',
-		label: __( 'What Automattic product would you like help with?', __i18n_text_domain__ ),
+		label: __( 'What product would you like help with?', __i18n_text_domain__ ),
 		type: 'text' as const,
 		Edit: 'select',
 		elements: [
@@ -208,13 +208,12 @@ export const HelpCenterA4AContactForm = () => {
 				/>
 
 				<Button
-					__next40pxDefaultSize
 					variant="primary"
 					type="submit"
 					disabled={ ! isValidForm || isPending }
 					isBusy={ isPending }
 				>
-					{ __( 'Submit form', __i18n_text_domain__ ) }
+					{ __( 'Send message', __i18n_text_domain__ ) }
 				</Button>
 
 				{ hasSubmitError && (


### PR DESCRIPTION
Context: 
p1765555456171349/1765554475.242039-slack-C0A34L1Q7J9
p1765556375395199/1765554475.242039-slack-C0A34L1Q7J9


## Proposed Changes

* Change button label to `Send message`.
* Change field label to `What product would you like help with?`

## Why are these changes being made?
* Make the Help center more polished.

## Testing Instructions

* Use the A4A live link and navigate to `/overview` page.
* Click the Get in touch button.
* Confirm the changes are correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?