### PR TITLE
Enable dashboard-related feature flags

### DIFF
--- a/client/state/dashboard/selectors/is-dashboard-enabled.ts
+++ b/client/state/dashboard/selectors/is-dashboard-enabled.ts
@@ -2,8 +2,8 @@ import { isEnabled } from '@automattic/calypso-config';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import type { AppState } from 'calypso/types';
 
-// TODO: Set to a specific user when feature is rolled out to a limited audience.
-export const OLDEST_ELIGIBLE_USER = Infinity;
+// TODO: Update user ID when feature is rolled out to a limited audience.
+export const OLDEST_ELIGIBLE_USER = 275022156;
 
 export const isDashboardEnabled = ( state: AppState ): boolean => {
 	if ( ! isEnabled( 'dashboard/v2' ) ) {

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -13,7 +13,7 @@
 	"features": {
 		"ciab/allow-domain-features": true,
 		"cookie-banner": true,
-		"dashboard": false,
+		"dashboard": true,
 		"dashboard/v2": false
 	},
 	"enable_all_sections": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -27,7 +27,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/v2": false,
+		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,6 +37,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,


### PR DESCRIPTION
Part of DOTMSD-958

## Proposed Changes

Enable all dashboard related feature flags, except for dashboard/v2 on production as we don't want to enable the opt-in on wp.com production just yet. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the opt-in is enabled on staging.
* Ensure my.wordpress.com is enabled all enviroments.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
