### PR TITLE
A4A: Add Woo critical announcement for plugin vulnerability.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { useMemo } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import { UpcomingEventProps } from 'calypso/a8c-for-agencies/components/upcoming-event/types';
+import WooLogo from 'calypso/assets/images/a8c-for-agencies/events/woo-logo.svg';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 export const useUpcomingEvents = () => {
@@ -11,6 +12,28 @@ export const useUpcomingEvents = () => {
 
 	return useMemo( () => {
 		const eventsData: UpcomingEventProps[] = [
+			{
+				id: 'a4a-woo-2025-12-23',
+				date: {
+					from: moment( '2025-12-23' ),
+					to: moment( '2026-01-05' ),
+				},
+				displayDate: translate( 'As soon as possible' ),
+				title: translate( 'Action Needed: Critical WooCommerce Update Available' ),
+				subtitle: translate( 'Automattic for Agencies' ),
+				descriptions: [
+					translate(
+						'A vulnerability has been identified in WooCommerce versions 8.1 through 10.4.2, and a patch is now available. Client sites hosted with Automattic are already protected. For any client sites hosted elsewhere, please update WooCommerce to the latest version as soon as possible. At this time, we have no indication that this vulnerability has been exploited.'
+					),
+				],
+				cta: {
+					label: translate( 'Read the announcement and FAQ ↗' ),
+					url: 'https://usabi.li/do/b8fc6strv3hm/tnzgph',
+				},
+				logoUrl: WooLogo,
+				trackEventName: 'calypso_a4a_overview_events_a4a_woo_2025_12_23_click',
+				dateClassName: 'a4a-event__date--critical',
+			},
 			{
 				id: 'a4a-partner-survey-2025-12-03',
 				date: {

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -18,9 +18,9 @@ export const useUpcomingEvents = () => {
 					from: moment( '2025-12-23' ),
 					to: moment( '2026-01-05' ),
 				},
-				displayDate: translate( 'As soon as possible' ),
+				displayDate: translate( 'Update as soon as possible' ),
 				title: translate( 'Action Needed: Critical WooCommerce Update Available' ),
-				subtitle: translate( 'Automattic for Agencies' ),
+				subtitle: translate( 'WooCommerce' ),
 				descriptions: [
 					translate(
 						'A vulnerability has been identified in WooCommerce versions 8.1 through 10.4.2, and a patch is now available. Client sites hosted with Automattic are already protected. For any client sites hosted elsewhere, please update WooCommerce to the latest version as soon as possible. At this time, we have no indication that this vulnerability has been exploited.'

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -23,12 +23,12 @@ export const useUpcomingEvents = () => {
 				subtitle: translate( 'WooCommerce' ),
 				descriptions: [
 					translate(
-						'A vulnerability has been identified in WooCommerce versions 8.1 through 10.4.2, and a patch is now available. Client sites hosted with Automattic are already protected. For any client sites hosted elsewhere, please update WooCommerce to the latest version as soon as possible. At this time, we have no indication that this vulnerability has been exploited.'
+						'A Store API vulnerability has been identified in WooCommerce versions 8.1 through 10.4.2, and a patch is now available. Client sites hosted with Automattic have been automatically patched. Please update WooCommerce on all client sites to the latest version (10.4.3) as soon as possible. We currently have no evidence of the vulnerability being used or exploited outside of our own security testing program.'
 					),
 				],
 				cta: {
 					label: translate( 'Read the announcement and FAQ ↗' ),
-					url: 'https://usabi.li/do/b8fc6strv3hm/tnzgph',
+					url: 'https://developer.woocommerce.com/2025/12/22/store-api-vulnerability-patched-in-woocommerce-8-1/',
 				},
 				logoUrl: WooLogo,
 				trackEventName: 'calypso_a4a_overview_events_a4a_woo_2025_12_23_click',

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -13,9 +13,9 @@ export const useUpcomingEvents = () => {
 	return useMemo( () => {
 		const eventsData: UpcomingEventProps[] = [
 			{
-				id: 'a4a-woo-2025-12-23',
+				id: 'a4a-woo-2025-12-22',
 				date: {
-					from: moment( '2025-12-23' ),
+					from: moment( '2025-12-22' ),
 					to: moment( '2026-01-05' ),
 				},
 				displayDate: translate( 'Update as soon as possible' ),
@@ -31,7 +31,7 @@ export const useUpcomingEvents = () => {
 					url: 'https://developer.woocommerce.com/2025/12/22/store-api-vulnerability-patched-in-woocommerce-8-1/',
 				},
 				logoUrl: WooLogo,
-				trackEventName: 'calypso_a4a_overview_events_a4a_woo_2025_12_23_click',
+				trackEventName: 'calypso_a4a_overview_events_a4a_woo_2025_12_22_click',
 				dateClassName: 'a4a-event__date--critical',
 			},
 			{

--- a/client/a8c-for-agencies/sections/overview/body/events/styles.scss
+++ b/client/a8c-for-agencies/sections/overview/body/events/styles.scss
@@ -33,6 +33,10 @@
 	color: var(--color-neutral-70);
 }
 
+.a4a-event__date--critical {
+	color: var(--color-scary-50);
+}
+
 .a4a-event__image--a4a,
 .a4a-event__image--klaviyo {
 	background-size: 90%;


### PR DESCRIPTION
## Proposed Changes

<img width="927" height="359" alt="Screenshot 2025-12-23 at 1 33 18 AM" src="https://github.com/user-attachments/assets/4e2bb660-46bb-47ef-8d63-96a25d375c7f" />



This pull request adds a new critical WooCommerce security update event to the upcoming events section for agencies, along with a visual indicator for critical events.

**New event and visual enhancements:**

* Added a new critical WooCommerce update event to the `useUpcomingEvents` hook, including title, description, CTA, and custom tracking event. The event uses a new WooCommerce logo and highlights the need for urgent action.
* Added a new CSS class `.a4a-event__date--critical` to style critical event dates with a distinct color for visibility.

## Why are these changes being made?

This is an urgent announcement that needs to be delivered to our agencies.

## Testing Instructions

* Use the A4A live link and navigate to the `/overview` page.
* Verify you see the new announcement, it redirects to the correct page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
