### PR TITLE
Fix CircularProgressBar sizing in flex contexts

### DIFF
--- a/packages/components/src/circular-progress-bar/index.tsx
+++ b/packages/components/src/circular-progress-bar/index.tsx
@@ -39,7 +39,7 @@ const CircularProgressBar = ( {
 				'desktop-scaling': enableDesktopScaling,
 				'is-success': variant === 'success',
 			} ) }
-			style={ { width: SIZE, height: SIZE } }
+			style={ { width: SIZE, height: SIZE, flex: `0 0 ${ SIZE }px` } }
 		>
 			<svg
 				viewBox={ `0 0 ${ SIZE } ${ SIZE }` }


### PR DESCRIPTION
Part of DOTMSD-880

## Proposed Changes

`CircularProgressBar` components should have a fixed width and height. It is set with inline `width`/`height` rules. The problem is that in flex environments `width`/`height` is ignored and the flex container rules are used instead.

This PR adds `flex: 0 0 ${SIZE}px` to `CircularProgressBar` root element to prevent shrinking in flex containers. It will be ignored when the component is in a non-flex container.

Note that in the MSD coming soon card this makes the text wrap more than it used to.

| Before | After |
| --- | --- |
|  <img width="540" height="422" alt="CleanShot 2025-12-18 at 11 59 10@2x" src="https://github.com/user-attachments/assets/ef7e3bfa-7918-4561-893d-571586d03f06" /> | <img width="542" height="420" alt="CleanShot 2025-12-18 at 11 58 54@2x" src="https://github.com/user-attachments/assets/50fe4f81-83e4-4ee1-a498-63ed9f7e91bc" /> |

But you will notice that in the before shot this is because the donut was starting to eat into the card's margins which is incorrect. So the extra wrapping is correct.

## Why are these changes being made?

The CircularProgressBar component was collapsing or rendering at incorrect sizes when placed inside flex containers. The `flex-basis` and `flex-shrink` properties ensure the component maintains its specified size regardless of flex container behaviour, preventing layout issues across the 15+ locations where this component is used.

## Testing Instructions

### Visual Verification

Test the CircularProgressBar displays at correct size (not collapsed/stretched) on these pages:

**Launchpad flows:**
1. `/home/:siteSlug` - My Home Launchpad card (40px donut)
2. `/setup/*` - Any setup flow sidebar (40px donut with progress text)
  - Although I don't think the full screen launchpad is available anymore 🤔 I used to test it with the `/setup/newsletter` flow, but it no longer appears to have a fullscreen launchpad.

**Monetization:**
5. `/subscribers/:siteSlug` - Subscriber Launchpad (40px donut)
6. `/earn/:siteSlug` - Earn Launchpad (40px donut)

**Performance:**
7. `/sites/performance/:siteSlug` - Performance score display (various sizes, 0-100 scale)

**Reader:**
8. `/reader/*` - Reader onboarding progress (40px donut during onboarding flow)

**Platform overviews:**
9. Jetpack Cloud `/overview` - Next steps progress (32px donut)
10. A4A `/overview` - Next steps progress (32px donut)

### Check for regressions:
- Verify donuts render as circles (not ovals/collapsed)
- Check progress text alignment remains centered
- Test across different viewport widths
- Confirm spacing around component unchanged

### Specific edge cases:
- Sites Dashboard: Tiny 16px donut should remain visible
- Performance page: Score display should maintain circular shape
- Launchpad sidebar: 40px donut with text should not shrink when sidebar resizes

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?