### PR TITLE
Domain Transfer Redesign: Remove breadcrumb from transfer in progress page

### DIFF
--- a/client/dashboard/domains/domain-transfer/index.tsx
+++ b/client/dashboard/domains/domain-transfer/index.tsx
@@ -3,7 +3,6 @@ import { domainQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import Breadcrumbs from '../../app/breadcrumbs';
 import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -23,7 +22,6 @@ export default function DomainTransfer() {
 			size="small"
 			header={
 				<PageHeader
-					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Transfer' ) }
 					description={
 						! isNewInboundTransferExperience


### PR DESCRIPTION
Fixes [DOMAINS-1976](https://linear.app/a8c/issue/DOMAINS-1976), replaces #107669

## Proposed Changes

This PR removes the breadcrumb from the transfer in progress pages.

### Screenshots

| Before | After |
| --- | --- |
| <img width="1001" height="1109" alt="Screenshot 2025-12-16 at 10 17 01" src="https://github.com/user-attachments/assets/a59ceb4e-3ced-450b-8d39-fd68132e59b6" /> | <img width="1001" height="1109" alt="Screenshot 2025-12-16 at 10 17 12" src="https://github.com/user-attachments/assets/280bd35d-34bd-41fd-bf29-a9b6ffad023b" /> |

## Why are these changes being made?

The transfer in progress pages are, effectively, the domain overview pages for domain transfers.

There's no domain overview page for an inbound transfer in progress, since there's nothing to manage before the domain is transferred to us.

This is part of the CfT feedbacks for the [Domain Transfer Redesign project](https://linear.app/a8c/project/implement-new-domain-transfer-designs-e7cf391f6e4a/overview).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the live Calypso link or build this branch locally
- Open the transfer setup page for an incoming transfer that's in progress in the Multi-Site Dashboard (`/v2/domains/<domain_name>/domain-transfer-setup`
- Ensure there's no breadcrumb in that page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
