### PR TITLE
A4A > Overview: update the events section text

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/events/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/index.tsx
@@ -21,9 +21,9 @@ const OverviewBodyEvents = () => {
 
 	return (
 		<Offering
-			title={ translate( 'Upcoming events' ) }
+			title={ translate( 'News and updates' ) }
 			description={ translate(
-				'Grow your business and level up by joining exclusive Automattic for Agencies events.'
+				'Stay informed with important announcements, events, and opportunities from Automattic for Agencies.'
 			) }
 		>
 			<div className="a4a-events">{ upcomingEvents.map( renderEvent ) }</div>


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-1960/overview-page-update-verbiage-of-upcoming-events-section

## Proposed Changes

This PR updates the events section text on the A4A Overview page.

## Testing Instructions

* Open the A4A live link > Go to Overview > Verify the events section heading & subheading is updated as shown below

<img width="1028" height="334" alt="Screenshot 2025-12-23 at 1 53 46 PM" src="https://github.com/user-attachments/assets/f0078f94-7e02-4d24-90d8-08f2441a23b6" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
