### PR TITLE
MSD: update default row size in grid view to 4

### DIFF
--- a/client/dashboard/sites/dataviews/views.ts
+++ b/client/dashboard/sites/dataviews/views.ts
@@ -18,7 +18,7 @@ export const DEFAULT_LAYOUTS: SupportedLayouts = {
 	},
 	grid: {
 		layout: {
-			previewSize: 230,
+			previewSize: 290,
 		},
 		showLevels: false,
 		showMedia: true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-643

## Proposed Changes

From: https://github.com/Automattic/wp-calypso/pull/104577, we updated the default page size to 12 because the columns are divisible by 12.

Somehow, the default column size is now 5. (I can't pinpoint which PR caused it.) This causes the last row to only consists of two cells, making it as if the paginated data is incomplete or it looks like the last page.

With this, we update the default row size to always show columns which are divisible by 12.

## Why are these changes being made?

Fixes a regression.

## Testing Instructions

1. Go to /v2/sites.
2. Click the top-right table icon and switch the view to Grid.
3. Try resizing your browser. Ensure you always get 1, 2, 3, or 4 columns per row, which are all divisible by 12, so that the last row is always full (if you have >= 12 sites).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
