### PR TITLE
GitHub Deployments: add pre-connect checks guards

### DIFF
--- a/client/sites/deployments/use-github-repository-checks-query.ts
+++ b/client/sites/deployments/use-github-repository-checks-query.ts
@@ -41,5 +41,6 @@ export const useGithubRepositoryChecksQuery = (
 		meta: {
 			persist: false,
 		},
+		enabled: !! installationId && !! repositoryOwner && !! repositoryName && !! repositoryBranch,
 	} );
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTDEV-276

## Proposed Changes

Update `useGithubRepositoryChecksQuery` to only run when all required parameters are present.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In some cases, we were firing the `pre-connect-checks` request with only `repository_branch` set and the other required parameters missing. This caused the API to respond with a 400.

Those are both noisy and misleading in dev tools, and they don’t represent a real failure of the user’s configuration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### To reproduce the original issue on trunk

- Go to the Deployments tab for a test site
- Open the DevTools Network panel
- Click the Connect repository button
- Check that the `https://public-api.wordpress.com/wpcom/v2/hosting/github/repository/pre-connect-checks?repository_branch=main&_envelope=1` request is sent multiple times, with a 400 response

https://github.com/user-attachments/assets/9fc2e8a3-0fad-4ce3-96c5-a2a72228a2ee

### To test the fix on this branch

- Go to the Deployments tab for a test site
- Open the DevTools Network panel
- Click the Connect repository button
- Check that the `https://public-api.wordpress.com/wpcom/v2/hosting/github/repository/pre-connect-checks?repository_branch=main&_envelope=1` request is not sent
- Proceed with selecting a repository
- Check that the `pre-connect-checks` request is only sent after selecting a repository, it has all the required parameters, and receives a 200 response

https://github.com/user-attachments/assets/8a1289e3-9cd6-471a-8c78-5cac3b3fbe54