### PR TITLE
MSD: Add snackbar back button to the Site Visibility page

### DIFF
--- a/client/dashboard/components/snackbar-back-button/index.tsx
+++ b/client/dashboard/components/snackbar-back-button/index.tsx
@@ -1,10 +1,25 @@
 import { useRouter, useCanGoBack } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
-import { isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { ReactNode } from 'react';
 
 import './style.scss';
+
+export function getSnackbarBackButtonText(
+	to: 'site-overview' | 'site-domains' | 'site-deployments'
+) {
+	switch ( to ) {
+		case 'site-overview':
+			return __( 'Back to Site Overview' );
+		case 'site-deployments':
+			return __( 'Back to Deployments' );
+		case 'site-domains':
+			return __( 'Back to Site Domain Names' );
+		default:
+			return null;
+	}
+}
 
 export default function SnackbarBackButton( { children }: { children: ReactNode } ) {
 	const router = useRouter();

--- a/client/dashboard/components/snackbar-back-button/index.tsx
+++ b/client/dashboard/components/snackbar-back-button/index.tsx
@@ -13,9 +13,9 @@ export function getSnackbarBackButtonText(
 		case 'site-overview':
 			return __( 'Back to Site Overview' );
 		case 'site-deployments':
-			return __( 'Back to Deployments' );
+			return __( 'Back to Site Deployments' );
 		case 'site-domains':
-			return __( 'Back to Site Domain Names' );
+			return __( 'Back to Site Domains' );
 		default:
 			return null;
 	}

--- a/client/dashboard/components/snackbar-back-button/index.tsx
+++ b/client/dashboard/components/snackbar-back-button/index.tsx
@@ -15,7 +15,7 @@ export function getSnackbarBackButtonText(
 		case 'site-deployments':
 			return __( 'Back to Site Deployments' );
 		case 'site-domains':
-			return __( 'Back to Site Domains' );
+			return __( 'Back to Site Domain Names' );
 		default:
 			return null;
 	}

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -11,7 +11,9 @@ import { useLocale } from '../../app/locale';
 import { domainRoute } from '../../app/router/domains';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import SnackbarBackButton from '../../components/snackbar-back-button';
+import SnackbarBackButton, {
+	getSnackbarBackButtonText,
+} from '../../components/snackbar-back-button';
 import { formatDate } from '../../utils/datetime';
 import { getDomainRenewalUrl } from '../../utils/domain';
 import Actions from './actions';
@@ -45,15 +47,7 @@ export default function DomainOverview() {
 	} );
 
 	const { back_to: domainsBackTo } = useSearch( { from: domainRoute.fullPath } );
-	let backButton = null;
-	switch ( domainsBackTo ) {
-		case 'site-domains':
-			backButton = <SnackbarBackButton>{ __( 'Back to Site Domain Names' ) }</SnackbarBackButton>;
-			break;
-		case 'site-overview':
-			backButton = <SnackbarBackButton>{ __( 'Back to Site Overview' ) }</SnackbarBackButton>;
-			break;
-	}
+	const snackbarBackButtonText = getSnackbarBackButtonText( domainsBackTo );
 
 	return (
 		<>
@@ -123,7 +117,9 @@ export default function DomainOverview() {
 				) }
 				<Actions />
 			</PageLayout>
-			{ backButton }
+			{ snackbarBackButtonText && (
+				<SnackbarBackButton>{ snackbarBackButtonText }</SnackbarBackButton>
+			) }
 		</>
 	);
 }

