### PR TITLE
Remove "Plan features" from MSD PurchaseSettings

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -206,16 +206,6 @@ function upgradePurchase( upgradeUrl: string ): void {
 }
 
 function ProductLink( { purchase }: { purchase: Purchase } ) {
-	if ( purchase.is_plan && purchase.site_slug ) {
-		const url = wpcomLink( '/plans/my-plan/' + purchase.site_slug );
-		const text = __( 'Plan features' );
-		return (
-			<MetadataItem>
-				<a href={ url }>{ text }</a>
-			</MetadataItem>
-		);
-	}
-
 	if (
 		( purchase.is_domain || purchase.product_slug === OFFSITE_REDIRECT ) &&
 		purchase.site_slug &&


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-305/remove-plan-category-and-features-link-from-purchase-settings

## Proposed Changes

This PR removes the "Plan features" link from the Purchase Settings page in the Multi Site Dashboard.

Before             |  After
:-------------------------:|:-------------------------:
<img width="706" height="321" alt="Screenshot 2025-12-19 at 11 31 06 AM" src="https://github.com/user-attachments/assets/48dc99ef-c294-4323-9d51-c5227f78931a" /> | <img width="687" height="304" alt="Screenshot 2025-12-19 at 11 31 11 AM" src="https://github.com/user-attachments/assets/9fe7d08f-92e9-40b9-8421-cad1ff7b3ae3" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This link was copied from the calypso purchase settings page but isn't very useful.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the purchase settings page for a plan.
- Verify that you don't see a "Plan features" link in the header.
