### PR TITLE
Stats: Fix page likes heading to show 'Page likes' for pages

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -72,7 +72,9 @@ export default function PostDetailHighlightsSection( {
 
 					<Card className="highlight-card">
 						<div className="highlight-card-heading">
-							<span>{ translate( 'Post likes' ) }</span>
+							<span>
+								{ post?.type === 'page' ? translate( 'Page likes' ) : translate( 'Post likes' ) }
+							</span>
 							<Count count={ post?.like_count || 0 } />
 						</div>
 						<PostLikes siteId={ siteId } postId={ postId } postType={ post?.type } />


### PR DESCRIPTION
## Summary

Fixes the stats page likes widget heading to correctly display "Page likes" when viewing stats for a page, instead of always showing "Post likes".

## Changes

- Modified `client/my-sites/stats/post-detail-highlights-section/index.tsx` to make the heading conditional based on `post?.type`
- The heading now shows:
  - "**Page likes**" when viewing stats for a page
  - "**Post likes**" when viewing stats for a post

## Implementation

The fix follows the same pattern already used in the `PostLikes` component (lines 101-105), which correctly handles the page vs post distinction for its "no likes" message.

**Before:**
```tsx
<span>{ translate( 'Post likes' ) }</span>
```

**After:**
```tsx
<span>
  { post?.type === 'page' 
    ? translate( 'Page likes' ) 
    : translate( 'Post likes' ) }
</span>
```

## Testing

- ✅ ESLint passed with no errors
- ✅ Code review verified logic matches existing patterns
- ✅ Prettier formatting applied

## Screenshots

See original issue for screenshot showing the bug.

Fixes #104716
