### PR TITLE
MSD: add Store Sandbox helper environment badge

### DIFF
--- a/client/lib/store-sandbox-helper/style.scss
+++ b/client/lib/store-sandbox-helper/style.scss
@@ -10,8 +10,8 @@
 	display: block;
 	position: absolute;
 	bottom: 100%;
-	padding: 12px 12px 0 12px;
+	padding: 12px;
 	background: #fff;
 	box-shadow: 0 0 0 1px #dcdcde;
-	width: 200px;
+	width: 230px;
 }

--- a/client/lib/store-sandbox-helper/style.scss
+++ b/client/lib/store-sandbox-helper/style.scss
@@ -1,5 +1,6 @@
 .store-sandbox-helper__menu-item.is-enabled {
-	color: var(--studio-red);
+	color: var(--studio-green);
+	color: var(--dashboard__foreground-color-success);
 }
 
 .store-sandbox-helper__popover {

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -19,6 +19,7 @@
 		"dashboard/v2": false,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
+		"dev/store-sandbox-helper": true,
 		"wordpress-ai-assistant": true
 	},
 	"enable_all_sections": false,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -15,7 +15,8 @@
 		"cookie-banner": false,
 		"dashboard/v2": false,
 		"dev/auth-helper": true,
-		"dev/preferences-helper": true
+		"dev/preferences-helper": true,
+		"dev/store-sandbox-helper": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -14,6 +14,7 @@
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
 		"dashboard/v2": false,
+		"dev/store-sandbox-helper": true,
 		"wordpress-ai-assistant": true
 	},
 	"enable_all_sections": false,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1456/msd-add-store-sandbox-helper-environment-badge

## Proposed Changes

This adds the Store Sandbox helper to the environment badge in all MSD environments except production (matching Calypso). It also fixes the padding and adds an `is-enabled` dashboard color variable to the parent item.

<img width="452" height="94" alt="CleanShot 2025-12-18 at 09 17 34@2x" src="https://github.com/user-attachments/assets/ad5377fe-86a5-4822-90de-7ea62976cfaa" />

## Why are these changes being made?

The Store Sandbox helper allows us to easily toggle Store Sandbox on/off for testing billing features. With the creation of `dashboard-*` environments, we lost the feature flag that gates the functionality.

## Testing Instructions

- `CALYPSO_ENV=dashboard-stage yarn start`
- visit http://my.localhost:3000/
- click on the environment badge in the bottom right
- verify that the Store Sandbox helper is available and can be toggled.