### PR TITLE
A4A > Marketplace: Implement term pricing toggle

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v1.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v1.tsx
@@ -24,7 +24,8 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import useFetchClientReferral from '../../client/hooks/use-fetch-client-referral';
 import { MarketplaceTypeContext } from '../context';
-import withMarketplaceType, { MARKETPLACE_TYPE_REFERRAL } from '../hoc/with-marketplace-type';
+import withMarketplaceProviders from '../hoc/with-marketplace-providers';
+import { MARKETPLACE_TYPE_REFERRAL } from '../hoc/with-marketplace-type';
 import useProductsById from '../hooks/use-products-by-id';
 import useProductsBySlug from '../hooks/use-products-by-slug';
 import useReferralDevSite from '../hooks/use-referral-dev-site';
@@ -319,4 +320,4 @@ function CheckoutV1( { isClient, referralBlogId }: Props ) {
 	);
 }
 
-export default withMarketplaceType( CheckoutV1 );
+export default withMarketplaceProviders( CheckoutV1 );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v2.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v2.tsx
@@ -9,7 +9,7 @@ import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 } from 'calypso/layout/hosting-dashboard/header';
 import BillingDragonCheckout from '../billing-dragon-checkout';
-import withMarketplaceType from '../hoc/with-marketplace-type';
+import withMarketplaceProviders from '../hoc/with-marketplace-providers';
 import useShoppingCart from '../hooks/use-shopping-cart';
 
 import './style-v2.scss';
@@ -52,4 +52,4 @@ function CheckoutV2() {
 	);
 }
 
-export default withMarketplaceType( CheckoutV2 );
+export default withMarketplaceProviders( CheckoutV2 );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -1,7 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useContext } from 'react';
 import { MarketplaceTypeContext } from '../context';
-import withMarketplaceType, { MARKETPLACE_TYPE_REFERRAL } from '../hoc/with-marketplace-type';
+import withMarketplaceProviders from '../hoc/with-marketplace-providers';
+import { MARKETPLACE_TYPE_REFERRAL } from '../hoc/with-marketplace-type';
 import CheckoutV1 from './checkout-v1';
 import CheckoutV2 from './checkout-v2';
 
@@ -28,4 +29,4 @@ function Checkout( { referralBlogId, isClient }: CheckoutProps ) {
 	return <CheckoutV1 referralBlogId={ referralBlogId } isClient={ isClient } />;
 }
 
-export default withMarketplaceType( Checkout );
+export default withMarketplaceProviders( Checkout );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -25,7 +25,8 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
-import withMarketplaceType, {
+import withMarketplaceProviders from '../hoc/with-marketplace-providers';
+import {
 	MARKETPLACE_TYPE_SESSION_STORAGE_KEY,
 	MARKETPLACE_TYPE_REGULAR,
 } from '../hoc/with-marketplace-type';
@@ -268,4 +269,4 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 	);
 }
 
-export default withMarketplaceType( RequestClientPayment );
+export default withMarketplaceProviders( RequestClientPayment );

