### PR TITLE
Fix broken intro pricing during upgrade on plans page

### DIFF
--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -258,7 +258,7 @@ const usePricingMetaForGridPlans = ( {
 								...( sitePlan?.pricing.introOffer && {
 									introOffer: {
 										...sitePlan?.pricing.introOffer,
-										rawPrice: introOfferPrice,
+										...( introOfferPrice && { rawPrice: introOfferPrice } ),
 									},
 								} ),
 							},
@@ -282,7 +282,7 @@ const usePricingMetaForGridPlans = ( {
 							...( sitePlan?.pricing.introOffer && {
 								introOffer: {
 									...sitePlan?.pricing.introOffer,
-									rawPrice: introOfferPrice,
+									...( introOfferPrice && { rawPrice: introOfferPrice } ),
 								},
 							} ),
 						},
@@ -314,7 +314,7 @@ const usePricingMetaForGridPlans = ( {
 							...( plan?.pricing.introOffer && {
 								introOffer: {
 									...plan?.pricing.introOffer,
-									rawPrice: introOfferPrice,
+									...( introOfferPrice && { rawPrice: introOfferPrice } ),
 								},
 							} ),
 						},
@@ -342,7 +342,7 @@ const usePricingMetaForGridPlans = ( {
 						...( plan?.pricing.introOffer && {
 							introOffer: {
 								...plan?.pricing.introOffer,
-								rawPrice: introOfferPrice,
+								...( introOfferPrice && { rawPrice: introOfferPrice } ),
 							},
 						} ),
 					},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1496

## Proposed Changes

The combination of an intro pricing of an old plan somehow confuses the population of fields and the intro pricing is overwritten

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* The way I tested it was with the user's view from the Zendesk SU in the linear issue above
* You need to also verify it works for any other user with a plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
