### PR TITLE
Show flash message in MSD site list after accepting a site invite

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -31,6 +31,7 @@ import {
 	getDefaultView,
 	recordViewChanges,
 } from './dataviews';
+import { InviteAcceptedFlashMessage } from './invite-accepted-flash-message';
 import noSitesIllustration from './no-sites-illustration.svg';
 import { SitesNotices } from './notices';
 import { SiteLink, SiteLink__ES } from './site-fields';
@@ -343,6 +344,7 @@ export default function Sites() {
 
 	return (
 		<>
+			<InviteAcceptedFlashMessage />
 			{ isModalOpen && (
 				<Modal title={ __( 'Add new site' ) } onRequestClose={ () => setIsModalOpen( false ) }>
 					<AddNewSite context="sites-dashboard" />

--- a/client/dashboard/sites/invite-accepted-flash-message.tsx
+++ b/client/dashboard/sites/invite-accepted-flash-message.tsx
@@ -1,15 +1,15 @@
-import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import FlashMessage from '../components/flash-message';
 
 export function InviteAcceptedFlashMessage() {
-	const { createSuccessNotice } = useDispatch( noticesStore );
+	const message = useRef( '' );
 
 	useEffect( () => {
 		if ( typeof window === 'undefined' ) {
 			return;
 		}
+
 		const params = new URLSearchParams( window.location.search );
 		if (
 			params.get( 'flash' ) === 'invite-accepted' &&
@@ -20,44 +20,40 @@ export function InviteAcceptedFlashMessage() {
 			const siteTitle = params.get( 'invite-site-title' )!;
 
 			// Construct role-based message (simplified for snackbar)
-			let message = '';
 			switch ( role ) {
 				case 'follower':
 					// Translators: %s is the site title.
-					message = sprintf( __( 'You’re now following %s.' ), siteTitle );
+					message.current = sprintf( __( 'You’re now following %s.' ), siteTitle );
 					break;
 				case 'viewer':
 					// Translators: %s is the site title.
-					message = sprintf( __( 'You’re now a viewer of %s.' ), siteTitle );
+					message.current = sprintf( __( 'You’re now a viewer of %s.' ), siteTitle );
 					break;
 				case 'administrator':
 					// Translators: %s is the site title.
-					message = sprintf( __( 'You’re now an Administrator of %s.' ), siteTitle );
+					message.current = sprintf( __( 'You’re now an Administrator of %s.' ), siteTitle );
 					break;
 				case 'editor':
 					// Translators: %s is the site title.
-					message = sprintf( __( 'You’re now an Editor of %s.' ), siteTitle );
+					message.current = sprintf( __( 'You’re now an Editor of %s.' ), siteTitle );
 					break;
 				case 'author':
 					// Translators: %s is the site title.
-					message = sprintf( __( 'You’re now an Author of %s.' ), siteTitle );
+					message.current = sprintf( __( 'You’re now an Author of %s.' ), siteTitle );
 					break;
 				case 'contributor':
 					// Translators: %s is the site title.
-					message = sprintf( __( 'You’re now a Contributor of %s.' ), siteTitle );
+					message.current = sprintf( __( 'You’re now a Contributor of %s.' ), siteTitle );
 					break;
 				case 'subscriber':
 					// Translators: %s is the site title.
-					message = sprintf( __( 'You’re now a Subscriber of %s.' ), siteTitle );
+					message.current = sprintf( __( 'You’re now a Subscriber of %s.' ), siteTitle );
 					break;
 				default:
 					// Translators: %s is the site title.
-					message = sprintf( __( '%s joined.' ), siteTitle );
+					message.current = sprintf( __( '%s joined.' ), siteTitle );
 			}
 
-			createSuccessNotice( message, { type: 'snackbar' } );
-
-			params.delete( 'flash' );
 			params.delete( 'invite-role' );
 			params.delete( 'invite-site-title' );
 			const newUrl =
@@ -65,10 +61,13 @@ export function InviteAcceptedFlashMessage() {
 			window.history.replaceState( {}, '', newUrl );
 		}
 
-		// This effect has side effects, like editing the URL. We only ever
-		// want to run it once on mount.
+		// This effect has side effects, like editing the URL. We only ever want to run it once on mount.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	return null;
+	if ( ! message.current ) {
+		return null;
+	}
+
+	return <FlashMessage id="invite-accepted" message={ message.current } />;
 }

--- a/client/dashboard/sites/invite-accepted-flash-message.tsx
+++ b/client/dashboard/sites/invite-accepted-flash-message.tsx
@@ -1,0 +1,74 @@
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useEffect } from 'react';
+
+export function InviteAcceptedFlashMessage() {
+	const { createSuccessNotice } = useDispatch( noticesStore );
+
+	useEffect( () => {
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+		const params = new URLSearchParams( window.location.search );
+		if (
+			params.get( 'flash' ) === 'invite-accepted' &&
+			params.get( 'invite-role' ) &&
+			params.get( 'invite-site-title' )
+		) {
+			const role = params.get( 'invite-role' )!;
+			const siteTitle = params.get( 'invite-site-title' )!;
+
+			// Construct role-based message (simplified for snackbar)
+			let message = '';
+			switch ( role ) {
+				case 'follower':
+					// Translators: %s is the site title.
+					message = sprintf( __( 'You’re now following %s.' ), siteTitle );
+					break;
+				case 'viewer':
+					// Translators: %s is the site title.
+					message = sprintf( __( 'You’re now a viewer of %s.' ), siteTitle );
+					break;
+				case 'administrator':
+					// Translators: %s is the site title.
+					message = sprintf( __( 'You’re now an Administrator of %s.' ), siteTitle );
+					break;
+				case 'editor':
+					// Translators: %s is the site title.
+					message = sprintf( __( 'You’re now an Editor of %s.' ), siteTitle );
+					break;
+				case 'author':
+					// Translators: %s is the site title.
+					message = sprintf( __( 'You’re now an Author of %s.' ), siteTitle );
+					break;
+				case 'contributor':
+					// Translators: %s is the site title.
+					message = sprintf( __( 'You’re now a Contributor of %s.' ), siteTitle );
+					break;
+				case 'subscriber':
+					// Translators: %s is the site title.
+					message = sprintf( __( 'You’re now a Subscriber of %s.' ), siteTitle );
+					break;
+				default:
+					// Translators: %s is the site title.
+					message = sprintf( __( '%s joined.' ), siteTitle );
+			}
+
+			createSuccessNotice( message, { type: 'snackbar' } );
+
+			params.delete( 'flash' );
+			params.delete( 'invite-role' );
+			params.delete( 'invite-site-title' );
+			const newUrl =
+				window.location.pathname + ( params.toString() ? '?' + params.toString() : '' );
+			window.history.replaceState( {}, '', newUrl );
+		}
+
+		// This effect has side effects, like editing the URL. We only ever
+		// want to run it once on mount.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	return null;
+}

--- a/client/my-sites/invites/utils.tsx
+++ b/client/my-sites/invites/utils.tsx
@@ -1,4 +1,5 @@
 import { determineUrlType, URL_TYPE } from '@automattic/calypso-url';
+import { addQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { logmeinUrl } from 'calypso/lib/logmein';
@@ -152,7 +153,15 @@ export function getRedirectAfterAccept( invite: InviteType, hasDashboardOptIn: b
 
 	const readerPath = '/reader';
 	const postsListPath = '/posts/' + invite.site.ID;
-	const mySitesPath = hasDashboardOptIn ? dashboardLink( '/sites' ) : '/sites';
+	const mySitesPath = hasDashboardOptIn
+		? dashboardLink(
+				addQueryArgs( '/sites', {
+					flash: 'invite-accepted',
+					'invite-role': invite.role,
+					'invite-site-title': invite.site.title || invite.site.URL,
+				} )
+		  )
+		: '/sites';
 	const getDestinationUrl = ( redirect: string ) => {
 		const remoteLoginHost = `https://${ invite.site.domain }`;
 		const remoteLoginBackUrl = ( destinationPath: string ) =>


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/107728

## Proposed Changes

* Add flash message component that displays success notice when landing on site list in the MSD after accepting site invite
* Pass role and site title through URL params to display appropriate message
* Clean up URL params after showing message

<img width="651" alt="CleanShot 2025-12-17 at 18 11 28@2x" src="https://github.com/user-attachments/assets/ac91fba6-7f5f-447b-8015-0543f72a77c5" />


## Why are these changes being made?

Good to let the user know the task has completed.

## Testing Instructions

### Prerequisites
- Dashboard opt-in enabled
- Access to site invite links for different roles

### Test Case 1: Accept invite as Administrator
1. Create or obtain invite link with Administrator role
2. Accept the invite (logged in or logged out flow)
3. Verify redirect to `/sites` with flash params in URL
4. Verify snackbar appears: "You’re now an Administrator of [Site Title]."
5. Verify URL params (`flash`, `invite-role`, `invite-site-title`) are removed from URL
6. Refresh page - snackbar should not reappear

### Test Case 2: Edge cases
1. Manually add flash params to URL and refresh - snackbar should appear
2. Accept invite without dashboard opt-in - should redirect to old `/sites` and show the old popup message.
3. Verify message only shows once per page load
4. Test with long site titles to ensure proper display

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?