### PR TITLE
MSD: Fix suspense query without preload

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -430,6 +430,8 @@ export const siteBackupsRoute = createRoute( {
 			queryClient.prefetchQuery( siteBackupActivityLogEntriesQuery( site.ID ) );
 			queryClient.prefetchQuery( siteBackupActivityLogGroupCountsQuery( site.ID ) );
 		}
+
+		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
 	},
 } ).lazy( () =>
 	import( '../../sites/backups' ).then( ( d ) =>

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -353,6 +353,14 @@ export const siteScanRoute = createRoute( {
 			throw redirect( { to: `/sites/${ siteSlug }` } );
 		}
 	},
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		await Promise.all( [
+			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
+			hasHostingFeature( site, HostingFeatures.SCAN ) &&
+				queryClient.ensureQueryData( siteScanQuery( site.ID ) ),
+		] );
+	},
 } );
 
 export const siteScanIndexRoute = createRoute( {
@@ -373,12 +381,6 @@ export const siteScanActiveThreatsRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteScanRoute,
 	path: 'active',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( hasHostingFeature( site, HostingFeatures.SCAN ) ) {
-			await queryClient.ensureQueryData( siteScanQuery( site.ID ) );
-		}
-	},
 } ).lazy( () =>
 	import( '../../sites/scan' ).then( ( d ) =>
 		createLazyRoute( 'site-scan-active-threats' )( {
@@ -397,12 +399,6 @@ export const siteScanHistoryRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteScanRoute,
 	path: 'history',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( hasHostingFeature( site, HostingFeatures.SCAN ) ) {
-			await queryClient.ensureQueryData( siteScanQuery( site.ID ) );
-		}
-	},
 } ).lazy( () =>
 	import( '../../sites/scan' ).then( ( d ) =>
 		createLazyRoute( 'site-scan-history' )( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/107709

## Proposed Changes

* Some pages use Suspense queries but do not preload them in the route loader. As a result, when navigating to these screens, a white screen is briefly displayed while the data is loading.
* This PR proposes changes to preload those suspense query within the loader to resolve it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's important to display loading state instead of white screen to users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites/:site
* Run `localStorage.removeItem('REACT_QUERY_OFFLINE_CACHE');` on your console
* Refresh the page
* Navigate to either Scan or Backups 
* Ensure you won't see the white screen content anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
