### PR TITLE
WIP: create-site timing e2e

### DIFF
--- a/test/e2e/specs/onboarding/create-site__timing.spec.ts
+++ b/test/e2e/specs/onboarding/create-site__timing.spec.ts
@@ -1,0 +1,94 @@
+import { NewTestUserDetails, NewUserResponse, RestAPIClient } from '@automattic/calypso-e2e';
+import { expect, tags, test } from '../../lib/pw-base';
+import { apiCloseAccount } from '../shared';
+
+test.describe(
+	'Performance: Create Site Timing',
+	{
+		tag: [ tags.CALYPSO_PR ],
+	},
+	() => {
+		let newUserDetails: NewUserResponse;
+		let testUser: NewTestUserDetails;
+
+		test( 'Create site step completes within 10 seconds', async ( {
+			flowStartWriting,
+			helperData,
+			page,
+		} ) => {
+			testUser = helperData.getNewTestUser( {
+				usernamePrefix: 'timing_test',
+			} );
+
+			await test.step( 'Given I visit the /setup/start-writing page', async function () {
+				await flowStartWriting.visit();
+			} );
+
+			await test.step( 'And I see the Create your account page', async function () {
+				await expect( flowStartWriting.userSignupPage.createYourAccountHeading ).toBeVisible();
+			} );
+
+			await test.step( 'When I sign up with my email', async function () {
+				newUserDetails = await flowStartWriting.userSignupPage.signupWithEmail( testUser.email );
+			} );
+
+			let elapsedMs: number;
+
+			await test.step( 'Then I wait for site creation to complete and measure elapsed time', async function () {
+				// Wait for the create-site step to appear (URL contains create-site)
+				// For new users with no sites, start-writing flow redirects directly to create-site
+				await page.waitForURL( /create-site/, { timeout: 30000 } );
+
+				// Start timing when create-site step is visible
+				const startTime = Date.now();
+
+				// Wait for processing to complete - the URL will change away from both
+				// create-site and processing steps. The start-writing flow redirects to
+				// wp-admin/post-new.php after successful site creation.
+				await page.waitForURL(
+					( url ) => {
+						const pathname = url.pathname;
+						return (
+							! pathname.includes( 'create-site' ) &&
+							! pathname.includes( 'processing' ) &&
+							// Ensure we've actually navigated somewhere meaningful
+							( pathname.includes( 'wp-admin' ) || pathname.includes( 'launchpad' ) )
+						);
+					},
+					{ timeout: 30000 }
+				);
+
+				elapsedMs = Date.now() - startTime;
+
+				// Log the elapsed time for debugging and CI visibility
+				// eslint-disable-next-line no-console
+				console.log( `Create site elapsed time: ${ elapsedMs }ms` );
+			} );
+
+			await test.step( 'And the elapsed time is less than 10 seconds', async function () {
+				expect(
+					elapsedMs,
+					`Create site took ${ elapsedMs }ms, which exceeds the 10000ms threshold`
+				).toBeLessThan( 10000 );
+			} );
+		} );
+
+		test.afterAll( 'Delete test user account', async function () {
+			if ( newUserDetails && testUser ) {
+				const restAPIClient = new RestAPIClient(
+					{
+						username: testUser.username,
+						password: testUser.password,
+					},
+					newUserDetails.body.bearer_token
+				);
+
+				await apiCloseAccount( restAPIClient, {
+					userID: newUserDetails.body.user_id,
+					username: newUserDetails.body.username,
+					email: testUser.email,
+				} );
+			}
+		} );
+	}
+);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
