### PR TITLE
MSD: Fix Help Center cannot open again

### DIFF
--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -7,7 +7,7 @@ import { initializeAnalytics } from '@automattic/calypso-analytics';
 import { useGetSupportInteractions } from '@automattic/odie-client/src/data/use-get-support-interactions';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { useSelect } from '@wordpress/data';
-import { createPortal, useEffect, useRef } from '@wordpress/element';
+import { createPortal, useEffect, useState } from '@wordpress/element';
 /**
  * Internal Dependencies
  */
@@ -30,7 +30,7 @@ const HelpCenter: React.FC< Container > = ( {
 	currentRoute = window.location.pathname + window.location.search + window.location.hash,
 } ) => {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
-	const portalParentRef = useRef< HTMLDivElement >();
+	const [ container, setContainer ] = useState< HTMLDivElement >();
 
 	const isHelpCenterShown = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
@@ -54,19 +54,20 @@ const HelpCenter: React.FC< Container > = ( {
 
 	// Create portal container on mount, cleanup on unmount
 	useEffect( () => {
-		if ( ! shouldUseUnifiedAgent && ! portalParentRef.current ) {
-			const div = document.createElement( 'div' );
+		let div: HTMLDivElement | undefined;
+		if ( ! shouldUseUnifiedAgent ) {
+			div = document.createElement( 'div' );
 			div.classList.add( 'help-center' );
 			div.setAttribute( 'role', 'dialog' );
 			div.setAttribute( 'aria-modal', 'true' );
 			div.setAttribute( 'aria-labelledby', 'header-text' );
 			document.body.appendChild( div );
-			portalParentRef.current = div;
+			setContainer( div );
 		}
 
 		return () => {
-			if ( portalParentRef.current?.parentNode ) {
-				document.body.removeChild( portalParentRef.current );
+			if ( div ) {
+				document.body.removeChild( div );
 			}
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -85,7 +86,7 @@ const HelpCenter: React.FC< Container > = ( {
 		);
 	}
 
-	if ( ! portalParentRef.current ) {
+	if ( ! container ) {
 		return null;
 	}
 
@@ -101,7 +102,7 @@ const HelpCenter: React.FC< Container > = ( {
 				<HelpCenterSmooch enableAuth={ isHelpCenterShown || hasOpenZendeskConversations } />
 			) }
 		</>,
-		portalParentRef.current
+		container
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix the issue that the Help Center cannot open again. The reason is we create the container when the help center app mounts and store it in the ref. However, it won't trigger re-render again after the container creates and append to document so the Help Center are not able to show.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Click Help Center icon to open it
* Close and open it again
* Ensure it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
