### PR TITLE
MSD: add busy state to action button while loading purchases in delete account

### DIFF
--- a/client/dashboard/me/profile-deletion/index.tsx
+++ b/client/dashboard/me/profile-deletion/index.tsx
@@ -22,7 +22,10 @@ export default function AccountDeletionSection() {
 			},
 		},
 	} );
-	const { data: purchases, isLoading: isFetchingPurchases } = useQuery( userPurchasesQuery() );
+	const { data: purchases, isLoading: isFetchingPurchases } = useQuery( {
+		...userPurchasesQuery(),
+		enabled: showConfirmModal,
+	} );
 
 	const handleConfirmDelete = () => {
 		mutation.mutate( void 0, {
@@ -64,14 +67,14 @@ export default function AccountDeletionSection() {
 				/>
 			</ActionList>
 
-			{ showConfirmModal && (
+			{ showConfirmModal && purchases && (
 				<AccountDeletionConfirmModal
 					onClose={ handleCloseModal }
 					onConfirm={ handleConfirmDelete }
 					username={ user.username }
 					isDeleting={ mutation.isPending }
 					siteCount={ user.site_count || 0 }
-					purchases={ purchases || [] }
+					purchases={ purchases }
 				/>
 			) }
 		</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

This PR fixes the loading state of the `Delete account` button.

Previously, it will show loading state even though the user has not done anything yet, which is scary. Now, it is in loading state only when the user clicks that button.

**Before**


https://github.com/user-attachments/assets/856ebdff-076e-4dac-a8cd-03863ac172b4



**After**


https://github.com/user-attachments/assets/03e97368-ce2a-4877-8abf-140d2a6484d8


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

1. Clear REACT_QUERY_OFFLINE_CACHE.
2. Go to `/v2/me/profile`.
3. Verify the new behavior of the Delete account button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
