### PR TITLE
GitHub Deployments: always re‑authorize installations

### DIFF
--- a/client/sites/deployments/components/installations-dropdown/use-live-installations.ts
+++ b/client/sites/deployments/components/installations-dropdown/use-live-installations.ts
@@ -22,7 +22,6 @@ const INSTALLATION_URL = 'https://public-api.wordpress.com/wpcom/v2/hosting/gith
 export const useLiveInstallations = () => {
 	const {
 		data: installations,
-		error: installationsError,
 		refetch,
 		isLoading: isLoadingInstallations,
 	} = useGithubInstallationsQuery();
@@ -56,7 +55,7 @@ export const useLiveInstallations = () => {
 		dispatch( recordTracksEvent( 'calypso_hosting_github_app_open_auth_popup_requested' ) );
 
 		const openedPopup = openPopup( {
-			url: installationsError?.name === 'UnauthorizedError' ? AUTHORIZATION_URL : INSTALLATION_URL,
+			url: AUTHORIZATION_URL,
 			onMessage: async ( data, popup ) => {
 				if ( 'github-app-authorized' === data.type ) {
 					dispatch( recordTracksEvent( 'calypso_hosting_github_app_authorised_success' ) );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTDEV-276

## Proposed Changes

* In `useLiveInstallations`, always open the GitHub popup with the authorization URL `/hosting/github/app-authorize` instead of conditionally skipping to the installations URL `/hosting/github/app-install`
* Keep the existing logic, which after a successful authorization, exchanges the code for an access token and saves it via the `/wpcom/v2/hosting/github/accounts` request, refetches installations, and then navigates the popup to the installations page

## Why are these changes being made?

Previously, `onNewInstallationRequest` chose between two URLs:

- If `GET /hosting/github/installations` failed with `UnauthorizedError`, it used the authorization URL, received a `github-app-authorized` message, exchanged the code, saved the new GitHub access token via `/hosting/github/accounts`, and then loaded the installations page.
- Otherwise, it went directly to the installations URL and only listened for `github-app-installed` messages, never receiving `github-app-authorized` and not calling the `/hosting/github/accounts` endpoint.

In the second path, when a user switches to a different GitHub account, we never update the stored GitHub access token for the WP.com user. All subsequent `/hosting/github/installations` calls continue using the old token. This causes:

- installations to appear empty or stale after re‑installing the app
- shows the “Install the WordPress.com app” / no‑repositories screen even after a seemingly successful connection

By always starting from the authorization URL, we ensure that every time the user goes through the popup we:

- get a fresh auth code for the current GitHub user
- exchange and store the new access token via `/hosting/github/accounts`
- load the installations page using that updated identity

This aligns the deployments flow with the behavior already used in the V2 dashboard (`useInstallGithub`) and should resolve the reported issues.

## Testing Instructions

### Setup

- Use a WP.com test user, and two GitHub accounts (*A* and *B*).
- Ensure the WP.com test user has a Business site, which is Atomic, so deployments are enabled on it

### (Optionally) Reproduce the original issue on trunk

#### With GitHub account *A*

   - Go to the site’s Deployments tab
   - Click `Select repository` and install the WordPress.com app as account *A*
   - Verify installations and repositories load as expected

#### With GitHub account *B*, still using the same WP.com user

   - Log out of GitHub user *A* and log in as *B*
   - In the same WP.com session, go to the test site’s Deployments tab and open DevTools
   - Click `Select repository` and install the WordPress.com app as account *B*
   - Allow permissions on some repositories
   - Check in DevTools Network tab:
     - You do **not** see a POST to `/wpcom/v2/hosting/github/accounts`
     - GET `/wpcom/v2/hosting/github/installations` still reflects account *A* results or returns an empty array
   - The UI either continues to show “Install the WordPress.com app” or the previous repositories list

Here's a video of this flow, trying to authenticate the GitHub account `flagstone21` after my account `gcsecsey` was authorized earlier:

https://github.com/user-attachments/assets/80cba492-cf62-481f-a0b1-a4c5b52f2f4b

### After applying this PR

#### With GitHub account *A*

   - Go to the site’s Deployments tab
   - Click `Select repository` and install the WordPress.com app as account *A*
   - Verify installations and repositories load as expected

#### With GitHub account *B*, still using the same WP.com user

   - Log out of GitHub user *A* and log in as *B*
   - In the same WP.com session, go to the test site’s Deployments tab and open DevTools
   - Click `Select repository` and install the WordPress.com app as account *B*
   - Allow permissions on some repositories
   - Check in the DevTools Network tab:
     - The popup loads the authorization URL `/wpcom/v2/hosting/github/app-authorize`
     - After confirming in GitHub, you see:
       - POST `/wpcom/v2/hosting/github/accounts` with the access token in the payload
       - Then GET `/wpcom/v2/hosting/github/installations`
   - The repositories list should now be based on account **B**’s installations, and you should be able to select a repo and complete the connection.

https://github.com/user-attachments/assets/61d860bb-32ab-41bb-befe-4ba317c98055