### PR TITLE
Add simple site blueprint loader

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -106,6 +106,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		partnerBundle,
 		gardenName,
 		gardenPartnerName,
+		blueprint,
 	} = useSelect(
 		( select: ( arg: string ) => OnboardSelect ) => ( {
 			domainItem: select( ONBOARD_STORE ).getSelectedDomain(),
@@ -119,6 +120,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			partnerBundle: select( ONBOARD_STORE ).getPartnerBundle(),
 			gardenName: select( ONBOARD_STORE ).getGardenName(),
 			gardenPartnerName: select( ONBOARD_STORE ).getGardenPartnerName(),
+			blueprint: select( ONBOARD_STORE ).getBlueprint(),
 		} ),
 		[]
 	);
@@ -236,7 +238,8 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			undefined, // siteGoals
 			gardenName,
 			gardenPartnerName,
-			urlQueryParams.get( 'spec_id' )
+			urlQueryParams.get( 'spec_id' ),
+			blueprint
 		);
 
 		// Poll for garden provisioning status if this is a garden site

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
@@ -1,6 +1,8 @@
+import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { getPHPVersions } from 'calypso/data/php-versions';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { initializeWordPressPlayground } from '../../lib/initialize-playground';
 import { PlaygroundError } from '../playground-error';
 import type { PlaygroundClient } from '@wp-playground/client';
