### PR TITLE
Add analytics tracking to MSD site switcher on add new site click

### DIFF
--- a/client/dashboard/sites/site-switcher/index.tsx
+++ b/client/dashboard/sites/site-switcher/index.tsx
@@ -8,10 +8,12 @@ import {
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import AddNewSite from '../add-new-site';
 import { SiteSwitcherBase } from './base';
 
 const SiteSwitcher = () => {
+	const { recordTracksEvent } = useAnalytics();
 	const [ isAddSiteModalOpen, setIsAddSiteModalOpen ] = useState( false );
 
 	return (
@@ -21,6 +23,7 @@ const SiteSwitcher = () => {
 					<MenuGroup>
 						<MenuItem
 							onClick={ () => {
+								recordTracksEvent( 'calypso_dashboard_site_switcher_add_new_site_click' );
 								onClose();
 								setIsAddSiteModalOpen( true );
 							} }


### PR DESCRIPTION
## Proposed Changes

* Add analytics tracking event `calypso_dashboard_site_switcher_add_new_site_click` when user clicks "Add new site" in the MSD site switcher

## Why are these changes being made?

Track user interaction with the "Add new site" option in the site switcher to understand feature usage and user behaviour patterns in the hosting dashboard.

pgz0xU-qp-p2#comment-537

## Testing Instructions

1. Navigate to the hosting dashboard site switcher
2. Open browser DevTools console
3. Click the site switcher dropdown
4. Click "Add new site" option
5. Verify in the network tab that a tracks event `calypso_dashboard_site_switcher_add_new_site_click` is fired
6. Verify the add site modal opens as expected

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?