--- a/client/a8c-for-agencies/sections/marketplace/common/term-pricing-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/term-pricing-toggle/index.tsx
@@ -1,3 +1,36 @@
+import {
+	ToggleControl,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useContext } from 'react';
+import { TermPricingContext } from '../../context';
+
 export default function TermPricingToggle() {
-	return <div>Billed: Toggle</div>;
+	const { termPricing, toggleTermPricing } = useContext( TermPricingContext );
+
+	const handleToggle = () => {
+		toggleTermPricing();
+	};
+
+	const isChecked = termPricing === 'yearly';
+
+	return (
+		<HStack className="a4a-marketplace__term-pricing-toggle" justify="flex-start" spacing={ 0 }>
+			<Text weight={ 500 }>{ __( 'Billed:' ) }</Text>
+			<Text as="span" variant={ isChecked ? 'muted' : undefined } style={ { marginInline: '8px' } }>
+				{ __( 'Monthly' ) }
+			</Text>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				checked={ isChecked }
+				onChange={ handleToggle }
+				label={ undefined }
+			/>
+			<Text as="span" variant={ ! isChecked ? 'muted' : undefined }>
+				{ __( 'Yearly' ) }
+			</Text>
+		</HStack>
+	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/context.ts
+++ b/client/a8c-for-agencies/sections/marketplace/context.ts
@@ -2,6 +2,7 @@ import { createContext } from 'react';
 import type {
 	ShoppingCartContext as ShoppingCartContextInterface,
 	MarketplaceTypeContext as MarketplaceTypeContextInterface,
+	TermPricingContext as TermPricingContextInterface,
 } from './types';
 
 export const ShoppingCartContext = createContext< ShoppingCartContextInterface >( {
@@ -17,6 +18,16 @@ export const MarketplaceTypeContext = createContext< MarketplaceTypeContextInter
 		return undefined;
 	},
 	toggleMarketplaceType: () => {
+		return undefined;
+	},
+} );
+
+export const TermPricingContext = createContext< TermPricingContextInterface >( {
+	termPricing: 'monthly',
+	setTermPricing: () => {
+		return undefined;
+	},
+	toggleTermPricing: () => {
 		return undefined;
 	},
 } );

--- a/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-providers.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-providers.tsx
@@ -1,0 +1,28 @@
+import { ComponentType } from 'react';
+import { MarketplaceType, TermPricingType } from '../types';
+import withMarketplaceType from './with-marketplace-type';
+import withTermPricing from './with-term-pricing';
+
+type ContextProps = {
+	defaultMarketplaceType?: MarketplaceType;
+	defaultTermPricing?: TermPricingType;
+};
+
+/**
+ * Higher-order component that provides both MarketplaceTypeContext and TermPricingContext.
+ * This is a convenience wrapper that composes withMarketplaceType and withTermPricing.
+ *
+ * @example
+ * ```tsx
+ * export default withMarketplaceProviders( MyComponent );
+ * ```
+ */
+function withMarketplaceProviders< T >(
+	WrappedComponent: ComponentType< T & ContextProps >
+): ComponentType< T & ContextProps > {
+	// Compose the HOCs - both contexts are independent, so order doesn't matter functionally
+	// This creates: MarketplaceTypeContext.Provider > TermPricingContext.Provider > WrappedComponent
+	return withMarketplaceType( withTermPricing( WrappedComponent ) );
+}
+
+export default withMarketplaceProviders;

--- a/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
@@ -13,7 +13,7 @@ export const MARKETPLACE_TYPE_REGULAR = 'regular';
 function withMarketplaceType< T >(
 	WrappedComponent: ComponentType< T & ContextProps >
 ): ComponentType< T & ContextProps > {
-	return ( props ) => {
+	const WithMarketplaceType = ( props: T & ContextProps ) => {
 		const defaultType =
 			props.defaultMarketplaceType ??
 			( sessionStorage.getItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY ) as MarketplaceType ) ??
@@ -46,6 +46,12 @@ function withMarketplaceType< T >(
 			</MarketplaceTypeContext.Provider>
 		);
 	};
+
+	WithMarketplaceType.displayName = `WithMarketplaceType(${
+		WrappedComponent.displayName || WrappedComponent.name || 'Component'
+	})`;
+
+	return WithMarketplaceType;
 }
 
 export default withMarketplaceType;

--- a/client/a8c-for-agencies/sections/marketplace/hoc/with-term-pricing.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hoc/with-term-pricing.tsx
@@ -1,4 +1,5 @@
-import { ComponentType, useState } from 'react';
+import { ComponentType, useCallback, useMemo } from 'react';
+import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
 import { TermPricingContext } from '../context';
 import { TermPricingType } from '../types';
 
@@ -6,7 +7,7 @@ type ContextProps = {
 	defaultTermPricing?: TermPricingType;
 };
 
-export const TERM_PRICING_SESSION_STORAGE_KEY = 'term-pricing';
+export const TERM_PRICING_PREFERENCE_KEY = 'a4a-marketplace-term-pricing';
 export const TERM_PRICING_MONTHLY = 'monthly';
 export const TERM_PRICING_YEARLY = 'yearly';
 
@@ -14,32 +15,34 @@ function withTermPricing< T >(
 	WrappedComponent: ComponentType< T & ContextProps >
 ): ComponentType< T & ContextProps > {
 	const WithTermPricing = ( props: T & ContextProps ) => {
-		const defaultType =
-			props.defaultTermPricing ??
-			( sessionStorage.getItem( TERM_PRICING_SESSION_STORAGE_KEY ) as TermPricingType ) ??
-			TERM_PRICING_YEARLY;
+		const defaultTermPricing = props.defaultTermPricing ?? TERM_PRICING_YEARLY;
 
-		const [ termPricing, setTermPricing ] = useState( defaultType );
+		const [ termPricingValue, updateTermPricing ] = useAsyncPreference< TermPricingType >( {
+			defaultValue: defaultTermPricing,
+			preferenceName: TERM_PRICING_PREFERENCE_KEY,
+		} );
 
-		const updateTermPricing = ( type: TermPricingType ) => {
-			sessionStorage.setItem( TERM_PRICING_SESSION_STORAGE_KEY, type );
-			setTermPricing( type );
-		};
+		// Handle async loading - use default until preference is loaded
+		const termPricing: TermPricingType =
+			termPricingValue === 'none' ? defaultTermPricing : termPricingValue;
 
-		const toggleTermPricing = () => {
+		const toggleTermPricing = useCallback( () => {
 			const nextType =
 				termPricing === TERM_PRICING_MONTHLY ? TERM_PRICING_YEARLY : TERM_PRICING_MONTHLY;
 			updateTermPricing( nextType );
-		};
+		}, [ termPricing, updateTermPricing ] );
+
+		const contextValue = useMemo(
+			() => ( {
+				termPricing,
+				setTermPricing: updateTermPricing,
+				toggleTermPricing,
+			} ),
+			[ termPricing, updateTermPricing, toggleTermPricing ]
+		);
 
 		return (
-			<TermPricingContext.Provider
-				value={ {
-					termPricing,
-					setTermPricing: updateTermPricing,
-					toggleTermPricing,
-				} }
-			>
+			<TermPricingContext.Provider value={ contextValue }>
 				<WrappedComponent { ...props } />
 			</TermPricingContext.Provider>
 		);

--- a/client/a8c-for-agencies/sections/marketplace/hoc/with-term-pricing.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hoc/with-term-pricing.tsx
@@ -1,0 +1,55 @@
+import { ComponentType, useState } from 'react';
+import { TermPricingContext } from '../context';
+import { TermPricingType } from '../types';
+
+type ContextProps = {
+	defaultTermPricing?: TermPricingType;
+};
+
+export const TERM_PRICING_SESSION_STORAGE_KEY = 'term-pricing';
+export const TERM_PRICING_MONTHLY = 'monthly';
+export const TERM_PRICING_YEARLY = 'yearly';
+
+function withTermPricing< T >(
+	WrappedComponent: ComponentType< T & ContextProps >
+): ComponentType< T & ContextProps > {
+	const WithTermPricing = ( props: T & ContextProps ) => {
+		const defaultType =
+			props.defaultTermPricing ??
+			( sessionStorage.getItem( TERM_PRICING_SESSION_STORAGE_KEY ) as TermPricingType ) ??
+			TERM_PRICING_YEARLY;
+
+		const [ termPricing, setTermPricing ] = useState( defaultType );
+
+		const updateTermPricing = ( type: TermPricingType ) => {
+			sessionStorage.setItem( TERM_PRICING_SESSION_STORAGE_KEY, type );
+			setTermPricing( type );
+		};
+
+		const toggleTermPricing = () => {
+			const nextType =
+				termPricing === TERM_PRICING_MONTHLY ? TERM_PRICING_YEARLY : TERM_PRICING_MONTHLY;
+			updateTermPricing( nextType );
+		};
+
+		return (
+			<TermPricingContext.Provider
+				value={ {
+					termPricing,
+					setTermPricing: updateTermPricing,
+					toggleTermPricing,
+				} }
+			>
+				<WrappedComponent { ...props } />
+			</TermPricingContext.Provider>
+		);
+	};
+
+	WithTermPricing.displayName = `WithTermPricing(${
+		WrappedComponent.displayName || WrappedComponent.name || 'Component'
+	})`;
+
+	return WithTermPricing;
+}
+
+export default withTermPricing;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -26,8 +26,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import ReferralToggle from '../common/referral-toggle';
 import TermPricingToggle from '../common/term-pricing-toggle';
-import withMarketplaceType from '../hoc/with-marketplace-type';
-import withTermPricing from '../hoc/with-term-pricing';
+import withMarketplaceProviders from '../hoc/with-marketplace-providers';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import HeroSection from './hero-section';
@@ -182,4 +181,4 @@ function HostingOverview( { section }: SectionProps ) {
 	);
 }
 
-export default withMarketplaceType( withTermPricing( HostingOverview ) );
+export default withMarketplaceProviders( HostingOverview );

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -24,7 +25,9 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import ReferralToggle from '../common/referral-toggle';
+import TermPricingToggle from '../common/term-pricing-toggle';
 import withMarketplaceType from '../hoc/with-marketplace-type';
+import withTermPricing from '../hoc/with-term-pricing';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import HeroSection from './hero-section';
@@ -124,35 +127,42 @@ function HostingOverview( { section }: SectionProps ) {
 						] }
 						hideOnMobile
 					/>
-					<Actions className="a4a-marketplace__header-actions">
-						<MobileSidebarNavigation />
-						<div ref={ ( ref ) => setReferralToggleRef( ref as HTMLElement | null ) }>
-							<ReferralToggle />
+					<Actions>
+						{ isEnabled( 'a4a-bd-term-pricing' ) && (
+							<div className="a4a-marketplace__header-actions">
+								<TermPricingToggle />
+							</div>
+						) }
+						<div className="a4a-marketplace__header-actions">
+							<MobileSidebarNavigation />
+							<div ref={ ( ref ) => setReferralToggleRef( ref as HTMLElement | null ) }>
+								<ReferralToggle />
+							</div>
+							<ShoppingCart
+								showCart={ showCart }
+								setShowCart={ setShowCart }
+								toggleCart={ toggleCart }
+								items={ selectedCartItems }
+								onRemoveItem={ onRemoveCartItem }
+								onCheckout={ () => {
+									page.redirect( A4A_MARKETPLACE_CHECKOUT_LINK );
+								} }
+							/>
+
+							<GuidedTourStep
+								className="a4a-marketplace__guided-tour"
+								id="marketplace-walkthrough-navigation"
+								tourId="marketplaceWalkthrough"
+								context={ sidebarRef }
+							/>
+
+							<GuidedTourStep
+								className="a4a-marketplace__guided-tour"
+								id="marketplace-walkthrough-referral-toggle"
+								tourId="marketplaceWalkthrough"
+								context={ referralToggleRef }
+							/>
 						</div>
-						<ShoppingCart
-							showCart={ showCart }
-							setShowCart={ setShowCart }
-							toggleCart={ toggleCart }
-							items={ selectedCartItems }
-							onRemoveItem={ onRemoveCartItem }
-							onCheckout={ () => {
-								page.redirect( A4A_MARKETPLACE_CHECKOUT_LINK );
-							} }
-						/>
-
-						<GuidedTourStep
-							className="a4a-marketplace__guided-tour"
-							id="marketplace-walkthrough-navigation"
-							tourId="marketplaceWalkthrough"
-							context={ sidebarRef }
-						/>
-
-						<GuidedTourStep
-							className="a4a-marketplace__guided-tour"
-							id="marketplace-walkthrough-referral-toggle"
-							tourId="marketplaceWalkthrough"
-							context={ referralToggleRef }
-						/>
 					</Actions>
 				</LayoutHeader>
 				<HeroSection
@@ -172,4 +182,4 @@ function HostingOverview( { section }: SectionProps ) {
 	);
 }
 
