### PR TITLE
Update return URL for the Add new domain button

### DIFF
--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -2,7 +2,7 @@ import { Button, Dropdown, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { search, globe, chevronUp, chevronDown } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import { wpcomLink } from '../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../utils/link';
 
 export function AddDomainButton( {
 	siteSlug,
@@ -24,6 +24,8 @@ export function AddDomainButton( {
 		if ( redirectTo ) {
 			queryArgs.redirect_to = redirectTo;
 		}
+
+		queryArgs.back_to = redirectToDashboardLink();
 		return queryArgs;
 	};
 

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -1,13 +1,12 @@
 import { domainsQuery, siteBySlugQuery, siteRedirectQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { Link, useRouter } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
-import { domainConnectionSetupRoute } from '../../app/router/domains';
 import { siteRoute, siteDomainsRoute, siteSettingsRedirectRoute } from '../../app/router/sites';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
 import { Notice } from '../../components/notice';
@@ -21,6 +20,7 @@ import {
 	SITE_CONTEXT_VIEW,
 	BulkActionsProgressNotice,
 } from '../../domains/dataviews';
+import { useDomainConnectionSetupTemplateUrl } from '../../utils/domain';
 import PrimaryDomainSelector from './primary-domain-selector';
 import type { DomainSummary } from '@automattic/api-core';
 
@@ -62,20 +62,8 @@ function SiteDomains() {
 		fields
 	);
 
-	const router = useRouter();
-
-	const domainConnectionSetupUrlRelativePath = router
-		.buildLocation( {
-			to: domainConnectionSetupRoute.fullPath,
-			params: { domainName: '%s' },
-		} )
-		.href.replace( '%25s', '%s' );
-
-	const domainConnectionSetupUrl = new URL(
-		domainConnectionSetupUrlRelativePath,
-		window.location.origin
-	).href;
 	const { basePath } = useAppContext();
+	const domainConnectionSetupUrl = useDomainConnectionSetupTemplateUrl();
 	const redirectTo = `${ basePath }/sites/${ site.slug }/domains`;
 
 	return (

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -11,7 +11,9 @@ import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
-import { redirectToDashboardLink } from '../../utils/link';
+import { useDomainConnectionSetupTemplateUrl } from '../../utils/domain';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { ShareSiteForm } from './share-site-form';
 import type { Site, SiteSettings } from '@automattic/api-core';
 import type { Field, Form } from '@wordpress/dataviews';
@@ -116,6 +118,7 @@ const robotForm = {
 } satisfies Form;
 
 export function PrivacyForm( { site, settings }: { site: Site; settings: SiteSettings } ) {
+	const domainConnectionSetupUrl = useDomainConnectionSetupTemplateUrl();
 	const { data: domains = [] } = useQuery( {
 		...domainsQuery(),
 		select: ( data ) => {
@@ -153,6 +156,20 @@ export function PrivacyForm( { site, settings }: { site: Site; settings: SiteSet
 		( [ key, value ] ) => formData[ key as keyof PrivacyFormData ] !== value
 	);
 	const { isPending } = mutation;
+
+	const getAddNewDomainUrl = () => {
+		const backUrl = redirectToDashboardLink( { supportBackport: true } );
+		if ( isDashboardBackport() ) {
+			return addQueryArgs( `/domains/add/${ site.slug }`, { redirect_to: backUrl } );
+		}
+
+		return addQueryArgs( wpcomLink( '/setup/domain' ), {
+			siteSlug: site.slug,
+			domainConnectionSetupUrl,
+			redirect_to: backUrl,
+			back_to: backUrl,
+		} );
+	};
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
@@ -209,12 +226,7 @@ export function PrivacyForm( { site, settings }: { site: Site; settings: SiteSet
 													{ __( 'Manage domains' ) }
 												</Button>
 											) : (
-												<Button
-													variant="secondary"
-													href={ addQueryArgs( `/domains/add/${ site.slug }`, {
-														redirect_to: redirectToDashboardLink( { supportBackport: true } ),
-													} ) }
-												>
+												<Button variant="secondary" href={ getAddNewDomainUrl() }>
 													{ __( 'Add new domain' ) }
 												</Button>
 											)

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -11,6 +11,7 @@ import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
+import { redirectToDashboardLink } from '../../utils/link';
 import { ShareSiteForm } from './share-site-form';
 import type { Site, SiteSettings } from '@automattic/api-core';
 import type { Field, Form } from '@wordpress/dataviews';
@@ -211,7 +212,7 @@ export function PrivacyForm( { site, settings }: { site: Site; settings: SiteSet
 												<Button
 													variant="secondary"
 													href={ addQueryArgs( `/domains/add/${ site.slug }`, {
-														redirect_to: window.location.pathname,
+														redirect_to: redirectToDashboardLink( { supportBackport: true } ),
 													} ) }
 												>
 													{ __( 'Add new domain' ) }

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -8,7 +8,6 @@ import {
 import { useRouter } from '@tanstack/react-router';
 import { isAfter, subMinutes, subDays } from 'date-fns';
 import { domainConnectionSetupRoute } from '../app/router/domains';
-import { dashboardLink } from './link';
 import { getRenewalUrlFromPurchase } from './purchase';
 import { hasPlanFeature } from './site-features';
 import { userHasFlag } from './user';
@@ -40,7 +39,7 @@ export function useDomainConnectionSetupTemplateUrl() {
 		} )
 		.href.replace( '%25s', '%s' );
 
-	return dashboardLink( domainConnectionSetupTemplateUrl );
+	return new URL( domainConnectionSetupTemplateUrl, window.location.origin ).href;
 }
 
 export function isRegisteredDomain( domain: DomainSummary ) {

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -5,7 +5,10 @@ import {
 	DomainStatus,
 	DomainTypes,
 } from '@automattic/api-core';
+import { useRouter } from '@tanstack/react-router';
 import { isAfter, subMinutes, subDays } from 'date-fns';
+import { domainConnectionSetupRoute } from '../app/router/domains';
+import { dashboardLink } from './link';
 import { getRenewalUrlFromPurchase } from './purchase';
 import { hasPlanFeature } from './site-features';
 import { userHasFlag } from './user';
@@ -26,6 +29,18 @@ export function getDomainSiteSlug( domain: DomainSummary ) {
 
 export function getDomainRenewalUrl( domain: DomainSummary, purchase: Purchase ) {
 	return getRenewalUrlFromPurchase( purchase, getDomainSiteSlug( domain ) );
+}
+
+export function useDomainConnectionSetupTemplateUrl() {
+	const router = useRouter();
+	const domainConnectionSetupTemplateUrl = router
+		.buildLocation( {
+			to: domainConnectionSetupRoute.fullPath,
+			params: { domainName: '%s' },
+		} )
+		.href.replace( '%25s', '%s' );
+
+	return dashboardLink( domainConnectionSetupTemplateUrl );
 }
 
 export function isRegisteredDomain( domain: DomainSummary ) {

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -25,9 +25,11 @@ export function wpcomLink( path: string ) {
  * This function returns the link to the dashboard.
  */
 export function dashboardLink( path: string = '' ) {
-	return config( 'env' ) === 'development'
-		? `http://my.localhost:3000${ path }`
-		: `https://my.wordpress.com${ path }`;
+	if ( config( 'env' ) === 'development' ) {
+		return new URL( path, 'http://my.localhost:3000' ).href;
+	}
+
+	return new URL( path, 'https://my.wordpress.com' ).href;
 }
 
 /**

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -18,7 +18,7 @@ export function dashboardOrigins(): string[] {
  * so that the link points to the local Calypso dev server.
  */
 export function wpcomLink( path: string ) {
-	return `${ config( 'wpcom_url' ) }${ path }`;
+	return new URL( path, config( 'wpcom_url' ) ).href;
 }
 
 /**

--- a/client/dashboard/utils/url.ts
+++ b/client/dashboard/utils/url.ts
@@ -1,6 +1,10 @@
 import { getProtocol } from '@wordpress/url';
 
 export function isRelativeUrl( url: string ) {
+	if ( ! url ) {
+		return false;
+	}
+
 	return ! url.startsWith( '//' ) && ! getProtocol( url );
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -82,7 +82,7 @@ const DomainSearchStep: StepType< {
 	const initialQuery = useQuery().get( 'new' ) ?? '';
 	const tldQuery = useQuery().get( 'tld' );
 	const source = useQuery().get( 'source' );
-	const backTo = useQuery().get( 'back_to' );
+	const backTo = useQuery().get( 'back_to' ) ?? '';
 	const sourceSlug = useQuery().get( 'sourceSlug' );
 	const { __ } = useI18n();
 
@@ -364,8 +364,11 @@ const DomainSearchStep: StepType< {
 				backDestination = defaultBackUrl;
 				backLabelText = sitesBackLabelText;
 
-				const isValidBackTo = dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
-				if ( backTo && ( isRelativeUrl( backTo ) || isValidBackTo ) ) {
+				const isSafeBackTo =
+					isRelativeUrl( backTo ) ||
+					dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
+
+				if ( isSafeBackTo ) {
 					backDestination = backTo;
 					backLabelText = __( 'Back' );
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -21,7 +21,7 @@ import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain
 import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { useWPCOMDomainSearchEvents } from 'calypso/components/domains/wpcom-domain-search/use-wpcom-domain-search-events';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { dashboardLink, dashboardOrigins } from 'calypso/dashboard/utils/link';
 import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -364,7 +364,8 @@ const DomainSearchStep: StepType< {
 				backDestination = defaultBackUrl;
 				backLabelText = sitesBackLabelText;
 
-				if ( backTo && isRelativeUrl( backTo ) ) {
+				const isValidBackTo = dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
+				if ( backTo && ( isRelativeUrl( backTo ) || isValidBackTo ) ) {
 					backDestination = backTo;
 					backLabelText = __( 'Back' );
 				}

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -14,7 +14,7 @@ import { useMemo } from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
 import { FreeDomainForAYearPromo } from 'calypso/components/domains/wpcom-domain-search/free-domain-for-a-year-promo';
 import { useQueryHandler } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
-import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { dashboardLink, dashboardOrigins } from 'calypso/dashboard/utils/link';
 import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { isMonthlyOrFreeFlow } from 'calypso/lib/cart-values/cart-items';
@@ -326,7 +326,8 @@ const DomainSearchUI = (
 			backLabelText = sitesBackLabelText;
 
 			const backTo = getQueryArg( window.location.href, 'back_to' )?.toString();
-			if ( backTo && isRelativeUrl( backTo ) ) {
+			const isValidBackTo = dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
+			if ( backTo && ( isRelativeUrl( backTo ) || isValidBackTo ) ) {
 				backUrl = backTo;
 				backLabelText = __( 'Back' );
 			}

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -325,9 +325,12 @@ const DomainSearchUI = (
 			backUrl = defaultBackUrl;
 			backLabelText = sitesBackLabelText;
 
-			const backTo = getQueryArg( window.location.href, 'back_to' )?.toString();
-			const isValidBackTo = dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
-			if ( backTo && ( isRelativeUrl( backTo ) || isValidBackTo ) ) {
+			const backTo = getQueryArg( window.location.href, 'back_to' )?.toString() ?? '';
+			const isSafeBackTo =
+				isRelativeUrl( backTo ) ||
+				dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
+
+			if ( isSafeBackTo ) {
 				backUrl = backTo;
 				backLabelText = __( 'Back' );
 			}


### PR DESCRIPTION
Part of DOTMSD-955

## Proposed Changes

Updates the return URL for this button.

<img width="750" height="663" alt="SCR-20251216-lxtv" src="https://github.com/user-attachments/assets/a5e873ef-2b65-4da0-bbcf-91806f7e206c" />

This PR also updates the domain search screen to accept a back_to with an absolute URL that points to a MSD origin.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that the button's redirect_to is an absolute URL to the MSD when accessed from the MSD 
* Ensure that the button's redirect_to is a relative URL to the backport when accessed from the backport
* Ensure that clicking the in-app Back button in the domain search screen correctly sends you back to the previous screen 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
