### PR TITLE
Help Center: Remove usage of resolved

### DIFF
--- a/packages/odie-client/src/data/use-manage-support-interaction.ts
+++ b/packages/odie-client/src/data/use-manage-support-interaction.ts
@@ -101,21 +101,9 @@ export const useManageSupportInteraction = () => {
 		},
 	} );
 
-	/**
-	 * Resolve a support interaction.
-	 */
-	const resolveInteraction = useMutation( {
-		mutationKey: [ 'support-interaction', 'resolve', isTestMode ],
-		mutationFn: ( { interactionId }: { interactionId: string } ) =>
-			handleSupportInteractionsFetch( 'PUT', `/${ interactionId }/status`, isTestMode, {
-				status: 'resolved',
-			} ),
-	} ).mutate;
-
 	return {
 		startNewInteraction: startNewInteraction.mutateAsync,
 		isMutating: startNewInteraction.isPending,
-		addEventToInteraction,
-		resolveInteraction,
+		addEventToInteraction: addEventToInteraction.mutateAsync,
 	};
 };

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -270,7 +270,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						event_source: 'odie',
 					} );
 				} else if ( supportInteraction && ! odieId && chatId ) {
-					supportInteraction = await addEventToInteraction.mutateAsync( {
+					supportInteraction = await addEventToInteraction( {
 						interactionId: supportInteraction.uuid,
 						eventData: {
 							event_external_id: chatId.toString(),

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -121,7 +121,7 @@ export const useCreateZendeskConversation = () => {
 			} );
 
 			if ( activeInteractionId ) {
-				interaction = await addEventToInteraction.mutateAsync( {
+				interaction = await addEventToInteraction( {
 					interactionId: activeInteractionId,
 					eventData: { event_source: 'zendesk', event_external_id: conversation.id },
 				} );

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -89,7 +89,7 @@ type InquiryType =
 	| 'unrelated-to-wordpress'
 	| 'request-for-human-support';
 
-type InteractionStatus = 'open' | 'closed' | 'resolved' | 'solved';
+type InteractionStatus = 'open' | 'closed' | 'solved';
 
 type ClassificationResults = {
 	inquiry_type?: InquiryType;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-15569/support-interaction-is-resolved-status-cancellable

'resolved' is not useful anymore as a Support Interaction status, this PR removes it.

## Testing steps

1. Apply this wpcom patch 198546-ghe-Automattic/wpcom and sandbox public api
2. Try to talk with Odie, escalate to live chat and open a new chat with ?help-center=happiness-engineer in the URL
3. All should work fine
4. Your chats should all be in the Support History