### PR TITLE
Add logic to close the survey when user click in the overlay

### DIFF
--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -114,3 +114,35 @@ export function addSurvicate() {
 
 	survicateScriptLoaded = true;
 }
+
+/**
+ * Triggers the Help Center feedback survey and ensures the Survicate overlay
+ * closes when the user clicks outside the modal.
+ * This is needed as the Survicate overlay click doesn't close correctly.
+ * See: https://a8c.slack.com/archives/C04H4NY6STW/p1766088738895199?thread_ts=1765290523.386849&cid=C04H4NY6STW
+ */
+export function showHelpCenterFeedbackSurvey() {
+	const survicate = window._sva;
+
+	if ( ! survicate?.invokeEvent ) {
+		return;
+	}
+
+	const handleSurveyDisplayed = () => {
+		const overlay = document.querySelector( '.sv__overlay.sv__overlay--dark' );
+
+		if ( ! overlay ) {
+			return;
+		}
+
+		const handleOverlayClick = () => {
+			survicate.destroyVisitor?.();
+		};
+
+		overlay.addEventListener( 'click', handleOverlayClick, { once: true } );
+		survicate.removeEventListener?.( 'survey_displayed', handleSurveyDisplayed );
+	};
+
+	survicate.addEventListener?.( 'survey_displayed', handleSurveyDisplayed );
+	survicate.invokeEvent( 'showFeedbackSurveyFromHelpCenter' );
+}

--- a/client/lib/analytics/survicate.js
+++ b/client/lib/analytics/survicate.js
@@ -129,7 +129,7 @@ export function showHelpCenterFeedbackSurvey() {
 	}
 
 	const handleSurveyDisplayed = () => {
-		const overlay = document.querySelector( '.sv__overlay.sv__overlay--dark' );
+		const overlay = document.querySelector( '#survicate-box .sv__overlay' );
 
 		if ( ! overlay ) {
 			return;

--- a/config/development.json
+++ b/config/development.json
@@ -18,7 +18,6 @@
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
 	"survicate_enabled": true,
-	"survicate_enabled_at_help_center": true,
 	"wpcom_url": "http://calypso.localhost:3000",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -150,6 +150,5 @@
 	"boom_analytics_key": "horizon",
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
-	"survicate_enabled": true,
-	"survicate_enabled_at_help_center": true
+	"survicate_enabled": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -185,6 +185,5 @@
 	"boom_analytics_key": "production",
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
-	"survicate_enabled": true,
-	"survicate_enabled_at_help_center": true
+	"survicate_enabled": true
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -188,6 +188,5 @@
 	"boom_analytics_key": "wpcalypso",
 	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
-	"survicate_enabled": true,
-	"survicate_enabled_at_help_center": true
+	"survicate_enabled": true
 }

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -66,6 +66,28 @@ export const HelpCenterMoreResources = () => {
 									onClick={ () => {
 										trackMoreResourcesButtonClick( 'feedback-survey' );
 										window._sva?.invokeEvent?.( 'showFeedbackSurveyFromHelpCenter' );
+
+										// Survicate overlay click doesn't close automatically, so we need to destroy the visitor to close the survey
+										const handleSurveyDisplayed = () => {
+											const overlay = document.querySelector( '.sv__overlay.sv__overlay--dark' );
+											if ( ! overlay ) {
+												return;
+											}
+
+											const handleOverlayClick = () => {
+												window._sva?.destroyVisitor?.();
+											};
+
+											overlay.addEventListener( 'click', handleOverlayClick, {
+												once: true,
+											} );
+											window._sva?.removeEventListener?.(
+												'survey_displayed',
+												handleSurveyDisplayed
+											);
+										};
+
+										window._sva?.addEventListener?.( 'survey_displayed', handleSurveyDisplayed );
 									} }
 									className="help-center-more-resources__survicate"
 								>

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -5,6 +5,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { backup, chevronRight, external, Icon, rss, thumbsUp, video } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useNavigate } from 'react-router-dom';
+import { showHelpCenterFeedbackSurvey } from 'calypso/lib/analytics/survicate';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 
 import './help-center-more-resources.scss';
@@ -65,29 +66,7 @@ export const HelpCenterMoreResources = () => {
 									type="button"
 									onClick={ () => {
 										trackMoreResourcesButtonClick( 'feedback-survey' );
-										window._sva?.invokeEvent?.( 'showFeedbackSurveyFromHelpCenter' );
-
-										// Survicate overlay click doesn't close automatically, so we need to destroy the visitor to close the survey
-										const handleSurveyDisplayed = () => {
-											const overlay = document.querySelector( '.sv__overlay.sv__overlay--dark' );
-											if ( ! overlay ) {
-												return;
-											}
-
-											const handleOverlayClick = () => {
-												window._sva?.destroyVisitor?.();
-											};
-
-											overlay.addEventListener( 'click', handleOverlayClick, {
-												once: true,
-											} );
-											window._sva?.removeEventListener?.(
-												'survey_displayed',
-												handleSurveyDisplayed
-											);
-										};
-
-										window._sva?.addEventListener?.( 'survey_displayed', handleSurveyDisplayed );
+										showHelpCenterFeedbackSurvey();
 									} }
 									className="help-center-more-resources__survicate"
 								>

--- a/packages/help-center/src/components/types.d.ts
+++ b/packages/help-center/src/components/types.d.ts
@@ -10,15 +10,6 @@ interface Window {
 	) => void;
 	_sva?: {
 		invokeEvent?: ( eventName: string ) => void;
-		addEventListener?: (
-			eventName: string,
-			callback: ( surveyId: string, surveyName: string ) => void
-		) => void;
-		removeEventListener?: (
-			eventName: string,
-			callback: ( surveyId: string, surveyName: string ) => void
-		) => void;
-		destroyVisitor?: () => void;
 	};
 }
 

--- a/packages/help-center/src/components/types.d.ts
+++ b/packages/help-center/src/components/types.d.ts
@@ -10,6 +10,15 @@ interface Window {
 	) => void;
 	_sva?: {
 		invokeEvent?: ( eventName: string ) => void;
+		addEventListener?: (
+			eventName: string,
+			callback: ( surveyId: string, surveyName: string ) => void
+		) => void;
+		removeEventListener?: (
+			eventName: string,
+			callback: ( surveyId: string, surveyName: string ) => void
+		) => void;
+		destroyVisitor?: () => void;
 	};
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/107757

## Proposed Changes


#### Before

https://github.com/user-attachments/assets/149b780d-e6be-4865-8958-34f7b5e76787

#### After

https://github.com/user-attachments/assets/b8f4c77f-8211-40dd-a84e-3b1dd311bcda


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want that users have a great UX when using Survicate overlay close on Dotcom

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the survey closes after the first click in the ovelay

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
