### PR TITLE
Add Survicate to the Calypso help center

### DIFF
--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { HelpCenter } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -43,6 +44,7 @@ export default function HelpCenterLoader( {
 	const selectedSite = useSelector( getSelectedSite );
 	const primarySiteSlug = useSelector( getPrimarySiteSlug );
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
+	const haveSurvicateEnabled = config( 'survicate_enabled_at_help_center' );
 
 	if ( ! loadHelpCenter ) {
 		return null;
@@ -73,6 +75,7 @@ export default function HelpCenterLoader( {
 			site={ selectedSite || primarySite }
 			currentUser={ user }
 			hasPurchases={ hasPurchases }
+			haveSurvicateEnabled={ haveSurvicateEnabled }
 			// hide Calypso's version of the help-center on Desktop, because the Editor has its own help-center
 			hidden={ sectionName === 'gutenberg-editor' && isDesktop }
 			onboardingUrl={ onboardingUrl() }

--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import { isEnabled } from '@automattic/calypso-config';
 import { HelpCenter } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -44,7 +44,7 @@ export default function HelpCenterLoader( {
 	const selectedSite = useSelector( getSelectedSite );
 	const primarySiteSlug = useSelector( getPrimarySiteSlug );
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
-	const haveSurvicateEnabled = config( 'survicate_enabled_at_help_center' );
+	const haveSurvicateEnabled = isEnabled( 'survicate_enabled_at_help_center' );
 
 	if ( ! loadHelpCenter ) {
 		return null;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -11,7 +11,7 @@
 	"google_recaptcha_site_key": false,
 	"hotjar_enabled": false,
 	"survicate_enabled": false,
-	"survicate_enabled_at_help_center": false,
+	"survicate_enabled_at_help_center": true,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -11,6 +11,7 @@
 	"google_recaptcha_site_key": false,
 	"hotjar_enabled": false,
 	"survicate_enabled": false,
+	"survicate_enabled_at_help_center": false,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",

--- a/config/development.json
+++ b/config/development.json
@@ -18,6 +18,7 @@
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
 	"survicate_enabled": true,
+	"survicate_enabled_at_help_center": true,
 	"wpcom_url": "http://calypso.localhost:3000",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -147,5 +147,6 @@
 	"boom_analytics_key": "horizon",
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
-	"survicate_enabled": true
+	"survicate_enabled": true,
+	"survicate_enabled_at_help_center": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -183,5 +183,5 @@
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
 	"survicate_enabled": true,
-	"survicate_enabled_at_help_center": false
+	"survicate_enabled_at_help_center": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -182,5 +182,6 @@
 	"boom_analytics_key": "production",
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
-	"survicate_enabled": true
+	"survicate_enabled": true,
+	"survicate_enabled_at_help_center": false
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -186,5 +186,6 @@
 	"boom_analytics_key": "wpcalypso",
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
-	"survicate_enabled": true
+	"survicate_enabled": true,
+	"survicate_enabled_at_help_center": true
 }

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -11,7 +11,7 @@ import './help-center-more-resources.scss';
 
 export const HelpCenterMoreResources = () => {
 	const { __ } = useI18n();
-	const { sectionName, disableChatSupport, haveSurvicateEnabled, source } = useHelpCenterContext();
+	const { sectionName, disableChatSupport, haveSurvicateEnabled } = useHelpCenterContext();
 	const navigate = useNavigate();
 
 	const trackMoreResourcesButtonClick = ( resource: string ) => {
@@ -31,8 +31,6 @@ export const HelpCenterMoreResources = () => {
 		} );
 		trackMoreResourcesButtonClick( resourceType );
 	};
-
-	const isCalypsoContext = source === 'wpcom';
 
 	return (
 		<div className="help-center-more-resources">
@@ -58,24 +56,26 @@ export const HelpCenterMoreResources = () => {
 						</div>
 					</li>
 				) }
-				{ haveSurvicateEnabled && isCalypsoContext && (
-					<li className="help-center-more-resources__resource-item help-center-link__item">
-						<div className="help-center-more-resources__resource-cell help-center-link__cell">
-							<button
-								type="button"
-								onClick={ () => {
-									trackMoreResourcesButtonClick( 'survicate' );
-									window._sva?.invokeEvent( 'showFeedbackSurveyFromHelpCenter' );
-								} }
-								className="help-center-more-resources__support-history"
-							>
-								<Icon icon={ thumbsUp } size={ 24 } />
-								<span>{ __( 'Share feedback', __i18n_text_domain__ ) }</span>
-								<Icon icon={ chevronRight } size={ 20 } />
-							</button>
-						</div>
-					</li>
-				) }
+				{ haveSurvicateEnabled &&
+					typeof window._sva !== 'undefined' &&
+					window._sva?.invokeEvent && (
+						<li className="help-center-more-resources__resource-item help-center-link__item">
+							<div className="help-center-more-resources__resource-cell help-center-link__cell">
+								<button
+									type="button"
+									onClick={ () => {
+										trackMoreResourcesButtonClick( 'feedback-survey' );
+										window._sva?.invokeEvent( 'showFeedbackSurveyFromHelpCenter' );
+									} }
+									className="help-center-more-resources__survicate"
+								>
+									<Icon icon={ thumbsUp } size={ 24 } />
+									<span>{ __( 'Share feedback', __i18n_text_domain__ ) }</span>
+									<Icon icon={ chevronRight } size={ 20 } />
+								</button>
+							</div>
+						</li>
+					) }
 				<li className="help-center-more-resources__resource-item help-center-link__item">
 					<div className="help-center-more-resources__resource-cell help-center-link__cell">
 						<a

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { backup, chevronRight, external, Icon, rss, video } from '@wordpress/icons';
+import { backup, chevronRight, external, Icon, rss, thumbsUp, video } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
@@ -11,7 +11,7 @@ import './help-center-more-resources.scss';
 
 export const HelpCenterMoreResources = () => {
 	const { __ } = useI18n();
-	const { sectionName, disableChatSupport } = useHelpCenterContext();
+	const { sectionName, disableChatSupport, haveSurvicateEnabled, source } = useHelpCenterContext();
 	const navigate = useNavigate();
 
 	const trackMoreResourcesButtonClick = ( resource: string ) => {
@@ -32,6 +32,8 @@ export const HelpCenterMoreResources = () => {
 		trackMoreResourcesButtonClick( resourceType );
 	};
 
+	const isCalypsoContext = source === 'wpcom';
+
 	return (
 		<div className="help-center-more-resources">
 			<h3 className="help-center__section-title">
@@ -51,6 +53,24 @@ export const HelpCenterMoreResources = () => {
 							>
 								<Icon icon={ backup } size={ 24 } />
 								<span>{ __( 'Support history', __i18n_text_domain__ ) }</span>
+								<Icon icon={ chevronRight } size={ 20 } />
+							</button>
+						</div>
+					</li>
+				) }
+				{ haveSurvicateEnabled && isCalypsoContext && (
+					<li className="help-center-more-resources__resource-item help-center-link__item">
+						<div className="help-center-more-resources__resource-cell help-center-link__cell">
+							<button
+								type="button"
+								onClick={ () => {
+									trackMoreResourcesButtonClick( 'survicate' );
+									window._sva?.invokeEvent( 'showFeedbackSurveyFromHelpCenter' );
+								} }
+								className="help-center-more-resources__support-history"
+							>
+								<Icon icon={ thumbsUp } size={ 24 } />
+								<span>{ __( 'Share feedback', __i18n_text_domain__ ) }</span>
 								<Icon icon={ chevronRight } size={ 20 } />
 							</button>
 						</div>

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -65,7 +65,7 @@ export const HelpCenterMoreResources = () => {
 									type="button"
 									onClick={ () => {
 										trackMoreResourcesButtonClick( 'feedback-survey' );
-										window._sva?.invokeEvent( 'showFeedbackSurveyFromHelpCenter' );
+										window._sva?.invokeEvent?.( 'showFeedbackSurveyFromHelpCenter' );
 									} }
 									className="help-center-more-resources__survicate"
 								>

--- a/packages/help-center/src/components/types.d.ts
+++ b/packages/help-center/src/components/types.d.ts
@@ -8,6 +8,9 @@ interface Window {
 			| ( ( callback: ( data: string | number ) => void ) => void )
 			| { id: number; value: string }[]
 	) => void;
+	_sva?: {
+		invokeEvent?: ( eventName: string ) => void;
+	};
 }
 
 declare module '*.jpg';

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -23,6 +23,7 @@ export type HelpCenterRequiredInformation = {
 		id: number;
 		pressableId?: number;
 	} | null;
+	haveSurvicateEnabled: boolean;
 };
 
 const defaultContext: HelpCenterRequiredInformation = {
@@ -75,6 +76,7 @@ const defaultContext: HelpCenterRequiredInformation = {
 	disableChatSupport: false,
 	hideMoreResources: false,
 	agency: null,
+	haveSurvicateEnabled: false,
 };
 
 const HelpCenterRequiredContext = createContext< HelpCenterRequiredInformation >( defaultContext );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTOBRD-376

## Proposed Changes

* We're adding Survicate to the Help Center

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to enable more Survicate Usage and still have a great UX for users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso with the flag `?test_survey=true` without being proxied
* Open the Help Center
* Click on "Share feedback"
* Make sure you'll see the Help Center

<img width="1577" height="952" alt="image" src="https://github.com/user-attachments/assets/199c85ad-54df-4f39-85ff-7c6ac9937540" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
