### PR TITLE
MSD: Protect against missing slug in domain upsell.

### DIFF
--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -55,7 +55,7 @@ const DomainUpsellCardContent = ( {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const { search, suggestedDomain } = useDomainSuggestion( site );
 
-	if ( ! suggestedDomain ) {
+	if ( ! search && ! suggestedDomain ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -22,13 +22,16 @@ const requiresPlanUpgrade = ( site: Site ) => {
 };
 
 const useDomainSuggestion = ( site: Site ) => {
-	const search = site.slug.split( '.' )[ 0 ];
-	const { data: allDomainSuggestions } = useQuery(
-		domainSuggestionsQuery( search, {
-			vendor: 'domain-upsell',
-			include_wordpressdotcom: false,
-		} )
-	);
+	const search = site.slug?.split( '.' )[ 0 ] ?? '';
+	const domainSuggestionQueryOptions = domainSuggestionsQuery( search, {
+		vendor: 'domain-upsell',
+		include_wordpressdotcom: false,
+	} );
+
+	const { data: allDomainSuggestions } = useQuery( {
+		...domainSuggestionQueryOptions,
+		enabled: !! search,
+	} );
 
 	return {
 		search,
@@ -51,6 +54,10 @@ const DomainUpsellCardContent = ( {
 } ) => {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const { search, suggestedDomain } = useDomainSuggestion( site );
+
+	if ( ! suggestedDomain ) {
+		return null;
+	}
 
 	const backUrl = redirectToDashboardLink( { supportBackport: true } );
 	const handleUpsell = async () => {

--- a/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import DomainUpsellCard from '../index';
+import type { Site } from '@automattic/api-core';
+
+const mockUseQuery = jest.fn();
+
+const mockSiteBase: Partial< Site > = {
+	ID: 123,
+	plan: {
+		is_free: true,
+		product_id: 1,
+		product_slug: 'free-plan',
+		product_name_short: 'Free',
+		expired: false,
+		features: {
+			active: [],
+		},
+	},
+	capabilities: {
+		manage_options: true,
+		update_plugins: true,
+	},
+	is_a4a_dev_site: false,
+	is_a8c: false,
+	is_deleted: false,
+	is_coming_soon: false,
+	is_private: false,
+	is_wpcom_atomic: true,
+	is_wpcom_flex: false,
+	is_wpcom_staging_site: false,
+	is_vip: false,
+	lang: 'en',
+	launch_status: 'launched',
+	site_migration: {
+		in_progress: false,
+		is_complete: false,
+	},
+	site_owner: 1,
+	jetpack: false,
+	jetpack_connection: false,
+	jetpack_modules: [],
+	was_ecommerce_trial: false,
+	was_migration_trial: false,
+	was_hosting_trial: false,
+	was_upgraded_from_trial: false,
+	is_garden: false,
+	garden_name: null,
+	garden_partner: null,
+	garden_is_provisioned: null,
+};
+
+jest.mock( '@automattic/api-queries', () => ( {
+	...jest.requireActual( '@automattic/api-queries' ),
+	siteCurrentPlanQuery: ( siteId: number ) => ( {
+		queryKey: [ 'site-current-plan', siteId ],
+		queryFn: () =>
+			Promise.resolve( {
+				id: 1,
+				has_domain_credit: true,
+			} ),
+	} ),
+	domainSuggestionsQuery: ( search: string ) => ( {
+		queryKey: [ 'domain-suggestions', search ],
+		queryFn: () =>
+			Promise.resolve( [
+				{
+					domain_name: `${ search }.com`,
+					product_slug: 'domain-product',
+				},
+			] ),
+	} ),
+} ) );
+
+jest.mock( '@tanstack/react-query', () => {
+	const actual = jest.requireActual( '@tanstack/react-query' );
+	return {
+		...actual,
+		useQuery: ( options: { queryKey?: unknown[]; enabled?: boolean } ) => {
+			mockUseQuery( options );
+			return actual.useQuery( options );
+		},
+	};
+} );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	...jest.requireActual( '@wordpress/i18n' ),
+	__: ( text: string ) => text,
+} ) );
+
+describe( 'DomainUpsellCard', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+		mockUseQuery.mockClear();
+	} );
+
+	test( 'renders when site has a slug', async () => {
+		const site: Site = {
+			...mockSiteBase,
+			slug: 'example.wordpress.com',
+			name: 'Example Site Name',
+			URL: 'https://example.wordpress.com',
+		} as Site;
+
+		render( <DomainUpsellCard site={ site } /> );
+
+		expect( await screen.findByText( 'Claim your free domain' ) ).toBeVisible();
+		// The blurred fallback should not be used when we have a suggestion.
+		expect( screen.queryByText( 'example' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'does not render when site slug is missing', async () => {
+		const site: Site = {
+			...mockSiteBase,
+			name: 'No Slug Site',
+			URL: 'https://no-slug.example.com',
+		} as Site;
+
+		render( <DomainUpsellCard site={ site } /> );
+
+		// Wait until the domain suggestions query has been registered and ensure it is disabled
+		// when slug is missing.
+		await waitFor( () => {
+			const domainSuggestionCall = mockUseQuery.mock.calls.find( ( [ options ] ) => {
+				if ( ! options || typeof options !== 'object' ) {
+					return false;
+				}
+
+				const typedOptions = options as { queryKey?: unknown[] };
+				return (
+					Array.isArray( typedOptions.queryKey ) &&
+					typedOptions.queryKey[ 0 ] === 'domain-suggestions'
+				);
+			} );
+
+			expect( domainSuggestionCall ).toBeDefined();
+			const [ options ] = domainSuggestionCall as [ { enabled?: boolean } ];
+			expect( options.enabled ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes/Why are these changes being made?


We're seeing the follow errors in our logs:

```
Cannot read properties of undefined (reading 'split')
https://wordpress.com/calypso/evergreen/2779.56b6e0d404832a021c1a.min.js:1:21528)
```

Although I'm unable to reproduce, it seems possible to have `slug` undefined which throws an error when `split` is called.

This PR makes sure we don't error when we don't have a slug and returns early if we don't have a suggested domain. It doesn't solve the underlying problem though. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
