### PR TITLE
Add test and make sure the help center is not reparented.

### DIFF
--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -65,8 +65,12 @@ const HelpCenter: React.FC< Container > = ( {
 		}
 
 		return () => {
-			if ( portalParentRef.current?.parentNode ) {
-				document.body.removeChild( portalParentRef.current );
+			const portalNode = portalParentRef.current;
+			const parentNode = portalNode?.parentNode;
+
+			if ( portalNode && parentNode ) {
+				parentNode.removeChild( portalNode );
+				portalParentRef.current = undefined;
 			}
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/help-center/src/components/test/help-center.tsx
+++ b/packages/help-center/src/components/test/help-center.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import HelpCenter from '../help-center';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	initializeAnalytics: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/odie-client/src/data/use-get-support-interactions', () => ( {
+	useGetSupportInteractions: () => ( {
+		data: [],
+		isLoading: false,
+	} ),
+} ) );
+
+jest.mock( '@automattic/zendesk-client', () => ( {
+	useCanConnectToZendeskMessaging: () => ( {
+		data: false,
+	} ),
+} ) );
+
+jest.mock( '../help-center-container', () => ( {
+	__esModule: true,
+	default: () => <div>help-center-container</div>,
+} ) );
+
+jest.mock( '../help-center-smooch', () => ( {
+	__esModule: true,
+	default: () => <div>help-center-smooch</div>,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: ( selector: ( select: any ) => unknown ) =>
+		selector( () => ( {
+			isHelpCenterShown: () => false,
+		} ) ),
+} ) );
+
+jest.mock( '../../stores', () => ( {
+	HELP_CENTER_STORE: 'help-center-store',
+} ) );
+
+jest.mock( '../../hooks', () => ( {
+	useShouldUseUnifiedAgent: () => false,
+	useChatStatus: () => ( {
+		isEligibleForChat: false,
+	} ),
+} ) );
+
+jest.mock( '@automattic/agents-manager', () => ( {
+	__esModule: true,
+	default: () => <div>unified-agent</div>,
+	getUseUnifiedExperienceFromInlineData: () => undefined,
+} ) );
+
+// A minimal currentUser object; runtime shape is not important for this test.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const minimalCurrentUser: any = {
+	ID: 1,
+};
+
+describe( 'HelpCenter portal cleanup', () => {
+	it( 'does not throw when the portal node has been reparented before unmount', async () => {
+		const { unmount } = render(
+			<HelpCenter
+				hidden={ false }
+				currentRoute="/"
+				handleClose={ jest.fn() }
+				currentUser={ minimalCurrentUser }
+				sectionName="test-section"
+			/>
+		);
+
+		await waitFor( () => {
+			expect( document.querySelector( '.help-center' ) ).not.toBeNull();
+		} );
+
+		const portal = document.querySelector( '.help-center' ) as HTMLDivElement | null;
+		expect( portal ).not.toBeNull();
+
+		// Simulate the portal being reparented away from document.body.
+		const altParent = document.createElement( 'div' );
+		document.body.appendChild( altParent );
+		altParent.appendChild( portal as HTMLDivElement );
+
+		expect( () => unmount() ).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes/Why are these changes being made?

We're getting the follow error in our logs:

```
Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

I unfortunately can't reproduce in production but looking at the HelpCenter code, it appears like we could have a bug. As such, I've added a test that exposes the bug and added a fix.

**Theory**

The Help Center portal cleanup always called `document.body.removeChild(portalParentRef.current)`, assuming the portal div was a direct child of document.body. If any code reparented the portal elsewhere in the DOM, unmounting would throw `The node to be removed is not a child of this node` because `document.body` was no longer its parent.

I need to be clear, I cannot reproduce and this is a theory :). I haven't been able to detach the help center from the `document.body`.


## Considerations

I think the issue was introduced in this PR: https://github.com/Automattic/wp-calypso/commit/9e5e81482a9d757293111d76e2778f0e7f24ab99

I'm not certain the change here is in the right direction. I'm hoping @wellyshen can provide guidance.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
