### PR TITLE
MSD: add busy state to action button while loading purchases in modals

### DIFF
--- a/client/dashboard/me/profile-deletion/index.tsx
+++ b/client/dashboard/me/profile-deletion/index.tsx
@@ -22,7 +22,10 @@ export default function AccountDeletionSection() {
 			},
 		},
 	} );
-	const { data: purchases, isLoading: isFetchingPurchases } = useQuery( userPurchasesQuery() );
+	const { data: purchases, isLoading: isFetchingPurchases } = useQuery( {
+		...userPurchasesQuery(),
+		enabled: showConfirmModal,
+	} );
 
 	const handleConfirmDelete = () => {
 		mutation.mutate( void 0, {
@@ -64,14 +67,14 @@ export default function AccountDeletionSection() {
 				/>
 			</ActionList>
 
-			{ showConfirmModal && (
+			{ showConfirmModal && purchases && (
 				<AccountDeletionConfirmModal
 					onClose={ handleCloseModal }
 					onConfirm={ handleConfirmDelete }
 					username={ user.username }
 					isDeleting={ mutation.isPending }
 					siteCount={ user.site_count || 0 }
-					purchases={ purchases || [] }
+					purchases={ purchases }
 				/>
 			) }
 		</>

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -1,3 +1,5 @@
+import { siteHasCancelablePurchasesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
@@ -51,7 +53,12 @@ const SiteResetAction = ( { site }: { site: Site } ) => {
 };
 
 const SiteLeaveAction = ( { site }: { site: Site } ) => {
+	const { user } = useAuth();
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const { data: hasPurchasesCancelable, isLoading } = useQuery( {
+		...siteHasCancelablePurchasesQuery( site.ID, user.ID ),
+		enabled: isModalOpen,
+	} );
 
 	return (
 		<>
@@ -59,21 +66,45 @@ const SiteLeaveAction = ( { site }: { site: Site } ) => {
 				title={ __( 'Leave site' ) }
 				description={ __( 'Leave this site and remove your access.' ) }
 				actions={
-					<Button variant="secondary" size="compact" onClick={ () => setIsModalOpen( true ) }>
+					<Button
+						variant="secondary"
+						size="compact"
+						isBusy={ isModalOpen && isLoading }
+						disabled={ isModalOpen && isLoading }
+						onClick={ () => setIsModalOpen( true ) }
+					>
 						{ __( 'Leave' ) }
 					</Button>
 				}
 			/>
-			{ isModalOpen && <SiteLeaveModal site={ site } onClose={ () => setIsModalOpen( false ) } /> }
+			{ isModalOpen && hasPurchasesCancelable !== undefined && (
+				<SiteLeaveModal
+					site={ site }
+					hasPurchasesCancelable={ hasPurchasesCancelable }
+					onClose={ () => setIsModalOpen( false ) }
+				/>
+			) }
 		</>
 	);
 };
 
 const SiteDeleteAction = ( { site }: { site: Site } ) => {
-	const [ isOpen, setIsOpen ] = useState( false );
+	const { user } = useAuth();
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const { data: hasPurchasesCancelable, isLoading } = useQuery( {
+		...siteHasCancelablePurchasesQuery( site.ID, user.ID ),
+		enabled: isModalOpen,
+	} );
 
 	const deleteButton = (
-		<Button variant="secondary" size="compact" isDestructive onClick={ () => setIsOpen( true ) }>
+		<Button
+			variant="secondary"
+			size="compact"
+			isDestructive
+			isBusy={ isModalOpen && isLoading }
+			disabled={ isModalOpen && isLoading }
+			onClick={ () => setIsModalOpen( true ) }
+		>
 			{ __( 'Delete' ) }
 		</Button>
 	);
@@ -86,7 +117,9 @@ const SiteDeleteAction = ( { site }: { site: Site } ) => {
 					description={ __( 'Delete staging site and all of its posts, media, and data.' ) }
 					actions={ deleteButton }
 				/>
-				{ isOpen && <StagingSiteDeleteModal site={ site } onClose={ () => setIsOpen( false ) } /> }
+				{ isModalOpen && (
+					<StagingSiteDeleteModal site={ site } onClose={ () => setIsModalOpen( false ) } />
+				) }
 			</>
 		);
 	}
@@ -100,7 +133,13 @@ const SiteDeleteAction = ( { site }: { site: Site } ) => {
 				) }
 				actions={ deleteButton }
 			/>
-			{ isOpen && <SiteDeleteModal site={ site } onClose={ () => setIsOpen( false ) } /> }
+			{ isModalOpen && hasPurchasesCancelable !== undefined && (
+				<SiteDeleteModal
+					site={ site }
+					hasPurchasesCancelable={ hasPurchasesCancelable }
+					onClose={ () => setIsModalOpen( false ) }
+				/>
+			) }
 		</>
 	);
 };

--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -1,9 +1,5 @@
 import { TrialPlans } from '@automattic/api-core';
-import {
-	p2HubP2sQuery,
-	siteDeleteMutation,
-	siteHasCancelablePurchasesQuery,
-} from '@automattic/api-queries';
+import { p2HubP2sQuery, siteDeleteMutation } from '@automattic/api-queries';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -19,7 +15,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
-import { useAuth } from '../../app/auth';
 import { purchasesRoute } from '../../app/router/me';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
@@ -242,18 +237,17 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 	);
 }
 
-export default function SiteDeleteModal( { site, onClose }: { site: Site; onClose: () => void } ) {
-	const { user } = useAuth();
-	const { isLoading, data: hasPurchasesCancelable } = useQuery(
-		siteHasCancelablePurchasesQuery( site.ID, user.ID )
-	);
-
+export default function SiteDeleteModal( {
+	site,
+	hasPurchasesCancelable,
+	onClose,
+}: {
+	site: Site;
+	hasPurchasesCancelable: boolean;
+	onClose: () => void;
+} ) {
 	const canBeDeleted = canDeleteSite( site ) && ! hasPurchasesCancelable;
 	const title = canBeDeleted ? __( 'Delete site' ) : __( 'Unable to delete site' );
-
-	if ( isLoading ) {
-		return null;
-	}
 
 	return (
 		<Modal title={ title } size="medium" onRequestClose={ onClose }>

--- a/client/dashboard/sites/site-leave-modal/content-info.tsx
+++ b/client/dashboard/sites/site-leave-modal/content-info.tsx
@@ -1,8 +1,4 @@
-import {
-	siteHasCancelablePurchasesQuery,
-	siteCurrentUserQuery,
-	siteUserDeleteMutation,
-} from '@automattic/api-queries';
+import { siteCurrentUserQuery, siteUserDeleteMutation } from '@automattic/api-queries';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -212,15 +208,12 @@ function ContentLeaveSite( { site, onClose }: ContentInfoProps ) {
 	);
 }
 
-export default function ContentInfo( { site, onClose }: ContentInfoProps ) {
+export default function ContentInfo( {
+	site,
+	hasPurchasesCancelable,
+	onClose,
+}: ContentInfoProps & { hasPurchasesCancelable: boolean } ) {
 	const { user } = useAuth();
-	const { data: hasPurchasesCancelable, isLoading: isLoadingHasPurchasesCancelable } = useQuery(
-		siteHasCancelablePurchasesQuery( site.ID, user.ID )
-	);
-
-	if ( isLoadingHasPurchasesCancelable ) {
-		return null;
-	}
 
 	const renderContent = () => {
 		if ( hasPurchasesCancelable ) {

--- a/client/dashboard/sites/site-leave-modal/index.tsx
+++ b/client/dashboard/sites/site-leave-modal/index.tsx
@@ -3,10 +3,18 @@ import { __ } from '@wordpress/i18n';
 import ContentInfo from './content-info';
 import type { ComponentProps } from 'react';
 
-export default function SiteLeaveModal( { site, onClose }: ComponentProps< typeof ContentInfo > ) {
+export default function SiteLeaveModal( {
+	site,
+	hasPurchasesCancelable,
+	onClose,
+}: ComponentProps< typeof ContentInfo > ) {
 	return (
 		<Modal title={ __( 'Leave site' ) } size="medium" onRequestClose={ onClose }>
-			<ContentInfo site={ site } onClose={ onClose } />
+			<ContentInfo
+				site={ site }
+				hasPurchasesCancelable={ hasPurchasesCancelable }
+				onClose={ onClose }
+			/>
 		</Modal>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

### Leave site

Before


https://github.com/user-attachments/assets/0fd7aadd-2be9-4778-9cc6-d49f097c80b4



After


https://github.com/user-attachments/assets/aabaac98-d309-4802-a7fc-b9e2c4c32157

### Delete site

Before


https://github.com/user-attachments/assets/0a63ad4b-960f-4be0-afdd-e746c870c154



After


https://github.com/user-attachments/assets/6328dbde-9d2d-4024-a2e7-367649ba51a4



### Delete account

Before


https://github.com/user-attachments/assets/856ebdff-076e-4dac-a8cd-03863ac172b4



After


https://github.com/user-attachments/assets/03e97368-ce2a-4877-8abf-140d2a6484d8



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?