### PR TITLE
MSD: Update dashboard e2e tests to use new URL without breaking TeamCity jobs

### DIFF
--- a/client/dashboard/README.md
+++ b/client/dashboard/README.md
@@ -49,10 +49,6 @@ We're using Calypso's existing infrastructure, which separates the actual tests 
 
 The setup itself lacks centralised documentation, IMO, particularly around decrypting the secrets necessary to letting Playwright run Calypso. What we get in return is a system that has already solved many problems (user authentication, etc.).
 
-### Caveat / question
-
-Why must Jest be passed an environment variable so that it tests on localhost and not wordpress.com? Right now we need to call `CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn workspace wp-e2e-tests test -- test/e2e/specs/dashboard/`. Why is that not the default?
-
 ### Sharing components with the hosting dashboard v1
 
 As we iterate on the new dashboard, we may want to share components with the existing hosting dashboard v1. The idea is to ship new screens and redesigns sooner in the existing dashboard, while we work on the new one. This is a temporary solution until we can fully migrate to the new dashboard.

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -140,6 +140,28 @@ export function getCalypsoURL(
 }
 
 /**
+ * Assembles and returns the URL to a specific route/asset/query in the Multi-site Dashboard.
+ *
+ * @param {string} route Additional state or page to build into the returned URL.
+ * @param {Object} queryStrings Key/value pair of additional query to build into into the returned URL.
+ * @returns {string} String representation of the constructed URL object.
+ */
+export function getDashboardURL(
+	route = '',
+	queryStrings: { [ key: string ]: string } = {}
+): string {
+	const base = envVariables.CALYPSO_BASE_URL;
+
+	const url = new URL( route, base );
+
+	Object.entries( queryStrings ).forEach( ( [ key, value ] ) =>
+		url.searchParams.append( key, value )
+	);
+
+	return url.toString();
+}
+
+/**
  * Returns whether the current Calypso environment is production
  * (i.e. https://wordpress.com).
  *

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -150,7 +150,7 @@ export function getDashboardURL(
 	route = '',
 	queryStrings: { [ key: string ]: string } = {}
 ): string {
-	const base = envVariables.CALYPSO_BASE_URL;
+	const base = envVariables.DASHBOARD_BASE_URL;
 
 	const url = new URL( route, base );
 

--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -172,6 +172,16 @@ export function isCalypsoProduction(): boolean {
 }
 
 /**
+ * Returns whether the current Calypso environment is a local dev build
+ * (i.e. http://calypso.localhost:3000).
+ *
+ * @returns {boolean} True if the current Calypso environment is production; false otherwise.
+ */
+export function isCalypsoLocalDevelopment(): boolean {
+	return envVariables.CALYPSO_BASE_URL === 'http://calypso.localhost:3000';
+}
+
+/**
  * Constructs a locale-specific path segment based on the provided locale.
  * If the locale is 'en' (English), returns an empty string (no path segment).
  * Otherwise, returns the locale code followed by a slash (e.g., 'fr/', 'es/').

--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -17,6 +17,7 @@ class EnvVariables implements SupportedEnvVariables {
 		CALYPSO_BASE_URL: 'http://calypso.localhost:3000',
 		COBLOCKS_EDGE: false,
 		COOKIES_PATH: path.join( process.cwd(), 'cookies' ),
+		DASHBOARD_BASE_URL: 'http://my.localhost:3000',
 		GUTENBERG_EDGE: false,
 		GUTENBERG_NIGHTLY: false,
 		HEADLESS: false,
@@ -217,10 +218,18 @@ class EnvVariables implements SupportedEnvVariables {
 
 	/**
 	 * Returns the Calypso base URL.
-	 * @example 'http://localhost:3000'
+	 * @example 'http://calypso.localhost:3000'
 	 */
 	get CALYPSO_BASE_URL(): string {
 		return this.getValidatedUrlEnvVar( 'CALYPSO_BASE_URL' );
+	}
+
+	/**
+	 * Returns the Dashboard base URL.
+	 * @example 'http://my.localhost:3000'
+	 */
+	get DASHBOARD_BASE_URL(): string {
+		return this.getValidatedUrlEnvVar( 'DASHBOARD_BASE_URL' );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/dashboard-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/dashboard-page.ts
@@ -5,13 +5,13 @@ import { Page } from 'playwright';
 /**
  * Internal dependencies
  */
-import { getCalypsoURL } from '../../data-helper';
+import { getDashboardURL } from '../../data-helper';
 
 /**
  * Dashboard page class for the new Multi-site Dashboard.
  *
  * This Page Object represents the new dashboard implementation
- * accessible under the /v2 path.
+ * accessible at my.wordpress.com.
  */
 export class DashboardPage {
 	/**
@@ -34,7 +34,7 @@ export class DashboardPage {
 	 * @returns Promise that resolves when navigation is complete.
 	 */
 	async visit(): Promise< void > {
-		await this.page.goto( getCalypsoURL( 'v2' ) );
+		await this.page.goto( getDashboardURL() );
 		// Wait for the main content to be visible
 		await this.page.getByRole( 'main' ).waitFor();
 	}
@@ -46,7 +46,7 @@ export class DashboardPage {
 	 */
 	async isLoaded(): Promise< boolean > {
 		const isMainContentVisible = await this.page.getByRole( 'main' ).isVisible();
-		const hasCorrectUrl = this.page.url().includes( '/v2' );
+		const hasCorrectUrl = this.page.url().includes( getDashboardURL() );
 		return isMainContentVisible && hasCorrectUrl;
 	}
 
@@ -76,12 +76,12 @@ export class DashboardPage {
 	/**
 	 * Visits a specific subpath within the dashboard.
 	 *
-	 * @param subpath - The subpath to visit under /v2.
+	 * @param path - The path to visit in the dashboard.
 	 * @returns Promise that resolves when navigation is complete.
 	 */
-	async visitPath( subpath: string ): Promise< void > {
-		const path = subpath.startsWith( '/' ) ? subpath : `/${ subpath }`;
-		await this.page.goto( getCalypsoURL( `v2${ path }` ) );
+	async visitPath( path: string ): Promise< void > {
+		const unslashed = path.startsWith( '/' ) ? path.substring( 1 ) : path;
+		await this.page.goto( getDashboardURL( unslashed ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/dashboard-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/dashboard-page.ts
@@ -80,8 +80,7 @@ export class DashboardPage {
 	 * @returns Promise that resolves when navigation is complete.
 	 */
 	async visitPath( path: string ): Promise< void > {
-		const unslashed = path.startsWith( '/' ) ? path.substring( 1 ) : path;
-		await this.page.goto( getDashboardURL( unslashed ) );
+		await this.page.goto( getDashboardURL( path ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
@@ -22,7 +22,6 @@ export class SiteSettingsPage {
 	 * @param {string} siteSlug Site URL.
 	 */
 	async visit( siteSlug: string, subPathSlug?: string ): Promise< void > {
-		// Patch for redirectToHostingDashboardBackportIfEnabled bug that doesn't account for tabs.
 		const pageUrl = getCalypsoURL(
 			`sites/${ siteSlug }/settings${ subPathSlug ? `/${ subPathSlug }` : '' }`
 		);

--- a/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
@@ -1,5 +1,4 @@
 import { Page } from 'playwright';
-import { envVariables } from '../..';
 import { getCalypsoURL } from '../../data-helper';
 
 /**
@@ -18,37 +17,36 @@ export class SiteSettingsPage {
 	}
 
 	/**
-	 * Visits the `/sites/settings/$tab` endpoint.
+	 * Visits the `/sites/$siteSlug/settings` page and optionally drill into a sub-page.
 	 *
 	 * @param {string} siteSlug Site URL.
-	 * @param {string} tab      Settings tab.
 	 */
-	async visit( siteSlug: string, tab: string = 'site' ): Promise< void > {
+	async visit( siteSlug: string, subPathSlug?: string ): Promise< void > {
 		// Patch for redirectToHostingDashboardBackportIfEnabled bug that doesn't account for tabs.
-		await this.page.goto( getCalypsoURL( `sites/settings/v2/${ siteSlug }/${ tab }` ), {
+		const pageUrl = getCalypsoURL(
+			`sites/${ siteSlug }/settings${ subPathSlug ? `/${ subPathSlug }` : '' }`
+		);
+		await this.page.goto( pageUrl, {
 			timeout: 20 * 1000,
 		} );
 	}
 
 	/**
 	 * Start the site launch process.
+	 * Must be on the "Site visibility" sub-page.
 	 */
 	async launchSite(): Promise< void > {
-		const launchSite = this.page.getByRole( 'button', { name: 'Launch site' } ).first();
+		const launchSite = this.page.getByRole( 'button', { name: 'Launch your site' } ).first();
 		await launchSite.click();
 	}
 
 	/**
-	 * Navigates to a given item in the sidebar.
+	 * Navigates to a given settings sub-path by label.
 	 *
-	 * @param {string} item Item to navigate to.
+	 * @param {string} itemLabel Item to navigate to.
 	 */
-	async navigateToSubmenu( item: string ) {
-		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			await this.page.getByRole( 'button', { name: 'General' } ).click();
-		}
-
-		await this.page.getByRole( 'link', { name: item } ).click();
+	async navigateToSubmenu( itemLabel: string ) {
+		await this.page.getByRole( 'link', { name: itemLabel } ).click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/types/env-variables.types.ts
+++ b/packages/calypso-e2e/src/types/env-variables.types.ts
@@ -23,6 +23,7 @@ export interface SupportedEnvVariables {
 	readonly CALYPSO_BASE_URL: string;
 	readonly COBLOCKS_EDGE: boolean;
 	readonly COOKIES_PATH: string;
+	readonly DASHBOARD_BASE_URL: string;
 	readonly GUTENBERG_EDGE: boolean;
 	readonly GUTENBERG_NIGHTLY: boolean;
 	readonly HEADLESS: boolean;

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -6,19 +6,20 @@ Environment Variables control much of the runtime configuration for E2E tests.
 
 ## Current Environment Variables
 
-| Name                  | Description                                                                                                          | Default                                             | Required |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------- |
-| ARTIFACTS_PATH        | Path on disk to test artifacts (screenshots, logs, etc).                                                             | `./results/`                                        | Optional |
-| AUTHENTICATE_ACCOUNTS | Comma-delimited list of accounts to pre-authenticate for later use.                                                  | `simpleSitePersonalPlanUser,atomicUser,defaultUser` | Optional |
-| CALYPSO_BASE_URL      | The base URL to use for Calypso e.g. `https://wordpress.com`, `http://calypso.localhost:3000`, etc.                  | `http://calypso.localhost:3000`                     | Optional |
-| COBLOCKS_EDGE         | Use the bleeding edge CoBlocks build.                                                                                | `false`                                             | Optional |
-| COOKIES_PATH          | Path on disk to the saved authenticated cookies.                                                                     | `./cookies/`                                        | Optional |
-| GUTENBERG_EDGE        | Use the bleeding edge Gutenberg build.                                                                               | `false`                                             | Optional |
-| HEADLESS              | Configure browser headless/headful mode.                                                                             | `false`                                             | Optional |
-| JETPACK_TARGET        | Which Jetpack install (`wpcom-production`, `wpcom-deployment`, `remote-site`) we are targeting through Calypso.      | `wpcom-production`                                  | Optional |
-| SLOW_MO               | Slow down the execution by given milliseconds.                                                                       | `0`                                                 | Optional |
-| TEST_LOCALES          | The locales to target for I18N testing (see more: [supported locales](../../../packages/i18n-utils/src/locales.ts)). | `en, es, fr`                                        | Optional |
-| TEST_ON_ATOMIC        | Use a user with an Atomic site.                                                                                      | `false`                                             | Optional |
-| VIEWPORT_NAME         | Specify the viewport to be used.                                                                                     | `desktop`                                           | Optional |
-| WOO_BASE_URL          | The base URL to use for WooCommerce.com marketing pages, typically accessed when not logged in.                      | `https://woocommerce.com`                           | Optional |
-| WPCOM_BASE_URL        | The base URL to use for WordPress.com marketing pages, typically accessed when not logged in.                        | `https://wordpress.com`                             | Optional |
+| Name                  | Description                                                                                                           | Default                                             | Required |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------- |
+| ARTIFACTS_PATH        | Path on disk to test artifacts (screenshots, logs, etc).                                                              | `./results/`                                        | Optional |
+| AUTHENTICATE_ACCOUNTS | Comma-delimited list of accounts to pre-authenticate for later use.                                                   | `simpleSitePersonalPlanUser,atomicUser,defaultUser` | Optional |
+| CALYPSO_BASE_URL      | The base URL to use for Calypso e.g. `https://wordpress.com`, `http://calypso.localhost:3000`, etc.                   | `http://calypso.localhost:3000`                     | Optional |
+| COBLOCKS_EDGE         | Use the bleeding edge CoBlocks build.                                                                                 | `false`                                             | Optional |
+| COOKIES_PATH          | Path on disk to the saved authenticated cookies.                                                                      | `./cookies/`                                        | Optional |
+| DASHBOARD_BASE_URL    | The base URL to use for Multi-site Dashboard e.g. `https://my.wordpress.com`, etc.                                    | `http://calypso.localhost:3000`                     | Optional |
+| GUTENBERG_EDGE        | Use the bleeding edge Gutenberg build.                                                                                | `false`                                             | Optional |
+| HEADLESS              | Configure browser headless/headful mode.                                                                              | `false`                                             | Optional |
+| JETPACK_TARGET        | Which Jetpack install (`wpcom-production`, `wpcom-deployment`, `remote-site`) we are targeting through Calypso.       | `wpcom-production`                                  | Optional |
+| SLOW_MO               | Slow down the execution by given milliseconds.                                                                        | `0`                                                 | Optional |
+| TEST_LOCALES          | The locales to target for I18N testing (see more: [supported locales](../../../packages/i18n-utils/src/locales.ts)).  | `en, es, fr`                                        | Optional |
+| TEST_ON_ATOMIC        | Use a user with an Atomic site.                                                                                       | `false`                                             | Optional |
+| VIEWPORT_NAME         | Specify the viewport to be used.                                                                                      | `desktop`                                           | Optional |
+| WOO_BASE_URL          | The base URL to use for WooCommerce.com marketing pages, typically accessed when not logged in.                       | `https://woocommerce.com`                           | Optional |
+| WPCOM_BASE_URL        | The base URL to use for WordPress.com marketing pages, typically accessed when not logged in.                         | `https://wordpress.com`                             | Optional |

--- a/test/e2e/specs/dashboard/dashboard__authentication.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__authentication.spec.ts
@@ -3,8 +3,8 @@ import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Dashboard: Authentication', { tag: [ tags.CALYPSO_PR ] }, () => {
 	test.skip(
-		DataHelper.isCalypsoProduction(),
-		'Skipping for WordPress.com as Multi-site Dashboard is not enabled yet.'
+		! DataHelper.isCalypsoLocalDevelopment(),
+		'Skipping until we have separated Multi-site Dashboard tests from WordPress.com tests.'
 	);
 
 	test( 'As an anonymous user, I can not see the dashboard page unless I am authenticated', async ( {

--- a/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
@@ -3,8 +3,8 @@ import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Dashboard: Basic & Routing', { tag: [ tags.CALYPSO_PR ] }, () => {
 	test.skip(
-		DataHelper.isCalypsoProduction(),
-		'Skipping for WordPress.com as Multi-site Dashboard is not enabled yet.'
+		! DataHelper.isCalypsoLocalDevelopment(),
+		'Skipping until we have separated Multi-site Dashboard tests from WordPress.com tests.'
 	);
 
 	test( 'As a WordPress.com user, I can see the new Multi-site Dashboard page as a list of my sites', async ( {

--- a/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
@@ -36,7 +36,7 @@ test.describe( 'Dashboard: Basic & Routing', { tag: [ tags.CALYPSO_PR ] }, () =>
 		} );
 
 		await test.step( 'When I visit the dashboard page', async function () {
-			await pageDashboard.visitPath( 'non-existent-page' );
+			await pageDashboard.visitPath( 'me/non-existent-page' );
 		} );
 
 		await test.step( 'Then I see a 404 error page', async function () {

--- a/test/e2e/specs/dashboard/settings__site-visibility.spec.ts
+++ b/test/e2e/specs/dashboard/settings__site-visibility.spec.ts
@@ -3,8 +3,8 @@ import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Dashboard: Site Visibility Settings', { tag: [ tags.CALYPSO_RELEASE ] }, () => {
 	test.skip(
-		DataHelper.isCalypsoProduction(),
-		'Skipping for WordPress.com as Multi-site Dashboard is not enabled yet.'
+		! DataHelper.isCalypsoLocalDevelopment(),
+		'Skipping until we have separated Multi-site Dashboard tests from WordPress.com tests.'
 	);
 
 	test( 'As a new simple site user, I can set my site visibility to Private, so that only I can see my site', async ( {

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -205,7 +205,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 	describe( 'Launch site without Focused Launchpad', function () {
 		it( 'Start site launch', async function () {
 			const siteSettingsPage = new SiteSettingsPage( page );
-			await siteSettingsPage.visit( newSiteDetails.blog_details.site_slug );
+			await siteSettingsPage.visit( newSiteDetails.blog_details.site_slug, 'site-visibility' );
 			await siteSettingsPage.launchSite();
 		} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-960

## Proposed Changes

* Update dashboard tests so they use the
* Skips dashboard tests on TeamCity until we either:
  * configure a new TeamCity job for the dashboard, or
  * we configure the Calypso TeamCity job to set both environment variables and run all tests as part of the same job.

The complication of running both sets of tests in the same TeamCity job, is that it would need to wait until _both_ calypso live links are ready. And then be configured to run against both calypso live links. The `wpcomLink` and `dashboardLink` functions wouldn't really know what those links are.

The complication of creating two separate TeamCity jobs is that Calypso PR tests would run against production Dashboard code, and Dashboard PR tests would run against production Calypso code. So the code might not match. But perhaps that's the right way? It reminds me of how we would test Jetpack, it always runs against production Calypso right?

If you wonder how a4a tests are running: it's basically a smoke test that runs against prod a4a, it never tests the a4a PR code. https://github.com/Automattic/wp-calypso/blob/41ddee66a033871dcdd9a4dc4edf1285fa6749a9/test/e2e/specs/a8c-for-agencies/signup__smoke.spec.ts#L17

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The e2e tests will start failing we retire the `/v2` path. This is preparing for that by not creating carnage in the build queue when the tests start failing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The dashboard tests still work when run locally
```bash
$ cd test/e2e
$ yarn build
$ yarn test:pw -- specs/dashboard
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
