### PR TITLE
A4A: Never use selectedSite for cart key in A4A checkout

### DIFF
--- a/client/my-sites/checkout/use-cart-key.ts
+++ b/client/my-sites/checkout/use-cart-key.ts
@@ -1,4 +1,5 @@
 import { useDebugValue } from 'react';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -21,6 +22,10 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 		currentUrlPath.includes( '/checkout/marketplace' ) && isLoggedOutCart;
 	const isUnifiedSitelessCheckout =
 		currentUrlPath.includes( '/checkout/unified' ) && isLoggedOutCart;
+	const isA4ASitelessCheckout =
+		isA8CForAgencies() &&
+		( currentUrlPath.includes( '/marketplace/checkout' ) ||
+			currentUrlPath.includes( '/client/checkout' ) );
 	const isNoSiteCart =
 		isJetpackCheckout ||
 		isAkismetSitelessCheckout ||
@@ -31,7 +36,7 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 			'no-user' === searchParams.get( 'cart' ) );
 
 	const cartKey = getCartKey( {
-		selectedSite,
+		selectedSite: isA4ASitelessCheckout ? null : selectedSite,
 		isLoggedOutCart,
 		isNoSiteCart,
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Linear issue: https://linear.app/a8c/issue/A4A-1818/cart-is-empty-after-adding-products
See Slack: p1766097914363859/1765540683.730759-slack-C09C81TQAPJ

## Proposed Changes

* When getting the cart key for a4a, never use the site slug. This force `no-site` for the cart key, which is ok for a4a (for now).
* Note: we'll probably need to figure something out for the [dev site checkout flow,](https://linear.app/a8c/issue/A4A-1611/implement-dev-site-purchase-flow-for-agencies) which is not siteless and so needs a real site id as the cart key. For now this hopefully fixes the immediate issue.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We've had an intermittent issue where the cart appears as empty when it shouldn't.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/marketplace/products?site_id=251079079` (replace the site id with one of your own - I tested with a JN site)
* In the marketplace add a wpcom site to the cart and visit checkout
* The checkout should load with products and not be empty
  * Also test on trunk to see if you can confirm an empty cart loads in this situation

<img width="1287" height="755" alt="Screenshot 2025-12-18 at 3 49 04 PM" src="https://github.com/user-attachments/assets/c671ffa9-37c7-4839-81ea-83fb9f50b2de" />

**BEFORE**
<img width="1293" height="662" alt="Screenshot 2025-12-18 at 3 49 54 PM" src="https://github.com/user-attachments/assets/572183a7-0b30-4666-a6e0-b2b430daf886" />

**AFTER**
<img width="1278" height="752" alt="Screenshot 2025-12-18 at 3 49 15 PM" src="https://github.com/user-attachments/assets/6741c92a-17c9-42a6-a35e-96d9e2fed0dd" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?