### PR TITLE
Update landing page link when Sites is set

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -88,17 +88,29 @@ const waitForPrefs = () => async ( dispatch, getState ) => {
 	}
 };
 
+const getSitesLink = ( isDashboardOptIn ) => {
+	if ( isDashboardOptIn ) {
+		// In development environments, don't redirect to the Dashboard subdomain as it might not be the intent.
+		// For instance, developers might use the Calypso Live link to test something not in the Dashboard,
+		// but they get redirected to the Dashboard subdomain, and lose the Calypso Live domain in the process.
+		// As a temporary workaround, we redirect to /home instead.
+		if ( config( 'env_id' ) !== 'production' ) {
+			return '/home';
+		}
+
+		return dashboardLink( '/sites' );
+	}
+
+	return '/sites';
+};
+
 async function getLoggedInLandingPage( { dispatch, getState } ) {
 	await dispatch( waitForPrefs() );
 	const useSitesAsLandingPage = hasSitesAsLandingPage( getState() );
 	const dashboardOptIn = hasDashboardOptIn( getState() );
 
 	if ( useSitesAsLandingPage ) {
-		if ( dashboardOptIn ) {
-			// Use absolute URL to force a hard reload.
-			return dashboardLink( '/sites' );
-		}
-		return '/sites';
+		return getSitesLink( dashboardOptIn );
 	}
 
 	const useReaderAsLandingPage = hasReadersAsLandingPage( getState() );
@@ -117,8 +129,9 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 		if ( getIsSubscriptionOnly( getState() ) ) {
 			return '/reader';
 		}
+
 		// there is no primary site or the site info couldn't be fetched. Redirect to Sites Dashboard.
-		return '/sites';
+		return getSitesLink( dashboardOptIn );
 	}
 
 	const isCustomerHomeEnabled = canCurrentUserUseCustomerHome(

--- a/client/root.js
+++ b/client/root.js
@@ -94,7 +94,7 @@ const getSitesLink = ( isDashboardOptIn ) => {
 	// but they get redirected to the Dashboard subdomain, and lose the Calypso Live domain in the process.
 	// As a temporary workaround, we send them to the v1 /sites instead.
 	// TODO: The workaround will need to change once we deprecate v1 /sites.
-	if ( isDashboardOptIn && config( 'env_id' ) === 'production' ) {
+	if ( isDashboardOptIn && ! [ 'development', 'wpcalypso' ].includes( config( 'env_id' ) ) ) {
 		return dashboardLink( '/sites' );
 	}
 

--- a/client/root.js
+++ b/client/root.js
@@ -89,15 +89,12 @@ const waitForPrefs = () => async ( dispatch, getState ) => {
 };
 
 const getSitesLink = ( isDashboardOptIn ) => {
-	if ( isDashboardOptIn ) {
-		// In development environments, don't redirect to the Dashboard subdomain as it might not be the intent.
-		// For instance, developers might use the Calypso Live link to test something not in the Dashboard,
-		// but they get redirected to the Dashboard subdomain, and lose the Calypso Live domain in the process.
-		// As a temporary workaround, we redirect to /home instead.
-		if ( config( 'env_id' ) !== 'production' ) {
-			return '/home';
-		}
-
+	// In development environments, don't redirect to the Dashboard subdomain as it might not be the intent.
+	// For instance, developers might use the Calypso Live link to test something not in the Dashboard,
+	// but they get redirected to the Dashboard subdomain, and lose the Calypso Live domain in the process.
+	// As a temporary workaround, we send them to the v1 /sites instead.
+	// TODO: The workaround will need to change once we deprecate v1 /sites.
+	if ( isDashboardOptIn && config( 'env_id' ) === 'production' ) {
 		return dashboardLink( '/sites' );
 	}
 


### PR DESCRIPTION
## Proposed Changes

Update the Sites landing page link to /home for non MSD opt-in development environment to /home. This is mainly to avoid redirecting to my.wordpress.com when people click on the Calypso Live link when they wanted to test something else, losing the Calypso Live link domain in the process.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link
* Ensure it opens v1 /sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
