### PR TITLE
Renewal pricing experiment: fix the price in terms message when coupon is applied

### DIFF
--- a/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
@@ -25,8 +25,9 @@ export function getRenewalPricingText( {
 	const { currencyCode, discountedPrice, originalPrice, billingPeriod, introOffer } = pricing;
 
 	const monthlyPrice = originalPrice?.monthly;
+	// Use the discounted price before the intro offer price since the discount is applied on top of it.
 	const currentFullPrice =
-		introOffer?.rawPrice?.full || discountedPrice?.full || originalPrice?.full;
+		discountedPrice?.full || introOffer?.rawPrice?.full || originalPrice?.full;
 
 	if ( ! monthlyPrice || ! currencyCode || ! currentFullPrice ) {
 		return null;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMART-79

## Proposed Changes

* Make sure that when a coupon discount is applied we'd show the full price based on that.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the onboarding flow with a coupon applied and a 'no_crossed_price' treatment.
* Make sure that the plans grid shows a `Get 12 months for X. Auto-renews at Y per month.` message where X would be the monthly price with the discount multiplied by the number of months.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
