### PR TITLE
Fix people URLs in multi-site dashboard

### DIFF
--- a/client/dashboard/components/logs-activity-formatted-block/index.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/index.tsx
@@ -16,6 +16,7 @@
 import { Fragment, type MouseEvent, type ReactNode } from 'react';
 import isA8CForAgencies from '../../../lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from '../../../lib/jetpack/is-jetpack-cloud';
+import { wpcomLink } from '../../utils/link';
 import type { ActivityBlockContent, ActivityBlockNode, ActivityBlockMeta } from './types';
 
 type BlockClickHandler = ( event: MouseEvent< HTMLAnchorElement > ) => void;
@@ -146,7 +147,7 @@ const Person: BlockRenderer = ( { content, children, onClick, meta } ) => {
 
 	return (
 		<a
-			href={ `/people/edit/${ siteId }/${ name }` }
+			href={ wpcomLink( `/people/edit/${ siteId }/${ name }` ) }
 			onClick={ onClick }
 			data-activity={ activity ?? meta.activity }
 			data-section={ section ?? meta.section ?? 'users' }

--- a/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
@@ -257,7 +257,7 @@ describe( 'Person blocks', () => {
 		} );
 
 		const link = screen.getByRole( 'link' );
-		expect( link ).toHaveAttribute( 'href', '/people/edit/site_id/tony' );
+		expect( link ).toHaveAttribute( 'href', 'https://wordpress.com/people/edit/site_id/tony' );
 		expect( link.querySelector( 'strong' ) ).toHaveTextContent( 'Tony Stark' );
 	} );
 

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -26,6 +26,7 @@ import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
+import { wpcomLink } from '../../utils/link';
 import type { Field } from '@wordpress/dataviews';
 
 export type TransferFormData = {
@@ -155,7 +156,7 @@ export default function TransferDomainToOtherUser() {
 							'You can transfer this domain to any administrator on this site. If the user you want to transfer is not currently an administrator, please <link>add them to the site first</link>.'
 						),
 						{
-							link: <a href={ `/people/new/${ domain.site_slug }` } />,
+							link: <a href={ wpcomLink( `/people/new/${ domain.site_slug }` ) } />,
 						}
 					) }
 				</Text>
@@ -179,7 +180,7 @@ export default function TransferDomainToOtherUser() {
 							'You can transfer this domain connection to any administrator on this site. If the user you want to transfer is not currently an administrator, please <link>add them to the site first</link>.'
 						),
 						{
-							link: <a href={ `/people/new/${ domain.site_slug }` } />,
+							link: <a href={ wpcomLink( `/people/new/${ domain.site_slug }` ) } />,
 						}
 					) }
 				</Text>


### PR DESCRIPTION
## Proposed Changes

* Wrap people page URLs with wpcomLink() in dashboard components

## Why are these changes being made?

With `my.wordpress.com` the links to `/people/...` would be broken because they should go to `wordpress.com/people/...`

## Testing Instructions

1. Navigate to Dashboard > Activity Logs
2. Find activity with user mention
3. Click user link - should navigate to people editor on wordpress.com
4. Go to Dashboard > Domains > Transfer domain
5. Click "add them to the site first" link - should navigate to add people page on wordpress.com

### Edge Cases
* Test in both dev (my.localhost:3000) and production environments

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?