### PR TITLE
The WordAds link in my-plans still doesn't know WoA sites exist

### DIFF
--- a/client/blocks/product-purchase-features-list/monetize-site.jsx
+++ b/client/blocks/product-purchase-features-list/monetize-site.jsx
@@ -3,9 +3,12 @@ import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg
 import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
-	const adSettingsUrl = selectedSite.jetpack
-		? '/marketing/traffic/' + selectedSite.slug
-		: '/earn/ads-settings/' + selectedSite.slug;
+	const isAtomic = selectedSite?.is_wpcom_atomic ?? false;
+	const isJetpack = selectedSite?.jetpack ?? false;
+	const adSettingsUrl =
+		! isJetpack || isAtomic
+			? '/earn/ads-earnings/' + selectedSite.slug
+			: '/marketing/traffic/' + selectedSite.slug;
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail


### PR DESCRIPTION
Fix it and point to the right place for WoA sites

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMART-89

## Proposed Changes

* Point Atomic sites to earn rather than traffic

## Why are these changes being made?

* Reported as a high-priority bug

## Testing Instructions

* On a Business Atomic, go to /plans and select my plan
* Check the WordAds card, it should point to earn, not traffic

<img width="585" height="282" alt="Screenshot 2025-12-16 at 9 17 47" src="https://github.com/user-attachments/assets/3e74cccf-2902-4035-b417-d5c732051dd3" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
