### PR TITLE
A4A > Tiers: Implement tier-level protection

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -96,7 +96,7 @@ const useMainMenuItems = ( path: string ) => {
 				icon: starEmpty,
 				path: '/',
 				link: A4A_AGENCY_TIER_LINK,
-				title: translate( 'Agency Tier' ),
+				title: translate( 'Agency tier' ),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Agency Tier',
 				},

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
@@ -15,10 +15,12 @@ export default function AgencyTierOverviewContent( {
 	currentAgencyTierId,
 	totalInfluencedRevenue,
 	isEarlyAccess,
+	isTierProtected,
 }: {
 	currentAgencyTierId?: AgencyTierType;
 	totalInfluencedRevenue: number;
 	isEarlyAccess: boolean;
+	isTierProtected: boolean;
 } ) {
 	return (
 		<VStack spacing={ 6 }>
@@ -30,7 +32,11 @@ export default function AgencyTierOverviewContent( {
 					/>
 				</CardBody>
 			</Card>
-			<TierCards currentAgencyTierId={ currentAgencyTierId } isEarlyAccess={ isEarlyAccess } />
+			<TierCards
+				currentAgencyTierId={ currentAgencyTierId }
+				isEarlyAccess={ isEarlyAccess }
+				isTierProtected={ isTierProtected }
+			/>
 			<Divider orientation="horizontal" margin={ 4 } style={ { color: '#F0F0F0' } } />
 			<TierBenefits currentAgencyTierId={ currentAgencyTierId } />
 		</VStack>

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
@@ -8,19 +8,18 @@ import InfluencedRevenue from './influenced-revenue';
 import TierBenefits from './tier-benefits';
 import TierCards from './tier-cards';
 import type { AgencyTierType } from './types';
+import type { AgencyTierStatus } from 'calypso/state/a8c-for-agencies/types';
 
 import './style.scss';
 
 export default function AgencyTierOverviewContent( {
 	currentAgencyTierId,
 	totalInfluencedRevenue,
-	isEarlyAccess,
-	isTierProtected,
+	tierStatus,
 }: {
 	currentAgencyTierId?: AgencyTierType;
 	totalInfluencedRevenue: number;
-	isEarlyAccess: boolean;
-	isTierProtected: boolean;
+	tierStatus?: AgencyTierStatus;
 } ) {
 	return (
 		<VStack spacing={ 6 }>
@@ -32,11 +31,7 @@ export default function AgencyTierOverviewContent( {
 					/>
 				</CardBody>
 			</Card>
-			<TierCards
-				currentAgencyTierId={ currentAgencyTierId }
-				isEarlyAccess={ isEarlyAccess }
-				isTierProtected={ isTierProtected }
-			/>
+			<TierCards currentAgencyTierId={ currentAgencyTierId } tierStatus={ tierStatus } />
 			<Divider orientation="horizontal" margin={ 4 } style={ { color: '#F0F0F0' } } />
 			<TierBenefits currentAgencyTierId={ currentAgencyTierId } />
 		</VStack>

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -93,8 +93,8 @@ export default function TierCards( {
 						} }
 					>
 						<CardBody style={ { display: 'flex', flexDirection: 'column', height: '100%' } }>
-							<VStack spacing={ 2 } style={ { flex: 1, justifyContent: 'flex-start' } }>
-								<HStack>
+							<VStack spacing={ 1 } style={ { flex: 1, justifyContent: 'flex-start' } }>
+								<HStack style={ { marginBlockEnd: '4px' } }>
 									<Heading level={ 3 } weight={ 500 }>
 										{ tier.name }
 									</Heading>
@@ -128,7 +128,7 @@ export default function TierCards( {
 								{ isCurrentTier && isTierProtected && (
 									<Text color={ TEXT_COLOR } style={ { fontStyle: 'italic' } } weight={ 700 }>
 										{ createInterpolateElement(
-											__( 'You’re tier level is protected. <a>Learn more</a>' ),
+											__( 'Your tier level is protected. <a>Learn more</a>' ),
 											{
 												a: (
 													<Button onClick={ handleViewTierProtectedInfo } variant="link">
@@ -139,6 +139,11 @@ export default function TierCards( {
 										) }
 									</Text>
 								) }
+							</VStack>
+							<VStack
+								spacing={ 1 }
+								style={ { flex: 1, justifyContent: 'flex-start', marginBlockStart: '8px' } }
+							>
 								<Text color={ TEXT_COLOR } weight={ 700 }>
 									{ tier.heading }
 								</Text>
@@ -147,7 +152,7 @@ export default function TierCards( {
 							<Button
 								onClick={ () => handleViewBenefits( tier.id as string ) }
 								variant={ isSecondary ? 'secondary' : 'primary' }
-								style={ { marginTop: '24px', alignSelf: 'flex-start' } }
+								style={ { marginBlockStart: '24px', alignSelf: 'flex-start' } }
 							>
 								{ hasHigherTier ? __( 'See what you’ll unlock' ) : __( 'View your benefits' ) }
 							</Button>

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -26,19 +26,22 @@ const TEXT_COLOR = 'var(--color-gray-700)';
 export default function TierCards( {
 	currentAgencyTierId,
 	isEarlyAccess,
+	isTierProtected,
 }: {
 	currentAgencyTierId?: AgencyTierType;
 	isEarlyAccess: boolean;
+	isTierProtected: boolean;
 } ) {
 	const dispatch = useDispatch();
 
 	const currentTier = getCurrentAgencyTier( currentAgencyTierId );
 
-	const isSmallViewport = useViewportMatch( 'huge', '<' );
+	const isSmallViewport = useViewportMatch( 'wide', '<' );
 
 	const [ showEarlyAccessModal, setShowEarlyAccessModal ] = useState( false );
+	const [ showTierProtectedModal, setShowTierProtectedModal ] = useState( false );
 
-	const handleLearnMore = () => {
+	const handleViewEarlyAccessInfo = () => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_agency_tier_early_access_learn_more_click', {
 				agency_tier: currentAgencyTierId,
@@ -47,6 +50,14 @@ export default function TierCards( {
 		setShowEarlyAccessModal( true );
 	};
 
+	const handleViewTierProtectedInfo = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_agency_tier_tier_protected_learn_more_click', {
+				agency_tier: currentAgencyTierId,
+			} )
+		);
+		setShowTierProtectedModal( true );
+	};
 	const handleViewBenefits = ( tierId: string ) => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_agency_tier_view_benefits_click', {
@@ -72,7 +83,10 @@ export default function TierCards( {
 					<Card
 						key={ tier.id }
 						style={ {
-							width: isSmallViewport ? '100%' : '33%',
+							width: '100%',
+							height: '100%',
+							display: 'flex',
+							flexDirection: 'column',
 							...( isCurrentTier && {
 								boxShadow: '0 0 0 1px var(--color-primary-50)',
 							} ),
@@ -96,7 +110,7 @@ export default function TierCards( {
 									<Badge
 										style={ { width: 'fit-content' } }
 										intent="default"
-										children={ __( 'Your Tier — Early Access' ) }
+										children={ __( 'Your tier — Early Access' ) }
 									/>
 								) }
 								<Text color={ TEXT_COLOR }>{ tier.description }</Text>
@@ -104,11 +118,25 @@ export default function TierCards( {
 									<Text color={ TEXT_COLOR } style={ { fontStyle: 'italic' } } weight={ 700 }>
 										{ createInterpolateElement( __( 'You’re in early. <a>Learn more</a>' ), {
 											a: (
-												<Button onClick={ handleLearnMore } variant="link">
+												<Button onClick={ handleViewEarlyAccessInfo } variant="link">
 													{ __( 'Learn more.' ) }
 												</Button>
 											),
 										} ) }
+									</Text>
+								) }
+								{ isCurrentTier && isTierProtected && (
+									<Text color={ TEXT_COLOR } style={ { fontStyle: 'italic' } } weight={ 700 }>
+										{ createInterpolateElement(
+											__( 'You’re tier level is protected. <a>Learn more</a>' ),
+											{
+												a: (
+													<Button onClick={ handleViewTierProtectedInfo } variant="link">
+														{ __( 'Learn more.' ) }
+													</Button>
+												),
+											}
+										) }
 									</Text>
 								) }
 								<Text color={ TEXT_COLOR } weight={ 700 }>
@@ -166,6 +194,36 @@ export default function TierCards( {
 					</VStack>
 				</Modal>
 			) }
+			{ showTierProtectedModal && currentTier && (
+				<Modal
+					isDismissible
+					size="medium"
+					onRequestClose={ () => setShowTierProtectedModal( false ) }
+					title={ __( 'Your tier level is protected' ) }
+				>
+					<VStack spacing={ 8 }>
+						<Text>
+							{ sprintf(
+								/* translators: %s is the tier name */
+								__(
+									'You earned the %s tier in the previous year, and your tier level is protected for the current year. This means you’re will not be downgraded during this year, regardless of your current influenced revenue.'
+								),
+								currentTier.name
+							) }
+						</Text>
+						<Text>
+							{ __(
+								'You can still move up to a higher tier if your influenced revenue qualifies. However, if you do not meet the minimum requirements for this tier, any downgrade will only occur when the next year’s cycle begins in January. This protection ensures you can continue to enjoy your current tier benefits throughout the year.'
+							) }
+						</Text>
+						<ButtonStack justify="flex-end">
+							<Button variant="primary" onClick={ () => setShowTierProtectedModal( false ) }>
+								{ __( 'Got it' ) }
+							</Button>
+						</ButtonStack>
+					</VStack>
+				</Modal>
+			) }
 		</>
 	);
 
@@ -178,8 +236,16 @@ export default function TierCards( {
 	}
 
 	return (
-		<HStack spacing={ 6 } style={ { justifyContent: 'space-between' } } alignment="stretch">
+		<div
+			style={ {
+				display: 'grid',
+				gridTemplateColumns: 'repeat(3, 1fr)',
+				gridAutoRows: '1fr',
+				gap: '24px',
+				alignItems: 'stretch',
+			} }
+		>
 			{ content }
-		</HStack>
+		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -20,17 +20,16 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentAgencyTier from '../lib/get-current-agency-tier';
 import { ALL_TIERS, TARGET_INFLUENCED_REVENUE } from './constants';
 import type { AgencyTierType } from './types';
+import type { AgencyTierStatus } from 'calypso/state/a8c-for-agencies/types';
 
 const TEXT_COLOR = 'var(--color-gray-700)';
 
 export default function TierCards( {
 	currentAgencyTierId,
-	isEarlyAccess,
-	isTierProtected,
+	tierStatus,
 }: {
 	currentAgencyTierId?: AgencyTierType;
-	isEarlyAccess: boolean;
-	isTierProtected: boolean;
+	tierStatus?: AgencyTierStatus;
 } ) {
 	const dispatch = useDispatch();
 
@@ -70,6 +69,9 @@ export default function TierCards( {
 			element.scrollIntoView( { behavior: 'smooth' } );
 		}
 	};
+
+	const isEarlyAccess = tierStatus === 'early_access';
+	const isTierProtected = tierStatus === 'tier_protected';
 
 	const content = (
 		<>

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -22,8 +22,7 @@ export default function AgencyTierOverview() {
 
 	const currentAgencyTierId = agency?.tier?.id;
 	const totalInfluencedRevenue = agency?.influenced_revenue ?? 0;
-	const isEarlyAccess = agency?.tier?.is_early_access ?? false;
-	const isTierProtected = agency?.tier?.is_tier_protected ?? false;
+	const tierStatus = agency?.tier?.status ?? undefined;
 
 	return (
 		<Layout title={ title } wide>
@@ -40,8 +39,7 @@ export default function AgencyTierOverview() {
 				<AgencyTierOverviewContent
 					currentAgencyTierId={ currentAgencyTierId }
 					totalInfluencedRevenue={ totalInfluencedRevenue }
-					isEarlyAccess={ isEarlyAccess }
-					isTierProtected={ isTierProtected }
+					tierStatus={ tierStatus }
 				/>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -23,6 +23,7 @@ export default function AgencyTierOverview() {
 	const currentAgencyTierId = agency?.tier?.id;
 	const totalInfluencedRevenue = agency?.influenced_revenue ?? 0;
 	const isEarlyAccess = agency?.tier?.is_early_access ?? false;
+	const isTierProtected = agency?.tier?.is_tier_protected ?? false;
 
 	return (
 		<Layout title={ title } wide>
@@ -40,6 +41,7 @@ export default function AgencyTierOverview() {
 					currentAgencyTierId={ currentAgencyTierId }
 					totalInfluencedRevenue={ totalInfluencedRevenue }
 					isEarlyAccess={ isEarlyAccess }
+					isTierProtected={ isTierProtected }
 				/>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
@@ -21,10 +21,12 @@ export default function AgencyTierProgressCard( {
 	currentAgencyTierId,
 	influencedRevenue,
 	isEarlyAccess,
+	isTierProtected,
 }: {
 	currentAgencyTierId?: AgencyTierType;
 	influencedRevenue: number;
 	isEarlyAccess: boolean;
+	isTierProtected: boolean;
 } ) {
 	const dispatch = useDispatch();
 
@@ -50,12 +52,19 @@ export default function AgencyTierProgressCard( {
 						<Heading level={ 4 } weight={ 500 }>
 							{ __( 'Your agency tier and benefits' ) }
 						</Heading>
-						<VStack spacing={ 3 }>
+						<VStack spacing={ 1 }>
 							{ isEarlyAccess && (
 								<Badge
-									style={ { width: 'fit-content' } }
+									style={ { width: 'fit-content', marginBottom: '4px' } }
 									intent="default"
 									children={ __( 'Early access' ) }
+								/>
+							) }
+							{ isTierProtected && (
+								<Badge
+									style={ { width: 'fit-content', marginBottom: '4px' } }
+									intent="default"
+									children={ __( 'Tier-level protected' ) }
 								/>
 							) }
 							<Heading level={ 3 } weight={ 500 }>
@@ -70,20 +79,20 @@ export default function AgencyTierProgressCard( {
 									  )
 									: currentTier.progressCardDescription }
 							</Text>
-							<InfluencedRevenue
-								currentAgencyTierId={ currentAgencyTierId }
-								totalInfluencedRevenue={ influencedRevenue }
-							/>
-							<ButtonStack justify="flex-start">
-								<Button
-									onClick={ handleExploreTiersAndBenefits }
-									href={ A4A_AGENCY_TIER_LINK }
-									variant="secondary"
-								>
-									{ __( 'Explore Tiers and benefits' ) }
-								</Button>
-							</ButtonStack>
 						</VStack>
+						<InfluencedRevenue
+							currentAgencyTierId={ currentAgencyTierId }
+							totalInfluencedRevenue={ influencedRevenue }
+						/>
+						<ButtonStack justify="flex-start">
+							<Button
+								onClick={ handleExploreTiersAndBenefits }
+								href={ A4A_AGENCY_TIER_LINK }
+								variant="secondary"
+							>
+								{ __( 'Explore Tiers and benefits' ) }
+							</Button>
+						</ButtonStack>
 					</VStack>
 				</CardBody>
 			</Card>

--- a/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
@@ -16,17 +16,16 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentAgencyTier from '../lib/get-current-agency-tier';
 import InfluencedRevenue from '../overview-content/influenced-revenue';
 import type { AgencyTierType } from '../overview-content/types';
+import type { AgencyTierStatus } from 'calypso/state/a8c-for-agencies/types';
 
 export default function AgencyTierProgressCard( {
 	currentAgencyTierId,
 	influencedRevenue,
-	isEarlyAccess,
-	isTierProtected,
+	tierStatus,
 }: {
 	currentAgencyTierId?: AgencyTierType;
 	influencedRevenue: number;
-	isEarlyAccess: boolean;
-	isTierProtected: boolean;
+	tierStatus?: AgencyTierStatus;
 } ) {
 	const dispatch = useDispatch();
 
@@ -53,14 +52,14 @@ export default function AgencyTierProgressCard( {
 							{ __( 'Your agency tier and benefits' ) }
 						</Heading>
 						<VStack spacing={ 1 }>
-							{ isEarlyAccess && (
+							{ tierStatus === 'early_access' && (
 								<Badge
 									style={ { width: 'fit-content', marginBottom: '4px' } }
 									intent="default"
 									children={ __( 'Early access' ) }
 								/>
 							) }
-							{ isTierProtected && (
+							{ tierStatus === 'tier_protected' && (
 								<Badge
 									style={ { width: 'fit-content', marginBottom: '4px' } }
 									intent="default"
@@ -71,7 +70,7 @@ export default function AgencyTierProgressCard( {
 								{ currentTier.name }
 							</Heading>
 							<Text color="#757575">
-								{ isEarlyAccess
+								{ tierStatus === 'early_access'
 									? sprintf(
 											/* translators: %s is the tier name */
 											'You’ve been given early access to %s tier benefits. Keep up the great work!',

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -14,6 +14,7 @@ export default function OverviewSidebarAgencyTier() {
 	const currentAgencyTierId = agency?.tier?.id;
 	const influencedRevenue = agency?.influenced_revenue;
 	const isEarlyAccess = agency?.tier?.is_early_access;
+	const isTierProtected = agency?.tier?.is_tier_protected;
 	const currentAgencyTierInfo = getAgencyTierInfo( currentAgencyTierId, translate );
 
 	if ( ! currentAgencyTierInfo ) {
@@ -25,6 +26,7 @@ export default function OverviewSidebarAgencyTier() {
 			currentAgencyTierId={ currentAgencyTierId }
 			influencedRevenue={ influencedRevenue ?? 0 }
 			isEarlyAccess={ !! isEarlyAccess }
+			isTierProtected={ !! isTierProtected }
 		/>
 	);
 }

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/index.tsx
@@ -13,8 +13,7 @@ export default function OverviewSidebarAgencyTier() {
 
 	const currentAgencyTierId = agency?.tier?.id;
 	const influencedRevenue = agency?.influenced_revenue;
-	const isEarlyAccess = agency?.tier?.is_early_access;
-	const isTierProtected = agency?.tier?.is_tier_protected;
+	const tierStatus = agency?.tier?.status ?? undefined;
 	const currentAgencyTierInfo = getAgencyTierInfo( currentAgencyTierId, translate );
 
 	if ( ! currentAgencyTierInfo ) {
@@ -25,8 +24,7 @@ export default function OverviewSidebarAgencyTier() {
 		<AgencyTierProgressCard
 			currentAgencyTierId={ currentAgencyTierId }
 			influencedRevenue={ influencedRevenue ?? 0 }
-			isEarlyAccess={ !! isEarlyAccess }
-			isTierProtected={ !! isTierProtected }
+			tierStatus={ tierStatus }
 		/>
 	);
 }

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -23,6 +23,7 @@ export interface TitanUsage {
 	orders: TitanOrder[];
 }
 
+export type AgencyTierStatus = 'early_access' | 'tier_protected';
 export interface Agency {
 	id: number;
 	name: string;
@@ -110,8 +111,7 @@ export interface Agency {
 		id: AgencyTier;
 		label: string;
 		features: string[];
-		is_early_access?: boolean;
-		is_tier_protected?: boolean;
+		status: AgencyTierStatus;
 	};
 	influenced_revenue: number;
 	approval_status: ApprovalStatus | '';

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -110,7 +110,8 @@ export interface Agency {
 		id: AgencyTier;
 		label: string;
 		features: string[];
-		is_early_access: boolean;
+		is_early_access?: boolean;
+		is_tier_protected?: boolean;
 	};
 	influenced_revenue: number;
 	approval_status: ApprovalStatus | '';


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/A4A-1938/add-tier-level-protected-tag-for-agencies-with-protected-tiers

Resolves https://linear.app/a8c/issue/A4A-1939/add-a-tier-level-protected-badge-along-with-a-modal-to-provide-more
Resolves https://linear.app/a8c/issue/A4A-1948/show-3-cards-on-one-row-on-large-screen

## Proposed Changes

This PR implements 

- Implements tier-level protection on the tier progress card (Overview view) & cards on the tiers overview page.
- Updates the menu item to "Agency tier".
- Makes some UI changes to the tier progress card (Overview view)

## Why are these changes being made?

* To show that the agency's tier is protected for the next year, even though the IAR doesn't qualify for them when it resets next year,

## Testing Instructions

* Patch 198259-ghe-Automattic/wpcom & set the agency to show the tier protection flag
* Open the A4A live link
* Verify the menu item is changed to "Agency tier". We'd fixed this earlier, but a rebase on another PR reverted this.


<img width="272" height="732" alt="Screenshot 2025-12-18 at 11 05 59 AM" src="https://github.com/user-attachments/assets/4cd0b839-50b6-4fb3-8527-7ff4f7d5eb90" />


* On the Overview page, verify the tier progress card is updated as shown below

<img width="507" height="308" alt="Screenshot 2025-12-18 at 11 01 37 AM" src="https://github.com/user-attachments/assets/3a77df29-6dcf-4935-ae81-09f6363269d5" />

* Go to the Agency tier page > Verify the card is updated as shown below and only 3 cards are shown per row

<img width="1524" height="711" alt="Screenshot 2025-12-19 at 10 49 17 AM" src="https://github.com/user-attachments/assets/774de2b6-ed53-4dd3-88a7-8884c34c20e4" />

* Click the "Learn more" link > Verify the modal is displayed as shown below

<img width="1524" height="711" alt="Screenshot 2025-12-19 at 10 49 20 AM" src="https://github.com/user-attachments/assets/1c8a8a1d-6e1c-416d-87c8-a93ec40f50bb" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?