### PR TITLE
agents-manager: Add setupHooks support for external providers

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -58,8 +58,8 @@ interface AgentDockProps {
 	markdownExtensions?: MarkdownExtensions;
 	/** Navigation continuation hook for post-navigation conversation resumption. */
 	useNavigationContinuation?: NavigationContinuationHook;
-	/** Setup hooks to register hook-dependent abilities (collected from all providers). */
-	setupHooks?: AbilitiesSetupHook[];
+	/** Setup hook to register hook-dependent abilities. */
+	useAbilitiesSetup?: AbilitiesSetupHook;
 }
 
 export default function AgentDock( {
@@ -71,7 +71,7 @@ export default function AgentDock( {
 	markdownComponents = {},
 	markdownExtensions = {},
 	useNavigationContinuation,
-	setupHooks,
+	useAbilitiesSetup,
 }: AgentDockProps ) {
 	const { setIsOpen } = useDispatch( AGENTS_MANAGER_STORE );
 	const { hasLoaded: isStoreReady, isOpen = false } = useSelect( ( select ) => {
@@ -138,9 +138,9 @@ export default function AgentDock( {
 		navigate,
 	} );
 
-	// Call all setup hooks to register hook-dependent abilities
-	// These hooks are stable after loadedProviders is set (AgentDock only renders after providers load)
-	setupHooks?.forEach( ( hook ) => hook() );
+	// Call setup hook to register hook-dependent abilities
+	// The hook is stable after loadedProviders is set (AgentDock only renders after providers load)
+	useAbilitiesSetup?.();
 
 	const handleNewChat = () => {
 		navigate( '/' );

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -140,15 +140,7 @@ export default function AgentDock( {
 
 	// Call all setup hooks to register hook-dependent abilities
 	// These hooks are stable after loadedProviders is set (AgentDock only renders after providers load)
-	if ( setupHooks?.length ) {
-		// eslint-disable-next-line no-console
-		console.log( `[AgentDock] Calling ${ setupHooks.length } setup hook(s)` );
-		setupHooks.forEach( ( hook, index ) => {
-			// eslint-disable-next-line no-console
-			console.log( `[AgentDock] Calling setup hook ${ index + 1 }/${ setupHooks.length }` );
-			hook();
-		} );
-	}
+	setupHooks?.forEach( ( hook ) => hook() );
 
 	const handleNewChat = () => {
 		navigate( '/' );

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -2,7 +2,6 @@ import {
 	getAgentManager,
 	useAgentChat,
 	type UseAgentChatConfig,
-	type SubmitOptions,
 } from '@automattic/agenttic-client';
 import {
 	type MarkdownComponents,
@@ -24,22 +23,11 @@ import AgentHistory from '../agent-history';
 import { type Options as ChatHeaderOptions } from '../chat-header';
 import SupportGuide from '../support-guide';
 import SupportGuides from '../support-guides';
+import type {
+	NavigationContinuationHook,
+	AbilitiesSetupHook,
+} from '../../utils/load-external-providers';
 import type { AgentsManagerSelect, HelpCenterSite } from '@automattic/data-stores';
-
-/**
- * Navigation continuation hook type
- */
-type NavigationContinuationHook = ( props: {
-	isProcessing: boolean;
-	onSubmit: ( message: string, options?: SubmitOptions ) => Promise< void >;
-	sessionId: string;
-	agentId: string;
-} ) => void;
-
-/**
- * Abilities setup hook type - registers hook-dependent abilities
- */
-type AbilitiesSetupHook = () => void;
 
 interface AgentDockProps {
 	/** The selected site object. */

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -36,6 +36,11 @@ type NavigationContinuationHook = ( props: {
 	agentId: string;
 } ) => void;
 
+/**
+ * Abilities setup hook type - registers hook-dependent abilities
+ */
+type AbilitiesSetupHook = () => void;
+
 interface AgentDockProps {
 	/** The selected site object. */
 	site?: HelpCenterSite | null;
@@ -53,6 +58,8 @@ interface AgentDockProps {
 	markdownExtensions?: MarkdownExtensions;
 	/** Navigation continuation hook for post-navigation conversation resumption. */
 	useNavigationContinuation?: NavigationContinuationHook;
+	/** Setup hooks to register hook-dependent abilities (collected from all providers). */
+	setupHooks?: AbilitiesSetupHook[];
 }
 
 export default function AgentDock( {
@@ -64,6 +71,7 @@ export default function AgentDock( {
 	markdownComponents = {},
 	markdownExtensions = {},
 	useNavigationContinuation,
+	setupHooks,
 }: AgentDockProps ) {
 	const { setIsOpen } = useDispatch( AGENTS_MANAGER_STORE );
 	const { hasLoaded: isStoreReady, isOpen = false } = useSelect( ( select ) => {
@@ -129,6 +137,18 @@ export default function AgentDock( {
 		setIsOpen,
 		navigate,
 	} );
+
+	// Call all setup hooks to register hook-dependent abilities
+	// These hooks are stable after loadedProviders is set (AgentDock only renders after providers load)
+	if ( setupHooks?.length ) {
+		// eslint-disable-next-line no-console
+		console.log( `[AgentDock] Calling ${ setupHooks.length } setup hook(s)` );
+		setupHooks.forEach( ( hook, index ) => {
+			// eslint-disable-next-line no-console
+			console.log( `[AgentDock] Calling setup hook ${ index + 1 }/${ setupHooks.length }` );
+			hook();
+		} );
+	}
 
 	const handleNewChat = () => {
 		navigate( '/' );

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -232,6 +232,7 @@ function AgentSetup( {
 			markdownComponents={ loadedProviders.markdownComponents || {} }
 			markdownExtensions={ loadedProviders.markdownExtensions || {} }
 			useNavigationContinuation={ loadedProviders.useNavigationContinuation }
+			setupHooks={ loadedProviders.setupHooks }
 		/>
 	);
 }

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -232,7 +232,7 @@ function AgentSetup( {
 			markdownComponents={ loadedProviders.markdownComponents || {} }
 			markdownExtensions={ loadedProviders.markdownExtensions || {} }
 			useNavigationContinuation={ loadedProviders.useNavigationContinuation }
-			setupHooks={ loadedProviders.setupHooks }
+			useAbilitiesSetup={ loadedProviders.useAbilitiesSetup }
 		/>
 	);
 }

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -105,18 +105,10 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			// Collect setup hooks from all providers (multiple plugins can register abilities)
 			if ( module.useAbilitiesSetup ) {
 				setupHooks.push( module.useAbilitiesSetup );
-				// eslint-disable-next-line no-console
-				console.log( `[AgentsManager] Collected useAbilitiesSetup hook from "${ moduleId }"` );
 			}
 
 			// eslint-disable-next-line no-console
-			console.log( `[AgentsManager] Loaded provider "${ moduleId }"`, {
-				hasToolProvider: !! module.toolProvider,
-				hasContextProvider: !! module.contextProvider,
-				hasSuggestions: !! module.suggestions,
-				hasNavigationContinuation: !! module.useNavigationContinuation,
-				hasAbilitiesSetup: !! module.useAbilitiesSetup,
-			} );
+			console.log( `[AgentsManager] Loaded provider "${ moduleId }"` );
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.warn( `[AgentsManager] Failed to load provider "${ moduleId }":`, error );

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -36,6 +36,13 @@ export type NavigationContinuationHook = ( props: {
 	agentId: string;
 } ) => void;
 
+/**
+ * Abilities setup hook type - provided by environments that need to register
+ * hook-dependent abilities (abilities that require React context to work).
+ * Called from AgentDock component to provide React context.
+ */
+export type AbilitiesSetupHook = () => void;
+
 export interface LoadedProviders {
 	toolProvider?: ToolProvider;
 	contextProvider?: ContextProvider;
@@ -43,6 +50,8 @@ export interface LoadedProviders {
 	markdownComponents?: MarkdownComponents;
 	markdownExtensions?: MarkdownExtensions;
 	useNavigationContinuation?: NavigationContinuationHook;
+	/** Setup hooks collected from all providers (called to register hook-dependent abilities) */
+	setupHooks?: AbilitiesSetupHook[];
 }
 
 /**
@@ -66,6 +75,8 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	let mergedMarkdownComponents: MarkdownComponents | undefined;
 	let mergedMarkdownExtensions: MarkdownExtensions | undefined;
 	let mergedNavigationContinuation: NavigationContinuationHook | undefined;
+	// Setup hooks are collected from all providers (not last-wins)
+	const setupHooks: AbilitiesSetupHook[] = [];
 
 	for ( const moduleId of agentProviders ) {
 		try {
@@ -91,9 +102,21 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			if ( module.useNavigationContinuation ) {
 				mergedNavigationContinuation = module.useNavigationContinuation;
 			}
+			// Collect setup hooks from all providers (multiple plugins can register abilities)
+			if ( module.useAbilitiesSetup ) {
+				setupHooks.push( module.useAbilitiesSetup );
+				// eslint-disable-next-line no-console
+				console.log( `[AgentsManager] Collected useAbilitiesSetup hook from "${ moduleId }"` );
+			}
 
 			// eslint-disable-next-line no-console
-			console.log( `[AgentsManager] Loaded provider "${ moduleId }"` );
+			console.log( `[AgentsManager] Loaded provider "${ moduleId }"`, {
+				hasToolProvider: !! module.toolProvider,
+				hasContextProvider: !! module.contextProvider,
+				hasSuggestions: !! module.suggestions,
+				hasNavigationContinuation: !! module.useNavigationContinuation,
+				hasAbilitiesSetup: !! module.useAbilitiesSetup,
+			} );
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.warn( `[AgentsManager] Failed to load provider "${ moduleId }":`, error );
@@ -107,5 +130,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		markdownComponents: mergedMarkdownComponents,
 		markdownExtensions: mergedMarkdownExtensions,
 		useNavigationContinuation: mergedNavigationContinuation,
+		setupHooks: setupHooks.length > 0 ? setupHooks : undefined,
 	};
 }

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -50,8 +50,7 @@ export interface LoadedProviders {
 	markdownComponents?: MarkdownComponents;
 	markdownExtensions?: MarkdownExtensions;
 	useNavigationContinuation?: NavigationContinuationHook;
-	/** Setup hooks collected from all providers (called to register hook-dependent abilities) */
-	setupHooks?: AbilitiesSetupHook[];
+	useAbilitiesSetup?: AbilitiesSetupHook;
 }
 
 /**
@@ -75,8 +74,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	let mergedMarkdownComponents: MarkdownComponents | undefined;
 	let mergedMarkdownExtensions: MarkdownExtensions | undefined;
 	let mergedNavigationContinuation: NavigationContinuationHook | undefined;
-	// Setup hooks are collected from all providers (not last-wins)
-	const setupHooks: AbilitiesSetupHook[] = [];
+	let mergedAbilitiesSetup: AbilitiesSetupHook | undefined;
 
 	for ( const moduleId of agentProviders ) {
 		try {
@@ -102,9 +100,8 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			if ( module.useNavigationContinuation ) {
 				mergedNavigationContinuation = module.useNavigationContinuation;
 			}
-			// Collect setup hooks from all providers (multiple plugins can register abilities)
 			if ( module.useAbilitiesSetup ) {
-				setupHooks.push( module.useAbilitiesSetup );
+				mergedAbilitiesSetup = module.useAbilitiesSetup;
 			}
 
 			// eslint-disable-next-line no-console
@@ -122,6 +119,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		markdownComponents: mergedMarkdownComponents,
 		markdownExtensions: mergedMarkdownExtensions,
 		useNavigationContinuation: mergedNavigationContinuation,
-		setupHooks: setupHooks.length > 0 ? setupHooks : undefined,
+		useAbilitiesSetup: mergedAbilitiesSetup,
 	};
 }


### PR DESCRIPTION
Part of BSKY-1463

## Proposed Changes

Enable external agent providers to register hook-dependent abilities by collecting and calling setup hooks from the AgentDock component.

**Changes:**
- `load-external-providers.ts`: Collect `useAbilitiesSetup` from all providers into `setupHooks` array
- `unified-ai-agent/index.tsx`: Pass `setupHooks` to AgentDock
- `agent-dock/index.tsx`: Call all setup hooks to register abilities

Unlike other provider properties (which use last-wins semantics), setupHooks are **collected** from ALL providers, allowing multiple plugins to register their own hook-dependent abilities.

**Why this is needed:**
Big Sky has abilities that require React hooks (`useSelect`, `useDispatch`) to access WordPress data stores. These can't be registered from a plain module - they need to be called from a React component context. This PR enables Help Center to call those hooks.

**Related PR:**
- big-sky-plugin: Automattic/big-sky-plugin#5301

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TBD – see Automattic/big-sky-plugin#5301

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
