### PR TITLE
MSD: Update site_name for Dashboard environments

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -11,7 +11,6 @@
 	"wpcom_url": "http://calypso.localhost:3000",
 	"wpcom_login_url": "https://wordpress.com/log-in",
 	"logout_url": "https://|subdomain|wordpress.com",
-	"site_name": "Hosting Dashboard",
 	"features": {
 		"always_use_logout_url": true,
 		"ciab/allow-domain-features": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -9,7 +9,6 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"wpcom_url": "https://wpcalypso.wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
-	"site_name": "Hosting Dashboard",
 	"features": {
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -9,7 +9,6 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"wpcom_url": "https://wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
-	"site_name": "Hosting Dashboard",
 	"features": {
 		"ciab/allow-domain-features": true,
 		"cookie-banner": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -9,7 +9,6 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"wpcom_url": "https://wordpress.com",
 	"wpcom_login_url": "https://wordpress.com/log-in",
-	"site_name": "Hosting Dashboard",
 	"features": {
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,


### PR DESCRIPTION
## Proposed Changes

Displaying "Hosting Dashboard" seems redundant, should be just "WordPress.com".

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
