### PR TITLE
GitHub Deployments: add back pre-selection logic

### DIFF
--- a/client/sites/deployments/components/installations-dropdown/use-live-installations.ts
+++ b/client/sites/deployments/components/installations-dropdown/use-live-installations.ts
@@ -1,10 +1,12 @@
 import config from '@automattic/calypso-config';
 import { useI18n } from '@wordpress/react-i18n';
 import { useLayoutEffect, useState } from 'react';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { postLoginRequest } from 'calypso/state/login/utils';
 import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useCodeDeploymentsQuery } from '../../deployments/use-code-deployments-query';
 import {
 	GitHubInstallationData,
 	useGithubInstallationsQuery,
@@ -20,12 +22,14 @@ const AUTHORIZATION_URL =
 const INSTALLATION_URL = 'https://public-api.wordpress.com/wpcom/v2/hosting/github/app-install';
 
 export const useLiveInstallations = () => {
+	const siteId = useSelector( getSelectedSiteId );
 	const {
 		data: installations,
 		error: installationsError,
 		refetch,
 		isLoading: isLoadingInstallations,
 	} = useGithubInstallationsQuery();
+	const { data: deployments = [] } = useCodeDeploymentsQuery( siteId );
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
 	const { saveGitHubCredentials } = useSaveGitHubCredentialsMutation();
@@ -36,8 +40,24 @@ export const useLiveInstallations = () => {
 			return;
 		}
 
+		// If there are existing deployments, try to pre-select the installation
+		// that matches the first deployment's installation_id
+		if ( deployments.length > 0 ) {
+			const firstDeploymentInstallationId = deployments[ 0 ]?.installation_id;
+			if ( firstDeploymentInstallationId ) {
+				const preselectedInstallation = installations.find(
+					( inst ) => inst.external_id === firstDeploymentInstallationId
+				);
+				if ( preselectedInstallation ) {
+					setInstallation( preselectedInstallation );
+					return;
+				}
+			}
+		}
+
+		// Fallback to first installation
 		setInstallation( installations[ 0 ] );
-	}, [ installations, installation ] );
+	}, [ installations, installation, deployments ] );
 
 	const authorizeApp = async ( { code }: { code: string } ) => {
 		const response = await postLoginRequest( 'exchange-social-auth-code', {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTDEV-276

## Proposed Changes

#106154 removed the `initialInstallationId` parameter from `useLiveInstallations`, which pre-selected an installation based on existing deployments `installation_id`. This PR adds this logic back.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
