### PR TITLE
Enable "survicate_enabled_at_help_center" feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -193,6 +193,7 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": true,
 		"subscriber-importer": true,
+		"survicate_enabled_at_help_center": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -121,6 +121,7 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
+		"survicate_enabled_at_help_center": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -157,6 +157,7 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
+		"survicate_enabled_at_help_center": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -160,6 +160,7 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
+		"survicate_enabled_at_help_center": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,


### PR DESCRIPTION
Related to #107757

## Proposed Changes

This PR enables the `survicate_enabled_at_help_center` feature flag in all Calypso environments.

## Why are these changes being made?

The feature flag wasn't enabled in #107757.

## Testing Instructions

- Code inspection
- Open a site dashboard in Calypso, open the help center and ensure the "Share feedback" option is there:

<img width="1469" height="1127" alt="Screenshot 2025-12-18 at 19 26 54" src="https://github.com/user-attachments/assets/68c9eb22-dcbe-47fa-a305-6947922f6f7d" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
