### PR TITLE
Chore: Update to @wordpress/dataviews^11.0.0

### DIFF
--- a/apps/design-system-docs/package.json
+++ b/apps/design-system-docs/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/base-styles": "^5.23.0",
 		"@wordpress/browserslist-config": "^6.23.0",
 		"@wordpress/components": "^30.9.0",
-		"@wordpress/dataviews": "^10.3.0",
+		"@wordpress/dataviews": "^11.0.0",
 		"docusaurus-plugin-sass": "^0.2.6",
 		"prism-react-renderer": "^2.4.1",
 		"react": "^18.3.1",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -34,7 +34,7 @@
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/data": "^10.23.0",
-		"@wordpress/dataviews": "^10.3.0",
+		"@wordpress/dataviews": "^11.0.0",
 		"@wordpress/element": "^6.23.0",
 		"@wordpress/i18n": "^5.23.0",
 		"@wordpress/icons": "^10.23.0",

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -3,6 +3,17 @@
 @import '@wordpress/dataviews/build-style/style.css';
 
 .dataviews-wrapper {
+	// This is a temporary fix to ensure the sticky actions column has the correct background color.
+	// TODO: Remove when https://github.com/WordPress/gutenberg/pull/73873 lands in Calypso.
+	.dataviews-view-table {
+		td,
+		th {
+			&.dataviews-view-table__actions-column--sticky {
+				background-color: var(--wp-dataviews-color-background, $white);
+			}
+		}
+	}
+
 	// Maybe move upstream to the gutenberg repository
 	width: 100%;
 	padding-block-end: 40px;

--- a/client/dashboard/components/dataviews/styles.scss
+++ b/client/dashboard/components/dataviews/styles.scss
@@ -1,6 +1,17 @@
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/mixins";
-@import '@wordpress/base-styles/colors';
+@import "@wordpress/base-styles/colors";
+
+// This is a temporary fix to ensure the sticky actions column has the correct background color.
+// TODO: Remove when https://github.com/WordPress/gutenberg/pull/73873 lands in Calypso.
+.dataviews-view-table {
+	td,
+	th {
+		&.dataviews-view-table__actions-column--sticky {
+			background-color: var(--wp-dataviews-color-background, $white);
+		}
+	}
+}
 
 // We manually compose the UI of the dataview without including the view actions, which results in extra padding and a border.
 .components-card__header + .components-card__body:has( > .dataviews-wrapper ):not( :has( .dataviews__view-actions ) ) {

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -161,7 +161,7 @@ export const defaultView: View = {
 	titleField: 'site',
 	fields: [ 'lastUpdate', 'nextUpdate', 'schedule', 'plugins', 'active' ],
 	sort: { field: 'site', direction: 'asc' },
-	groupByField: 'scheduleId',
+	groupBy: { field: 'scheduleId', direction: 'asc' },
 	mediaField: 'icon.ico',
 	showMedia: true,
 };

--- a/client/dashboard/sites/performance/performance-insight-table.tsx
+++ b/client/dashboard/sites/performance/performance-insight-table.tsx
@@ -8,6 +8,7 @@ import type {
 	PerformanceMetricAuditDetails,
 	PerformanceMetricAuditDetailsItem,
 } from '@automattic/api-core';
+import type { SortDirection } from '@wordpress/dataviews';
 
 const renderNode = (
 	data: { [ key: string ]: any },
@@ -108,7 +109,9 @@ const PerformanceInsightTable = ( {
 	const view = {
 		fields: fields.map( ( field ) => field.id ),
 		type: 'table' as const,
-		groupByField: details.isEntityGrouped ? 'entity' : undefined,
+		groupBy: details.isEntityGrouped
+			? { field: 'entity', direction: 'asc' as SortDirection }
+			: undefined,
 		layout: {
 			enableMoving: false,
 		},

--- a/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
@@ -27,7 +27,7 @@ import { AutoRenewDiolog } from './components/auto-renew-dialog';
 import { useDomainsDataViewsContext } from './use-context';
 
 export function useActions(
-	viewType: 'table' | 'list' | 'grid' | 'pickerGrid' | 'pickerTable',
+	viewType: 'table' | 'list' | 'grid' | 'pickerGrid' | 'pickerTable' | 'activity',
 	onClose?: () => void
 ) {
 	const translate = useTranslate();

--- a/client/package.json
+++ b/client/package.json
@@ -106,7 +106,7 @@
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/compose": "^7.23.0",
 		"@wordpress/data": "^10.23.0",
-		"@wordpress/dataviews": "^10.3.0",
+		"@wordpress/dataviews": "^11.0.0",
 		"@wordpress/date": "^5.23.0",
 		"@wordpress/dom": "^4.23.0",
 		"@wordpress/edit-post": "^8.23.0",

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -264,7 +264,7 @@ export function useActions( {
 		site: SiteExcerptData,
 		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher'
 	) => void;
-	viewType: 'list' | 'table' | 'grid' | 'pickerGrid' | 'pickerTable';
+	viewType: 'list' | 'table' | 'grid' | 'pickerGrid' | 'pickerTable' | 'activity';
 } ): Action< SiteExcerptData >[] {
 	const { __ } = useI18n();
 	const localizeUrl = useLocalizeUrl();

--- a/client/sites/components/sites-dataviews/site-icon.tsx
+++ b/client/sites/components/sites-dataviews/site-icon.tsx
@@ -21,7 +21,7 @@ export default function SiteIcon( {
 		site: SiteExcerptData,
 		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher'
 	) => void;
-	viewType: 'list' | 'table' | 'grid' | 'breadcrumb' | 'pickerGrid' | 'pickerTable';
+	viewType: 'list' | 'table' | 'grid' | 'breadcrumb' | 'pickerGrid' | 'pickerTable' | 'activity';
 	disableClick?: boolean;
 } ) {
 	const { adminUrl } = useSiteAdminInterfaceData( site.ID );

--- a/package.json
+++ b/package.json
@@ -365,7 +365,7 @@
 		"@wordpress/customize-widgets": "5.23.0",
 		"@wordpress/data-controls": "4.23.0",
 		"@wordpress/data": "^10.23.0",
-		"@wordpress/dataviews": "^10.3.0",
+		"@wordpress/dataviews": "^11.0.0",
 		"@wordpress/date": "5.23.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.24.0",
 		"@wordpress/deprecated": "4.23.0",

--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -36,7 +36,7 @@
 	},
 	"dependencies": {
 		"@automattic/shopping-cart": "workspace:^",
-		"@wordpress/dataviews": "^10.3.0",
+		"@wordpress/dataviews": "^11.0.0",
 		"@wordpress/i18n": "^5.23.0",
 		"he": "^1.2.0",
 		"tslib": "^2.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,7 +386,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
-    "@wordpress/dataviews": "npm:^10.3.0"
+    "@wordpress/dataviews": "npm:^11.0.0"
     "@wordpress/i18n": "npm:^5.23.0"
     he: "npm:^1.2.0"
     react: "npm:^18.3.1"
@@ -1264,7 +1264,7 @@ __metadata:
     "@wordpress/base-styles": "npm:^5.23.0"
     "@wordpress/browserslist-config": "npm:^6.23.0"
     "@wordpress/components": "npm:^30.9.0"
-    "@wordpress/dataviews": "npm:^10.3.0"
+    "@wordpress/dataviews": "npm:^11.0.0"
     docusaurus-plugin-sass: "npm:^0.2.6"
     prism-react-renderer: "npm:^2.4.1"
     react: "npm:^18.3.1"
@@ -1815,7 +1815,7 @@ __metadata:
     "@automattic/wp-babel-makepot": "workspace:^"
     "@wordpress/components": "npm:^30.9.0"
     "@wordpress/data": "npm:^10.23.0"
-    "@wordpress/dataviews": "npm:^10.3.0"
+    "@wordpress/dataviews": "npm:^11.0.0"
     "@wordpress/element": "npm:^6.23.0"
     "@wordpress/i18n": "npm:^5.23.0"
     "@wordpress/icons": "npm:^10.23.0"
@@ -12391,24 +12391,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dataviews@npm:^10.3.0":
-  version: 10.3.0
-  resolution: "@wordpress/dataviews@npm:10.3.0"
+"@wordpress/dataviews@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "@wordpress/dataviews@npm:11.0.0"
   dependencies:
     "@ariakit/react": "npm:^0.4.15"
-    "@wordpress/base-styles": "npm:^6.11.0"
-    "@wordpress/components": "npm:^30.8.0"
-    "@wordpress/compose": "npm:^7.35.0"
-    "@wordpress/data": "npm:^10.35.0"
-    "@wordpress/date": "npm:^5.35.0"
-    "@wordpress/element": "npm:^6.35.0"
-    "@wordpress/i18n": "npm:^6.8.0"
-    "@wordpress/icons": "npm:^11.2.0"
-    "@wordpress/keycodes": "npm:^4.35.0"
-    "@wordpress/primitives": "npm:^4.35.0"
-    "@wordpress/private-apis": "npm:^1.35.0"
-    "@wordpress/url": "npm:^4.35.0"
-    "@wordpress/warning": "npm:^3.35.0"
+    "@wordpress/base-styles": "npm:^6.12.0"
+    "@wordpress/components": "npm:^30.9.0"
+    "@wordpress/compose": "npm:^7.36.0"
+    "@wordpress/data": "npm:^10.36.0"
+    "@wordpress/date": "npm:^5.36.0"
+    "@wordpress/dom": "npm:^4.36.0"
+    "@wordpress/element": "npm:^6.36.0"
+    "@wordpress/i18n": "npm:^6.9.0"
+    "@wordpress/icons": "npm:^11.3.0"
+    "@wordpress/keycodes": "npm:^4.36.0"
+    "@wordpress/primitives": "npm:^4.36.0"
+    "@wordpress/private-apis": "npm:^1.36.0"
+    "@wordpress/url": "npm:^4.36.0"
+    "@wordpress/warning": "npm:^3.36.0"
     clsx: "npm:^2.1.1"
     colord: "npm:^2.7.0"
     date-fns: "npm:^4.1.0"
@@ -12418,7 +12419,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: aeb420b6204a1bc5327864adb9e83095b968cf2ae59af4b5b124acac10de8e544998aa1b26d9847b699674294abb3212be6928f8351904ba964da5f6e9577402
+  checksum: 4b51f5708dc148a3e6ef0d72670cd8fd2fdc9fe64e2712f7ae1146bc2c6b225f0d01b677ac88fa48bbf9b1fbb8caf54c15cdf70d6995d784c348519ece453123
   languageName: node
   linkType: hard
 
@@ -15408,7 +15409,7 @@ __metadata:
     "@wordpress/components": "npm:^30.9.0"
     "@wordpress/compose": "npm:^7.23.0"
     "@wordpress/data": "npm:^10.23.0"
-    "@wordpress/dataviews": "npm:^10.3.0"
+    "@wordpress/dataviews": "npm:^11.0.0"
     "@wordpress/date": "npm:^5.23.0"
     "@wordpress/dom": "npm:^4.23.0"
     "@wordpress/edit-post": "npm:^8.23.0"


### PR DESCRIPTION
## Proposed Changes

Upgrade to [@wordpress/dataviews@11.0.0](https://github.com/WordPress/gutenberg/blob/trunk/packages/dataviews/CHANGELOG.md#1100-2025-11-26).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke test Calypso screens in the onboarding, v1 & v2 dashboards, Reader, and Calypso admin.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
