### PR TITLE
Theme Showcase: Update the border radius of badges

### DIFF
--- a/packages/components/src/theme-type-badge/bundled-badge/style.scss
+++ b/packages/components/src/theme-type-badge/bundled-badge/style.scss
@@ -6,7 +6,7 @@
 	height: 20px;
 	line-height: 20px;
 	padding: 0 10px 0 9px;
-	border-radius: 20px; /* stylelint-disable-line scales/radii */
+	border-radius: 4px;
 	box-sizing: border-box;
 	font-size: 0.75rem;
 	color: var(--studio-white);

--- a/packages/components/src/theme-type-badge/premium-badge/style.scss
+++ b/packages/components/src/theme-type-badge/premium-badge/style.scss
@@ -4,7 +4,7 @@
 	height: 20px;
 	line-height: 20px;
 	padding: 0 10px 0 9px;
-	border-radius: 20px; /* stylelint-disable-line scales/radii */
+	border-radius: 4px;
 	margin-left: 10px;
 	box-sizing: border-box;
 	font-size: 0.75rem;

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -236,7 +236,7 @@ $theme-card-info-margin-top: 16px;
 	-webkit-font-smoothing: antialiased;
 
 	&-badge {
-		border-radius: 20px;  /* stylelint-disable-line scales/radii */
+		border-radius: 4px;
 		flex: 0 0 auto;
 		text-transform: none;
 		font-size: $font-body-extra-small;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTTHEM-143

## Proposed Changes

* Update the border radius of badges to 4px for consistency

| Badge | Before | After |
| - | - | - |
| Active | <img width="89" height="35" alt="image" src="https://github.com/user-attachments/assets/e24bf8f5-5f1c-4aff-b25d-d709957bc576" />|<img width="86" height="34" alt="image" src="https://github.com/user-attachments/assets/c6e950dd-b86e-4c24-a036-87f67db9d322" />|
| Included with plan | <img width="129" height="31" alt="image" src="https://github.com/user-attachments/assets/6f87216d-41f7-44e3-a45a-2c09958cb267" /> | Unchanged |
| Free | <img width="56" height="37" alt="image" src="https://github.com/user-attachments/assets/36e7b553-8478-4cce-b121-345f23f44abf" />| Unchanged|
| Personal |<img width="158" height="28" alt="image" src="https://github.com/user-attachments/assets/70abbcf2-2499-42d9-a255-373cae80426a" />|<img width="157" height="31" alt="image" src="https://github.com/user-attachments/assets/a27cc067-9e99-47a8-8ff7-d0e07d154016" />|
| Premium |<img width="164" height="31" alt="image" src="https://github.com/user-attachments/assets/d037ac7e-63eb-4522-b39e-87bf5d5fc264" />|<img width="160" height="32" alt="image" src="https://github.com/user-attachments/assets/1d53ff19-5cd3-4cac-b8f3-dc7680ac7e83" />|
| Business |<img width="224" height="35" alt="image" src="https://github.com/user-attachments/assets/6d71f9cd-64c9-4541-89ae-8a0eaea719df" />|<img width="223" height="30" alt="image" src="https://github.com/user-attachments/assets/f28abc59-b328-4df6-a4e9-b799a5d72488" />|
| Community | <img width="89" height="31" alt="image" src="https://github.com/user-attachments/assets/8c721811-c18f-4994-9948-9d6e89f9e3fb" />|<img width="88" height="30" alt="image" src="https://github.com/user-attachments/assets/117cd3a2-5498-4b56-baf7-4727328ffdf7" />|
| Partner |<img width="74" height="38" alt="image" src="https://github.com/user-attachments/assets/fd5ba5ac-a3e1-4774-b152-e0deb9493c88" />|<img width="68" height="31" alt="image" src="https://github.com/user-attachments/assets/3f633902-6fc1-4a0b-8ed4-293aa45b5517" />|
| Woo |<img width="145" height="35" alt="image" src="https://github.com/user-attachments/assets/eea146e8-9ad1-4d8f-b60f-1212272fbd6c" />|<img width="146" height="26" alt="image" src="https://github.com/user-attachments/assets/619c7fb4-9025-49fc-ab24-7344a0e6529b" />|
| Price | <img width="211" height="34" alt="image" src="https://github.com/user-attachments/assets/bd7ba907-2b7d-4ede-916f-4027c6cba963" />|<img width="216" height="35" alt="image" src="https://github.com/user-attachments/assets/07453d01-0795-4993-9d8a-cd4c407c4c6a" />|

**The Premium Badges next to Style variations**

| Before | After |
| - | - |
|<img width="164" height="32" alt="image" src="https://github.com/user-attachments/assets/bd902e52-2714-4d8c-8850-563d80d48452" />|<img width="161" height="37" alt="image" src="https://github.com/user-attachments/assets/53ca5ada-09ee-4e8b-9a2e-77ae6b842435" />|
|<img width="223" height="36" alt="image" src="https://github.com/user-attachments/assets/80753641-04d8-465b-9223-c0754b87afc4" />|<img width="226" height="34" alt="image" src="https://github.com/user-attachments/assets/68d01d8d-bda1-4350-9c63-a481924922ff" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Style consistency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /theme/:site on your site with different plans
* Ensure all the badges mentioned above look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
