### PR TITLE
MSD: fix link for Delete domain button

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -5,7 +5,7 @@ import {
 	removePurchaseMutation,
 	purchaseQuery,
 } from '@automattic/api-queries';
-import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
 	Button,
@@ -19,6 +19,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useState } from 'react';
 import { useAuth } from '../../app/auth';
 import { domainRoute, domainsIndexRoute, domainTransferRoute } from '../../app/router/domains';
+import { purchaseSettingsRoute, cancelPurchaseRoute } from '../../app/router/me';
 import { ActionList } from '../../components/action-list';
 import InlineSupportLink from '../../components/inline-support-link';
 import RemoveDomainDialog from '../../components/purchase-dialogs/remove-domain-dialog';
@@ -41,7 +42,7 @@ export default function Actions() {
 	const { user } = useAuth();
 	const { domainName } = domainRoute.useParams();
 	const { data: domain } = useSuspenseQuery( domainQuery( domainName ) );
-	const { data: purchase } = useQuery(
+	const { data: purchase } = useSuspenseQuery(
 		purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
 	);
 	const { mutate: disconnectDomain, isPending: isDisconnecting } = useMutation(
@@ -90,7 +91,7 @@ export default function Actions() {
 	);
 
 	const availableActions = {
-		renew: purchase?.is_renewable && domain.current_user_is_owner,
+		renew: purchase.is_renewable && domain.current_user_is_owner,
 		transfer: shouldShowTransferAction( domain ),
 		transferIn: shouldShowTransferInAction( domain ),
 		disconnect: shouldShowDisconnectAction( domain ),
@@ -115,7 +116,7 @@ export default function Actions() {
 							<Button
 								size="compact"
 								variant="secondary"
-								href={ getDomainRenewalUrl( domain, purchase! ) }
+								href={ getDomainRenewalUrl( domain, purchase ) }
 							>
 								{ __( 'Renew' ) }
 							</Button>
@@ -181,14 +182,15 @@ export default function Actions() {
 						title={ getDeleteTitle( domain ) }
 						description={ getDeleteDescription( domain ) }
 						actions={
-							<Button
+							<RouterLinkButton
 								size="compact"
 								variant="secondary"
 								isDestructive
-								href={ `/me/purchases/${ purchase?.site_slug }/${ purchase?.ID }` }
+								to={ purchaseSettingsRoute.fullPath }
+								params={ { purchaseId: purchase.ID } }
 							>
 								{ getDeleteLabel( domain ) }
-							</Button>
+							</RouterLinkButton>
 						}
 					/>
 				) }
@@ -197,14 +199,15 @@ export default function Actions() {
 						title={ getDeleteTitle( domain ) }
 						description={ getDeleteDescription( domain ) }
 						actions={
-							<Button
+							<RouterLinkButton
 								size="compact"
 								variant="secondary"
 								isDestructive
-								href={ `/me/purchases/${ purchase?.site_slug }/${ purchase?.ID }/cancel` }
+								to={ cancelPurchaseRoute.fullPath }
+								params={ { purchaseId: purchase.ID } }
 							>
 								{ getDeleteLabel( domain ) }
-							</Button>
+							</RouterLinkButton>
 						}
 					/>
 				) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

Fix this button:

<img width="685" height="110" alt="image" src="https://github.com/user-attachments/assets/9863e0c4-9c2e-4123-9089-94033fc60c8c" />



## Testing Instructions

1. Go to `/v2/domains`
2. Click a custom domain
3. Click the above delete button
4. Verify you see the purchase cancellation page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
