### PR TITLE
MDS: add MCP settings

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -805,14 +805,14 @@ export const mcpRoute = createRoute( {
 	} ),
 	getParentRoute: () => meRoute,
 	path: 'mcp',
+	loader: async () => {
+		await queryClient.ensureQueryData( userSettingsQuery() );
+	},
 } );
 
 export const mcpIndexRoute = createRoute( {
 	getParentRoute: () => mcpRoute,
 	path: '/',
-	loader: async () => {
-		await queryClient.ensureQueryData( userSettingsQuery() );
-	},
 } ).lazy( () =>
 	import( '../../me/mcp' ).then( ( d ) =>
 		createLazyRoute( 'mcp' )( {
@@ -825,15 +825,12 @@ export const mcpSetupRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
-				title: __( 'MCP Setup' ),
+				title: __( 'MCP Client Setup' ),
 			},
 		],
 	} ),
 	getParentRoute: () => mcpRoute,
 	path: 'setup',
-	loader: async () => {
-		await queryClient.ensureQueryData( userSettingsQuery() );
-	},
 } ).lazy( () =>
 	import( '../../me/mcp/setup' ).then( ( d ) =>
 		createLazyRoute( 'mcp-setup' )( {
@@ -911,12 +908,12 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		meRoutes.push( blockedSitesRoute );
 	}
 
-	if ( config.supports.me.apps ) {
-		meRoutes.push( appsRoute );
-	}
-
 	if ( isEnabled( 'mcp-settings' ) ) {
 		meRoutes.push( mcpRoute.addChildren( [ mcpIndexRoute, mcpSetupRoute ] ) );
+	}
+
+	if ( config.supports.me.apps ) {
+		meRoutes.push( appsRoute );
 	}
 
 	return [ meRoute.addChildren( meRoutes ) ];

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -805,6 +805,11 @@ export const mcpRoute = createRoute( {
 	} ),
 	getParentRoute: () => meRoute,
 	path: 'mcp',
+} );
+
+export const mcpIndexRoute = createRoute( {
+	getParentRoute: () => mcpRoute,
+	path: '/',
 	loader: async () => {
 		await queryClient.ensureQueryData( userSettingsQuery() );
 	},
@@ -911,7 +916,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 	}
 
 	if ( isEnabled( 'mcp-settings' ) ) {
-		meRoutes.push( mcpRoute.addChildren( [ mcpSetupRoute ] ) );
+		meRoutes.push( mcpRoute.addChildren( [ mcpIndexRoute, mcpSetupRoute ] ) );
 	}
 
 	return [ meRoute.addChildren( meRoutes ) ];

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -24,6 +24,7 @@ import {
 	plansQuery,
 	userNotificationsDevicesQuery,
 } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { getMonetizeSubscriptionsPageTitle } from '../../me/billing-monetize-subscriptions/title';
@@ -794,6 +795,48 @@ export const appsRoute = createRoute( {
 	)
 );
 
+export const mcpRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'MCP Account Settings' ),
+			},
+		],
+	} ),
+	getParentRoute: () => meRoute,
+	path: 'mcp',
+	loader: async () => {
+		await queryClient.ensureQueryData( userSettingsQuery() );
+	},
+} ).lazy( () =>
+	import( '../../me/mcp' ).then( ( d ) =>
+		createLazyRoute( 'mcp' )( {
+			component: d.default,
+		} )
+	)
+);
+
+export const mcpSetupRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'MCP Setup' ),
+			},
+		],
+	} ),
+	getParentRoute: () => mcpRoute,
+	path: 'setup',
+	loader: async () => {
+		await queryClient.ensureQueryData( userSettingsQuery() );
+	},
+} ).lazy( () =>
+	import( '../../me/mcp/setup' ).then( ( d ) =>
+		createLazyRoute( 'mcp-setup' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createMeRoutes = ( config: AppConfig ) => {
 	if ( ! config.supports.me ) {
 		return [];
@@ -865,6 +908,10 @@ export const createMeRoutes = ( config: AppConfig ) => {
 
 	if ( config.supports.me.apps ) {
 		meRoutes.push( appsRoute );
+	}
+
+	if ( isEnabled( 'mcp-settings' ) ) {
+		meRoutes.push( mcpRoute.addChildren( [ mcpSetupRoute ] ) );
 	}
 
 	return [ meRoute.addChildren( meRoutes ) ];

--- a/client/dashboard/me/mcp/categories.ts
+++ b/client/dashboard/me/mcp/categories.ts
@@ -31,63 +31,45 @@ export const CATEGORY_ORDER = [
 /**
  * Get the display category for a tool based on its ID and API category
  * @param toolId - The tool ID (e.g., 'wpcom-mcp/user-profile')
- * @param apiCategory - The category from the API (e.g., 'user', 'content', 'site')
  * @returns The display category name
  */
-export function getDisplayCategory( toolId: string, apiCategory: string ): string {
+export function getDisplayCategory( toolId: string ): string {
 	// Extract the tool name from the full ID (e.g., 'user-profile' from 'wpcom-mcp/user-profile')
 	const toolName = toolId.replace( 'wpcom-mcp/', '' );
 
-	// Sites & Content
-	if (
-		toolName === 'user-sites-resource' ||
-		toolName === 'user-sites' ||
-		toolName === 'site-users' ||
-		toolName === 'posts-search' ||
-		toolName === 'post-get' ||
-		toolName === 'site-comments-search'
-	) {
-		return DISPLAY_CATEGORIES.SITES_CONTENT;
-	}
+	const TOOL_CATEGORY_MAP: Record< string, string > = {
+		// Sites & Content
+		'user-sites-resource': DISPLAY_CATEGORIES.SITES_CONTENT,
+		'user-sites': DISPLAY_CATEGORIES.SITES_CONTENT,
+		'site-users': DISPLAY_CATEGORIES.SITES_CONTENT,
+		'posts-search': DISPLAY_CATEGORIES.SITES_CONTENT,
+		'post-get': DISPLAY_CATEGORIES.SITES_CONTENT,
+		'site-comments-search': DISPLAY_CATEGORIES.SITES_CONTENT,
 
-	// Account
-	if (
-		toolName === 'user-profile' ||
-		toolName === 'user-security' ||
-		toolName === 'user-achievements'
-	) {
-		return DISPLAY_CATEGORIES.ACCOUNT;
-	}
+		// Account
+		'user-profile': DISPLAY_CATEGORIES.ACCOUNT,
+		'user-security': DISPLAY_CATEGORIES.ACCOUNT,
+		'user-achievements': DISPLAY_CATEGORIES.ACCOUNT,
 
-	// Billing
-	if ( toolName === 'user-subscriptions' ) {
-		return DISPLAY_CATEGORIES.BILLING;
-	}
+		// Billing
+		'user-subscriptions': DISPLAY_CATEGORIES.BILLING,
 
-	// Notifications
-	if ( toolName === 'user-notifications' || toolName === 'user-notifications-inbox' ) {
-		return DISPLAY_CATEGORIES.NOTIFICATIONS;
-	}
+		// Notifications
+		'user-notifications': DISPLAY_CATEGORIES.NOTIFICATIONS,
+		'user-notifications-inbox': DISPLAY_CATEGORIES.NOTIFICATIONS,
 
-	// Domains & Integrations
-	if ( toolName === 'user-domains' || toolName === 'user-connections' ) {
-		return DISPLAY_CATEGORIES.DOMAINS_INTEGRATIONS;
-	}
+		// Domains & Integrations
+		'user-domains': DISPLAY_CATEGORIES.DOMAINS_INTEGRATIONS,
+		'user-connections': DISPLAY_CATEGORIES.DOMAINS_INTEGRATIONS,
 
-	// Site Configuration
-	if (
-		toolName === 'site-plugins' ||
-		toolName === 'site-settings' ||
-		toolName === 'site-statistics'
-	) {
-		return DISPLAY_CATEGORIES.SITE_CONFIGURATION;
-	}
+		// Site Configuration
+		'site-plugins': DISPLAY_CATEGORIES.SITE_CONFIGURATION,
+		'site-settings': DISPLAY_CATEGORIES.SITE_CONFIGURATION,
+		'site-statistics': DISPLAY_CATEGORIES.SITE_CONFIGURATION,
 
-	// Developer & Testing
-	if ( toolName === 'sample-prompt' ) {
-		return DISPLAY_CATEGORIES.DEVELOPER_TESTING;
-	}
+		// Developer & Testing
+		'sample-prompt': DISPLAY_CATEGORIES.DEVELOPER_TESTING,
+	};
 
-	// Default to either the API category or uncategorized
-	return apiCategory || DISPLAY_CATEGORIES.UNCATEGORIZED;
+	return TOOL_CATEGORY_MAP[ toolName ] || DISPLAY_CATEGORIES.UNCATEGORIZED;
 }

--- a/client/dashboard/me/mcp/categories.ts
+++ b/client/dashboard/me/mcp/categories.ts
@@ -1,0 +1,93 @@
+/**
+ * MCP Tools Category Mapping
+ *
+ * Maps tool IDs and API categories to display categories for the MCP settings page.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+export const DISPLAY_CATEGORIES = {
+	SITES_CONTENT: __( 'Sites & Content', 'calypso' ),
+	ACCOUNT: __( 'Account', 'calypso' ),
+	BILLING: __( 'Billing', 'calypso' ),
+	NOTIFICATIONS: __( 'Notifications', 'calypso' ),
+	DOMAINS_INTEGRATIONS: __( 'Domains & Integrations', 'calypso' ),
+	SITE_CONFIGURATION: __( 'Site Configuration', 'calypso' ),
+	DEVELOPER_TESTING: __( 'Developer & Testing', 'calypso' ),
+	UNCATEGORIZED: __( 'Uncategorized', 'calypso' ),
+} as const;
+
+export const CATEGORY_ORDER = [
+	DISPLAY_CATEGORIES.SITES_CONTENT,
+	DISPLAY_CATEGORIES.ACCOUNT,
+	DISPLAY_CATEGORIES.BILLING,
+	DISPLAY_CATEGORIES.NOTIFICATIONS,
+	DISPLAY_CATEGORIES.DOMAINS_INTEGRATIONS,
+	DISPLAY_CATEGORIES.SITE_CONFIGURATION,
+	DISPLAY_CATEGORIES.DEVELOPER_TESTING,
+	DISPLAY_CATEGORIES.UNCATEGORIZED,
+] as const;
+
+/**
+ * Get the display category for a tool based on its ID and API category
+ * @param toolId - The tool ID (e.g., 'wpcom-mcp/user-profile')
+ * @param apiCategory - The category from the API (e.g., 'user', 'content', 'site')
+ * @returns The display category name
+ */
+export function getDisplayCategory( toolId: string, apiCategory: string ): string {
+	// Extract the tool name from the full ID (e.g., 'user-profile' from 'wpcom-mcp/user-profile')
+	const toolName = toolId.replace( 'wpcom-mcp/', '' );
+
+	// Sites & Content
+	if (
+		toolName === 'user-sites-resource' ||
+		toolName === 'user-sites' ||
+		toolName === 'site-users' ||
+		toolName === 'posts-search' ||
+		toolName === 'post-get' ||
+		toolName === 'site-comments-search'
+	) {
+		return DISPLAY_CATEGORIES.SITES_CONTENT;
+	}
+
+	// Account
+	if (
+		toolName === 'user-profile' ||
+		toolName === 'user-security' ||
+		toolName === 'user-achievements'
+	) {
+		return DISPLAY_CATEGORIES.ACCOUNT;
+	}
+
+	// Billing
+	if ( toolName === 'user-subscriptions' ) {
+		return DISPLAY_CATEGORIES.BILLING;
+	}
+
+	// Notifications
+	if ( toolName === 'user-notifications' || toolName === 'user-notifications-inbox' ) {
+		return DISPLAY_CATEGORIES.NOTIFICATIONS;
+	}
+
+	// Domains & Integrations
+	if ( toolName === 'user-domains' || toolName === 'user-connections' ) {
+		return DISPLAY_CATEGORIES.DOMAINS_INTEGRATIONS;
+	}
+
+	// Site Configuration
+	if (
+		toolName === 'site-plugins' ||
+		toolName === 'site-settings' ||
+		toolName === 'site-statistics'
+	) {
+		return DISPLAY_CATEGORIES.SITE_CONFIGURATION;
+	}
+
+	// Developer & Testing
+	if ( toolName === 'sample-prompt' ) {
+		return DISPLAY_CATEGORIES.DEVELOPER_TESTING;
+	}
+
+	// Default to either the API category or uncategorized
+	return apiCategory || DISPLAY_CATEGORIES.UNCATEGORIZED;
+}

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -1,0 +1,332 @@
+import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	ToggleControl,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { getAccountMcpAbilities, getSiteAccountToolsEnabled } from '../../../me/mcp/utils';
+import { useAppContext } from '../../app/context';
+import { Card, CardBody } from '../../components/card';
+import ComponentViewTracker from '../../components/component-view-tracker';
+import InlineSupportLink from '../../components/inline-support-link';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
+import PreferencesLoginSiteDropdown from '../preferences-primary-site/site-dropdown';
+import type { Site } from '@automattic/api-core';
+
+interface McpAbility {
+	title: string;
+	description: string;
+	enabled: boolean;
+}
+
+interface McpSite {
+	blog_id: number;
+	account_tools_enabled?: boolean;
+	abilities?: Record< string, unknown >;
+}
+
+function McpComponent() {
+	const queryClient = useQueryClient();
+	const { queries } = useAppContext();
+	// @ts-expect-error - site_visibility is valid but not in type definition
+	const { data: sites = [] } = useQuery( queries.sitesQuery( { site_visibility: 'visible' } ) ) as {
+		data: Site[];
+	};
+	const {
+		data: userSettings,
+		isLoading: isLoadingUserSettings,
+		error: userSettingsError,
+	} = useQuery( userSettingsQuery() );
+
+	// Site selector state for disabling MCP access on specific sites
+	const [ selectedSiteId, setSelectedSiteId ] = useState( '' );
+
+	// Use the standard userSettingsMutation with snackbar notifications
+	const mutation = useMutation( {
+		...userSettingsMutation(),
+		meta: {
+			snackbar: {
+				success: __( 'MCP settings saved.' ),
+				error: __( 'Failed to save MCP settings.' ),
+			},
+		},
+		onSuccess: ( newData: any ) => {
+			// Update the cache with the new data from the API response
+			queryClient.setQueryData( userSettingsQuery().queryKey, newData as any );
+		},
+	} );
+
+	// Handle error states only - allow loading to continue so reauth can show
+	if ( userSettingsError ) {
+		return null;
+	}
+
+	// Get account-level tools from user settings using the new nested structure
+	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
+	const availableTools = Object.entries( mcpAbilities );
+	const hasTools = availableTools.length > 0;
+
+	// Check if any tools are enabled (for master toggle state)
+	const anyToolsEnabled =
+		hasTools && Object.values( mcpAbilities ).some( ( tool ) => tool.enabled );
+
+	const handleToolChange = ( toolId: string, enabled: boolean ) => {
+		// Create minimal payload with only the changed tool (just boolean)
+		const payload = {
+			mcp_abilities: {
+				account: {
+					[ toolId ]: enabled,
+				},
+			},
+		};
+		mutation.mutate( payload as any );
+	};
+
+	const handleMasterToggle = ( enabled: boolean ) => {
+		// Create payload with all tools set to the same state (just booleans)
+		const accountAbilities: Record< string, boolean > = {};
+		Object.keys( mcpAbilities ).forEach( ( toolId ) => {
+			accountAbilities[ toolId ] = enabled;
+		} );
+
+		const payload = {
+			mcp_abilities: {
+				account: accountAbilities,
+			},
+		};
+		mutation.mutate( payload as any );
+	};
+
+	const handleSiteToggle = ( siteId: string, enabled: boolean ) => {
+		// Get current sites array from nested structure
+		const currentSites = ( userSettings?.mcp_abilities?.sites as McpSite[] | undefined ) || [];
+
+		// Find existing site entry
+		const siteIndex = currentSites.findIndex(
+			( site: McpSite ) => site.blog_id === parseInt( siteId, 10 )
+		);
+
+		let newSites;
+		if ( enabled ) {
+			// Enabling: remove from sites array (use defaults)
+			if ( siteIndex >= 0 ) {
+				// Remove the site entry entirely
+				newSites = currentSites.filter( ( _site: McpSite, index: number ) => index !== siteIndex );
+			} else {
+				// Site not in array, already using defaults
+				newSites = currentSites;
+			}
+		} else if ( siteIndex >= 0 ) {
+			// Disabling: update existing site entry
+			newSites = [ ...currentSites ];
+			newSites[ siteIndex ] = {
+				...newSites[ siteIndex ],
+				account_tools_enabled: false,
+			};
+		} else {
+			// Disabling: add new site entry with override
+			newSites = [
+				...currentSites,
+				{
+					blog_id: parseInt( siteId ),
+					account_tools_enabled: false,
+					abilities: {},
+				},
+			];
+		}
+
+		// For the API payload, we need to send the site being toggled as an array
+		// The API expects sites to be an array with blog_id fields
+		const sitesPayload = [];
+		if ( enabled ) {
+			// Enabling: send the site with account_tools_enabled: true
+			sitesPayload.push( {
+				blog_id: parseInt( siteId ),
+				account_tools_enabled: true,
+			} );
+		} else {
+			// Disabling: send the site with account_tools_enabled: false
+			sitesPayload.push( {
+				blog_id: parseInt( siteId ),
+				account_tools_enabled: false,
+			} );
+		}
+
+		// Only include sites in payload if there are any sites to send
+		// Don't include account object - only send the sites being changed
+		const payload = {
+			mcp_abilities: {
+				...( sitesPayload.length > 0 && { sites: sitesPayload } ),
+			},
+		};
+		mutation.mutate( payload as any );
+	};
+
+	// Helper function to render tools section using ExtrasToggleCard pattern
+	const renderToolsSection = ( tools: Array< [ string, McpAbility ] > ) => {
+		if ( ! tools || tools.length === 0 ) {
+			return null;
+		}
+
+		return (
+			<Card isRounded={ false }>
+				<CardBody>
+					<VStack spacing={ 8 }>
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'Available MCP Tools' ) }
+							description={ __( 'Choose which AI tools you want to use.' ) }
+						/>
+
+						{ /* Individual tool toggles */ }
+						<VStack>
+							{ tools.map( ( [ toolId, tool ]: [ string, McpAbility ] ) => (
+								<ToggleControl
+									key={ toolId }
+									__nextHasNoMarginBottom
+									checked={ tool.enabled }
+									disabled={ mutation.isPending }
+									label={ tool.title }
+									help={ tool.description }
+									onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+								/>
+							) ) }
+						</VStack>
+					</VStack>
+				</CardBody>
+			</Card>
+		);
+	};
+
+	const renderContent = () => {
+		// Use mcpAbilities directly since we're using auto-save
+		const accountToolsToShow = availableTools;
+
+		return (
+			<VStack spacing={ 8 }>
+				{ /* MCP Tool Access Master Toggle */ }
+				<Card isRounded={ false }>
+					<CardBody>
+						<VStack spacing={ 8 }>
+							<SectionHeader
+								level={ 3 }
+								title={ __( 'MCP Tool Access' ) }
+								description={ __(
+									'Control which MCP tools can access your WordPress.com account and sites.'
+								) }
+							/>
+
+							<div
+								style={ {
+									display: 'flex',
+									justifyContent: 'space-between',
+									alignItems: 'center',
+								} }
+							>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									checked={ anyToolsEnabled }
+									onChange={ handleMasterToggle }
+									label={
+										<Text weight="bold">
+											{ anyToolsEnabled
+												? __( 'Disable MCP Tool Access' )
+												: __( 'Enable MCP Tool Access' ) }
+										</Text>
+									}
+								/>
+								{ anyToolsEnabled && (
+									<Link to="/me/mcp/setup">
+										<Button variant="secondary">{ __( 'Configure MCP Client' ) }</Button>
+									</Link>
+								) }
+							</div>
+						</VStack>
+					</CardBody>
+				</Card>
+
+				{ /* Site-Specific Settings */ }
+				{ hasTools && anyToolsEnabled && (
+					<Card isRounded={ false }>
+						<CardBody>
+							<VStack spacing={ 8 }>
+								<SectionHeader
+									level={ 3 }
+									title={ __( 'Site-specific MCP settings' ) }
+									description={ __(
+										'Choose a site to block all MCP tools for all users on that site. This overrides your account settings.'
+									) }
+								/>
+
+								<PreferencesLoginSiteDropdown
+									sites={ sites }
+									value={ selectedSiteId }
+									onChange={ ( value ) => setSelectedSiteId( value || '' ) }
+									label={ __( 'Select a site to disable MCP access' ) }
+									isLoading={ false }
+								/>
+
+								{ selectedSiteId && anyToolsEnabled && (
+									<ToggleControl
+										__nextHasNoMarginBottom
+										checked={ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId ) }
+										disabled={ mutation.isPending }
+										onChange={ ( enabled ) => handleSiteToggle( selectedSiteId, enabled ) }
+										label={
+											<Text weight="bold">
+												{ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId )
+													? __( 'Disable MCP access for this site' )
+													: __( 'Enable MCP access for this site' ) }
+											</Text>
+										}
+									/>
+								) }
+							</VStack>
+						</CardBody>
+					</Card>
+				) }
+
+				{ /* Account Tools Sections */ }
+				{ hasTools && renderToolsSection( accountToolsToShow ) }
+			</VStack>
+		);
+	};
+
+	// Check if MCP settings feature is enabled
+	if ( ! config.isEnabled( 'mcp-settings' ) ) {
+		return null;
+	}
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'MCP Account Settings' ) }
+					description={ createInterpolateElement(
+						__(
+							'MCP (Model Context Protocol) enables AI assistants to securely access and interact with your WordPress.com data. <link>Learn more.</link>'
+						),
+						{
+							link: <InlineSupportLink supportContext="mcp" />,
+						}
+					) }
+				/>
+			}
+		>
+			<ComponentViewTracker eventName="calypso_dashboard_mcp_view" />
+			{ ! isLoadingUserSettings && renderContent() }
+		</PageLayout>
+	);
+}
+
+export default McpComponent;

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -1,6 +1,6 @@
 import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
 	Button,
