### PR TITLE
A4A: Update KB article links to view articles via the Help center.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import illustration from 'calypso/assets/images/a8c-for-agencies/request-wp-admin-access-illustration.svg';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -9,13 +10,14 @@ import './style.scss';
 export function A4ARequestWPAdminAccess() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const onLearnMoreClick = () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_wp_admin_access_click' ) );
+		showSupportGuide(
+			'https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#allowing-team-members-to-access-wp-admin'
+		);
 	};
-
-	const kbArticleUrl =
-		'https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#allowing-team-members-to-access-wp-admin';
 
 	return (
 		<div className="a4a-request-wp-admin-access">
@@ -31,9 +33,7 @@ export function A4ARequestWPAdminAccess() {
 				<Button
 					variant="link"
 					className="a4a-request-wp-admin-access__learn-more-button"
-					href={ kbArticleUrl }
 					onClick={ onLearnMoreClick }
-					target="_blank"
 				>
 					{ translate( 'Learn more about team member permissions ↗' ) }
 				</Button>

--- a/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-request-wp-admin-access/index.tsx
@@ -35,7 +35,7 @@ export function A4ARequestWPAdminAccess() {
 					className="a4a-request-wp-admin-access__learn-more-button"
 					onClick={ onLearnMoreClick }
 				>
-					{ translate( 'Learn more about team member permissions ↗' ) }
+					{ translate( 'Learn more about team member permissions' ) }
 				</Button>
 			</div>
 			<div className="a4a-request-wp-admin-access__illustration">

--- a/client/a8c-for-agencies/hooks/use-help-center.ts
+++ b/client/a8c-for-agencies/hooks/use-help-center.ts
@@ -35,6 +35,11 @@ export default function useHelpCenter() {
 		}
 	};
 
+	const showSupportGuide = ( link: string ) => {
+		setShowHelpCenter( true );
+		setNavigateToRoute( '/post?link=' + encodeURIComponent( link ) );
+	};
+
 	const hasSupportFormHash =
 		window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
 		window.location.hash === CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT ||
@@ -65,6 +70,7 @@ export default function useHelpCenter() {
 
 	return {
 		toggleHelpCenter: handleToggleHelpCenter,
+		showSupportGuide,
 		show,
 	};
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/woopayments-custom-description/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/woopayments-custom-description/index.tsx
@@ -1,6 +1,7 @@
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -9,6 +10,7 @@ import './style.scss';
 export default function WooPaymentsCustomDescription() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const onLearnMoreClick = useCallback( () => {
 		dispatch(
@@ -16,7 +18,10 @@ export default function WooPaymentsCustomDescription() {
 				'calypso_marketplace_products_overview_woopayments_learn_more_revenue_share_click'
 			)
 		);
-	}, [ dispatch ] );
+		showSupportGuide(
+			'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/'
+		);
+	}, [ dispatch, showSupportGuide ] );
 
 	const onViewFullTermsClick = useCallback( () => {
 		dispatch(
@@ -41,14 +46,8 @@ export default function WooPaymentsCustomDescription() {
 						'To qualify for revenue sharing, you must install and connect the Automattic for Agencies plugin and WooPayments extension on your client sites. We recommend using this marketplace to install WooPayments after adding the Automattic for Agencies plugin for easier license and client site management. {{a}}Learn more{{/a}}',
 						{
 							components: {
-								a: (
-									<a
-										href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
-										target="_blank"
-										rel="noopener noreferrer"
-										onClick={ onLearnMoreClick }
-									></a>
-								),
+								// eslint-disable-next-line jsx-a11y/anchor-is-valid
+								a: <a onClick={ onLearnMoreClick } href="#" />,
 							},
 						}
 					) }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/woopayments-revenue-share-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/woopayments-revenue-share-notice/index.tsx
@@ -1,10 +1,12 @@
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 
 import './style.scss';
 
 export default function WooPaymentsRevenueShareNotice() {
 	const translate = useTranslate();
+	const { showSupportGuide } = useHelpCenter();
 
 	return (
 		<div className="product-card__revenue-share-notice">
@@ -15,13 +17,15 @@ export default function WooPaymentsRevenueShareNotice() {
 					{
 						components: {
 							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-is-valid
 								<a
-									href="https://agencieshelp.automattic.com/knowledge-base/the-automattic-for-agencies-client-plugin/"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									A4A
-								</a>
+									onClick={ () =>
+										showSupportGuide(
+											'https://agencieshelp.automattic.com/knowledge-base/the-automattic-for-agencies-client-plugin/'
+										)
+									}
+									href="#"
+								/>
 							),
 						},
 					}

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-faqs/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-faqs/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 import { A4A_MIGRATIONS_PAYMENT_SETTINGS } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import FoldableFAQ from 'calypso/components/foldable-faq';
 import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch } from 'calypso/state';
@@ -13,6 +14,7 @@ import './style.scss';
 export default function MigrationsFAQs() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const onFaqToggle = useCallback(
 		( faqArgs: { id: string; buttonId: string; isExpanded: boolean; height: number } ) => {
@@ -147,13 +149,15 @@ export default function MigrationsFAQs() {
 				{
 					components: {
 						PayoutKBLink: (
+							// eslint-disable-next-line jsx-a11y/anchor-is-valid
 							<a
-								href="https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/"
-								target="_blank"
-								rel="noreferrer"
-								onClick={ () =>
-									dispatch( recordTracksEvent( 'calypso_a4a_migrations_payout_kb_link_click' ) )
-								}
+								onClick={ () => {
+									dispatch( recordTracksEvent( 'calypso_a4a_migrations_payout_kb_link_click' ) );
+									showSupportGuide(
+										'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/'
+									);
+								} }
+								href="#"
 							/>
 						),
 						PaymentSettingLink: (

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -214,8 +214,8 @@ const PartnerDirectoryDashboard = () => {
 			className="partner-directory-dashboard__learn-more-section"
 			heading={ translate( 'Learn more about the program' ) }
 		>
-			<ExternalLink
-				href="#"
+			<Button
+				variant="link"
 				onClick={ () =>
 					showSupportGuide(
 						'https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings'
@@ -223,10 +223,10 @@ const PartnerDirectoryDashboard = () => {
 				}
 			>
 				{ translate( 'How does the approval process work?' ) }
-			</ExternalLink>
+			</Button>
 			<br />
-			<ExternalLink
-				href="#"
+			<Button
+				variant="link"
 				onClick={ () =>
 					showSupportGuide(
 						'https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings/#profile-content'
@@ -234,7 +234,7 @@ const PartnerDirectoryDashboard = () => {
 				}
 			>
 				{ translate( 'What can I put on my public profile?' ) }
-			</ExternalLink>
+			</Button>
 		</StepSection>
 	);
 

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StepSection from 'calypso/a8c-for-agencies/components/step-section';
 import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import { useDispatch, useSelector } from 'calypso/state';
 import { setActiveAgency } from 'calypso/state/a8c-for-agencies/agency/actions';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -46,6 +47,7 @@ interface StatusBadge {
 const PartnerDirectoryDashboard = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const agency = useSelector( getActiveAgency );
 
@@ -212,11 +214,25 @@ const PartnerDirectoryDashboard = () => {
 			className="partner-directory-dashboard__learn-more-section"
 			heading={ translate( 'Learn more about the program' ) }
 		>
-			<ExternalLink href="https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings">
+			<ExternalLink
+				href="#"
+				onClick={ () =>
+					showSupportGuide(
+						'https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings'
+					)
+				}
+			>
 				{ translate( 'How does the approval process work?' ) }
 			</ExternalLink>
 			<br />
-			<ExternalLink href="https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings/#profile-content">
+			<ExternalLink
+				href="#"
+				onClick={ () =>
+					showSupportGuide(
+						'https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings/#profile-content'
+					)
+				}
+			>
 				{ translate( 'What can I put on my public profile?' ) }
 			</ExternalLink>
 		</StepSection>

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -1,4 +1,5 @@
 import { formatCurrency } from '@automattic/number-formatters';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import {
 	ConsolidatedStatsCard,
@@ -32,14 +33,13 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 					popoverTitle={ translate( 'Total payouts' ) }
 					popoverContent={ translate(
 						'The exact amount your agency has been paid out for referrals.' +
-							'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
+							'{{br/}}{{br/}}{{a}}Learn more{{/a}}',
 						{
 							components: {
 								a: (
-									// eslint-disable-next-line jsx-a11y/anchor-is-valid
-									<a
+									<Button
+										variant="link"
 										onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) }
-										href="#"
 									/>
 								),
 								br: <br />,
@@ -59,12 +59,14 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 				popoverTitle={ translate( 'Pending orders' ) }
 				popoverContent={ translate(
 					'These are the number of pending referrals (unpaid carts). ' +
-						'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
+						'{{br/}}{{br/}}{{a}}Learn more{{/a}}',
 					{
 						components: {
 							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-is-valid
-								<a onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) } href="#" />
+								<Button
+									variant="link"
+									onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) }
+								/>
 							),
 							br: <br />,
 						},

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -6,6 +6,7 @@ import {
 } from 'calypso/a8c-for-agencies/components/consolidated-stats-card';
 import { AGENCY_EARNINGS_LEARN_MORE_LINK } from 'calypso/a8c-for-agencies/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import useGetConsolidatedPayoutData from '../hooks/use-get-consolidated-payout-data';
 import PayoutCards from './payout-cards';
 import type { Referral } from '../types';
@@ -20,6 +21,7 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 	const { data: productsData, isFetching } = useProductsQuery( false, false, true );
 	const { previousQuarterExpectedCommission, pendingOrders, currentQuarterExpectedCommission } =
 		useGetConsolidatedPayoutData( referrals, productsData );
+	const { showSupportGuide } = useHelpCenter();
 
 	return (
 		<ConsolidatedStatsGroup className="consolidated-view">
@@ -34,10 +36,10 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 						{
 							components: {
 								a: (
+									// eslint-disable-next-line jsx-a11y/anchor-is-valid
 									<a
-										href={ AGENCY_EARNINGS_LEARN_MORE_LINK }
-										target="_blank"
-										rel="noreferrer noopener"
+										onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) }
+										href="#"
 									/>
 								),
 								br: <br />,
@@ -61,11 +63,8 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 					{
 						components: {
 							a: (
-								<a
-									href={ AGENCY_EARNINGS_LEARN_MORE_LINK }
-									target="_blank"
-									rel="noreferrer noopener"
-								/>
+								// eslint-disable-next-line jsx-a11y/anchor-is-valid
+								<a onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) } href="#" />
 							),
 							br: <br />,
 						},

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
@@ -3,6 +3,7 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { ConsolidatedStatsCard } from 'calypso/a8c-for-agencies/components/consolidated-stats-card';
 import { AGENCY_EARNINGS_LEARN_MORE_LINK } from 'calypso/a8c-for-agencies/constants';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import useGetPayoutData from '../hooks/use-get-payout-data';
 
 import './style.scss';
@@ -25,6 +26,7 @@ function PayoutAmount( {
 	handleHalfQuarter?: boolean;
 } ) {
 	const translate = useTranslate();
+	const { showSupportGuide } = useHelpCenter();
 
 	return (
 		<ConsolidatedStatsCard
@@ -69,9 +71,7 @@ function PayoutAmount( {
 
 					<div>
 						<Button
-							href={ AGENCY_EARNINGS_LEARN_MORE_LINK }
-							target="_blank"
-							rel="noreferrer noopener"
+							onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) }
 							variant="link"
 						>
 							{ translate( 'Learn more' ) } ↗

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/payout-cards.tsx
@@ -74,7 +74,7 @@ function PayoutAmount( {
 							onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) }
 							variant="link"
 						>
-							{ translate( 'Learn more' ) } ↗
+							{ translate( 'Learn more' ) }
 						</Button>
 					</div>
 				</div>

--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -96,7 +96,7 @@ export default function GetStarted() {
 						variant="link"
 						onClick={ onLearnMoreClick }
 					>
-						{ translate( 'Team members Knowledge Base article ↗' ) }
+						{ translate( 'Team members Knowledge Base article' ) }
 					</Button>
 					<br />
 				</StepSection>

--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -7,6 +7,7 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import { A4A_TEAM_INVITE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StepSection from 'calypso/a8c-for-agencies/components/step-section';
 import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
@@ -20,6 +21,7 @@ import './style.scss';
 export default function GetStarted() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const isDesktop = useDesktopBreakpoint();
 
@@ -31,6 +33,9 @@ export default function GetStarted() {
 
 	const onLearnMoreClick = () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_managing_members_click' ) );
+		showSupportGuide(
+			'https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members'
+		);
 	};
 
 	return (
@@ -89,8 +94,6 @@ export default function GetStarted() {
 					<Button
 						className="team-list-get-started__learn-more-button"
 						variant="link"
-						target="_blank"
-						href="https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members"
 						onClick={ onLearnMoreClick }
 					>
 						{ translate( 'Team members Knowledge Base article ↗' ) }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
@@ -1,4 +1,5 @@
 import { formatCurrency } from '@automattic/number-formatters';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import {
 	ConsolidatedStatsCard,
@@ -27,18 +28,17 @@ const WooPaymentsConsolidatedViews = () => {
 				popoverTitle={ translate( 'Total WooPayments commissions paid' ) }
 				popoverContent={ translate(
 					'The total amount of transactions processed through WooPayments across all your client sites. ' +
-						'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
+						'{{br/}}{{br/}}{{a}}Learn more{{/a}}',
 					{
 						components: {
 							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-is-valid
-								<a
+								<Button
+									variant="link"
 									onClick={ () =>
 										showSupportGuide(
 											'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/'
 										)
 									}
-									href="#"
 								/>
 							),
 							br: <br />,

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
@@ -4,11 +4,13 @@ import {
 	ConsolidatedStatsCard,
 	ConsolidatedStatsGroup,
 } from 'calypso/a8c-for-agencies/components/consolidated-stats-card';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import PayoutCards from '../../referrals/consolidated-view/payout-cards';
 import { useWooPaymentsContext } from '../context';
 
 const WooPaymentsConsolidatedViews = () => {
 	const translate = useTranslate();
+	const { showSupportGuide } = useHelpCenter();
 
 	const { woopaymentsData, isLoadingWooPaymentsData } = useWooPaymentsContext();
 	const totalCommission = woopaymentsData?.data?.total?.payout ?? 0;
@@ -16,9 +18,6 @@ const WooPaymentsConsolidatedViews = () => {
 		woopaymentsData?.data?.estimated?.previous_quarter?.payout ?? 0;
 	const currentQuarterExpectedCommission =
 		woopaymentsData?.data?.estimated?.current_quarter?.payout ?? 0;
-
-	const learnMoreLink =
-		'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/';
 
 	return (
 		<ConsolidatedStatsGroup className="consolidated-view">
@@ -31,7 +30,17 @@ const WooPaymentsConsolidatedViews = () => {
 						'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
 					{
 						components: {
-							a: <a href={ learnMoreLink } target="_blank" rel="noreferrer noopener" />,
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-is-valid
+								<a
+									onClick={ () =>
+										showSupportGuide(
+											'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/'
+										)
+									}
+									href="#"
+								/>
+							),
 							br: <br />,
 						},
 					}

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import StepSection from 'calypso/a8c-for-agencies/components/step-section';
 import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
@@ -37,7 +37,8 @@ const WooPaymentsDashboardEmptyState = () => {
 				</StepSectionItem>
 			</StepSection>
 			<StepSection heading={ translate( 'Learn more about the program' ) }>
-				<ExternalLink
+				<Button
+					variant="link"
 					onClick={ () => {
 						dispatch(
 							recordTracksEvent( 'calypso_a4a_woopayments_learn_more_about_program_click' )
@@ -46,10 +47,9 @@ const WooPaymentsDashboardEmptyState = () => {
 							'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/'
 						);
 					} }
-					href="#"
 				>
 					{ translate( 'Check out the full details in the Knowledge Base' ) }
-				</ExternalLink>
+				</Button>
 			</StepSection>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -2,6 +2,7 @@ import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import StepSection from 'calypso/a8c-for-agencies/components/step-section';
 import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import wooPaymentsLogo from 'calypso/assets/images/a8c-for-agencies/woopayments/logo.svg';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -10,6 +11,7 @@ import AddWooPaymentsToSite from '../../add-woopayments-to-site';
 const WooPaymentsDashboardEmptyState = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	return (
 		<div className="woopayments-dashboard-empty-state__content">
@@ -40,8 +42,11 @@ const WooPaymentsDashboardEmptyState = () => {
 						dispatch(
 							recordTracksEvent( 'calypso_a4a_woopayments_learn_more_about_program_click' )
 						);
+						showSupportGuide(
+							'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/'
+						);
 					} }
-					href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
+					href="#"
 				>
 					{ translate( 'Check out the full details in the Knowledge Base' ) }
 				</ExternalLink>

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
@@ -243,17 +243,17 @@ const WooPaymentsOverview = () => {
 	);
 
 	const seeFullTermsLink = (
-		<ExternalLink
+		<Button
+			variant="link"
 			onClick={ () => {
 				dispatch( recordTracksEvent( 'calypso_a4a_woopayments_see_full_terms_click' ) );
 				showSupportGuide(
 					'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/'
 				);
 			} }
-			href="#"
 		>
 			{ translate( 'See full terms' ) }
-		</ExternalLink>
+		</Button>
 	);
 
 	return (

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
@@ -11,6 +11,7 @@ import PageSectionColumns from 'calypso/a8c-for-agencies/components/page-section
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_WOOPAYMENTS_DASHBOARD_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import { formatCurrencyCompact } from 'calypso/a8c-for-agencies/lib/currency';
 import { extractStrings } from 'calypso/a8c-for-agencies/lib/translation';
 import cartImage from 'calypso/assets/images/a8c-for-agencies/woopayments/cart.png';
@@ -35,6 +36,7 @@ import './style.scss';
 const WooPaymentsOverview = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const title = translate( 'WooPayments commissions' );
 
@@ -244,8 +246,11 @@ const WooPaymentsOverview = () => {
 		<ExternalLink
 			onClick={ () => {
 				dispatch( recordTracksEvent( 'calypso_a4a_woopayments_see_full_terms_click' ) );
+				showSupportGuide(
+					'https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/'
+				);
 			} }
-			href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
+			href="#"
 		>
 			{ translate( 'See full terms' ) }
 		</ExternalLink>


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/A4A-1942/fix-a4a-dashboard-links-to-help-center-docs


**NOTE: This is not an exhaustive list and only some of the links are updated. Those will be addressed on follow-up PRs.**

## Proposed Changes

This pull request refactors how external Knowledge Base (KB) links are handled across the Automattic for Agencies frontend. Instead of opening KB articles in a new tab, clicking these links now opens the relevant article directly in the in-app Help Center modal, providing a more integrated user experience. This change is implemented consistently across multiple components and sections by introducing and utilizing a new `showSupportGuide` method from the `useHelpCenter` hook.

**Help Center Integration and Link Handling:**

* Introduced a new `showSupportGuide` method in the `useHelpCenter` hook, enabling programmatic navigation to specific KB articles within the Help Center modal. (`client/a8c-for-agencies/hooks/use-help-center.ts`) [[1]](diffhunk://#diff-180c605250d4095e7413c9fc73326babca1cf9240996fb0f7f6cab5c1db937fcR38-R42) [[2]](diffhunk://#diff-180c605250d4095e7413c9fc73326babca1cf9240996fb0f7f6cab5c1db937fcR68)
* Updated all relevant components and sections (e.g., team management, WooPayments, migrations, partner directory, referrals) to use `showSupportGuide` for KB article links, replacing direct external links with in-app modal navigation. [[1]](diffhunk://#diff-5bf540f1092e5135208f216a3a7e4955fd64460f177963bba92545c1bac158f4R3) [[2]](diffhunk://#diff-5bf540f1092e5135208f216a3a7e4955fd64460f177963bba92545c1bac158f4R13-L19) [[3]](diffhunk://#diff-5bf540f1092e5135208f216a3a7e4955fd64460f177963bba92545c1bac158f4L34-L36) [[4]](diffhunk://#diff-48cf7c6338e694d6fc08a0b1273bdc5f2e33e9ba21b1a0386b8394f766de300cR4) [[5]](diffhunk://#diff-48cf7c6338e694d6fc08a0b1273bdc5f2e33e9ba21b1a0386b8394f766de300cR13-R24) [[6]](diffhunk://#diff-48cf7c6338e694d6fc08a0b1273bdc5f2e33e9ba21b1a0386b8394f766de300cL44-R50) [[7]](diffhunk://#diff-3aa7ba8a2eab1eb18bd945cf7d2f9ed29564b75fb570bc351f2e4ba7ea4511beR3-R9) [[8]](diffhunk://#diff-3aa7ba8a2eab1eb18bd945cf7d2f9ed29564b75fb570bc351f2e4ba7ea4511beR20-R28) [[9]](diffhunk://#diff-d8d3f61245b943af2c0be98b8dd5c3facd67a1e807e3a7a550e76ef7bf2c88fdR6) [[10]](diffhunk://#diff-d8d3f61245b943af2c0be98b8dd5c3facd67a1e807e3a7a550e76ef7bf2c88fdR17) [[11]](diffhunk://#diff-d8d3f61245b943af2c0be98b8dd5c3facd67a1e807e3a7a550e76ef7bf2c88fdR152-R160) [[12]](diffhunk://#diff-ceb71444581e12894880fc95b14016736d25a765fe5c6c6796f20b03094d5905R10) [[13]](diffhunk://#diff-ceb71444581e12894880fc95b14016736d25a765fe5c6c6796f20b03094d5905R50) [[14]](diffhunk://#diff-ceb71444581e12894880fc95b14016736d25a765fe5c6c6796f20b03094d5905L215-R235) [[15]](diffhunk://#diff-da77e4d590f83af7a2e013a7005b2e4d1a2738111c772702bf6e48d68929e96cR9) [[16]](diffhunk://#diff-da77e4d590f83af7a2e013a7005b2e4d1a2738111c772702bf6e48d68929e96cR24) [[17]](diffhunk://#diff-da77e4d590f83af7a2e013a7005b2e4d1a2738111c772702bf6e48d68929e96cR39-R42) [[18]](diffhunk://#diff-da77e4d590f83af7a2e013a7005b2e4d1a2738111c772702bf6e48d68929e96cL64-R67) [[19]](diffhunk://#diff-c3efdf4f41a0c159251e70fb0b85595a8d2dfb398eb464f8bf2db60a272751f9R6) [[20]](diffhunk://#diff-c3efdf4f41a0c159251e70fb0b85595a8d2dfb398eb464f8bf2db60a272751f9R29) [[21]](diffhunk://#diff-c3efdf4f41a0c159251e70fb0b85595a8d2dfb398eb464f8bf2db60a272751f9L72-R74) [[22]](diffhunk://#diff-37efc15829be58ee43fd1c5383c4a5e369d5de75feff3da8d4df35cf711b2c46R10) [[23]](diffhunk://#diff-37efc15829be58ee43fd1c5383c4a5e369d5de75feff3da8d4df35cf711b2c46R24) [[24]](diffhunk://#diff-37efc15829be58ee43fd1c5383c4a5e369d5de75feff3da8d4df35cf711b2c46R36-R38) [[25]](diffhunk://#diff-37efc15829be58ee43fd1c5383c4a5e369d5de75feff3da8d4df35cf711b2c46L92-L93) [[26]](diffhunk://#diff-f9b8252a7e73fcb8b49383a00cfe5fff9000d9292532ff13aeeb71e872cfb30dR7-R13) [[27]](diffhunk://#diff-f9b8252a7e73fcb8b49383a00cfe5fff9000d9292532ff13aeeb71e872cfb30dL20-L22)

**User Experience Improvements:**

* Ensured that all "Learn more" or KB article links now open within the Help Center modal instead of navigating away from the app or opening a new browser tab, resulting in a smoother and more consistent user experience. [[1]](diffhunk://#diff-5bf540f1092e5135208f216a3a7e4955fd64460f177963bba92545c1bac158f4L34-L36) [[2]](diffhunk://#diff-48cf7c6338e694d6fc08a0b1273bdc5f2e33e9ba21b1a0386b8394f766de300cL44-R50) [[3]](diffhunk://#diff-3aa7ba8a2eab1eb18bd945cf7d2f9ed29564b75fb570bc351f2e4ba7ea4511beR20-R28) [[4]](diffhunk://#diff-d8d3f61245b943af2c0be98b8dd5c3facd67a1e807e3a7a550e76ef7bf2c88fdR152-R160) [[5]](diffhunk://#diff-ceb71444581e12894880fc95b14016736d25a765fe5c6c6796f20b03094d5905L215-R235) [[6]](diffhunk://#diff-da77e4d590f83af7a2e013a7005b2e4d1a2738111c772702bf6e48d68929e96cR39-R42) [[7]](diffhunk://#diff-da77e4d590f83af7a2e013a7005b2e4d1a2738111c772702bf6e48d68929e96cL64-R67) [[8]](diffhunk://#diff-c3efdf4f41a0c159251e70fb0b85595a8d2dfb398eb464f8bf2db60a272751f9L72-R74) [[9]](diffhunk://#diff-37efc15829be58ee43fd1c5383c4a5e369d5de75feff3da8d4df35cf711b2c46L92-L93)

**Code Consistency and Cleanup:**

* Removed now-unnecessary `href`, `target`, and `rel` attributes from KB anchor tags and buttons, and replaced them with click handlers that trigger the Help Center modal. [[1]](diffhunk://#diff-5bf540f1092e5135208f216a3a7e4955fd64460f177963bba92545c1bac158f4L34-L36) [[2]](diffhunk://#diff-48cf7c6338e694d6fc08a0b1273bdc5f2e33e9ba21b1a0386b8394f766de300cL44-R50) [[3]](diffhunk://#diff-3aa7ba8a2eab1eb18bd945cf7d2f9ed29564b75fb570bc351f2e4ba7ea4511beR20-R28) [[4]](diffhunk://#diff-d8d3f61245b943af2c0be98b8dd5c3facd67a1e807e3a7a550e76ef7bf2c88fdR152-R160) [[5]](diffhunk://#diff-ceb71444581e12894880fc95b14016736d25a765fe5c6c6796f20b03094d5905L215-R235) [[6]](diffhunk://#diff-da77e4d590f83af7a2e013a7005b2e4d1a2738111c772702bf6e48d68929e96cR39-R42) [[7]](diffhunk://#diff-da77e4d590f83af7a2e013a7005b2e4d1a2738111c772702bf6e48d68929e96cL64-R67) [[8]](diffhunk://#diff-c3efdf4f41a0c159251e70fb0b85595a8d2dfb398eb464f8bf2db60a272751f9L72-R74) [[9]](diffhunk://#diff-37efc15829be58ee43fd1c5383c4a5e369d5de75feff3da8d4df35cf711b2c46L92-L93)
* Updated all relevant imports to include the new `useHelpCenter` hook where necessary. [[1]](diffhunk://#diff-5bf540f1092e5135208f216a3a7e4955fd64460f177963bba92545c1bac158f4R3) [[2]](diffhunk://#diff-48cf7c6338e694d6fc08a0b1273bdc5f2e33e9ba21b1a0386b8394f766de300cR4) [[3]](diffhunk://#diff-3aa7ba8a2eab1eb18bd945cf7d2f9ed29564b75fb570bc351f2e4ba7ea4511beR3-R9) [[4]](diffhunk://#diff-d8d3f61245b943af2c0be98b8dd5c3facd67a1e807e3a7a550e76ef7bf2c88fdR6) [[5]](diffhunk://#diff-ceb71444581e12894880fc95b14016736d25a765fe5c6c6796f20b03094d5905R10) [[6]](diffhunk://#diff-da77e4d590f83af7a2e013a7005b2e4d1a2738111c772702bf6e48d68929e96cR9) [[7]](diffhunk://#diff-c3efdf4f41a0c159251e70fb0b85595a8d2dfb398eb464f8bf2db60a272751f9R6) [[8]](diffhunk://#diff-37efc15829be58ee43fd1c5383c4a5e369d5de75feff3da8d4df35cf711b2c46R10) [[9]](diffhunk://#diff-f9b8252a7e73fcb8b49383a00cfe5fff9000d9292532ff13aeeb71e872cfb30dR7-R13)

These changes collectively modernize the way help content is presented, keeping users within the application context and offering a more seamless support experience.

## Why are these changes being made?

* Using the Help center to view KB articles is less disruptive because it displays the article inline instead of opening a new tab.

## Testing Instructions


* Use the A4A live link and navigate to `/overview` page.
* Verify the following if it works correctly.

| Description | Image |
|--------|--------|
| In the Partner Directory Dashboard screen | <img width="1554" height="1004" alt="Screenshot 2025-12-22 at 7 02 37 PM 1" src="https://github.com/user-attachments/assets/b954e20f-2f03-47a2-a22f-6ff5fece7671" /> |
| In the Teams page (empty list) | <img width="1610" height="1099" alt="Screenshot 2025-12-22 at 7 03 31 PM" src="https://github.com/user-attachments/assets/6757a1b0-0eff-4bd9-bfba-39947c3890e3" /> |
| In the WooPayments product card | <img width="1839" height="1262" alt="Screenshot 2025-12-22 at 7 05 21 PM" src="https://github.com/user-attachments/assets/805195c2-540c-4d91-bf3d-0e3117c56983" /> |
| In the Migrations FAQ | <img width="1628" height="234" alt="Screenshot 2025-12-22 at 7 07 26 PM" src="https://github.com/user-attachments/assets/7bc48d1c-0873-4488-a159-bf02127d30ba" /> |
| In the Referrals and WooPayments commission card | <img width="1493" height="1182" alt="Screenshot 2025-12-22 at 7 08 23 PM 1" src="https://github.com/user-attachments/assets/4e123ef4-c10b-4791-9f78-c6fd93cf5f85" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
