### PR TITLE
MSD Plugins: Make `PluginSwitcher` look more like `DataViews`

### DIFF
--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -14,7 +14,9 @@ import type { View, Field } from '@wordpress/dataviews';
 import type { PropsWithChildren } from 'react';
 
 export default function SwitcherContent< T >( {
+	itemAlignment,
 	itemClassName,
+	itemSpacing,
 	items,
 	searchableFields,
 	searchClassName,
@@ -30,7 +32,9 @@ export default function SwitcherContent< T >( {
 	onClose,
 	onItemClick,
 }: PropsWithChildren< {
+	itemAlignment?: string;
 	itemClassName?: string | ( ( item: T ) => string );
+	itemSpacing?: number;
 	items?: T[];
 	searchClassName?: string;
 	searchableFields: Field< T >[];
@@ -87,7 +91,12 @@ export default function SwitcherContent< T >( {
 							} }
 							resetScroll={ resetScroll }
 						>
-							<HStack justify="flex-start" alignment="center" expanded>
+							<HStack
+								justify="flex-start"
+								alignment={ itemAlignment || 'center' }
+								expanded
+								{ ...( itemSpacing ? { spacing: itemSpacing } : {} ) }
+							>
 								{ renderItemMedia( { item, context: 'list', size: 32 } ) }
 								<VStack spacing={ 0 }>
 									{ renderItemTitle( { item, context: 'list' } ) }

--- a/client/dashboard/plugins/manage/components/plugin-sites.scss
+++ b/client/dashboard/plugins/manage/components/plugin-sites.scss
@@ -1,3 +1,5 @@
+@import './variables.scss';
+
 .plugin-icon-placeholder {
 	width: 32px;
 	height: 32px;
@@ -13,9 +15,7 @@ img.plugin-icon {
 }
 
 .plugin-sites-card-body {
-	// take into account header and nav plus border (64+1), page layout padding (32),
-	// page title/description (80), and gap between title/description and the cards (32)
-	max-height: calc(100vh - 2 * ( 64px + 1px ) - 2 * 32px - 80px - 32px);
+	max-height: $card-height;
 	padding-inline-start: 0;
 	padding-inline-end: 0;
 	overflow-y: auto;

--- a/client/dashboard/plugins/manage/components/plugin-switcher.scss
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.scss
@@ -1,3 +1,5 @@
+@import './variables.scss';
+
 .plugin-icon-wrapper {
 	border-radius: 4px;
 	overflow: clip;
@@ -24,9 +26,7 @@
 }
 
 .plugin-switcher-card-body {
-	// take into account header and nav plus border (64+1), page layout padding (32),
-	// page title/description (80), and gap between title/description and the cards (32)
-	max-height: calc(100vh - 2 * ( 64px + 1px ) - 2 * 32px - 80px - 32px);
+	max-height: $card-height;
 	padding: 8px 0 0;
 	overflow-y: auto;
 }

--- a/client/dashboard/plugins/manage/components/plugin-switcher.scss
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.scss
@@ -1,13 +1,18 @@
 .plugin-icon-wrapper {
 	border-radius: 4px;
+	overflow: clip;
 	position: relative;
-	width: 40px;
-	height: 40px;
+	width: 52px;
+	height: 52px;
 	flex-shrink: 0;
 
 	&.is-fallback {
 		background: #c3c4c7;
 		fill: #fff;
+
+		svg {
+			fill: var(--wp-components-color-foreground, #1e1e1e);
+		}
 	}
 }
 
@@ -22,23 +27,38 @@
 	// take into account header and nav plus border (64+1), page layout padding (32),
 	// page title/description (80), and gap between title/description and the cards (32)
 	max-height: calc(100vh - 2 * ( 64px + 1px ) - 2 * 32px - 80px - 32px);
-	padding-inline-start: 0;
-	padding-inline-end: 0;
+	padding: 8px 0 0;
 	overflow-y: auto;
 }
 
 .plugin-switcher-search {
-	padding: 0 calc(4px * 6) calc(4px * 4);
+	padding: calc(4px * 4) calc(4px * 6);
 	width: fit-content;
 }
 
 .plugin-switcher-item {
 	border-top: 1px solid #f0f0f0;
-	padding: calc(4px * 2.5) calc(4px * 6);
+	padding: calc(4px * 4) calc(4px * 6);
 
-	&.is-selected,
+	&.is-selected {
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
+
+		.plugin-switcher-item-site-count {
+			color: var(--wp-admin-theme-color);
+		}
+	}
+
+	&.is-selected + & {
+		border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
+	}
+
 	&:hover {
 		background-color: #f8f8f8;
+
+		.plugin-switcher-item-site-count {
+			color: var(--wp-admin-theme-color);
+		}
 	}
 
 	&:focus:not(:disabled),
@@ -49,6 +69,8 @@
 }
 
 .plugin-switcher-item-name {
+	color: #2f2f2f;
+	font-weight: 500;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	text-wrap-mode: nowrap;

--- a/client/dashboard/plugins/manage/components/plugin-switcher.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.tsx
@@ -13,8 +13,8 @@ import { PluginListRow } from '../types';
 
 import './plugin-switcher.scss';
 
-const ICON_SIZE = 40;
-const FALLBACK_ICON_SIZE = 30;
+const ICON_SIZE = 52;
+const FALLBACK_ICON_SIZE = 39;
 
 export const PluginSwitcher = ( {
 	pluginsWithIcon,
@@ -116,14 +116,14 @@ export const PluginSwitcher = ( {
 			: '';
 
 		return (
-			<VStack spacing={ 0 }>
+			<VStack spacing={ 1 }>
 				{ /* @ts-expect-error: Can only set one of `children` or `props.dangerouslySetInnerHTML`. */ }
 				<Text
 					className="plugin-switcher-item-name"
 					dangerouslySetInnerHTML={ { __html: item.name } }
 					title={ item.name }
 				/>
-				<Text variant="muted">
+				<Text className="plugin-switcher-item-site-count" variant="muted">
 					{ updatesText ? `${ sitesText }, ${ updatesText }` : sitesText }
 				</Text>
 			</VStack>
@@ -134,7 +134,9 @@ export const PluginSwitcher = ( {
 		<Card>
 			<CardBody className="plugin-switcher-card-body" ref={ scrollRef }>
 				<SwitcherContent
+					itemAlignment="start"
 					itemClassName={ itemClassName }
+					itemSpacing={ 3 }
 					searchClassName="plugin-switcher-search"
 					view={ view }
 					onChangeView={ onChangeView }

--- a/client/dashboard/plugins/manage/components/variables.scss
+++ b/client/dashboard/plugins/manage/components/variables.scss
@@ -1,0 +1,4 @@
+// take into account header and nav plus border (64+1), page layout padding (32),
+// page title/description (80), gap between title/description and the cards (32),
+// and select button border (1)
+$card-height: calc(100vh - 2 * ( 64px + 1px ) - 2 * 32px - 80px - 32px - 1px);

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -143,7 +143,7 @@ export default function PluginsList() {
 			}
 			notices={ <OptInWelcome tracksContext="plugins" /> }
 		>
-			<Grid columns={ 2 } gap={ 6 } templateColumns="392px 1fr">
+			<Grid columns={ 2 } gap={ 3 } templateColumns="392px 1fr">
 				<PluginSwitcher
 					pluginsWithIcon={ pluginsWithIcon }
 					searchableFields={ searchableFields }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-966

## Proposed Changes

* Style `PluginSwitcher` so it looks more like `DataViews`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So it's more consistent with the rest of the dasboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/v2/plugins`
* Check that the plugins list (left side column) looks more `DataViews`y than it did, comparing to what you can find on `/v2/sites/{siteId}/backups`, for example

|Before|After|
|---|---|
|<img width="3850" height="1917" alt="image" src="https://github.com/user-attachments/assets/67d6ba0c-5f78-4506-8d31-48d067a9417b" />|<img width="3850" height="1917" alt="image" src="https://github.com/user-attachments/assets/8bbe66e4-cb16-4af5-b6d6-f044398ead8a" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
