### PR TITLE
Remove OR divider from WooCommerce 2FA login screen

### DIFF
--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -4,7 +4,6 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { FormDivider } from 'calypso/blocks/authentication';
 import getGravatarOAuth2Flow from 'calypso/lib/get-gravatar-oauth2-flow';
 import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { isWebAuthnSupported } from 'calypso/lib/webauthn';
@@ -12,7 +11,6 @@ import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/stat
 import { sendSmsCode } from 'calypso/state/login/actions';
 import { isTwoFactorAuthTypeSupported } from 'calypso/state/login/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
-import getIsWoo from 'calypso/state/selectors/get-is-woo';
 
 import './two-factor-actions.scss';
 
@@ -22,7 +20,6 @@ class TwoFactorActions extends Component {
 		isAuthenticatorSupported: PropTypes.bool.isRequired,
 		isSecurityKeySupported: PropTypes.bool.isRequired,
 		isSmsSupported: PropTypes.bool.isRequired,
-		isWoo: PropTypes.bool.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		sendSmsCode: PropTypes.func.isRequired,
 		switchTwoFactorAuthType: PropTypes.func.isRequired,
@@ -72,7 +69,6 @@ class TwoFactorActions extends Component {
 			isBackupCodeSupported,
 			isSecurityKeySupported,
 			isSmsSupported,
-			isWoo,
 			translate,
 			twoFactorAuthType,
 		} = this.props;
@@ -95,7 +91,6 @@ class TwoFactorActions extends Component {
 
 		return (
 			<Fragment>
-				{ isWoo && twoFactorAuthType !== 'push' && <FormDivider /> }
 				<Card className="two-factor-authentication__actions">
 					{ isSecurityKeyAvailable && (
 						<Button
@@ -159,7 +154,6 @@ export default connect(
 			isBackupCodeSupported: isTwoFactorAuthTypeSupported( state, 'backup' ),
 			isSmsSupported: isTwoFactorAuthTypeSupported( state, 'sms' ),
 			isSecurityKeySupported: isTwoFactorAuthTypeSupported( state, 'webauthn' ),
-			isWoo: getIsWoo( state ),
 		};
 	},
 	{


### PR DESCRIPTION
Fixes WCCOM-2102

## Proposed Changes

<img width="852" height="949" alt="image" src="https://github.com/user-attachments/assets/fa58f317-8d79-4159-afbe-1fd2471305d8" />

Removing this "or" element to fix the layout

## Testing Instructions

- With a WordPress.com account with 2FA, login to WooCommerce.com. 
- using the same account, attempt logging into the Woo's Jetpack flow (Woo core onboarding and WooPayments)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
