### PR TITLE
Subscribers: Add aria label and properties to actions button

### DIFF
--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -64,6 +64,9 @@ const SubscribersHeaderPopover = ( {
 				ref={ buttonRef }
 				icon={ <Icon icon={ moreVertical } size={ 18 } /> }
 				size="compact"
+				aria-label={ translate( 'Subscriber actions menu' ) }
+				aria-expanded={ isVisible }
+				aria-haspopup="menu"
 			/>
 
 			<PopoverMenu


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/NL-310/accessiblity-feedback-unlabelled-subscriber-download-button

## Proposed Changes

* Add `aria-label`, `aria-expanded`, and `aria-haspopup` to the Subscribers header popover button so that the svg-only button has a label that can be read by a screen reader, and can indicate that it opens a popup, and whether that popup is open. The popover already has a menu role.

<img width="675" height="89" alt="Markup 2025-12-04 at 11 17 54" src="https://github.com/user-attachments/assets/f34e5987-b405-4010-b867-1d9d62b468ff" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve accessibility in response to screen reader user feedback.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Jetpack > Subscribers and verify that you can navigate the header with a screen reader like VoiceOver. The label should be recognized and read.
* You can also check the page with the axe DevTools extension, which currently returns [this error](https://dequeuniversity.com/rules/axe/4.11/button-name?application=AxeChrome) for the page. With this change, the error is resolved.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
