### PR TITLE
Plugins Dashboard: Show plugin name even if user doesn't have it installed on any site

### DIFF
--- a/client/dashboard/plugins/plugin/index.tsx
+++ b/client/dashboard/plugins/plugin/index.tsx
@@ -1,4 +1,4 @@
-import { type PluginItem, Site } from '@automattic/api-core';
+import { MarketplacePlugin, type PluginItem, Site, WpOrgPlugin } from '@automattic/api-core';
 import { privateApis } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
@@ -22,7 +22,7 @@ type PluginTabsProps = {
 	isLoading: boolean;
 	sitesWithThisPlugin: SiteWithPluginData[];
 	sitesWithoutThisPlugin: Site[];
-	plugin: PluginItem | undefined;
+	plugin: PluginItem | MarketplacePlugin | WpOrgPlugin | undefined;
 	pluginName?: string;
 	pluginBySiteId: Map< number, PluginItem >;
 };
@@ -89,7 +89,8 @@ export function PluginTabs( {
 				<SitesWithThisPlugin
 					pluginSlug={ pluginSlug }
 					isLoading={ isLoading }
-					plugin={ plugin }
+					// plugin will only be MarketplacePlugin | WpOrgPlugin when there are no sites with it installed
+					plugin={ plugin as PluginItem | undefined }
 					pluginBySiteId={ pluginBySiteId }
 					setOptimisticDelete={ setOptimisticDelete }
 					sitesWithThisPlugin={ sitesWithThisPluginExcludingDeleted }

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -84,9 +84,14 @@ export const usePlugin = ( pluginSlug: string ) => {
 
 	const siteIdsWithThisPlugin = Array.from( pluginBySiteId.keys() );
 
-	const pluginData = pluginBySiteId.size
-		? pluginBySiteId.get( siteIdsWithThisPlugin[ 0 ] )
-		: undefined;
+	let pluginData;
+	if ( pluginBySiteId.size ) {
+		pluginData = pluginBySiteId.get( siteIdsWithThisPlugin[ 0 ] );
+	} else if ( isMarketplacePlugin ) {
+		pluginData = marketplacePlugins?.results[ pluginSlug ];
+	} else if ( wpOrgPlugin ) {
+		pluginData = wpOrgPlugin;
+	}
 
 	const [ sitesWithThisPlugin, sitesWithoutThisPlugin ]: [ SiteWithPluginData[], Site[] ] = sites
 		? sites

--- a/client/dashboard/plugins/plugin/utils/map-to-plugin-list-row.ts
+++ b/client/dashboard/plugins/plugin/utils/map-to-plugin-list-row.ts
@@ -1,8 +1,9 @@
-import { SiteWithPluginData, usePlugin } from '../use-plugin';
+import { PluginItem } from '@automattic/api-core';
+import { SiteWithPluginData } from '../use-plugin';
 import type { PluginListRow } from '../../manage/types';
 
 export const mapToPluginListRow = (
-	plugin: ReturnType< typeof usePlugin >[ 'plugin' ],
+	plugin: PluginItem | undefined,
 	items: SiteWithPluginData[]
 ): Partial< PluginListRow > => {
 	return {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-15563

## Proposed Changes

* Get the plugin data from wporg/marketplace if it's not amongst the user's plugins

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users can see a `Plugin not found` message if they don't have it installed on any site:

<img width="3674" height="1605" alt="image" src="https://github.com/user-attachments/assets/dced2ee1-d8c9-4cb4-ae73-27da2fb772dd" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview 
* Go to `/v2/plugins/manage/aino-blocks` (or another plugin slug that you don't have installed on any sites)
* Check that the plugin name is shown

<img width="3674" height="1605" alt="image" src="https://github.com/user-attachments/assets/107c391c-73b9-4a82-b4e5-201ae07b4d04" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
