### PR TITLE
Studio: Update studio name on `/me` screens

### DIFF
--- a/client/blocks/get-apps/apps-config.tsx
+++ b/client/blocks/get-apps/apps-config.tsx
@@ -161,8 +161,10 @@ export const createWordPressStudioConfig = (
 		id: 'wordpress-studio',
 		logo: StudioAppLogo,
 		logoName: 'studio-app-logo',
-		title: translate( 'Studio by WordPress.com' ),
-		subtitle: translate( 'A fast, free way to develop locally with WordPress.' ),
+		title: translate( 'WordPress Studio' ),
+		subtitle: translate(
+			'A fast, free way to develop locally with WordPress. Share your local sites with clients or colleagues and keep your local development process smooth and simple.'
+		),
 		link: translate( 'Visit {{a}}developer.wordpress.com/studio{{/a}} on your desktop.', {
 			components: {
 				a: <a href="https://developer.wordpress.com/studio/" />,

--- a/client/me/developer/features/studio-card.tsx
+++ b/client/me/developer/features/studio-card.tsx
@@ -12,9 +12,7 @@ export const StudioCard = () => {
 	return (
 		<Card className="developer-features-list__item">
 			<div className="developer-features-list__item-tag">{ translate( 'New' ) }</div>
-			<div className="developer-features-list__item-title">
-				{ translate( 'Studio by WordPress.com' ) }
-			</div>
+			<div className="developer-features-list__item-title">{ translate( 'WordPress Studio' ) }</div>
 			<div className="developer-features-list__item-description">
 				{ translate(
 					'A fast, free way to develop locally with WordPress. Share your local sites with clients or colleagues and keep your local development process smooth and simple.'


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STU-810

## Proposed Changes

* Update studio app name to WordPress Studio on /me/get-apps and /me/developer screens

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We changed Studio app name to "WordPress Studio" from "Studio by WordPress.com"
<img width="2198" height="1810" alt="CleanShot 2025-12-15 at 18 31 37@2x" src="https://github.com/user-attachments/assets/7c555966-8f35-45b2-99ba-b7d5fe894803" />

<img width="2220" height="2094" alt="CleanShot 2025-12-15 at 18 31 43 2@2x" src="https://github.com/user-attachments/assets/b70dba5b-f4c9-4f71-9b72-bb9291bf0416" />




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally or use Calypso live link
* Visit /me/get-apps and make sure name is updated and description looks good. I have used description from /me/developer screen to look consistent.  
* Visit /me/developer and make sure Studio app description is updated. 




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
