### PR TITLE
MSD: Using the list type of DataViews for the plugin switcher on Manage plugins

### DIFF
--- a/client/dashboard/plugins/manage/components/plugin-switcher.scss
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.scss
@@ -1,8 +1,8 @@
 .plugin-icon-wrapper {
 	border-radius: 4px;
 	position: relative;
-	width: 40px;
-	height: 40px;
+	width: 100%;
+	height: 100%;
 	flex-shrink: 0;
 
 	&.is-fallback {
@@ -18,13 +18,14 @@
 	transform: translate(-50%, -50%);
 }
 
-.plugin-switcher-card-body {
+.plugin-switcher-card .components-card__body {
+	display: flex;
+	flex-direction: column;
 	// take into account header and nav plus border (64+1), page layout padding (32),
 	// page title/description (80), and gap between title/description and the cards (32)
 	max-height: calc(100vh - 2 * ( 64px + 1px ) - 2 * 32px - 80px - 32px);
 	padding-inline-start: 0;
 	padding-inline-end: 0;
-	overflow-y: auto;
 }
 
 .plugin-switcher-search {
@@ -49,6 +50,7 @@
 }
 
 .plugin-switcher-item-name {
+	display: block;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	text-wrap-mode: nowrap;

--- a/client/dashboard/plugins/manage/components/plugin-switcher.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.tsx
@@ -1,104 +1,61 @@
-import { __experimentalVStack as VStack, Icon } from '@wordpress/components';
-import { Field, View } from '@wordpress/dataviews';
-import { _n, sprintf } from '@wordpress/i18n';
-import { plugins as pluginIcon } from '@wordpress/icons';
-import clsx from 'clsx';
-import { useCallback } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { DataViews } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 import { pluginRoute } from '../../../app/router/plugins';
-import { Card, CardBody } from '../../../components/card';
-import SwitcherContent from '../../../components/switcher/switcher-content';
-import { Text } from '../../../components/text';
-import { PluginListRow } from '../types';
-
+import { DataViewsCard } from '../../../components/dataviews';
+import type { PluginListRow } from '../types';
+import type { Field, View } from '@wordpress/dataviews';
+import type { ComponentProps } from 'react';
 import './plugin-switcher.scss';
-
-const ICON_SIZE = 40;
-const FALLBACK_ICON_SIZE = 30;
 
 export const PluginSwitcher = ( {
 	pluginsWithIcon,
-	searchableFields,
 	selectedPluginSlug = '',
 	view,
+	fields,
+	paginationInfo,
+	onChangeView,
 }: {
 	pluginsWithIcon: PluginListRow[];
-	searchableFields: Field< PluginListRow >[];
 	selectedPluginSlug?: string;
 	view: View;
+	fields: Field< PluginListRow >[];
+	paginationInfo: ComponentProps< typeof DataViews< PluginListRow > >[ 'paginationInfo' ];
+	onChangeView: ( newView: View ) => void;
 } ) => {
-	const itemClassName = useCallback(
-		( item: PluginListRow ) =>
-			clsx( 'plugin-switcher-item', {
-				'is-selected': selectedPluginSlug === item.slug,
-			} ),
-		[ selectedPluginSlug ]
-	);
+	const navigate = useNavigate();
 
-	const renderItemMedia = useCallback( ( { item }: { item: PluginListRow } ) => {
-		const icon = item.icon ? (
-			<img src={ item.icon } alt={ item.name } width={ ICON_SIZE } height={ ICON_SIZE } />
-		) : (
-			<Icon icon={ pluginIcon } size={ FALLBACK_ICON_SIZE } className="plugin-icon-fallback" />
-		);
-
-		return (
-			<div className={ clsx( 'plugin-icon-wrapper', { 'is-fallback': ! item.icon } ) }>
-				{ icon }
-			</div>
-		);
-	}, [] );
-
-	const renderItemTitle = useCallback( ( { item }: { item: PluginListRow } ) => {
-		const sitesText = sprintf(
-			// translators: %(siteCount)d is the number of sites the plugin is installed on.
-			_n( '%(siteCount)d site', '%(siteCount)d sites', item.sitesCount ),
-			{ siteCount: item.sitesCount }
-		);
-
-		const updatesText = item.sitesWithPluginUpdate.length
-			? sprintf(
-					// translators: %(updateCount)d is the number of updates available.
-					_n(
-						'%(updateCount)d update available',
-						'%(updateCount)d updates available',
-						item.sitesWithPluginUpdate.length
-					),
-					{ updateCount: item.sitesWithPluginUpdate.length }
-			  )
-			: '';
-
-		return (
-			<VStack spacing={ 0 }>
-				{ /* @ts-expect-error: Can only set one of `children` or `props.dangerouslySetInnerHTML`. */ }
-				<Text
-					className="plugin-switcher-item-name"
-					dangerouslySetInnerHTML={ { __html: item.name } }
-					title={ item.name }
-				/>
-				<Text variant="muted">
-					{ updatesText ? `${ sitesText }, ${ updatesText }` : sitesText }
-				</Text>
-			</VStack>
-		);
-	}, [] );
+	const onChangeSelection = ( selection: string[] ) => {
+		if ( selection.length > 0 ) {
+			navigate( {
+				to: pluginRoute.fullPath,
+				params: { pluginId: selection[ 0 ] },
+				resetScroll: false,
+			} );
+		}
+	};
 
 	return (
-		<Card>
-			<CardBody className="plugin-switcher-card-body">
-				<SwitcherContent
-					itemClassName={ itemClassName }
-					searchClassName="plugin-switcher-search"
-					initialView={ view }
-					items={ pluginsWithIcon }
-					resetScroll={ false }
-					getItemUrl={ ( item ) => pluginRoute.to.replace( '$pluginId', item.slug ) }
-					renderItemMedia={ renderItemMedia }
-					renderItemTitle={ renderItemTitle }
-					searchableFields={ searchableFields }
-					onClose={ () => {} }
-					width="auto"
-				/>
-			</CardBody>
-		</Card>
+		<DataViewsCard className="plugin-switcher-card">
+			<DataViews< PluginListRow >
+				getItemId={ ( item ) => item.slug }
+				data={ pluginsWithIcon }
+				fields={ fields }
+				view={ view }
+				onChangeView={ onChangeView }
+				isLoading={ ! pluginsWithIcon }
+				defaultLayouts={ { list: {} } }
+				paginationInfo={ paginationInfo }
+				onChangeSelection={ onChangeSelection }
+				selection={ selectedPluginSlug ? [ selectedPluginSlug ] : [] }
+				empty={
+					<p>
+						{ view.search
+							? __( 'No results for this search term' )
+							: __( 'No results for this period' ) }
+					</p>
+				}
+			/>
+		</DataViewsCard>
 	);
 };

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -6,57 +6,127 @@ import {
 } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
-import { __experimentalGrid as Grid } from '@wordpress/components';
+import { __experimentalGrid as Grid, Icon } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { filterSortAndPaginate, View } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
-import { useMemo } from 'react';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { plugins as pluginIcon } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { OptInWelcome } from '../../components/opt-in-welcome';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import { Text } from '../../components/text';
 import { PluginSites } from './components/plugin-sites';
 import { PluginSwitcher } from './components/plugin-switcher';
 import { useSitesById } from './hooks/use-sites-by-id';
 import { mapApiPluginsToDataViewPlugins } from './utils';
 import type { PluginListRow } from './types';
+import type { Field, View } from '@wordpress/dataviews';
 
-const view: View = {
-	type: 'list',
-	page: 1,
-	perPage: 100,
-	sort: { field: 'name', direction: 'asc' },
+const ICON_SIZE = 40;
+
+const FALLBACK_ICON_SIZE = 30;
+
+const getFields = () => {
+	const fields: Field< PluginListRow >[] = [
+		{
+			id: 'icon',
+			label: __( 'Icon' ),
+			render: ( { item } ) => {
+				const icon = item.icon ? (
+					<img src={ item.icon } alt={ item.name } width={ ICON_SIZE } height={ ICON_SIZE } />
+				) : (
+					<Icon icon={ pluginIcon } size={ FALLBACK_ICON_SIZE } className="plugin-icon-fallback" />
+				);
+
+				return (
+					<div className={ clsx( 'plugin-icon-wrapper', { 'is-fallback': ! item.icon } ) }>
+						{ icon }
+					</div>
+				);
+			},
+			enableSorting: false,
+			enableHiding: false,
+		},
+		{
+			id: 'title',
+			label: __( 'Title' ),
+			getValue: ( { item } ) => item.name,
+			render: ( { item } ) => (
+				/* @ts-expect-error: Can only set one of `children` or `props.dangerouslySetInnerHTML`. */
+				<Text
+					className="plugin-switcher-item-name"
+					dangerouslySetInnerHTML={ { __html: item.name } }
+					title={ item.name }
+				/>
+			),
+			enableGlobalSearch: true,
+			enableHiding: false,
+		},
+		{
+			id: 'available_sites',
+			label: __( 'Available sites' ),
+			render: ( { item } ) => {
+				const sitesText = sprintf(
+					// translators: %(siteCount)d is the number of sites the plugin is installed on.
+					_n( '%(siteCount)d site', '%(siteCount)d sites', item.sitesCount ),
+					{ siteCount: item.sitesCount }
+				);
+
+				const updatesText = item.sitesWithPluginUpdate.length
+					? sprintf(
+							// translators: %(updateCount)d is the number of updates available.
+							_n(
+								'%(updateCount)d update available',
+								'%(updateCount)d updates available',
+								item.sitesWithPluginUpdate.length
+							),
+							{ updateCount: item.sitesWithPluginUpdate.length }
+					  )
+					: '';
+
+				return (
+					<Text variant="muted">
+						{ updatesText ? `${ sitesText }, ${ updatesText }` : sitesText }
+					</Text>
+				);
+			},
+			enableSorting: false,
+			enableHiding: false,
+		},
+	];
+
+	return fields;
 };
-const searchableFields = [
-	{
-		id: 'name',
-		getValue: ( { item }: { item: PluginListRow } ) => item.name,
-	},
-	{
-		id: 'slug',
-		getValue: ( { item }: { item: PluginListRow } ) => item.slug,
-	},
-];
 
 export default function PluginsList() {
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const { data: sitesPlugins } = useQuery( pluginsQuery() );
 	const { sitesById } = useSitesById();
 	const { pluginId: pluginSlug } = useParams( { strict: false } );
-	const fields = useMemo( () => {
-		return searchableFields.map( ( searchableField ) => ( {
-			...searchableField,
-			enableGlobalSearch: true,
-		} ) );
-	}, [] );
-	const { data: plugins } = useMemo(
+
+	const [ view, setView ] = useState< View >( {
+		type: 'list',
+		fields: [ 'available_sites' ],
+		titleField: 'title',
+		mediaField: 'icon',
+		page: 1,
+		perPage: 10,
+		sort: { field: 'title', direction: 'asc' },
+	} );
+
+	const fields = useMemo( () => getFields(), [] );
+
+	const { data: plugins, paginationInfo } = useMemo(
 		() =>
 			filterSortAndPaginate(
 				mapApiPluginsToDataViewPlugins( sitesById, sitesPlugins ),
 				view,
 				fields
 			),
-		[ sitesById, sitesPlugins, fields ]
+		[ sitesById, sitesPlugins, view, fields ]
 	);
 	const selectedPluginSlug = pluginSlug || plugins[ 0 ]?.slug;
 	const { data: marketplacePlugins } = useQuery( marketplacePluginsQuery() );
@@ -101,6 +171,10 @@ export default function PluginsList() {
 		} );
 	}, [ plugins, iconBySlug ] );
 
+	const onChangeView = ( newView: View ) => {
+		setView( newView );
+	};
+
 	if ( isSmallViewport ) {
 		return (
 			<PageLayout
@@ -121,8 +195,10 @@ export default function PluginsList() {
 				) : (
 					<PluginSwitcher
 						pluginsWithIcon={ pluginsWithIcon }
-						searchableFields={ searchableFields }
 						view={ view }
+						fields={ fields }
+						paginationInfo={ paginationInfo }
+						onChangeView={ onChangeView }
 					/>
 				) }
 			</PageLayout>
@@ -143,9 +219,11 @@ export default function PluginsList() {
 			<Grid columns={ 2 } gap={ 6 } templateColumns="392px 1fr">
 				<PluginSwitcher
 					pluginsWithIcon={ pluginsWithIcon }
-					searchableFields={ searchableFields }
 					selectedPluginSlug={ selectedPluginSlug }
 					view={ view }
+					fields={ fields }
+					paginationInfo={ paginationInfo }
+					onChangeView={ onChangeView }
 				/>
 
 				<PluginSites selectedPluginSlug={ selectedPluginSlug } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Try to use the list type of DataViews for the plugin switcher on Manage plugins screen instead of using `SwitcherContent`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2/plugins
* Scroll down on the left card plugins list, select any plugin, change pages, etc.
* Ensure it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
