### PR TITLE
Renewal pricing experiment: pricing grid changes

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -13,6 +13,7 @@ jest.mock( '@automattic/data-stores', () => ( {
 	Plans: {
 		useCurrentPlan: jest.fn(),
 		useCurrentPlanExpiryDate: jest.fn(),
+		usePricingMetaForGridPlans: jest.fn(),
 	},
 } ) );
 jest.mock( 'i18n-calypso', () => ( {
@@ -111,6 +112,7 @@ describe( 'useGenerateActionHook', () => {
 		);
 
 		( Plans.useCurrentPlan as jest.Mock ).mockImplementation( () => null );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockImplementation( () => ( {} ) );
 	} );
 
 	it( 'should handle enterprise plans', () => {

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -18,7 +18,6 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { AddOns, PlanPricing, Plans } from '@automattic/data-stores';
-import useRenewalPricingPostButtonText from '@automattic/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text';
 import { useState } from '@wordpress/element';
 import { type LocalizeProps, type TranslateResult, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
@@ -31,6 +30,7 @@ import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selecto
 import isCurrentPlanPaid from 'calypso/state/sites/selectors/is-current-plan-paid';
 import { IAppState } from 'calypso/state/types';
 import useGenerateActionCallback from './use-generate-action-callback';
+import useRenewalPricingPostButtonText from './use-renewal-pricing-post-button-text';
 import type {
 	GridAction,
 	PlansIntent,
@@ -72,6 +72,9 @@ export default function useGenerateActionHook( {
 	showModalAndExit,
 	coupon,
 	useCheckPlanAvailabilityForPurchase,
+	showBillingDescriptionForIncreasedRenewalPrice,
+	enableCategorisedFeatures,
+	reflectStorageSelectionInPlanPrices,
 }: {
 	siteId?: number | null;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
@@ -82,6 +85,9 @@ export default function useGenerateActionHook( {
 	showModalAndExit?: ( planSlug: PlanSlug ) => boolean;
 	coupon?: string;
 	useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase;
+	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
+	enableCategorisedFeatures?: boolean;
+	reflectStorageSelectionInPlanPrices?: boolean;
 } ): UseAction {
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
@@ -137,6 +143,9 @@ export default function useGenerateActionHook( {
 			coupon,
 			siteId,
 			useCheckPlanAvailabilityForPurchase,
+			showBillingDescriptionForIncreasedRenewalPrice,
+			enableCategorisedFeatures,
+			reflectStorageSelectionInPlanPrices,
 		} );
 		/**
 		 * 1. Enterprise Plan actions

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -18,6 +18,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { AddOns, PlanPricing, Plans } from '@automattic/data-stores';
+import useRenewalPricingPostButtonText from '@automattic/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text';
 import { useState } from '@wordpress/element';
 import { type LocalizeProps, type TranslateResult, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
@@ -57,6 +58,8 @@ type UseActionHookProps = {
 	 * We can safely derive `planTitle` from one of the data-store or calypso-products hooks/selectors.
 	 */
 	planTitle?: TranslateResult;
+	pricing?: Plans.PricingMetaForGridPlan | null;
+	isMonthlyPlan?: boolean;
 };
 
 export default function useGenerateActionHook( {
@@ -68,6 +71,7 @@ export default function useGenerateActionHook( {
 	isLaunchPage,
 	showModalAndExit,
 	coupon,
+	useCheckPlanAvailabilityForPurchase,
 }: {
 	siteId?: number | null;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
@@ -77,6 +81,7 @@ export default function useGenerateActionHook( {
 	isLaunchPage: boolean | null;
 	showModalAndExit?: ( planSlug: PlanSlug ) => boolean;
 	coupon?: string;
+	useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase;
 } ): UseAction {
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
@@ -121,7 +126,18 @@ export default function useGenerateActionHook( {
 		billingPeriod,
 		currentPlanBillingPeriod,
 		planTitle,
+		pricing,
+		isMonthlyPlan,
 	}: UseActionHookProps ): GridAction => {
+		// Get renewal pricing text - this will be used as postButtonText if available
+		const renewalPricingText = useRenewalPricingPostButtonText( {
+			planSlug,
+			pricing,
+			isMonthlyPlan,
+			coupon,
+			siteId,
+			useCheckPlanAvailabilityForPurchase,
+		} );
 		/**
 		 * 1. Enterprise Plan actions
 		 */
@@ -157,7 +173,7 @@ export default function useGenerateActionHook( {
 		 * 3. Onboarding actions
 		 */
 		if ( isInSignup ) {
-			return getSignupAction( {
+			const action = getSignupAction( {
 				getActionCallback,
 				planSlug,
 				cartItemForPlan,
@@ -171,12 +187,16 @@ export default function useGenerateActionHook( {
 				eligibleForFreeHostingTrial,
 				plansIntent,
 			} );
+			return {
+				...action,
+				postButtonText: action.postButtonText || renewalPricingText || undefined,
+			};
 		}
 
 		/**
 		 * 4. Logged-In (Admin) Plans actions
 		 */
-		return getLoggedInPlansAction( {
+		const action = getLoggedInPlansAction( {
 			getActionCallback,
 			planSlug,
 			cartItemForPlan,
@@ -197,6 +217,10 @@ export default function useGenerateActionHook( {
 			isLoading,
 			plansIntent,
 		} );
+		return {
+			...action,
+			postButtonText: renewalPricingText || action.postButtonText || undefined,
+		};
 	};
 
 	return useActionHook;

--- a/client/my-sites/plans-features-main/hooks/use-renewal-pricing-post-button-text.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-pricing-post-button-text.tsx
@@ -6,9 +6,8 @@ import {
 	TERM_ANNUALLY,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
+import { getRenewalPricingText } from '@automattic/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text';
 import { useTranslate } from 'i18n-calypso';
-import { usePlansGridContext } from '../../grid-context';
-import { getRenewalPricingText } from './get-renewal-pricing-text';
 import type { Plans as PlansType } from '@automattic/data-stores';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -19,6 +18,9 @@ interface UseRenewalPricingPostButtonTextProps {
 	coupon?: string;
 	siteId?: number | null;
 	useCheckPlanAvailabilityForPurchase: PlansType.UseCheckPlanAvailabilityForPurchase;
+	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
+	enableCategorisedFeatures?: boolean;
+	reflectStorageSelectionInPlanPrices?: boolean;
 }
 
 export default function useRenewalPricingPostButtonText( {
@@ -28,13 +30,11 @@ export default function useRenewalPricingPostButtonText( {
 	coupon,
 	siteId,
 	useCheckPlanAvailabilityForPurchase,
+	showBillingDescriptionForIncreasedRenewalPrice,
+	enableCategorisedFeatures,
+	reflectStorageSelectionInPlanPrices,
 }: UseRenewalPricingPostButtonTextProps ): TranslateResult | null {
 	const translate = useTranslate();
-	const {
-		showBillingDescriptionForIncreasedRenewalPrice,
-		enableCategorisedFeatures,
-		reflectStorageSelectionInPlanPrices,
-	} = usePlansGridContext();
 
 	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
 	const yearlyVariantPricingData = Plans.usePricingMetaForGridPlans( {
@@ -99,3 +99,4 @@ export default function useRenewalPricingPostButtonText( {
 		translate,
 	} );
 }
+

--- a/client/my-sites/plans-features-main/hooks/use-renewal-pricing-post-button-text.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-pricing-post-button-text.tsx
@@ -99,4 +99,3 @@ export default function useRenewalPricingPostButtonText( {
 		translate,
 	} );
 }
-

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -412,6 +412,7 @@ const PlansFeaturesMain = ( {
 		isLaunchPage,
 		showModalAndExit,
 		coupon,
+		useCheckPlanAvailabilityForPurchase,
 	} );
 
 	const isDomainOnlySite = useSelector( ( state: IAppState ) =>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -83,10 +83,7 @@ import useFilteredDisplayedIntervals from './hooks/use-filtered-displayed-interv
 import useGenerateActionHook from './hooks/use-generate-action-hook';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
-import {
-	useRenewalPricingExperiment,
-	isRenewalPricingTreatment,
-} from './hooks/use-renewal-price-experiment';
+import { useRenewalPricingExperiment } from './hooks/use-renewal-price-experiment';
 import useSelectedFeature from './hooks/use-selected-feature';
 import useGetFreeSubdomainSuggestion from './hooks/use-suggested-free-domain-from-paid-domain';
 import type {
@@ -243,7 +240,6 @@ const PlansFeaturesMain = ( {
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
 
 	const [ , renewalPricingVariation ] = useRenewalPricingExperiment( flowName );
-	const isRenewalPricingExperiment = isRenewalPricingTreatment( renewalPricingVariation );
 
 	const eligibleForWpcomMonthlyPlans = useSelector( ( state: IAppState ) =>
 		isEligibleForWpComMonthlyPlan( state, siteId )
@@ -967,7 +963,7 @@ const PlansFeaturesMain = ( {
 													useCheckPlanAvailabilityForPurchase={
 														useCheckPlanAvailabilityForPurchase
 													}
-													isRenewalPricingExperiment={ isRenewalPricingExperiment }
+													renewalPricingVariation={ renewalPricingVariation }
 													enableFeatureTooltips
 													featureGroupMap={ featureGroupMapForComparisonGrid }
 													enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -239,7 +239,8 @@ const PlansFeaturesMain = ( {
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
 
-	const [ , renewalPricingVariation ] = useRenewalPricingExperiment( flowName );
+	const [ isRenewalPricingExperimentLoading, renewalPricingVariation ] =
+		useRenewalPricingExperiment( flowName );
 
 	const eligibleForWpcomMonthlyPlans = useSelector( ( state: IAppState ) =>
 		isEligibleForWpComMonthlyPlan( state, siteId )
@@ -681,7 +682,10 @@ const PlansFeaturesMain = ( {
 			! gridPlansForComparisonGrid
 	);
 
-	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
+	const isPlansGridReady =
+		! isLoadingGridPlans &&
+		! resolvedSubdomainName.isLoading &&
+		! isRenewalPricingExperimentLoading;
 
 	const isMobile = useMobileBreakpoint();
 	const enablePlanTypeSelectorStickyBehavior = isMobile && showPlanTypeSelectorDropdown;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -904,7 +904,7 @@ const PlansFeaturesMain = ( {
 										}
 										enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 										showSimplifiedBillingDescription={ isInSignup }
-										renewalPricingVariation={ renewalPricingVariation }
+										showBillingDescriptionForIncreasedRenewalPrice={ renewalPricingVariation }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }
@@ -964,7 +964,7 @@ const PlansFeaturesMain = ( {
 													useCheckPlanAvailabilityForPurchase={
 														useCheckPlanAvailabilityForPurchase
 													}
-													renewalPricingVariation={ renewalPricingVariation }
+													showBillingDescriptionForIncreasedRenewalPrice={ renewalPricingVariation }
 													enableFeatureTooltips
 													featureGroupMap={ featureGroupMapForComparisonGrid }
 													enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -904,6 +904,7 @@ const PlansFeaturesMain = ( {
 										}
 										enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 										showSimplifiedBillingDescription={ isInSignup }
+										renewalPricingVariation={ renewalPricingVariation }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -83,6 +83,10 @@ import useFilteredDisplayedIntervals from './hooks/use-filtered-displayed-interv
 import useGenerateActionHook from './hooks/use-generate-action-hook';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
+import {
+	useRenewalPricingExperiment,
+	isRenewalPricingTreatment,
+} from './hooks/use-renewal-price-experiment';
 import useSelectedFeature from './hooks/use-selected-feature';
 import useGetFreeSubdomainSuggestion from './hooks/use-suggested-free-domain-from-paid-domain';
 import type {
@@ -237,6 +241,9 @@ const PlansFeaturesMain = ( {
 	const [ showPlansComparisonGrid, setShowPlansComparisonGrid ] = useState( false );
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
+
+	const [ , renewalPricingVariation ] = useRenewalPricingExperiment( flowName );
+	const isRenewalPricingExperiment = isRenewalPricingTreatment( renewalPricingVariation );
 
 	const eligibleForWpcomMonthlyPlans = useSelector( ( state: IAppState ) =>
 		isEligibleForWpComMonthlyPlan( state, siteId )
@@ -960,6 +967,7 @@ const PlansFeaturesMain = ( {
 													useCheckPlanAvailabilityForPurchase={
 														useCheckPlanAvailabilityForPurchase
 													}
+													isRenewalPricingExperiment={ isRenewalPricingExperiment }
 													enableFeatureTooltips
 													featureGroupMap={ featureGroupMapForComparisonGrid }
 													enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -413,6 +413,9 @@ const PlansFeaturesMain = ( {
 		showModalAndExit,
 		coupon,
 		useCheckPlanAvailabilityForPurchase,
+		showBillingDescriptionForIncreasedRenewalPrice: renewalPricingVariation,
+		enableCategorisedFeatures: showSimplifiedFeatures,
+		reflectStorageSelectionInPlanPrices: true,
 	} );
 
 	const isDomainOnlySite = useSelector( ( state: IAppState ) =>

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -21,6 +21,9 @@ jest.mock( '../hooks/use-suggested-free-domain-from-paid-domain', () => () => ( 
 	wpcomFreeDomainSuggestion: { isLoading: false, result: { domain_name: 'suggestion.com' } },
 	invalidateDomainSuggestionCache: () => {},
 } ) );
+jest.mock( '../hooks/use-renewal-price-experiment', () => ( {
+	useRenewalPricingExperiment: jest.fn( () => [ false, null ] ),
+} ) );
 jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	getByPurchaseId: jest.fn(),
 } ) );

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -476,6 +476,7 @@ const ComparisonGridHeaderCell = ( {
 				showMonthlyPrice={ false }
 				isStuck={ false }
 				visibleGridPlans={ visibleGridPlans }
+				showPostButtonText={ false }
 			/>
 		</Cell>
 	);

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -383,7 +383,7 @@ const ComparisonGridHeaderCell = ( {
 	showRefundPeriod,
 	isStuck,
 }: ComparisonGridHeaderCellProps ) => {
-	const { gridPlansIndex } = usePlansGridContext();
+	const { gridPlansIndex, showBillingDescriptionForIncreasedRenewalPrice } = usePlansGridContext();
 	const gridPlan = gridPlansIndex[ planSlug ];
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
 		renderedGridPlans: visibleGridPlans,
@@ -476,7 +476,7 @@ const ComparisonGridHeaderCell = ( {
 				showMonthlyPrice={ false }
 				isStuck={ false }
 				visibleGridPlans={ visibleGridPlans }
-				showPostButtonText={ false }
+				showPostButtonText={ showBillingDescriptionForIncreasedRenewalPrice ? false : true }
 			/>
 		</Cell>
 	);

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -1158,6 +1158,7 @@ const WrappedComparisonGrid = ( {
 	enableTermSavingsPriceDisplay,
 	reflectStorageSelectionInPlanPrices,
 	showSimplifiedBillingDescription,
+	isRenewalPricingExperiment,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -1207,6 +1208,7 @@ const WrappedComparisonGrid = ( {
 				enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 				reflectStorageSelectionInPlanPrices={ reflectStorageSelectionInPlanPrices }
 				showSimplifiedBillingDescription={ showSimplifiedBillingDescription }
+				isRenewalPricingExperiment={ isRenewalPricingExperiment }
 			>
 				<ComparisonGrid
 					intervalType={ intervalType }

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -1158,7 +1158,7 @@ const WrappedComparisonGrid = ( {
 	enableTermSavingsPriceDisplay,
 	reflectStorageSelectionInPlanPrices,
 	showSimplifiedBillingDescription,
-	renewalPricingVariation,
+	showBillingDescriptionForIncreasedRenewalPrice,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -1208,7 +1208,9 @@ const WrappedComparisonGrid = ( {
 				enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 				reflectStorageSelectionInPlanPrices={ reflectStorageSelectionInPlanPrices }
 				showSimplifiedBillingDescription={ showSimplifiedBillingDescription }
-				renewalPricingVariation={ renewalPricingVariation }
+				showBillingDescriptionForIncreasedRenewalPrice={
+					showBillingDescriptionForIncreasedRenewalPrice
+				}
 			>
 				<ComparisonGrid
 					intervalType={ intervalType }

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -1158,7 +1158,7 @@ const WrappedComparisonGrid = ( {
 	enableTermSavingsPriceDisplay,
 	reflectStorageSelectionInPlanPrices,
 	showSimplifiedBillingDescription,
-	isRenewalPricingExperiment,
+	renewalPricingVariation,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -1208,7 +1208,7 @@ const WrappedComparisonGrid = ( {
 				enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 				reflectStorageSelectionInPlanPrices={ reflectStorageSelectionInPlanPrices }
 				showSimplifiedBillingDescription={ showSimplifiedBillingDescription }
-				isRenewalPricingExperiment={ isRenewalPricingExperiment }
+				renewalPricingVariation={ renewalPricingVariation }
 			>
 				<ComparisonGrid
 					intervalType={ intervalType }

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -397,7 +397,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		enterpriseFeaturesList,
 		enableTermSavingsPriceDisplay,
 		showSimplifiedBillingDescription,
-		renewalPricingVariation,
+		showBillingDescriptionForIncreasedRenewalPrice,
 	} = props;
 
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -456,7 +456,9 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				enterpriseFeaturesList={ enterpriseFeaturesList }
 				enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 				showSimplifiedBillingDescription={ showSimplifiedBillingDescription }
-				renewalPricingVariation={ renewalPricingVariation }
+				showBillingDescriptionForIncreasedRenewalPrice={
+					showBillingDescriptionForIncreasedRenewalPrice
+				}
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />
 			</PlansGridContextProvider>

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -397,6 +397,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		enterpriseFeaturesList,
 		enableTermSavingsPriceDisplay,
 		showSimplifiedBillingDescription,
+		renewalPricingVariation,
 	} = props;
 
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -455,6 +456,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				enterpriseFeaturesList={ enterpriseFeaturesList }
 				enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 				showSimplifiedBillingDescription={ showSimplifiedBillingDescription }
+				renewalPricingVariation={ renewalPricingVariation }
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />
 			</PlansGridContextProvider>

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -10,6 +10,7 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
+import useRenewalPricingPostButtonText from '../../../hooks/data-store/use-renewal-pricing-post-button-text';
 import useIsLargeCurrency from '../../../hooks/use-is-large-currency';
 import { usePlanPricingInfoFromGridPlans } from '../../../hooks/use-plan-pricing-info-from-grid-plans';
 import PlanButton from '../../plan-button';
@@ -111,6 +112,15 @@ const ActionButton = ( {
 		selectedStorageAddOn,
 	} );
 
+	// Get renewal pricing text for FeaturesGrid (below button)
+	const renewalPricingText = useRenewalPricingPostButtonText( {
+		planSlug,
+		pricing: gridPlansIndex[ planSlug ]?.pricing,
+	} );
+
+	// Use renewal pricing text if available, otherwise use the postButtonText from useAction
+	const finalPostButtonText = renewalPricingText || postButtonText;
+
 	const busy = status === 'blocked';
 
 	const defaultStorageOption = useDefaultStorageOption( { planSlug } );
@@ -197,8 +207,8 @@ const ActionButton = ( {
 					>
 						{ text }
 					</PlanButton>
-					{ postButtonText && (
-						<span className="plans-grid-next-action-button__label">{ postButtonText }</span>
+					{ finalPostButtonText && (
+						<span className="plans-grid-next-action-button__label">{ finalPostButtonText }</span>
 					) }
 				</>
 			);

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -47,7 +47,7 @@ const ActionButton = ( {
 		gridPlansIndex,
 		siteId,
 		helpers: { useAction },
-		renewalPricingVariation,
+		showBillingDescriptionForIncreasedRenewalPrice,
 	} = usePlansGridContext();
 	const {
 		current,
@@ -217,7 +217,7 @@ const ActionButton = ( {
 					{ finalPostButtonText && (
 						<span
 							className={ clsx( 'plans-grid-next-action-button__label', {
-								'is-left-aligned': renewalPricingVariation,
+								'is-left-aligned': showBillingDescriptionForIncreasedRenewalPrice,
 							} ) }
 						>
 							{ finalPostButtonText }

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -30,6 +30,7 @@ type ActionButtonProps = {
 	showMonthlyPrice: boolean;
 	isStuck: boolean;
 	visibleGridPlans: GridPlan[];
+	showPostButtonText?: boolean;
 };
 
 const ActionButton = ( {
@@ -40,6 +41,7 @@ const ActionButton = ( {
 	isStuck,
 	isInSignup,
 	isMonthlyPlan,
+	showPostButtonText = true,
 }: ActionButtonProps ) => {
 	const translate = useTranslate();
 	const {
@@ -203,7 +205,7 @@ const ActionButton = ( {
 					>
 						{ text }
 					</PlanButton>
-					{ postButtonText && (
+					{ showPostButtonText && postButtonText && (
 						<span
 							className={ clsx( 'plans-grid-next-action-button__label', {
 								'is-left-aligned': showBillingDescriptionForIncreasedRenewalPrice,

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -116,6 +116,11 @@ const ActionButton = ( {
 	const renewalPricingText = useRenewalPricingPostButtonText( {
 		planSlug,
 		pricing: gridPlansIndex[ planSlug ]?.pricing,
+		isMonthlyPlan,
+		coupon: usePlansGridContext().coupon,
+		siteId,
+		useCheckPlanAvailabilityForPurchase:
+			usePlansGridContext().helpers.useCheckPlanAvailabilityForPurchase,
 	} );
 
 	// Use renewal pricing text if available, otherwise use the postButtonText from useAction

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -11,7 +11,6 @@ import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
-import useRenewalPricingPostButtonText from '../../../hooks/data-store/use-renewal-pricing-post-button-text';
 import useIsLargeCurrency from '../../../hooks/use-is-large-currency';
 import { usePlanPricingInfoFromGridPlans } from '../../../hooks/use-plan-pricing-info-from-grid-plans';
 import PlanButton from '../../plan-button';
@@ -97,6 +96,8 @@ const ActionButton = ( {
 		cartItemForPlan,
 		currentPlanBillingPeriod,
 		selectedStorageAddOn,
+		pricing: gridPlansIndex[ planSlug ]?.pricing,
+		isMonthlyPlan,
 	} );
 	const {
 		primary: { callback: freeTrialCallback, text: freeTrialText },
@@ -112,21 +113,9 @@ const ActionButton = ( {
 		cartItemForPlan: { product_slug: freeTrialPlanSlug ?? PLAN_FREE },
 		currentPlanBillingPeriod,
 		selectedStorageAddOn,
-	} );
-
-	// Get renewal pricing text for FeaturesGrid (below button)
-	const renewalPricingText = useRenewalPricingPostButtonText( {
-		planSlug,
-		pricing: gridPlansIndex[ planSlug ]?.pricing,
+		pricing: gridPlansIndex[ freeTrialPlanSlug ?? PLAN_FREE ]?.pricing,
 		isMonthlyPlan,
-		coupon: usePlansGridContext().coupon,
-		siteId,
-		useCheckPlanAvailabilityForPurchase:
-			usePlansGridContext().helpers.useCheckPlanAvailabilityForPurchase,
 	} );
-
-	// Use renewal pricing text if available, otherwise use the postButtonText from useAction
-	const finalPostButtonText = renewalPricingText || postButtonText;
 
 	const busy = status === 'blocked';
 
@@ -214,13 +203,13 @@ const ActionButton = ( {
 					>
 						{ text }
 					</PlanButton>
-					{ finalPostButtonText && (
+					{ postButtonText && (
 						<span
 							className={ clsx( 'plans-grid-next-action-button__label', {
 								'is-left-aligned': showBillingDescriptionForIncreasedRenewalPrice,
 							} ) }
 						>
-							{ finalPostButtonText }
+							{ postButtonText }
 						</span>
 					) }
 				</>

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -8,6 +8,7 @@ import {
 import { AddOns, WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useSelect } from '@wordpress/data';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
 import useRenewalPricingPostButtonText from '../../../hooks/data-store/use-renewal-pricing-post-button-text';
@@ -46,6 +47,7 @@ const ActionButton = ( {
 		gridPlansIndex,
 		siteId,
 		helpers: { useAction },
+		renewalPricingVariation,
 	} = usePlansGridContext();
 	const {
 		current,
@@ -213,7 +215,13 @@ const ActionButton = ( {
 						{ text }
 					</PlanButton>
 					{ finalPostButtonText && (
-						<span className="plans-grid-next-action-button__label">{ finalPostButtonText }</span>
+						<span
+							className={ clsx( 'plans-grid-next-action-button__label', {
+								'is-left-aligned': renewalPricingVariation,
+							} ) }
+						>
+							{ finalPostButtonText }
+						</span>
 					) }
 				</>
 			);

--- a/packages/plans-grid-next/src/components/shared/action-button/style.scss
+++ b/packages/plans-grid-next/src/components/shared/action-button/style.scss
@@ -3,6 +3,10 @@
 	font-size: 0.75rem;
 	display: block;
 	margin-top: 10px;
+
+	&.is-left-aligned {
+		text-align: left;
+	}
 }
 
 .plans-grid-next-action-button__multi {

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -51,6 +51,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		siteId,
 		coupon,
 		helpers,
+		renewalPricingVariation,
 	} = usePlansGridContext();
 	const { isAnyPlanPriceDiscounted, setIsAnyPlanPriceDiscounted } = useHeaderPriceContext();
 	const {
@@ -86,7 +87,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	const termVariantPrice =
 		termVariantPricing?.discountedPrice.monthly ?? termVariantPricing?.originalPrice.monthly ?? 0;
 	const planPrice = discountedPrice.monthly ?? originalPrice.monthly ?? 0;
-	const savings =
+	let savings =
 		termVariantPrice > planPrice
 			? Math.floor( ( ( termVariantPrice - planPrice ) / termVariantPrice ) * 100 )
 			: 0;
@@ -110,13 +111,36 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	if ( isWpcomEnterpriseGridPlan( planSlug ) || ! isPricedPlan ) {
 		return null;
 	}
+	const isRenewalPricingTreatment = renewalPricingVariation?.includes( 'crossed_price' );
 
 	if ( isGridPlanOnIntroOffer ) {
+		// Use the monthly plan price for renewal pricing, instead of the intro offer renewal price
+		const compareToMonthlyPrice =
+			( isRenewalPricingTreatment && termVariantPricing
+				? termVariantPricing.originalPrice.monthly
+				: originalPrice.monthly ) ?? 0;
+		const monthlyPrice =
+			typeof discountedPrice.monthly === 'number'
+				? discountedPrice.monthly
+				: introOffer.rawPrice.monthly;
+		if ( isRenewalPricingTreatment && compareToMonthlyPrice > monthlyPrice ) {
+			savings = Math.floor(
+				( ( compareToMonthlyPrice - monthlyPrice ) / compareToMonthlyPrice ) * 100
+			);
+		}
+		const hideCrossedPrice =
+			isRenewalPricingTreatment && renewalPricingVariation === 'no_crossed_price';
+
 		return (
 			<div className="plans-grid-next-header-price">
 				{ ! current && (
 					<div className="plans-grid-next-header-price__badge">
-						{ translate( 'Special Offer' ) }
+						{ isRenewalPricingTreatment
+							? translate( 'Save %(savings)d%%', {
+									args: { savings },
+									comment: 'Example: Save 35%',
+							  } )
+							: translate( 'Special Offer' ) }
 					</div>
 				) }
 				<div
@@ -124,22 +148,20 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 						'is-large-currency': isLargeCurrency,
 					} ) }
 				>
+					{ ! hideCrossedPrice && (
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ compareToMonthlyPrice }
+							displayPerMonthNotation={ false }
+							isLargeCurrency
+							isSmallestUnit
+							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
+							original
+						/>
+					) }
 					<PlanPrice
 						currencyCode={ currencyCode }
-						rawPrice={ originalPrice.monthly }
-						displayPerMonthNotation={ false }
-						isLargeCurrency
-						isSmallestUnit
-						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
-						original
-					/>
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={
-							typeof discountedPrice.monthly === 'number'
-								? discountedPrice.monthly
-								: introOffer.rawPrice.monthly
-						}
+						rawPrice={ monthlyPrice }
 						displayPerMonthNotation={ false }
 						isLargeCurrency
 						isSmallestUnit

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -145,7 +145,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 				) }
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
-						'is-large-currency': isLargeCurrency,
+						'is-large-currency': isLargeCurrency && ! isRenewalPricingTreatment,
 					} ) }
 				>
 					{ ! hideCrossedPrice && (
@@ -153,7 +153,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 							currencyCode={ currencyCode }
 							rawPrice={ compareToMonthlyPrice }
 							displayPerMonthNotation={ false }
-							isLargeCurrency
+							isLargeCurrency={ isLargeCurrency && ! isRenewalPricingTreatment }
 							isSmallestUnit
 							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
 							original
@@ -163,7 +163,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 						currencyCode={ currencyCode }
 						rawPrice={ monthlyPrice }
 						displayPerMonthNotation={ false }
-						isLargeCurrency
+						isLargeCurrency={ isLargeCurrency && ! isRenewalPricingTreatment }
 						isSmallestUnit
 						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
 						discounted

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -69,11 +69,12 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	const isGridPlanOnIntroOffer = introOffer && ! introOffer.isOfferComplete;
 
 	const { prices } = usePlanPricingInfoFromGridPlans( { gridPlans: visibleGridPlans } );
-	const isLargeCurrency = useIsLargeCurrency( {
-		prices,
-		currencyCode: currencyCode || 'USD',
-		ignoreWhitespace: true,
-	} );
+	const isLargeCurrency =
+		useIsLargeCurrency( {
+			prices,
+			currencyCode: currencyCode || 'USD',
+			ignoreWhitespace: true,
+		} ) && ! showBillingDescriptionForIncreasedRenewalPrice?.includes( 'crossed_price' ); // a temporary fix to handle an issue with isLargeCurrency logic for intro offers
 
 	const termVariantPlanSlug = useTermVariantPlanSlugForSavings( { planSlug, billingPeriod } );
 	const termVariantPricing = Plans.usePricingMetaForGridPlans( {
@@ -111,33 +112,29 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	if ( isWpcomEnterpriseGridPlan( planSlug ) || ! isPricedPlan ) {
 		return null;
 	}
-	const isRenewalPricingTreatment =
-		showBillingDescriptionForIncreasedRenewalPrice?.includes( 'crossed_price' );
 
 	if ( isGridPlanOnIntroOffer ) {
 		// Use the monthly plan price for renewal pricing, instead of the intro offer renewal price
 		const compareToMonthlyPrice =
-			( isRenewalPricingTreatment && termVariantPricing
+			( showBillingDescriptionForIncreasedRenewalPrice && termVariantPricing
 				? termVariantPricing.originalPrice.monthly
 				: originalPrice.monthly ) ?? 0;
 		const monthlyPrice =
 			typeof discountedPrice.monthly === 'number'
 				? discountedPrice.monthly
 				: introOffer.rawPrice.monthly;
-		if ( isRenewalPricingTreatment && compareToMonthlyPrice > monthlyPrice ) {
+		if ( showBillingDescriptionForIncreasedRenewalPrice && compareToMonthlyPrice > monthlyPrice ) {
 			savings = Math.floor(
 				( ( compareToMonthlyPrice - monthlyPrice ) / compareToMonthlyPrice ) * 100
 			);
 		}
-		const hideCrossedPrice =
-			isRenewalPricingTreatment &&
-			showBillingDescriptionForIncreasedRenewalPrice === 'no_crossed_price';
+		const hideCrossedPrice = showBillingDescriptionForIncreasedRenewalPrice === 'no_crossed_price';
 
 		return (
 			<div className="plans-grid-next-header-price">
 				{ ! current && (
 					<div className="plans-grid-next-header-price__badge">
-						{ isRenewalPricingTreatment
+						{ showBillingDescriptionForIncreasedRenewalPrice
 							? translate( 'Save %(savings)d%%', {
 									args: { savings },
 									comment: 'Example: Save 35%',
@@ -147,7 +144,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 				) }
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
-						'is-large-currency': isLargeCurrency && ! isRenewalPricingTreatment,
+						'is-large-currency': isLargeCurrency,
 					} ) }
 				>
 					{ ! hideCrossedPrice && (
@@ -155,7 +152,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 							currencyCode={ currencyCode }
 							rawPrice={ compareToMonthlyPrice }
 							displayPerMonthNotation={ false }
-							isLargeCurrency={ isLargeCurrency && ! isRenewalPricingTreatment }
+							isLargeCurrency={ isLargeCurrency }
 							isSmallestUnit
 							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
 							original
@@ -165,7 +162,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 						currencyCode={ currencyCode }
 						rawPrice={ monthlyPrice }
 						displayPerMonthNotation={ false }
-						isLargeCurrency={ isLargeCurrency && ! isRenewalPricingTreatment }
+						isLargeCurrency={ isLargeCurrency }
 						isSmallestUnit
 						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
 						discounted

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -51,7 +51,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		siteId,
 		coupon,
 		helpers,
-		renewalPricingVariation,
+		showBillingDescriptionForIncreasedRenewalPrice,
 	} = usePlansGridContext();
 	const { isAnyPlanPriceDiscounted, setIsAnyPlanPriceDiscounted } = useHeaderPriceContext();
 	const {
@@ -111,7 +111,8 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	if ( isWpcomEnterpriseGridPlan( planSlug ) || ! isPricedPlan ) {
 		return null;
 	}
-	const isRenewalPricingTreatment = renewalPricingVariation?.includes( 'crossed_price' );
+	const isRenewalPricingTreatment =
+		showBillingDescriptionForIncreasedRenewalPrice?.includes( 'crossed_price' );
 
 	if ( isGridPlanOnIntroOffer ) {
 		// Use the monthly plan price for renewal pricing, instead of the intro offer renewal price
@@ -129,7 +130,8 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			);
 		}
 		const hideCrossedPrice =
-			isRenewalPricingTreatment && renewalPricingVariation === 'no_crossed_price';
+			isRenewalPricingTreatment &&
+			showBillingDescriptionForIncreasedRenewalPrice === 'no_crossed_price';
 
 		return (
 			<div className="plans-grid-next-header-price">

--- a/packages/plans-grid-next/src/components/test/actions-button.tsx
+++ b/packages/plans-grid-next/src/components/test/actions-button.tsx
@@ -10,6 +10,7 @@ jest.mock( '@wordpress/data', () => ( {
 	createReduxStore: jest.fn(),
 	createSelector: jest.fn(),
 	register: jest.fn(),
+	registerStore: jest.fn(),
 	useDispatch: jest.fn(),
 } ) );
 jest.mock( '@wordpress/element', () => ( {
@@ -25,6 +26,10 @@ jest.mock( '@automattic/data-stores', () => ( {
 	},
 	Purchases: {
 		useSitePurchasesByProductSlug: jest.fn(),
+	},
+	Plans: {
+		...jest.requireActual( '@automattic/data-stores' ).Plans,
+		usePricingMetaForGridPlans: jest.fn(),
 	},
 } ) );
 jest.mock( 'i18n-calypso', () => ( {

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -32,6 +32,7 @@ interface PlansGridContext {
 	enterpriseFeaturesList?: string[];
 	reflectStorageSelectionInPlanPrices?: boolean;
 	showSimplifiedBillingDescription?: boolean;
+	isRenewalPricingExperiment?: boolean;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
@@ -58,6 +59,7 @@ const PlansGridContextProvider = ( {
 	enterpriseFeaturesList,
 	reflectStorageSelectionInPlanPrices,
 	showSimplifiedBillingDescription,
+	isRenewalPricingExperiment,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
@@ -93,6 +95,7 @@ const PlansGridContextProvider = ( {
 				enterpriseFeaturesList,
 				reflectStorageSelectionInPlanPrices,
 				showSimplifiedBillingDescription,
+				isRenewalPricingExperiment,
 			} }
 		>
 			{ children }

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -32,7 +32,7 @@ interface PlansGridContext {
 	enterpriseFeaturesList?: string[];
 	reflectStorageSelectionInPlanPrices?: boolean;
 	showSimplifiedBillingDescription?: boolean;
-	isRenewalPricingExperiment?: boolean;
+	renewalPricingVariation?: string | null;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
@@ -59,7 +59,7 @@ const PlansGridContextProvider = ( {
 	enterpriseFeaturesList,
 	reflectStorageSelectionInPlanPrices,
 	showSimplifiedBillingDescription,
-	isRenewalPricingExperiment,
+	renewalPricingVariation,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
@@ -95,7 +95,7 @@ const PlansGridContextProvider = ( {
 				enterpriseFeaturesList,
 				reflectStorageSelectionInPlanPrices,
 				showSimplifiedBillingDescription,
-				isRenewalPricingExperiment,
+				renewalPricingVariation,
 			} }
 		>
 			{ children }

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -32,7 +32,7 @@ interface PlansGridContext {
 	enterpriseFeaturesList?: string[];
 	reflectStorageSelectionInPlanPrices?: boolean;
 	showSimplifiedBillingDescription?: boolean;
-	renewalPricingVariation?: string | null;
+	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
@@ -59,7 +59,7 @@ const PlansGridContextProvider = ( {
 	enterpriseFeaturesList,
 	reflectStorageSelectionInPlanPrices,
 	showSimplifiedBillingDescription,
-	renewalPricingVariation,
+	showBillingDescriptionForIncreasedRenewalPrice,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
@@ -95,7 +95,7 @@ const PlansGridContextProvider = ( {
 				enterpriseFeaturesList,
 				reflectStorageSelectionInPlanPrices,
 				showSimplifiedBillingDescription,
-				renewalPricingVariation,
+				showBillingDescriptionForIncreasedRenewalPrice,
 			} }
 		>
 			{ children }

--- a/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
@@ -9,7 +9,7 @@ import type { TranslateResult } from 'i18n-calypso';
 
 interface GetRenewalPricingTextParams {
 	pricing: PlansType.PricingMetaForGridPlan;
-	renewalPricingVariation: string | null | undefined;
+	showBillingDescriptionForIncreasedRenewalPrice: string | null | undefined;
 	translate: ( text: string, options?: any ) => TranslateResult;
 }
 
@@ -19,7 +19,7 @@ interface GetRenewalPricingTextParams {
  */
 export function getRenewalPricingText( {
 	pricing,
-	renewalPricingVariation,
+	showBillingDescriptionForIncreasedRenewalPrice,
 	translate,
 }: GetRenewalPricingTextParams ): TranslateResult | null {
 	const { currencyCode, discountedPrice, originalPrice, billingPeriod, introOffer } = pricing;
@@ -54,7 +54,7 @@ export function getRenewalPricingText( {
 	}
 
 	// Different text based on variation
-	if ( renewalPricingVariation === 'crossed_price' ) {
+	if ( showBillingDescriptionForIncreasedRenewalPrice === 'crossed_price' ) {
 		return translate( 'Auto-renews at %(price)s per month. Billed every %(months)s months.', {
 			args: {
 				price: formattedMonthlyPrice,
@@ -63,7 +63,7 @@ export function getRenewalPricingText( {
 			comment:
 				'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
 		} );
-	} else if ( renewalPricingVariation === 'no_crossed_price' ) {
+	} else if ( showBillingDescriptionForIncreasedRenewalPrice === 'no_crossed_price' ) {
 		return translate(
 			'Get %(months)s months for %(fullPrice)s. Auto-renews at %(price)s per month.',
 			{

--- a/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
@@ -1,0 +1,82 @@
+import {
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
+	PLAN_TRIENNIAL_PERIOD,
+} from '@automattic/calypso-products';
+import { formatCurrency } from '@automattic/number-formatters';
+import type { Plans as PlansType } from '@automattic/data-stores';
+import type { TranslateResult } from 'i18n-calypso';
+
+interface GetRenewalPricingTextParams {
+	pricing: PlansType.PricingMetaForGridPlan;
+	renewalPricingVariation: string | null | undefined;
+	translate: ( text: string, options?: any ) => TranslateResult;
+}
+
+/**
+ * Generates renewal pricing text based on the pricing variation.
+ * This is shared between use-plan-billing-description and use-renewal-pricing-post-button-text.
+ */
+export function getRenewalPricingText( {
+	pricing,
+	renewalPricingVariation,
+	translate,
+}: GetRenewalPricingTextParams ): TranslateResult | null {
+	const { currencyCode, discountedPrice, originalPrice, billingPeriod, introOffer } = pricing;
+
+	const monthlyPrice = originalPrice?.monthly;
+	const currentFullPrice =
+		introOffer?.rawPrice?.full || discountedPrice?.full || originalPrice?.full;
+
+	if ( ! monthlyPrice || ! currencyCode || ! currentFullPrice ) {
+		return null;
+	}
+
+	const formattedMonthlyPrice = formatCurrency( monthlyPrice, currencyCode, {
+		stripZeros: true,
+		isSmallestUnit: true,
+	} );
+
+	const formattedFullPrice = formatCurrency( currentFullPrice, currencyCode, {
+		stripZeros: true,
+		isSmallestUnit: true,
+	} );
+
+	// Determine the billing period in months
+	let billingMonths = 12; // default to annual
+
+	if ( billingPeriod === PLAN_BIENNIAL_PERIOD ) {
+		billingMonths = 24;
+	} else if ( billingPeriod === PLAN_TRIENNIAL_PERIOD ) {
+		billingMonths = 36;
+	} else if ( billingPeriod === PLAN_ANNUAL_PERIOD ) {
+		billingMonths = 12;
+	}
+
+	// Different text based on variation
+	if ( renewalPricingVariation === 'crossed_price' ) {
+		return translate( 'Auto-renews at %(price)s per month. Billed every %(months)s months.', {
+			args: {
+				price: formattedMonthlyPrice,
+				months: billingMonths,
+			},
+			comment:
+				'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
+		} );
+	} else if ( renewalPricingVariation === 'no_crossed_price' ) {
+		return translate(
+			'Get %(months)s months for %(fullPrice)s. Auto-renews at %(price)s per month.',
+			{
+				args: {
+					months: billingMonths,
+					fullPrice: formattedFullPrice,
+					price: formattedMonthlyPrice,
+				},
+				comment:
+					'%(months)s is the billing period (12, 24, or 36), %(fullPrice)s is the current/intro total price like $100, %(price)s is the renewal monthly price like $12',
+			}
+		);
+	}
+
+	return null;
+}

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -75,11 +75,19 @@ export default function usePlanBillingDescription( {
 			return translate( 'per month' );
 		}
 
-		const yearlyVariantMaybeDiscountedPrice = Number.isFinite(
+		let yearlyVariantMaybeDiscountedPrice = Number.isFinite(
 			yearlyVariantPricing.discountedPrice?.monthly
 		)
 			? yearlyVariantPricing.discountedPrice?.monthly
 			: yearlyVariantPricing.originalPrice?.monthly;
+
+		if ( renewalPricingVariation ) {
+			yearlyVariantMaybeDiscountedPrice = Number.isFinite(
+				yearlyVariantPricing.discountedPrice?.monthly
+			)
+				? yearlyVariantPricing.discountedPrice?.monthly
+				: yearlyVariantPricing.introOffer?.rawPrice?.monthly ?? null;
+		}
 
 		if (
 			yearlyVariantMaybeDiscountedPrice &&

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -35,8 +35,11 @@ export default function usePlanBillingDescription( {
 }: UsePlanBillingDescriptionProps ) {
 	const translate = useTranslate();
 	const { currencyCode, originalPrice, discountedPrice, billingPeriod, introOffer } = pricing || {};
-	const { reflectStorageSelectionInPlanPrices, showSimplifiedBillingDescription } =
-		usePlansGridContext();
+	const {
+		reflectStorageSelectionInPlanPrices,
+		showSimplifiedBillingDescription,
+		isRenewalPricingExperiment,
+	} = usePlansGridContext();
 	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
 
 	const yearlyVariantPricing = Plans.usePricingMetaForGridPlans( {
@@ -108,7 +111,12 @@ export default function usePlanBillingDescription( {
 	 *   1. We only expose introOffers to monthly & yearly plans for now (so no need to introduce more translations just yet)
 	 *   2. We only expose month & year based intervals for now (so no need to introduce more translations just yet)
 	 */
-	if ( introOffer?.intervalCount && introOffer.intervalUnit && ! introOffer.isOfferComplete ) {
+	if (
+		introOffer?.intervalCount &&
+		introOffer.intervalUnit &&
+		! introOffer.isOfferComplete &&
+		! isRenewalPricingExperiment
+	) {
 		const discountedPriceFull =
 			typeof discountedPrice?.full === 'number' ? discountedPrice.full : introOffer?.rawPrice?.full;
 
@@ -284,6 +292,38 @@ export default function usePlanBillingDescription( {
 				}
 			);
 		}
+	} else if ( isRenewalPricingExperiment ) {
+		// For renewal pricing treatment, show the auto-renewal text instead of billing description
+		const monthlyPrice = discountedPrice?.monthly || originalPrice?.monthly;
+
+		if ( ! monthlyPrice || ! currencyCode ) {
+			return null;
+		}
+
+		const formattedPrice = formatCurrency( monthlyPrice, currencyCode, {
+			stripZeros: true,
+			isSmallestUnit: true,
+		} );
+
+		// Determine the billing period in months
+		let billingMonths = 12; // default to annual
+
+		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
+			billingMonths = 24;
+		} else if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
+			billingMonths = 36;
+		} else if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
+			billingMonths = 12;
+		}
+
+		return translate( 'Auto-renews as %(price)s per month. Billed every %(months)s months.', {
+			args: {
+				price: formattedPrice,
+				months: billingMonths,
+			},
+			comment:
+				'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
+		} );
 	} else if ( showSimplifiedBillingDescription ) {
 		// Use simplified billing description
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -69,6 +69,12 @@ export default function usePlanBillingDescription( {
 		yearlyVariantPricing &&
 		( ! introOffer || introOffer.isOfferComplete )
 	) {
+		// For renewal pricing experiment in FeaturesGrid, show "per month" and move savings text to post-button area
+		// For ComparisonGrid, keep the original savings text above the button
+		if ( renewalPricingVariation && enableCategorisedFeatures ) {
+			return translate( 'per month' );
+		}
+
 		const yearlyVariantMaybeDiscountedPrice = Number.isFinite(
 			yearlyVariantPricing.discountedPrice?.monthly
 		)

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -269,7 +269,15 @@ export default function usePlanBillingDescription( {
 		return null;
 	}
 
-	if ( discountedPriceFullTermText ) {
+	// For renewal pricing experiment with intro pricing
+	if ( renewalPricingVariation && discountedPriceFullTermText ) {
+		// In FeaturesGrid, show "per month" above button
+		if ( enableCategorisedFeatures ) {
+			return translate( 'per month' );
+		}
+		// In ComparisonGrid, continue to renewal pricing section below (don't return here)
+	} else if ( discountedPriceFullTermText ) {
+		// Show intro pricing for non-experiment users
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 			return translate(
 				'per month, %(fullTermDiscountedPriceText)s for the first year, excl. taxes',
@@ -299,7 +307,9 @@ export default function usePlanBillingDescription( {
 				}
 			);
 		}
-	} else if ( renewalPricingVariation ) {
+	}
+
+	if ( renewalPricingVariation ) {
 		// For renewal pricing experiment, show variation-specific text
 		// In FeaturesGrid (enableCategorisedFeatures), show "per month" and move renewal text below CTA
 		// In ComparisonGrid, show full renewal text above CTA

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -39,7 +39,7 @@ export default function usePlanBillingDescription( {
 	const {
 		reflectStorageSelectionInPlanPrices,
 		showSimplifiedBillingDescription,
-		renewalPricingVariation,
+		showBillingDescriptionForIncreasedRenewalPrice,
 		enableCategorisedFeatures,
 	} = usePlansGridContext();
 	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
@@ -72,7 +72,7 @@ export default function usePlanBillingDescription( {
 	) {
 		// For renewal pricing experiment in FeaturesGrid, show "per month" and move savings text to post-button area
 		// For ComparisonGrid, keep the original savings text above the button
-		if ( renewalPricingVariation && enableCategorisedFeatures ) {
+		if ( showBillingDescriptionForIncreasedRenewalPrice && enableCategorisedFeatures ) {
 			return translate( 'per month' );
 		}
 
@@ -82,7 +82,7 @@ export default function usePlanBillingDescription( {
 			? yearlyVariantPricing.discountedPrice?.monthly
 			: yearlyVariantPricing.originalPrice?.monthly;
 
-		if ( renewalPricingVariation ) {
+		if ( showBillingDescriptionForIncreasedRenewalPrice ) {
 			yearlyVariantMaybeDiscountedPrice = Number.isFinite(
 				yearlyVariantPricing.discountedPrice?.monthly
 			)
@@ -131,7 +131,7 @@ export default function usePlanBillingDescription( {
 		introOffer?.intervalCount &&
 		introOffer.intervalUnit &&
 		! introOffer.isOfferComplete &&
-		! renewalPricingVariation
+		! showBillingDescriptionForIncreasedRenewalPrice
 	) {
 		const discountedPriceFull =
 			typeof discountedPrice?.full === 'number' ? discountedPrice.full : introOffer?.rawPrice?.full;
@@ -279,7 +279,7 @@ export default function usePlanBillingDescription( {
 	}
 
 	// For renewal pricing experiment with intro pricing
-	if ( renewalPricingVariation && discountedPriceFullTermText ) {
+	if ( showBillingDescriptionForIncreasedRenewalPrice && discountedPriceFullTermText ) {
 		// In FeaturesGrid, show "per month" above button
 		if ( enableCategorisedFeatures ) {
 			return translate( 'per month' );
@@ -318,7 +318,7 @@ export default function usePlanBillingDescription( {
 		}
 	}
 
-	if ( renewalPricingVariation ) {
+	if ( showBillingDescriptionForIncreasedRenewalPrice ) {
 		// For renewal pricing experiment, show variation-specific text
 		// In FeaturesGrid (enableCategorisedFeatures), show "per month" and move renewal text below CTA
 		// In ComparisonGrid, show full renewal text above CTA
@@ -328,7 +328,7 @@ export default function usePlanBillingDescription( {
 
 		return getRenewalPricingText( {
 			pricing,
-			renewalPricingVariation,
+			showBillingDescriptionForIncreasedRenewalPrice,
 			translate,
 		} );
 	} else if ( showSimplifiedBillingDescription ) {

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -13,6 +13,7 @@ import { Plans } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../grid-context';
+import { getRenewalPricingText } from './get-renewal-pricing-text';
 import type { GridPlan } from '../../types';
 
 interface UsePlanBillingDescriptionProps {
@@ -325,58 +326,11 @@ export default function usePlanBillingDescription( {
 			return translate( 'per month' );
 		}
 
-		const monthlyPrice = originalPrice?.monthly;
-		const currentFullPrice =
-			introOffer?.rawPrice?.full || discountedPrice?.full || originalPrice?.full;
-		if ( ! monthlyPrice || ! currencyCode || ! currentFullPrice ) {
-			return null;
-		}
-		const formattedMonthlyPrice = formatCurrency( monthlyPrice, currencyCode, {
-			stripZeros: true,
-			isSmallestUnit: true,
+		return getRenewalPricingText( {
+			pricing,
+			renewalPricingVariation,
+			translate,
 		} );
-		const formattedFullPrice = formatCurrency( currentFullPrice, currencyCode, {
-			stripZeros: true,
-			isSmallestUnit: true,
-		} );
-
-		// Determine the billing period in months
-		let billingMonths = 12; // default to annual
-
-		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-			billingMonths = 24;
-		} else if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
-			billingMonths = 36;
-		} else if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-			billingMonths = 12;
-		}
-
-		// Different text based on variation
-		if ( renewalPricingVariation === 'crossed_price' ) {
-			return translate( 'Auto-renews at %(price)s per month. Billed every %(months)s months.', {
-				args: {
-					price: formattedMonthlyPrice,
-					months: billingMonths,
-				},
-				comment:
-					'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
-			} );
-		} else if ( renewalPricingVariation === 'no_crossed_price' ) {
-			return translate(
-				'Get %(months)s months for %(fullPrice)s. Auto-renews at %(price)s per month.',
-				{
-					args: {
-						months: billingMonths,
-						fullPrice: formattedFullPrice,
-						price: formattedMonthlyPrice,
-					},
-					comment:
-						'%(months)s is the billing period (12, 24, or 36), %(fullPrice)s is the current/intro total price like $100, %(price)s is the renewal monthly price like $12',
-				}
-			);
-		}
-
-		return null;
 	} else if ( showSimplifiedBillingDescription ) {
 		// Use simplified billing description
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -38,7 +38,7 @@ export default function usePlanBillingDescription( {
 	const {
 		reflectStorageSelectionInPlanPrices,
 		showSimplifiedBillingDescription,
-		isRenewalPricingExperiment,
+		renewalPricingVariation,
 	} = usePlansGridContext();
 	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
 
@@ -115,7 +115,7 @@ export default function usePlanBillingDescription( {
 		introOffer?.intervalCount &&
 		introOffer.intervalUnit &&
 		! introOffer.isOfferComplete &&
-		! isRenewalPricingExperiment
+		! renewalPricingVariation
 	) {
 		const discountedPriceFull =
 			typeof discountedPrice?.full === 'number' ? discountedPrice.full : introOffer?.rawPrice?.full;
@@ -292,15 +292,21 @@ export default function usePlanBillingDescription( {
 				}
 			);
 		}
-	} else if ( isRenewalPricingExperiment ) {
-		// For renewal pricing treatment, show the auto-renewal text instead of billing description
+	} else if ( renewalPricingVariation ) {
+		// For renewal pricing experiment, show variation-specific text
 		const monthlyPrice = discountedPrice?.monthly || originalPrice?.monthly;
+		const fullPrice = discountedPrice?.full || originalPrice?.full;
 
-		if ( ! monthlyPrice || ! currencyCode ) {
+		if ( ! monthlyPrice || ! fullPrice || ! currencyCode ) {
 			return null;
 		}
 
-		const formattedPrice = formatCurrency( monthlyPrice, currencyCode, {
+		const formattedMonthlyPrice = formatCurrency( monthlyPrice, currencyCode, {
+			stripZeros: true,
+			isSmallestUnit: true,
+		} );
+
+		const formattedFullPrice = formatCurrency( fullPrice, currencyCode, {
 			stripZeros: true,
 			isSmallestUnit: true,
 		} );
@@ -316,14 +322,32 @@ export default function usePlanBillingDescription( {
 			billingMonths = 12;
 		}
 
-		return translate( 'Auto-renews as %(price)s per month. Billed every %(months)s months.', {
-			args: {
-				price: formattedPrice,
-				months: billingMonths,
-			},
-			comment:
-				'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
-		} );
+		// Different text based on variation
+		if ( renewalPricingVariation === 'crossed_price' ) {
+			return translate( 'Auto-renews at %(price)s per month. Billed every %(months)s months.', {
+				args: {
+					price: formattedMonthlyPrice,
+					months: billingMonths,
+				},
+				comment:
+					'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
+			} );
+		} else if ( renewalPricingVariation === 'no_crossed_price' ) {
+			return translate(
+				'Get %(months)s months for %(fullPrice)s. Auto-renews at %(price)s per month.',
+				{
+					args: {
+						months: billingMonths,
+						fullPrice: formattedFullPrice,
+						price: formattedMonthlyPrice,
+					},
+					comment:
+						'%(months)s is the billing period (12, 24, or 36), %(fullPrice)s is the total price like $120, %(price)s is the monthly price like $10',
+				}
+			);
+		}
+
+		return null;
 	} else if ( showSimplifiedBillingDescription ) {
 		// Use simplified billing description
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -39,6 +39,7 @@ export default function usePlanBillingDescription( {
 		reflectStorageSelectionInPlanPrices,
 		showSimplifiedBillingDescription,
 		renewalPricingVariation,
+		enableCategorisedFeatures,
 	} = usePlansGridContext();
 	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
 
@@ -294,6 +295,12 @@ export default function usePlanBillingDescription( {
 		}
 	} else if ( renewalPricingVariation ) {
 		// For renewal pricing experiment, show variation-specific text
+		// In FeaturesGrid (enableCategorisedFeatures), show "per month" and move renewal text below CTA
+		// In ComparisonGrid, show full renewal text above CTA
+		if ( enableCategorisedFeatures ) {
+			return translate( 'per month' );
+		}
+
 		const monthlyPrice = originalPrice?.monthly;
 		const currentFullPrice =
 			introOffer?.rawPrice?.full || discountedPrice?.full || originalPrice?.full;

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -294,19 +294,17 @@ export default function usePlanBillingDescription( {
 		}
 	} else if ( renewalPricingVariation ) {
 		// For renewal pricing experiment, show variation-specific text
-		const monthlyPrice = discountedPrice?.monthly || originalPrice?.monthly;
-		const fullPrice = discountedPrice?.full || originalPrice?.full;
-
-		if ( ! monthlyPrice || ! fullPrice || ! currencyCode ) {
+		const monthlyPrice = originalPrice?.monthly;
+		const currentFullPrice =
+			introOffer?.rawPrice?.full || discountedPrice?.full || originalPrice?.full;
+		if ( ! monthlyPrice || ! currencyCode || ! currentFullPrice ) {
 			return null;
 		}
-
 		const formattedMonthlyPrice = formatCurrency( monthlyPrice, currencyCode, {
 			stripZeros: true,
 			isSmallestUnit: true,
 		} );
-
-		const formattedFullPrice = formatCurrency( fullPrice, currencyCode, {
+		const formattedFullPrice = formatCurrency( currentFullPrice, currencyCode, {
 			stripZeros: true,
 			isSmallestUnit: true,
 		} );
@@ -342,7 +340,7 @@ export default function usePlanBillingDescription( {
 						price: formattedMonthlyPrice,
 					},
 					comment:
-						'%(months)s is the billing period (12, 24, or 36), %(fullPrice)s is the total price like $120, %(price)s is the monthly price like $10',
+						'%(months)s is the billing period (12, 24, or 36), %(fullPrice)s is the current/intro total price like $100, %(price)s is the renewal monthly price like $12',
 				}
 			);
 		}

--- a/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
@@ -1,0 +1,94 @@
+import {
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
+	PLAN_TRIENNIAL_PERIOD,
+	isWpComFreePlan,
+	isWpcomEnterpriseGridPlan,
+	type PlanSlug,
+} from '@automattic/calypso-products';
+import { formatCurrency } from '@automattic/number-formatters';
+import { useTranslate } from 'i18n-calypso';
+import { usePlansGridContext } from '../../grid-context';
+import type { PlanPricing } from '@automattic/data-stores';
+import type { TranslateResult } from 'i18n-calypso';
+
+interface UseRenewalPricingPostButtonTextProps {
+	planSlug: PlanSlug;
+	pricing?: PlanPricing | null;
+}
+
+export default function useRenewalPricingPostButtonText( {
+	planSlug,
+	pricing,
+}: UseRenewalPricingPostButtonTextProps ): TranslateResult | null {
+	const translate = useTranslate();
+	const { renewalPricingVariation, enableCategorisedFeatures } = usePlansGridContext();
+
+	// Only show in FeaturesGrid (when enableCategorisedFeatures is true) and when in experiment
+	if ( ! renewalPricingVariation || ! enableCategorisedFeatures || ! pricing ) {
+		return null;
+	}
+
+	const { currencyCode, discountedPrice, originalPrice, billingPeriod, introOffer } = pricing;
+
+	// Don't show for free or enterprise plans
+	if ( isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug ) ) {
+		return null;
+	}
+
+	const monthlyPrice = originalPrice?.monthly;
+	const currentFullPrice =
+		introOffer?.rawPrice?.full || discountedPrice?.full || originalPrice?.full;
+
+	if ( ! monthlyPrice || ! currencyCode || ! currentFullPrice ) {
+		return null;
+	}
+
+	const formattedMonthlyPrice = formatCurrency( monthlyPrice, currencyCode, {
+		stripZeros: true,
+		isSmallestUnit: true,
+	} );
+
+	const formattedFullPrice = formatCurrency( currentFullPrice, currencyCode, {
+		stripZeros: true,
+		isSmallestUnit: true,
+	} );
+
+	// Determine the billing period in months
+	let billingMonths = 12; // default to annual
+
+	if ( billingPeriod === PLAN_BIENNIAL_PERIOD ) {
+		billingMonths = 24;
+	} else if ( billingPeriod === PLAN_TRIENNIAL_PERIOD ) {
+		billingMonths = 36;
+	} else if ( billingPeriod === PLAN_ANNUAL_PERIOD ) {
+		billingMonths = 12;
+	}
+
+	// Different text based on variation
+	if ( renewalPricingVariation === 'crossed_price' ) {
+		return translate( 'Auto-renews at %(price)s per month. Billed every %(months)s months.', {
+			args: {
+				price: formattedMonthlyPrice,
+				months: billingMonths,
+			},
+			comment:
+				'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
+		} );
+	} else if ( renewalPricingVariation === 'no_crossed_price' ) {
+		return translate(
+			'Get %(months)s months for %(fullPrice)s. Auto-renews at %(price)s per month.',
+			{
+				args: {
+					months: billingMonths,
+					fullPrice: formattedFullPrice,
+					price: formattedMonthlyPrice,
+				},
+				comment:
+					'%(months)s is the billing period (12, 24, or 36), %(fullPrice)s is the current/intro total price like $100, %(price)s is the renewal monthly price like $12',
+			}
+		);
+	}
+
+	return null;
+}

--- a/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
@@ -5,24 +5,51 @@ import {
 	isWpComFreePlan,
 	isWpcomEnterpriseGridPlan,
 	type PlanSlug,
+	getPlanSlugForTermVariant,
+	TERM_ANNUALLY,
 } from '@automattic/calypso-products';
+import { Plans } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../grid-context';
-import type { PlanPricing } from '@automattic/data-stores';
+import type { Plans as PlansType } from '@automattic/data-stores';
 import type { TranslateResult } from 'i18n-calypso';
 
 interface UseRenewalPricingPostButtonTextProps {
 	planSlug: PlanSlug;
-	pricing?: PlanPricing | null;
+	pricing?: PlansType.PricingMetaForGridPlan | null;
+	isMonthlyPlan?: boolean;
+	coupon?: string;
+	siteId?: number | null;
+	useCheckPlanAvailabilityForPurchase: PlansType.UseCheckPlanAvailabilityForPurchase;
 }
 
 export default function useRenewalPricingPostButtonText( {
 	planSlug,
 	pricing,
+	isMonthlyPlan,
+	coupon,
+	siteId,
+	useCheckPlanAvailabilityForPurchase,
 }: UseRenewalPricingPostButtonTextProps ): TranslateResult | null {
 	const translate = useTranslate();
-	const { renewalPricingVariation, enableCategorisedFeatures } = usePlansGridContext();
+	const {
+		renewalPricingVariation,
+		enableCategorisedFeatures,
+		reflectStorageSelectionInPlanPrices,
+	} = usePlansGridContext();
+
+	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
+	const yearlyVariantPricingData = Plans.usePricingMetaForGridPlans( {
+		planSlugs: yearlyVariantPlanSlug ? [ yearlyVariantPlanSlug ] : [],
+		coupon,
+		siteId,
+		useCheckPlanAvailabilityForPurchase,
+		reflectStorageSelectionInPlanPrices,
+	} );
+	const yearlyVariantPricing = yearlyVariantPlanSlug
+		? yearlyVariantPricingData?.[ yearlyVariantPlanSlug ]
+		: null;
 
 	// Only show in FeaturesGrid (when enableCategorisedFeatures is true) and when in experiment
 	if ( ! renewalPricingVariation || ! enableCategorisedFeatures || ! pricing ) {
@@ -30,6 +57,36 @@ export default function useRenewalPricingPostButtonText( {
 	}
 
 	const { currencyCode, discountedPrice, originalPrice, billingPeriod, introOffer } = pricing;
+
+	// For monthly plans, show the savings message
+	if (
+		isMonthlyPlan &&
+		originalPrice?.monthly &&
+		yearlyVariantPricing &&
+		( ! introOffer || introOffer.isOfferComplete )
+	) {
+		const yearlyVariantMaybeDiscountedPrice = Number.isFinite(
+			yearlyVariantPricing.discountedPrice?.monthly
+		)
+			? yearlyVariantPricing.discountedPrice?.monthly
+			: yearlyVariantPricing.originalPrice?.monthly;
+
+		if (
+			yearlyVariantMaybeDiscountedPrice &&
+			yearlyVariantMaybeDiscountedPrice < originalPrice.monthly
+		) {
+			return translate( 'Save %(discountRate)s%% by paying annually', {
+				args: {
+					discountRate: Math.floor(
+						( 100 * ( originalPrice.monthly - yearlyVariantMaybeDiscountedPrice ) ) /
+							originalPrice.monthly
+					),
+				},
+			} );
+		}
+
+		return null;
+	}
 
 	// Don't show for free or enterprise plans
 	if ( isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug ) ) {

--- a/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
@@ -51,7 +51,6 @@ export default function useRenewalPricingPostButtonText( {
 		? yearlyVariantPricingData?.[ yearlyVariantPlanSlug ]
 		: null;
 
-	// Only show in FeaturesGrid (when enableCategorisedFeatures is true) and when in experiment
 	if ( ! renewalPricingVariation || ! enableCategorisedFeatures || ! pricing ) {
 		return null;
 	}

--- a/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
@@ -1,7 +1,4 @@
 import {
-	PLAN_ANNUAL_PERIOD,
-	PLAN_BIENNIAL_PERIOD,
-	PLAN_TRIENNIAL_PERIOD,
 	isWpComFreePlan,
 	isWpcomEnterpriseGridPlan,
 	type PlanSlug,
@@ -9,9 +6,9 @@ import {
 	TERM_ANNUALLY,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
-import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../grid-context';
+import { getRenewalPricingText } from './get-renewal-pricing-text';
 import type { Plans as PlansType } from '@automattic/data-stores';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -60,7 +57,7 @@ export default function useRenewalPricingPostButtonText( {
 		return null;
 	}
 
-	const { currencyCode, discountedPrice, originalPrice, billingPeriod, introOffer } = pricing;
+	const { originalPrice, introOffer } = pricing;
 
 	// For monthly plans, show the savings message
 	if (
@@ -92,59 +89,9 @@ export default function useRenewalPricingPostButtonText( {
 		return null;
 	}
 
-	const monthlyPrice = originalPrice?.monthly;
-	const currentFullPrice =
-		introOffer?.rawPrice?.full || discountedPrice?.full || originalPrice?.full;
-
-	if ( ! monthlyPrice || ! currencyCode || ! currentFullPrice ) {
-		return null;
-	}
-
-	const formattedMonthlyPrice = formatCurrency( monthlyPrice, currencyCode, {
-		stripZeros: true,
-		isSmallestUnit: true,
+	return getRenewalPricingText( {
+		pricing,
+		renewalPricingVariation,
+		translate,
 	} );
-
-	const formattedFullPrice = formatCurrency( currentFullPrice, currencyCode, {
-		stripZeros: true,
-		isSmallestUnit: true,
-	} );
-
-	// Determine the billing period in months
-	let billingMonths = 12; // default to annual
-
-	if ( billingPeriod === PLAN_BIENNIAL_PERIOD ) {
-		billingMonths = 24;
-	} else if ( billingPeriod === PLAN_TRIENNIAL_PERIOD ) {
-		billingMonths = 36;
-	} else if ( billingPeriod === PLAN_ANNUAL_PERIOD ) {
-		billingMonths = 12;
-	}
-
-	// Different text based on variation
-	if ( renewalPricingVariation === 'crossed_price' ) {
-		return translate( 'Auto-renews at %(price)s per month. Billed every %(months)s months.', {
-			args: {
-				price: formattedMonthlyPrice,
-				months: billingMonths,
-			},
-			comment:
-				'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
-		} );
-	} else if ( renewalPricingVariation === 'no_crossed_price' ) {
-		return translate(
-			'Get %(months)s months for %(fullPrice)s. Auto-renews at %(price)s per month.',
-			{
-				args: {
-					months: billingMonths,
-					fullPrice: formattedFullPrice,
-					price: formattedMonthlyPrice,
-				},
-				comment:
-					'%(months)s is the billing period (12, 24, or 36), %(fullPrice)s is the current/intro total price like $100, %(price)s is the renewal monthly price like $12',
-			}
-		);
-	}
-
-	return null;
 }

--- a/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
@@ -56,6 +56,11 @@ export default function useRenewalPricingPostButtonText( {
 		return null;
 	}
 
+	// Don't show for free or enterprise plans
+	if ( isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug ) ) {
+		return null;
+	}
+
 	const { currencyCode, discountedPrice, originalPrice, billingPeriod, introOffer } = pricing;
 
 	// For monthly plans, show the savings message
@@ -69,7 +74,7 @@ export default function useRenewalPricingPostButtonText( {
 			yearlyVariantPricing.discountedPrice?.monthly
 		)
 			? yearlyVariantPricing.discountedPrice?.monthly
-			: yearlyVariantPricing.originalPrice?.monthly;
+			: yearlyVariantPricing.introOffer?.rawPrice?.monthly;
 
 		if (
 			yearlyVariantMaybeDiscountedPrice &&
@@ -85,11 +90,6 @@ export default function useRenewalPricingPostButtonText( {
 			} );
 		}
 
-		return null;
-	}
-
-	// Don't show for free or enterprise plans
-	if ( isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug ) ) {
 		return null;
 	}
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-renewal-pricing-post-button-text.tsx
@@ -31,7 +31,7 @@ export default function useRenewalPricingPostButtonText( {
 }: UseRenewalPricingPostButtonTextProps ): TranslateResult | null {
 	const translate = useTranslate();
 	const {
-		renewalPricingVariation,
+		showBillingDescriptionForIncreasedRenewalPrice,
 		enableCategorisedFeatures,
 		reflectStorageSelectionInPlanPrices,
 	} = usePlansGridContext();
@@ -48,7 +48,11 @@ export default function useRenewalPricingPostButtonText( {
 		? yearlyVariantPricingData?.[ yearlyVariantPlanSlug ]
 		: null;
 
-	if ( ! renewalPricingVariation || ! enableCategorisedFeatures || ! pricing ) {
+	if (
+		! showBillingDescriptionForIncreasedRenewalPrice ||
+		! enableCategorisedFeatures ||
+		! pricing
+	) {
 		return null;
 	}
 
@@ -91,7 +95,7 @@ export default function useRenewalPricingPostButtonText( {
 
 	return getRenewalPricingText( {
 		pricing,
-		renewalPricingVariation,
+		showBillingDescriptionForIncreasedRenewalPrice,
 		translate,
 	} );
 }

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -252,6 +252,10 @@ export type GridContextProps = {
 	 * Enable simplified billing description
 	 */
 	showSimplifiedBillingDescription?: boolean;
+	/**
+	 * Enable renewal pricing treatment (simplified billing description with renewal text below CTA)
+	 */
+	isRenewalPricingExperiment?: boolean;
 };
 
 export type ComparisonGridExternalProps = Omit<

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -180,6 +180,8 @@ export type UseAction = ( {
 	planTitle,
 	priceString,
 	selectedStorageAddOn,
+	pricing,
+	isMonthlyPlan,
 }: {
 	availableForPurchase?: boolean;
 	billingPeriod?: PlanPricing[ 'billPeriod' ];
@@ -192,6 +194,8 @@ export type UseAction = ( {
 	planTitle?: TranslateResult;
 	priceString?: string;
 	selectedStorageAddOn?: AddOns.AddOnMeta | null;
+	pricing?: Plans.PricingMetaForGridPlan | null;
+	isMonthlyPlan?: boolean;
 } ) => GridAction;
 
 export type GridContextProps = {

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -253,9 +253,9 @@ export type GridContextProps = {
 	 */
 	showSimplifiedBillingDescription?: boolean;
 	/**
-	 * Enable renewal pricing treatment (simplified billing description with renewal text below CTA)
+	 * Renewal pricing experiment variation name (e.g., 'crossed_price', 'no_crossed_price')
 	 */
-	isRenewalPricingExperiment?: boolean;
+	renewalPricingVariation?: string | null;
 };
 
 export type ComparisonGridExternalProps = Omit<

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -253,9 +253,9 @@ export type GridContextProps = {
 	 */
 	showSimplifiedBillingDescription?: boolean;
 	/**
-	 * Renewal pricing experiment variation name (e.g., 'crossed_price', 'no_crossed_price')
+	 * If, and how to present increased renewal pricing (null, 'crossed_price', 'no_crossed_price')
 	 */
-	renewalPricingVariation?: string | null;
+	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
 };
 
 export type ComparisonGridExternalProps = Omit<


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMART-79

## Proposed Changes

* Implement the pricing grid changes for increased renewal pricing experiment.

**Control:**
<img width="1373" height="527" alt="calypso-control" src="https://github.com/user-attachments/assets/a3381ba1-4cef-43c7-bed1-2b705d3f4755" />

**Treatment 1:**
<img width="1373" height="559" alt="calypso_crossed_price" src="https://github.com/user-attachments/assets/07ca7baf-c3ce-4f03-803b-4a39f3d7fc7d" />

**Treatment 2:**
<img width="1373" height="587" alt="calypso_no_crossed_price" src="https://github.com/user-attachments/assets/1aed4307-884e-4a5d-8403-1bac6f558dd8" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Testing on Calypso.live or calypso.localhost, assign yourself to control, then test the /setup/onboarding/plans and /plans/{your site} routes to confirm that they match the current experience.
* Test with the two treatment variants and confirm that they match the designs.
* Check that the prices are not shown for the `onboarding-pm` flow, or when the user currency is not USD or the user locale is not English.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
