### PR TITLE
Theme Showcase: Retrieve the commercial info for Community themes

### DIFF
--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -11,7 +11,7 @@ const DEFAULT_PAGE_SIZE = 24;
 const DEFAULT_CATEGORY = 'all';
 const DEFAULT_FIRST_PAGE = 1;
 
-const WPORG_THEMES_ENDPOINT = 'https://api.wordpress.org/themes/info/1.1/';
+const WPORG_THEMES_ENDPOINT = 'https://api.wordpress.org/themes/info/1.2/';
 const WPORG_CORE_TRANSLATIONS_ENDPOINT = 'https://api.wordpress.org/translations/core/1.0/';
 const WPORG_CORE_VERSIONS_ENDPOINT = 'https://api.wordpress.org/core/version-check/1.7/';
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1471,6 +1471,8 @@ export default connect(
 			isActivatingTheme: getIsActivatingTheme( state, siteId ),
 			isInstallingTheme: getIsInstallingTheme( state, themeId, siteId ),
 			hasActivatedTheme: getHasActivatedTheme( state, siteId ),
+			isThemeCommercial: !! theme?.is_commercial,
+			commercialThemeExternalSupportUrl: theme?.external_support_url || null,
 		};
 	},
 	{

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -305,7 +305,7 @@ describe( 'actions', () => {
 						'Content-Type': 'application/json',
 					} )
 					.get(
-						'/themes/info/1.1/?action=query_themes&request%5Bfields%5D%5Bextended_author%5D=true'
+						'/themes/info/1.2/?action=query_themes&request%5Bfields%5D%5Bextended_author%5D=true'
 					)
 					.reply( 200, {
 						info: { page: 1, pages: 123, results: 2452 },
@@ -441,12 +441,12 @@ describe( 'actions', () => {
 						'Content-Type': 'application/json',
 					} )
 					.get(
-						'/themes/info/1.1/?action=theme_information&request%5Bfields%5D%5Bextended_author%5D=true' +
+						'/themes/info/1.2/?action=theme_information&request%5Bfields%5D%5Bextended_author%5D=true' +
 							'&request%5Bslug%5D=twentyseventeen'
 					)
 					.reply( 200, { slug: 'twentyseventeen', name: 'Twenty Seventeen' } )
 					.get(
-						'/themes/info/1.1/?action=theme_information&request%5Bfields%5D%5Bextended_author%5D=true' +
+						'/themes/info/1.2/?action=theme_information&request%5Bfields%5D%5Bextended_author%5D=true' +
 							'&request%5Bslug%5D=twentyumpteen'
 					)
 					.reply( 200, 'false' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTTHEM-144

## Proposed Changes

* Bump the Dotorg API themes endpoint version to 1.2.
* Include the commercial info in the theme object used by the `ThemeSheet` component.

These details will be used in the UI in a separate PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to clarify that some external (Community) themes might offer paid upgrades that are not included in any of the WordPress.com plans.

Core's "Commercial" labelling is not perfect (it involves a voluntary disclosure from the theme developer), but it's a start.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/theme/astra`.
* Open the browser's dev tools at the Network tab, and filter by `api.wordpress.org`.
* Ensure the request calls the 1.2 version of the endpoint (`https://api.wordpress.org/themes/info/1.2/`).
* Ensure that the response includes an `is_commercial` property (which is true for Astra).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