-export default withMarketplaceType( HostingOverview );
+export default withMarketplaceType( withTermPricing( HostingOverview ) );

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/style.scss
@@ -40,12 +40,30 @@
 	}
 
 	.hosting-dashboard-layout__header-actions {
-		background-color: var( --color-surface );
-		border-radius: 8px;
-		padding: 8px 24px 8px 20px;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-direction: column-reverse;
 
 		.shopping-cart {
 			margin: 0;
+		}
+
+		.a4a-marketplace__header-actions {
+			background-color: var( --color-surface );
+			border-radius: 8px;
+			padding: 8px 24px 8px 20px;
+			min-height: 40px;
+			width: calc(100% - 44px); // 44px is the padding of the actions container
+		}
+
+		@include break-large {
+			flex-direction: row;
+
+			.a4a-marketplace__header-actions {
+				height: 40px;
+				width: auto;
+			}
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -27,6 +27,7 @@ import TermPricingToggle from '../common/term-pricing-toggle';
 import { PRODUCT_FILTER_KEY_CATEGORIES } from '../constants';
 import { MarketplaceTypeContext, ShoppingCartContext } from '../context';
 import withMarketplaceType from '../hoc/with-marketplace-type';
+import withTermPricing from '../hoc/with-term-pricing';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import useCompactOnScroll from './hooks/use-compact-on-scroll';
@@ -236,4 +237,4 @@ export function ProductsOverview( { siteId, suggestedProduct, productBrand, sear
 	);
 }
 
-export default withMarketplaceType( ProductsOverview );
+export default withMarketplaceType( withTermPricing( ProductsOverview ) );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -26,8 +26,7 @@ import ReferralToggle from '../common/referral-toggle';
 import TermPricingToggle from '../common/term-pricing-toggle';
 import { PRODUCT_FILTER_KEY_CATEGORIES } from '../constants';
 import { MarketplaceTypeContext, ShoppingCartContext } from '../context';
-import withMarketplaceType from '../hoc/with-marketplace-type';
-import withTermPricing from '../hoc/with-term-pricing';
+import withMarketplaceProviders from '../hoc/with-marketplace-providers';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import useCompactOnScroll from './hooks/use-compact-on-scroll';
@@ -237,4 +236,4 @@ export function ProductsOverview( { siteId, suggestedProduct, productBrand, sear
 	);
 }
 
-export default withMarketplaceType( withTermPricing( ProductsOverview ) );
+export default withMarketplaceProviders( ProductsOverview );

--- a/client/a8c-for-agencies/sections/marketplace/shared.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shared.scss
@@ -17,7 +17,7 @@
 	}
 }
 
