### PR TITLE
Plans grid: apply proration credits for intro offers (flagged)

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -150,6 +150,7 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
+		"plans/pricing-grid-checkout-parity-intro-offers": false,
 		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,6 +90,7 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
+		"plans/pricing-grid-checkout-parity-intro-offers": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"post-editor/checkout-overlay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -116,6 +116,7 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
+		"plans/pricing-grid-checkout-parity-intro-offers": false,
 		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -115,6 +115,7 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
+		"plans/pricing-grid-checkout-parity-intro-offers": false,
 		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,6 +87,7 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
+		"plans/pricing-grid-checkout-parity-intro-offers": false,
 		"plans/self-service-downgrade": false,
 		"post-list/qr-code-link": false,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -122,6 +122,7 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
+		"plans/pricing-grid-checkout-parity-intro-offers": false,
 		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,

--- a/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -5,6 +5,9 @@
 /**
  * Default mock implementations
  */
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn(),
 	combineReducers: jest.fn(),
@@ -29,6 +32,7 @@ jest.mock( '../../../wpcom-plans-ui', () => ( {
 	store: 'wpcom-plans-ui',
 } ) );
 
+import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_PERSONAL, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { useSelect } from '@wordpress/data';
 import * as Plans from '../../';
@@ -38,6 +42,7 @@ import { STORAGE_ADD_ONS_MOCK } from '../../../add-ons/mocks';
 import * as Purchases from '../../../purchases';
 import * as WpcomPlansUI from '../../../wpcom-plans-ui';
 import { COST_OVERRIDE_REASONS } from '../../constants';
+import { PRICING_GRID_INTRO_OFFER_CHECKOUT_PARITY_FEATURE_FLAG } from '../use-is-pricing-grid-intro-offer-checkout-parity-enabled';
 import usePricingMetaForGridPlans from '../use-pricing-meta-for-grid-plans';
 
 const siteId = 100;