@@ -39,15 +39,12 @@ interface McpSite {
 function McpComponent() {
 	const queryClient = useQueryClient();
 	const { queries } = useAppContext();
-	// @ts-expect-error - site_visibility is valid but not in type definition
-	const { data: sites = [] } = useQuery( queries.sitesQuery( { site_visibility: 'visible' } ) ) as {
+	const { data: sites = [] } = useQuery(
+		queries.sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
+	) as {
 		data: Site[];
 	};
-	const {
-		data: userSettings,
-		isLoading: isLoadingUserSettings,
-		error: userSettingsError,
-	} = useQuery( userSettingsQuery() );
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	// Site selector state for disabling MCP access on specific sites
 	const [ selectedSiteId, setSelectedSiteId ] = useState( '' );
@@ -66,11 +63,6 @@ function McpComponent() {
 			queryClient.setQueryData( userSettingsQuery().queryKey, newData as any );
 		},
 	} );
-
-	// Handle error states only - allow loading to continue so reauth can show
-	if ( userSettingsError ) {
-		return null;
-	}
 
 	// Get account-level tools from user settings using the new nested structure
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
@@ -363,7 +355,7 @@ function McpComponent() {
 			}
 		>
 			<ComponentViewTracker eventName="calypso_dashboard_mcp_view" />
-			{ ! isLoadingUserSettings && renderContent() }
+			{ renderContent() }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -7,6 +7,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	ToggleControl,
+	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -212,7 +213,12 @@ function McpComponent() {
 
 								return (
 									<VStack key={ categoryName } spacing={ 4 }>
-										<Text as="h4" size={ 14 } weight={ 600 }>
+										<Text
+											as="h4"
+											size="x-small"
+											weight={ 500 }
+											style={ { textTransform: 'uppercase' } }
+										>
 											{ categoryName }
 										</Text>
 										<VStack spacing={ 4 }>
@@ -248,13 +254,7 @@ function McpComponent() {
 				<Card>
 					<CardBody>
 						<VStack spacing={ 4 }>
-							<div
-								style={ {
-									display: 'flex',
-									justifyContent: 'space-between',
-									alignItems: 'center',
-								} }
-							>
+							<HStack justify="space-between" alignment="center">
 								<SectionHeader
 									level={ 3 }
 									title={ __( 'MCP Tool Access' ) }
@@ -267,7 +267,7 @@ function McpComponent() {
 										<Button variant="secondary">{ __( 'Configure MCP Client' ) }</Button>
 									</Link>
 								) }
-							</div>
+							</HStack>
 
 							<ToggleControl
 								__nextHasNoMarginBottom

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -40,7 +40,7 @@ interface McpSite {
 function McpComponent() {
 	const queryClient = useQueryClient();
 	const { queries } = useAppContext();
-	const { data: sites = [] } = useQuery(
+	const { data: sites = [], isLoading: isLoadingSites } = useQuery(
 		queries.sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
 	) as {
 		data: Site[];
@@ -116,6 +116,10 @@ function McpComponent() {
 		} );
 
 		return grouped;
+	};
+
+	const handleSiteDropdownChange = ( value: string | null | undefined ) => {
+		setSelectedSiteId( value ? Number( value ) : null );
 	};
 
 	const handleSiteToggle = ( siteId: number, enabled: boolean ) => {
@@ -299,11 +303,9 @@ function McpComponent() {
 								<PreferencesLoginSiteDropdown
 									sites={ sites }
 									value={ selectedSiteId !== null ? String( selectedSiteId ) : '' }
-									onChange={ ( value: string | null ) =>
-										setSelectedSiteId( value ? Number( value ) : null )
-									}
+									onChange={ handleSiteDropdownChange }
 									label={ __( 'Select a site to disable AI access' ) }
-									isLoading={ false }
+									isLoading={ isLoadingSites }
 								/>
 
 								{ selectedSiteId !== null && anyToolsEnabled && (

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -1,9 +1,7 @@
 import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { useQuery, useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
 import {
-	Button,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 	ToggleControl,
@@ -19,6 +17,7 @@ import ComponentViewTracker from '../../components/component-view-tracker';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
 import PreferencesLoginSiteDropdown from '../preferences-primary-site/site-dropdown';
 import { CATEGORY_ORDER, getDisplayCategory } from './categories';
@@ -265,11 +264,13 @@ function McpComponent() {
 									) }
 								/>
 								<VStack style={ { flexShrink: 0 } }>
-									<Link to="/me/mcp/setup">
-										<Button variant="secondary" disabled={ ! anyToolsEnabled }>
-											{ __( 'Configure MCP Client' ) }
-										</Button>
-									</Link>
+									<RouterLinkButton
+										to="/me/mcp/setup"
+										variant="secondary"
+										disabled={ ! anyToolsEnabled }
+									>
+										{ __( 'Configure MCP Client' ) }
+									</RouterLinkButton>
 								</VStack>
 							</HStack>
 

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -176,13 +176,13 @@ function McpComponent() {
 					newSites = newSites.filter( ( _site: McpSite, index: number ) => index !== siteIndex );
 				}
 			} else if ( siteIndex >= 0 ) {
-				// Update existing site entry
+				// Disabling: update existing site entry
 				newSites[ siteIndex ] = {
 					...newSites[ siteIndex ],
 					account_tools_enabled: false,
 				};
 			} else {
-				// Add new site entry with override
+				// Disabling: add new site entry with override
 				newSites.push( {
 					blog_id: siteId,
 					account_tools_enabled: false,
@@ -246,7 +246,7 @@ function McpComponent() {
 									<VStack key={ categoryName } spacing={ 4 }>
 										<Text
 											as="h4"
-											size="x-small"
+											size="11px"
 											weight={ 500 }
 											style={ { textTransform: 'uppercase' } }
 										>

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -255,9 +255,9 @@ function McpComponent() {
 							<HStack justify="space-between" alignment="top">
 								<SectionHeader
 									level={ 3 }
-									title={ __( 'MCP Tool Access' ) }
+									title={ __( 'AI Access' ) }
 									description={ __(
-										'Control which MCP tools can access your WordPress.com account and sites.'
+										'Control what AI assistants can access your WordPress.com account and sites.'
 									) }
 								/>
 								{ anyToolsEnabled && (
@@ -275,9 +275,7 @@ function McpComponent() {
 								onChange={ handleMasterToggle }
 								label={
 									<Text>
-										{ anyToolsEnabled
-											? __( 'Disable MCP Tool Access' )
-											: __( 'Enable MCP Tool Access' ) }
+										{ anyToolsEnabled ? __( 'Disable AI Access' ) : __( 'Enable AI Access' ) }
 									</Text>
 								}
 							/>
@@ -294,7 +292,7 @@ function McpComponent() {
 									level={ 3 }
 									title={ __( 'Site-specific MCP settings' ) }
 									description={ __(
-										'Choose a site to block all MCP tools for all users on that site. This overrides your account settings.'
+										'Choose a site to block AI access for all users on that site. This overrides your account settings.'
 									) }
 								/>
 
@@ -304,7 +302,7 @@ function McpComponent() {
 									onChange={ ( value: string | null ) =>
 										setSelectedSiteId( value ? Number( value ) : null )
 									}
-									label={ __( 'Select a site to disable MCP access' ) }
+									label={ __( 'Select a site to disable AI access' ) }
 									isLoading={ false }
 								/>
 
@@ -317,8 +315,8 @@ function McpComponent() {
 										label={
 											<Text>
 												{ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId )
-													? __( 'Disable MCP access for this site' )
-													: __( 'Enable MCP access for this site' ) }
+													? __( 'Disable AI access for this site' )
+													: __( 'Enable AI access for this site' ) }
 											</Text>
 										}
 									/>

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -40,11 +40,11 @@ interface McpSite {
 function McpComponent() {
 	const queryClient = useQueryClient();
 	const { queries } = useAppContext();
-	const { data: sites = [], isLoading: isLoadingSites } = useQuery(
+	const sitesQueryResult = useQuery(
 		queries.sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
-	) as {
-		data: Site[];
-	};
+	);
+	const sites = ( sitesQueryResult.data as Site[] | undefined ) ?? [];
+	const isLoadingSites = sitesQueryResult.isLoading;
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	// Site selector state for disabling MCP access on specific sites
@@ -264,13 +264,13 @@ function McpComponent() {
 										'Control what AI assistants can access your WordPress.com account and sites.'
 									) }
 								/>
-								{ anyToolsEnabled && (
-									<VStack style={ { flexShrink: 0 } }>
-										<Link to="/me/mcp/setup">
-											<Button variant="secondary">{ __( 'Configure MCP Client' ) }</Button>
-										</Link>
-									</VStack>
-								) }
+								<VStack style={ { flexShrink: 0 } }>
+									<Link to="/me/mcp/setup">
+										<Button variant="secondary" disabled={ ! anyToolsEnabled }>
+											{ __( 'Configure MCP Client' ) }
+										</Button>
+									</Link>
+								</VStack>
 							</HStack>
 
 							<ToggleControl

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -20,12 +20,14 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
 import PreferencesLoginSiteDropdown from '../preferences-primary-site/site-dropdown';
+import { CATEGORY_ORDER, getDisplayCategory } from './categories';
 import type { Site } from '@automattic/api-core';
 
 interface McpAbility {
 	title: string;
 	description: string;
 	enabled: boolean;
+	category?: string;
 }
 
 interface McpSite {
@@ -106,6 +108,23 @@ function McpComponent() {
 		mutation.mutate( payload as any );
 	};
 
+	// Group tools by display category
+	const groupToolsByCategory = (
+		tools: Array< [ string, McpAbility ] >
+	): Record< string, Array< [ string, McpAbility ] > > => {
+		const grouped: Record< string, Array< [ string, McpAbility ] > > = {};
+
+		tools.forEach( ( [ toolId, tool ] ) => {
+			const displayCategory = getDisplayCategory( toolId, tool.category || '' );
+			if ( ! grouped[ displayCategory ] ) {
+				grouped[ displayCategory ] = [];
+			}
+			grouped[ displayCategory ].push( [ toolId, tool ] );
+		} );
+
+		return grouped;
+	};
+
 	const handleSiteToggle = ( siteId: string, enabled: boolean ) => {
 		// Get current sites array from nested structure
 		const currentSites = ( userSettings?.mcp_abilities?.sites as McpSite[] | undefined ) || [];
@@ -171,35 +190,55 @@ function McpComponent() {
 		mutation.mutate( payload as any );
 	};
 
-	// Helper function to render tools section using ExtrasToggleCard pattern
+	// Helper function to render tools section with categories
 	const renderToolsSection = ( tools: Array< [ string, McpAbility ] > ) => {
 		if ( ! tools || tools.length === 0 ) {
 			return null;
 		}
 
+		const groupedTools = groupToolsByCategory( tools );
+
 		return (
-			<Card isRounded={ false }>
+			<Card>
 				<CardBody>
-					<VStack spacing={ 8 }>
+					<VStack spacing={ 4 }>
 						<SectionHeader
 							level={ 3 }
-							title={ __( 'Available MCP Tools' ) }
-							description={ __( 'Choose which AI tools you want to use.' ) }
+							title={ __( 'What the AI can access' ) }
+							description={ __(
+								'Control which parts of your account and sites the AI is allowed to use.'
+							) }
 						/>
 
-						{ /* Individual tool toggles */ }
-						<VStack>
-							{ tools.map( ( [ toolId, tool ]: [ string, McpAbility ] ) => (
-								<ToggleControl
-									key={ toolId }
-									__nextHasNoMarginBottom
-									checked={ tool.enabled }
-									disabled={ mutation.isPending }
-									label={ tool.title }
-									help={ tool.description }
-									onChange={ ( checked ) => handleToolChange( toolId, checked ) }
-								/>
-							) ) }
+						{ /* Render tools grouped by category */ }
+						<VStack spacing={ 4 }>
+							{ CATEGORY_ORDER.map( ( categoryName ) => {
+								const categoryTools = groupedTools[ categoryName ];
+								if ( ! categoryTools || categoryTools.length === 0 ) {
+									return null;
+								}
+
+								return (
+									<VStack key={ categoryName } spacing={ 4 }>
+										<Text as="h4" size={ 14 } weight={ 600 }>
+											{ categoryName }
+										</Text>
+										<VStack spacing={ 4 }>
+											{ categoryTools.map( ( [ toolId, tool ]: [ string, McpAbility ] ) => (
+												<ToggleControl
+													key={ toolId }
+													__nextHasNoMarginBottom
+													checked={ tool.enabled }
+													disabled={ mutation.isPending }
+													label={ tool.title }
+													help={ tool.description }
+													onChange={ ( checked ) => handleToolChange( toolId, checked ) }
+												/>
+											) ) }
+										</VStack>
+									</VStack>
+								);
+							} ) }
 						</VStack>
 					</VStack>
 				</CardBody>
@@ -214,17 +253,9 @@ function McpComponent() {
 		return (
 			<VStack spacing={ 8 }>
 				{ /* MCP Tool Access Master Toggle */ }
-				<Card isRounded={ false }>
+				<Card>
 					<CardBody>
-						<VStack spacing={ 8 }>
-							<SectionHeader
-								level={ 3 }
-								title={ __( 'MCP Tool Access' ) }
-								description={ __(
-									'Control which MCP tools can access your WordPress.com account and sites.'
-								) }
-							/>
-
+						<VStack spacing={ 4 }>
 							<div
 								style={ {
 									display: 'flex',
@@ -232,17 +263,12 @@ function McpComponent() {
 									alignItems: 'center',
 								} }
 							>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									checked={ anyToolsEnabled }
-									onChange={ handleMasterToggle }
-									label={
-										<Text weight="bold">
-											{ anyToolsEnabled
-												? __( 'Disable MCP Tool Access' )
-												: __( 'Enable MCP Tool Access' ) }
-										</Text>
-									}
+								<SectionHeader
+									level={ 3 }
+									title={ __( 'MCP Tool Access' ) }
+									description={ __(
+										'Control which MCP tools can access your WordPress.com account and sites.'
+									) }
 								/>
 								{ anyToolsEnabled && (
 									<Link to="/me/mcp/setup">
@@ -250,15 +276,28 @@ function McpComponent() {
 									</Link>
 								) }
 							</div>
+
+							<ToggleControl
+								__nextHasNoMarginBottom
+								checked={ anyToolsEnabled }
+								onChange={ handleMasterToggle }
+								label={
+									<Text weight="bold">
+										{ anyToolsEnabled
+											? __( 'Disable MCP Tool Access' )
+											: __( 'Enable MCP Tool Access' ) }
+									</Text>
+								}
+							/>
 						</VStack>
 					</CardBody>
 				</Card>
 
 				{ /* Site-Specific Settings */ }
 				{ hasTools && anyToolsEnabled && (
-					<Card isRounded={ false }>
+					<Card>
 						<CardBody>
-							<VStack spacing={ 8 }>
+							<VStack spacing={ 4 }>
 								<SectionHeader
 									level={ 3 }
 									title={ __( 'Site-specific MCP settings' ) }
@@ -311,7 +350,7 @@ function McpComponent() {
 			size="small"
 			header={
 				<PageHeader
-					title={ __( 'MCP Account Settings' ) }
+					title={ __( 'MCP' ) }
 					description={ createInterpolateElement(
 						__(
 							'MCP (Model Context Protocol) enables AI assistants to securely access and interact with your WordPress.com data. <link>Learn more.</link>'

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -345,10 +345,10 @@ function McpComponent() {
 					title={ __( 'MCP' ) }
 					description={ createInterpolateElement(
 						__(
-							'MCP (Model Context Protocol) enables AI assistants to securely access and interact with your WordPress.com data. <link>Learn more.</link>'
+							'MCP (Model Context Protocol) enables AI assistants to securely access and interact with your WordPress.com data. <learnMoreLink/>'
 						),
 						{
-							link: <InlineSupportLink supportContext="mcp" />,
+							learnMoreLink: <InlineSupportLink supportContext="mcp" />,
 						}
 					) }
 				/>

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -1,6 +1,6 @@
 import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { useQuery, useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
@@ -38,7 +38,6 @@ interface McpSite {
 }
 
 function McpComponent() {
-	const queryClient = useQueryClient();
 	const { queries } = useAppContext();
 	const sitesQueryResult = useQuery(
 		queries.sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
@@ -57,10 +56,6 @@ function McpComponent() {
 				success: __( 'MCP settings saved.' ),
 				error: __( 'Failed to save MCP settings.' ),
 			},
-		},
-		onSuccess: ( newData: any ) => {
-			// Update the cache with the new data from the API response
-			queryClient.setQueryData( userSettingsQuery().queryKey, newData as any );
 		},
 	} );
 

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -6,6 +6,7 @@ import {
 	__experimentalText as Text,
 	ToggleControl,
 	__experimentalHStack as HStack,
+	FormTokenField,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -19,7 +20,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
-import PreferencesLoginSiteDropdown from '../preferences-primary-site/site-dropdown';
+import { getSiteDisplayName } from '../../utils/site-name';
 import { CATEGORY_ORDER, getDisplayCategory } from './categories';
 import type { Site } from '@automattic/api-core';
 
@@ -43,11 +44,10 @@ function McpComponent() {
 		queries.sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
 	);
 	const sites = ( sitesQueryResult.data as Site[] | undefined ) ?? [];
-	const isLoadingSites = sitesQueryResult.isLoading;
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	// Site selector state for disabling MCP access on specific sites
-	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( null );
+	const [ selectedSiteIds, setSelectedSiteIds ] = useState< number[] >( [] );
 
 	// Use the standard userSettingsMutation with snackbar notifications
 	const mutation = useMutation( {
@@ -117,65 +117,87 @@ function McpComponent() {
 		return grouped;
 	};
 
-	const handleSiteDropdownChange = ( value: string | null | undefined ) => {
-		setSelectedSiteId( value ? Number( value ) : null );
+	// Convert sites to suggestions for FormTokenField
+	// Format: "siteId|siteName" - ID for uniqueness, name for searchability
+	// FormTokenField will automatically filter out already selected sites
+	const siteSuggestions = sites.map( ( site ) => {
+		const siteName = getSiteDisplayName( site );
+		return `${ site.ID }|${ siteName }`;
+	} );
+
+	// Convert selected site IDs to token values (using the same format)
+	const selectedSiteTokens = selectedSiteIds.map( ( siteId ) => {
+		const site = sites.find( ( s ) => s.ID === siteId );
+		if ( ! site ) {
+			return String( siteId );
+		}
+		const siteName = getSiteDisplayName( site );
+		return `${ siteId }|${ siteName }`;
+	} );
+
+	// Display transform to show site name (extract from "id|name" format)
+	const displaySiteName = ( tokenValue: string ) => {
+		// Extract site name from "id|name" format, or fallback to just the value
+		const parts = tokenValue.split( '|' );
+		return parts.length > 1 ? parts[ 1 ] : tokenValue;
 	};
 
-	const handleSiteToggle = ( siteId: number, enabled: boolean ) => {
+	const handleSiteTokensChange = ( tokens: ( string | { value: string; title?: string } )[] ) => {
+		// Convert token values (format: "id|name") back to site IDs
+		// FormTokenField can return either string[] or TokenItem[], so we normalize to strings
+		const tokenStrings = tokens.map( ( token ) =>
+			typeof token === 'string' ? token : token.value
+		);
+		const newSiteIds = tokenStrings
+			.map( ( token ) => {
+				// Extract site ID from "id|name" format
+				const parts = token.split( '|' );
+				const siteId = Number( parts[ 0 ] );
+				return isNaN( siteId ) ? undefined : siteId;
+			} )
+			.filter( ( id ): id is number => id !== undefined );
+		setSelectedSiteIds( newSiteIds );
+	};
+
+	const handleAllSitesToggle = ( enabled: boolean ) => {
 		// Get current sites array from nested structure
 		const currentSites = ( userSettings?.mcp_abilities?.sites as McpSite[] | undefined ) || [];
 
-		// Find existing site entry
-		const siteIndex = currentSites.findIndex( ( site: McpSite ) => site.blog_id === siteId );
+		// Build the new sites array by processing all selected sites
+		let newSites = [ ...currentSites ];
 
-		let newSites;
-		if ( enabled ) {
-			// Enabling: remove from sites array (use defaults)
-			if ( siteIndex >= 0 ) {
-				// Remove the site entry entirely
-				newSites = currentSites.filter( ( _site: McpSite, index: number ) => index !== siteIndex );
+		selectedSiteIds.forEach( ( siteId ) => {
+			const siteIndex = newSites.findIndex( ( site: McpSite ) => site.blog_id === siteId );
+
+			if ( enabled ) {
+				// Enabling: remove from sites array (use defaults)
+				if ( siteIndex >= 0 ) {
+					// Remove the site entry entirely
+					newSites = newSites.filter( ( _site: McpSite, index: number ) => index !== siteIndex );
+				}
+			} else if ( siteIndex >= 0 ) {
+				// Update existing site entry
+				newSites[ siteIndex ] = {
+					...newSites[ siteIndex ],
+					account_tools_enabled: false,
+				};
 			} else {
-				// Site not in array, already using defaults
-				newSites = currentSites;
-			}
-		} else if ( siteIndex >= 0 ) {
-			// Disabling: update existing site entry
-			newSites = [ ...currentSites ];
-			newSites[ siteIndex ] = {
-				...newSites[ siteIndex ],
-				account_tools_enabled: false,
-			};
-		} else {
-			// Disabling: add new site entry with override
-			newSites = [
-				...currentSites,
-				{
+				// Add new site entry with override
+				newSites.push( {
 					blog_id: siteId,
 					account_tools_enabled: false,
 					abilities: {},
-				},
-			];
-		}
+				} );
+			}
+		} );
 
-		// For the API payload, we need to send the site being toggled as an array
-		// The API expects sites to be an array with blog_id fields
-		const sitesPayload = [];
-		if ( enabled ) {
-			// Enabling: send the site with account_tools_enabled: true
-			sitesPayload.push( {
-				blog_id: siteId,
-				account_tools_enabled: true,
-			} );
-		} else {
-			// Disabling: send the site with account_tools_enabled: false
-			sitesPayload.push( {
-				blog_id: siteId,
-				account_tools_enabled: false,
-			} );
-		}
+		// For the API payload, send all selected sites
+		const sitesPayload = selectedSiteIds.map( ( siteId ) => ( {
+			blog_id: siteId,
+			account_tools_enabled: enabled,
+		} ) );
 
 		// Only include sites in payload if there are any sites to send
-		// Don't include account object - only send the sites being changed
 		const payload = {
 			mcp_abilities: {
 				...( sitesPayload.length > 0 && { sites: sitesPayload } ),
@@ -183,6 +205,14 @@ function McpComponent() {
 		};
 		mutation.mutate( payload as any );
 	};
+
+	// Check if all selected sites have AI access enabled
+	const allSelectedSitesEnabled =
+		selectedSiteIds.length > 0
+			? selectedSiteIds.every( ( siteId ) =>
+					getSiteAccountToolsEnabled( userSettings || {}, siteId )
+			  )
+			: false;
 
 	// Helper function to render tools section with categories
 	const renderToolsSection = ( tools: Array< [ string, McpAbility ] > ) => {
@@ -297,29 +327,34 @@ function McpComponent() {
 									level={ 3 }
 									title={ __( 'Site-specific MCP settings' ) }
 									description={ __(
-										'Choose a site to block AI access for all users on that site. This overrides your account settings.'
+										'Choose sites to manage AI access for all users on those sites. This overrides your account settings.'
 									) }
 								/>
 
-								<PreferencesLoginSiteDropdown
-									sites={ sites }
-									value={ selectedSiteId !== null ? String( selectedSiteId ) : '' }
-									onChange={ handleSiteDropdownChange }
-									label={ __( 'Select a site to disable AI access' ) }
-									isLoading={ isLoadingSites }
+								<FormTokenField
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									label={ __( 'Select sites to manage AI access' ) }
+									value={ selectedSiteTokens }
+									suggestions={ siteSuggestions }
+									onChange={ handleSiteTokensChange }
+									displayTransform={ displaySiteName }
+									placeholder={ __( 'Type to search and select sites…' ) }
+									__experimentalShowHowTo={ false }
+									__experimentalExpandOnFocus
 								/>
 
-								{ selectedSiteId !== null && anyToolsEnabled && (
+								{ selectedSiteIds.length > 0 && (
 									<ToggleControl
 										__nextHasNoMarginBottom
-										checked={ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId ) }
+										checked={ allSelectedSitesEnabled }
 										disabled={ mutation.isPending }
-										onChange={ ( enabled ) => handleSiteToggle( selectedSiteId, enabled ) }
+										onChange={ handleAllSitesToggle }
 										label={
 											<Text>
-												{ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId )
-													? __( 'Disable AI access for this site' )
-													: __( 'Enable AI access for this site' ) }
+												{ allSelectedSitesEnabled
+													? __( 'Disable AI access for selected sites' )
+													: __( 'Enable AI access for selected sites' ) }
 											</Text>
 										}
 									/>

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -115,7 +115,7 @@ function McpComponent() {
 		const grouped: Record< string, Array< [ string, McpAbility ] > > = {};
 
 		tools.forEach( ( [ toolId, tool ] ) => {
-			const displayCategory = getDisplayCategory( toolId, tool.category || '' );
+			const displayCategory = getDisplayCategory( toolId );
 			if ( ! grouped[ displayCategory ] ) {
 				grouped[ displayCategory ] = [];
 			}

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -48,7 +48,7 @@ function McpComponent() {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	// Site selector state for disabling MCP access on specific sites
-	const [ selectedSiteId, setSelectedSiteId ] = useState( '' );
+	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( null );
 
 	// Use the standard userSettingsMutation with snackbar notifications
 	const mutation = useMutation( {
@@ -118,14 +118,12 @@ function McpComponent() {
 		return grouped;
 	};
 
-	const handleSiteToggle = ( siteId: string, enabled: boolean ) => {
+	const handleSiteToggle = ( siteId: number, enabled: boolean ) => {
 		// Get current sites array from nested structure
 		const currentSites = ( userSettings?.mcp_abilities?.sites as McpSite[] | undefined ) || [];
 
 		// Find existing site entry
-		const siteIndex = currentSites.findIndex(
-			( site: McpSite ) => site.blog_id === parseInt( siteId, 10 )
-		);
+		const siteIndex = currentSites.findIndex( ( site: McpSite ) => site.blog_id === siteId );
 
 		let newSites;
 		if ( enabled ) {
@@ -149,7 +147,7 @@ function McpComponent() {
 			newSites = [
 				...currentSites,
 				{
-					blog_id: parseInt( siteId ),
+					blog_id: siteId,
 					account_tools_enabled: false,
 					abilities: {},
 				},
@@ -162,13 +160,13 @@ function McpComponent() {
 		if ( enabled ) {
 			// Enabling: send the site with account_tools_enabled: true
 			sitesPayload.push( {
-				blog_id: parseInt( siteId ),
+				blog_id: siteId,
 				account_tools_enabled: true,
 			} );
 		} else {
 			// Disabling: send the site with account_tools_enabled: false
 			sitesPayload.push( {
-				blog_id: parseInt( siteId ),
+				blog_id: siteId,
 				account_tools_enabled: false,
 			} );
 		}
@@ -254,7 +252,7 @@ function McpComponent() {
 				<Card>
 					<CardBody>
 						<VStack spacing={ 4 }>
-							<HStack justify="space-between" alignment="center">
+							<HStack justify="space-between" alignment="top">
 								<SectionHeader
 									level={ 3 }
 									title={ __( 'MCP Tool Access' ) }
@@ -263,9 +261,11 @@ function McpComponent() {
 									) }
 								/>
 								{ anyToolsEnabled && (
-									<Link to="/me/mcp/setup">
-										<Button variant="secondary">{ __( 'Configure MCP Client' ) }</Button>
-									</Link>
+									<VStack style={ { flexShrink: 0 } }>
+										<Link to="/me/mcp/setup">
+											<Button variant="secondary">{ __( 'Configure MCP Client' ) }</Button>
+										</Link>
+									</VStack>
 								) }
 							</HStack>
 
@@ -274,7 +274,7 @@ function McpComponent() {
 								checked={ anyToolsEnabled }
 								onChange={ handleMasterToggle }
 								label={
-									<Text weight="bold">
+									<Text>
 										{ anyToolsEnabled
 											? __( 'Disable MCP Tool Access' )
 											: __( 'Enable MCP Tool Access' ) }
@@ -300,20 +300,22 @@ function McpComponent() {
 
 								<PreferencesLoginSiteDropdown
 									sites={ sites }
-									value={ selectedSiteId }
-									onChange={ ( value ) => setSelectedSiteId( value || '' ) }
+									value={ selectedSiteId !== null ? String( selectedSiteId ) : '' }
+									onChange={ ( value: string | null ) =>
+										setSelectedSiteId( value ? Number( value ) : null )
+									}
 									label={ __( 'Select a site to disable MCP access' ) }
 									isLoading={ false }
 								/>
 
-								{ selectedSiteId && anyToolsEnabled && (
+								{ selectedSiteId !== null && anyToolsEnabled && (
 									<ToggleControl
 										__nextHasNoMarginBottom
 										checked={ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId ) }
 										disabled={ mutation.isPending }
 										onChange={ ( enabled ) => handleSiteToggle( selectedSiteId, enabled ) }
 										label={
-											<Text weight="bold">
+											<Text>
 												{ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId )
 													? __( 'Disable MCP access for this site' )
 													: __( 'Enable MCP access for this site' ) }

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -20,7 +20,7 @@ import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
-import { SectionHeader } from '../../components/section-header';
+import { SectionHeader } from '../../../components/section-header';
 
 function McpSetupComponent() {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
@@ -134,6 +134,7 @@ function McpSetupComponent() {
 					<PageHeader
 						title={ __( 'MCP Client Setup' ) }
 						description={ __( 'Configure your MCP client to connect to WordPress.com.' ) }
+						prefix={ <Breadcrumbs length={ 2 } /> }
 					/>
 				}
 			>
@@ -142,12 +143,12 @@ function McpSetupComponent() {
 					<CardBody>
 						<SectionHeader level={ 3 } title={ __( 'Setup Required' ) } />
 						<VStack spacing={ 4 }>
-							<Text as="p" size="medium">
-								{ __( 'No MCP tools are currently enabled for your account.' ) }
+							<Text as="p" size="medium" variant="muted">
+								{ __( 'No MCP access is currently enabled for your account.' ) }
 							</Text>
-							<Text as="p" size="medium">
+							<Text as="p" size="medium" variant="muted">
 								{ __(
-									'MCP tools define what actions and data your MCP client can access on your account. You need to enable at least one tool in the main MCP settings before configuring your client.'
+									'MCP access defines what actions and data your MCP client can access on your account. You need to enable MCP access in the main MCP settings before configuring your client.'
 								) }
 							</Text>
 							<Link to="/me/mcp">
@@ -306,8 +307,12 @@ function McpSetupComponent() {
 
 				<Card>
 					<CardBody>
-						<SectionHeader level={ 3 } title={ __( 'Manual Setup' ) } />
-						<VStack spacing={ 4 }>
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'Manual Setup' ) }
+							style={ { marginBottom: '4px' } }
+						/>
+						<VStack spacing={ 2 }>
 							<HStack justify="space-between" alignment="center">
 								{ clientDocumentation[ selectedMcpClient ] && (
 									<ExternalLink
@@ -345,8 +350,8 @@ function McpSetupComponent() {
 								) }
 								style={ { minHeight: '240px' } }
 							/>
-							<ul style={ { listStyle: 'none', padding: '0', margin: '0' } }>
-								<li style={ { marginBottom: '4px' } }>
+							<VStack spacing={ 2 }>
+								<Text as="p" size="small">
 									{ createInterpolateElement(
 										sprintf(
 											/* translators: %s is the server name identifier */
@@ -372,8 +377,8 @@ function McpSetupComponent() {
 											),
 										}
 									) }
-								</li>
-								<li>
+								</Text>
+								<Text as="p" size="small">
 									{ createInterpolateElement(
 										sprintf(
 											/* translators: %s is the package name */
@@ -397,8 +402,8 @@ function McpSetupComponent() {
 											),
 										}
 									) }
-								</li>
-							</ul>
+								</Text>
+							</VStack>
 						</VStack>
 					</CardBody>
 				</Card>

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -1,5 +1,5 @@
 import { userSettingsQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
 	Button,
@@ -18,23 +18,20 @@ import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
-import { SectionHeader } from '../../../components/section-header';
 
 function McpSetupComponent() {
-	const {
-		data: userSettings,
-		isLoading: isLoadingUserSettings,
-		error: userSettingsError,
-	} = useQuery( userSettingsQuery() );
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	// MCP client selection for configuration format
-	const [ selectedMcpClient, setSelectedMcpClient ] = useState( 'claude' );
+	const [ selectedMcpClient, setSelectedMcpClient ] = useState< McpClient >( 'claude' );
 
 	// Copy button state
 	const [ copyStatus, setCopyStatus ] = useState( 'idle' );
 
+	type McpClient = 'claude' | 'cursor' | 'vscode' | 'continue' | 'default';
+
 	// MCP client options
-	const mcpClientOptions = [
+	const mcpClientOptions: Array< { label: string; value: McpClient } > = [
 		{ label: 'Claude Desktop', value: 'claude' },
 		{ label: 'Cursor', value: 'cursor' },
 		{ label: 'VS Code', value: 'vscode' },
@@ -43,7 +40,7 @@ function McpSetupComponent() {
 	];
 
 	// Documentation links for each client
-	const clientDocumentation = {
+	const clientDocumentation: Record< McpClient, string > = {
 		claude: 'https://docs.claude.com/en/docs/mcp',
 		vscode: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
 		cursor: 'https://docs.cursor.com/en/context/mcp',
@@ -54,7 +51,7 @@ function McpSetupComponent() {
 	const serverName = 'wpcom-mcp';
 
 	// Generate MCP configuration based on selected client
-	const generateMcpConfig = ( client ) => {
+	const generateMcpConfig = ( client: McpClient ) => {
 		const baseConfig = {
 			command: 'npx',
 			args: [ '-y', '@automattic/mcp-wpcom-remote@latest' ],
@@ -123,13 +120,8 @@ function McpSetupComponent() {
 		}
 	};
 
-	// Handle error states only - allow loading to continue so reauth can show
-	if ( userSettingsError ) {
-		return null;
-	}
-
 	// Check if any account-level tools are enabled using the new nested structure
-	const hasEnabledTools = hasEnabledAccountTools( userSettings );
+	const hasEnabledTools = hasEnabledAccountTools( userSettings || {} );
 
 	if ( ! hasEnabledTools ) {
 		return (
@@ -143,30 +135,30 @@ function McpSetupComponent() {
 				}
 			>
 				<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
-				{ ! isLoadingUserSettings && (
-					<>
-						<SectionHeader label={ __( 'Setup Required' ) } />
-						<Card>
-							<CardBody>
-								<VStack spacing={ 4 }>
-									<Text as="p" size="medium">
-										{ __( 'No MCP tools are currently enabled for your account.' ) }
-									</Text>
-									<Text as="p" size="medium">
-										{ __(
-											'MCP tools define what actions and data your MCP client can access on your account. You need to enable at least one tool in the main MCP settings before configuring your client.'
-										) }
-									</Text>
-									<Link to="/me/mcp">
-										<Button variant="primary" style={ { alignSelf: 'flex-start' } }>
-											{ __( 'Go to MCP Settings' ) }
-										</Button>
-									</Link>
-								</VStack>
-							</CardBody>
-						</Card>
-					</>
-				) }
+				<>
+					<Text as="h2" size="large" weight={ 600 }>
+						{ __( 'Setup Required' ) }
+					</Text>
+					<Card>
+						<CardBody>
+							<VStack spacing={ 4 }>
+								<Text as="p" size="medium">
+									{ __( 'No MCP tools are currently enabled for your account.' ) }
+								</Text>
+								<Text as="p" size="medium">
+									{ __(
+										'MCP tools define what actions and data your MCP client can access on your account. You need to enable at least one tool in the main MCP settings before configuring your client.'
+									) }
+								</Text>
+								<Link to="/me/mcp">
+									<Button variant="primary" style={ { alignSelf: 'flex-start' } }>
+										{ __( 'Go to MCP Settings' ) }
+									</Button>
+								</Link>
+							</VStack>
+						</CardBody>
+					</Card>
+				</>
 			</PageLayout>
 		);
 	}
@@ -174,264 +166,259 @@ function McpSetupComponent() {
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'MCP Client Setup' ) } /> }>
 			<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
-			{ ! isLoadingUserSettings && (
-				<>
+			<>
+				<Card>
+					<CardBody>
+						<VStack spacing={ 4 }>
+							<Text as="h1" size="large" weight={ 500 }>
+								{ __( 'Connect AI Assistant to WordPress.com (MCP)' ) }
+							</Text>
+							<Text as="p" size="medium" variant="muted">
+								{ __(
+									'WordPress.com provides MCP (Model Context Protocol) support, which allows AI assistants to interact directly with your WordPress.com account.'
+								) }
+							</Text>
+							<Text as="p" size="medium" variant="muted">
+								{ __(
+									'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account. It works by:'
+								) }
+							</Text>
+							<VStack spacing={ 2 }>
+								<ul style={ { color: '#757575', paddingLeft: '20px', margin: '0' } }>
+									<li>
+										<Text as="p" size="medium" variant="muted">
+											{ __(
+												'Running a bridge server using the WordPress.com-specific MCP package'
+											) }
+										</Text>
+									</li>
+									<li>
+										<Text as="p" size="medium" variant="muted">
+											{ __(
+												'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
+											) }
+										</Text>
+									</li>
+									<li>
+										<Text as="p" size="medium" variant="muted">
+											{ __(
+												"Providing real-time access to your account's content and management features"
+											) }
+										</Text>
+									</li>
+								</ul>
+							</VStack>
+						</VStack>
+					</CardBody>
+				</Card>
+
+				<div style={ { marginTop: '24px' } }>
 					<Card>
 						<CardBody>
 							<VStack spacing={ 4 }>
 								<Text as="h1" size="large" weight={ 500 }>
-									{ __( 'Connect AI Assistant to WordPress.com (MCP)' ) }
+									{ __( 'MCP Client Configuration' ) }
 								</Text>
-								<Text as="p" size="medium" variant="muted">
-									{ __(
-										'WordPress.com provides MCP (Model Context Protocol) support, which allows AI assistants to interact directly with your WordPress.com account.'
+								<SelectControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									label={ __( 'MCP Client' ) }
+									value={ selectedMcpClient }
+									options={ mcpClientOptions }
+									onChange={ setSelectedMcpClient }
+									help={ __(
+										'Choose your MCP client to get the correct configuration format. Then, follow the instructions below.'
 									) }
+								/>
+							</VStack>
+						</CardBody>
+					</Card>
+				</div>
+
+				{ ( selectedMcpClient === 'claude' || selectedMcpClient === 'cursor' ) && (
+					<div style={ { marginTop: '24px' } }>
+						<Card>
+							<CardBody>
+								{ /* Quick Setup for Claude Desktop */ }
+								{ selectedMcpClient === 'claude' && (
+									<VStack spacing={ 4 }>
+										<Text as="h1" size="large" weight={ 500 }>
+											{ __( 'Quick Setup' ) }
+										</Text>
+										<Text as="p" size="medium" variant="muted">
+											{ __(
+												'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
+											) }
+										</Text>
+										<Text as="p" size="medium" variant="muted">
+											{ __( 'Installation steps:' ) }
+										</Text>
+										<ol style={ { color: '#757575', paddingLeft: '20px', margin: '0' } }>
+											<li>
+												<Text as="p" size="medium" variant="muted">
+													{ __( 'Click the download button' ) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" size="medium" variant="muted">
+													{ __( 'Double-click the downloaded file' ) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" size="medium" variant="muted">
+													{ __( "Follow Claude Desktop's setup instructions" ) }
+												</Text>
+											</li>
+										</ol>
+										<Button
+											variant="primary"
+											href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
+											target="_blank"
+											style={ { alignSelf: 'flex-start' } }
+										>
+											{ __( 'Download MCPB File' ) }
+										</Button>
+									</VStack>
+								) }
+
+								{ /* Quick Setup for Cursor */ }
+								{ selectedMcpClient === 'cursor' && (
+									<VStack spacing={ 4 }>
+										<Text as="h1" size={ 16 } weight={ 600 }>
+											{ __( 'Quick Setup' ) }
+										</Text>
+										<Text as="p" size="medium" variant="muted">
+											{ __(
+												'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
+											) }
+										</Text>
+										<Button
+											variant="primary"
+											href="https://cursor.com/en/install-mcp?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhdXRvbWF0dGljL21jcC13cGNvbS1yZW1vdGVAbGF0ZXN0Il19"
+											target="_blank"
+											style={ { alignSelf: 'flex-start' } }
+										>
+											{ __( 'Install in Cursor' ) }
+										</Button>
+									</VStack>
+								) }
+							</CardBody>
+						</Card>
+					</div>
+				) }
+
+				<div style={ { marginTop: '24px' } }>
+					<Card>
+						<CardBody>
+							<VStack spacing={ 4 }>
+								<Text as="h1" size="large" weight={ 500 }>
+									{ __( 'Manual Setup' ) }
 								</Text>
-								<Text as="p" size="medium" variant="muted">
-									{ __(
-										'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account. It works by:'
-									) }
-								</Text>
+
 								<VStack spacing={ 2 }>
-									<ul style={ { color: '#757575', paddingLeft: '20px', margin: '0' } }>
-										<li>
-											<Text as="p" size="medium" variant="muted">
-												{ __(
-													'Running a bridge server using the WordPress.com-specific MCP package'
-												) }
-											</Text>
+									<div
+										style={ {
+											display: 'flex',
+											justifyContent: 'space-between',
+											alignItems: 'center',
+										} }
+									>
+										{ clientDocumentation[ selectedMcpClient ] && (
+											<ExternalLink
+												href={ clientDocumentation[ selectedMcpClient ] }
+												style={ { fontSize: 'inherit', textTransform: 'uppercase' } }
+											>
+												{ selectedMcpClient === 'default'
+													? __( 'View setup instructions for other MCP client' )
+													: sprintf(
+															/* translators: %s is the name of the MCP client */
+															__( 'View setup instructions for %s' ),
+															mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )
+																?.label || ''
+													  ) }
+											</ExternalLink>
+										) }
+										<Button
+											icon={ getCopyIcon() }
+											variant="tertiary"
+											size="small"
+											style={ {
+												color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
+											} }
+											onClick={ copyToClipboard }
+											aria-label={ __( 'Copy configuration to clipboard' ) }
+										/>
+									</div>
+									<TextareaControl
+										__nextHasNoMarginBottom
+										value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+										onChange={ () => {} } // Required prop for read-only textarea
+										readOnly
+										help={ __(
+											"Copy this configuration and paste it into your MCP client's settings."
+										) }
+										style={ { minHeight: '240px' } }
+									/>
+									<ul style={ { listStyle: 'none', padding: '0', margin: '0' } }>
+										<li style={ { marginBottom: '4px' } }>
+											{ createInterpolateElement(
+												sprintf(
+													/* translators: %s is the server name identifier */
+													__(
+														'<code>%s</code> is a unique identifier for this WordPress.com account connection'
+													),
+													serverName
+												),
+												{
+													code: (
+														<code
+															key="server-name"
+															style={ {
+																backgroundColor: '#f0f0f1',
+																padding: '2px 6px',
+																borderRadius: '3px',
+																fontFamily: 'monospace',
+																fontSize: '13px',
+															} }
+														>
+															{ serverName }
+														</code>
+													),
+												}
+											) }
 										</li>
 										<li>
-											<Text as="p" size="medium" variant="muted">
-												{ __(
-													'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
-												) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" size="medium" variant="muted">
-												{ __(
-													"Providing real-time access to your account's content and management features"
-												) }
-											</Text>
+											{ createInterpolateElement(
+												sprintf(
+													/* translators: %s is the package name */
+													__( '<code>%s</code> is the official WordPress.com MCP server package' ),
+													'@automattic/mcp-wpcom-remote'
+												),
+												{
+													code: (
+														<code
+															key="package-name"
+															style={ {
+																backgroundColor: '#f0f0f1',
+																padding: '2px 6px',
+																borderRadius: '3px',
+																fontFamily: 'monospace',
+																fontSize: '13px',
+															} }
+														>
+															@automattic/mcp-wpcom-remote
+														</code>
+													),
+												}
+											) }
 										</li>
 									</ul>
 								</VStack>
 							</VStack>
 						</CardBody>
 					</Card>
-
-					<div style={ { marginTop: '24px' } }>
-						<Card>
-							<CardBody>
-								<VStack spacing={ 4 }>
-									<Text as="h1" size="large" weight={ 500 }>
-										{ __( 'MCP Client Configuration' ) }
-									</Text>
-									<SelectControl
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-										label={ __( 'MCP Client' ) }
-										value={ selectedMcpClient }
-										options={ mcpClientOptions }
-										onChange={ setSelectedMcpClient }
-										help={ __(
-											'Choose your MCP client to get the correct configuration format. Then, follow the instructions below.'
-										) }
-									/>
-								</VStack>
-							</CardBody>
-						</Card>
-					</div>
-
-					{ ( selectedMcpClient === 'claude' || selectedMcpClient === 'cursor' ) && (
-						<div style={ { marginTop: '24px' } }>
-							<Card>
-								<CardBody>
-									{ /* Quick Setup for Claude Desktop */ }
-									{ selectedMcpClient === 'claude' && (
-										<VStack spacing={ 4 }>
-											<Text as="h1" size="large" weight={ 500 }>
-												{ __( 'Quick Setup' ) }
-											</Text>
-											<Text as="p" size="medium" variant="muted">
-												{ __(
-													'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
-												) }
-											</Text>
-											<Text as="p" size="medium" variant="muted">
-												{ __( 'Installation steps:' ) }
-											</Text>
-											<ol style={ { color: '#757575', paddingLeft: '20px', margin: '0' } }>
-												<li>
-													<Text as="p" size="medium" variant="muted">
-														{ __( 'Click the download button' ) }
-													</Text>
-												</li>
-												<li>
-													<Text as="p" size="medium" variant="muted">
-														{ __( 'Double-click the downloaded file' ) }
-													</Text>
-												</li>
-												<li>
-													<Text as="p" size="medium" variant="muted">
-														{ __( "Follow Claude Desktop's setup instructions" ) }
-													</Text>
-												</li>
-											</ol>
-											<Button
-												variant="primary"
-												href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
-												target="_blank"
-												style={ { alignSelf: 'flex-start' } }
-											>
-												{ __( 'Download MCPB File' ) }
-											</Button>
-										</VStack>
-									) }
-
-									{ /* Quick Setup for Cursor */ }
-									{ selectedMcpClient === 'cursor' && (
-										<VStack spacing={ 4 }>
-											<Text as="h1" size={ 16 } weight={ 600 }>
-												{ __( 'Quick Setup' ) }
-											</Text>
-											<Text as="p" size="medium" variant="muted">
-												{ __(
-													'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
-												) }
-											</Text>
-											<Button
-												variant="primary"
-												href="https://cursor.com/en/install-mcp?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhdXRvbWF0dGljL21jcC13cGNvbS1yZW1vdGVAbGF0ZXN0Il19"
-												target="_blank"
-												style={ { alignSelf: 'flex-start' } }
-											>
-												{ __( 'Install in Cursor' ) }
-											</Button>
-										</VStack>
-									) }
-								</CardBody>
-							</Card>
-						</div>
-					) }
-
-					<div style={ { marginTop: '24px' } }>
-						<Card>
-							<CardBody>
-								<VStack spacing={ 4 }>
-									<Text as="h1" size="large" weight={ 500 }>
-										{ __( 'Manual Setup' ) }
-									</Text>
-
-									<VStack spacing={ 2 }>
-										<div
-											style={ {
-												display: 'flex',
-												justifyContent: 'space-between',
-												alignItems: 'center',
-											} }
-										>
-											{ clientDocumentation[ selectedMcpClient ] && (
-												<ExternalLink
-													href={ clientDocumentation[ selectedMcpClient ] }
-													target="_blank"
-													style={ { fontSize: 'inherit', textTransform: 'uppercase' } }
-												>
-													{ selectedMcpClient === 'default'
-														? __( 'View setup instructions for other MCP client' )
-														: sprintf(
-																/* translators: %s is the name of the MCP client */
-																__( 'View setup instructions for %s' ),
-																mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )
-																	?.label || ''
-														  ) }
-												</ExternalLink>
-											) }
-											<Button
-												icon={ getCopyIcon() }
-												variant="tertiary"
-												size="small"
-												style={ {
-													color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
-												} }
-												onClick={ copyToClipboard }
-												aria-label={ __( 'Copy configuration to clipboard' ) }
-											/>
-										</div>
-										<TextareaControl
-											__nextHasNoMarginBottom
-											value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
-											onChange={ () => {} } // Required prop for read-only textarea
-											readOnly
-											help={ __(
-												"Copy this configuration and paste it into your MCP client's settings."
-											) }
-											style={ { minHeight: '240px' } }
-										/>
-										<ul style={ { listStyle: 'none', padding: '0', margin: '0' } }>
-											<li style={ { marginBottom: '4px' } }>
-												{ createInterpolateElement(
-													sprintf(
-														/* translators: %s is the server name identifier */
-														__(
-															'<code>%s</code> is a unique identifier for this WordPress.com account connection'
-														),
-														serverName
-													),
-													{
-														code: (
-															<code
-																key="server-name"
-																style={ {
-																	backgroundColor: '#f0f0f1',
-																	padding: '2px 6px',
-																	borderRadius: '3px',
-																	fontFamily: 'monospace',
-																	fontSize: '13px',
-																} }
-															>
-																{ serverName }
-															</code>
-														),
-													}
-												) }
-											</li>
-											<li>
-												{ createInterpolateElement(
-													sprintf(
-														/* translators: %s is the package name */
-														__(
-															'<code>%s</code> is the official WordPress.com MCP server package'
-														),
-														'@automattic/mcp-wpcom-remote'
-													),
-													{
-														code: (
-															<code
-																key="package-name"
-																style={ {
-																	backgroundColor: '#f0f0f1',
-																	padding: '2px 6px',
-																	borderRadius: '3px',
-																	fontFamily: 'monospace',
-																	fontSize: '13px',
-																} }
-															>
-																@automattic/mcp-wpcom-remote
-															</code>
-														),
-													}
-												) }
-											</li>
-										</ul>
-									</VStack>
-								</VStack>
-							</CardBody>
-						</Card>
-					</div>
-				</>
-			) }
+				</div>
+			</>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -307,11 +307,7 @@ function McpSetupComponent() {
 
 				<Card>
 					<CardBody>
-						<SectionHeader
-							level={ 3 }
-							title={ __( 'Manual Setup' ) }
-							style={ { marginBottom: '4px' } }
-						/>
+						<SectionHeader level={ 3 } title={ __( 'Manual Setup' ) } />
 						<VStack spacing={ 2 }>
 							<HStack justify="space-between" alignment="center">
 								{ clientDocumentation[ selectedMcpClient ] && (

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -1,0 +1,424 @@
+import { userSettingsQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import {
+	Button,
+	ExternalLink,
+	TextareaControl,
+	SelectControl,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { copy, check, error } from '@wordpress/icons';
+import { useState } from 'react';
+import { hasEnabledAccountTools } from '../../../../me/mcp/utils';
+import { Card, CardBody } from '../../../components/card';
+import ComponentViewTracker from '../../../components/component-view-tracker';
+import { PageHeader } from '../../../components/page-header';
+import PageLayout from '../../../components/page-layout';
+import { SectionHeader } from '../../../components/section-header';
+
+function McpSetupComponent() {
+	const {
+		data: userSettings,
+		isLoading: isLoadingUserSettings,
+		error: userSettingsError,
+	} = useQuery( userSettingsQuery() );
+
+	// MCP client selection for configuration format
+	const [ selectedMcpClient, setSelectedMcpClient ] = useState( 'claude' );
+
+	// Copy button state
+	const [ copyStatus, setCopyStatus ] = useState( 'idle' );
+
+	// MCP client options
+	const mcpClientOptions = [
+		{ label: 'Claude Desktop', value: 'claude' },
+		{ label: 'Cursor', value: 'cursor' },
+		{ label: 'VS Code', value: 'vscode' },
+		{ label: 'Continue', value: 'continue' },
+		{ label: __( 'Other MCP client' ), value: 'default' },
+	];
+
+	// Documentation links for each client
+	const clientDocumentation = {
+		claude: 'https://docs.claude.com/en/docs/mcp',
+		vscode: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
+		cursor: 'https://docs.cursor.com/en/context/mcp',
+		continue: 'https://docs.continue.dev/customize/deep-dives/mcp',
+		default: 'https://modelcontextprotocol.io/docs/develop/connect-local-servers',
+	};
+
+	const serverName = 'wpcom-mcp';
+
+	// Generate MCP configuration based on selected client
+	const generateMcpConfig = ( client ) => {
+		const baseConfig = {
+			command: 'npx',
+			args: [ '-y', '@automattic/mcp-wpcom-remote@latest' ],
+		};
+
+		switch ( client ) {
+			case 'claude':
+				return {
+					mcpServers: {
+						[ serverName ]: baseConfig,
+					},
+				};
+			case 'vscode':
+				return {
+					servers: {
+						[ serverName ]: baseConfig,
+					},
+				};
+			case 'cursor':
+				return {
+					mcpServers: {
+						[ serverName ]: baseConfig,
+					},
+				};
+			case 'continue':
+				return {
+					mcpServers: [
+						{
+							name: serverName,
+							...baseConfig,
+						},
+					],
+				};
+			default:
+				return {
+					mcpServers: {
+						[ serverName ]: baseConfig,
+					},
+				};
+		}
+	};
+
+	// Copy MCP configuration to clipboard
+	const copyToClipboard = async () => {
+		const configText = JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 );
+
+		try {
+			await navigator.clipboard.writeText( configText );
+			setCopyStatus( 'success' );
+			setTimeout( () => setCopyStatus( 'idle' ), 2000 );
+		} catch ( err ) {
+			setCopyStatus( 'error' );
+			setTimeout( () => setCopyStatus( 'idle' ), 2000 );
+		}
+	};
+
+	// Helper function to get the appropriate icon based on copy status
+	const getCopyIcon = () => {
+		switch ( copyStatus ) {
+			case 'success':
+				return check;
+			case 'error':
+				return error;
+			default:
+				return copy;
+		}
+	};
+
+	// Handle error states only - allow loading to continue so reauth can show
+	if ( userSettingsError ) {
+		return null;
+	}
+
+	// Check if any account-level tools are enabled using the new nested structure
+	const hasEnabledTools = hasEnabledAccountTools( userSettings );
+
+	if ( ! hasEnabledTools ) {
+		return (
+			<PageLayout
+				size="small"
+				header={
+					<PageHeader
+						title={ __( 'MCP Setup' ) }
+						description={ __( 'Configure your MCP client to connect to WordPress.com.' ) }
+					/>
+				}
+			>
+				<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
+				{ ! isLoadingUserSettings && (
+					<>
+						<SectionHeader label={ __( 'Setup Required' ) } />
+						<Card isRounded={ false }>
+							<CardBody>
+								<VStack spacing={ 4 }>
+									<Text as="p" size="medium">
+										{ __( 'No MCP tools are currently enabled for your account.' ) }
+									</Text>
+									<Text as="p" size="medium">
+										{ __(
+											'MCP tools define what actions and data your MCP client can access on your account. You need to enable at least one tool in the main MCP settings before configuring your client.'
+										) }
+									</Text>
+									<Link to="/me/mcp">
+										<Button variant="primary" style={ { alignSelf: 'flex-start' } }>
+											{ __( 'Go to MCP Settings' ) }
+										</Button>
+									</Link>
+								</VStack>
+							</CardBody>
+						</Card>
+					</>
+				) }
+			</PageLayout>
+		);
+	}
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					title={ __( 'WordPress.com MCP Setup' ) }
+					description={ __( 'Configure your MCP client to connect to WordPress.com.' ) }
+				/>
+			}
+		>
+			<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
+			{ ! isLoadingUserSettings && (
+				<>
+					<Card style={ { borderRadius: '0' } }>
+						<CardBody>
+							<VStack spacing={ 4 }>
+								<Text as="p" size="medium">
+									{ __(
+										'WordPress.com provides MCP (Model Context Protocol) support, which allows AI assistants to interact directly with your WordPress.com account.'
+									) }
+								</Text>
+								<Text as="p" size="medium">
+									{ __(
+										'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account. It works by:'
+									) }
+								</Text>
+								<VStack spacing={ 2 }>
+									<ul>
+										<li>
+											{ __(
+												'Running a bridge server using the WordPress.com-specific MCP package'
+											) }
+										</li>
+										<li>
+											{ __(
+												'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
+											) }
+										</li>
+										<li>
+											{ __(
+												"Providing real-time access to your account's content and management features"
+											) }
+										</li>
+									</ul>
+								</VStack>
+							</VStack>
+						</CardBody>
+					</Card>
+
+					<div style={ { marginTop: '24px' } }>
+						<SectionHeader label={ __( 'MCP Client Configuration' ) } />
+						<Card isRounded={ false }>
+							<CardBody>
+								<VStack spacing={ 6 }>
+									<SelectControl
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+										label={ __( 'MCP Client' ) }
+										value={ selectedMcpClient }
+										options={ mcpClientOptions }
+										onChange={ setSelectedMcpClient }
+										help={ __( 'Choose your MCP client to get the correct configuration format.' ) }
+									/>
+
+									{ /* Quick Setup for Claude Desktop */ }
+									{ selectedMcpClient === 'claude' && (
+										<VStack spacing={ 4 } style={ { borderBottom: '1px solid #e0e0e0' } }>
+											<Text as="h1" size={ 16 } weight={ 600 }>
+												{ __( 'Quick Setup' ) }
+											</Text>
+											<Text as="p" size="medium">
+												{ __(
+													'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
+												) }
+											</Text>
+											<Button
+												variant="primary"
+												href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
+												target="_blank"
+												style={ { alignSelf: 'flex-start' } }
+											>
+												{ __( 'Download MCPB File' ) }
+											</Button>
+											<Text as="p" size="medium">
+												{ __( 'Installation steps:' ) }
+											</Text>
+											<ol>
+												<li>
+													<Text as="p" size="medium">
+														{ __( 'Click the download button above' ) }
+													</Text>
+												</li>
+												<li>
+													<Text as="p" size="medium">
+														{ __( 'Double-click the downloaded file' ) }
+													</Text>
+												</li>
+												<li>
+													<Text as="p" size="medium">
+														{ __( "Follow Claude Desktop's setup instructions" ) }
+													</Text>
+												</li>
+											</ol>
+										</VStack>
+									) }
+
+									{ /* Quick Setup for Cursor */ }
+									{ selectedMcpClient === 'cursor' && (
+										<VStack
+											spacing={ 4 }
+											style={ { borderBottom: '1px solid #e0e0e0', paddingBottom: '24px' } }
+										>
+											<Text as="h1" size={ 16 } weight={ 600 }>
+												{ __( 'Quick Setup' ) }
+											</Text>
+											<Text as="p" size="medium">
+												{ __(
+													'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
+												) }
+											</Text>
+											<Button
+												variant="primary"
+												href="https://cursor.com/en/install-mcp?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhdXRvbWF0dGljL21jcC13cGNvbS1yZW1vdGVAbGF0ZXN0Il19"
+												target="_blank"
+												style={ { alignSelf: 'flex-start' } }
+											>
+												{ __( 'Install in Cursor' ) }
+											</Button>
+										</VStack>
+									) }
+
+									<VStack spacing={ 4 }>
+										<Text as="h1" size={ 16 } weight={ 600 }>
+											{ __( 'Manual Setup' ) }
+										</Text>
+
+										<VStack spacing={ 3 }>
+											<div
+												style={ {
+													display: 'flex',
+													justifyContent: 'space-between',
+													alignItems: 'center',
+												} }
+											>
+												{ clientDocumentation[ selectedMcpClient ] && (
+													<ExternalLink
+														href={ clientDocumentation[ selectedMcpClient ] }
+														target="_blank"
+														style={ { fontSize: 'inherit' } }
+													>
+														{ selectedMcpClient === 'default'
+															? __( 'View setup instructions for other MCP client' )
+															: sprintf(
+																	/* translators: %s is the name of the MCP client */
+																	__( 'View setup instructions for %s' ),
+																	mcpClientOptions.find(
+																		( opt ) => opt.value === selectedMcpClient
+																	)?.label || ''
+															  ) }
+													</ExternalLink>
+												) }
+												<Button
+													icon={ getCopyIcon() }
+													variant="tertiary"
+													size="small"
+													style={ {
+														color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
+													} }
+													onClick={ copyToClipboard }
+													aria-label={ __( 'Copy configuration to clipboard' ) }
+												/>
+											</div>
+											<TextareaControl
+												__nextHasNoMarginBottom
+												value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+												onChange={ () => {} } // Required prop for read-only textarea
+												readOnly
+												help={ __(
+													"Copy this configuration and paste it into your MCP client's settings."
+												) }
+												style={ { minHeight: '240px' } }
+											/>
+										</VStack>
+									</VStack>
+								</VStack>
+								<VStack spacing={ 3 }>
+									<ul style={ { listStyle: 'none', padding: '0', margin: '0' } }>
+										<li>
+											{ createInterpolateElement(
+												sprintf(
+													/* translators: %s is the server name identifier */
+													__(
+														'<code>%s</code> is a unique identifier for this WordPress.com account connection'
+													),
+													serverName
+												),
+												{
+													code: (
+														<code
+															key="server-name"
+															style={ {
+																backgroundColor: '#f0f0f1',
+																padding: '2px 6px',
+																borderRadius: '3px',
+																fontFamily: 'monospace',
+																fontSize: '13px',
+															} }
+														>
+															{ serverName }
+														</code>
+													),
+												}
+											) }
+										</li>
+										<li>
+											{ createInterpolateElement(
+												sprintf(
+													/* translators: %s is the package name */
+													__( '<code>%s</code> is the official WordPress.com MCP server package' ),
+													'@automattic/mcp-wpcom-remote'
+												),
+												{
+													code: (
+														<code
+															key="package-name"
+															style={ {
+																backgroundColor: '#f0f0f1',
+																padding: '2px 6px',
+																borderRadius: '3px',
+																fontFamily: 'monospace',
+																fontSize: '13px',
+															} }
+														>
+															@automattic/mcp-wpcom-remote
+														</code>
+													),
+												}
+											) }
+										</li>
+									</ul>
+								</VStack>
+							</CardBody>
+						</Card>
+					</div>
+				</>
+			) }
+		</PageLayout>
+	);
+}
+
+export default McpSetupComponent;

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -235,7 +235,9 @@ function McpSetupComponent() {
 										value={ selectedMcpClient }
 										options={ mcpClientOptions }
 										onChange={ setSelectedMcpClient }
-										help={ __( 'Choose your MCP client to get the correct configuration format.' ) }
+										help={ __(
+											'Choose your MCP client to get the correct configuration format. Then, follow the instructions below.'
+										) }
 									/>
 								</VStack>
 							</CardBody>
@@ -322,7 +324,7 @@ function McpSetupComponent() {
 										{ __( 'Manual Setup' ) }
 									</Text>
 
-									<VStack spacing={ 3 }>
+									<VStack spacing={ 2 }>
 										<div
 											style={ {
 												display: 'flex',
@@ -367,63 +369,63 @@ function McpSetupComponent() {
 											) }
 											style={ { minHeight: '240px' } }
 										/>
+										<ul style={ { listStyle: 'none', padding: '0', margin: '0' } }>
+											<li style={ { marginBottom: '4px' } }>
+												{ createInterpolateElement(
+													sprintf(
+														/* translators: %s is the server name identifier */
+														__(
+															'<code>%s</code> is a unique identifier for this WordPress.com account connection'
+														),
+														serverName
+													),
+													{
+														code: (
+															<code
+																key="server-name"
+																style={ {
+																	backgroundColor: '#f0f0f1',
+																	padding: '2px 6px',
+																	borderRadius: '3px',
+																	fontFamily: 'monospace',
+																	fontSize: '13px',
+																} }
+															>
+																{ serverName }
+															</code>
+														),
+													}
+												) }
+											</li>
+											<li>
+												{ createInterpolateElement(
+													sprintf(
+														/* translators: %s is the package name */
+														__(
+															'<code>%s</code> is the official WordPress.com MCP server package'
+														),
+														'@automattic/mcp-wpcom-remote'
+													),
+													{
+														code: (
+															<code
+																key="package-name"
+																style={ {
+																	backgroundColor: '#f0f0f1',
+																	padding: '2px 6px',
+																	borderRadius: '3px',
+																	fontFamily: 'monospace',
+																	fontSize: '13px',
+																} }
+															>
+																@automattic/mcp-wpcom-remote
+															</code>
+														),
+													}
+												) }
+											</li>
+										</ul>
 									</VStack>
-								</VStack>
-								<VStack spacing={ 3 }>
-									<ul style={ { listStyle: 'none', padding: '0', margin: '0' } }>
-										<li>
-											{ createInterpolateElement(
-												sprintf(
-													/* translators: %s is the server name identifier */
-													__(
-														'<code>%s</code> is a unique identifier for this WordPress.com account connection'
-													),
-													serverName
-												),
-												{
-													code: (
-														<code
-															key="server-name"
-															style={ {
-																backgroundColor: '#f0f0f1',
-																padding: '2px 6px',
-																borderRadius: '3px',
-																fontFamily: 'monospace',
-																fontSize: '13px',
-															} }
-														>
-															{ serverName }
-														</code>
-													),
-												}
-											) }
-										</li>
-										<li>
-											{ createInterpolateElement(
-												sprintf(
-													/* translators: %s is the package name */
-													__( '<code>%s</code> is the official WordPress.com MCP server package' ),
-													'@automattic/mcp-wpcom-remote'
-												),
-												{
-													code: (
-														<code
-															key="package-name"
-															style={ {
-																backgroundColor: '#f0f0f1',
-																padding: '2px 6px',
-																borderRadius: '3px',
-																fontFamily: 'monospace',
-																fontSize: '13px',
-															} }
-														>
-															@automattic/mcp-wpcom-remote
-														</code>
-													),
-												}
-											) }
-										</li>
-									</ul>
 								</VStack>
 							</CardBody>
 						</Card>

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -8,16 +8,19 @@ import {
 	SelectControl,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
+	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { copy, check, error } from '@wordpress/icons';
 import { useState } from 'react';
 import { hasEnabledAccountTools } from '../../../../me/mcp/utils';
+import Breadcrumbs from '../../../app/breadcrumbs';
 import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
 
 function McpSetupComponent() {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
@@ -135,44 +138,46 @@ function McpSetupComponent() {
 				}
 			>
 				<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
-				<>
-					<Text as="h2" size="large" weight={ 600 }>
-						{ __( 'Setup Required' ) }
-					</Text>
-					<Card>
-						<CardBody>
-							<VStack spacing={ 4 }>
-								<Text as="p" size="medium">
-									{ __( 'No MCP tools are currently enabled for your account.' ) }
-								</Text>
-								<Text as="p" size="medium">
-									{ __(
-										'MCP tools define what actions and data your MCP client can access on your account. You need to enable at least one tool in the main MCP settings before configuring your client.'
-									) }
-								</Text>
-								<Link to="/me/mcp">
-									<Button variant="primary" style={ { alignSelf: 'flex-start' } }>
-										{ __( 'Go to MCP Settings' ) }
-									</Button>
-								</Link>
-							</VStack>
-						</CardBody>
-					</Card>
-				</>
+				<Card>
+					<CardBody>
+						<SectionHeader level={ 3 } title={ __( 'Setup Required' ) } />
+						<VStack spacing={ 4 }>
+							<Text as="p" size="medium">
+								{ __( 'No MCP tools are currently enabled for your account.' ) }
+							</Text>
+							<Text as="p" size="medium">
+								{ __(
+									'MCP tools define what actions and data your MCP client can access on your account. You need to enable at least one tool in the main MCP settings before configuring your client.'
+								) }
+							</Text>
+							<Link to="/me/mcp">
+								<Button variant="primary" style={ { alignSelf: 'flex-start' } }>
+									{ __( 'Go to MCP Settings' ) }
+								</Button>
+							</Link>
+						</VStack>
+					</CardBody>
+				</Card>
 			</PageLayout>
 		);
 	}
 
 	return (
-		<PageLayout size="small" header={ <PageHeader title={ __( 'MCP Client Setup' ) } /> }>
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader title={ __( 'MCP Client Setup' ) } prefix={ <Breadcrumbs length={ 2 } /> } />
+			}
+		>
 			<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
 			<>
 				<Card>
 					<CardBody>
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'Connect AI Assistant to WordPress.com (MCP)' ) }
+						/>
 						<VStack spacing={ 4 }>
-							<Text as="h1" size="large" weight={ 500 }>
-								{ __( 'Connect AI Assistant to WordPress.com (MCP)' ) }
-							</Text>
 							<Text as="p" size="medium" variant="muted">
 								{ __(
 									'WordPress.com provides MCP (Model Context Protocol) support, which allows AI assistants to interact directly with your WordPress.com account.'
@@ -212,212 +217,191 @@ function McpSetupComponent() {
 					</CardBody>
 				</Card>
 
-				<div style={ { marginTop: '24px' } }>
-					<Card>
-						<CardBody>
-							<VStack spacing={ 4 }>
-								<Text as="h1" size="large" weight={ 500 }>
-									{ __( 'MCP Client Configuration' ) }
-								</Text>
-								<SelectControl
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									label={ __( 'MCP Client' ) }
-									value={ selectedMcpClient }
-									options={ mcpClientOptions }
-									onChange={ setSelectedMcpClient }
-									help={ __(
-										'Choose your MCP client to get the correct configuration format. Then, follow the instructions below.'
-									) }
-								/>
-							</VStack>
-						</CardBody>
-					</Card>
-				</div>
+				<Card>
+					<CardBody>
+						<SectionHeader level={ 3 } title={ __( 'MCP Client Configuration' ) } />
+						<VStack spacing={ 4 }>
+							<SelectControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'MCP Client' ) }
+								value={ selectedMcpClient }
+								options={ mcpClientOptions }
+								onChange={ setSelectedMcpClient }
+								help={ __(
+									'Choose your MCP client to get the correct configuration format. Then, follow the instructions below.'
+								) }
+							/>
+						</VStack>
+					</CardBody>
+				</Card>
 
 				{ ( selectedMcpClient === 'claude' || selectedMcpClient === 'cursor' ) && (
-					<div style={ { marginTop: '24px' } }>
-						<Card>
-							<CardBody>
-								{ /* Quick Setup for Claude Desktop */ }
-								{ selectedMcpClient === 'claude' && (
-									<VStack spacing={ 4 }>
-										<Text as="h1" size="large" weight={ 500 }>
-											{ __( 'Quick Setup' ) }
-										</Text>
-										<Text as="p" size="medium" variant="muted">
-											{ __(
-												'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
-											) }
-										</Text>
-										<Text as="p" size="medium" variant="muted">
-											{ __( 'Installation steps:' ) }
-										</Text>
-										<ol style={ { color: '#757575', paddingLeft: '20px', margin: '0' } }>
-											<li>
-												<Text as="p" size="medium" variant="muted">
-													{ __( 'Click the download button' ) }
-												</Text>
-											</li>
-											<li>
-												<Text as="p" size="medium" variant="muted">
-													{ __( 'Double-click the downloaded file' ) }
-												</Text>
-											</li>
-											<li>
-												<Text as="p" size="medium" variant="muted">
-													{ __( "Follow Claude Desktop's setup instructions" ) }
-												</Text>
-											</li>
-										</ol>
-										<Button
-											variant="primary"
-											href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
-											target="_blank"
-											style={ { alignSelf: 'flex-start' } }
-										>
-											{ __( 'Download MCPB File' ) }
-										</Button>
-									</VStack>
-								) }
-
-								{ /* Quick Setup for Cursor */ }
-								{ selectedMcpClient === 'cursor' && (
-									<VStack spacing={ 4 }>
-										<Text as="h1" size={ 16 } weight={ 600 }>
-											{ __( 'Quick Setup' ) }
-										</Text>
-										<Text as="p" size="medium" variant="muted">
-											{ __(
-												'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
-											) }
-										</Text>
-										<Button
-											variant="primary"
-											href="https://cursor.com/en/install-mcp?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhdXRvbWF0dGljL21jcC13cGNvbS1yZW1vdGVAbGF0ZXN0Il19"
-											target="_blank"
-											style={ { alignSelf: 'flex-start' } }
-										>
-											{ __( 'Install in Cursor' ) }
-										</Button>
-									</VStack>
-								) }
-							</CardBody>
-						</Card>
-					</div>
-				) }
-
-				<div style={ { marginTop: '24px' } }>
 					<Card>
 						<CardBody>
-							<VStack spacing={ 4 }>
-								<Text as="h1" size="large" weight={ 500 }>
-									{ __( 'Manual Setup' ) }
-								</Text>
-
-								<VStack spacing={ 2 }>
-									<div
-										style={ {
-											display: 'flex',
-											justifyContent: 'space-between',
-											alignItems: 'center',
-										} }
-									>
-										{ clientDocumentation[ selectedMcpClient ] && (
-											<ExternalLink
-												href={ clientDocumentation[ selectedMcpClient ] }
-												style={ { fontSize: 'inherit', textTransform: 'uppercase' } }
-											>
-												{ selectedMcpClient === 'default'
-													? __( 'View setup instructions for other MCP client' )
-													: sprintf(
-															/* translators: %s is the name of the MCP client */
-															__( 'View setup instructions for %s' ),
-															mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )
-																?.label || ''
-													  ) }
-											</ExternalLink>
+							<SectionHeader level={ 3 } title={ __( 'Quick Setup' ) } />
+							{ /* Quick Setup for Claude Desktop */ }
+							{ selectedMcpClient === 'claude' && (
+								<VStack spacing={ 4 }>
+									<Text as="p" size="medium" variant="muted">
+										{ __(
+											'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
 										) }
-										<Button
-											icon={ getCopyIcon() }
-											variant="tertiary"
-											size="small"
-											style={ {
-												color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
-											} }
-											onClick={ copyToClipboard }
-											aria-label={ __( 'Copy configuration to clipboard' ) }
-										/>
-									</div>
-									<TextareaControl
-										__nextHasNoMarginBottom
-										value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
-										onChange={ () => {} } // Required prop for read-only textarea
-										readOnly
-										help={ __(
-											"Copy this configuration and paste it into your MCP client's settings."
-										) }
-										style={ { minHeight: '240px' } }
-									/>
-									<ul style={ { listStyle: 'none', padding: '0', margin: '0' } }>
-										<li style={ { marginBottom: '4px' } }>
-											{ createInterpolateElement(
-												sprintf(
-													/* translators: %s is the server name identifier */
-													__(
-														'<code>%s</code> is a unique identifier for this WordPress.com account connection'
-													),
-													serverName
-												),
-												{
-													code: (
-														<code
-															key="server-name"
-															style={ {
-																backgroundColor: '#f0f0f1',
-																padding: '2px 6px',
-																borderRadius: '3px',
-																fontFamily: 'monospace',
-																fontSize: '13px',
-															} }
-														>
-															{ serverName }
-														</code>
-													),
-												}
-											) }
+									</Text>
+									<Text as="p" size="medium" variant="muted">
+										{ __( 'Installation steps:' ) }
+									</Text>
+									<ol style={ { color: '#757575', paddingLeft: '20px', margin: '0' } }>
+										<li>
+											<Text as="p" size="medium" variant="muted">
+												{ __( 'Click the download button' ) }
+											</Text>
 										</li>
 										<li>
-											{ createInterpolateElement(
-												sprintf(
-													/* translators: %s is the package name */
-													__( '<code>%s</code> is the official WordPress.com MCP server package' ),
-													'@automattic/mcp-wpcom-remote'
-												),
-												{
-													code: (
-														<code
-															key="package-name"
-															style={ {
-																backgroundColor: '#f0f0f1',
-																padding: '2px 6px',
-																borderRadius: '3px',
-																fontFamily: 'monospace',
-																fontSize: '13px',
-															} }
-														>
-															@automattic/mcp-wpcom-remote
-														</code>
-													),
-												}
-											) }
+											<Text as="p" size="medium" variant="muted">
+												{ __( 'Double-click the downloaded file' ) }
+											</Text>
 										</li>
-									</ul>
+										<li>
+											<Text as="p" size="medium" variant="muted">
+												{ __( "Follow Claude Desktop's setup instructions" ) }
+											</Text>
+										</li>
+									</ol>
+									<Button
+										variant="primary"
+										href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
+										target="_blank"
+										style={ { alignSelf: 'flex-start' } }
+									>
+										{ __( 'Download MCPB File' ) }
+									</Button>
 								</VStack>
-							</VStack>
+							) }
+
+							{ /* Quick Setup for Cursor */ }
+							{ selectedMcpClient === 'cursor' && (
+								<VStack spacing={ 4 }>
+									<Text as="h1" size={ 16 } weight={ 600 }>
+										{ __( 'Quick Setup' ) }
+									</Text>
+									<Text as="p" size="medium" variant="muted">
+										{ __(
+											'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
+										) }
+									</Text>
+									<Button
+										variant="primary"
+										href="https://cursor.com/en/install-mcp?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhdXRvbWF0dGljL21jcC13cGNvbS1yZW1vdGVAbGF0ZXN0Il19"
+										target="_blank"
+										style={ { alignSelf: 'flex-start' } }
+									>
+										{ __( 'Install in Cursor' ) }
+									</Button>
+								</VStack>
+							) }
 						</CardBody>
 					</Card>
-				</div>
+				) }
+
+				<Card>
+					<CardBody>
+						<SectionHeader level={ 3 } title={ __( 'Manual Setup' ) } />
+						<VStack spacing={ 4 }>
+							<HStack justify="space-between" alignment="center">
+								{ clientDocumentation[ selectedMcpClient ] && (
+									<ExternalLink
+										href={ clientDocumentation[ selectedMcpClient ] }
+										style={ { fontSize: 'inherit', textTransform: 'uppercase' } }
+									>
+										{ selectedMcpClient === 'default'
+											? __( 'View setup instructions for other MCP client' )
+											: sprintf(
+													/* translators: %s is the name of the MCP client */
+													__( 'View setup instructions for %s' ),
+													mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )
+														?.label || ''
+											  ) }
+									</ExternalLink>
+								) }
+								<Button
+									icon={ getCopyIcon() }
+									variant="tertiary"
+									size="small"
+									style={ {
+										color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
+									} }
+									onClick={ copyToClipboard }
+									aria-label={ __( 'Copy configuration to clipboard' ) }
+								/>
+							</HStack>
+							<TextareaControl
+								__nextHasNoMarginBottom
+								value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+								onChange={ () => {} } // Required prop for read-only textarea
+								readOnly
+								help={ __(
+									"Copy this configuration and paste it into your MCP client's settings."
+								) }
+								style={ { minHeight: '240px' } }
+							/>
+							<ul style={ { listStyle: 'none', padding: '0', margin: '0' } }>
+								<li style={ { marginBottom: '4px' } }>
+									{ createInterpolateElement(
+										sprintf(
+											/* translators: %s is the server name identifier */
+											__(
+												'<code>%s</code> is a unique identifier for this WordPress.com account connection'
+											),
+											serverName
+										),
+										{
+											code: (
+												<code
+													key="server-name"
+													style={ {
+														backgroundColor: '#f0f0f1',
+														padding: '2px 6px',
+														borderRadius: '3px',
+														fontFamily: 'monospace',
+														fontSize: '13px',
+													} }
+												>
+													{ serverName }
+												</code>
+											),
+										}
+									) }
+								</li>
+								<li>
+									{ createInterpolateElement(
+										sprintf(
+											/* translators: %s is the package name */
+											__( '<code>%s</code> is the official WordPress.com MCP server package' ),
+											'@automattic/mcp-wpcom-remote'
+										),
+										{
+											code: (
+												<code
+													key="package-name"
+													style={ {
+														backgroundColor: '#f0f0f1',
+														padding: '2px 6px',
+														borderRadius: '3px',
+														fontFamily: 'monospace',
+														fontSize: '13px',
+													} }
+												>
+													@automattic/mcp-wpcom-remote
+												</code>
+											),
+										}
+									) }
+								</li>
+							</ul>
+						</VStack>
+					</CardBody>
+				</Card>
 			</>
 		</PageLayout>
 	);

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -265,7 +265,7 @@ function McpSetupComponent() {
 										</li>
 										<li>
 											<Text as="p" size="medium" variant="muted">
-												{ __( "Follow Claude Desktop's setup instructions" ) }
+												{ __( 'Follow Claude Desktop‘s setup instructions' ) }
 											</Text>
 										</li>
 									</ol>

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -193,7 +193,7 @@ function McpSetupComponent() {
 									) }
 								</Text>
 								<VStack spacing={ 2 }>
-									<ul style={ { color: '#757575' } }>
+									<ul style={ { color: '#757575', paddingLeft: '20px', margin: '0' } }>
 										<li>
 											<Text as="p" size="medium" variant="muted">
 												{ __(
@@ -260,7 +260,7 @@ function McpSetupComponent() {
 											<Text as="p" size="medium" variant="muted">
 												{ __( 'Installation steps:' ) }
 											</Text>
-											<ol style={ { color: '#757575' } }>
+											<ol style={ { color: '#757575', paddingLeft: '20px', margin: '0' } }>
 												<li>
 													<Text as="p" size="medium" variant="muted">
 														{ __( 'Click the download button' ) }

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -137,7 +137,7 @@ function McpSetupComponent() {
 				size="small"
 				header={
 					<PageHeader
-						title={ __( 'MCP Setup' ) }
+						title={ __( 'MCP Client Setup' ) }
 						description={ __( 'Configure your MCP client to connect to WordPress.com.' ) }
 					/>
 				}
@@ -146,7 +146,7 @@ function McpSetupComponent() {
 				{ ! isLoadingUserSettings && (
 					<>
 						<SectionHeader label={ __( 'Setup Required' ) } />
-						<Card isRounded={ false }>
+						<Card>
 							<CardBody>
 								<VStack spacing={ 4 }>
 									<Text as="p" size="medium">
@@ -172,47 +172,48 @@ function McpSetupComponent() {
 	}
 
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader
-					title={ __( 'WordPress.com MCP Setup' ) }
-					description={ __( 'Configure your MCP client to connect to WordPress.com.' ) }
-				/>
-			}
-		>
+		<PageLayout size="small" header={ <PageHeader title={ __( 'MCP Client Setup' ) } /> }>
 			<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
 			{ ! isLoadingUserSettings && (
 				<>
-					<Card style={ { borderRadius: '0' } }>
+					<Card>
 						<CardBody>
 							<VStack spacing={ 4 }>
-								<Text as="p" size="medium">
+								<Text as="h1" size="large" weight={ 500 }>
+									{ __( 'Connect AI Assistant to WordPress.com (MCP)' ) }
+								</Text>
+								<Text as="p" size="medium" variant="muted">
 									{ __(
 										'WordPress.com provides MCP (Model Context Protocol) support, which allows AI assistants to interact directly with your WordPress.com account.'
 									) }
 								</Text>
-								<Text as="p" size="medium">
+								<Text as="p" size="medium" variant="muted">
 									{ __(
 										'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account. It works by:'
 									) }
 								</Text>
 								<VStack spacing={ 2 }>
-									<ul>
+									<ul style={ { color: '#757575' } }>
 										<li>
-											{ __(
-												'Running a bridge server using the WordPress.com-specific MCP package'
-											) }
+											<Text as="p" size="medium" variant="muted">
+												{ __(
+													'Running a bridge server using the WordPress.com-specific MCP package'
+												) }
+											</Text>
 										</li>
 										<li>
-											{ __(
-												'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
-											) }
+											<Text as="p" size="medium" variant="muted">
+												{ __(
+													'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
+												) }
+											</Text>
 										</li>
 										<li>
-											{ __(
-												"Providing real-time access to your account's content and management features"
-											) }
+											<Text as="p" size="medium" variant="muted">
+												{ __(
+													"Providing real-time access to your account's content and management features"
+												) }
+											</Text>
 										</li>
 									</ul>
 								</VStack>
@@ -221,10 +222,12 @@ function McpSetupComponent() {
 					</Card>
 
 					<div style={ { marginTop: '24px' } }>
-						<SectionHeader label={ __( 'MCP Client Configuration' ) } />
-						<Card isRounded={ false }>
+						<Card>
 							<CardBody>
-								<VStack spacing={ 6 }>
+								<VStack spacing={ 4 }>
+									<Text as="h1" size="large" weight={ 500 }>
+										{ __( 'MCP Client Configuration' ) }
+									</Text>
 									<SelectControl
 										__next40pxDefaultSize
 										__nextHasNoMarginBottom
@@ -234,18 +237,46 @@ function McpSetupComponent() {
 										onChange={ setSelectedMcpClient }
 										help={ __( 'Choose your MCP client to get the correct configuration format.' ) }
 									/>
+								</VStack>
+							</CardBody>
+						</Card>
+					</div>
 
+					{ ( selectedMcpClient === 'claude' || selectedMcpClient === 'cursor' ) && (
+						<div style={ { marginTop: '24px' } }>
+							<Card>
+								<CardBody>
 									{ /* Quick Setup for Claude Desktop */ }
 									{ selectedMcpClient === 'claude' && (
-										<VStack spacing={ 4 } style={ { borderBottom: '1px solid #e0e0e0' } }>
-											<Text as="h1" size={ 16 } weight={ 600 }>
+										<VStack spacing={ 4 }>
+											<Text as="h1" size="large" weight={ 500 }>
 												{ __( 'Quick Setup' ) }
 											</Text>
-											<Text as="p" size="medium">
+											<Text as="p" size="medium" variant="muted">
 												{ __(
 													'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
 												) }
 											</Text>
+											<Text as="p" size="medium" variant="muted">
+												{ __( 'Installation steps:' ) }
+											</Text>
+											<ol style={ { color: '#757575' } }>
+												<li>
+													<Text as="p" size="medium" variant="muted">
+														{ __( 'Click the download button' ) }
+													</Text>
+												</li>
+												<li>
+													<Text as="p" size="medium" variant="muted">
+														{ __( 'Double-click the downloaded file' ) }
+													</Text>
+												</li>
+												<li>
+													<Text as="p" size="medium" variant="muted">
+														{ __( "Follow Claude Desktop's setup instructions" ) }
+													</Text>
+												</li>
+											</ol>
 											<Button
 												variant="primary"
 												href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
@@ -254,39 +285,16 @@ function McpSetupComponent() {
 											>
 												{ __( 'Download MCPB File' ) }
 											</Button>
-											<Text as="p" size="medium">
-												{ __( 'Installation steps:' ) }
-											</Text>
-											<ol>
-												<li>
-													<Text as="p" size="medium">
-														{ __( 'Click the download button above' ) }
-													</Text>
-												</li>
-												<li>
-													<Text as="p" size="medium">
-														{ __( 'Double-click the downloaded file' ) }
-													</Text>
-												</li>
-												<li>
-													<Text as="p" size="medium">
-														{ __( "Follow Claude Desktop's setup instructions" ) }
-													</Text>
-												</li>
-											</ol>
 										</VStack>
 									) }
 
 									{ /* Quick Setup for Cursor */ }
 									{ selectedMcpClient === 'cursor' && (
-										<VStack
-											spacing={ 4 }
-											style={ { borderBottom: '1px solid #e0e0e0', paddingBottom: '24px' } }
-										>
+										<VStack spacing={ 4 }>
 											<Text as="h1" size={ 16 } weight={ 600 }>
 												{ __( 'Quick Setup' ) }
 											</Text>
-											<Text as="p" size="medium">
+											<Text as="p" size="medium" variant="muted">
 												{ __(
 													'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
 												) }
@@ -301,59 +309,64 @@ function McpSetupComponent() {
 											</Button>
 										</VStack>
 									) }
+								</CardBody>
+							</Card>
+						</div>
+					) }
 
-									<VStack spacing={ 4 }>
-										<Text as="h1" size={ 16 } weight={ 600 }>
-											{ __( 'Manual Setup' ) }
-										</Text>
+					<div style={ { marginTop: '24px' } }>
+						<Card>
+							<CardBody>
+								<VStack spacing={ 4 }>
+									<Text as="h1" size="large" weight={ 500 }>
+										{ __( 'Manual Setup' ) }
+									</Text>
 
-										<VStack spacing={ 3 }>
-											<div
+									<VStack spacing={ 3 }>
+										<div
+											style={ {
+												display: 'flex',
+												justifyContent: 'space-between',
+												alignItems: 'center',
+											} }
+										>
+											{ clientDocumentation[ selectedMcpClient ] && (
+												<ExternalLink
+													href={ clientDocumentation[ selectedMcpClient ] }
+													target="_blank"
+													style={ { fontSize: 'inherit', textTransform: 'uppercase' } }
+												>
+													{ selectedMcpClient === 'default'
+														? __( 'View setup instructions for other MCP client' )
+														: sprintf(
+																/* translators: %s is the name of the MCP client */
+																__( 'View setup instructions for %s' ),
+																mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )
+																	?.label || ''
+														  ) }
+												</ExternalLink>
+											) }
+											<Button
+												icon={ getCopyIcon() }
+												variant="tertiary"
+												size="small"
 												style={ {
-													display: 'flex',
-													justifyContent: 'space-between',
-													alignItems: 'center',
+													color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
 												} }
-											>
-												{ clientDocumentation[ selectedMcpClient ] && (
-													<ExternalLink
-														href={ clientDocumentation[ selectedMcpClient ] }
-														target="_blank"
-														style={ { fontSize: 'inherit' } }
-													>
-														{ selectedMcpClient === 'default'
-															? __( 'View setup instructions for other MCP client' )
-															: sprintf(
-																	/* translators: %s is the name of the MCP client */
-																	__( 'View setup instructions for %s' ),
-																	mcpClientOptions.find(
-																		( opt ) => opt.value === selectedMcpClient
-																	)?.label || ''
-															  ) }
-													</ExternalLink>
-												) }
-												<Button
-													icon={ getCopyIcon() }
-													variant="tertiary"
-													size="small"
-													style={ {
-														color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
-													} }
-													onClick={ copyToClipboard }
-													aria-label={ __( 'Copy configuration to clipboard' ) }
-												/>
-											</div>
-											<TextareaControl
-												__nextHasNoMarginBottom
-												value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
-												onChange={ () => {} } // Required prop for read-only textarea
-												readOnly
-												help={ __(
-													"Copy this configuration and paste it into your MCP client's settings."
-												) }
-												style={ { minHeight: '240px' } }
+												onClick={ copyToClipboard }
+												aria-label={ __( 'Copy configuration to clipboard' ) }
 											/>
-										</VStack>
+										</div>
+										<TextareaControl
+											__nextHasNoMarginBottom
+											value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+											onChange={ () => {} } // Required prop for read-only textarea
+											readOnly
+											help={ __(
+												"Copy this configuration and paste it into your MCP client's settings."
+											) }
+											style={ { minHeight: '240px' } }
+										/>
 									</VStack>
 								</VStack>
 								<VStack spacing={ 3 }>

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -1,6 +1,5 @@
 import { userSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
 import {
 	Button,
 	ExternalLink,
@@ -20,6 +19,7 @@ import { Card, CardBody } from '../../../components/card';
 import ComponentViewTracker from '../../../components/component-view-tracker';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import RouterLinkButton from '../../../components/router-link-button';
 import { SectionHeader } from '../../../components/section-header';
 
 function McpSetupComponent() {
@@ -141,21 +141,25 @@ function McpSetupComponent() {
 				<ComponentViewTracker eventName="calypso_dashboard_mcp_setup_view" />
 				<Card>
 					<CardBody>
-						<SectionHeader level={ 3 } title={ __( 'Setup Required' ) } />
 						<VStack spacing={ 4 }>
-							<Text as="p" size="medium" variant="muted">
-								{ __( 'No MCP access is currently enabled for your account.' ) }
-							</Text>
-							<Text as="p" size="medium" variant="muted">
-								{ __(
-									'MCP access defines what actions and data your MCP client can access on your account. You need to enable MCP access in the main MCP settings before configuring your client.'
-								) }
-							</Text>
-							<Link to="/me/mcp">
-								<Button variant="primary" style={ { alignSelf: 'flex-start' } }>
+							<SectionHeader level={ 3 } title={ __( 'Setup Required' ) } />
+							<VStack spacing={ 4 }>
+								<Text as="p" variant="muted">
+									{ __( 'No MCP access is currently enabled for your account.' ) }
+								</Text>
+								<Text as="p" variant="muted">
+									{ __(
+										'MCP access defines what actions and data your MCP client can access on your account. You need to enable MCP access in the main MCP settings before configuring your client.'
+									) }
+								</Text>
+								<RouterLinkButton
+									to="/me/mcp"
+									variant="primary"
+									style={ { alignSelf: 'flex-start' } }
+								>
 									{ __( 'Go to MCP Settings' ) }
-								</Button>
-							</Link>
+								</RouterLinkButton>
+							</VStack>
 						</VStack>
 					</CardBody>
 				</Card>
@@ -174,45 +178,47 @@ function McpSetupComponent() {
 			<>
 				<Card>
 					<CardBody>
-						<SectionHeader
-							level={ 3 }
-							title={ __( 'Connect AI Assistant to WordPress.com (MCP)' ) }
-						/>
 						<VStack spacing={ 4 }>
-							<Text as="p" size="medium" variant="muted">
-								{ __(
-									'WordPress.com provides MCP (Model Context Protocol) support, which allows AI assistants to interact directly with your WordPress.com account.'
-								) }
-							</Text>
-							<Text as="p" size="medium" variant="muted">
-								{ __(
-									'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account. It works by:'
-								) }
-							</Text>
-							<VStack spacing={ 2 }>
-								<ul style={ { color: '#757575', paddingLeft: '20px', margin: '0' } }>
-									<li>
-										<Text as="p" size="medium" variant="muted">
-											{ __(
-												'Running a bridge server using the WordPress.com-specific MCP package'
-											) }
-										</Text>
-									</li>
-									<li>
-										<Text as="p" size="medium" variant="muted">
-											{ __(
-												'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
-											) }
-										</Text>
-									</li>
-									<li>
-										<Text as="p" size="medium" variant="muted">
-											{ __(
-												"Providing real-time access to your account's content and management features"
-											) }
-										</Text>
-									</li>
-								</ul>
+							<SectionHeader
+								level={ 3 }
+								title={ __( 'Connect AI Assistant to WordPress.com (MCP)' ) }
+							/>
+							<VStack spacing={ 4 }>
+								<Text as="p" variant="muted">
+									{ __(
+										'WordPress.com provides MCP (Model Context Protocol) support, which allows AI assistants to interact directly with your WordPress.com account.'
+									) }
+								</Text>
+								<Text as="p" variant="muted">
+									{ __(
+										'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account. It works by:'
+									) }
+								</Text>
+								<VStack spacing={ 2 }>
+									<ul style={ { color: '#757575', paddingInlineStart: '20px', margin: '0' } }>
+										<li>
+											<Text as="p" variant="muted">
+												{ __(
+													'Running a bridge server using the WordPress.com-specific MCP package'
+												) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" variant="muted">
+												{ __(
+													'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
+												) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" variant="muted">
+												{ __(
+													'Providing real-time access to your account’s content and management features'
+												) }
+											</Text>
+										</li>
+									</ul>
+								</VStack>
 							</VStack>
 						</VStack>
 					</CardBody>
@@ -220,19 +226,21 @@ function McpSetupComponent() {
 
 				<Card>
 					<CardBody>
-						<SectionHeader level={ 3 } title={ __( 'MCP Client Configuration' ) } />
 						<VStack spacing={ 4 }>
-							<SelectControl
-								__next40pxDefaultSize
-								__nextHasNoMarginBottom
-								label={ __( 'MCP Client' ) }
-								value={ selectedMcpClient }
-								options={ mcpClientOptions }
-								onChange={ setSelectedMcpClient }
-								help={ __(
-									'Choose your MCP client to get the correct configuration format. Then, follow the instructions below.'
-								) }
-							/>
+							<SectionHeader level={ 3 } title={ __( 'MCP Client Configuration' ) } />
+							<VStack spacing={ 4 }>
+								<SelectControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									label={ __( 'MCP Client' ) }
+									value={ selectedMcpClient }
+									options={ mcpClientOptions }
+									onChange={ setSelectedMcpClient }
+									help={ __(
+										'Choose your MCP client to get the correct configuration format. Then, follow the instructions below.'
+									) }
+								/>
+							</VStack>
 						</VStack>
 					</CardBody>
 				</Card>
@@ -240,165 +248,166 @@ function McpSetupComponent() {
 				{ ( selectedMcpClient === 'claude' || selectedMcpClient === 'cursor' ) && (
 					<Card>
 						<CardBody>
-							<SectionHeader level={ 3 } title={ __( 'Quick Setup' ) } />
-							{ /* Quick Setup for Claude Desktop */ }
-							{ selectedMcpClient === 'claude' && (
-								<VStack spacing={ 4 }>
-									<Text as="p" size="medium" variant="muted">
-										{ __(
-											'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
-										) }
-									</Text>
-									<Text as="p" size="medium" variant="muted">
-										{ __( 'Installation steps:' ) }
-									</Text>
-									<ol style={ { color: '#757575', paddingLeft: '20px', margin: '0' } }>
-										<li>
-											<Text as="p" size="medium" variant="muted">
-												{ __( 'Click the download button' ) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" size="medium" variant="muted">
-												{ __( 'Double-click the downloaded file' ) }
-											</Text>
-										</li>
-										<li>
-											<Text as="p" size="medium" variant="muted">
-												{ __( 'Follow Claude Desktop‘s setup instructions' ) }
-											</Text>
-										</li>
-									</ol>
-									<Button
-										variant="primary"
-										href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
-										target="_blank"
-										style={ { alignSelf: 'flex-start' } }
-									>
-										{ __( 'Download MCPB File' ) }
-									</Button>
-								</VStack>
-							) }
+							<VStack spacing={ 4 }>
+								<SectionHeader level={ 3 } title={ __( 'Quick Setup' ) } />
+								{ /* Quick Setup for Claude Desktop */ }
+								{ selectedMcpClient === 'claude' && (
+									<VStack spacing={ 4 }>
+										<Text as="p" variant="muted">
+											{ __(
+												'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
+											) }
+										</Text>
+										<Text as="p" variant="muted">
+											{ __( 'Installation steps:' ) }
+										</Text>
+										<ol style={ { color: '#757575', paddingInlineStart: '20px', margin: '0' } }>
+											<li>
+												<Text as="p" variant="muted">
+													{ __( 'Click the download button' ) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" variant="muted">
+													{ __( 'Double-click the downloaded file' ) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" variant="muted">
+													{ __( 'Follow Claude Desktop‘s setup instructions' ) }
+												</Text>
+											</li>
+										</ol>
+										<Button
+											variant="primary"
+											href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
+											target="_blank"
+											style={ { alignSelf: 'flex-start' } }
+										>
+											{ __( 'Download MCPB File' ) }
+										</Button>
+									</VStack>
+								) }
 
-							{ /* Quick Setup for Cursor */ }
-							{ selectedMcpClient === 'cursor' && (
-								<VStack spacing={ 4 }>
-									<Text as="h1" size={ 16 } weight={ 600 }>
-										{ __( 'Quick Setup' ) }
-									</Text>
-									<Text as="p" size="medium" variant="muted">
-										{ __(
-											'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
-										) }
-									</Text>
-									<Button
-										variant="primary"
-										href="https://cursor.com/en/install-mcp?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhdXRvbWF0dGljL21jcC13cGNvbS1yZW1vdGVAbGF0ZXN0Il19"
-										target="_blank"
-										style={ { alignSelf: 'flex-start' } }
-									>
-										{ __( 'Install in Cursor' ) }
-									</Button>
-								</VStack>
-							) }
+								{ /* Quick Setup for Cursor */ }
+								{ selectedMcpClient === 'cursor' && (
+									<VStack spacing={ 4 }>
+										<Text as="p" variant="muted">
+											{ __(
+												'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
+											) }
+										</Text>
+										<Button
+											variant="primary"
+											href="https://cursor.com/en/install-mcp?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhdXRvbWF0dGljL21jcC13cGNvbS1yZW1vdGVAbGF0ZXN0Il19"
+											target="_blank"
+											style={ { alignSelf: 'flex-start' } }
+										>
+											{ __( 'Install in Cursor' ) }
+										</Button>
+									</VStack>
+								) }
+							</VStack>
 						</CardBody>
 					</Card>
 				) }
 
 				<Card>
 					<CardBody>
-						<SectionHeader level={ 3 } title={ __( 'Manual Setup' ) } />
 						<VStack spacing={ 2 }>
-							<HStack justify="space-between" alignment="center">
-								{ clientDocumentation[ selectedMcpClient ] && (
-									<ExternalLink
-										href={ clientDocumentation[ selectedMcpClient ] }
-										style={ { fontSize: 'inherit', textTransform: 'uppercase' } }
-									>
-										{ selectedMcpClient === 'default'
-											? __( 'View setup instructions for other MCP client' )
-											: sprintf(
-													/* translators: %s is the name of the MCP client */
-													__( 'View setup instructions for %s' ),
-													mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )
-														?.label || ''
-											  ) }
-									</ExternalLink>
-								) }
-								<Button
-									icon={ getCopyIcon() }
-									variant="tertiary"
-									size="small"
-									style={ {
-										color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
-									} }
-									onClick={ copyToClipboard }
-									aria-label={ __( 'Copy configuration to clipboard' ) }
+							<SectionHeader level={ 3 } title={ __( 'Manual Setup' ) } />
+							<VStack spacing={ 1 }>
+								<HStack justify="space-between" alignment="center">
+									{ clientDocumentation[ selectedMcpClient ] && (
+										<ExternalLink
+											href={ clientDocumentation[ selectedMcpClient ] }
+											style={ { fontSize: '11px', textTransform: 'uppercase' } }
+										>
+											{ selectedMcpClient === 'default'
+												? __( 'View setup instructions for other MCP client' )
+												: sprintf(
+														/* translators: %s is the name of the MCP client */
+														__( 'View setup instructions for %s' ),
+														mcpClientOptions.find( ( opt ) => opt.value === selectedMcpClient )
+															?.label || ''
+												  ) }
+										</ExternalLink>
+									) }
+									<Button
+										icon={ getCopyIcon() }
+										variant="tertiary"
+										iconSize={ 20 }
+										style={ {
+											color: copyStatus === 'error' ? 'var(--color-error)' : undefined,
+										} }
+										onClick={ copyToClipboard }
+										aria-label={ __( 'Copy configuration to clipboard' ) }
+									/>
+								</HStack>
+								<TextareaControl
+									__nextHasNoMarginBottom
+									value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
+									onChange={ () => {} } // Required prop for read-only textarea
+									readOnly
+									help={ __(
+										'Copy this configuration and paste it into your MCP client’s settings.'
+									) }
+									style={ { minHeight: '240px' } }
 								/>
-							</HStack>
-							<TextareaControl
-								__nextHasNoMarginBottom
-								value={ JSON.stringify( generateMcpConfig( selectedMcpClient ), null, 2 ) }
-								onChange={ () => {} } // Required prop for read-only textarea
-								readOnly
-								help={ __(
-									"Copy this configuration and paste it into your MCP client's settings."
-								) }
-								style={ { minHeight: '240px' } }
-							/>
-							<VStack spacing={ 2 }>
-								<Text as="p" size="small">
-									{ createInterpolateElement(
-										sprintf(
-											/* translators: %s is the server name identifier */
-											__(
-												'<code>%s</code> is a unique identifier for this WordPress.com account connection'
+								<VStack spacing={ 1 }>
+									<Text size="12px">
+										{ createInterpolateElement(
+											sprintf(
+												/* translators: %s is the server name identifier */
+												__(
+													'<code>%s</code> is a unique identifier for this WordPress.com account connection'
+												),
+												serverName
 											),
-											serverName
-										),
-										{
-											code: (
-												<code
-													key="server-name"
-													style={ {
-														backgroundColor: '#f0f0f1',
-														padding: '2px 6px',
-														borderRadius: '3px',
-														fontFamily: 'monospace',
-														fontSize: '13px',
-													} }
-												>
-													{ serverName }
-												</code>
+											{
+												code: (
+													<code
+														key="server-name"
+														style={ {
+															backgroundColor: '#f0f0f1',
+															padding: '2px 6px',
+															borderRadius: '3px',
+															fontFamily: 'monospace',
+															fontSize: '13px',
+														} }
+													>
+														{ serverName }
+													</code>
+												),
+											}
+										) }
+									</Text>
+									<Text size="12px">
+										{ createInterpolateElement(
+											sprintf(
+												/* translators: %s is the package name */
+												__( '<code>%s</code> is the official WordPress.com MCP server package' ),
+												'@automattic/mcp-wpcom-remote'
 											),
-										}
-									) }
-								</Text>
-								<Text as="p" size="small">
-									{ createInterpolateElement(
-										sprintf(
-											/* translators: %s is the package name */
-											__( '<code>%s</code> is the official WordPress.com MCP server package' ),
-											'@automattic/mcp-wpcom-remote'
-										),
-										{
-											code: (
-												<code
-													key="package-name"
-													style={ {
-														backgroundColor: '#f0f0f1',
-														padding: '2px 6px',
-														borderRadius: '3px',
-														fontFamily: 'monospace',
-														fontSize: '13px',
-													} }
-												>
-													@automattic/mcp-wpcom-remote
-												</code>
-											),
-										}
-									) }
-								</Text>
+											{
+												code: (
+													<code
+														key="package-name"
+														style={ {
+															backgroundColor: '#f0f0f1',
+															padding: '2px 6px',
+															borderRadius: '3px',
+															fontFamily: 'monospace',
+															fontSize: '13px',
+														} }
+													>
+														@automattic/mcp-wpcom-remote
+													</code>
+												),
+											}
+										) }
+									</Text>
+								</VStack>
 							</VStack>
 						</VStack>
 					</CardBody>

--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
 import MenuDivider from '../../components/menu-divider';
@@ -28,6 +29,9 @@ const MeMenu = () => {
 			) }
 			{ hasAppSupport( supports, 'apps' ) && (
 				<ResponsiveMenu.Item to="/me/apps">{ __( 'Apps' ) }</ResponsiveMenu.Item>
+			) }
+			{ isEnabled( 'mcp-settings' ) && (
+				<ResponsiveMenu.Item to="/me/mcp">{ __( 'MCP' ) }</ResponsiveMenu.Item>
 			) }
 		</ResponsiveMenu>
 	);

--- a/client/dashboard/me/me-menu/index.tsx
+++ b/client/dashboard/me/me-menu/index.tsx
@@ -27,11 +27,11 @@ const MeMenu = () => {
 			{ supports.reader && (
 				<ResponsiveMenu.Item to="/me/blocked-sites">{ __( 'Blocked sites' ) }</ResponsiveMenu.Item>
 			) }
-			{ hasAppSupport( supports, 'apps' ) && (
-				<ResponsiveMenu.Item to="/me/apps">{ __( 'Apps' ) }</ResponsiveMenu.Item>
-			) }
 			{ isEnabled( 'mcp-settings' ) && (
 				<ResponsiveMenu.Item to="/me/mcp">{ __( 'MCP' ) }</ResponsiveMenu.Item>
+			) }
+			{ hasAppSupport( supports, 'apps' ) && (
+				<ResponsiveMenu.Item to="/me/apps">{ __( 'Apps' ) }</ResponsiveMenu.Item>
 			) }
 		</ResponsiveMenu>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/DSGCOM-317/mcp-adapt-flows-for-the-multi-site-dashboard#comment-236bfcba

Adds MCP (Model Context Protocol) settings pages to the Multi-site Dashboard, allowing users to configure AI assistant access to their WordPress.com account and sites. This is a feature-flagged addition that integrates with the existing MCP infrastructure.

<img width="707" height="476" alt="Screenshot 2025-12-23 at 19 17 51" src="https://github.com/user-attachments/assets/e4a2f336-746a-48f0-8426-ee2a177711a4" />
<img width="344" height="989" alt="Screenshot 2025-12-23 at 19 07 04" src="https://github.com/user-attachments/assets/05cf8a96-952b-4425-bfe3-2b7043c46e96" />
<img width="542" height="1067" alt="Screenshot 2025-12-23 at 19 06 39" src="https://github.com/user-attachments/assets/f54d254b-1c28-40d7-a5f1-f9dd75142525" />
<img width="678" height="385" alt="Screenshot 2025-12-23 at 19 04 12" src="https://github.com/user-attachments/assets/9a08a6d0-1cfd-4f87-8ca7-1c46b5301b67" />

## Proposed Changes

#### New Routes (`client/dashboard/app/router/me.tsx`)
- Added `mcpRoute` (parent route with loader for `userSettingsQuery`)
- Added `mcpIndexRoute` (main MCP settings page at `/me/mcp`)
- Added `mcpSetupRoute` (MCP client setup page at `/me/mcp/setup`)
- Routes are conditionally registered based on `mcp-settings` feature flag

#### New Components

**MCP Settings Page** (`client/dashboard/me/mcp/index.tsx`)
- AI Access master toggle to enable/disable all MCP tools
- Categorized tool list organized by display categories (Sites & Content, Account, Billing, etc.)
- Site-specific settings to disable MCP access per site
- "Configure MCP Client" button (disabled when no tools are enabled)
- Uses `useSuspenseQuery` for user settings (preloaded at route level)
- Uses `useQuery` for sites list with loading state
- Auto-save with snackbar notifications via React Query mutations

**MCP Client Setup Page** (`client/dashboard/me/mcp/setup/index.tsx`)
- Multi-client support (Claude Desktop, Cursor, VS Code, Continue, Other)
- Client-specific configuration JSON generation
- Quick setup options:
  - Claude Desktop: MCPB file download
  - Cursor: One-click install link
- Manual setup with copy-to-clipboard functionality
- Documentation links for each client
- Validation to ensure at least one tool is enabled before setup

**Category Mapping** (`client/dashboard/me/mcp/categories.ts`)
- Maps tool IDs to display categories
- Defines category order for consistent UI
- Handles uncategorized tools

#### Navigation (`client/dashboard/me/me-menu/index.tsx`)
- Added "MCP" menu item (conditionally shown based on `mcp-settings` feature flag)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click to the `Dashboard Live` link in https://github.com/Automattic/wp-calypso/pull/107830#issuecomment-3681715648
* Go to MCP settings `/me/mcp/` 
* Confirm works as expects and is inline with the figma design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
