### PR TITLE
OAuth: Improve design of the loading screen

### DIFF
--- a/client/oauth2/components/authorize.tsx
+++ b/client/oauth2/components/authorize.tsx
@@ -180,8 +180,10 @@ function Authorize( {
 	let content = null;
 	if ( isLoading || ! meta ) {
 		content = (
-			<div className="oauth2-connect__loading">
-				<Spinner />
+			<div className="oauth2-connect oauth2-connect--loading">
+				<div className="oauth2-connect__loading">
+					<Spinner />
+				</div>
 			</div>
 		);
 	} else if ( error ) {

--- a/client/oauth2/components/authorize.tsx
+++ b/client/oauth2/components/authorize.tsx
@@ -182,7 +182,6 @@ function Authorize( {
 		content = (
 			<div className="oauth2-connect__loading">
 				<Spinner />
-				<p>{ translate( 'Loading authorization details…' ) }</p>
 			</div>
 		);
 	} else if ( error ) {

--- a/client/oauth2/style.scss
+++ b/client/oauth2/style.scss
@@ -210,6 +210,18 @@
 	font-size: 14px;
 }
 
+.oauth2-connect--loading {
+	min-height: 400px;
+	
+	.oauth2-connect__loading {
+		display: flex;
+		align-items: flex-start;
+		justify-content: center;
+		height: 400px;
+		padding-top: 40px;
+	}
+}
+
 .oauth2-connect__error {
 	color: #d63638;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-15528

## Proposed Changes

This PR adjusts the loading styles for the OAuth page by removing the unnecessary text and adjusting the size of the spinner:

<img width="961" height="493" alt="Screenshot 2025-12-17 at 3 45 46 PM" src="https://github.com/user-attachments/assets/e0374bb6-c2a9-4420-9f71-7763883c1456" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Apply the diff from 198014-ghe-Automattic/wpcom
* Sandbox the public API
* Apply the following diff:

```diff --git a/client/oauth2/components/authorize.tsx b/client/oauth2/components/authorize.tsx
index 646c991f3b5..7d455962ba6 100644
--- a/client/oauth2/components/authorize.tsx
+++ b/client/oauth2/components/authorize.tsx
@@ -93,13 +93,15 @@ function Authorize( {
        const {
                data: meta,
                error,
-               isLoading,
+               //isLoading,
        } = useAuthorizeMeta( {
                params,
                // Only fetch if user is logged in (not just when check is complete)
                enabled: userCheckComplete && isLoggedIn,
        } );
 
+       const isLoading = true;
:
```

* Logged in, go to http://calypso.localhost:3000/oauth2/authorize?client_id=95109&response_type=token&redirect_uri=wpcom-local-dev%3A%2F%2Fauth&scope=global&from-calypso=1
* Observe the loading state that contains only the spinner and no text (as indicated on the screenshot above)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?