@@ -94,6 +99,7 @@ const useCheckPlanAvailabilityForPurchase = () => {
 describe( 'usePricingMetaForGridPlans', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		jest.mocked( isEnabled ).mockImplementation( () => false );
 		Purchases.useSitePurchaseById.mockImplementation( () => undefined );
 		Plans.useIntroOffers.mockImplementation( () => ( {
 			[ PLAN_BUSINESS ]: null,
@@ -336,6 +342,109 @@ describe( 'usePricingMetaForGridPlans', () => {
 		};
 
 		expect( pricingMeta ).toEqual( expectedPricingMeta );
+	} );
+
+	it( 'should not suppress prorated discounted price for intro offer plans when checkout-parity flag is enabled', () => {
+		jest.mocked( isEnabled ).mockImplementation( ( feature ) => {
+			return feature === PRICING_GRID_INTRO_OFFER_CHECKOUT_PARITY_FEATURE_FLAG;
+		} );
+
+		Plans.useIntroOffers.mockImplementation( () => ( {
+			[ PLAN_BUSINESS ]: introOffer,
+		} ) );
+		Plans.useSitePlans.mockImplementation( () => ( {
+			isLoading: false,
+			data: {
+				[ PLAN_BUSINESS ]: {
+					...SITE_PLANS[ PLAN_BUSINESS ],
+					pricing: {
+						...SITE_PLANS[ PLAN_BUSINESS ].pricing,
+						costOverrides: [ { overrideCode: COST_OVERRIDE_REASONS.RECENT_PLAN_PRORATION } ],
+						introOffer,
+					},
+				},
+			},
+		} ) );
+
+		const pricingMeta = usePricingMetaForGridPlans( {
+			planSlugs: [ PLAN_BUSINESS ],
+			siteId,
+			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
+			withProratedDiscounts: false,
+		} );
+
+		expect( pricingMeta?.[ PLAN_BUSINESS ]?.discountedPrice ).toEqual( {
+			full: 250,
+			monthly: 250,
+		} );
+	} );
+
+	it( 'should not suppress domain proration discounted price for intro offer plans when checkout-parity flag is enabled', () => {
+		jest.mocked( isEnabled ).mockImplementation( ( feature ) => {
+			return feature === PRICING_GRID_INTRO_OFFER_CHECKOUT_PARITY_FEATURE_FLAG;
+		} );
+
+		Plans.useIntroOffers.mockImplementation( () => ( {
+			[ PLAN_BUSINESS ]: introOffer,
+		} ) );
+		Plans.useSitePlans.mockImplementation( () => ( {
+			isLoading: false,
+			data: {
+				[ PLAN_BUSINESS ]: {
+					...SITE_PLANS[ PLAN_BUSINESS ],
+					pricing: {
+						...SITE_PLANS[ PLAN_BUSINESS ].pricing,
+						costOverrides: [ { overrideCode: COST_OVERRIDE_REASONS.RECENT_DOMAIN_PRORATION } ],
+						introOffer,
+					},
+				},
+			},
+		} ) );
+
+		const pricingMeta = usePricingMetaForGridPlans( {
+			planSlugs: [ PLAN_BUSINESS ],
+			siteId,
+			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
+			withProratedDiscounts: false,
+		} );
+
+		expect( pricingMeta?.[ PLAN_BUSINESS ]?.discountedPrice ).toEqual( {
+			full: 250,
+			monthly: 250,
+		} );
+	} );
+
+	it( 'should suppress plan proration discounted price even when override is not first (flag disabled)', () => {
+		Plans.useSitePlans.mockImplementation( () => ( {
+			isLoading: false,
+			data: {
+				[ PLAN_BUSINESS ]: {
+					...SITE_PLANS[ PLAN_BUSINESS ],
+					pricing: {
+						...SITE_PLANS[ PLAN_BUSINESS ].pricing,
+						costOverrides: [
+							{ overrideCode: 'coupon-discount' },
+							{ overrideCode: COST_OVERRIDE_REASONS.RECENT_PLAN_PRORATION },
+						],
+					},
+				},
+			},
+		} ) );
+
+		const pricingMeta = usePricingMetaForGridPlans( {
+			planSlugs: [ PLAN_BUSINESS ],
+			siteId,
+			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
+			withProratedDiscounts: false,
+		} );
+
+		expect( pricingMeta?.[ PLAN_BUSINESS ]?.discountedPrice ).toEqual( {
+			full: null,
+			monthly: null,
+		} );
 	} );
 
 	it( 'should return intro offer pricing and standard pricing adjusted by storage selection', () => {

--- a/packages/data-stores/src/plans/hooks/use-is-pricing-grid-intro-offer-checkout-parity-enabled.ts
+++ b/packages/data-stores/src/plans/hooks/use-is-pricing-grid-intro-offer-checkout-parity-enabled.ts
@@ -1,0 +1,12 @@
+import { isEnabled } from '@automattic/calypso-config';
+
+export const PRICING_GRID_INTRO_OFFER_CHECKOUT_PARITY_FEATURE_FLAG =
+	'plans/pricing-grid-checkout-parity-intro-offers';
+
+/**
+ * Centralized eligibility for showing checkout-parity pricing (proration credits included)
+ * in the plans pricing grid, scoped to *intro offer* plans only.
+ */
+export default function useIsPricingGridIntroOfferCheckoutParityEnabled(): boolean {
+	return isEnabled( PRICING_GRID_INTRO_OFFER_CHECKOUT_PARITY_FEATURE_FLAG );
+}

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -10,6 +10,7 @@ import * as AddOns from '../../add-ons';
 import * as Purchases from '../../purchases';
 import * as WpcomPlansUI from '../../wpcom-plans-ui';
 import { COST_OVERRIDE_REASONS } from '../constants';
+import useIsPricingGridIntroOfferCheckoutParityEnabled from './use-is-pricing-grid-intro-offer-checkout-parity-enabled';
 
 export type UseCheckPlanAvailabilityForPurchase = ( {
 	planSlugs,
@@ -89,6 +90,8 @@ const usePricingMetaForGridPlans = ( {
 	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
 	const introOffers = Plans.useIntroOffers( { siteId, coupon } );
+	const isPricingGridIntroOfferCheckoutParityEnabled =
+		useIsPricingGridIntroOfferCheckoutParityEnabled();
 	const purchasedPlan = Purchases.useSitePurchaseById( {
 		siteId,
 		purchaseId: currentPlan?.purchaseId,
@@ -144,6 +147,12 @@ const usePricingMetaForGridPlans = ( {
 				const storageAddOnPriceYearly = selectedStorageAddOn?.prices?.yearlyPrice || 0;
 
 				const introOffer = introOffers?.[ planSlug ];
+				const shouldIncludeProrationDiscountsForIntroOffer =
+					isPricingGridIntroOfferCheckoutParityEnabled &&
+					!! introOffer &&
+					! introOffer.isOfferComplete;
+				const effectiveWithProratedDiscounts =
+					withProratedDiscounts || shouldIncludeProrationDiscountsForIntroOffer;
 
 				const introOfferPrice = introOffer
 					? ( {
@@ -234,16 +243,16 @@ const usePricingMetaForGridPlans = ( {
 					// If there is, however, a sale coupon, show the discounted price
 					// without proration. This isn't ideal, but is intentional. Because of
 					// this, the price will differ between the plans grid and checkout screen.
-					const costOverrideCode = sitePlan?.pricing?.costOverrides?.[ 0 ]?.overrideCode;
 					const hasProratedCostOverride =
-						costOverrideCode &&
-						[
-							COST_OVERRIDE_REASONS.RECENT_PLAN_PRORATION,
-							COST_OVERRIDE_REASONS.RECENT_DOMAIN_PRORATION,
-						].includes( costOverrideCode );
+						sitePlan?.pricing?.costOverrides?.some( ( override ) =>
+							[
+								COST_OVERRIDE_REASONS.RECENT_PLAN_PRORATION,
+								COST_OVERRIDE_REASONS.RECENT_DOMAIN_PRORATION,
+							].includes( override.overrideCode )
+						) ?? false;
 					if (
 						! sitePlan?.pricing?.hasSaleCoupon &&
-						! withProratedDiscounts &&
+						! effectiveWithProratedDiscounts &&
 						hasProratedCostOverride
 					) {
 						return [

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -31,6 +31,7 @@ export { default as useCurrentPlan } from './hooks/use-current-plan';
 export { default as useCurrentPlanTerm } from './hooks/use-current-plan-term';
 export { default as useIntroOffers } from './hooks/use-intro-offers';
 export { default as useIntroOffersForWooExpress } from './hooks/use-intro-offers-for-woo-express';
+export { default as useIsPricingGridIntroOfferCheckoutParityEnabled } from './hooks/use-is-pricing-grid-intro-offer-checkout-parity-enabled';
 export { default as usePricingMetaForGridPlans } from './hooks/use-pricing-meta-for-grid-plans';
 export { default as useCurrentPlanExpiryDate } from './hooks/use-current-plan-expiry-date';
 


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/M4R73CH-479

## Proposed Changes
- Add feature flag `plans/pricing-grid-checkout-parity-intro-offers` (default off).
- For plans with an active **introductory offer** (“Special Offer”), allow prorated/upgrade credits from site pricing to affect the displayed grid price when the flag is enabled.
- Remove brittle reliance on `costOverrides[0]` by scanning all cost overrides when determining proration-related suppression.
- Add unit tests covering intro offer + plan/domain proration combinations and override ordering.

## Why are these changes being made?
Today, when a plan has an intro offer, checkout can apply additional credits (e.g. plan/domain proration) on top of the intro-offer base price. The pricing grid, however, suppresses some proration-derived discounts (only for certain override codes, like domain and plan credits, and only if they are the first override), leading to mismatches and inconsistent behavior across credit sources. Proration from add-on purchase credits is not suppressed, for instance: https://linear.app/a8c/issue/M4R73CH-479/intro-offers-prorated-credits-and-intro-offers-should-work-together#comment-3197842a

This change makes grid pricing for **intro-offer plans** consistent with what users can actually pay at checkout by allowing prorated credits to be reflected in the grid’s discounted price calculation (behind a feature flag for safe rollout).

## Testing Instructions
1. Enable the flag via URL: add `?flags=plans/pricing-grid-checkout-parity-intro-offers` to Calypso (see `config/README.md`).
2. Open a site’s plans page (e.g. `/plans/:siteSlug`) where plans show a **Special Offer** and the site has proration/upgrade credits.
3. Verify that the “Special Offer” price in the grid reflects the credits (compare to checkout’s plan line item subtotal for the same plan).
4. Disable the flag via URL: `?flags=-plans/pricing-grid-checkout-parity-intro-offers` and confirm the previous behavior returns.

## Pre-merge Checklist
- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript/React/console errors?
- [ ] Have you tested accessibility for your changes?
