### PR TITLE
MSD: redirect /overview/:slug to my.wp.com/sites/:slug if opted in

### DIFF
--- a/client/sites/overview/index.tsx
+++ b/client/sites/overview/index.tsx
@@ -22,10 +22,8 @@ import {
 	EDIT_CONTACT_INFO,
 } from 'calypso/my-sites/domains/domain-management/subpage-wrapper/subpages';
 import emailController from 'calypso/my-sites/email/controller';
-import { OVERVIEW } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
-import { redirectToDashboardIfOptedIn } from '../v2/site-overview/controller';
-import { overview } from './controller';
+import { redirectToSiteOverview } from './controller';
 
 function registerSiteDomainPage( { path, controllers }: { path: string; controllers: any[] } ) {
 	page(
@@ -52,14 +50,7 @@ export default function () {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		redirectIfCurrentUserCannot( 'manage_options' ),
-		redirectToDashboardIfOptedIn,
-		redirectIfP2,
-		redirectIfJetpackNonAtomic,
-		navigation,
-		overview,
-		siteDashboard( OVERVIEW ),
-		makeLayout,
-		clientRender
+		redirectToSiteOverview
 	);
 
 	// Domain pages under site overview's context.

--- a/client/sites/overview/index.tsx
+++ b/client/sites/overview/index.tsx
@@ -24,7 +24,7 @@ import {
 import emailController from 'calypso/my-sites/email/controller';
 import { OVERVIEW } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
-import { redirectToHostingDashboardBackportIfEnabled } from '../v2/site-overview/controller';
+import { redirectToDashboardIfOptedIn } from '../v2/site-overview/controller';
 import { overview } from './controller';
 
 function registerSiteDomainPage( { path, controllers }: { path: string; controllers: any[] } ) {
@@ -52,7 +52,7 @@ export default function () {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		redirectIfCurrentUserCannot( 'manage_options' ),
-		redirectToHostingDashboardBackportIfEnabled,
+		redirectToDashboardIfOptedIn,
 		redirectIfP2,
 		redirectIfJetpackNonAtomic,
 		navigation,

--- a/client/sites/v2/site-overview/controller.tsx
+++ b/client/sites/v2/site-overview/controller.tsx
@@ -1,11 +1,13 @@
-import { dashboardLink } from 'calypso/dashboard/utils/link';
-import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
+import { isEnabled } from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
-export function redirectToDashboardIfOptedIn( context: PageJSContext, next: () => void ) {
-	if ( hasDashboardOptIn( context.store.getState() ) ) {
-		window.location.href = dashboardLink( `/sites/${ context.params.site }` );
-		return;
+export function redirectToHostingDashboardBackportIfEnabled(
+	context: PageJSContext,
+	next: () => void
+) {
+	if ( isEnabled( 'dashboard/v2/backport/site-overview' ) ) {
+		return page.redirect( `/sites/${ context.params.site }` );
 	}
 
 	next();

--- a/client/sites/v2/site-overview/controller.tsx
+++ b/client/sites/v2/site-overview/controller.tsx
@@ -1,13 +1,11 @@
-import { isEnabled } from '@automattic/calypso-config';
-import page from '@automattic/calypso-router';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
-export function redirectToHostingDashboardBackportIfEnabled(
-	context: PageJSContext,
-	next: () => void
-) {
-	if ( isEnabled( 'dashboard/v2/backport/site-overview' ) ) {
-		return page.redirect( `/sites/${ context.params.site }` );
+export function redirectToDashboardIfOptedIn( context: PageJSContext, next: () => void ) {
+	if ( hasDashboardOptIn( context.store.getState() ) ) {
+		window.location.href = dashboardLink( `/sites/${ context.params.site }` );
+		return;
 	}
 
 	next();


### PR DESCRIPTION
Fixes DOTMSD-953

## Proposed Changes

This PR updates the `/overview/:siteSlug` route to redirect to `my.wordpress.com/sites/:siteSlug` if the current user opts in to the new Multi-site dashboard.

## Why are these changes being made?

The site overview page needs to point to MSD if the user opts in.

`/overview/:siteSlug` is the URL which is used in external parties like the nav-unification Hosting sidebar menu, A4A, command palette, etc.

Note that the v1 `wordpress.com/sites/:siteSlug` route is left intact so that user can still access v1 screens if needed.

## Testing Instructions

1. Go to https://wpcalypso.wordpress.com/me/account; then opt out from the Hosting Dashboard.
2. Using the Calypso live link, visit `/overview/:siteSlug` and verify you see the v1 site overview.
2. Using the Calypso live link, visit `/sites/:siteSlug` and verify you also see the v1 site overview.
1. Go to https://wpcalypso.wordpress.com/me/account; then opt IN to the Hosting Dashboard.
2. Using the Calypso live link, visit `/overview/:siteSlug` and verify you are redirected to the v2 site overview.
2. Using the Calypso live link, visit `/sites/:siteSlug` and verify you still see the v1 site overview.
2. Using the DASHBOARD live link, visit `/sites/:siteSlug` and verify you see the v2 site overview.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
