### PR TITLE
MSD: remove /domains redirection which conflicts with local MSD /domains

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -878,7 +878,7 @@ function wpcomPages( app ) {
 		res.redirect( 301, newRoute );
 	} );
 
-	app.get( [ '/domains', '/start/domain-first' ], function ( req, res ) {
+	app.get( [ '/start/domain-first' ], function ( req, res ) {
 		let redirectUrl = '/start/domain';
 		const domain = get( req, 'query.new', false );
 		if ( domain ) {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1024,18 +1024,6 @@ describe( 'main app', () => {
 	} );
 
 	describe( 'Route /domains', () => {
-		it( 'redirects from /domains to /start/domain', async () => {
-			const { response } = await app.run( { request: { url: '/domains' } } );
-			expect( response.redirect ).toHaveBeenCalledWith( '/start/domain' );
-		} );
-
-		it( 'redirects from /domains to /start/domain with selected domain', async () => {
-			const { response } = await app.run( {
-				request: { url: '/domains', query: { new: 'my-domain.com' } },
-			} );
-			expect( response.redirect ).toHaveBeenCalledWith( '/start/domain?new=my-domain.com' );
-		} );
-
 		it( 'redirects from /start/domain-first to /start/domain', async () => {
 			const { response } = await app.run( { request: { url: '/start/domain-first' } } );
 			expect( response.redirect ).toHaveBeenCalledWith( '/start/domain' );


### PR DESCRIPTION
## Proposed Changes

Remove the `/domains` -> `/start/domains` redirection from Calypso. Note that this is essentially a dead code, as https://wordpress.com/domains already points to a landing page (not served by Calypso).

## Why are these changes being made?

It makes `my.localhost:3000/domains` on `development` environment to follow that redirection instead of opening the Domains page. 😬 

## Testing Instructions

1. Check out this PR locally
2. Run `yarn start`
3. Type `http://my.localhost:3000/domains` on your browser.
4. Verify that the Domains screen loads instead of redirecting to `/start/domains`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
