### PR TITLE
MSD: Remove "downgrade" language from PurchaseSettings

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -296,7 +296,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 	if ( purchase.is_cancelable ) {
 		return (
 			<ActionList.ActionItem
-				title={ __( 'Downgrade or cancel your subscription' ) }
+				title={ __( 'Cancel subscription' ) }
 				description={ __( 'We’ll be sorry to see you go!' ) }
 				actions={
 					<Button
@@ -309,7 +309,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 							} )
 						}
 					>
-						{ __( 'Downgrade or cancel' ) }
+						{ __( 'Cancel' ) }
 					</Button>
 				}
 			/>
@@ -331,7 +331,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 							} )
 						}
 					>
-						{ __( 'Remove subscription' ) }
+						{ __( 'Remove' ) }
 					</Button>
 				}
 			/>
@@ -365,7 +365,7 @@ function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 						upgradePurchase( upgradeUrl );
 					} }
 				>
-					{ __( 'Upgrade subscription' ) }
+					{ __( 'Upgrade' ) }
 				</Button>
 			}
 		/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-304/remove-downgrade-language-on-purchase-settings

## Proposed Changes

This PR adjusts the wording of the subscription buttons in the Multi Site Dashboard Purchase Settings page to make the following changes:

- Removes the word "downgrade" since downgrade paths are currently hidden within the cancel flow and not easily accessible.
- Removes the word "subscription" from the cancel, remove, and upgrade buttons since the word is already present in the section title for those buttons.

Before             |  After
:-------------------------:|:-------------------------:
<img width="697" height="268" alt="Screenshot 2025-12-19 at 9 29 12 AM" src="https://github.com/user-attachments/assets/a361e334-0b3f-43f1-b7f5-a2fbb75a95f0" /> | <img width="686" height="262" alt="Screenshot 2025-12-19 at 9 30 52 AM" src="https://github.com/user-attachments/assets/f21132a1-06ee-4ca3-943b-7289206cf202" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the purchase settings page for a purchase that can be cancelled.
- Verify that you no longer see any "downgrade" language.