### PR TITLE
A4A: Address Help Center CFT feedback.

### DIFF
--- a/client/a8c-for-agencies/hooks/use-help-center.ts
+++ b/client/a8c-for-agencies/hooks/use-help-center.ts
@@ -47,7 +47,7 @@ export default function useHelpCenter() {
 		const handleHashChange = () => {
 			if ( hasSupportFormHash && isEnabled( 'a4a-help-center' ) ) {
 				setShowHelpCenter( true );
-				setNavigateToRoute( '/a4a-contact-form' );
+				setNavigateToRoute( '/contact-form' );
 				history.pushState( null, '', window.location.pathname + window.location.search );
 			}
 		};

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -67,6 +67,10 @@ const fields: Field< FormData >[] = [
 		Edit: 'select',
 		elements: [
 			{
+				label: __( 'Choose a product', __i18n_text_domain__ ),
+				value: '',
+			},
+			{
 				label: __( 'Automattic for Agencies', __i18n_text_domain__ ),
 				value: 'a4a',
 			},
@@ -147,7 +151,7 @@ export const HelpCenterA4AContactForm = () => {
 		name: currentUser?.display_name ?? '',
 		email: currentUser?.email ?? '',
 		site: '',
-		product: 'a4a',
+		product: '',
 		message: '',
 		pressable_contact: 'sales',
 	} );

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -50,7 +50,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const containerRef = useRef< HTMLDivElement >( null );
 	const navigate = useNavigate();
 	const { setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
-	const { sectionName, site, source } = useHelpCenterContext();
+	const { sectionName, site, source, disableChatSupport } = useHelpCenterContext();
 	const { data, isLoading: isLoadingSupportStatus } = useSupportStatus();
 	const { forceEmailSupport } = useChatStatus();
 	const currentSiteDomain = site?.domain;
@@ -131,7 +131,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 								sectionName={ sectionName }
 								currentSiteDomain={ currentSiteDomain }
 								isEligibleForChat={ isUserEligibleForPaidSupport }
-								forceEmailSupport={ !! forceEmailSupport }
+								forceEmailSupport={ !! forceEmailSupport || disableChatSupport }
 							/>
 						}
 					/>

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -50,7 +50,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const containerRef = useRef< HTMLDivElement >( null );
 	const navigate = useNavigate();
 	const { setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
-	const { sectionName, site } = useHelpCenterContext();
+	const { sectionName, site, source } = useHelpCenterContext();
 	const { data, isLoading: isLoadingSupportStatus } = useSupportStatus();
 	const { forceEmailSupport } = useChatStatus();
 	const currentSiteDomain = site?.domain;
@@ -135,8 +135,10 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 							/>
 						}
 					/>
-					<Route path="/contact-form" element={ <HelpCenterContactForm /> } />
-					<Route path="/a4a-contact-form" element={ <HelpCenterA4AContactForm /> } />
+					<Route
+						path="/contact-form"
+						element={ source === 'a4a' ? <HelpCenterA4AContactForm /> : <HelpCenterContactForm /> }
+					/>
 					<Route path="/success" element={ <SuccessScreen /> } />
 					<Route
 						path="/support-guides"

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -59,7 +59,6 @@ const EllipsisMenu = () => {
 	const { __ } = useI18n();
 	const navigate = useNavigate();
 	const { recentConversations } = useGetHistoryChats();
-	const { disableChatSupport } = useHelpCenterContext();
 	const { areSoundNotificationsEnabled } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
@@ -99,23 +98,19 @@ const EllipsisMenu = () => {
 					<Menu.ItemLabel>{ __( 'Minimize', __i18n_text_domain__ ) }</Menu.ItemLabel>
 				</Menu.Item>
 				<Menu.Separator />
-				{ ! disableChatSupport && (
-					<>
-						<Menu.Item
-							onClick={ clearChat }
-							prefix={ <Icon icon={ comment } width={ 24 } height={ 24 } /> }
-						>
-							<Menu.ItemLabel>{ __( 'New chat', __i18n_text_domain__ ) }</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu.Item
-							onClick={ handleViewChats }
-							prefix={ <Icon icon={ backup } width={ 24 } height={ 24 } /> }
-						>
-							<Menu.ItemLabel>{ __( 'Support history', __i18n_text_domain__ ) }</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu.Separator />
-					</>
-				) }
+				<Menu.Item
+					onClick={ clearChat }
+					prefix={ <Icon icon={ comment } width={ 24 } height={ 24 } /> }
+				>
+					<Menu.ItemLabel>{ __( 'New chat', __i18n_text_domain__ ) }</Menu.ItemLabel>
+				</Menu.Item>
+				<Menu.Item
+					onClick={ handleViewChats }
+					prefix={ <Icon icon={ backup } width={ 24 } height={ 24 } /> }
+				>
+					<Menu.ItemLabel>{ __( 'Support history', __i18n_text_domain__ ) }</Menu.ItemLabel>
+				</Menu.Item>
+				<Menu.Separator />
 				<Menu.Item
 					onClick={ toggleSoundNotifications }
 					prefix={
@@ -213,6 +208,8 @@ const HelpCenterHeader = ( { onDismiss }: Header ) => {
 		};
 	}, [] );
 
+	const { disableChatSupport } = useHelpCenterContext();
+
 	const classNames = clsx(
 		'help-center__container-header',
 		location?.pathname?.replace( /^\//, '' ),
@@ -254,7 +251,18 @@ const HelpCenterHeader = ( { onDismiss }: Header ) => {
 			<Flex>
 				{ shouldShowBackButton ? <BackButton /> : null }
 				<HeaderText />
-				<EllipsisMenu />
+				{ disableChatSupport ? (
+					<Button
+						label={ __( 'Minimize Help Center', __i18n_text_domain__ ) }
+						tooltipPosition="top left"
+						icon={ lineSolid }
+						onClick={ () => setIsMinimized( true ) }
+					/>
+				) : (
+					// We only show the ellipsis menu if chat support is enabled
+					<EllipsisMenu />
+				) }
+
 				<Button
 					className="help-center-header__close"
 					label={ __( 'Close Help Center', __i18n_text_domain__ ) }

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -8,9 +8,7 @@ export function useStillNeedHelpURL() {
 
 	let url = '/contact-form';
 
-	if ( isA8CForAgencies() ) {
-		url = '/a4a-contact-form';
-	} else if ( shouldUseWapuu ) {
+	if ( shouldUseWapuu && ! isA8CForAgencies() ) {
 		url = '/odie';
 	}
 


### PR DESCRIPTION
Context: pgjTho-1yl-p2

## Proposed Changes

This pull request updates the Help Center's contact form flow, particularly for "Automattic for Agencies" (A4A) users, and refines how chat support is handled and displayed. The main changes unify the contact form route, improve product selection for users, and adjust UI elements based on chat support availability.

**Contact Form Routing and Product Selection:**

* Unified the contact form route for A4A users by removing the separate `/a4a-contact-form` path and using `/contact-form` for all users. The correct form is now shown based on the user's source. [[1]](diffhunk://#diff-180c605250d4095e7413c9fc73326babca1cf9240996fb0f7f6cab5c1db937fcL50-R50) [[2]](diffhunk://#diff-d2074a1d5192e133f78462249474fc4870d9962bd0c23bd765b44e2f63d451ffL134-R141) [[3]](diffhunk://#diff-2f48388711ec590643b9ffb553813decfb8cac10b6942dc7e6b475c8b2453458L11-R11)
* Updated the product selection dropdown in the contact form to include a default "Choose a product" option and set the initial product value to an empty string, requiring explicit user selection. [[1]](diffhunk://#diff-0d5731e675b77983cee175e110e33345defcfaad57975a54616692fede3cdc97R69-R72) [[2]](diffhunk://#diff-0d5731e675b77983cee175e110e33345defcfaad57975a54616692fede3cdc97L150-R154)

**Chat Support and UI Adjustments:**

* Adjusted the logic to disable chat support: if chat is disabled, the ellipsis menu is replaced by a "Minimize Help Center" button, and related UI code is updated accordingly. [[1]](diffhunk://#diff-d2074a1d5192e133f78462249474fc4870d9962bd0c23bd765b44e2f63d451ffL53-R53) [[2]](diffhunk://#diff-d2074a1d5192e133f78462249474fc4870d9962bd0c23bd765b44e2f63d451ffL134-R141) [[3]](diffhunk://#diff-6d695461450043c8cea24395dd84ed555f1a377dda8d826ec9845a339b685903R211-R212) [[4]](diffhunk://#diff-6d695461450043c8cea24395dd84ed555f1a377dda8d826ec9845a339b685903R254-R265) [[5]](diffhunk://#diff-6d695461450043c8cea24395dd84ed555f1a377dda8d826ec9845a339b685903L62) [[6]](diffhunk://#diff-6d695461450043c8cea24395dd84ed555f1a377dda8d826ec9845a339b685903L102-L103) [[7]](diffhunk://#diff-6d695461450043c8cea24395dd84ed555f1a377dda8d826ec9845a339b685903L117-L118)

<img width="428" height="288" alt="Screenshot 2025-12-15 at 3 17 54 PM" src="https://github.com/user-attachments/assets/56f9bee5-5a43-409c-947e-978886bc6492" />



## Why are these changes being made?

* This is part of the cohesive support in A4A project.

## Testing Instructions

* Use the A4A live link and navigate to `/overview`
* Click the Help center button at the sidebar's footer.
* Verify that the minimize button works great.
* Next open any article and scroll down below to see the feedback button.
* Select a negative feedback and confirm you see the email support option. Clicking the option should bring you to the contact form.
* In the form, verify that the default value for the 'Product' field is empty.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?