### PR TITLE
Domain Transfer Redesign: Make breadcrumb not clickable in transfer in progress page

### DIFF
--- a/client/dashboard/app/breadcrumbs/index.tsx
+++ b/client/dashboard/app/breadcrumbs/index.tsx
@@ -16,9 +16,18 @@ interface BreadcrumbsProps {
 	 * Receives the href and label of the clicked item.
 	 */
 	onItemClick?: ( href: string, label: string ) => void;
+	/**
+	 * Optional. Whether to render the breadcrumb items as links.
+	 * @default true
+	 */
+	renderAsLinks?: boolean;
 }
 
-export default function Breadcrumbs( { length, onItemClick }: BreadcrumbsProps ) {
+export default function Breadcrumbs( {
+	length,
+	onItemClick,
+	renderAsLinks = true,
+}: BreadcrumbsProps ) {
 	const matches = useMatches();
 
 	const items: BreadcrumbItemProps[] = matches
@@ -35,16 +44,20 @@ export default function Breadcrumbs( { length, onItemClick }: BreadcrumbsProps )
 	return (
 		<BreadcrumbsComponent
 			items={ items }
-			renderItemLink={ ( { href, label, ...rest } ) => (
-				<Link
-					to={ href }
-					search={ getTransientQueryParamsAtPathname( href ) }
-					onClick={ () => onItemClick?.( href, label ) }
-					{ ...rest }
-				>
-					{ label }
-				</Link>
-			) }
+			renderItemLink={ ( { href, label, ...rest } ) =>
+				renderAsLinks ? (
+					<Link
+						to={ href }
+						search={ getTransientQueryParamsAtPathname( href ) }
+						onClick={ () => onItemClick?.( href, label ) }
+						{ ...rest }
+					>
+						{ label }
+					</Link>
+				) : (
+					<span { ...rest }>{ label }</span>
+				)
+			}
 		/>
 	);
 }

--- a/client/dashboard/domains/domain-transfer/index.tsx
+++ b/client/dashboard/domains/domain-transfer/index.tsx
@@ -23,7 +23,7 @@ export default function DomainTransfer() {
 			size="small"
 			header={
 				<PageHeader
-					prefix={ <Breadcrumbs length={ 2 } /> }
+					prefix={ <Breadcrumbs length={ 2 } renderAsLinks={ false } /> }
 					title={ __( 'Transfer' ) }
 					description={
 						! isNewInboundTransferExperience


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOMAINS-1961](https://linear.app/a8c/issue/DOMAINS-1961)

## Proposed Changes

This PR:
- Adds a `renderAsLinks` property to the `Breadcrumbs` component
- Makes the breadcrumbs in the transfer in progress pages not clickable

### Screenshots

| Before | After |
| --- | --- |
| <img width="1094" height="855" alt="Screenshot 2025-12-12 at 13 38 48" src="https://github.com/user-attachments/assets/3e5f5755-9d2a-4c00-bc1a-da18e902396e" /> | <img width="1010" height="855" alt="Screenshot 2025-12-12 at 13 10 29" src="https://github.com/user-attachments/assets/f18ec35c-e997-4e63-b423-0ebc86e6925a" /> |

## Why are these changes being made?

There's no domain overview page for an inbound transfer in progress, since there's nothing to manage before the domain is transferred to us.

This is part of the CfT feedbacks for the [Domain Transfer Redesign project](https://linear.app/a8c/project/implement-new-domain-transfer-designs-e7cf391f6e4a/overview).

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Open the transfer setup page for an incoming transfer that's in progress in the Multi-Site Dashboard (`/v2/domains/<domain_name>/domain-transfer-setup`
- Ensure the breadcrumb with the domain name is not clickable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
