### PR TITLE
e2e tests: Update purchase button selector and improve timeout handling in CartCheckoutPage

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -66,7 +66,6 @@ const selectors = {
 		envVariables.VIEWPORT_NAME === 'mobile'
 			? '.wp-checkout__total-price'
 			: '.wp-checkout-order-summary__total-price',
-	purchaseButton: '.checkout-submit-button button:has-text("Pay")',
 	thirdPartyDeveloperCheckboxLabel:
 		'You agree that an account may be created on a third party developer’s site related to the products you have purchased.',
 
@@ -331,10 +330,10 @@ export class CartCheckoutPage {
 	/**
 	 * Complete the purchase by clicking on the 'Pay' button.
 	 */
-	async purchase( { timeout }: { timeout?: number } = {} ): Promise< void > {
+	async purchase( { timeout }: { timeout: number } = { timeout: 60000 } ): Promise< void > {
 		await Promise.all( [
 			this.page.waitForResponse( /.*me\/transactions.*/, { timeout: timeout } ),
-			this.page.click( selectors.purchaseButton ),
+			this.page.getByRole( 'button', { name: 'Pay now' } ).click(),
 		] );
 	}
 

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
@@ -10,7 +10,7 @@ import { apiCloseAccount } from '../shared';
 test.describe(
 	'Signup: Lifecycle: Logged Out Home Page, signup, onboard, launch and cancel subscription',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_RELEASE, tags.CALYPSO_PR ],
 		annotation: {
 			type: 'flowchart',
 			description:


### PR DESCRIPTION

Fixes QAO-184

## Proposed Changes

Fixes `signup__with-theme-LOHP.spec.ts:25:7 One: As a new WordPress.com user I can sign up for a new Premium plan site using a theme from the Logged Out Home Page`

- use a stronger locator for the Pay Now button - it was resolved to 2 elements:
```
waiting for locator('.checkout-submit-button button:has-text("Pay")')
        - locator resolved to 2 elements. Proceeding with the first one: <button disabled class="checkout-button css-l5z8ss e15u1fbk0">Select a payment card</button>
```
- increased the timeout waiting for `/.*me\/transactions.*/` response to 60s. The default of 10s is not always enough.


## Testing Instructions

```
yarn build
yarn test:pw signup__with-theme-LOHP
```