### PR TITLE
HelpCenter: Revert customizer positioning

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -62,7 +62,6 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 	const isMobile = useMobileBreakpoint();
 	const classNames = clsx( 'help-center__container', isMobile ? 'is-mobile' : 'is-desktop', {
 		'is-minimized': isMinimized,
-		[ `section-${ sectionName }` ]: !! sectionName,
 	} );
 
 	useActionHooks();

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -104,11 +104,6 @@
 		right: 50px;
 		bottom: 50px;
 
-		&.section-customizer {
-			left: 50px;
-			right: auto;
-		}
-
 		&:not( .react-draggable-dragging ) {
 			transition: all 0.2s ease-in-out;
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
<img width="1909" height="931" alt="Screenshot 2025-12-16 at 17 19 27" src="https://github.com/user-attachments/assets/ebc60d22-e69b-4f7f-a859-b25699570a76" />

Part of #
Reverts the positioning changes of the help center in the customizer.
We want to keep consistency and ensure that the help center opens in the same place.

## Proposed Changes

* Remove positioning customizations

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistent UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Wire up the related PR:https://github.com/Automattic/jetpack/pull/46278
* cd apps/help-center and run `yarn dev --sync`
* Ensure that the help center opens at the correct position in the customizer

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
