### PR TITLE
Help Center: Disable auth-dependant queries when the user is logged out

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -114,11 +114,13 @@ const LayoutLoggedOut = ( {
 		! isWooOAuth2Client( oauth2Client );
 
 	const loadHelpCenter =
-		isLoggedIn &&
-		// we want to show only the Help center in my home and the help section (but not the FAB)
-		( [ 'home', 'help' ].includes( sectionName ) ||
-			currentRoute?.startsWith( '/start/do-it-for-me/' ) ) &&
-		userAllowedToHelpCenter;
+		// Load for all logged out users, but for some logged in users.
+		( isLoggedIn === false && isEnabled( 'help-center/logged-out' ) ) ||
+		( isLoggedIn &&
+			// we want to show only the Help center in my home and the help section (but not the FAB)
+			( [ 'home', 'help' ].includes( sectionName ) ||
+				currentRoute?.startsWith( '/start/do-it-for-me/' ) ) &&
+			userAllowedToHelpCenter );
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -114,8 +114,10 @@ const LayoutLoggedOut = ( {
 		! isWooOAuth2Client( oauth2Client );
 
 	const loadHelpCenter =
-		// Load for all logged out users, but for some logged in users.
-		( isLoggedIn === false && isEnabled( 'help-center/logged-out' ) ) ||
+		// Load for all logged out users only on the devdocs page.
+		( isLoggedIn === false &&
+			isEnabled( 'help-center/logged-out' ) &&
+			'devdocs' === sectionName ) ||
 		( isLoggedIn &&
 			// we want to show only the Help center in my home and the help section (but not the FAB)
 			( [ 'home', 'help' ].includes( sectionName ) ||

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { WordPressWordmark, WordPressLogo } from '@automattic/components';
 import {
 	isDefaultLocale,
@@ -111,6 +112,23 @@ class MasterbarLoggedOut extends Component {
 					comment: 'Should be shorter than ~12 chars',
 				} ) }
 			</Item>
+		);
+	}
+
+	renderHelpCenter() {
+		if ( ! isEnabled( 'help-center/logged-out' ) ) {
+			return null;
+		}
+
+		const { siteId, translate } = this.props;
+
+		return (
+			<AsyncLoad
+				require="./masterbar-help-center"
+				siteId={ siteId }
+				tooltip={ translate( 'Help' ) }
+				placeholder={ null }
+			/>
 		);
 	}
 
@@ -243,6 +261,7 @@ class MasterbarLoggedOut extends Component {
 				) }
 				{ sectionName !== 'reader' && (
 					<div className="masterbar__login-links">
+						{ this.renderHelpCenter() }
 						{ this.renderLoginItem() }
 						{ this.renderSignupItem() }
 					</div>

--- a/config/development.json
+++ b/config/development.json
@@ -75,6 +75,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help/gpt-response": true,
+		"help-center/logged-out": true,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
 		"hosting/datacenter-picker": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -48,6 +48,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help/gpt-response": true,
+		"help-center/logged-out": true,
 		"hosting-server-settings-enhancements": true,
 		"summer-special-2025": true,
 		"summer-special-2025-banner": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -32,6 +32,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/checkout-version": true,
+		"help-center/logged-out": true,
 		"ciab/allow-domain-features": true,
 		"checkout/razorpay": true,
 		"checkout/vgs-ebanx": true,

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -5,7 +5,7 @@ import { Location } from 'history';
 import { default as wpcomRequestPromise, canAccessWpcomApis } from 'wpcom-proxy-request';
 import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
-import { isE2ETest } from '../utils';
+import { isE2ETest, isLoggedIn } from '../utils';
 import { STORE_KEY } from './constants';
 import type { HelpCenterOptions, HelpCenterSelect, HelpCenterShowOptions } from './types';
 import type { APIFetchOptions } from '../shared-types';
@@ -16,6 +16,10 @@ import type { APIFetchOptions } from '../shared-types';
  * @param isMinimized - Whether the help center is minimized.
  */
 export const saveOpenState = ( isShown: boolean | undefined, isMinimized: boolean | undefined ) => {
+	if ( ! isLoggedIn() ) {
+		return null;
+	}
+
 	const saveState: Record< string, boolean | null > = {};
 
 	if ( typeof isShown === 'boolean' ) {

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -1,7 +1,7 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 import { registerPlugins } from '../plugins';
-import { isE2ETest, isInSupportSession } from '../utils';
+import { isE2ETest, isInSupportSession, isLoggedIn } from '../utils';
 import { controls as wpcomRequestControls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
@@ -13,7 +13,7 @@ export type { State };
 let isRegistered = false;
 
 export function register(): typeof STORE_KEY {
-	const enabledPersistedOpenState = ! isE2ETest() && ! isInSupportSession();
+	const enabledPersistedOpenState = ! isE2ETest() && ! isInSupportSession() && isLoggedIn();
 
 	registerPlugins();
 

--- a/packages/data-stores/src/utils.ts
+++ b/packages/data-stores/src/utils.ts
@@ -2,7 +2,9 @@
  * Utility functions shared across data stores
  */
 
-declare const helpCenterData: { isProxied: boolean; isSU: boolean; isSSP: boolean } | undefined;
+declare const helpCenterData:
+	| { isProxied: boolean; isSU: boolean; isSSP: boolean; currentUser: { ID: number } }
+	| undefined;
 declare const isSupportSession: boolean;
 declare const isSSP: boolean;
 
@@ -29,4 +31,13 @@ export const isInSupportSession = () => {
 		);
 	}
 	return false;
+};
+
+export const isLoggedIn = () => {
+	return (
+		// Calypso
+		( typeof window !== 'undefined' && !! window.currentUser?.ID ) ||
+		// wp-admin and Gutenberg
+		( typeof helpCenterData !== 'undefined' && !! helpCenterData?.currentUser?.ID )
+	);
 };

--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -25,7 +25,9 @@ export function HelpCenterChat( {
 	const preventOdieAccess = ! shouldUseWapuu && ! isUserEligibleForPaidSupport && ! isLoadingStatus;
 	const { currentUser, site, isCommerceGarden, newInteractionsBotSlug, newInteractionsBotVersion } =
 		useHelpCenterContext();
-	const { data: canConnectToZendesk, isLoading } = useCanConnectToZendeskMessaging();
+	const { data: canConnectToZendesk, isLoading } = useCanConnectToZendeskMessaging(
+		!! currentUser?.ID
+	);
 	const { search } = useLocation();
 	const { data } = useSupportStatus( ! isCommerceGarden );
 	const params = new URLSearchParams( search );

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -15,6 +15,7 @@ import { useQueryClient, QueryClient } from '@tanstack/react-query';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import Smooch from 'smooch';
+import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useChatStatus } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
 import { getClientId, getZendeskConversations } from './utils';
@@ -91,9 +92,10 @@ const playNotificationSound = () => {
 
 const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } ) => {
 	const { isEligibleForChat } = useChatStatus();
+	const { currentUser } = useHelpCenterContext();
 	const queryClient = useQueryClient();
 	const smoochRef = useRef< HTMLDivElement >( null );
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
 	const {
 		isHelpCenterShown,
 		isChatLoaded,

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -38,7 +38,7 @@ const HelpCenter: React.FC< Container > = ( {
 	}, [] );
 	const { currentUser, site, sectionName } = useHelpCenterContext();
 	const { isEligibleForChat } = useChatStatus();
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
 	const { data: supportInteractionsOpen, isLoading: isLoadingOpenInteractions } =
 		useGetSupportInteractions( 'zendesk' );
 	const hasOpenZendeskConversations =

--- a/packages/help-center/src/components/notices.tsx
+++ b/packages/help-center/src/components/notices.tsx
@@ -15,8 +15,8 @@ import './notices.scss';
 import { HELP_CENTER_STORE } from '../stores';
 
 export const BlockedZendeskNotice: React.FC = () => {
-	const { sectionName } = useHelpCenterContext();
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
+	const { currentUser, sectionName } = useHelpCenterContext();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
 	const { isEligibleForChat } = useChatStatus();
 	const { setShowSupportDoc } = useDispatch( HELP_CENTER_STORE );
 

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -1,5 +1,6 @@
 import { ODIE_NEW_INTERACTIONS_BOT_SLUG } from '@automattic/odie-client/src/constants';
 import { useContext, createContext } from '@wordpress/element';
+import { useNewInteractionsBotConfig } from '../hooks/use-new-interaction-bot-config';
 import type { CurrentUser, HelpCenterSite } from '@automattic/data-stores';
 
 export type HelpCenterRequiredInformation = {
@@ -86,10 +87,11 @@ export const HelpCenterRequiredContextProvider: React.FC< {
 	value: Partial< HelpCenterRequiredInformation > &
 		Pick< HelpCenterRequiredInformation, 'currentUser' | 'sectionName' >;
 } > = function ( { children, value } ) {
+	const newInteractionsBotConfig = useNewInteractionsBotConfig();
 	return (
 		<HelpCenterRequiredContext.Provider
 			value={ {
-				...Object.assign( {}, defaultContext, value ),
+				...Object.assign( {}, defaultContext, newInteractionsBotConfig, value ),
 			} }
 		>
 			{ children }

--- a/packages/help-center/src/data/use-support-status.ts
+++ b/packages/help-center/src/data/use-support-status.ts
@@ -1,6 +1,7 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { SupportStatus } from '../types';
 
 // Bump me to invalidate the cache.
@@ -12,13 +13,15 @@ interface APIFetchOptions {
 }
 
 export function useSupportStatus( enabled = true ) {
+	const { currentUser } = useHelpCenterContext();
+
 	return useQuery< SupportStatus, Error >( {
 		queryKey: [ 'support-status', VERSION ],
 		queryFn: async () =>
 			canAccessWpcomApis()
 				? await wpcomRequest( { path: '/help/support-status', apiNamespace: 'wpcom/v2' } )
 				: await apiFetch( { path: 'help-center/support-status', global: true } as APIFetchOptions ),
-		enabled,
+		enabled: enabled && !! currentUser?.ID,
 		refetchOnWindowFocus: false,
 		placeholderData: keepPreviousData,
 		staleTime: 180000, // 3mins.

--- a/packages/help-center/src/hooks/use-new-interaction-bot-config.ts
+++ b/packages/help-center/src/hooks/use-new-interaction-bot-config.ts
@@ -1,0 +1,13 @@
+import { useHelpCenterContext } from '../contexts/HelpCenterContext';
+
+export function useNewInteractionsBotConfig() {
+	const { currentUser } = useHelpCenterContext();
+
+	if ( ! currentUser?.ID ) {
+		return {
+			newInteractionsBotSlug: 'wpcom-chat-loggedout',
+		};
+	}
+
+	return {};
+}

--- a/packages/help-center/src/hooks/use-should-use-wapuu.ts
+++ b/packages/help-center/src/hooks/use-should-use-wapuu.ts
@@ -10,7 +10,8 @@ function isWapuuFlagSetInURL(): boolean {
 
 export const useShouldUseWapuu = () => {
 	const { data: supportStatus } = useSupportStatus();
-	const wapuuAssistantEnabled = Boolean( supportStatus?.eligibility?.wapuu_assistant_enabled );
+	// Only disable when explicitly disabled in the support status.
+	const wapuuAssistantDisabled = supportStatus?.eligibility?.wapuu_assistant_enabled === false;
 
 	// Force Wapuu via URL flag (config is not available in wp-admin)
 	const isFlagSetInURL = isWapuuFlagSetInURL();
@@ -18,5 +19,5 @@ export const useShouldUseWapuu = () => {
 	// Wapuu can be enabled via config
 	const isConfigEnabled = config.isEnabled( 'wapuu' );
 
-	return wapuuAssistantEnabled || isFlagSetInURL || isConfigEnabled;
+	return ! wapuuAssistantDisabled || isFlagSetInURL || isConfigEnabled;
 };

--- a/packages/odie-client/src/components/message/index.tsx
+++ b/packages/odie-client/src/components/message/index.tsx
@@ -22,7 +22,7 @@ export type MessageIndicators = {
 	isLastMessage: boolean;
 };
 
-const ChatMessage = ( { message, currentUser, header }: ChatMessageProps ) => {
+const ChatMessage = ( { message, header }: ChatMessageProps ) => {
 	const { botName } = useOdieAssistantContext();
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 
@@ -34,7 +34,7 @@ const ChatMessage = ( { message, currentUser, header }: ChatMessageProps ) => {
 		event.stopPropagation();
 	};
 
-	if ( ! currentUser || ! botName ) {
+	if ( ! botName ) {
 		return null;
 	}
 

--- a/packages/odie-client/src/data/use-get-support-interactions.ts
+++ b/packages/odie-client/src/data/use-get-support-interactions.ts
@@ -1,5 +1,6 @@
 import { isTestModeEnvironment, useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { useQuery } from '@tanstack/react-query';
+import { useOdieAssistantContext } from '../context';
 import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
 import type { SupportProvider } from '../types';
 
@@ -12,8 +13,9 @@ export const useGetSupportInteractions = (
 	enabled = true
 ) => {
 	const isTestMode = isTestModeEnvironment();
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( enabled );
-	let shouldFetch = enabled;
+	const { currentUser } = useOdieAssistantContext();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
+	let shouldFetch = enabled && !! currentUser?.ID;
 	// Only fetch Zendesk interactions if the user can connect to Zendesk.
 	if ( ( provider === 'zendesk' || provider === 'zendesk-staging' ) && ! canConnectToZendesk ) {
 		shouldFetch = false;

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -56,7 +56,7 @@ export type CurrentUser = {
 	display_name: string;
 	avatar_URL?: string;
 	email?: string;
-	id?: number;
+	ID?: number;
 };
 
 export type Source = {


### PR DESCRIPTION
Fixes DOTCOM-15395

## Proposed Changes

Allow users to access Odie unless banned. 

## Why are these changes being made?
For logged out support. 

## Testing Instructions

1. Visit the live link while incognito and logged out.
2. Open DevTools > Network.
3. Filter by XHR.
4. Open the Help Center from the masterbar.
5. There shouldn't be any 403 requests.