### PR TITLE
MSD: remove redundant cache warmup in backported site overview

### DIFF
--- a/client/sites/v2/site-overview/index.tsx
+++ b/client/sites/v2/site-overview/index.tsx
@@ -1,10 +1,9 @@
-import { persistQueryClientPromise, siteBySlugQuery, queryClient } from '@automattic/api-queries';
+import { persistQueryClientPromise, queryClient } from '@automattic/api-queries';
 import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { getSite } from 'calypso/state/sites/selectors';
 import { useAnalyticsClient } from '../hooks/use-analytics-client';
 import Layout from './layout';
 import router from './router';
@@ -14,7 +13,6 @@ export default function DashboardBackportSiteOverview( { siteSlug }: { siteSlug?
 	const rootInstanceRef = useRef< ReturnType< typeof createRoot > | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
 	const user = useSelector( ( state ) => getCurrentUser( state ) );
-	const site = useSelector( ( state ) => getSite( state, siteSlug ) );
 	const analyticsClient = useAnalyticsClient( router );
 
 	// Initialize the root instance.
@@ -56,13 +54,7 @@ export default function DashboardBackportSiteOverview( { siteSlug }: { siteSlug?
 		if ( user ) {
 			queryClient.setQueryData( AUTH_QUERY_KEY, user );
 		}
-
-		if ( site ) {
-			// The site type used by the Hosting Dashboard is slightly different, but _mostly_ compatible,
-			// so this is safe to copy in to the cache.
-			queryClient.setQueryData( siteBySlugQuery( site.slug ).queryKey, site as any ); // eslint-disable-line @typescript-eslint/no-explicit-any
-		}
-	}, [ user, site ] );
+	}, [ user ] );
 
 	return <div className="dashboard-backport-site-overview" ref={ containerRef } />;
 }

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -50,7 +50,7 @@ export interface Site {
 	};
 	plan?: SitePlan;
 	capabilities: SiteCapabilities;
-	subscribers_count?: number; // Can be undefined if query cache is prefilled from old Calypso Redux store.
+	subscribers_count: number;
 	options?: SiteOptions; // Can be undefined for deleted sites.
 	is_a4a_dev_site: boolean;
 	is_a8c: boolean;


### PR DESCRIPTION
Resolves p1766454044479459-slack-CRWCHQGUB

## Proposed Changes

Removes a redundant cache optimization in backported site overview. It's no longer necessary, as we also populate it from the site list via this PR:

- https://github.com/Automattic/wp-calypso/pull/106002

## Why are these changes being made?

The old approach warms up the cache using the site data from the old redux store, which contains incomplete fields such as `slug`. This caused race condition, where sometimes that version of cache is used, resulting crash in some places where it expects a defined `site.slug`.

## Testing Instructions

1. Go to <Calypso live link>/sites (v1).
2. Click around. Click some sites.
3. Verify you don't experience performance regression compared to production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
