### PR TITLE
MSD Bulk actions: Stop polling endpoint if there are no jobs

### DIFF
--- a/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
+++ b/client/dashboard/domains/dataviews/bulk-actions-progress-notice.tsx
@@ -26,7 +26,11 @@ export const BulkActionsProgressNotice = () => {
 		refetchInterval: ( query ) => {
 			const lastJob = getLastJob( query.state.data );
 
-			return lastJob?.complete ? false : 1_000;
+			if ( ! lastJob || lastJob.complete ) {
+				return false;
+			}
+
+			return 1_000;
 		},
 		meta: { persist: false },
 		staleTime: 0,


### PR DESCRIPTION
Fixes p1766000102356059-slack-C04H4NY6STW.

## Proposed Changes

Stop polling the bulk actions endpoint if there are no jobs registered in the bulk actions API.

Once the user dispatches a bulk actions operation, the endpoint is refetched and then we start polling until job completion. Rinse and repeat.

## Testing Instructions

Hardcode `get_bulk_action_status` so it returns `new WP_REST_Response( null, 200 );`, and proxy the public API to your sandbox.

Enter `/v2/domains` (on trunk) and verify you see a bulk actions query every second.

Check out this PR, reload the page, and verify you only get one.