### PR TITLE
Domain Transfer Redesign: Redirect user to transfer setup page after checkout when they buy a single domain transfer

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -1,5 +1,5 @@
 import { DotcomFeatures } from '@automattic/api-core';
-import { isDomainMapping } from '@automattic/calypso-products';
+import { isDomainMapping, isDomainTransfer } from '@automattic/calypso-products';
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import {
 	DOMAIN_FLOW,
@@ -100,6 +100,8 @@ const domain: FlowV2< typeof initialize > = {
 			// domains page to guide users through the connection process.
 			const hasOnlyDomainConnection =
 				domainCartItems && domainCartItems.length === 1 && isDomainMapping( domainCartItems[ 0 ] );
+			const hasOnlyDomainTransfer =
+				domainCartItems && domainCartItems.length === 1 && isDomainTransfer( domainCartItems[ 0 ] );
 
 			// Use the redirect_to query param if provided, otherwise fall back to v2 domains
 			let destination = redirectTo || dashboardLink( `/sites/${ siteSlug }/domains` );
@@ -109,6 +111,16 @@ const domain: FlowV2< typeof initialize > = {
 				const domain = domainCartItems[ 0 ].meta;
 				if ( domain ) {
 					destination = dashboardLink( `/domains/${ domain }/domain-connection-setup` );
+				}
+			}
+
+			// Send single domain transfers to domain-transfer-setup.
+			// TODO: The `redirecTo` parameter was introduced in https://github.com/Automattic/wp-calypso/pull/107439,
+			// check if this will break anything
+			if ( hasOnlyDomainTransfer ) {
+				const domain = domainCartItems[ 0 ].meta;
+				if ( domain ) {
+					destination = dashboardLink( `/domains/${ domain }/domain-transfer-setup` );
 				}
 			}
 

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -115,8 +115,6 @@ const domain: FlowV2< typeof initialize > = {
 			}
 
 			// Send single domain transfers to domain-transfer-setup.
-			// TODO: The `redirecTo` parameter was introduced in https://github.com/Automattic/wp-calypso/pull/107439,
-			// check if this will break anything
 			if ( hasOnlyDomainTransfer ) {
 				const domain = domainCartItems[ 0 ].meta;
 				if ( domain ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DOMAINS-1957](https://linear.app/a8c/issue/DOMAINS-1957)

## Proposed Changes

This PR updates the redirect destination after a user completes checkout for a single domain transfer in the Multi-Site Dashboard. In those cases, the user will be redirected to the `/domains/<domain>/domain-transfer-setup` URL, which shows instructions for what they have to do to start their domain transfer.

### Demo

- Before

https://github.com/user-attachments/assets/b1f4b508-10fd-4a9e-9af1-fbd056de4551

- After

https://github.com/user-attachments/assets/a72f7f08-2371-4475-8daa-3edcbe6f305e

## Why are these changes being made?

If a user purchased a single domain transfer, we should take them directly to the domain transfer setup page so they don't lose momentum and know what they need to do next.

This is part of the [Domain Transfer Redesign](https://linear.app/a8c/project/implement-new-domain-transfer-designs-e7cf391f6e4a/overview) project.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to the Multi-Site Dashboard (`my.localhost:3000` or `/v2`)
- Go to a site and buy a domain transfer for it
- After checkout, ensure you're redirected to the domain transfer setup page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
