### PR TITLE
Holiday snow: update ending day for snow

### DIFF
--- a/client/dashboard/sites/settings-holiday-snow/index.tsx
+++ b/client/dashboard/sites/settings-holiday-snow/index.tsx
@@ -19,7 +19,7 @@ import type { Field, FormField } from '@wordpress/dataviews';
 const fields: Field< SiteSettings >[] = [
 	{
 		id: 'jetpack_holiday_snow_enabled',
-		label: __( 'Show falling snow on my site until January 4th' ),
+		label: __( 'Show falling snow on my site until January 6th' ),
 		Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
 			const { id, getValue } = field;
 			return (

--- a/client/dashboard/sites/settings-holiday-snow/utils.ts
+++ b/client/dashboard/sites/settings-holiday-snow/utils.ts
@@ -2,7 +2,7 @@ import { isWithinInterval, startOfDay } from 'date-fns';
 import { isSimple } from '../../utils/site-types';
 import type { Site } from '@automattic/api-core';
 
-// Holiday Snow is available on WordPress.com sites only from December 1 through January 4.
+// Holiday Snow is available on WordPress.com sites only from December 1 through January 6.
 export function isHolidaySnowAvailable( site: Site ) {
 	if ( ! isSimple( site ) && ! site.is_wpcom_atomic ) {
 		return false;
@@ -12,7 +12,7 @@ export function isHolidaySnowAvailable( site: Site ) {
 
 	const year = today.getFullYear();
 	const start = new Date( year, 11, 1 );
-	const end = new Date( year + 1, 0, 4 );
+	const end = new Date( year + 1, 0, 6 );
 
 	return isWithinInterval( today, { start, end } );
 }

--- a/client/sites/settings/site/holiday-snow.jsx
+++ b/client/sites/settings/site/holiday-snow.jsx
@@ -4,16 +4,16 @@ import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { PanelCard, PanelCardDescription, PanelCardHeading } from 'calypso/components/panel';
 
-// Add settings for holiday snow: ability to enable snow on the site until January 4th.
+// Add settings for holiday snow: ability to enable snow on the site until January 6th.
 export default function HolidaySnow( { fields, handleToggle, isSaving, onSave, disabled } ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 
-	// Only display the card between December 1st and January 4th.
+	// Only display the card between December 1st and January 6th.
 	const today = moment();
 	const currentYear = today.year();
 	const startDate = moment( { year: currentYear, month: 11, date: 1 } ); // moment months are 0-indexed
-	const endDate = moment( { year: currentYear, month: 0, date: 4 } ); // moment months are 0-indexed
+	const endDate = moment( { year: currentYear, month: 0, date: 6 } ); // moment months are 0-indexed
 
 	if ( today.isBefore( startDate, 'day' ) && today.isAfter( endDate, 'day' ) ) {
 		return null;
@@ -37,7 +37,7 @@ export default function HolidaySnow( { fields, handleToggle, isSaving, onSave, d
 		<PanelCard>
 			<PanelCardHeading>{ translate( 'Holiday snow' ) }</PanelCardHeading>
 			<PanelCardDescription>
-				{ translate( 'Show falling snow on my site until January 4th.' ) }
+				{ translate( 'Show falling snow on my site until January 6th.' ) }
 			</PanelCardDescription>
 			{ renderForm() }
 			<Button busy={ isSaving } disabled={ disabled } onClick={ onSave }>


### PR DESCRIPTION
## Proposed Changes

Snow now falls until January 6th.

See https://github.com/Automattic/jetpack/pull/46139/

## Testing Instructions

* Check the 2 setting screens ; the date should now be up to date.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
