### PR TITLE
Reader: Fix short post rendering on Reader

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -23,7 +23,7 @@ import { getReaderTeams } from 'calypso/state/teams/selectors';
 import PostByline from './byline';
 import ConversationPost from './conversation-post';
 import GalleryPost from './gallery';
-import PhotoPost from './photo';
+import PostPhoto from './photo';
 import PostCardComments from './post-card-comments';
 import StandardPost from './standard';
 import './style.scss';
@@ -156,7 +156,7 @@ class ReaderPostCard extends Component {
 		if ( isEligibleForUnseen( { isWPForTeamsItem, currentRoute, hasOrganization } ) ) {
 			isSeen = post?.is_seen;
 		}
-		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY ) && ! compact;
+		const isPostPhoto = !! ( post.display_type & DisplayTypes.PHOTO_ONLY ) && ! compact;
 		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY ) && ! compact;
 		const isVideo = !! ( post.display_type & DisplayTypes.FEATURED_VIDEO ) && ! compact;
 		const title = truncate( post.title, { length: 140, separator: /,? +/ } );
@@ -171,7 +171,7 @@ class ReaderPostCard extends Component {
 
 		const classes = clsx( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,
-			'is-photo': isPhotoPost,
+			'is-photo': isPostPhoto,
 			'is-gallery': isGalleryPost,
 			'is-selected': isSelected,
 			'is-seen': isSeen,
@@ -237,9 +237,9 @@ class ReaderPostCard extends Component {
 					{ readerPostActions }
 				</CompactPostCard>
 			);
-		} else if ( isPhotoPost ) {
+		} else if ( isPostPhoto ) {
 			readerPostCard = (
-				<PhotoPost
+				<PostPhoto
 					post={ post }
 					site={ site }
 					title={ title }
@@ -249,7 +249,7 @@ class ReaderPostCard extends Component {
 					postKey={ postKey }
 				>
 					{ readerPostActions }
-				</PhotoPost>
+				</PostPhoto>
 			);
 		} else if ( isGalleryPost ) {
 			readerPostCard = (
@@ -272,7 +272,7 @@ class ReaderPostCard extends Component {
 			);
 		}
 
-		const onClick = ! isPhotoPost ? this.handleCardClick : noop;
+		const onClick = ! isPostPhoto ? this.handleCardClick : noop;
 		return (
 			<Card className={ classes } onClick={ onClick } tagName="article">
 				{ ! compact && postByline }

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -94,7 +94,7 @@ export function classifyPost( post ) {
 		displayType ^= DISPLAY_TYPES.PHOTO_ONLY;
 	}
 
-	if ( post.canonical_media && post.canonical_media.mediaType === 'video' ) {
+	if ( post.canonical_media?.mediaType === 'video' ) {
 		displayType ^= DISPLAY_TYPES.FEATURED_VIDEO;
 	}
 

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -86,9 +86,9 @@ export function classifyPost( post ) {
 	if ( imagesForGallery.length >= GALLERY_MIN_IMAGES ) {
 		displayType ^= DISPLAY_TYPES.GALLERY;
 	} else if (
-		post.canonical_media &&
-		post.canonical_media.mediaType === 'image' &&
-		post.canonical_media.width >= PHOTO_ONLY_MIN_WIDTH &&
+		post.content_images?.length === 1 &&
+		post.canonical_media?.mediaType === 'image' &&
+		post.canonical_media?.width >= PHOTO_ONLY_MIN_WIDTH &&
 		hasShortContent( post )
 	) {
 		displayType ^= DISPLAY_TYPES.PHOTO_ONLY;

--- a/client/state/reader/posts/test/normalization-rules.js
+++ b/client/state/reader/posts/test/normalization-rules.js
@@ -18,9 +18,39 @@ describe( 'normalization-rules', () => {
 			verifyClassification( {}, [ DISPLAY_TYPES.UNCLASSIFIED ] );
 		} );
 
+		test( 'should classify a GALLERY post', () => {
+			verifyClassification(
+				{
+					images: [
+						{ src: 'http://example.com/foo1.jpg', width: 800, height: 600 },
+						{ src: 'http://example.com/foo2.jpg', width: 1024, height: 768 },
+						{ src: 'http://example.com/foo3.jpg', width: 640, height: 480 },
+						{ src: 'http://example.com/foo4.jpg', width: 1024, height: 768 },
+						{ src: 'http://example.com/foo5.jpg', width: 1024, height: 768 },
+					],
+				},
+				[ DISPLAY_TYPES.GALLERY ]
+			);
+		} );
+
+		test( 'should classify as UNCLASSIFIED if the post has more than 1 image', () => {
+			verifyClassification(
+				{
+					canonical_media: {
+						mediaType: 'image',
+						width: 1000,
+					},
+					content_images: [ { width: 1000 }, { width: 50 }, { width: 50 }, { width: 50 } ],
+					better_excerpt_no_html: 'no '.repeat( 5 ),
+				},
+				[ DISPLAY_TYPES.UNCLASSIFIED ]
+			);
+		} );
+
 		test( 'should classify a PHOTO_ONLY post', () => {
 			verifyClassification(
 				{
+					content_images: [ { src: 'http://example.com/foo.jpg' } ],
 					canonical_media: {
 						mediaType: 'image',
 						width: 1000,
@@ -34,6 +64,7 @@ describe( 'normalization-rules', () => {
 		test( 'should not classify a PHOTO_ONLY post if the content is too long', () => {
 			verifyClassification(
 				{
+					content_images: [ { src: 'http://example.com/foo.jpg' } ],
 					canonical_media: {
 						mediaType: 'image',
 						width: 1000,
@@ -44,31 +75,14 @@ describe( 'normalization-rules', () => {
 			);
 		} );
 
-		test( 'should classify a PHOTO_ONLY post if it has enough images for a gallery, but not all of them are big enough', () => {
-			verifyClassification(
-				{
-					canonical_media: {
-						mediaType: 'image',
-						width: 1000,
-					},
-					content_images: [
-						{
-							width: 1000,
-						},
-						{
-							width: 50,
-						},
-						{
-							width: 50,
-						},
-						{
-							width: 50,
-						},
-					],
-					better_excerpt_no_html: 'no '.repeat( 5 ),
-				},
-				[ DISPLAY_TYPES.PHOTO_ONLY ]
-			);
+		test( 'should classify a FEATURED_VIDEO post', () => {
+			verifyClassification( { canonical_media: { mediaType: 'video' } }, [
+				DISPLAY_TYPES.FEATURED_VIDEO,
+			] );
+		} );
+
+		test( 'should classify an X_POST post', () => {
+			verifyClassification( { tags: { 'p2-xpost': true } }, [ DISPLAY_TYPES.X_POST ] );
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Issue: [READ-236](https://linear.app/a8c/issue/READ-236)

## Proposed Changes

Fix post rendering on Reader feed if the post have more than 1 images.

| Before | After |
| -------|------| 
| <img width="680" height="623" alt="image" src="https://github.com/user-attachments/assets/247341c7-bfd6-42d8-9a26-edec1fd57a56" /> | <img width="741" height="760" alt="image" src="https://github.com/user-attachments/assets/2d1344f9-521d-450a-bb3e-cbc6569cefa9" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In Reader we shows different kind of post previews in Reader feed based on the type of the post. One of that preview is `PostPhoto` which is shown if the post have an image with short content (85 length).

The current logic doesn't cover the scenario where we have more than one image with the short content so in this PR we've updated the logic to cover this case.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Subscribe to veselin blog. (`reader/feeds/152023972`).
2. Go to `/reader/recent/152023972`.
3. Verify that the "Halo" post from Dec 11, 2025 is appearing as expected i.e. show 2 images instead of 1.
4. Verify that the preview of posts with single images are not changed. (can use Dec 12 post of same blog for testing).

Bonus: Verify the change with some other blogs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [N/A] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
