### PR TITLE
Domain Transfer Redesign: Fix cancel transfer link in the domain transfer setup page

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
@@ -6,7 +6,7 @@ import {
 	siteByIdQuery,
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
@@ -20,6 +20,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { domainTransferSetupRoute } from '../../app/router/domains';
+import { purchaseSettingsRoute } from '../../app/router/me';
 import { siteDomainsRoute } from '../../app/router/sites';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody, CardDivider } from '../../components/card';
@@ -263,9 +264,12 @@ export default function DomainTransferSetup() {
 									{ __( 'Contact support' ) }
 								</InlineSupportLink>
 								{ purchase && shouldShowRemoveAction( domain, purchase ) && (
-									<a href={ `/me/purchases/${ purchase?.site_slug }/${ purchase?.ID }` }>
+									<Link
+										to={ purchaseSettingsRoute.fullPath }
+										params={ { purchaseId: purchase.ID } }
+									>
 										{ __( 'Cancel transfer' ) }
-									</a>
+									</Link>
 								) }
 							</VStack>
 						</VStack>


### PR DESCRIPTION
Part of [DOMENG-298](https://linear.app/a8c/issue/DOMENG-298)

## Proposed Changes

This PR fixes the "Cancel transfer" link's URL in the MSD domain transfer setup page.

<img width="1026" height="1162" alt="Screenshot 2025-12-22 at 16 39 52" src="https://github.com/user-attachments/assets/f6b86399-dfb8-4183-8a88-59a4637e72f7" />

### Demo

- Before

https://github.com/user-attachments/assets/d554e6c1-777c-45b8-a380-b6e5101dc590

- After

https://github.com/user-attachments/assets/19bf0497-2fc8-4b00-a5f7-b73636b4bf8d

## Why are these changes being made?

Previously the link went to a 404 page (it was actually the Calypso purchase management URL), now it goes to the correct purchase management URL in the MSD.

## Testing Instructions

- Open the live link or build this branch locally
- In the Multi-Site Dashboard, open the transfer setup page for a transfer in pending start status
- Ensure the link goes to the purchase management page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
