### PR TITLE
MSD: Fix shouldIncludeA8COwned option

### DIFF
--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -55,7 +55,7 @@ export default function CIABSites() {
 	} );
 
 	const { sites, sites__ES, isLoadingSites, isPlaceholderData, hasNoData, totalItems } =
-		useSiteListQuery( view, isRestoringAccount );
+		useSiteListQuery( view, { isRestoringAccount, isAutomattician } );
 
 	const fields = useFields( { isAutomattician, viewType: view.type } );
 	const fields__ES = useFields__ES( { isAutomattician, viewType: view.type } );

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -62,7 +62,9 @@ const getFetchSitesOptions = (
 		! filters.some( ( item: Filter ) => item.field === 'is_a8c' && item.value === false );
 
 	if (
-		filters.find( ( item: Filter ) => item.field === 'status' && item.value.includes( 'deleted' ) )
+		filters.find(
+			( item: Filter ) => item.field === 'status' && item.value?.includes?.( 'deleted' )
+		)
 	) {
 		return { site_visibility: 'deleted', include_a8c_owned: shouldIncludeA8COwned };
 	}

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -61,7 +61,9 @@ const getFetchSitesOptions = (
 		isAutomattician &&
 		! filters.some( ( item: Filter ) => item.field === 'is_a8c' && item.value === false );
 
-	if ( filters.find( ( item: Filter ) => item.field === 'status' && item.value === 'deleted' ) ) {
+	if (
+		filters.find( ( item: Filter ) => item.field === 'status' && item.value.includes( 'deleted' ) )
+	) {
 		return { site_visibility: 'deleted', include_a8c_owned: shouldIncludeA8COwned };
 	}
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -45,13 +45,21 @@ import type {
 } from '@automattic/api-core';
 import type { View, Filter } from '@wordpress/dataviews';
 
-const getFetchSitesOptions = ( view: View, isRestoringAccount: boolean ): FetchSitesOptions => {
+type SiteListQueryOptions = {
+	isRestoringAccount: boolean;
+	isAutomattician: boolean;
+};
+
+const getFetchSitesOptions = (
+	view: View,
+	{ isRestoringAccount, isAutomattician }: SiteListQueryOptions
+): FetchSitesOptions => {
 	const filters = view.filters ?? [];
 
 	// Include A8C sites unless explicitly excluded from the filter.
-	const shouldIncludeA8COwned = ! filters.some(
-		( item: Filter ) => item.field === 'is_a8c' && item.value === false
-	);
+	const shouldIncludeA8COwned =
+		isAutomattician &&
+		! filters.some( ( item: Filter ) => item.field === 'is_a8c' && item.value === false );
 
 	if ( filters.find( ( item: Filter ) => item.field === 'status' && item.value === 'deleted' ) ) {
 		return { site_visibility: 'deleted', include_a8c_owned: shouldIncludeA8COwned };
@@ -171,7 +179,7 @@ function getFetchSiteListParams(
 /**
  * Enables the correct site query based on the dataviews/v2/es-site-list feature flag.
  */
-export function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
+export function useSiteListQuery( view: View, options: SiteListQueryOptions ) {
 	const { queries } = useAppContext();
 
 	const { data: siteFilters } = useQuery( {
@@ -192,7 +200,7 @@ export function useSiteListQuery( view: View, isRestoringAccount: boolean ) {
 	} );
 
 	const sitesQueryResult = useQuery( {
-		...queries.sitesQuery( getFetchSitesOptions( view, isRestoringAccount ) ),
+		...queries.sitesQuery( getFetchSitesOptions( view, options ) ),
 		placeholderData: keepPreviousData,
 		enabled: ! isEnabled( 'dashboard/v2/es-site-list' ),
 	} );
@@ -259,7 +267,7 @@ export default function Sites() {
 	} );
 
 	const { sites, sites__ES, isLoadingSites, isPlaceholderData, hasNoData, totalItems } =
-		useSiteListQuery( view, isRestoringAccount );
+		useSiteListQuery( view, { isRestoringAccount, isAutomattician } );
 
 	const fields = useFields( { isAutomattician, viewType: view.type } );
 	const fields__ES = useFields__ES( { isAutomattician, viewType: view.type } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1766384556644789-slack-CRWCHQGUB

## Proposed Changes

* The logic `shouldIncludeA8COwned` is incorrect as it would be true even if you're not using a8c account (the filter won't include a8c field so the value of `! filters.some( ... )`is always true. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should only fetch the visible sites by default

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using your non-a8c account
* Go to /sites
* Ensure yon won't see any deleted sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?