### PR TITLE
MSD: Always get all sites by default temporarily

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -75,7 +75,7 @@ const getFetchSitesOptions = (
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
 		// Temporarily set the default value to all as people may set some of blogs to invisible and
 		// we should consider whether it makes senses to display visible sites by default.
-		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'all',
+		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : /* 'visible' */ 'all',
 		include_a8c_owned: shouldIncludeA8COwned,
 	};
 };

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -75,7 +75,8 @@ const getFetchSitesOptions = (
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
 		// Temporarily set the default value to all as people may set some of blogs to invisible and
 		// we should consider whether it makes senses to display visible sites by default.
-		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : /* 'visible' */ 'all',
+		site_visibility:
+			view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : /* 'visible' */ 'all',
 		include_a8c_owned: shouldIncludeA8COwned,
 	};
 };

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -73,7 +73,9 @@ const getFetchSitesOptions = (
 	return {
 		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
-		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
+		// Temporarily set the default value to all as people may set some of blogs to invisible and
+		// we should consider whether it makes senses to display visible sites by default.
+		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'all',
 		include_a8c_owned: shouldIncludeA8COwned,
 	};
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-974
Report of p1766497801143829-slack-C02FMH4G8

## Proposed Changes

* Before https://github.com/Automattic/wp-calypso/pull/107824, we displayed all sites by default. This meant that users would see sites that were marked as invisible via “My Blogs.” However, “My Blogs” has been deprecated for a long time, and there is currently no way to control site visibility (see https://github.com/Automattic/wp-calypso/issues/98770).
* As a result, it’s better to continue showing all sites for now. We should update the endpoint later to ignore the `blog_visibility` metadata and restore the `site_visibility: visible` behavior, which would automatically exclude deleted sites by default.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should also show invisible sites to users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* You should see all of your sites including deleted sites by default

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?