### PR TITLE
A4A > Marketplace: Fix upsell checkout

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v2.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v2.tsx
@@ -1,4 +1,3 @@
-import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
@@ -23,8 +22,6 @@ function CheckoutV2() {
 
 	// Fetch selected products by slug for site checkout
 	const { selectedProductsBySlug } = useProductsBySlug();
-
-	const siteId = getQueryArg( window.location.href, 'site_id' )?.toString();
 
 	const title = translate( 'Checkout' );
 
@@ -55,7 +52,9 @@ function CheckoutV2() {
 			<LayoutBody>
 				<BillingDragonCheckout
 					withA8cLogo={ false }
-					cartItems={ siteId ? selectedProductsBySlug : selectedCartItems }
+					cartItems={
+						selectedProductsBySlug.length > 0 ? selectedProductsBySlug : selectedCartItems
+					}
 				/>
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v2.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v2.tsx
@@ -1,3 +1,4 @@
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
@@ -10,6 +11,7 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import BillingDragonCheckout from '../billing-dragon-checkout';
 import withMarketplaceProviders from '../hoc/with-marketplace-providers';
+import useProductsBySlug from '../hooks/use-products-by-slug';
 import useShoppingCart from '../hooks/use-shopping-cart';
 
 import './style-v2.scss';
@@ -18,6 +20,11 @@ function CheckoutV2() {
 	const translate = useTranslate();
 
 	const { selectedCartItems } = useShoppingCart();
+
+	// Fetch selected products by slug for site checkout
+	const { selectedProductsBySlug } = useProductsBySlug();
+
+	const siteId = getQueryArg( window.location.href, 'site_id' )?.toString();
 
 	const title = translate( 'Checkout' );
 
@@ -46,7 +53,10 @@ function CheckoutV2() {
 				</LayoutHeader>
 			</LayoutTop>
 			<LayoutBody>
-				<BillingDragonCheckout withA8cLogo={ false } cartItems={ selectedCartItems } />
+				<BillingDragonCheckout
+					withA8cLogo={ false }
+					cartItems={ siteId ? selectedProductsBySlug : selectedCartItems }
+				/>
 			</LayoutBody>
 		</Layout>
 	);


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-1953/checkout-fix-the-checkout-not-loading-products-issue-for-upsell

## Proposed Changes

This PR fixes an issue where checkout does not load products when clicking the upsell from the site details.

## Why are these changes being made?

* To fix an issue with the empty cart on checkout.

## Testing Instructions

* Open the A4A live link
* Use an agency account with BD enabled
* Go to any site details that don't have backup > Click the `Add Jetpack VaultPress Backup` button > Verify the checkout loads the backup product or you can manually append the URL with: /marketplace/checkout?product_slug=jetpack-backup-t1&source=sitesdashboard&site_id={any_site_id}
* Replace the `product_slug` on the URL with the following products > Verify it loads fine

1) jetpack-backup-t1 
2) jetpack-boost 
3) jetpack-scan 
4) jetpack-search 
5) jetpack-monitor
6) jetpack-social-v1

<img width="689" height="378" alt="Screenshot 2025-12-19 at 11 50 55 AM" src="https://github.com/user-attachments/assets/c88cfaaa-ae58-4091-a24e-6456ef0c0303" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