@@ -18,6 +20,7 @@ export function PlaygroundIframe( {
 	const recommendedPHPVersion = getPHPVersions().recommendedValue;
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const [ playgroundError, setPlaygroundError ] = useState< string | null >( null );
+	const { setBlueprint } = useDispatch( ONBOARD_STORE );
 
 	const createNewPlayground = () => {
 		// Clear the 'playground' parameter from the URL
@@ -36,8 +39,9 @@ export function PlaygroundIframe( {
 		}
 
 		initializeWordPressPlayground( iframeRef.current, recommendedPHPVersion, setSearchParams )
-			.then( ( client ) => {
-				setPlaygroundClient( client );
+			.then( ( result ) => {
+				setPlaygroundClient( result.client );
+				setBlueprint( result.blueprint );
 			} )
 			.catch( ( error ) => {
 				if ( error.message === 'WordPress installation has failed.' ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
@@ -37,7 +37,10 @@ describe( 'Playground', () => {
 		mockPlaygroundClientInstance = {
 			run: jest.fn().mockImplementation( () => Promise.resolve( { text: 'plans-playground' } ) ),
 		};
-		initializeWordPressPlayground.mockResolvedValue( mockPlaygroundClientInstance );
+		initializeWordPressPlayground.mockResolvedValue( {
+			blueprint: null,
+			client: mockPlaygroundClientInstance,
+		} );
 	} );
 
 	describe( 'step', () => {

--- a/client/landing/stepper/hooks/use-create-site-hook.ts
+++ b/client/landing/stepper/hooks/use-create-site-hook.ts
@@ -30,6 +30,7 @@ type Params = {
 	siteIntent?: string;
 	siteGoals?: SiteGoal[];
 	planCartItems?: MinimalRequestCartProduct[] | null;
+	blueprint?: string | null;
 };
 
 async function fillCart(
@@ -78,6 +79,7 @@ export const createSite = async ( {
 	sourceSlug,
 	siteIntent,
 	planCartItems,
+	blueprint = null,
 }: Params ) => {
 	const newSiteParams = getNewSiteParams( {
 		flowToCheck: flowName,
@@ -91,6 +93,7 @@ export const createSite = async ( {
 		sourceSlug,
 		siteIntent,
 		partnerBundle,
+		blueprint,
 	} );
 
 	const locale = getLocaleSlug();

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -373,6 +373,11 @@ export const setGardenPartnerName = ( gardenPartnerName: string | null ) => ( {
 	gardenPartnerName,
 } );
 
+export const setBlueprint = ( blueprint: string | null ) => ( {
+	type: 'SET_BLUEPRINT' as const,
+	blueprint,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -434,4 +439,5 @@ export type OnboardAction = ReturnType<
 	| typeof setSignupDomainOrigin
 	| typeof setGardenName
 	| typeof setGardenPartnerName
+	| typeof setBlueprint
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -635,6 +635,16 @@ export const gardenPartnerName: Reducer< string | null, OnboardAction > = (
 	return state;
 };
 
+export const blueprint: Reducer< string | null, OnboardAction > = ( state = null, action ) => {
+	if ( action.type === 'SET_BLUEPRINT' ) {
+		return action.blueprint;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return null;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainCartItem,
@@ -685,6 +695,7 @@ const reducer = combineReducers( {
 	signupDomainOrigin,
 	gardenName,
 	gardenPartnerName,
+	blueprint,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -83,3 +83,4 @@ export const getPaidSubscribers = ( state: State ) => state.paidSubscribers;
 export const getPartnerBundle = ( state: State ) => state.partnerBundle;
 export const getGardenName = ( state: State ) => state.gardenName;
 export const getGardenPartnerName = ( state: State ) => state.gardenPartnerName;
+export const getBlueprint = ( state: State ) => state.blueprint;

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -32,6 +32,7 @@ interface GetNewSiteParams {
 	partnerBundle: string | null;
 	sourceSlug?: string;
 	siteIntent?: string;
+	blueprint?: string | null;
 }
 
 type NewSiteParams = {
@@ -53,6 +54,7 @@ type NewSiteParams = {
 		wpcom_public_coming_soon: 0 | 1;
 		site_accent_color?: string;
 		site_intent?: string;
+		blueprint?: string;
 	};
 	validate: boolean;
 };
@@ -102,6 +104,7 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 		sourceSlug,
 		siteIntent,
 		partnerBundle,
+		blueprint,
 	} = params;
 
 	// We will use the default annotation instead of theme annotation as fallback,
@@ -126,6 +129,7 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 			...( themeSlugWithRepo && { theme: themeSlugWithRepo } ),
 			...( siteIntent && { site_intent: siteIntent } ),
 			...( partnerBundle && { site_partner_bundle: partnerBundle } ),
+			...( blueprint && { blueprint: blueprint } ),
 		},
 		validate: false,
 	};
@@ -152,7 +156,8 @@ export const createSiteWithCart = async (
 	siteGoals?: SiteGoal[],
 	gardenName?: string | null,
 	gardenPartnerName?: string | null,
-	specId?: string | null
+	specId?: string | null,
+	blueprint?: string | null
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
@@ -170,6 +175,7 @@ export const createSiteWithCart = async (
 		sourceSlug,
 		siteIntent,
 		partnerBundle,
+		blueprint,
 	} );
 
 	// if ( isEmpty( bearerToken ) && 'onboarding-registrationless' === flowToCheck ) {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -259,7 +259,7 @@ export const usePlanTypesWithIntent = ( {
 			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		case 'plans-playground':
-			planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		case 'plans-playground-premium':
 			// This plan intent is currently not utilized but will be soon


### PR DESCRIPTION
This PR adds a blueprint loader for both newly created and preexisting free sites.

See: https://linear.app/a8c/issue/PLAYGRD-239/create-golden-path-to-create-a-simple-site-with-a-predefined-blueprint

## Proposed Changes

* Remove Business/WooCommerce filter.
* Remove redirect to import page for playground free sites
* Add `blueprint` field to site creation endpoint
* Add check on current running `rest/v1.1/sites/__ID__imports/`
* Add support to `importerWordpress` page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To let the user use blueprints in all kinds of plans
* To let the user apply a blueprint

## Testing Instructions

> [!TIP]
> If your user has a security key enabled, you will not log in to http://calypso.localhost:3000, because it's not https. What you can do is to change the `AUTH` field in the bottom right DEV menu to to `OAUTH`. This will automatically log in you. If this not work be sure to use another user without a key.

Create a site from a blueprint:

* Apply 198037-ghe-Automattic/wpcom and follow testing instructions
* Checkout `add/new-site-from-blueprint`
* `yarn start`
* Select a free site
* Visit `http://calypso.localhost:3000/setup/site-setup/importerWordpress?siteSlug=__BLOG_ID__.wordpress.com`
* Select a blueprint JSON
* The import page refreshes every five seconds. You should see some confetti


https://github.com/user-attachments/assets/1bb6084d-65ae-4147-aff6-a80b2fb3d386

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?