### PR TITLE
Allow users to select plan before going to checkout

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -30,10 +30,12 @@ function useUpgradeHandler( {
 	siteSlug,
 	coupon,
 	cartHandler,
+	redirectTo,
 }: {
 	siteSlug?: string | null;
 	coupon?: string;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
+	redirectTo?: string;
 } ) {
 	const processCartItems = useCallback(
 		( cartItems?: MinimalRequestCartProduct[] | null ) => {
@@ -62,12 +64,15 @@ function useUpgradeHandler( {
 				? `/checkout/${ siteSlug }/${ planPath },${ cartItemForStorageAddOn.product_slug }:-q-${ cartItemForStorageAddOn.quantity }`
 				: `/checkout/${ siteSlug }/${ planPath }`;
 
-			const checkoutUrlWithArgs = addQueryArgs( { ...( coupon && { coupon } ) }, checkoutUrl );
+			const checkoutUrlWithArgs = addQueryArgs(
+				{ ...( coupon && { coupon } ), ...( redirectTo && { redirect_to: redirectTo } ) },
+				checkoutUrl
+			);
 
 			page( checkoutUrlWithArgs );
 			return;
 		},
-		[ siteSlug, coupon, cartHandler ]
+		[ siteSlug, coupon, cartHandler, redirectTo ]
 	);
 
 	return useCallback(
@@ -154,6 +159,7 @@ function useGenerateActionCallback( {
 	sitePlanSlug,
 	siteId,
 	coupon,
+	redirectTo,
 }: {
 	currentPlan: Plans.SitePlan | undefined;
 	eligibleForFreeHostingTrial: boolean;
@@ -164,6 +170,7 @@ function useGenerateActionCallback( {
 	sitePlanSlug?: PlanSlug | null;
 	siteId?: number | null;
 	coupon?: string;
+	redirectTo?: string;
 } ): UseActionCallback {
 	const siteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
 	const siteUrl = useSelector( ( state: IAppState ) => siteId && getSiteUrl( state, siteId ) );
@@ -177,7 +184,7 @@ function useGenerateActionCallback( {
 			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 			: null
 	);
-	const handleUpgradeClick = useUpgradeHandler( { siteSlug, coupon, cartHandler } );
+	const handleUpgradeClick = useUpgradeHandler( { siteSlug, coupon, cartHandler, redirectTo } );
 	const handleDowngradeClick = useDowngradeHandler( {
 		siteSlug,
 		siteUrl: siteUrl || '',

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -31,11 +31,13 @@ function useUpgradeHandler( {
 	coupon,
 	cartHandler,
 	redirectTo,
+	pluginSlug,
 }: {
 	siteSlug?: string | null;
 	coupon?: string;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
 	redirectTo?: string;
+	pluginSlug?: string;
 } ) {
 	const processCartItems = useCallback(
 		( cartItems?: MinimalRequestCartProduct[] | null ) => {
@@ -60,9 +62,19 @@ function useUpgradeHandler( {
 				? getPlanPath( cartItemForPlan.product_slug )
 				: '';
 
-			const checkoutUrl = cartItemForStorageAddOn
-				? `/checkout/${ siteSlug }/${ planPath },${ cartItemForStorageAddOn.product_slug }:-q-${ cartItemForStorageAddOn.quantity }`
-				: `/checkout/${ siteSlug }/${ planPath }`;
+			let checkoutUrl = `/checkout/${ siteSlug }/${ planPath }`;
+
+			// Append storage add-on if present
+			if ( cartItemForStorageAddOn ) {
+				checkoutUrl = `/checkout/${ siteSlug }/${ planPath },${ cartItemForStorageAddOn.product_slug }:-q-${ cartItemForStorageAddOn.quantity }`;
+			}
+
+			// Append plugin if present
+			if ( pluginSlug ) {
+				checkoutUrl = cartItemForStorageAddOn
+					? `${ checkoutUrl },${ pluginSlug }`
+					: `/checkout/${ siteSlug }/${ planPath },${ pluginSlug }`;
+			}
 
 			const checkoutUrlWithArgs = addQueryArgs(
 				{ ...( coupon && { coupon } ), ...( redirectTo && { redirect_to: redirectTo } ) },
@@ -72,7 +84,7 @@ function useUpgradeHandler( {
 			page( checkoutUrlWithArgs );
 			return;
 		},
-		[ siteSlug, coupon, cartHandler, redirectTo ]
+		[ siteSlug, coupon, cartHandler, redirectTo, pluginSlug ]
 	);
 
 	return useCallback(
@@ -160,6 +172,7 @@ function useGenerateActionCallback( {
 	siteId,
 	coupon,
 	redirectTo,
+	pluginSlug,
 }: {
 	currentPlan: Plans.SitePlan | undefined;
 	eligibleForFreeHostingTrial: boolean;
@@ -171,6 +184,7 @@ function useGenerateActionCallback( {
 	siteId?: number | null;
 	coupon?: string;
 	redirectTo?: string;
+	pluginSlug?: string;
 } ): UseActionCallback {
 	const siteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
 	const siteUrl = useSelector( ( state: IAppState ) => siteId && getSiteUrl( state, siteId ) );
@@ -184,7 +198,13 @@ function useGenerateActionCallback( {
 			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 			: null
 	);
-	const handleUpgradeClick = useUpgradeHandler( { siteSlug, coupon, cartHandler, redirectTo } );
+	const handleUpgradeClick = useUpgradeHandler( {
+		siteSlug,
+		coupon,
+		cartHandler,
+		redirectTo,
+		pluginSlug,
+	} );
 	const handleDowngradeClick = useDowngradeHandler( {
 		siteSlug,
 		siteUrl: siteUrl || '',

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -68,6 +68,7 @@ export default function useGenerateActionHook( {
 	isLaunchPage,
 	showModalAndExit,
 	coupon,
+	redirectTo,
 }: {
 	siteId?: number | null;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
@@ -77,6 +78,7 @@ export default function useGenerateActionHook( {
 	isLaunchPage: boolean | null;
 	showModalAndExit?: ( planSlug: PlanSlug ) => boolean;
 	coupon?: string;
+	redirectTo?: string;
 } ): UseAction {
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
@@ -107,6 +109,7 @@ export default function useGenerateActionHook( {
 		sitePlanSlug,
 		siteId,
 		coupon,
+		redirectTo,
 	} );
 
 	const useActionHook = ( {

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -69,6 +69,7 @@ export default function useGenerateActionHook( {
 	showModalAndExit,
 	coupon,
 	redirectTo,
+	pluginSlug,
 }: {
 	siteId?: number | null;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
@@ -79,6 +80,7 @@ export default function useGenerateActionHook( {
 	showModalAndExit?: ( planSlug: PlanSlug ) => boolean;
 	coupon?: string;
 	redirectTo?: string;
+	pluginSlug?: string;
 } ): UseAction {
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
@@ -110,6 +112,7 @@ export default function useGenerateActionHook( {
 		siteId,
 		coupon,
 		redirectTo,
+		pluginSlug,
 	} );
 
 	const useActionHook = ( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -114,6 +114,7 @@ export interface PlansFeaturesMainProps {
 	selectedFeature?: string;
 	onUpgradeClick?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
 	redirectTo?: string;
+	pluginSlug?: string;
 	redirectToAddDomainFlow?: boolean;
 	hidePlanTypeSelector?: boolean;
 	paidDomainName?: string;
@@ -198,6 +199,7 @@ const PlansFeaturesMain = ( {
 	onUpgradeClick,
 	hidePlanTypeSelector,
 	redirectTo,
+	pluginSlug,
 	redirectToAddDomainFlow,
 	siteId,
 	selectedPlan,
@@ -411,6 +413,7 @@ const PlansFeaturesMain = ( {
 		showModalAndExit,
 		coupon,
 		redirectTo,
+		pluginSlug,
 	} );
 
 	const isDomainOnlySite = useSelector( ( state: IAppState ) =>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -113,6 +113,7 @@ export interface PlansFeaturesMainProps {
 	selectedPlan?: PlanSlug;
 	selectedFeature?: string;
 	onUpgradeClick?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
+	redirectTo?: string;
 	redirectToAddDomainFlow?: boolean;
 	hidePlanTypeSelector?: boolean;
 	paidDomainName?: string;
@@ -196,6 +197,7 @@ const PlansFeaturesMain = ( {
 	isDomainTransfer,
 	onUpgradeClick,
 	hidePlanTypeSelector,
+	redirectTo,
 	redirectToAddDomainFlow,
 	siteId,
 	selectedPlan,
@@ -408,6 +410,7 @@ const PlansFeaturesMain = ( {
 		isLaunchPage,
 		showModalAndExit,
 		coupon,
+		redirectTo,
 	} );
 
 	const isDomainOnlySite = useSelector( ( state: IAppState ) =>

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -54,6 +54,7 @@ export function plans( context, next ) {
 			coupon={ coupon }
 			discountEndDate={ context.query.ts }
 			redirectTo={ context.query.redirect_to }
+			pluginSlug={ context.query.plugin_slug }
 			redirectToAddDomainFlow={
 				context.query.addDomainFlow !== undefined
 					? context.query.addDomainFlow === 'true'

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -70,6 +70,7 @@ class PlansComponent extends Component {
 		customerType: PropTypes.string,
 		selectedFeature: PropTypes.string,
 		redirectTo: PropTypes.string,
+		pluginSlug: PropTypes.string,
 		selectedSite: PropTypes.object,
 	};
 
@@ -168,6 +169,7 @@ class PlansComponent extends Component {
 				selectedFeature={ this.props.selectedFeature }
 				selectedPlan={ this.props.selectedPlan }
 				redirectTo={ this.props.redirectTo }
+				pluginSlug={ this.props.pluginSlug }
 				coupon={ this.props.coupon }
 				discountEndDate={ this.props.discountEndDate }
 				siteId={ selectedSite?.ID }

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -290,8 +290,10 @@ function onClickInstallPlugin( {
 
 		if ( upgradeAndInstall ) {
 			// Redirect to plans page to let user choose a plan, then redirect to checkout with plugin
-			const checkoutUrl = `/checkout/${ selectedSite.slug }/${ product_slug }`;
-			return page( `/plans/${ selectedSite.slug }?redirect_to=${ checkoutUrl }#step2` );
+			const checkoutUrl = `/checkout/${ selectedSite.slug }/${ product_slug }#step2`;
+			return page(
+				`/plans/${ selectedSite.slug }?redirect_to=${ encodeURIComponent( checkoutUrl ) }`
+			);
 		}
 
 		return page( `/checkout/${ selectedSite.slug }/${ product_slug }#step2` );
@@ -304,10 +306,12 @@ function onClickInstallPlugin( {
 	}
 
 	// After buying a plan we need to redirect to the plugin install page.
-	const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
+	const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }#step2`;
 	if ( upgradeAndInstall ) {
 		// Redirect to plans page to let user choose a plan, then redirect to plugin install
-		return page( `/plans/${ selectedSite.slug }?redirect_to=${ installPluginURL }#step2` );
+		return page(
+			`/plans/${ selectedSite.slug }?redirect_to=${ encodeURIComponent( installPluginURL ) }`
+		);
 	}
 
 	// No need to go through checkout, go to install page directly.

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -10,7 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
-import { marketplacePlanToAdd, getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
+import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import useAtomicSiteHasEquivalentFeatureToPlugin from 'calypso/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -289,13 +289,9 @@ function onClickInstallPlugin( {
 		const product_slug = getProductSlugByPeriodVariation( variation, productsList );
 
 		if ( upgradeAndInstall ) {
-			// We also need to add a business plan to the cart.
-			return page(
-				`/checkout/${ selectedSite.slug }/${ marketplacePlanToAdd(
-					selectedSite?.plan,
-					billingPeriod
-				) },${ product_slug }`
-			);
+			// Redirect to plans page to let user choose a plan, then redirect to checkout with plugin
+			const checkoutUrl = `/checkout/${ selectedSite.slug }/${ product_slug }`;
+			return page( `/plans/${ selectedSite.slug }?redirect_to=${ checkoutUrl }#step2` );
 		}
 
 		return page( `/checkout/${ selectedSite.slug }/${ product_slug }#step2` );
@@ -310,13 +306,8 @@ function onClickInstallPlugin( {
 	// After buying a plan we need to redirect to the plugin install page.
 	const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
 	if ( upgradeAndInstall ) {
-		// We also need to add a business plan to the cart.
-		return page(
-			`/checkout/${ selectedSite.slug }/${ marketplacePlanToAdd(
-				selectedSite?.plan,
-				billingPeriod
-			) }?redirect_to=${ installPluginURL }#step2`
-		);
+		// Redirect to plans page to let user choose a plan, then redirect to plugin install
+		return page( `/plans/${ selectedSite.slug }?redirect_to=${ installPluginURL }#step2` );
 	}
 
 	// No need to go through checkout, go to install page directly.

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -280,6 +280,7 @@ function onClickInstallPlugin( {
 
 	dispatch( productToBeInstalled( plugin.slug, selectedSite.slug ) );
 
+	const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }#step2`;
 	if ( isMarketplaceProduct ) {
 		// We need to add the product to the  cart.
 		// Plugin install is handled on the backend by activating the subscription.
@@ -289,11 +290,12 @@ function onClickInstallPlugin( {
 		const product_slug = getProductSlugByPeriodVariation( variation, productsList );
 
 		if ( upgradeAndInstall ) {
-			// Redirect to plans page to let user choose a plan, then redirect to checkout with plugin
-			const checkoutUrl = `/checkout/${ selectedSite.slug }/${ product_slug }#step2`;
+			// Redirect to plans page to let user choose a plan, then checkout with both plan and plugin
 			return page(
-				`/plans/${ selectedSite.slug }?plan=personal_bundle&redirect_to=${ encodeURIComponent(
-					checkoutUrl
+				`/plans/${
+					selectedSite.slug
+				}?plan=personal_bundle&plugin_slug=${ product_slug }&redirect_to=${ encodeURIComponent(
+					installPluginURL
 				) }`
 			);
 		}
@@ -308,7 +310,6 @@ function onClickInstallPlugin( {
 	}
 
 	// After buying a plan we need to redirect to the plugin install page.
-	const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }#step2`;
 	if ( upgradeAndInstall ) {
 		// Redirect to plans page to let user choose a plan, then redirect to plugin install
 		return page(

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -292,7 +292,9 @@ function onClickInstallPlugin( {
 			// Redirect to plans page to let user choose a plan, then redirect to checkout with plugin
 			const checkoutUrl = `/checkout/${ selectedSite.slug }/${ product_slug }#step2`;
 			return page(
-				`/plans/${ selectedSite.slug }?redirect_to=${ encodeURIComponent( checkoutUrl ) }`
+				`/plans/${ selectedSite.slug }?plan=personal_bundle&redirect_to=${ encodeURIComponent(
+					checkoutUrl
+				) }`
 			);
 		}
 
@@ -310,7 +312,9 @@ function onClickInstallPlugin( {
 	if ( upgradeAndInstall ) {
 		// Redirect to plans page to let user choose a plan, then redirect to plugin install
 		return page(
-			`/plans/${ selectedSite.slug }?redirect_to=${ encodeURIComponent( installPluginURL ) }`
+			`/plans/${ selectedSite.slug }?plan=personal_bundle&redirect_to=${ encodeURIComponent(
+				installPluginURL
+			) }`
 		);
 	}
 

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -552,15 +552,7 @@ function FreePrice( { shouldUpgrade } ) {
 		<>
 			{ translate( 'Free' ) }
 			{ ( ! isLoggedIn || ! selectedSite || shouldUpgrade ) && (
-				<span className="plugin-details-cta__notice">
-					{ translate(
-						// Translators: %(planName)s is the name of a plan (e.g. Creator or Business)
-						'on %(planName)s plan',
-						{
-							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-						}
-					) }
-				</span>
+				<span className="plugin-details-cta__notice">{ translate( 'on paid plans' ) }</span>
 			) }
 		</>
 	);

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -134,7 +134,7 @@ export const PlanUSPS: React.FC< Props > = ( {
 	const lowestPlan = PLAN_PERSONAL;
 
 	const lowestPlanDisplayCost = useSelector( ( state ) => {
-		return getProductDisplayCost( state, lowestPlan || '', true );
+		return getProductDisplayCost( state, lowestPlan, true );
 	} );
 
 	const monthlyLabel = translate( 'month' );

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -5,7 +5,6 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_MONTHLY,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
-	getPlan,
 } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { Icon, check } from '@wordpress/icons';
@@ -130,12 +129,15 @@ export const PlanUSPS: React.FC< Props > = ( {
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 	const supportText = usePluginsSupportText();
 	const requiredPlan = useRequiredPlan( shouldUpgrade );
-	const planDisplayCost = useSelector( ( state ) => {
-		return getProductDisplayCost( state, requiredPlan || '' );
+
+	// Always use Personal plan as it's the lowest tier paid plan
+	const lowestPlan = PLAN_PERSONAL;
+
+	const lowestPlanDisplayCost = useSelector( ( state ) => {
+		return getProductDisplayCost( state, lowestPlan || '', true );
 	} );
+
 	const monthlyLabel = translate( 'month' );
-	const annualLabel = translate( 'year' );
-	const periodicityLabel = isAnnualPeriod ? annualLabel : monthlyLabel;
 
 	if ( ! shouldUpgrade ) {
 		return null;
@@ -145,29 +147,14 @@ export const PlanUSPS: React.FC< Props > = ( {
 	switch ( requiredPlan ) {
 		case PLAN_PERSONAL:
 		case PLAN_PERSONAL_MONTHLY:
-			planText = translate(
-				'Included in the %(personalPlanName)s plan (%(cost)s/%(periodicity)s):',
-				{
-					args: {
-						personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() as string,
-						cost: planDisplayCost as string,
-						periodicity: periodicityLabel,
-					},
-				}
-			);
-			break;
 		case PLAN_BUSINESS:
 		case PLAN_BUSINESS_MONTHLY:
-			planText = translate(
-				'Included in the %(businessPlanName)s plan (%(cost)s/%(periodicity)s):',
-				{
-					args: {
-						businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() as string,
-						cost: planDisplayCost as string,
-						periodicity: periodicityLabel,
-					},
-				}
-			);
+			planText = translate( 'Included on all paid plans (starting at %(cost)s/%(periodicity)s)', {
+				args: {
+					cost: lowestPlanDisplayCost as string,
+					periodicity: monthlyLabel,
+				},
+			} );
 			break;
 		case PLAN_ECOMMERCE_TRIAL_MONTHLY:
 			planText = translate( 'Included in ecommerce plans:' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to:
- WOOMKT-496
- WOOMKT-494

## Proposed Changes

- Updated pricing labels from plan-specific (e.g., "Included in the Business plan") to generic "Included on all paid plans"
- Add price display to always show annual plan pricing as monthly equivalent
- Updated "Free on Business plan" to "Free on paid plans"
- Redirect users to `/plans/:site` instead of directly to checkout when they don't have a plan
- Implemented `redirect_to` parameter flow: Plugin page > Plans page > Checkout > Plugin installation
- Added `redirectTo` prop support throughout plans page infrastructure
- Updated checkout URL generation to preserve redirect destination

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Business is not a necessary plan anymore. This should be updated to promote paid plans. The purchase information as well as the upgrade path, that should bring users to a pricing grid step, where they can choose their preferred plan, before the activation path starts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or apply this PR to your local environment
* On a free site, navigate to:
  * `/plugins/wordpress-seo-premium/:site`
     * Verify the section shows "Included on all paid plans (starting at US$4/month)" 
     *  <img width="1072" height="713" alt="Captura de Tela 2025-12-12 às 16 30 14" src="https://github.com/user-attachments/assets/190eaa98-7d4f-4998-a9df-2dff0b0704eb" />

  * `/plugins/contact-form-7/:site`
     * Verify pricing shows "Free on paid plans" (not "Free on Business plan")
     * Verify the section shows "Included on all paid plans (starting at US$4/month)" 
     * <img width="1090" height="695" alt="Captura de Tela 2025-12-12 às 16 31 52" src="https://github.com/user-attachments/assets/2284a24b-f88b-461d-ad1d-44d958962161" />

* Now on `/plugins/wordpress-seo-premium/:site`
   * Click on `Purchase and activate`
   * Verify you're redirected to `/plans/:site?redirect_to=/marketplace/plugin/.../install/...`
   * Select any plan
   * Verify you're redirected to checkout with the `redirect_to` parameter preserved
   * Complete checkout
   * Verify you're redirected back to the plugin installation page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