--- a/client/dashboard/sites/deployments-list/dataviews/fields.tsx
+++ b/client/dashboard/sites/deployments-list/dataviews/fields.tsx
@@ -51,7 +51,7 @@ export function useFields( {
 						<Link
 							to={ siteSettingsRepositoriesManageRoute.fullPath }
 							params={ { siteSlug, deploymentId: item.code_deployment_id } }
-							search={ { back_to: 'deployments' } }
+							search={ { back_to: 'site-deployments' } }
 						>
 							{ repo }
 						</Link>

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -153,7 +153,7 @@ function DeploymentsList() {
 							<RouterLinkButton
 								to={ siteSettingsRepositoriesRoute.fullPath }
 								params={ { siteSlug } }
-								search={ { back_to: 'deployments' } }
+								search={ { back_to: 'site-deployments' } }
 								variant="secondary"
 								__next40pxDefaultSize
 							>

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/index.tsx
@@ -1,7 +1,8 @@
 import { useRouterState } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
 import { CalloutOverlay } from '../../components/callout-overlay';
-import SnackbarBackButton from '../../components/snackbar-back-button';
+import SnackbarBackButton, {
+	getSnackbarBackButtonText,
+} from '../../components/snackbar-back-button';
 import HostingFeatureGate from '../hosting-feature-gate';
 import ActivationCallout from './activation';
 import UpsellCallout, { UpsellCalloutProps } from './upsell';
@@ -35,8 +36,9 @@ export default function HostingFeatureGatedWithCallout( {
 
 	const { site, upsellId, upsellFeatureId, feature } = props;
 
-	const backButton = search.back_to === 'overview' && (
-		<SnackbarBackButton>{ __( 'Back to Overview' ) }</SnackbarBackButton>
+	const snackbarBackButtonText = getSnackbarBackButtonText( search.back_to );
+	const backButton = snackbarBackButtonText && (
+		<SnackbarBackButton>{ snackbarBackButtonText }</SnackbarBackButton>
 	);
 
 	return (

--- a/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-overview-card/index.tsx
@@ -33,7 +33,7 @@ export default function HostingFeatureGatedWithOverviewCard( {
 		intent: 'upsell' as const,
 		link: isRelativeUrl( upsellLink )
 			? addQueryArgs( upsellLink, {
-					back_to: 'overview',
+					back_to: 'site-overview',
 			  } )
 			: upsellLink,
 	};

--- a/client/dashboard/sites/overview-agency-site-share-card/index.tsx
+++ b/client/dashboard/sites/overview-agency-site-share-card/index.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { link } from '@wordpress/icons';
 import OverviewCard from '../../components/overview-card';
+import { getSiteVisibilityURL } from '../../utils/site-url';
 import type { Site } from '@automattic/api-core';
 
 export default function AgencySiteShareCard( { site }: { site: Site } ) {
@@ -14,7 +15,7 @@ export default function AgencySiteShareCard( { site }: { site: Site } ) {
 			icon={ link }
 			heading={ heading }
 			description={ __( 'Collaborators with the link can view your site.' ) }
-			link={ `/sites/${ site.slug }/settings/site-visibility` }
+			link={ getSiteVisibilityURL( site, { back_to: 'site-overview' } ) }
 			title={ __( 'Share' ) }
 			tracksId="site-overview-agency-site-share"
 		/>

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -140,7 +140,7 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 				{ ...CARD_PROPS }
 				heading={ __( 'No results' ) }
 				description={ __( 'Launch your site to test performance.' ) }
-				link={ getSiteVisibilityURL( site ) }
+				link={ getSiteVisibilityURL( site, { back_to: 'site-overview' } ) }
 			/>
 		);
 	}
@@ -151,7 +151,7 @@ function PerformanceCardContent( { site }: { site: Site } ) {
 				{ ...CARD_PROPS }
 				heading={ __( 'No results' ) }
 				description={ __( 'Make your site public to test performance.' ) }
-				link={ getSiteVisibilityURL( site ) }
+				link={ getSiteVisibilityURL( site, { back_to: 'site-overview' } ) }
 			/>
 		);
 	}

--- a/client/dashboard/sites/overview-visibility-card/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card/index.tsx
@@ -47,7 +47,7 @@ function VisibilityCardUnlaunched( { site }: { site: Site } ) {
 				? {
 						heading: __( 'Launch site' ),
 						description: __( 'Ready to go public?' ),
-						link: getSiteVisibilityURL( site ),
+						link: getSiteVisibilityURL( site, { back_to: 'site-overview' } ),
 				  }
 				: {
 						heading: __( 'Coming soon' ),
@@ -75,7 +75,7 @@ function VisibilityCardComingSoon( { site }: { site: Site } ) {
 					? __( 'Visitors will see a coming soon page.' )
 					: __( 'Ready to go public?' )
 			}
-			link={ getSiteVisibilityURL( site ) }
+			link={ getSiteVisibilityURL( site, { back_to: 'site-overview' } ) }
 		/>
 	);
 }
@@ -87,7 +87,7 @@ function VisibilityCardPrivate( { site }: { site: Site } ) {
 			icon={ lockOutline }
 			heading={ __( 'Private' ) }
 			description={ __( 'Only invited users can view your site.' ) }
-			link={ getSiteVisibilityURL( site ) }
+			link={ getSiteVisibilityURL( site, { back_to: 'site-overview' } ) }
 		/>
 	);
 }
@@ -103,7 +103,7 @@ function VisibilityCardPublic( { site }: { site: Site } ) {
 			icon={ published }
 			heading={ __( 'Public' ) }
 			description={ description }
-			link={ getSiteVisibilityURL( site ) }
+			link={ getSiteVisibilityURL( site, { back_to: 'site-overview' } ) }
 			intent="success"
 		/>
 	);

--- a/client/dashboard/sites/settings-repositories/back-to-deployments-button.tsx
+++ b/client/dashboard/sites/settings-repositories/back-to-deployments-button.tsx
@@ -1,6 +1,0 @@
-import { __ } from '@wordpress/i18n';
-import SnackbarBackButton from '../../components/snackbar-back-button';
-
-export function BackToDeploymentsButton() {
-	return <SnackbarBackButton>{ __( 'Back to Deployments' ) }</SnackbarBackButton>;
-}

--- a/client/dashboard/sites/settings-repositories/configure-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/configure-repository.tsx
@@ -15,7 +15,9 @@ import {
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { BackToDeploymentsButton } from './back-to-deployments-button';
+import SnackbarBackButton, {
+	getSnackbarBackButtonText,
+} from '../../components/snackbar-back-button';
 import { ConnectRepositoryForm } from './connect-repository-form';
 
 export default function ConfigureRepository() {
@@ -29,7 +31,7 @@ export default function ConfigureRepository() {
 		from: navigateFrom,
 	} );
 	const search = siteSettingsRepositoriesManageRoute.useSearch();
-	const showBackToDeployments = search?.back_to === 'deployments';
+	const snackbarBackButtonText = getSnackbarBackButtonText( search?.back_to );
 
 	const handleCancel = () => {
 		navigate( { to: siteSettingsRepositoriesRoute.fullPath } );
@@ -84,7 +86,9 @@ export default function ConfigureRepository() {
 					</CardBody>
 				</Card>
 			</PageLayout>
-			{ showBackToDeployments && <BackToDeploymentsButton /> }
+			{ snackbarBackButtonText && (
+				<SnackbarBackButton>{ snackbarBackButtonText }</SnackbarBackButton>
+			) }
 		</>
 	);
 }

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -22,12 +22,14 @@ import {
 import { DataViewsCard } from '../../components/dataviews';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import SnackbarBackButton, {
+	getSnackbarBackButtonText,
+} from '../../components/snackbar-back-button';
 import { hasHostingFeature } from '../../utils/site-features';
 import illustrationUrl from '../deployments/deployments-callout-illustration.svg';
 import GithubIcon from '../deployments/icons/github';
 import { TriggerDeploymentModalForm } from '../deployments-list/trigger-deployment-modal-form';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
-import { BackToDeploymentsButton } from './back-to-deployments-button';
 import { useRepositoryFields } from './dataviews/fields';
 import { DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews/views';
 import { DisconnectRepositoryModalContent } from './disconnect-repository-modal-content';
@@ -161,7 +163,7 @@ function SiteRepositories() {
 	const navigate = useNavigate( { from: siteSettingsRepositoriesRoute.fullPath } );
 	const canConnect = hasHostingFeature( site, HostingFeatures.DEPLOYMENT );
 	const search = siteSettingsRepositoriesRoute.useSearch();
-	const showBackToDeployments = search?.back_to === 'deployments';
+	const snackbarBackButtonText = getSnackbarBackButtonText( search?.back_to );
 
 	const handleConnectRepository = () => {
 		navigate( { to: siteSettingsRepositoriesConnectRoute.fullPath } );
@@ -201,7 +203,9 @@ function SiteRepositories() {
 					<RepositoriesList />
 				</HostingFeatureGatedWithCallout>
 			</PageLayout>
-			{ showBackToDeployments && <BackToDeploymentsButton /> }
+			{ snackbarBackButtonText && (
+				<SnackbarBackButton>{ snackbarBackButtonText }</SnackbarBackButton>
+			) }
 		</>
 	);
 }

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -8,7 +8,9 @@ import { siteSettingsSiteVisibilityRoute } from '../../app/router/sites';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import SnackbarBackButton from '../../components/snackbar-back-button';
+import SnackbarBackButton, {
+	getSnackbarBackButtonText,
+} from '../../components/snackbar-back-button';
 import { LaunchAgencyDevelopmentSiteForm, LaunchForm } from './launch-form';
 import { PrivacyForm } from './privacy-form';
 import { ShareSiteForm } from './share-site-form';
@@ -42,12 +44,12 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 	};
 
 	const renderBackButton = () => {
-		switch ( back_to ) {
-			case 'site-overview':
-				return <SnackbarBackButton>{ __( 'Back to Site Overview' ) }</SnackbarBackButton>;
-			default:
-				return null;
+		const snackbarBackButtonText = getSnackbarBackButtonText( back_to );
+		if ( ! snackbarBackButtonText ) {
+			return null;
 		}
+
+		return <SnackbarBackButton>{ snackbarBackButtonText }</SnackbarBackButton>;
 	};
 
 	return (

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -1,11 +1,14 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSearch } from '@tanstack/react-router';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { siteSettingsSiteVisibilityRoute } from '../../app/router/sites';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import SnackbarBackButton from '../../components/snackbar-back-button';
 import { LaunchAgencyDevelopmentSiteForm, LaunchForm } from './launch-form';
 import { PrivacyForm } from './privacy-form';
 import { ShareSiteForm } from './share-site-form';
@@ -13,6 +16,9 @@ import { ShareSiteForm } from './share-site-form';
 export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
+	const { back_to } = useSearch( {
+		from: siteSettingsSiteVisibilityRoute.fullPath,
+	} );
 
 	if ( ! settings ) {
 		return null;
@@ -35,6 +41,15 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 		return <PrivacyForm site={ site } settings={ settings } />;
 	};
 
+	const renderBackButton = () => {
+		switch ( back_to ) {
+			case 'site-overview':
+				return <SnackbarBackButton>{ __( 'Back to Site Overview' ) }</SnackbarBackButton>;
+			default:
+				return null;
+		}
+	};
+
 	return (
 		<PageLayout
 			size="small"
@@ -52,6 +67,7 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 			}
 		>
 			{ renderContent() }
+			{ renderBackButton() }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -52,10 +52,13 @@ export function getSiteEditUrl( site: Site, isSiteUsingBlockTheme?: boolean ) {
 /**
  * Returns the URL for the site visibility settings page.
  */
-export function getSiteVisibilityURL( site: Site ) {
+export function getSiteVisibilityURL( site: Site, options?: { back_to: 'site-overview' } ) {
 	if ( isSelfHostedJetpackConnected( site ) ) {
 		return undefined;
 	}
 
-	return `/sites/${ site.slug }/settings/site-visibility`;
+	const siteVisibilityURL = `/sites/${ site.slug }/settings/site-visibility`;
+	return options?.back_to
+		? addQueryArgs( siteVisibilityURL, { back_to: options.back_to } )
+		: siteVisibilityURL;
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -52,13 +52,10 @@ export function getSiteEditUrl( site: Site, isSiteUsingBlockTheme?: boolean ) {
 /**
  * Returns the URL for the site visibility settings page.
  */
-export function getSiteVisibilityURL( site: Site, options?: { back_to: 'site-overview' } ) {
+export function getSiteVisibilityURL( site: Site, queryArgs?: { back_to: 'site-overview' } ) {
 	if ( isSelfHostedJetpackConnected( site ) ) {
 		return undefined;
 	}
 
-	const siteVisibilityURL = `/sites/${ site.slug }/settings/site-visibility`;
-	return options?.back_to
-		? addQueryArgs( siteVisibilityURL, { back_to: options.back_to } )
-		: siteVisibilityURL;
+	return addQueryArgs( `/sites/${ site.slug }/settings/site-visibility`, queryArgs );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Add snackbar back button to the Site Visibility page

<img width="226" height="53" alt="image" src="https://github.com/user-attachments/assets/caa177ad-e9e2-4b7c-9563-09a439e77217" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It would be better to allow people to go back to previous page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site
* Select visibility card
* Ensure you can see the back button at left-bottom corner
* Click the button
* Ensure you can go back to the Site Overview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
