### PR TITLE
MSD: Support DreamHost and DigitalOcean provider name

### DIFF
--- a/client/dashboard/utils/site-provider.ts
+++ b/client/dashboard/utils/site-provider.ts
@@ -7,6 +7,7 @@ export function getSiteProviderName( site: Pick< Site, 'hosting_provider_guess' 
 		automattic: 'WordPress.com',
 		dreamhost: 'DreamHost',
 		jurassic_ninja: 'Jurassic Ninja',
+		digitalocean: 'DigitalOcean',
 		pressable: 'Pressable',
 	};
 

--- a/client/dashboard/utils/site-provider.ts
+++ b/client/dashboard/utils/site-provider.ts
@@ -1,7 +1,6 @@
 import type { Site } from '@automattic/api-core';
 
 export const DEFAULT_PROVIDER_NAME = 'WordPress.com';
-
 export function getSiteProviderName( site: Pick< Site, 'hosting_provider_guess' > ) {
 	const providerNameMap: Record< string, string > = {
 		automattic: 'WordPress.com',
@@ -11,5 +10,5 @@ export function getSiteProviderName( site: Pick< Site, 'hosting_provider_guess' 
 		pressable: 'Pressable',
 	};
 
-	return providerNameMap[ site.hosting_provider_guess ?? '' ];
+	return providerNameMap[ site.hosting_provider_guess ?? '' ] ?? site.hosting_provider_guess;
 }

--- a/client/dashboard/utils/site-provider.ts
+++ b/client/dashboard/utils/site-provider.ts
@@ -3,15 +3,12 @@ import type { Site } from '@automattic/api-core';
 export const DEFAULT_PROVIDER_NAME = 'WordPress.com';
 
 export function getSiteProviderName( site: Pick< Site, 'hosting_provider_guess' > ) {
-	const provider = site.hosting_provider_guess;
-	let providerName;
-	if ( provider === 'jurassic_ninja' ) {
-		providerName = 'Jurassic Ninja';
-	} else if ( provider === 'pressable' ) {
-		providerName = 'Pressable';
-	} else if ( provider === 'automattic' ) {
-		providerName = 'WordPress.com';
-	}
+	const providerNameMap: Record< string, string > = {
+		automattic: 'WordPress.com',
+		dreamhost: 'DreamHost',
+		jurassic_ninja: 'Jurassic Ninja',
+		pressable: 'Pressable',
+	};
 
-	return providerName;
+	return providerNameMap[ site.hosting_provider_guess ?? '' ];
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-947

## Proposed Changes

* Support DreamHost and DigitalOcean provider name

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should display correct provider name as much as possible

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 198118-ghe-Automattic/wpcom to your sandbox
* Sandbox your endpoint
* I don't have a dreamhost site...
* Go to /v2/sites
* Check the result of /me/sites
* Ensure the `hosting_provider_guess` won't always be `unknown`. At least, the Pressable sites should be `pressable` and the JN sites should be `jurassic_ninja`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?