### PR TITLE
A4A: Implement A4A Client express checkout in WPCOM checkout.

### DIFF
--- a/client/a8c-for-agencies/sections/client/hooks/use-client-checkout.ts
+++ b/client/a8c-for-agencies/sections/client/hooks/use-client-checkout.ts
@@ -1,6 +1,7 @@
 import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import useProductsById from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id';
 import { getClientReferralQueryArgs } from 'calypso/a8c-for-agencies/sections/marketplace/lib/get-client-referral-query-args';
@@ -16,6 +17,7 @@ type Props = {
 };
 
 export default function useClientCheckout( { expressMode = false }: Props ) {
+	const translate = useTranslate();
 	const [ isReady, setIsReady ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
 
@@ -104,19 +106,19 @@ export default function useClientCheckout( { expressMode = false }: Props ) {
 		}
 	}, [ expressMode, referral?.client?.email, checkoutStoreDispatch ] );
 
-	// Debugging: Set a timeout to force showing the checkout after 10 seconds
+	// Debugging: Set a timeout after 30 seconds
 	useEffect( () => {
 		if ( isReady || error ) {
 			return;
 		}
 
 		const timeoutId = setTimeout( () => {
-			debug( '[A4A Checkout] Timeout reached, showing checkout anyway' );
-			setIsReady( true );
-		}, 10000 );
+			debug( '[A4A Checkout] Timeout reached' );
+			setError( translate( 'Unable to load shopping cart.' ) );
+		}, 30000 );
 
 		return () => clearTimeout( timeoutId );
