### PR TITLE
Add setup site ai step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
@@ -1,0 +1,90 @@
+import { BigSkyLogo, SummaryButton } from '@automattic/components';
+import { Step } from '@automattic/onboarding';
+import { __experimentalVStack as VStack, Button, Icon } from '@wordpress/components';
+import { code } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSiteData } from '../../../../hooks/use-site-data';
+import type { Step as StepType } from '../../types';
+import './style.scss';
+
+const SetupYourSiteAIStep: StepType = ( { navigation } ) => {
+	const { siteSlug, siteId } = useSiteData();
+	const translate = useTranslate();
+
+	const handleBuildWithAI = () => {
+		recordTracksEvent( 'calypso_setup_your_site_ai_build_with_ai_click' );
+
+		navigation.submit( {
+			setupChoice: 'build-with-ai',
+			siteSlug,
+			siteId,
+		} );
+	};
+
+	const handleBlankSite = () => {
+		recordTracksEvent( 'calypso_setup_your_site_ai_blank_site_click' );
+
+		navigation.submit( {
+			setupChoice: 'blank-site',
+			siteSlug,
+		} );
+	};
+
+	const handleMigrate = () => {
+		recordTracksEvent( 'calypso_setup_your_site_ai_migrate_click' );
+
+		navigation.submit( {
+			setupChoice: 'migrate',
+			siteSlug,
+			siteId,
+		} );
+	};
+
+	const stepContent = (
+		<VStack alignment="top" spacing={ 3 }>
+			<SummaryButton
+				title={ translate( 'Build with AI' ) }
+				description={ translate( 'Prompt, edit, and launch a site in just a few clicks.' ) }
+				decoration={ <BigSkyLogo.CentralLogo heartless /> }
+				onClick={ handleBuildWithAI }
+			/>
+			<SummaryButton
+				title={ translate( 'Start with a blank site' ) }
+				description={ translate(
+					'Get started instantly with a simple, ready-to-go WordPress site.'
+				) }
+				decoration={ <Icon icon={ code } /> }
+				onClick={ handleBlankSite }
+			/>
+			<Button
+				className="setup-your-site-ai__migrate-button"
+				variant="link"
+				onClick={ handleMigrate }
+			>
+				{ translate( 'Or migrate your site' ) }
+			</Button>
+		</VStack>
+	);
+
+	return (
+		<Step.CenteredColumnLayout
+			className="setup-your-site-ai-step"
+			columnWidth={ 5 }
+			verticalAlign="center"
+			topBar={ <Step.TopBar /> }
+			heading={
+				<Step.Heading
+					text={ translate( 'Set up your site' ) }
+					subText={ translate(
+						"No matter what you want to do, there's an easy way to get started"
+					) }
+				/>
+			}
+		>
+			{ stepContent }
+		</Step.CenteredColumnLayout>
+	);
+};
+
+export default SetupYourSiteAIStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/style.scss
@@ -1,0 +1,20 @@
+.setup-your-site-ai-step {
+	.summary-button.has-density-low  {
+		border-radius: 8px;
+		
+		// adjust gap between title and strapline
+		[data-wp-component="VStack"]:has(.summary-button-title) {
+			gap: $grid-unit-05;
+		}
+
+		.summary-button-title{
+			font-weight: 500;
+		}
+	}
+
+	.setup-your-site-ai__migrate-button {
+		color: var(--color-primary, #0675c4);
+		text-decoration: none;
+	}	
+}
+

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -338,6 +338,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/post-checkout/post-checkout-onboarding' ),
 	},
 
+	SETUP_YOUR_SITE_AI: {
+		slug: 'setup-your-site-ai',
+		asyncComponent: () => import( './steps-repository/setup-your-site-ai' ),
+	},
+
 	SEGMENTATION_SURVEY: {
 		slug: 'segmentation-survey',
 		asyncComponent: () => import( './steps-repository/segmentation-survey' ),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
<img width="1024" height="864" alt="Screenshot 2025-12-15 at 05 28 39" src="https://github.com/user-attachments/assets/4424f0be-3436-4752-a59a-3c906c8137e0" />

Part of #DOTCOM-15248

## Proposed Changes

* Add setup site with ai step

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Build new flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Wire the step in the onboarding just to test it by adding its name to the steps array:
```
STEPS.SETUP_YOUR_SITE_AI
``` 
* Navigate to `setup/onboarding/setup-your-site-ai?siteSlug=MYSITE.wordpress.com`
* Compare against the [designs](https://www.figma.com/design/CgvvoLeSGOUTLQxDiqU62t/%F0%9F%A7%AD-Dotcom-Onboarding--JTBD-?node-id=7363-24339&m=dev)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
