### PR TITLE
Plugins Dashboard: Get rid of enigmatic `onSuccess` function

### DIFF
--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -61,8 +61,8 @@ export const SitesWithThisPlugin = ( {
 	setOptimisticDelete,
 	sitesWithThisPlugin,
 }: SitesWithThisPluginProps ) => {
-	const { mutateAsync } = useMutation( sitePluginUpdateMutation() );
-	const updateAction = buildBulkSitesPluginAction( mutateAsync );
+	const { mutateAsync: updateMutate } = useMutation( sitePluginUpdateMutation() );
+	const updateAction = buildBulkSitesPluginAction( updateMutate );
 	const [ view, setView ] = useState< View >( defaultView );
 	const { mutateAsync: activateMutate } = useMutation( sitePluginActivateMutation() );
 	const { mutateAsync: deactivateMutate } = useMutation( sitePluginDeactivateMutation() );

--- a/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-with-this-plugin.tsx
@@ -402,18 +402,13 @@ export const SitesWithThisPlugin = ( {
 						label: __( 'Delete' ),
 						modalHeader: getModalHeader( 'delete' ),
 						RenderModal: ( { items, closeModal } ) => {
-							const { mutateAsync: deactivate } = useMutation( {
-								...sitePluginDeactivateMutation(),
-								onSuccess: () => {},
-							} );
-							const { mutateAsync: disableAutoupdate } = useMutation( {
-								...sitePluginAutoupdateDisableMutation(),
-								onSuccess: () => {},
-							} );
-							const { mutateAsync: remove } = useMutation( {
-								...sitePluginRemoveMutation(),
-								onSuccess: () => {},
-							} );
+							const { mutateAsync: deactivate } = useMutation(
+								sitePluginDeactivateMutation( false )
+							);
+							const { mutateAsync: disableAutoupdate } = useMutation(
+								sitePluginAutoupdateDisableMutation( false )
+							);
+							const { mutateAsync: remove } = useMutation( sitePluginRemoveMutation( false ) );
 
 							const action = async ( items: PluginListRow[] ) => {
 								const bulkDeactivate = buildBulkSitesPluginAction( deactivate );

--- a/packages/api-queries/src/site-plugins.ts
+++ b/packages/api-queries/src/site-plugins.ts
@@ -65,11 +65,15 @@ export const sitePluginActivateMutation = () =>
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidatePluginsForSite( vars.siteId ),
 	} );
 
-export const sitePluginDeactivateMutation = () =>
+export const sitePluginDeactivateMutation = ( invalidateQueriesOnSuccess = true ) =>
 	mutationOptions( {
 		mutationFn: ( vars: { siteId: number; pluginId: string } ) =>
 			deactivateSitePlugin( vars.siteId, vars.pluginId ),
-		onSuccess: ( _data, vars: { siteId: number } ) => invalidatePluginsForSite( vars.siteId ),
+		onSuccess: ( _data, vars: { siteId: number } ) => {
+			if ( invalidateQueriesOnSuccess ) {
+				invalidatePluginsForSite( vars.siteId );
+			}
+		},
 	} );
 
 export const sitePluginUpdateMutation = () =>
@@ -86,11 +90,15 @@ export const sitePluginAutoupdateEnableMutation = () =>
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidatePluginsForSite( vars.siteId ),
 	} );
 
-export const sitePluginAutoupdateDisableMutation = () =>
+export const sitePluginAutoupdateDisableMutation = ( invalidateQueriesOnSuccess = true ) =>
 	mutationOptions( {
 		mutationFn: ( vars: { siteId: number; pluginId: string } ) =>
 			disableSitePluginAutoupdate( vars.siteId, vars.pluginId ),
-		onSuccess: ( _data, vars: { siteId: number } ) => invalidatePluginsForSite( vars.siteId ),
+		onSuccess: ( _data, vars: { siteId: number } ) => {
+			if ( invalidateQueriesOnSuccess ) {
+				invalidatePluginsForSite( vars.siteId );
+			}
+		},
 	} );
 
 export const sitePluginInstallMutation = () =>
@@ -100,9 +108,13 @@ export const sitePluginInstallMutation = () =>
 		onSuccess: ( _data, vars: { siteId: number } ) => invalidatePluginsForSite( vars.siteId ),
 	} );
 
-export const sitePluginRemoveMutation = () =>
+export const sitePluginRemoveMutation = ( invalidateQueriesOnSuccess = true ) =>
 	mutationOptions( {
 		mutationFn: ( vars: { siteId: number; pluginId: string } ) =>
 			removeSitePlugin( vars.siteId, vars.pluginId ),
-		onSuccess: ( _data, vars: { siteId: number } ) => invalidatePluginsForSite( vars.siteId ),
+		onSuccess: ( _data, vars: { siteId: number } ) => {
+			if ( invalidateQueriesOnSuccess ) {
+				invalidatePluginsForSite( vars.siteId );
+			}
+		},
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-15564

## Proposed Changes

* We need some of the plugin mutation queries to not run query invalidation after each call in order to not trigger an unnecessary amount of refetch queries, since the invalidation is done after all the mutations. Instead of having a noop `onSuccess` param, it's better to set `invalidateQueriesOnSuccess` as an argument on the mutation functions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve code readability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just check the code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
