### PR TITLE
Theme Showcase: Add commercial disclaimer

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -16,8 +16,9 @@ import {
 	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Badge } from '@automattic/ui';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
-import { MenuItem, Dropdown, Notice, NavigableMenu } from '@wordpress/components';
+import { MenuItem, Dropdown, Notice, NavigableMenu, ExternalLink } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { chevronDown, chevronUp, Icon, external } from '@wordpress/icons';
 import { hasQueryArg } from '@wordpress/url';
@@ -655,9 +656,27 @@ class ThemeSheet extends Component {
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
 					</div>
+					{ this.renderDisclaimer() }
 				</div>
 				{ ! retired && this.renderStyleVariations() }
 			</div>
+		);
+	};
+
+	renderDisclaimer = () => {
+		const { is_commercial, external_support_url, translate } = this.props;
+		if ( ! is_commercial ) {
+			return null;
+		}
+
+		return (
+			<Badge style={ { width: '100%' } }>
+				{ translate( 'This theme offers additional paid commercial upgrades or support.' ) }
+				&nbsp;
+				<ExternalLink href={ external_support_url } style={ { color: 'inherit' } }>
+					{ translate( 'View support' ) }
+				</ExternalLink>
+			</Badge>
 		);
 	};
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -16,11 +16,18 @@ import {
 	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Badge } from '@automattic/ui';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
-import { MenuItem, Dropdown, Notice, NavigableMenu, ExternalLink } from '@wordpress/components';
+import {
+	MenuItem,
+	Dropdown,
+	Notice,
+	NavigableMenu,
+	ExternalLink,
+	privateApis,
+} from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { chevronDown, chevronUp, Icon, external } from '@wordpress/icons';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { hasQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { localize, getLocaleSlug } from 'i18n-calypso';
@@ -119,6 +126,13 @@ import ThemeStyleVariations from './theme-style-variations';
 import ThemeSupportTab from './theme-support-tab';
 
 import './style.scss';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Badge } = unlock( privateApis );
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -671,11 +685,14 @@ class ThemeSheet extends Component {
 
 		return (
 			<Badge style={ { width: '100%' } }>
-				{ translate( 'This theme offers additional paid commercial upgrades or support.' ) }
-				&nbsp;
-				<ExternalLink href={ external_support_url } style={ { color: 'inherit' } }>
-					{ translate( 'View support' ) }
-				</ExternalLink>
+				{ /* Wrap the content in another <span> to prevent truncation. */ }
+				<span style={ { whiteSpace: 'pre-wrap' } }>
+					{ translate( 'This theme offers additional paid commercial upgrades or support.' ) }
+					&nbsp;
+					<ExternalLink href={ external_support_url } style={ { color: 'inherit' } }>
+						{ translate( 'View support' ) }
+					</ExternalLink>
+				</span>
 			</Badge>
 		);
 	};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTTHEM-136

## Proposed Changes

* Add commercial disclaimer to site's level Theme Showcase

<img width="523" height="177" alt="image" src="https://github.com/user-attachments/assets/a3f6938f-cced-4110-b738-a425d219c057" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Show a disclaimer for Commercial themes, help users understand some themes might require paid upgrades, outside the WordPress.com paid plan

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/theme/astra/:your-business-site
* Ensure you can see the commercial disclaimer

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
