### PR TITLE
Update CIAB Site Spec screen UI

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSpec } from 'calypso/lib/site-spec';
+import { getCiabSiteSpecConfig, type SiteSpecConfig } from 'calypso/lib/site-spec/utils';
 import type { Step as StepType } from '../../types';
 
 const SiteSpec: StepType = function SiteSpec() {
@@ -10,15 +11,9 @@ const SiteSpec: StepType = function SiteSpec() {
 	const queryParams = useQuery();
 	const source = queryParams.get( 'source' );
 
-	let siteSpecConfig;
+	let siteSpecConfig: SiteSpecConfig | undefined;
 	if ( source && source.startsWith( 'ciab-' ) ) {
-		siteSpecConfig = {
-			buildSiteUrl: '/setup/ai-site-builder/?create_garden_site=1&spec_id=',
-			backButton: {
-				enabled: true,
-				url: '/ciab/sites',
-			},
-		};
+		siteSpecConfig = getCiabSiteSpecConfig() as SiteSpecConfig;
 	}
 
 	useSiteSpec( { siteSpecConfig } );

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -27,8 +27,8 @@ export interface BackButtonConfig {
 
 // Config structure for the client
 export interface SiteSpecConfig {
-	agentUrl?: string | void;
-	agentId?: string | void;
+	agentUrl?: string;
+	agentId?: string;
 	buildSiteUrl?: string;
 	theme?: {
 		// Branding
@@ -121,11 +121,6 @@ export interface SiteSpecConfig {
 		label?: string;
 		callback?: () => void;
 	};
-	locale?: string;
-	source?: string;
-
-	// Remote theme ingestion (deferred and gated by VITE_SITESPEC_ENABLE_REMOTE_THEME)
-	themeUrl?: string; // When enabled, URL to fetch a JSON theme payload (tokens/slots)
 }
 
 // Config key for URL functions
@@ -219,6 +214,23 @@ export function getCiabSiteSpecConfig(): SiteSpecConfig {
 				border: '#000000',
 				muted: '#E3E8EF',
 			},
+			cssVariables: {
+				'--spec-preview-input-bg': 'rgba(0, 0, 0, 0.04)',
+				// For the create-site button
+				'--spec-preview-create-bg':
+					'var(--ss-suggestion-solid-bg, var(--ss-color-primary, #000000))',
+				'--spec-preview-create-fg':
+					'var(--ss-suggestion-solid-text, var(--ss-color-primary-foreground, #F5F7FA))',
+				'--spec-preview-create-border':
+					'1px solid var(--ss-suggestion-solid-border, var(--ss-color-primary, #000000))',
+
+				// For the footer submit button
+				'--spec-preview-chip-bg': 'var(--ss-suggestion-solid-bg, var(--ss-color-primary, #000000))',
+				'--spec-preview-chip-fg':
+					'var(--ss-suggestion-solid-text, var(--ss-color-primary-foreground, #F5F7FA))',
+				'--spec-preview-chip-border':
+					'1px solid var(--ss-suggestion-solid-border, var(--ss-color-primary, #000000))',
+			},
 			promptSuggestions: {
 				variant: 'solid' as const,
 				background: '#000000',
@@ -231,42 +243,42 @@ export function getCiabSiteSpecConfig(): SiteSpecConfig {
 				enabled: true,
 				items: [
 					{
-						label: __( 'Take a bookings for a hair salon', 'site-spec' ),
+						label: __( 'Take bookings for a hair salon' ),
 						prompt: __(
 							"Create a trendy, fashion-forward hair salon website with a sleek, modern, polished aesthetic. Use black, cool gray, white, and accents of electric blue, emerald, or magenta. Apply stylish, confident copy and elegant sans-serif fonts like Bonita. Highlight the salon's unique skills and ensure the design feels vibrant and engaging.",
 							'site-spec'
 						),
 					},
 					{
-						label: __( 'Offer personal training sessions', 'site-spec' ),
+						label: __( 'Offer personal training sessions' ),
 						prompt: __(
 							'Create a high-intensity fitness instructor website with an energetic, bold, dynamic aesthetic using black, deep red, electric orange, and charcoal gray. Use urgent, inspiring, direct copy and powerful sport-style sans-serif fonts like Jumpshot. Design the site to motivate users to book a training session.',
 							'site-spec'
 						),
 					},
 					{
-						label: __( 'Create an online plant shop', 'site-spec' ),
+						label: __( 'Create an online plant shop' ),
 						prompt: __(
 							'Create an eco-friendly plant store website with a natural, earthy, calming aesthetic using forest green, moss, terra cotta, warm beige, and natural white. Use nurturing, organic copy and fonts like Mollani Nature Script or Plantae. Showcase the full breadth of products with a fresh, inviting design.',
 							'site-spec'
 						),
 					},
 					{
-						label: __( 'Host cooking workshops', 'site-spec' ),
+						label: __( 'Host cooking workshops' ),
 						prompt: __(
 							'Create a fun, family-friendly cooking workshop website with a warm, inviting, colorful, playful aesthetic. Use bright yellow, orange, tomato red, warm brown, and cream tones. Apply warm, appetizing copy and friendly, whimsical fonts like Pacifico or Amatic SC. Design the site to encourage users to book a workshop.',
 							'site-spec'
 						),
 					},
 					{
-						label: __( 'Sell handmade jewelry online', 'site-spec' ),
+						label: __( 'Sell handmade jewelry' ),
 						prompt: __(
 							'Create a handmade, one-of-a-kind jewelry store website with a rustic, intricate, elegant aesthetic. Use deep browns, terracotta, moss green, metallic gold or silver, and soft neutrals. Apply personal, inviting copy and refined script or serif fonts like Parisienne or Cormorant Garamond. Design the site to encourage users to buy online.',
 							'site-spec'
 						),
 					},
 					{
-						label: __( 'Rent out photography equipment', 'site-spec' ),
+						label: __( 'Rent out photography equipment' ),
 						prompt: __(
 							'Create a high-tech, modern photography equipment rental website with a sleek, minimalist, futuristic aesthetic. Use charcoal gray, black, white, cool blue, and electric yellow/green accents. Apply informative, precise copy and clean, technical fonts like Kyrial Sans Pro or Zyphor. Design the site to encourage users to rent equipment.',
 							'site-spec'
@@ -287,7 +299,7 @@ export function getCiabSiteSpecConfig(): SiteSpecConfig {
 				headings: "'Inter', sans-serif",
 			},
 			poweredBy: {
-				label: 'Powered by',
+				label: __( 'Powered by' ),
 				logo: 'https://woocommerce.com/wp-content/uploads/2025/01/Logo-Black.png',
 				url: 'https://woocommerce.com',
 			},

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { __ } from '@wordpress/i18n';
 
 // Raw config structure from the server
 interface SiteSpecRawConfig {
@@ -9,21 +10,122 @@ interface SiteSpecRawConfig {
 	css_url: string;
 }
 
+export interface ToSConfig {
+	userGuidelinesPrefix?: string;
+	userGuidelinesText?: string;
+	userGuidelinesUrl?: string;
+	showToS?: boolean;
+	contentHtml?: string;
+}
+
+export interface BackButtonConfig {
+	url?: string;
+	label?: string;
+	enabled?: boolean;
+	useHistory?: boolean;
+}
+
 // Config structure for the client
 export interface SiteSpecConfig {
-	agentUrl?: string;
-	agentId?: string;
+	agentUrl?: string | void;
+	agentId?: string | void;
 	buildSiteUrl?: string;
-	locale?: string;
+	theme?: {
+		// Branding
+		brandIcon?: SVGRectElement | string | null; // ReactElement or image URL; null hides
+		brandIconAlt?: string; // Alt text for brandIcon when string URL
+		brandIconHeight?: number | string;
+		initialIcon?: SVGRectElement | string | null; // ReactElement or image URL; null hides
+		initialIconAlt?: string; // Alt text for initialIcon when string URL
+
+		// Copy overrides
+		onboardingTitle?: string; // e.g., "Make a website as unique as you."
+		onboardingSubtitle?: string; // Optional subheader text under the title
+
+		// Colors and shape tokens
+		brandColor?: string; // Back-compat primary brand color
+		colors?: {
+			background?: string;
+			primary?: string;
+			primaryForeground?: string;
+			foreground?: string;
+			border?: string;
+			muted?: string;
+			mutedForeground?: string;
+		};
+		radius?: {
+			base?: string; // e.g., '12px'
+			input?: string; // e.g., '12px'
+		};
+
+		// Powered by
+		poweredBy?: {
+			label?: string; // e.g., 'Powered by'
+			logo?: SVGRectElement | string; // React element or image URL
+			logoAlt?: string; // Alt text for logo when string URL
+			url?: string; // Click-through link
+			position?: 'header' | 'footer';
+		};
+
+		promptSuggestions?: {
+			variant?: 'glass' | 'solid';
+			background?: string;
+			border?: string;
+			text?: string;
+			hoverOpacity?: number;
+			hoverBackground?: string;
+			hoverBorder?: string;
+			hoverText?: string;
+			enabled?: boolean;
+			items?: Array< {
+				label: string;
+				prompt: string;
+			} >;
+		};
+
+		buttons?: {
+			textColor?: string;
+			hoverTextColor?: string;
+		};
+
+		effects?: {
+			glow?: boolean;
+			glowColor?: string; // Optional color of the glow overlay
+		};
+
+		typography?: {
+			body?: string;
+			headings?: string;
+		};
+
+		// Identification/metadata
+		brandId?: string; // Analytics/diagnostics identifier
+		version?: string; // Theme schema/version tag
+
+		// Styling hooks
+		className?: string; // Custom class on root container
+		cssVariables?: Record< string, string >; // Arbitrary CSS custom props
+	};
+	tosConfig?: ToSConfig;
+	placeholder?: string | string[];
 	tracking?: {
-		enabled?: boolean;
-		prefix?: string;
-		getOverrides?: ( eventName: string ) => Record< string, string >;
+		enabled: boolean;
+		prefix: string;
+		getOverrides?: ( event: string ) => Record< string, any >;
 	};
-	backButton?: {
+	backButton?: BackButtonConfig;
+	exitButton?: {
 		enabled?: boolean;
-		url?: string;
+		color?: string;
+		hoverColor?: string;
+		label?: string;
+		callback?: () => void;
 	};
+	locale?: string;
+	source?: string;
+
+	// Remote theme ingestion (deferred and gated by VITE_SITESPEC_ENABLE_REMOTE_THEME)
+	themeUrl?: string; // When enabled, URL to fetch a JSON theme payload (tokens/slots)
 }
 
 // Config key for URL functions
@@ -85,4 +187,117 @@ export function getDefaultSiteSpecConfig(): SiteSpecConfig {
 			} ),
 		},
 	};
+}
+
+/**
+ * Retrieves the CIAB-specific SiteSpec configuration.
+ * @returns {SiteSpecConfig} Configuration object for CIAB (Commerce in a Box) flow
+ */
+export function getCiabSiteSpecConfig(): SiteSpecConfig {
+	return {
+		buildSiteUrl: '/setup/ai-site-builder/?create_garden_site=1&spec_id=',
+		backButton: {
+			enabled: true,
+			url: '/ciab/sites',
+		},
+		theme: {
+			brandId: 'ciab',
+			brandIcon: 'https://woocommerce.com/wp-content/uploads/2025/01/Logo-Black.png',
+			initialIcon: 'https://woocommerce.com/wp-content/uploads/2025/01/Logo-Black.png',
+			brandIconHeight: 32,
+			brandColor: '#000000',
+			onboardingTitle: __( 'Your success story sarts here.', 'site-spec' ),
+			onboardingSubtitle: __(
+				"Tell us about what you sell or offer, and we'll start building your online store.",
+				'site-spec'
+			),
+			colors: {
+				background: '#F5F7FA',
+				primary: '#000000',
+				primaryForeground: '#F5F7FA',
+				foreground: '#1F2933',
+				border: '#000000',
+				muted: '#E3E8EF',
+			},
+			promptSuggestions: {
+				variant: 'solid' as const,
+				background: '#000000',
+				border: '#000000',
+				text: '#F5F7FA',
+				hoverBackground: '#111111',
+				hoverBorder: '#000000',
+				hoverText: '#F5F7FA',
+				hoverOpacity: 0.85,
+				enabled: true,
+				items: [
+					{
+						label: __( 'Take a bookings for a hair salon', 'site-spec' ),
+						prompt: __(
+							"Create a trendy, fashion-forward hair salon website with a sleek, modern, polished aesthetic. Use black, cool gray, white, and accents of electric blue, emerald, or magenta. Apply stylish, confident copy and elegant sans-serif fonts like Bonita. Highlight the salon's unique skills and ensure the design feels vibrant and engaging.",
+							'site-spec'
+						),
+					},
+					{
+						label: __( 'Offer personal training sessions', 'site-spec' ),
+						prompt: __(
+							'Create a high-intensity fitness instructor website with an energetic, bold, dynamic aesthetic using black, deep red, electric orange, and charcoal gray. Use urgent, inspiring, direct copy and powerful sport-style sans-serif fonts like Jumpshot. Design the site to motivate users to book a training session.',
+							'site-spec'
+						),
+					},
+					{
+						label: __( 'Create an online plant shop', 'site-spec' ),
+						prompt: __(
+							'Create an eco-friendly plant store website with a natural, earthy, calming aesthetic using forest green, moss, terra cotta, warm beige, and natural white. Use nurturing, organic copy and fonts like Mollani Nature Script or Plantae. Showcase the full breadth of products with a fresh, inviting design.',
+							'site-spec'
+						),
+					},
+					{
+						label: __( 'Host cooking workshops', 'site-spec' ),
+						prompt: __(
+							'Create a fun, family-friendly cooking workshop website with a warm, inviting, colorful, playful aesthetic. Use bright yellow, orange, tomato red, warm brown, and cream tones. Apply warm, appetizing copy and friendly, whimsical fonts like Pacifico or Amatic SC. Design the site to encourage users to book a workshop.',
+							'site-spec'
+						),
+					},
+					{
+						label: __( 'Sell handmade jewelry online', 'site-spec' ),
+						prompt: __(
+							'Create a handmade, one-of-a-kind jewelry store website with a rustic, intricate, elegant aesthetic. Use deep browns, terracotta, moss green, metallic gold or silver, and soft neutrals. Apply personal, inviting copy and refined script or serif fonts like Parisienne or Cormorant Garamond. Design the site to encourage users to buy online.',
+							'site-spec'
+						),
+					},
+					{
+						label: __( 'Rent out photography equipment', 'site-spec' ),
+						prompt: __(
+							'Create a high-tech, modern photography equipment rental website with a sleek, minimalist, futuristic aesthetic. Use charcoal gray, black, white, cool blue, and electric yellow/green accents. Apply informative, precise copy and clean, technical fonts like Kyrial Sans Pro or Zyphor. Design the site to encourage users to rent equipment.',
+							'site-spec'
+						),
+					},
+				],
+			},
+			radius: {
+				base: '14px',
+				input: '14px',
+			},
+			effects: {
+				glow: true,
+				glowColor: '#eee',
+			},
+			typography: {
+				body: "'Inter', sans-serif",
+				headings: "'Inter', sans-serif",
+			},
+			poweredBy: {
+				label: 'Powered by',
+				logo: 'https://woocommerce.com/wp-content/uploads/2025/01/Logo-Black.png',
+				url: 'https://woocommerce.com',
+			},
+			buttons: {
+				textColor: '#1F2933',
+				hoverTextColor: '#000000',
+			},
+		},
+		tosConfig: {
+			showToS: false,
+		},
+	} as SiteSpecConfig;
 }

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -189,11 +189,17 @@ export function getDefaultSiteSpecConfig(): SiteSpecConfig {
  * @returns {SiteSpecConfig} Configuration object for CIAB (Commerce in a Box) flow
  */
 export function getCiabSiteSpecConfig(): SiteSpecConfig {
+	// Check for 'referrer' parameter
+	const ref = new URLSearchParams( window.location.search ).get( 'ref' );
+
 	return {
 		buildSiteUrl: '/setup/ai-site-builder/?create_garden_site=1&spec_id=',
 		backButton: {
-			enabled: true,
+			enabled: ref === 'new-site-popover',
 			url: '/ciab/sites',
+		},
+		exitButton: {
+			enabled: false,
 		},
 		theme: {
 			brandId: 'ciab',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes BSKY-1397
Fixes BSKY-1384

## Proposed Changes

Updates the CIAB Site Spec screen with different branding elements. Uses the Woo logo for now instead of partner brand. 

<img width="1584" height="945" alt="image" src="https://github.com/user-attachments/assets/18676b6c-89b3-4252-9e53-4d9a3f405f3d" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- http://calypso.localhost:3000/setup/ai-site-builder-spec/site-spec?source=ciab-sites-dashboard
- Chat with it
- Confirm the specs, edit the specs

Everything should look reasonably ok. Doesn't need to be perfect, there will be follow-ups. 

No impact should be seen on http://calypso.localhost:3000/setup/ai-site-builder-spec/site-spec without the ciab source. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