-	}, [ isReady, error ] );
+	}, [ isReady, error, translate ] );
 
 	return {
 		isReady,

--- a/client/a8c-for-agencies/sections/client/hooks/use-client-checkout.ts
+++ b/client/a8c-for-agencies/sections/client/hooks/use-client-checkout.ts
@@ -1,0 +1,105 @@
+import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
+import debugFactory from 'debug';
+import { useEffect, useState } from 'react';
+import useProductsById from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id';
+import { getClientReferralQueryArgs } from 'calypso/a8c-for-agencies/sections/marketplace/lib/get-client-referral-query-args';
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import useFetchClientReferral from './use-fetch-client-referral';
+
+const debug = debugFactory( 'client:checkout-v2' );
+
+export default function useClientCheckout() {
+	const [ isReady, setIsReady ] = useState( false );
+	const [ error, setError ] = useState< string | null >( null );
+
+	const queryArgs = getClientReferralQueryArgs();
+	const { data: referral } = useFetchClientReferral( queryArgs );
+	const { referredProducts } = useProductsById( referral?.products ?? [] );
+
+	// Access the shopping cart API
+	const { replaceProductsInCart, responseCart } = useShoppingCart( 'no-site' );
+
+	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
+
+	const emailMismatchWithReferralClient = referral?.client?.email !== userEmail;
+
+	// Add products to cart when referral data is loaded
+	useEffect( () => {
+		// Skip if we're already ready or have an error
+		if ( isReady || error ) {
+			debug( '[A4A Checkout] Already ready or has error' );
+			return;
+		}
+
+		if ( ! referredProducts || referredProducts.length === 0 ) {
+			debug( '[A4A Checkout] No referred products' );
+			return;
+		}
+
+		debug( '[A4A Checkout] Referral', referral );
+		debug( '[A4A Checkout] Referred products', referredProducts );
+
+		const productsToAdd = referredProducts.map( ( product ) => {
+			return createRequestCartProduct( {
+				// When using the wpcom checkout we use alternative a4a-specific billing product ids for wpcom and jetpack products.
+				product_id: product.alternative_product_id || product.product_id,
+				product_slug: product.slug,
+				extra: {
+					isA4ASitelessCheckout: true,
+					referral_id: queryArgs.referralId,
+					agency_id: queryArgs.agencyId,
+				},
+			} );
+		} );
+
+		debug( '[A4A Checkout] Products to add', productsToAdd );
+
+		// Replace products in cart
+		if ( productsToAdd.length > 0 ) {
+			replaceProductsInCart( productsToAdd )
+				.then( () => {
+					debug( '[A4A Checkout] Products added to cart successfully' );
+					debug( '[A4A Checkout] Cart', responseCart );
+					setIsReady( true );
+				} )
+				.catch( ( err ) => {
+					debug( '[A4A Checkout] Failed to add products to cart:', err );
+					setError( 'Failed to add products to cart' );
+				} );
+		} else {
+			debug( '[A4A Checkout] No matching products found to add to cart' );
+			setError( 'Could not find the requested products' );
+		}
+	}, [
+		isReady,
+		error,
+		referredProducts,
+		referral,
+		replaceProductsInCart,
+		responseCart,
+		queryArgs.referralId,
+		queryArgs.agencyId,
+	] );
+
+	// Debugging: Set a timeout to force showing the checkout after 10 seconds
+	useEffect( () => {
+		if ( isReady || error ) {
+			return;
+		}
+
+		const timeoutId = setTimeout( () => {
+			debug( '[A4A Checkout] Timeout reached, showing checkout anyway' );
+			setIsReady( true );
+		}, 10000 );
+
+		return () => clearTimeout( timeoutId );
+	}, [ isReady, error ] );
+
+	return {
+		isReady,
+		error,
+		emailMismatchWithReferralClient,
+		referral,
+	};
+}

--- a/client/a8c-for-agencies/sections/client/hooks/use-client-checkout.ts
+++ b/client/a8c-for-agencies/sections/client/hooks/use-client-checkout.ts
@@ -1,15 +1,21 @@
 import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
+import { useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useEffect, useState } from 'react';
 import useProductsById from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id';
 import { getClientReferralQueryArgs } from 'calypso/a8c-for-agencies/sections/marketplace/lib/get-client-referral-query-args';
+import { CHECKOUT_STORE } from 'calypso/my-sites/checkout/src/lib/wpcom-store';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import useFetchClientReferral from './use-fetch-client-referral';
 
 const debug = debugFactory( 'client:checkout-v2' );
 
-export default function useClientCheckout() {
+type Props = {
+	expressMode?: boolean;
+};
+
+export default function useClientCheckout( { expressMode = false }: Props ) {
 	const [ isReady, setIsReady ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
 
@@ -18,9 +24,14 @@ export default function useClientCheckout() {
 	const { referredProducts } = useProductsById( referral?.products ?? [] );
 
 	// Access the shopping cart API
-	const { replaceProductsInCart, responseCart } = useShoppingCart( 'no-site' );
+	const { replaceProductsInCart, responseCart } = useShoppingCart(
+		expressMode ? 'no-user' : 'no-site'
+	);
 
 	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
+
+	// Access checkout store to set email for express checkout
+	const checkoutStoreDispatch = useDispatch( CHECKOUT_STORE );
 
 	const emailMismatchWithReferralClient = referral?.client?.email !== userEmail;
 
@@ -81,6 +92,17 @@ export default function useClientCheckout() {
 		queryArgs.referralId,
 		queryArgs.agencyId,
 	] );
+
+	// Set referral client email in checkout store for express checkout
+	useEffect( () => {
+		if ( expressMode && referral?.client?.email && checkoutStoreDispatch ) {
+			debug(
+				'[A4A Checkout] Setting referral client email in checkout store:',
+				referral.client.email
+			);
+			checkoutStoreDispatch.updateEmail( referral.client.email );
+		}
+	}, [ expressMode, referral?.client?.email, checkoutStoreDispatch ] );
 
 	// Debugging: Set a timeout to force showing the checkout after 10 seconds
 	useEffect( () => {

--- a/client/a8c-for-agencies/sections/client/hooks/use-fetch-client-referral.ts
+++ b/client/a8c-for-agencies/sections/client/hooks/use-fetch-client-referral.ts
@@ -11,6 +11,7 @@ export default function useFetchClientReferral( {
 	referralId?: number;
 	secret?: string;
 } ) {
+	const isExpressCheckout = window.location.pathname.startsWith( '/checkout/a4a' );
 	const isClient = isClientView();
 	const data = useQuery( {
 		queryKey: [ 'a4a-client-referral', agencyId, referralId, secret ],
@@ -24,7 +25,7 @@ export default function useFetchClientReferral( {
 					secret,
 				}
 			),
-		enabled: isClient && !! agencyId && !! referralId && !! secret,
+		enabled: ( isClient || isExpressCheckout ) && !! agencyId && !! referralId && !! secret,
 		refetchOnWindowFocus: false,
 	} );
 

--- a/client/a8c-for-agencies/sections/client/hooks/use-fetch-client-referral.ts
+++ b/client/a8c-for-agencies/sections/client/hooks/use-fetch-client-referral.ts
@@ -11,7 +11,7 @@ export default function useFetchClientReferral( {
 	referralId?: number;
 	secret?: string;
 } ) {
-	const isExpressCheckout = window.location.pathname.startsWith( '/checkout/a4a' );
+	const isExpressCheckout = window.location.pathname.startsWith( '/checkout/agency/referral' );
 	const isClient = isClientView();
 	const data = useQuery( {
 		queryKey: [ 'a4a-client-referral', agencyId, referralId, secret ],

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -20,7 +20,9 @@ import './style.scss';
 function ClientCheckoutContent() {
 	const translate = useTranslate();
 
-	const { isReady, error, emailMismatchWithReferralClient, referral } = useClientCheckout();
+	const { isReady, error, emailMismatchWithReferralClient, referral } = useClientCheckout( {
+		expressMode: false,
+	} );
 
 	if ( ! isReady ) {
 		return <ClientCheckoutV2Placeholder />;

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -1,116 +1,26 @@
 import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
-import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
-import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
-import useProductsById from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id';
-import { getClientReferralQueryArgs } from 'calypso/a8c-for-agencies/sections/marketplace/lib/get-client-referral-query-args';
 import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
 import { useSelector } from 'calypso/state';
-import { getCurrentUser, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import ClientCheckoutV2Error from '../../checkout-v2-error';
 import ClientCheckoutV2Placeholder from '../../checkout-v2-placeholder';
-import useFetchClientReferral from '../../hooks/use-fetch-client-referral';
+import useClientCheckout from '../../hooks/use-client-checkout';
 
 import './style.scss';
-
-const debug = debugFactory( 'client:checkout-v2' );
 
 /**
  * Client Checkout Component using the WordPress.com checkout
  */
 function ClientCheckoutContent() {
 	const translate = useTranslate();
-	const [ isReady, setIsReady ] = useState( false );
-	const [ error, setError ] = useState< string | null >( null );
 
-	const queryArgs = getClientReferralQueryArgs();
-	const { data: referral } = useFetchClientReferral( queryArgs );
-	const { referredProducts } = useProductsById( referral?.products ?? [] );
-
-	// Access the shopping cart API
-	const { replaceProductsInCart, responseCart } = useShoppingCart( 'no-site' );
-
-	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
-
-	const emailMismatchWithReferralClient = referral?.client?.email !== userEmail;
-
-	// Add products to cart when referral data is loaded
-	useEffect( () => {
-		// Skip if we're already ready or have an error
-		if ( isReady || error ) {
-			debug( '[A4A Checkout] Already ready or has error' );
-			return;
-		}
-
-		if ( ! referredProducts || referredProducts.length === 0 ) {
-			debug( '[A4A Checkout] No referred products' );
-			return;
-		}
-
-		debug( '[A4A Checkout] Referral', referral );
-		debug( '[A4A Checkout] Referred products', referredProducts );
-
-		const productsToAdd = referredProducts.map( ( product ) => {
-			return createRequestCartProduct( {
-				// When using the wpcom checkout we use alternative a4a-specific billing product ids for wpcom and jetpack products.
-				product_id: product.alternative_product_id || product.product_id,
-				product_slug: product.slug,
-				extra: {
-					isA4ASitelessCheckout: true,
-					referral_id: queryArgs.referralId,
-					agency_id: queryArgs.agencyId,
-				},
-			} );
-		} );
-
-		debug( '[A4A Checkout] Products to add', productsToAdd );
-
-		// Replace products in cart
-		if ( productsToAdd.length > 0 ) {
-			replaceProductsInCart( productsToAdd )
-				.then( () => {
-					debug( '[A4A Checkout] Products added to cart successfully' );
-					debug( '[A4A Checkout] Cart', responseCart );
-					setIsReady( true );
-				} )
-				.catch( ( err ) => {
-					debug( '[A4A Checkout] Failed to add products to cart:', err );
-					setError( 'Failed to add products to cart' );
-				} );
-		} else {
-			debug( '[A4A Checkout] No matching products found to add to cart' );
-			setError( 'Could not find the requested products' );
-		}
-	}, [
-		isReady,
-		error,
-		referredProducts,
-		referral,
-		replaceProductsInCart,
-		responseCart,
-		queryArgs.referralId,
-		queryArgs.agencyId,
-	] );
-
-	// Debugging: Set a timeout to force showing the checkout after 10 seconds
-	useEffect( () => {
-		if ( isReady || error ) {
-			return;
-		}
-
-		const timeoutId = setTimeout( () => {
-			debug( '[A4A Checkout] Timeout reached, showing checkout anyway' );
-			setIsReady( true );
-		}, 10000 );
-
-		return () => clearTimeout( timeoutId );
-	}, [ isReady, error ] );
+	const { isReady, error, emailMismatchWithReferralClient, referral } = useClientCheckout();
 
 	if ( ! isReady ) {
 		return <ClientCheckoutV2Placeholder />;

--- a/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
@@ -6,15 +6,16 @@ import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/st
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
 import { useSelector } from 'calypso/state';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { getCurrentUserLocale, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import ClientCheckoutV2Error from '../../checkout-v2-error';
 import ClientCheckoutV2Placeholder from '../../checkout-v2-placeholder';
 import useClientCheckout from '../../hooks/use-client-checkout';
 
 function ClientExpressCheckoutContent() {
 	const translate = useTranslate();
+	const userLoggedIn = useSelector( isUserLoggedIn );
 
-	const { isReady, error } = useClientCheckout( { expressMode: true } );
+	const { isReady, error } = useClientCheckout( { expressMode: ! userLoggedIn } );
 
 	if ( ! isReady ) {
 		return <ClientCheckoutV2Placeholder />;
@@ -29,7 +30,7 @@ function ClientExpressCheckoutContent() {
 			sitelessCheckoutType="a4a"
 			redirectTo="https://agencies.automattic.com/client/subscriptions"
 			customizedPreviousPath="https://agencies.automattic.com/client/subscriptions"
-			isLoggedOutCart
+			isLoggedOutCart={ ! userLoggedIn }
 			siteSlug=""
 			siteId={ 0 }
 		/>

--- a/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
@@ -14,7 +14,7 @@ import useClientCheckout from '../../hooks/use-client-checkout';
 function ClientExpressCheckoutContent() {
 	const translate = useTranslate();
 
-	const { isReady, error } = useClientCheckout();
+	const { isReady, error } = useClientCheckout( { expressMode: true } );
 
 	if ( ! isReady ) {
 		return <ClientCheckoutV2Placeholder />;
@@ -29,6 +29,7 @@ function ClientExpressCheckoutContent() {
 			sitelessCheckoutType="a4a"
 			redirectTo="https://agencies.automattic.com/client/subscriptions"
 			customizedPreviousPath="https://agencies.automattic.com/client/subscriptions"
+			isLoggedOutCart
 			siteSlug=""
 			siteId={ 0 }
 		/>

--- a/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
@@ -11,6 +11,8 @@ import ClientCheckoutV2Error from '../../checkout-v2-error';
 import ClientCheckoutV2Placeholder from '../../checkout-v2-placeholder';
 import useClientCheckout from '../../hooks/use-client-checkout';
 
+const EXPRESS_CHECKOUT_REDIRECT_URL = 'https://agencies.automattic.com/client/subscriptions';
+
 function ClientExpressCheckoutContent() {
 	const translate = useTranslate();
 	const userLoggedIn = useSelector( isUserLoggedIn );
@@ -28,8 +30,8 @@ function ClientExpressCheckoutContent() {
 	return (
 		<CheckoutMain
 			sitelessCheckoutType="a4a"
-			redirectTo="https://agencies.automattic.com/client/subscriptions"
-			customizedPreviousPath="https://agencies.automattic.com/client/subscriptions"
+			redirectTo={ EXPRESS_CHECKOUT_REDIRECT_URL }
+			customizedPreviousPath={ EXPRESS_CHECKOUT_REDIRECT_URL }
 			isLoggedOutCart={ ! userLoggedIn }
 			siteSlug=""
 			siteId={ 0 }

--- a/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/express-checkout/index.tsx
@@ -1,0 +1,55 @@
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
+import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
+import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import ClientCheckoutV2Error from '../../checkout-v2-error';
+import ClientCheckoutV2Placeholder from '../../checkout-v2-placeholder';
+import useClientCheckout from '../../hooks/use-client-checkout';
+
+function ClientExpressCheckoutContent() {
+	const translate = useTranslate();
+
+	const { isReady, error } = useClientCheckout();
+
+	if ( ! isReady ) {
+		return <ClientCheckoutV2Placeholder />;
+	}
+
+	if ( error ) {
+		return <ClientCheckoutV2Error title={ translate( 'Error' ) } message={ error } />;
+	}
+
+	return (
+		<CheckoutMain
+			sitelessCheckoutType="a4a"
+			redirectTo="https://agencies.automattic.com/client/subscriptions"
+			customizedPreviousPath="https://agencies.automattic.com/client/subscriptions"
+			siteSlug=""
+			siteId={ 0 }
+		/>
+	);
+}
+
+export default function ClientExpressCheckout() {
+	const translate = useTranslate();
+	const locale = useSelector( getCurrentUserLocale );
+
+	return (
+		<CheckoutErrorBoundary
+			errorMessage={ translate( 'Sorry, there was an error loading the checkout page.' ) }
+		>
+			<CalypsoShoppingCartProvider shouldShowPersistentErrors>
+				<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
+					<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+						<ClientExpressCheckoutContent />
+					</RazorpayHookProvider>
+				</StripeHookProvider>
+			</CalypsoShoppingCartProvider>
+		</CheckoutErrorBoundary>
+	);
+}

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -3,6 +3,7 @@ import { checkoutTheme } from '@automattic/composite-checkout';
 import { ThemeProvider } from '@emotion/react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import AkismetLogo from 'calypso/components/akismet-logo';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
@@ -52,6 +53,10 @@ const CheckoutMasterbar = ( {
 			return 'akismet';
 		}
 
+		if ( window.location.pathname.startsWith( '/checkout/a4a' ) ) {
+			return 'a4a';
+		}
+
 		if ( isGravatarDomain ) {
 			return 'gravatar';
 		}
@@ -70,6 +75,7 @@ const CheckoutMasterbar = ( {
 				'masterbar--is-wpcom': checkoutType === 'wpcom',
 				'masterbar--is-jetpack': checkoutType === 'jetpack',
 				'masterbar--is-akismet': checkoutType === 'akismet',
+				'masterbar--is-a4a': checkoutType === 'a4a',
 			} ) }
 		>
 			<div className="masterbar__secure-checkout">
@@ -94,6 +100,7 @@ const CheckoutMasterbar = ( {
 				) }
 				{ checkoutType === 'akismet' && <AkismetLogo className="masterbar__akismet-wordmark" /> }
 				{ checkoutType === 'gravatar' && <GravatarTextLogo /> }
+				{ checkoutType === 'a4a' && <A4ALogo full size={ 14 } /> }
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>
 			</div>
 			{ title && <Item className="masterbar__item-title">{ title }</Item> }

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -53,7 +53,7 @@ const CheckoutMasterbar = ( {
 			return 'akismet';
 		}
 
-		if ( window.location.pathname.startsWith( '/checkout/a4a' ) ) {
+		if ( window.location.pathname.startsWith( '/checkout/agency/referral' ) ) {
 			return 'a4a';
 		}
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -115,7 +115,8 @@ body.is-mobile-app-view {
 		padding-inline-end: 1.5em;
 
 		&.masterbar--is-akismet,
-		&.masterbar--is-jetpack {
+		&.masterbar--is-jetpack,
+		&.masterbar--is-a4a {
 			padding-inline-start: 1.5em;
 		}
 
@@ -1085,7 +1086,8 @@ a.masterbar__quick-language-switcher {
 	align-items: center;
 
 	.masterbar--is-akismet &,
-	.masterbar--is-jetpack & {
+	.masterbar--is-jetpack &,
+	.masterbar--is-a4a & {
 		column-gap: 1em;
 	}
 
@@ -1140,7 +1142,8 @@ a.masterbar__quick-language-switcher {
 			margin-left: 16px;
 		}
 
-		.masterbar--is-jetpack & {
+		.masterbar--is-jetpack &
+		.masterbar--is-a4a & {
 			transform: translateY(0.5px);
 		}
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -2,6 +2,7 @@ import { isJetpackLegacyItem, isJetpackLegacyTermUpgrade } from '@automattic/cal
 import page from '@automattic/calypso-router';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
+import ClientExpressCheckout from 'calypso/a8c-for-agencies/sections/client/primary/express-checkout';
 import DocumentHead from 'calypso/components/data/document-head';
 import { setSectionMiddleware } from 'calypso/controller';
 import { CALYPSO_PLANS_PAGE } from 'calypso/jetpack-connect/constants';
@@ -126,7 +127,20 @@ function sitelessCheckout( context, next, extraProps ) {
 }
 
 export function checkoutA4ASiteless( context, next ) {
-	sitelessCheckout( context, next, { sitelessCheckoutType: 'a4a', siteSlug: '', siteId: 0 } );
+	const CheckoutSitelessDocumentTitle = () => {
+		const translate = useTranslate();
+		return <DocumentHead title={ translate( 'Checkout' ) } />;
+	};
+
+	context.primary = (
+		<>
+			<CheckoutSitelessDocumentTitle />
+
+			<ClientExpressCheckout />
+		</>
+	);
+
+	next();
 }
 
 export function checkout( context, next ) {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -125,6 +125,10 @@ function sitelessCheckout( context, next, extraProps ) {
 	next();
 }
 
+export function checkoutA4ASiteless( context, next ) {
+	sitelessCheckout( context, next, { sitelessCheckoutType: 'a4a', siteSlug: '', siteId: 0 } );
+}
+
 export function checkout( context, next ) {
 	const { feature, plan, purchaseId } = context.params;
 	const state = context.store.getState();

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -50,7 +50,7 @@ export default function () {
 	);
 
 	page(
-		`/checkout/a4a`,
+		`/checkout/agency/referral`,
 		setLocaleMiddleware(),
 		noSite,
 		checkoutA4ASiteless,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -16,6 +16,7 @@ import {
 	checkoutJetpackSiteless,
 	checkoutMarketplaceSiteless,
 	checkoutUnifiedSiteless,
+	checkoutA4ASiteless,
 	checkoutThankYou,
 	licensingPendingAsyncActivation,
 	licensingThankYouManualActivationInstructions,
@@ -44,6 +45,15 @@ export default function () {
 		setLocaleMiddleware(),
 		noSite,
 		checkoutJetpackSiteless,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		`/checkout/a4a`,
+		setLocaleMiddleware(),
+		noSite,
+		checkoutA4ASiteless,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -150,8 +150,7 @@ export default function CheckoutMain( {
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const { razorpayConfiguration, isRazorpayLoading, razorpayLoadingError } = useRazorpay();
 	const createUserAndSiteBeforeTransaction =
-		Boolean( isLoggedOutCart || isNoSiteCart ) &&
-		( ! isSiteless || sitelessCheckoutType === 'a4a' ); // Allow account creation for A4A siteless checkout when user is logged out (express mode)
+		Boolean( isLoggedOutCart || isNoSiteCart ) && ! isSiteless;
 	const reduxDispatch = useDispatch();
 
 	const updatedSiteSlug = useMemo( () => {

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -150,7 +150,8 @@ export default function CheckoutMain( {
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const { razorpayConfiguration, isRazorpayLoading, razorpayLoadingError } = useRazorpay();
 	const createUserAndSiteBeforeTransaction =
-		Boolean( isLoggedOutCart || isNoSiteCart ) && ! isSiteless;
+		Boolean( isLoggedOutCart || isNoSiteCart ) &&
+		( ! isSiteless || sitelessCheckoutType === 'a4a' ); // Allow account creation for A4A siteless checkout when user is logged out (express mode)
 	const reduxDispatch = useDispatch();
 
 	const updatedSiteSlug = useMemo( () => {

--- a/client/my-sites/checkout/src/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/src/components/contact-details-container.tsx
@@ -91,6 +91,15 @@ export default function ContactDetailsContainer( {
 		updateDomainContactFields( details );
 	};
 
+	// Check if we're in A4A express checkout (siteless checkout with logged out cart)
+	const isA4AExpressCheckout =
+		isLoggedOutCart &&
+		responseCart.products.some( ( product ) => product.extra?.isA4ASitelessCheckout );
+
+	// Disable email field if we're in A4A express checkout and email is already set (from referral)
+	const isEmailDisabledForA4A =
+		isA4AExpressCheckout && contactDetails.email && contactDetails.email.trim() !== '';
+
 	switch ( contactDetailsType ) {
 		case 'domain':
 			return (
@@ -132,10 +141,13 @@ export default function ContactDetailsContainer( {
 							id="email"
 							type="email"
 							label={ String( translate( 'Email' ) ) }
-							disabled={ isDisabled }
+							disabled={ isDisabled || isEmailDisabledForA4A }
 							value={ contactDetails.email ?? '' }
 							onChange={ ( value ) => {
-								updateEmail( value );
+								// Prevent updating email if it's disabled for A4A express checkout
+								if ( ! isEmailDisabledForA4A ) {
+									updateEmail( value );
+								}
 							} }
 							autoComplete="email"
 							isError={ email?.isTouched && ! isValid( email ) }

--- a/client/my-sites/checkout/src/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/src/components/contact-details-container.tsx
@@ -97,8 +97,11 @@ export default function ContactDetailsContainer( {
 		responseCart.products.some( ( product ) => product.extra?.isA4ASitelessCheckout );
 
 	// Disable email field if we're in A4A express checkout and email is already set (from referral)
-	const isEmailDisabledForA4A =
-		isA4AExpressCheckout && contactDetails.email && contactDetails.email.trim() !== '';
+	const isEmailDisabledForA4A = !! (
+		isA4AExpressCheckout &&
+		contactDetails.email &&
+		contactDetails.email.trim() !== ''
+	);
 
 	switch ( contactDetailsType ) {
 		case 'domain':

--- a/client/my-sites/checkout/src/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/src/components/contact-details-container.tsx
@@ -147,10 +147,7 @@ export default function ContactDetailsContainer( {
 							disabled={ isDisabled || isEmailDisabledForA4A }
 							value={ contactDetails.email ?? '' }
 							onChange={ ( value ) => {
-								// Prevent updating email if it's disabled for A4A express checkout
-								if ( ! isEmailDisabledForA4A ) {
-									updateEmail( value );
-								}
+								updateEmail( value );
 							} }
 							autoComplete="email"
 							isError={ email?.isTouched && ! isValid( email ) }

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -234,6 +234,12 @@ function chooseAddHandler( {
 		return 'addProductFromBillingIntent';
 	}
 
+	// A4A checkout handles products directly via replaceProductsInCart in the checkout component
+	// so we should not try to add products from localStorage or other sources
+	if ( sitelessCheckoutType === 'a4a' ) {
+		return 'doNotAdd';
+	}
+
 	if ( ! isLoading ) {
 		return 'doNotAdd';
 	}

--- a/client/my-sites/checkout/src/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/src/lib/create-wpcom-account-before-transaction.ts
@@ -13,6 +13,9 @@ export async function createWpcomAccountBeforeTransaction(
 	const isAkismetUserLessCheckout = transactionCart.products.some(
 		( product ) => product.extra.isAkismetSitelessCheckout
 	);
+	const isA4AUserLessCheckout = transactionCart.products.some(
+		( product ) => product.extra.isA4ASitelessCheckout
+	);
 	const isGiftingCheckout = transactionCart.products.some(
 		( product ) => product.extra.isGiftPurchase
 	);
@@ -23,6 +26,9 @@ export async function createWpcomAccountBeforeTransaction(
 		}
 		if ( isAkismetUserLessCheckout ) {
 			return 'akismet-userless-checkout';
+		}
+		if ( isA4AUserLessCheckout ) {
+			return 'a4a-userless-checkout';
 		}
 		if ( isGiftingCheckout ) {
 			return 'gifting-userless-checkout';

--- a/client/my-sites/checkout/src/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/src/lib/submit-wpcom-transaction.ts
@@ -27,7 +27,11 @@ export default async function submitWpcomTransaction(
 ): Promise< WPCOMTransactionEndpointResponse > {
 	const isUserLessCheckout =
 		payload.cart.products.some( ( product ) => {
-			return product.extra.isJetpackCheckout || product.extra.isAkismetSitelessCheckout;
+			return (
+				product.extra.isJetpackCheckout ||
+				product.extra.isAkismetSitelessCheckout ||
+				product.extra.isA4ASitelessCheckout
+			);
 		} ) && payload.cart.cart_key === 'no-user';
 
 	if ( transactionOptions.createUserAndSiteBeforeTransaction || isUserLessCheckout ) {

--- a/client/my-sites/checkout/src/lib/translate-cart.ts
+++ b/client/my-sites/checkout/src/lib/translate-cart.ts
@@ -56,7 +56,11 @@ export function createTransactionEndpointCartFromResponseCart( {
 } ): RequestCart {
 	if (
 		responseCart.products.some( ( product ) => {
-			return product.extra.isJetpackCheckout || product.extra.isAkismetSitelessCheckout;
+			return (
+				product.extra.isJetpackCheckout ||
+				product.extra.isAkismetSitelessCheckout ||
+				product.extra.isA4ASitelessCheckout
+			);
 		} )
 	) {
 		const isUserLess = responseCart.cart_key === 'no-user';

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -808,4 +808,112 @@ describe( 'CheckoutMain', () => {
 		} );
 		expect( screen.getByText( 'Loading checkout' ) ).toBeInTheDocument();
 	} );
+
+	describe( 'A4A express checkout', () => {
+		it( 'renders checkout for A4A siteless checkout type', async () => {
+			const cartChanges = { products: [] };
+			render(
+				<MockCheckout
+					initialCart={ initialCart }
+					setCart={ mockSetCartEndpoint }
+					cartChanges={ cartChanges }
+					additionalProps={ {
+						sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
+						isLoggedOutCart: true,
+						siteSlug: '',
+						siteId: 0,
+					} }
+				/>
+			);
+			await waitFor( () => {
+				expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
+			} );
+		} );
+
+		it( 'renders checkout for A4A express checkout with logged-out user', async () => {
+			const cartChanges = { products: [] };
+			render(
+				<MockCheckout
+					initialCart={ initialCart }
+					setCart={ mockSetCartEndpoint }
+					cartChanges={ cartChanges }
+					useUndefinedSiteId
+					additionalProps={ {
+						sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
+						isLoggedOutCart: true,
+						siteSlug: '',
+						siteId: 0,
+					} }
+				/>
+			);
+			await waitFor( () => {
+				expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
+			} );
+		} );
+
+		it( 'applies A4A theme colors when sitelessCheckoutType is a4a', async () => {
+			const cartChanges = { products: [] };
+			const { container } = render(
+				<MockCheckout
+					initialCart={ initialCart }
+					setCart={ mockSetCartEndpoint }
+					cartChanges={ cartChanges }
+					additionalProps={ {
+						sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
+						isLoggedOutCart: true,
+						siteSlug: '',
+						siteId: 0,
+					} }
+				/>
+			);
+			await waitFor( () => {
+				// Check that checkout renders (theme colors are applied internally)
+				expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
+			} );
+			// The theme is applied via CSS variables, so we verify the component renders
+			// The actual color values are set in the CheckoutProvider theme prop
+			expect( container ).toBeInTheDocument();
+		} );
+
+		it( 'handles A4A siteless checkout with empty siteSlug', async () => {
+			const cartChanges = { products: [] };
+			render(
+				<MockCheckout
+					initialCart={ initialCart }
+					setCart={ mockSetCartEndpoint }
+					cartChanges={ cartChanges }
+					additionalProps={ {
+						sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
+						isLoggedOutCart: true,
+						siteSlug: '',
+						siteId: 0,
+					} }
+				/>
+			);
+			await waitFor( () => {
+				expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
+			} );
+			expect( navigate ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not redirect when A4A checkout has empty cart on load', async () => {
+			const cartChanges = { products: [] };
+			render(
+				<MockCheckout
+					initialCart={ initialCart }
+					setCart={ mockSetCartEndpoint }
+					cartChanges={ cartChanges }
+					additionalProps={ {
+						sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
+						isLoggedOutCart: true,
+						siteSlug: '',
+						siteId: 0,
+					} }
+				/>
+			);
+			await waitFor( async () => {
+				expect( navigate ).not.toHaveBeenCalled();
+			} );
+		} );
+	} );
 } );

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -809,111 +809,35 @@ describe( 'CheckoutMain', () => {
 		expect( screen.getByText( 'Loading checkout' ) ).toBeInTheDocument();
 	} );
 
-	describe( 'A4A express checkout', () => {
-		it( 'renders checkout for A4A siteless checkout type', async () => {
-			const cartChanges = { products: [] };
-			render(
-				<MockCheckout
-					initialCart={ initialCart }
-					setCart={ mockSetCartEndpoint }
-					cartChanges={ cartChanges }
-					additionalProps={ {
-						sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
-						isLoggedOutCart: true,
-						siteSlug: '',
-						siteId: 0,
-					} }
-				/>
-			);
-			await waitFor( () => {
-				expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
-			} );
-		} );
+	it( 'Disables email field in A4A express checkout', async () => {
+		const cartChanges = {
+			products: [
+				{
+					...planWithoutDomain,
+					extra: { ...planWithoutDomain.extra, isA4ASitelessCheckout: true },
+				},
+			],
+		};
 
-		it( 'renders checkout for A4A express checkout with logged-out user', async () => {
-			const cartChanges = { products: [] };
-			render(
-				<MockCheckout
-					initialCart={ initialCart }
-					setCart={ mockSetCartEndpoint }
-					cartChanges={ cartChanges }
-					useUndefinedSiteId
-					additionalProps={ {
-						sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
-						isLoggedOutCart: true,
-						siteSlug: '',
-						siteId: 0,
-					} }
-				/>
-			);
-			await waitFor( () => {
-				expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
-			} );
-		} );
+		// For A4A, we supply email during pre-load.
+		dispatch( CHECKOUT_STORE ).updateEmail( 'test@example.com' );
 
-		it( 'applies A4A theme colors when sitelessCheckoutType is a4a', async () => {
-			const cartChanges = { products: [] };
-			const { container } = render(
-				<MockCheckout
-					initialCart={ initialCart }
-					setCart={ mockSetCartEndpoint }
-					cartChanges={ cartChanges }
-					additionalProps={ {
-						sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
-						isLoggedOutCart: true,
-						siteSlug: '',
-						siteId: 0,
-					} }
-				/>
-			);
-			await waitFor( () => {
-				// Check that checkout renders (theme colors are applied internally)
-				expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
-			} );
-			// The theme is applied via CSS variables, so we verify the component renders
-			// The actual color values are set in the CheckoutProvider theme prop
-			expect( container ).toBeInTheDocument();
-		} );
-
-		it( 'handles A4A siteless checkout with empty siteSlug', async () => {
-			const cartChanges = { products: [] };
-			render(
-				<MockCheckout
-					initialCart={ initialCart }
-					setCart={ mockSetCartEndpoint }
-					cartChanges={ cartChanges }
-					additionalProps={ {
-						sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
-						isLoggedOutCart: true,
-						siteSlug: '',
-						siteId: 0,
-					} }
-				/>
-			);
-			await waitFor( () => {
-				expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
-			} );
-			expect( navigate ).not.toHaveBeenCalled();
-		} );
-
-		it( 'does not redirect when A4A checkout has empty cart on load', async () => {
-			const cartChanges = { products: [] };
-			render(
-				<MockCheckout
-					initialCart={ initialCart }
-					setCart={ mockSetCartEndpoint }
-					cartChanges={ cartChanges }
-					additionalProps={ {
-						sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
-						isLoggedOutCart: true,
-						siteSlug: '',
-						siteId: 0,
-					} }
-				/>
-			);
-			await waitFor( async () => {
-				expect( navigate ).not.toHaveBeenCalled();
-			} );
-		} );
+		render(
+			<MockCheckout
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ {
+					sitelessCheckoutType: 'a4a' as SitelessCheckoutType,
+					isLoggedOutCart: true,
+					siteSlug: '',
+					siteId: 0,
+				} }
+			/>
+		);
+		await waitFor( () => {
+			const emailField = screen.getByLabelText( 'Email' );
+			expect( emailField ).toBeDisabled();
+		}, [] );
 	} );
 } );


### PR DESCRIPTION
This PR expands the current WPCOM checkout system to include support for A4A client checkout.


<img width="1725" height="966" alt="Screenshot 2025-12-19 at 7 33 04 PM" src="https://github.com/user-attachments/assets/59daec3f-ce86-4410-85da-a883cff9e6f1" />

Depends on 196798-ghe-Automattic/wpcom

## Proposed Changes

This pull request introduces support for the A8C for Agencies (A4A) express checkout flow, enabling a siteless, userless checkout experience tailored for agency-referred clients. The changes add a new route and controller for the A4A checkout, centralize and reuse cart/referral logic, update the masterbar and checkout UI for A4A branding, and ensure the email field is handled correctly in this context.

Key changes include:

**A4A Express Checkout Implementation:**

- Added a new `useClientCheckout` hook to encapsulate and centralize logic for handling agency referrals, cart population, and express checkout email management. This replaces duplicated logic in both standard and express checkout components. [[1]](diffhunk://#diff-5982ef2446c95971fc636d761b83b9d4460de09128f8e2b0818a83a3d96b3492R1-R127) [[2]](diffhunk://#diff-bd33d4b133108bec614a1fa23fd82a1772f2e2cd3a98f16bcbbd38c136c88adfL4-L113) [[3]](diffhunk://#diff-d8ef722bfb226085f6d256f5432f426a2bb1131e75490fd7e245a264cba95fa9R1-R56)
- Introduced a new express checkout route (`/checkout/a4a`) with corresponding controller and page registration, rendering the new express checkout component. [[1]](diffhunk://#diff-121d76e37793ffb57d38601255fbf8a800444ac8b9d26f7fdd53367d2fd6ca75R5) [[2]](diffhunk://#diff-121d76e37793ffb57d38601255fbf8a800444ac8b9d26f7fdd53367d2fd6ca75R129-R145) [[3]](diffhunk://#diff-0bae88accae0ca6957b9ec7f00d5be8e6d042c096757c5fb29452544a720fedfR19) [[4]](diffhunk://#diff-0bae88accae0ca6957b9ec7f00d5be8e6d042c096757c5fb29452544a720fedfR52-R60)

**Referral and Cart Logic Enhancements:**

- Updated the referral fetching logic to work for both client and express checkout flows by detecting the route and enabling the query accordingly. [[1]](diffhunk://#diff-cb66bcb7f224dfd3acaeb7a07468e919bf6b0b70eae336c2a8c6f6f9d84ab27dR14) [[2]](diffhunk://#diff-cb66bcb7f224dfd3acaeb7a07468e919bf6b0b70eae336c2a8c6f6f9d84ab27dL27-R28)
- Modified cart product preparation logic to prevent duplicate product addition in A4A siteless checkouts, ensuring products are only added via the new centralized hook.

**Checkout UI and Branding:**

- Updated the masterbar to detect and display A4A checkout branding, including the A4A logo and specific styling. [[1]](diffhunk://#diff-dca6247b8e90e9a4ab3319f196724a20846c4c811f0bb031617aeeb368c51241R6) [[2]](diffhunk://#diff-dca6247b8e90e9a4ab3319f196724a20846c4c811f0bb031617aeeb368c51241R56-R59) [[3]](diffhunk://#diff-dca6247b8e90e9a4ab3319f196724a20846c4c811f0bb031617aeeb368c51241R78) [[4]](diffhunk://#diff-dca6247b8e90e9a4ab3319f196724a20846c4c811f0bb031617aeeb368c51241R103) [[5]](diffhunk://#diff-74a7f764baf1aba48b58c7636f591656cbb715e354de256bf387937a3e439c97L118-R119) [[6]](diffhunk://#diff-74a7f764baf1aba48b58c7636f591656cbb715e354de256bf387937a3e439c97L1083-R1085) [[7]](diffhunk://#diff-74a7f764baf1aba48b58c7636f591656cbb715e354de256bf387937a3e439c97L1138-R1141)
- Updated the contact details form to disable the email field during A4A express checkout if the referral email is already set, preventing accidental changes. [[1]](diffhunk://#diff-b7eef0e4d3cfac8f5742ed77c49af3d31b4548bd91a8fff8089f5d65cd689a28R94-R105) [[2]](diffhunk://#diff-b7eef0e4d3cfac8f5742ed77c49af3d31b4548bd91a8fff8089f5d65cd689a28L135-R153)

**Transaction and Account Creation:**

- Enhanced transaction logic to recognize and handle A4A userless checkouts, ensuring correct account creation flows. [[1]](diffhunk://#diff-b800444fa923f2734a3b5360d77812816716ad9ec8a27eb5dbb348e724abd9f3R16-R18) [[2]](diffhunk://#diff-b800444fa923f2734a3b5360d77812816716ad9ec8a27eb5dbb348e724abd9f3R30-R32)

## Why are these changes being made?

The aim is to enable A4A clients to complete purchases without logging in, thereby reducing friction in the process and improving overall conversion rates.


## Testing Instructions
This needs to be tested with 196798-ghe-Automattic/wpcom
Refer to the PR for setting up your sandbox. This will require the Store sandbox to test with a fake CC.

* Once you have set up your sandbox, spin up this branch locally.
* In agencies.automattic.com, create a referral and copy the link.
* Once you obtain the link. Open an Incognito tab and use the referral link (test with new email), but replace the domain and path with the following  (ensure you keep the query parameters):
```
https://agencies.automattic.com/client/checkout/v2 > http://calypso.localhost:3000/checkout/agency/referral

e.g.
https://agencies.automattic.com/client/checkout/v2?agency_id=AGENCY_ID&referral_id=REFERRAL_ID&secret=SECRET&client_id=CLIENT_IT > 
http://calypso.localhost:3000/checkout/agency/referral?agency_id=AGENCY_ID&referral_id=REFERRAL_ID&secret=SECRET&client_id=CLIENT_IT
```
* Proceed to test the checkout. **Ensure that you enable 3rd-party cookies when testing so the flow will work properly.**
* After completing the checkout, you should be redirected to
* https://agencies.automattic.com/client/subscriptions
<img width="1725" height="1046" alt="Screenshot 2025-12-19 at 7 43 38 PM" src="https://github.com/user-attachments/assets/d274b92b-f0e1-4627-b280-18535be56eb8" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?