### PR TITLE
MSD: open links to onboarding URLs in the same tab

### DIFF
--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -13,7 +13,7 @@ import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useAnalytics } from '../../app/analytics';
 import { Card, CardBody } from '../../components/card';
-import { isRelativeUrl } from '../../utils/url';
+import { isOnboardingUrl, isRelativeUrl } from '../../utils/url';
 import ComponentViewTracker from '../component-view-tracker';
 import { Text } from '../text';
 import { TextSkeleton } from '../text-skeleton';
@@ -91,7 +91,7 @@ export default function OverviewCard( {
 		return <>&nbsp;</>;
 	};
 
-	const isRelativeLink = link && isRelativeUrl( link );
+	const isRelativeLink = link && ( isRelativeUrl( link ) || isOnboardingUrl( link ) );
 
 	let relativeLink: string | undefined = undefined;
 	let externalLink: string | undefined = undefined;

--- a/client/dashboard/sites/overview-migrate-site-card/index.tsx
+++ b/client/dashboard/sites/overview-migrate-site-card/index.tsx
@@ -12,7 +12,7 @@ export default function MigrateSiteCard( { site }: { site: Site } ) {
 			title={ __( 'Migrate' ) }
 			heading={ __( 'Migrate site' ) }
 			description={ __( 'Bring your site to WordPress.com.' ) }
-			externalLink={ addQueryArgs( wpcomLink( '/setup/site-migration' ), {
+			link={ addQueryArgs( wpcomLink( '/setup/site-migration' ), {
 				siteSlug: site.slug,
 			} ) }
 			intent="upsell"

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -11,10 +11,11 @@ import {
 	shield,
 	video,
 } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
 import { purchaseSettingsRoute, purchasesRoute } from '../app/router/me';
 import { hasPlanFeature } from '../utils/site-features';
 import { isDashboardBackport } from './is-dashboard-backport';
-import { wpcomLink } from './link';
+import { redirectToDashboardLink, wpcomLink } from './link';
 import { isCommerceGarden, isSelfHostedJetpackConnected } from './site-types';
 import type {
 	JetpackFeatureSlug,
@@ -150,9 +151,14 @@ export function useSitePlanManageURL( site: Site, purchase?: Purchase ) {
 	}
 
 	if ( site.plan?.is_free ) {
+		const backUrl = redirectToDashboardLink();
+
 		return isCommerceGarden( site )
 			? wpcomLink( `/setup/woo-hosted-plans?siteSlug=${ site.slug }` )
-			: wpcomLink( `/setup/plan-upgrade?siteSlug=${ site.slug }` );
+			: addQueryArgs( wpcomLink( '/setup/plan-upgrade' ), {
+					siteSlug: site.slug,
+					cancel_to: backUrl,
+			  } );
 	}
 
 	if ( isDashboardBackport() ) {

--- a/client/dashboard/utils/url.ts
+++ b/client/dashboard/utils/url.ts
@@ -1,4 +1,5 @@
 import { getProtocol } from '@wordpress/url';
+import { wpcomLink } from './link';
 
 export function isRelativeUrl( url: string ) {
 	if ( ! url ) {
@@ -9,8 +10,7 @@ export function isRelativeUrl( url: string ) {
 }
 
 export function isOnboardingUrl( url: string ) {
-	const path = new URL( url, window.location.origin ).pathname;
-	return path.startsWith( '/setup' ) || path.startsWith( '/start' );
+	return [ '/setup', '/start' ].some( ( path ) => url.startsWith( wpcomLink( path ) ) );
 }
 
 export function urlToSlug( url: string ) {

--- a/client/dashboard/utils/url.ts
+++ b/client/dashboard/utils/url.ts
@@ -8,6 +8,11 @@ export function isRelativeUrl( url: string ) {
 	return ! url.startsWith( '//' ) && ! getProtocol( url );
 }
 
+export function isOnboardingUrl( url: string ) {
+	const path = new URL( url, window.location.origin ).pathname;
+	return path.startsWith( '/setup' ) || path.startsWith( '/start' );
+}
+
 export function urlToSlug( url: string ) {
 	return url.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
 }


### PR DESCRIPTION
Context: p1766384230527879/1766384076.560999-slack-CRWCHQGUB

## Proposed Changes

This PR updates the behavior of the "Migrate site" and "Plan" cards in the Site Overview screen to open in the new tab.

(See the arrow)

|Before|After|
|-|-|
|<img width="679" height="156" alt="image" src="https://github.com/user-attachments/assets/dd1ec853-a445-4893-8a0b-4e3fa5eda2ef" />|<img width="686" height="173" alt="image" src="https://github.com/user-attachments/assets/59b29713-31ba-482b-a6da-aa5b828e96f8" />|


## Why are these changes being made?

We are treating onboarding screens as the same "app" as MSD, not as external party.

## Testing Instructions

1. Go to `<MSD live link>/sites/:siteSlug` of a Free site.
2. Verify both the Migrate site and Plan cards open in the same tab.
3. Verify you can click "Back" at the top-left corner and it redirects you back in the Site Overview.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?