-.a4a-marketplace__header-actions {
+.main.hosting-dashboard-layout .a4a-marketplace__header-actions {
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -26,9 +26,16 @@
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {
-		.current-section button {
+		header.current-section button {
 			border: none;
+			padding: 0;
 		}
 		justify-content: space-between;
+	}
+
+	.a4a-marketplace__term-pricing-toggle {
+		@include breakpoint-deprecated( "<660px" ) {
+			justify-content: center;
+		}
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/types.ts
+++ b/client/a8c-for-agencies/sections/marketplace/types.ts
@@ -27,3 +27,11 @@ export interface AssignLicenseProps {
 }
 
 export type HostingType = 'pressable-hosting' | 'wpcom-hosting';
+
+export type TermPricingType = 'monthly' | 'yearly';
+
+export interface TermPricingContext {
+	termPricing: TermPricingType;
+	setTermPricing: ( value: TermPricingType ) => void;
+	toggleTermPricing: () => void;
+}


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1926/marketplace-show-monthlyearly-pricing-for-hosting-and-products

Resolves https://linear.app/a8c/issue/A4A-1927/implement-toggle-on-the-hosting-page-to-display-monthlyyearly-pricing
Resolves https://linear.app/a8c/issue/A4A-1928/implement-toggle-on-the-products-page-to-display-monthlyyearly-pricing

## Proposed Changes

This PR implements the term-pricing toggle on the Marketplace for the Hosting & Products pages.

## Why are these changes being made?

* To be able to toggle between monthly and yearly pricing on the Marketplace. 

## Testing Instructions

* Open the A4A live link
* Go to Marketplace > Hosting > Verify you can see the term-pricing toggle as shown below. Verify the toggle works as expected > Refresh the page > Verify the toggle state is restored. Please note that the prices won't change; it will be implemented in a different PR.

<img width="372" height="875" alt="Screenshot 2025-12-16 at 10 49 52 AM" src="https://github.com/user-attachments/assets/65383742-fa14-4afa-b69f-48ab236e2443" />

<img width="1920" height="783" alt="Screenshot 2025-12-16 at 10 50 21 AM" src="https://github.com/user-attachments/assets/02219ba9-3125-45e4-a7a4-a6cf1481dbb0" />


* Go to Products > Verify you can see the term-pricing toggle as shown below. Verify the toggle works as expected > Refresh the page > Verify the toggle state is restored. 

<img width="372" height="875" alt="Screenshot 2025-12-16 at 10 49 57 AM" src="https://github.com/user-attachments/assets/55e4a32b-8aac-465b-a105-e162198f8299" />

<img width="1920" height="735" alt="Screenshot 2025-12-16 at 10 50 13 AM" src="https://github.com/user-attachments/assets/bf68bf70-4318-4cfd-b000-4b8798b52e8c" />


* Append the URL with `?flags=-a4a-bd-term-pricing` and verify the UI looks good as shown below for Hosting & Products pages.

<img width="1920" height="738" alt="Screenshot 2025-12-16 at 10 50 43 AM" src="https://github.com/user-attachments/assets/bf6047e2-ea88-4fcb-a193-0dca63dc05bb" />

<img width="372" height="872" alt="Screenshot 2025-12-16 at 10 51 39 AM" src="https://github.com/user-attachments/assets/23ec1342-71d9-4e23-b50c-956cc022f607" />

<img width="372" height="872" alt="Screenshot 2025-12-16 at 10 51 45 AM" src="https://github.com/user-attachments/assets/56ade834-e106-4107-89a7-26831e392939" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
