### PR TITLE
MSD: more friendly handling of Jetpack connection issue

### DIFF
--- a/client/dashboard/sites/site/error.tsx
+++ b/client/dashboard/sites/site/error.tsx
@@ -1,8 +1,9 @@
 import { DashboardDataError } from '@automattic/api-core';
-import { Notice } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import UnknownError from '../../app/500';
 import { siteRoute } from '../../app/router/sites';
+import { Notice } from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
@@ -24,7 +25,6 @@ function InaccessibleJetpackError( { error }: { error: Error } ) {
 			header={
 				<PageHeader
 					title={ siteSlug }
-					description={ __( 'Your Jetpack site can not be reached at this time.' ) }
 					actions={
 						<RouterLinkButton to="/sites" variant="primary" __next40pxDefaultSize>
 							{ __( 'Go to Sites' ) }
@@ -33,7 +33,15 @@ function InaccessibleJetpackError( { error }: { error: Error } ) {
 				/>
 			}
 			notices={
-				<Notice status="error" isDismissible={ false }>
+				<Notice
+					variant="error"
+					title={ __( 'Your Jetpack site can not be reached at this time.' ) }
+					actions={
+						<ExternalLink href="https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/">
+							{ __( 'Troubleshoot your Jetpack site' ) }
+						</ExternalLink>
+					}
+				>
 					{ error.message }
 				</Notice>
 			}

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -16,9 +16,13 @@ import EnvironmentSwitcher from './environment-switcher';
 
 function Site() {
 	const { siteSlug } = siteRoute.useParams();
-	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const { data: site, isError, error } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { components } = useAppContext();
 	const SiteSwitcher = useMemo( () => lazy( components.siteSwitcher ), [ components ] );
+
+	if ( isError ) {
+		throw error;
+	}
 
 	if ( ! canManageSite( site ) ) {
 		throw notFound();

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -69,7 +69,7 @@ export async function fetchSite( siteIdOrSlug: number | string ): Promise< Site 
 			{ fields: JOINED_SITE_FIELDS, options: JOINED_SITE_OPTIONS }
 		);
 	} catch ( error ) {
-		if ( isWpError( error ) && error.error === 'parse_error' ) {
+		if ( isWpError( error ) && error.message.startsWith( 'The Jetpack site is inaccessible' ) ) {
 			throw new DashboardDataError( 'inaccessible_jetpack', error );
 		}
 		throw error;


### PR DESCRIPTION
Context: p1766452699519759-slack-CRWCHQGUB

## Proposed Changes

This PR fixes Jetpack connection handling in MSD:

1. Updated the condition for detecting Jetpack connection issue. Previously it checks whether `error.error === 'parse_error'`. However, I checked in some cases that the `error` could be other than that (`resource_not_found`, `unauthorized_error`...) so I updated it to: `error.message.startsWith( 'The Jetpack site is inaccessible' )`.
2. The site list endpoint could return a valid site object even though the get-site endpoint returns error. Previously, the user would NOT see error when they click that site and go to site overview. It's because we serve the cached site data from site list. Now, we throw error and serve the error component if the get-site endpoint does return error during background re-fetch.
3. Show a link to Jetpack doc to help the user diagnose the issue.

Before

<img width="837" height="274" alt="image" src="https://github.com/user-attachments/assets/3b8abd99-8d00-4a0e-ba6c-04eef927992a" />


or if the error is not `parse_error`:

<img width="836" height="292" alt="image" src="https://github.com/user-attachments/assets/63e0b31d-5a6e-4f85-a171-2aa9bf13bd7d" />

---

After

<img width="837" height="328" alt="image" src="https://github.com/user-attachments/assets/31b9f468-16b3-491a-8e38-a046fcf90ee7" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. I hope you still have an old Jurassic Ninja site.
2. Go to `<Dashboard live link>/sites`.
3. Search your site.
4. Click on it.
5. Verify you go to the site overview.
6. Wait until the background re-fetch finishes.
7. Verify you see the error message as described above.
8. Verify the link takes you to the Jetpack support doc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?