### PR TITLE
MSD opt in: Fix redirect URLs in invitation accept flow

### DIFF
--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -9,6 +9,7 @@ import InviteAccept from 'calypso/my-sites/invites/invite-accept';
 import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
 import { setUserEmailVerified } from 'calypso/state/current-user/actions';
 import { getCurrentUserEmail, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
 import { acceptInvite as acceptInviteAction } from 'calypso/state/invites/actions';
 
 /**
@@ -38,7 +39,10 @@ export function acceptInvite( context, next ) {
 		context.store
 			.dispatch( acceptInviteAction( acceptedInvite, emailVerificationSecret ) )
 			.then( () => {
-				const redirect = getRedirectAfterAccept( acceptedInvite );
+				const redirect = getRedirectAfterAccept(
+					acceptedInvite,
+					hasDashboardOptIn( context.store.getState() )
+				);
 				debug( 'Accepted invite and redirecting to:  ' + redirect );
 				navigate( redirect );
 			} )

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -16,6 +16,7 @@ import LoggedOut from 'calypso/my-sites/invites/invite-accept-logged-out';
 import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
 import { successNotice, infoNotice } from 'calypso/state/notices/actions';
 import { hideMasterbar } from 'calypso/state/ui/actions';
 import normalizeInvite from './utils/normalize-invite';
@@ -152,7 +153,7 @@ class InviteAccept extends Component {
 
 		const props = {
 			invite,
-			redirectTo: getRedirectAfterAccept( invite ),
+			redirectTo: getRedirectAfterAccept( invite, this.props.hasDashboardOptIn ),
 			decline: this.decline,
 			signInLink: this.signInLink(),
 			forceMatchingEmail: this.isMatchEmailError(),
@@ -289,9 +290,12 @@ class InviteAccept extends Component {
 	}
 }
 
-export default connect( ( state ) => ( { user: getCurrentUser( state ) } ), {
-	successNotice,
-	infoNotice,
-	hideMasterbar,
-	redirectToLogout,
-} )( localize( InviteAccept ) );
+export default connect(
+	( state ) => ( { user: getCurrentUser( state ), hasDashboardOptIn: hasDashboardOptIn( state ) } ),
+	{
+		successNotice,
+		infoNotice,
+		hideMasterbar,
+		redirectToLogout,
+	}
+)( localize( InviteAccept ) );

--- a/client/my-sites/invites/utils.tsx
+++ b/client/my-sites/invites/utils.tsx
@@ -1,4 +1,6 @@
+import { determineUrlType, URL_TYPE } from '@automattic/calypso-url';
 import i18n from 'i18n-calypso';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { logmeinUrl } from 'calypso/lib/logmein';
 
 type InviteType = {
@@ -143,18 +145,20 @@ export function acceptedNotice(
 	}
 }
 
-export function getRedirectAfterAccept( invite: InviteType ) {
+export function getRedirectAfterAccept( invite: InviteType, hasDashboardOptIn: boolean ) {
 	if ( invite.site.is_wpforteams_site ) {
 		return `https://${ invite.site.domain }`;
 	}
 
 	const readerPath = '/reader';
 	const postsListPath = '/posts/' + invite.site.ID;
-	const mySitesPath = '/sites';
+	const mySitesPath = hasDashboardOptIn ? dashboardLink( '/sites' ) : '/sites';
 	const getDestinationUrl = ( redirect: string ) => {
 		const remoteLoginHost = `https://${ invite.site.domain }`;
 		const remoteLoginBackUrl = ( destinationPath: string ) =>
-			`https://wordpress.com${ destinationPath }`;
+			determineUrlType( destinationPath ) === URL_TYPE.ABSOLUTE
+				? destinationPath
+				: `https://wordpress.com${ destinationPath }`;
 		const destination = logmeinUrl( remoteLoginHost, remoteLoginBackUrl( redirect ) );
 		const isMissingLogmein = destination === remoteLoginHost;
 		return isMissingLogmein ? redirect : destination;


### PR DESCRIPTION
## Proposed Changes

The site invitation flow should land the user in the correct dashboard depending on their preference.

In the `/accept-invite` router and in the `<InviteAccept>` component, after successfully accepting the invitation we redirect. We now check their opt-in status when choosing the location.

A trade off with this implementation, is that if the user accepts the invite via the notification drop down in the v1 interface, then they might expect to stay within the v1 interface. But I am not sure what the best way to achieve this would be.

I see that v1 also shows this notification after accepting the invite.

<img width="683" alt="CleanShot 2025-12-17 at 17 01 15@2x" src="https://github.com/user-attachments/assets/55789ba2-4b4b-4c11-a62c-03ec45709b65" />

It's a nice touch, so I'll follow up in another PR to show a flash message on v2.
Edit: https://github.com/Automattic/wp-calypso/pull/107730

## Why are these changes being made?

After being invited to a site you land on this page

<img width="653" alt="CleanShot 2025-12-17 at 15 27 34@2x" src="https://github.com/user-attachments/assets/bbd1ae13-d4f6-4e32-a26b-f8b9e7b0842c" />

But when you click "join" you are always taken to v1 `/sites`. We should honour the user's preference in this flow.

## Testing Instructions

**Setup:**
1. Create a test site or use an existing one
2. Generate an invitation link for the site (invite a user to the site)
3. Copy the invitation URL

**Testing with Dashboard v2 opt-in:**
1. Log in with a user that has dashboard v2 opt-in enabled
2. Open the invitation URL in a new browser tab
3. **Before clicking the "Join" button**, change the page URL to `calypso.localhost:3000/accept-invite/...` (replace the hostname while keeping the path and parameters)
4. Click the "Join" button
5. Verify you are redirected to the dashboard v2 URL

**Testing without Dashboard v2 opt-in:**
1. Log in with a user that does NOT have dashboard v2 opt-in enabled
2. Open the invitation URL in a new browser tab
3. **Before clicking the "Join" button**, change the page URL to `calypso.localhost:3000/accept-invite/...` (replace the hostname while keeping the path and parameters)
4. Click the "Join" button
5. Verify you are still redirected to the classic v1 sites page

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?