### PR TITLE
Fix domain connection styles overridden by component CSS loading order in my.wordpress.com

### DIFF
--- a/client/dashboard/components/action-list/style.scss
+++ b/client/dashboard/components/action-list/style.scss
@@ -16,6 +16,7 @@
 	}
 	.action-item {
 		border-bottom: 1px solid $gray-100;
+		padding: $grid-unit-20 0;
 		&:last-child {
 			border-bottom: none;
 		}

--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar-style.scss
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar-style.scss
@@ -1,6 +1,10 @@
 @import '@wordpress/base-styles/variables';
 
 .dns-propagation-progress-bar {
+	/*
+	 * !important is required because WordPress component CSS may be loaded after page-specific styles,
+	 * causing it to override our custom styles (for example, on my.wordpress.com).
+	 */
 	width: 100% !important;
 	height: 4px !important;
 

--- a/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar-style.scss
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-propagation-progress-bar-style.scss
@@ -1,8 +1,8 @@
 @import '@wordpress/base-styles/variables';
 
 .dns-propagation-progress-bar {
-	width: 100%;
-	height: 4px;
+	width: 100% !important;
+	height: 4px !important;
 
 	/* Change the progress bar color to the theme color */
 	& > div {

--- a/client/dashboard/domains/domain-connection-setup/style.scss
+++ b/client/dashboard/domains/domain-connection-setup/style.scss
@@ -8,7 +8,7 @@
 			fill: var(--dashboard__background-color-success);
 		}
 	}
-	&__title {
+	.dashboard-domain-connection-verification__title {
 		@include body-large;
 	}
 	.summary-button.components-button .summary-button-title {


### PR DESCRIPTION
Closes [DOMENG-290](https://linear.app/a8c/issue/DOMENG-290/fix-domain-connection-progress-bar-and-domain-name-style)

## Proposed Changes
* Add `!important` flags to DNS propagation progress bar width and height styles to ensure they override WordPress component defaults
* Increase CSS selector specificity for domain connection verification title by changing from `&__title` to `.dashboard-domain-connection-verification__title` nested selector

## Why are these changes being made?
In my wordpress.com, @wordpress/components css are loaded after our components'styles.

## Testing Instructions
Code inspection

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
