### PR TITLE
Reader: Enable MSD reader version in production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -100,6 +100,7 @@
 		"purchases/new-payment-methods": true,
 		"reader": true,
 		"reader/discover/freshly-pressed": true,
+		"reader/msd-enabled": true,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,
 		"safari-idb-mitigation": true,

--- a/config/production.json
+++ b/config/production.json
@@ -129,6 +129,7 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/discover/freshly-pressed": true,
+		"reader/msd-enabled": true,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
## Proposed Changes
* Enable the `reader/msd-enabled` flag in production

> [!IMPORTANT]
It will not enable the new reader MSD version for all users until the feature flag `dashboard/v2` is enabled and users opt in to try it, via the `/me/account` settings.


## Testing Instructions
* Run `yarn run feature-search  "reader/msd-enabled"`
* Compare the state with this image

<img width="794" height="588" alt="CleanShot 2025-12-19 at 17 54 46@2x" src="https://github.com/user-attachments/assets/fee4861a-765c-4870-839b-4d26e45e2bb7" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
