### PR TITLE
Update cancel and back links to new dashboard route

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/woo-hosted-plans.ts
+++ b/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/woo-hosted-plans.ts
@@ -2,6 +2,7 @@ import { WOO_HOSTED_PLANS_FLOW } from '@automattic/onboarding';
 import { resolveSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
 import { FlowV2, SubmitHandler } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -46,7 +47,7 @@ async function initialize() {
 	const hasAccess = await checkUserHasAccess();
 
 	if ( ! hasAccess ) {
-		window.location.assign( '/ciab/sites' );
+		window.location.assign( dashboardLink( '/ciab/sites' ) );
 		return false;
 	}
 
@@ -66,7 +67,7 @@ const wooHostedPlansFlow: FlowV2< typeof initialize > = {
 		const backTo = query.get( 'back_to' ) ?? query.get( 'cancel_to' ) ?? undefined;
 
 		// Validate back_to to prevent open redirect - must not be external
-		const safeBackTo = backTo && ! isExternal( backTo ) ? backTo : '/ciab/sites';
+		const safeBackTo = backTo && ! isExternal( backTo ) ? backTo : dashboardLink( '/ciab/sites' );
 
 		return {
 			[ STEPS.UNIFIED_PLANS.slug ]: {
@@ -110,7 +111,7 @@ const wooHostedPlansFlow: FlowV2< typeof initialize > = {
 							// Note: Not using goToCheckout utility because it hardcodes signup=1
 							// Checkout validates redirect_to to prevent open redirects
 							const finalUrl = addQueryArgs( checkoutUrl, {
-								redirect_to: redirectTo || '/ciab/sites',
+								redirect_to: redirectTo || dashboardLink( '/ciab/sites' ),
 								cancel_to: currentPath,
 							} );
 

--- a/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/woo-hosted-plans.ts
+++ b/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/woo-hosted-plans.ts
@@ -121,7 +121,7 @@ const wooHostedPlansFlow: FlowV2< typeof initialize > = {
 					}
 
 					// If no cart items, something went wrong - redirect to sites
-					window.location.assign( '/sites' );
+					window.location.assign( dashboardLink( '/ciab/sites' ) );
 					break;
 				}
 			}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1457/ciab-plans-select-a-plan-back-button-goes-to-a-404

## Proposed Changes

This updates the cancel and back fallback routes for the `/setup/woo-hosted-plans/` flow to use the new CIAB dashboard routes.

## Why are these changes being made?

The CIAB dashboard now exists at `my.wordpress.com/ciab/sites/` (previously it was at `wordpress.com/ciab/sites/`). The Woo Hosted plans upgrade flow had a number of hardcoded instances of the old address as relative links. Using the `dashboardLink()` helper should handle the dashboard routing in a future-proof way.

## Testing Instructions

- visit `my.localhost:3000/ciab/sites`
- create a new site (and proceed through the site setup process)
- once you're redirected to CIAB admin, you should see a nudge to upgrade in the bottom left
- click the nudge
- at the redirected setup flow, replace `wordpress.com` with `calypso.localhost:3000` and refresh the page
- click "back"
- verify that you are redirected to `my.localhost:3000/ciab/sites`
