### PR TITLE
Fix jp test

### DIFF
--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -104,7 +104,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await socialConnectionsManager.clearIntercepts();
 			} );
 
-			test( 'Should verify that auto-sharing is available for new posts', async function () {
+			it( 'Should verify that auto-sharing is available for new posts', async function () {
 				await socialConnectionsManager.mockSocialConnections();
 
 				await Promise.all( [
@@ -130,7 +130,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				expect( await mediaButton.isVisible() ).toBe( features.mediaSharing );
 			} );
 
-			test( `Should verify that resharing ${
+			it( `Should verify that resharing ${
 				features.resharing ? 'IS' : 'is NOT'
 			} available`, async function () {
 				let connectionTestPromise = Promise.resolve();
@@ -214,10 +214,9 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 
 				// Verify whether the upgrade nudge/link is visible.
 				if ( ! features.resharing ) {
-					const upgradeLink = section.getByRole( 'link', { name: 'Upgrade now' } );
-					// The upgrade CTA is a button instead of a link until some API call finishes to get the checkout URL, which makes it a link.
-					// So, we need to wait for the link to appear.
-					await upgradeLink.waitFor();
+					const upgradeButton = section.getByRole( 'button', { name: 'Upgrade now' } );
+					// Wait for the upgrade button to appear.
+					await upgradeButton.waitFor();
 				}
 
 				const content = await section.textContent();
@@ -227,7 +226,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				expect( content?.includes( message ) ).toBe( ! features.resharing );
 			} );
 
-			test( `Should verify that manual sharing ${
+			it( `Should verify that manual sharing ${
 				features.manualSharing ? 'IS' : 'is NOT'
 			} available`, async function () {
 				// Open the Jetpack sidebar.
@@ -268,7 +267,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				expect( await manualSharing.isVisible() ).toBe( features.manualSharing );
 			} );
 
-			test( `Should verify that Social Image Generator ${
+			it( `Should verify that Social Image Generator ${
 				features.socialImageGenerator ? 'IS' : 'is NOT'
 			} available`, async function () {
 				await socialConnectionsManager.mockSocialConnections();


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix failing e2e

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
