### PR TITLE
MSD: point domain-related links to correct Stepper routes and redirect/back URLs

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/educational-content-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/educational-content-step.tsx
@@ -16,7 +16,6 @@ import {
 import { useState } from 'react';
 import * as React from 'react';
 import imgConnectDomain from 'calypso/assets/images/cancellation/connect-domain.png';
-import imgFreeDomain from 'calypso/assets/images/cancellation/free-domain.png';
 import imgLoadingTime from 'calypso/assets/images/cancellation/loading-time.png';
 import imgSEO from 'calypso/assets/images/cancellation/seo.png';
 import { useHelpCenter } from '../../../../../app/help-center';
@@ -150,56 +149,6 @@ export default function EducationalContentStep( { type, siteSlug, ...props }: St
 									}
 								) }
 							</div>
-						</li>
-					</ul>
-				</Content>
-			);
-		case 'education:free-domain':
-			return (
-				<Content
-					image={ imgFreeDomain }
-					title={ __( 'Step-by-step guide to get a free domain' ) }
-					onDecline={ props.onDecline }
-				>
-					<p>
-						{ __(
-							'You can register a free domain name for one year with the purchase of any WordPress.com annual or two-year plan!'
-						) }
-					</p>
-					<ul>
-						<li>
-							{ createInterpolateElement(
-								__(
-									'Go to Upgrades → Domains and click <link>Add a Domain</link> to register your plan’s free domain'
-								),
-								{
-									link: <Button href={ `/domains/add/${ siteSlug }` } variant="link" />,
-								}
-							) }
-						</li>
-						<li>
-							{ __(
-								'Choose from all popular extensions including .com, .org, .net, .shop, and .blog.'
-							) }
-						</li>
-						<li>
-							{ __( 'Make it your site’s primary domain (no “WordPress.com” in the address!)' ) }
-						</li>
-						<li>{ __( 'After the first year, your domain will renew at the regular price.' ) }</li>
-						<li>
-							{ __(
-								'If you have trouble claiming your free domain, contact us and we’ll assist you.'
-							) }
-						</li>
-						<li>
-							{ createInterpolateElement( __( 'Read more about domains <link>here</link>.' ), {
-								link: (
-									<Button
-										href={ localizeUrl( 'https://wordpress.com/support/domains/register-domain/' ) }
-										variant="link"
-									/>
-								),
-							} ) }
 						</li>
 					</ul>
 				</Content>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-upsell-type.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-upsell-type.ts
@@ -24,7 +24,6 @@ type UpsellType =
 	| 'live-chat:domains'
 	| 'education:loading-time'
 	| 'education:seo'
-	| 'education:free-domain'
 	| 'education:domain-connection'
 	| 'upgrade-atomic';
 

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -20,7 +20,7 @@ import {
 	SITE_CONTEXT_VIEW,
 	BulkActionsProgressNotice,
 } from '../../domains/dataviews';
-import { useDomainConnectionSetupTemplateUrl } from '../../utils/domain';
+import { getDomainConnectionSetupTemplateUrl } from '../../utils/domain-url';
 import PrimaryDomainSelector from './primary-domain-selector';
 import type { DomainSummary } from '@automattic/api-core';
 
@@ -63,7 +63,7 @@ function SiteDomains() {
 	);
 
 	const { basePath } = useAppContext();
-	const domainConnectionSetupUrl = useDomainConnectionSetupTemplateUrl();
+	const domainConnectionSetupUrl = getDomainConnectionSetupTemplateUrl();
 	const redirectTo = `${ basePath }/sites/${ site.slug }/domains`;
 
 	return (

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -5,15 +5,14 @@ import { __experimentalVStack as VStack, Button, CheckboxControl } from '@wordpr
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
-import { useDomainConnectionSetupTemplateUrl } from '../../utils/domain';
+import RouterLinkButton from '../../components/router-link-button';
+import { getAddSiteDomainUrl } from '../../utils/domain-url';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
-import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { ShareSiteForm } from './share-site-form';
 import type { Site, SiteSettings } from '@automattic/api-core';
 import type { Field, Form } from '@wordpress/dataviews';
@@ -118,7 +117,6 @@ const robotForm = {
 } satisfies Form;
 
 export function PrivacyForm( { site, settings }: { site: Site; settings: SiteSettings } ) {
-	const domainConnectionSetupUrl = useDomainConnectionSetupTemplateUrl();
 	const { data: domains = [] } = useQuery( {
 		...domainsQuery(),
 		select: ( data ) => {
@@ -156,20 +154,6 @@ export function PrivacyForm( { site, settings }: { site: Site; settings: SiteSet
 		( [ key, value ] ) => formData[ key as keyof PrivacyFormData ] !== value
 	);
 	const { isPending } = mutation;
-
-	const getAddNewDomainUrl = () => {
-		const backUrl = redirectToDashboardLink( { supportBackport: true } );
-		if ( isDashboardBackport() ) {
-			return addQueryArgs( `/domains/add/${ site.slug }`, { redirect_to: backUrl } );
-		}
-
-		return addQueryArgs( wpcomLink( '/setup/domain' ), {
-			siteSlug: site.slug,
-			domainConnectionSetupUrl,
-			redirect_to: backUrl,
-			back_to: backUrl,
-		} );
-	};
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
@@ -222,11 +206,18 @@ export function PrivacyForm( { site, settings }: { site: Site; settings: SiteSet
 										density="medium"
 										actions={
 											hasNonWpcomDomain ? (
-												<Button variant="secondary" href={ `/domains/manage/${ site.slug }` }>
+												<RouterLinkButton
+													variant="secondary"
+													to={
+														isDashboardBackport()
+															? `/domains/manage/${ site.slug }`
+															: `/sites/${ site.slug }/domains`
+													}
+												>
 													{ __( 'Manage domains' ) }
-												</Button>
+												</RouterLinkButton>
 											) : (
-												<Button variant="secondary" href={ getAddNewDomainUrl() }>
+												<Button variant="secondary" href={ getAddSiteDomainUrl( site.slug ) }>
 													{ __( 'Add new domain' ) }
 												</Button>
 											)

--- a/client/dashboard/sites/site-change-address-modal/content.tsx
+++ b/client/dashboard/sites/site-change-address-modal/content.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { __experimentalVStack as VStack, Button, ExternalLink, Icon } from '@wordpress/components';
+import { __experimentalVStack as VStack, Button, Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -18,6 +18,7 @@ import { ButtonStack } from '../../components/button-stack';
 import SuffixInputControl from '../../components/input-control/suffix-input-control';
 import Notice from '../../components/notice';
 import { Text } from '../../components/text';
+import { getAddSiteDomainUrl } from '../../utils/domain-url';
 import type { Site, DomainSummary } from '@automattic/api-core';
 import type { DataFormControlProps, Field } from '@wordpress/dataviews';
 
@@ -134,10 +135,10 @@ const NewSiteAddressForm = ( {
 					<Text>
 						{ createInterpolateElement(
 							__(
-								'Before changing site address, consider <link>add a custom domain</link> instead?'
+								'Before changing site address, consider <link>adding a custom domain</link> instead?'
 							),
 							{
-								link: <ExternalLink href={ `/domains/add/${ site.slug }` } children={ null } />,
+								link: <a href={ getAddSiteDomainUrl( site.slug ) } />,
 							}
 						) }
 					</Text>

--- a/client/dashboard/sites/ssh-migration-complete/index.tsx
+++ b/client/dashboard/sites/ssh-migration-complete/index.tsx
@@ -8,8 +8,10 @@ import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
+import { getAddSiteDomainUrl } from '../../utils/domain-url';
 
 export default function SSHMigrationComplete( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
@@ -20,12 +22,10 @@ export default function SSHMigrationComplete( { siteSlug }: { siteSlug: string }
 
 	const handleGetStarted = () => {
 		recordTracksEvent( 'calypso_dashboard_ssh_migration_complete_get_started_click' );
-		window.location.href = `/domains/add/${ site.slug }`;
 	};
 
 	const handleDoLater = () => {
 		recordTracksEvent( 'calypso_dashboard_ssh_migration_complete_do_later_click' );
-		window.location.href = `/sites/${ site.slug }`;
 	};
 
 	const handlePreviewClick = () => {
@@ -71,12 +71,20 @@ export default function SSHMigrationComplete( { siteSlug }: { siteSlug: string }
 									) }
 							</Text>
 							<ButtonStack justify="flex-start" expanded={ false }>
-								<Button variant="primary" onClick={ handleGetStarted }>
+								<Button
+									variant="primary"
+									onClick={ handleGetStarted }
+									href={ getAddSiteDomainUrl( site.slug ) }
+								>
 									{ __( 'Get started' ) }
 								</Button>
-								<Button variant="secondary" onClick={ handleDoLater }>
+								<RouterLinkButton
+									variant="secondary"
+									onClick={ handleDoLater }
+									to={ `/sites/${ site.slug }` }
+								>
 									{ __( 'I’ll do this later' ) }
-								</Button>
+								</RouterLinkButton>
 							</ButtonStack>
 						</VStack>
 					</CardBody>

--- a/client/dashboard/utils/domain-url.ts
+++ b/client/dashboard/utils/domain-url.ts
@@ -1,0 +1,27 @@
+import { addQueryArgs } from '@wordpress/url';
+import { domainConnectionSetupRoute } from '../app/router/domains';
+import { isDashboardBackport } from './is-dashboard-backport';
+import { redirectToDashboardLink, wpcomLink } from './link';
+
+export function getDomainConnectionSetupTemplateUrl() {
+	const domainConnectionSetupTemplateUrl = domainConnectionSetupRoute.fullPath.replace(
+		'$domainName',
+		'%s'
+	);
+	return new URL( domainConnectionSetupTemplateUrl, window.location.origin ).href;
+}
+
+export function getAddSiteDomainUrl( siteSlug: string ) {
+	const backUrl = redirectToDashboardLink( { supportBackport: true } );
+
+	if ( isDashboardBackport() ) {
+		return addQueryArgs( `/domains/add/${ siteSlug }`, { redirect_to: backUrl } );
+	}
+
+	return addQueryArgs( wpcomLink( '/setup/domain' ), {
+		siteSlug,
+		domainConnectionSetupUrl: getDomainConnectionSetupTemplateUrl(),
+		back_to: backUrl,
+		redirect_to: backUrl,
+	} );
+}

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -5,9 +5,7 @@ import {
 	DomainStatus,
 	DomainTypes,
 } from '@automattic/api-core';
-import { useRouter } from '@tanstack/react-router';
 import { isAfter, subMinutes, subDays } from 'date-fns';
-import { domainConnectionSetupRoute } from '../app/router/domains';
 import { getRenewalUrlFromPurchase } from './purchase';
 import { hasPlanFeature } from './site-features';
 import { userHasFlag } from './user';
@@ -28,18 +26,6 @@ export function getDomainSiteSlug( domain: DomainSummary ) {
 
 export function getDomainRenewalUrl( domain: DomainSummary, purchase: Purchase ) {
 	return getRenewalUrlFromPurchase( purchase, getDomainSiteSlug( domain ) );
-}
-
-export function useDomainConnectionSetupTemplateUrl() {
-	const router = useRouter();
-	const domainConnectionSetupTemplateUrl = router
-		.buildLocation( {
-			to: domainConnectionSetupRoute.fullPath,
-			params: { domainName: '%s' },
-		} )
-		.href.replace( '%25s', '%s' );
-
-	return new URL( domainConnectionSetupTemplateUrl, window.location.origin ).href;
 }
 
 export function isRegisteredDomain( domain: DomainSummary ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-903

## Proposed Changes

- Refactor `useDomainConnectionSetupTemplateUrl()` -> `getDomainConnectionSetupTemplateUrl()` (non-hook)
- Introduce `getAddSiteDomainUrl()`, for "Add domain", which returns correct route, taking backport into account
- Fix "Manage domains" URL, which returns correct route, taking backport into account

## Why are these changes being made?

`my.wordpress.com` readiness audit.

## Testing Instructions

Check inline comments to check individual scenario.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
