### PR TITLE
Domain Transfer Redesign: Fix the "Domain name transfer guide" support page link in the domain transfer pages

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -646,6 +646,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/incoming-domain-transfer/#step-3-log-into-your-domain-provider-s-account',
 		post_id: 137759,
 	},
+	'transfer-domain-name-to-wordpress-com': {
+		link: 'https://wordpress.com/support/domains/incoming-domain-transfer/',
+		post_id: 137759,
+	},
 	'domain-registrations-and-privacy': {
 		link: 'https://wordpress.com/support/domains/private-domain-registration/#what-is-privacy-protection',
 		post_id: 365563,

--- a/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/new-transfer-setup.tsx
@@ -257,7 +257,7 @@ export default function DomainTransferSetup() {
 								{ __( 'Need help?' ) }
 							</Text>
 							<VStack spacing={ 2 }>
-								<InlineSupportLink supportContext="transfer-domain-registration">
+								<InlineSupportLink supportContext="transfer-domain-name-to-wordpress-com">
 									{ __( 'Domain name transfer guide' ) }
 								</InlineSupportLink>
 								<InlineSupportLink supportContext="general-support-options">

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/transfer-step.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/transfer-step.tsx
@@ -74,7 +74,7 @@ export const InboundTransferStep = ( {
 							{ __( 'Need help?' ) }
 						</Text>
 						<VStack spacing={ 2 }>
-							<InlineSupportLink supportContext="transfer-domain-registration">
+							<InlineSupportLink supportContext="transfer-domain-name-to-wordpress-com">
 								{ __( 'Domain name transfer guide' ) }
 							</InlineSupportLink>
 							<InlineSupportLink supportContext="general-support-options">


### PR DESCRIPTION
Fixes [DOMENG-299](https://linear.app/a8c/issue/DOMENG-299)

## Proposed Changes

This PR fixes the "Domain name transfer guide" support page link in the domain transfer pages.

<img width="1026" height="1162" alt="Screenshot 2025-12-22 at 18 06 44" src="https://github.com/user-attachments/assets/eed931cc-9c8a-402e-a58e-5b9ef285102f" />

### Screenshots

| Before | After |
| --- | --- |
| <img width="1026" height="1162" alt="Screenshot 2025-12-22 at 17 38 26" src="https://github.com/user-attachments/assets/40eeba8b-dc9d-4eb7-8d46-b6b484f5df23" /> | <img width="1026" height="1162" alt="Screenshot 2025-12-22 at 17 49 10" src="https://github.com/user-attachments/assets/7d32ce3a-285e-46fb-96b9-ffddbb5764be" /> |

## Why are these changes being made?

Before, clicking on the "Domain name transfer guide" link in the transfer setup or overview pages opened the support page to transfer domains outside of WPCOM, when we wanted to show the opposite, the guide to transfer domains inside WPCOM.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- In the Multi-Site Dashboard, open the transfer setup page for a transfer in pending start status
- Ensure the "Domain name transfer guide" link opens the inbound domain transfer support page, and not the outbound domain transfer one

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
