### PR TITLE
Show Expired status for monetize subscriptions past their end date

### DIFF
--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
@@ -7,7 +7,8 @@ import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import SiteIcon from '../../components/site-icon';
-import { formatDate } from '../../utils/datetime';
+import { Text } from '../../components/text';
+import { formatDate, isWithinLast, getRelativeTimeString } from '../../utils/datetime';
 
 export const MonetizeSubscriptionTerms = ( {
 	subscription,
@@ -26,7 +27,14 @@ export const MonetizeSubscriptionTerms = ( {
 
 	// Show "Expired" for past dates
 	if ( isExpired ) {
-		return <>{ __( 'Expired' ) }</>;
+		const isExpiredToday = isWithinLast( endDate, 24, 'hours' );
+		const expiredTodayText = __( 'Expired today' );
+		// translators: timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"
+		const expiredFromNowText = sprintf( __( 'Expired %(timeSinceExpiry)s' ), {
+			timeSinceExpiry: getRelativeTimeString( endDate ),
+		} );
+
+		return <Text intent="error">{ isExpiredToday ? expiredTodayText : expiredFromNowText }</Text>;
 	}
 
 	// Show renewal or expiry for future dates

--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
@@ -9,7 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { isToday } from 'date-fns';
 import SiteIcon from '../../components/site-icon';
 import { Text } from '../../components/text';
-import { formatDate, getRelativeTimeString } from '../../utils/datetime';
+import { formatDate, getRelativeTimeString, parseDateAsUTC } from '../../utils/datetime';
 
 export const MonetizeSubscriptionTerms = ( {
 	subscription,
@@ -22,8 +22,8 @@ export const MonetizeSubscriptionTerms = ( {
 		return <>{ __( 'Never expires' ) }</>;
 	}
 
-	// Check if end_date is in the past (convert to ISO 8601 and append Z to parse as UTC)
-	const endDate = new Date( subscription.end_date.replace( ' ', 'T' ) + 'Z' );
+	// Check if end_date is in the past
+	const endDate = parseDateAsUTC( subscription.end_date );
 	const isExpired = endDate < new Date();
 
 	// Show "Expired" for past dates
@@ -44,14 +44,14 @@ export const MonetizeSubscriptionTerms = ( {
 			{ subscription.renew_interval === null
 				? // translators: %(date)s is the date the subscription expires. Format is LL (e.g. January 1, 2020).
 				  sprintf( __( 'Expires on %(date)s' ), {
-						date: formatDate( new Date( subscription.end_date.replace( ' ', 'T' ) + 'Z' ), locale, {
+						date: formatDate( endDate, locale, {
 							dateStyle: 'long',
 						} ),
 				  } )
 				: // translators: %(amount)s is the renewal price, %(date)s is the date the subscription renews. Format is LL (e.g. January 1, 2020).
 				  sprintf( __( 'Renews at %(amount)s on %(date)s' ), {
 						amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
-						date: formatDate( new Date( subscription.end_date.replace( ' ', 'T' ) + 'Z' ), locale, {
+						date: formatDate( endDate, locale, {
 							dateStyle: 'long',
 						} ),
 				  } ) }

--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
@@ -6,9 +6,10 @@ import { useQuery } from '@tanstack/react-query';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { isToday } from 'date-fns';
 import SiteIcon from '../../components/site-icon';
 import { Text } from '../../components/text';
-import { formatDate, isWithinLast, getRelativeTimeString } from '../../utils/datetime';
+import { formatDate, getRelativeTimeString } from '../../utils/datetime';
 
 export const MonetizeSubscriptionTerms = ( {
 	subscription,
@@ -27,7 +28,7 @@ export const MonetizeSubscriptionTerms = ( {
 
 	// Show "Expired" for past dates
 	if ( isExpired ) {
-		const isExpiredToday = isWithinLast( endDate, 24, 'hours' );
+		const isExpiredToday = isToday( endDate );
 		const expiredTodayText = __( 'Expired today' );
 		// translators: timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"
 		const expiredFromNowText = sprintf( __( 'Expired %(timeSinceExpiry)s' ), {

--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
@@ -22,8 +22,8 @@ export const MonetizeSubscriptionTerms = ( {
 		return <>{ __( 'Never expires' ) }</>;
 	}
 
-	// Check if end_date is in the past
-	const endDate = new Date( subscription.end_date );
+	// Check if end_date is in the past (convert to ISO 8601 and append Z to parse as UTC)
+	const endDate = new Date( subscription.end_date.replace( ' ', 'T' ) + 'Z' );
 	const isExpired = endDate < new Date();
 
 	// Show "Expired" for past dates
@@ -44,14 +44,14 @@ export const MonetizeSubscriptionTerms = ( {
 			{ subscription.renew_interval === null
 				? // translators: %(date)s is the date the subscription expires. Format is LL (e.g. January 1, 2020).
 				  sprintf( __( 'Expires on %(date)s' ), {
-						date: formatDate( new Date( Date.parse( subscription?.end_date ?? '' ) ), locale, {
+						date: formatDate( new Date( subscription.end_date.replace( ' ', 'T' ) + 'Z' ), locale, {
 							dateStyle: 'long',
 						} ),
 				  } )
 				: // translators: %(amount)s is the renewal price, %(date)s is the date the subscription renews. Format is LL (e.g. January 1, 2020).
 				  sprintf( __( 'Renews at %(amount)s on %(date)s' ), {
 						amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
-						date: formatDate( new Date( Date.parse( subscription?.end_date ?? '' ) ), locale, {
+						date: formatDate( new Date( subscription.end_date.replace( ' ', 'T' ) + 'Z' ), locale, {
 							dateStyle: 'long',
 						} ),
 				  } ) }

--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-item.tsx
@@ -20,6 +20,16 @@ export const MonetizeSubscriptionTerms = ( {
 		return <>{ __( 'Never expires' ) }</>;
 	}
 
+	// Check if end_date is in the past
+	const endDate = new Date( subscription.end_date );
+	const isExpired = endDate < new Date();
+
+	// Show "Expired" for past dates
+	if ( isExpired ) {
+		return <>{ __( 'Expired' ) }</>;
+	}
+
+	// Show renewal or expiry for future dates
 	return (
 		<>
 			{ subscription.renew_interval === null
@@ -29,7 +39,7 @@ export const MonetizeSubscriptionTerms = ( {
 							dateStyle: 'long',
 						} ),
 				  } )
-				: // translators: %(siteUrl)s is the URL of the site. %(date)s is the date the subscription renews. . Format is LL (e.g. January 1, 2020).
+				: // translators: %(amount)s is the renewal price, %(date)s is the date the subscription renews. Format is LL (e.g. January 1, 2020).
 				  sprintf( __( 'Renews at %(amount)s on %(date)s' ), {
 						amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
 						date: formatDate( new Date( Date.parse( subscription?.end_date ?? '' ) ), locale, {

--- a/client/dashboard/utils/datetime.ts
+++ b/client/dashboard/utils/datetime.ts
@@ -303,3 +303,17 @@ export function formatSiteYmd( date: Date ) {
 	const day = String( date.getDate() ).padStart( 2, '0' );
 	return `${ year }-${ month }-${ day }`;
 }
+
+/**
+ * Parse a date string as UTC, handling MySQL and ISO8601 formats.
+ */
+export function parseDateAsUTC( dateString: string ): Date {
+	// Handle datetime without timezone: "YYYY-MM-DD HH:MM:SS" or "YYYY-MM-DDTHH:MM:SS" (optional microseconds)
+	const match = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2}(?:\.\d+)?)$/.exec( dateString.trim() );
+	if ( match ) {
+		return new Date( `${ match[ 1 ] }T${ match[ 2 ] }Z` );
+	}
+
+	// Everything else - pass through unchanged
+	return new Date( dateString );
+}

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -21,7 +21,21 @@ export const MembershipTerms = ( { subscription }: { subscription: MembershipSub
 	const isExpired = endDate.isBefore( moment() );
 
 	if ( isExpired ) {
-		return <>{ translate( 'Expired' ) }</>;
+		const isExpiredToday = moment().diff( endDate, 'hours' ) < 24;
+
+		return (
+			<span className="purchase-item__is-error">
+				{ isExpiredToday
+					? translate( 'Expired today' )
+					: translate( 'Expired %(timeSinceExpiry)s', {
+							args: {
+								timeSinceExpiry: endDate.fromNow(),
+							},
+							context:
+								'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
+					  } ) }
+			</span>
+		);
 	}
 
 	return (

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -21,7 +21,7 @@ export const MembershipTerms = ( { subscription }: { subscription: MembershipSub
 	const isExpired = endDate.isBefore( moment() );
 
 	if ( isExpired ) {
-		const isExpiredToday = moment().diff( endDate, 'hours' ) < 24;
+		const isExpiredToday = moment().isSame( endDate, 'day' );
 
 		return (
 			<span className="purchase-item__is-error">

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -16,18 +16,26 @@ export const MembershipTerms = ( { subscription }: { subscription: MembershipSub
 		return <>{ translate( 'Never expires' ) }</>;
 	}
 
+	// Check if expired
+	const endDate = moment( subscription.end_date );
+	const isExpired = endDate.isBefore( moment() );
+
+	if ( isExpired ) {
+		return <>{ translate( 'Expired' ) }</>;
+	}
+
 	return (
 		<>
 			{ subscription.renew_interval === null
 				? translate( 'Expires on %(date)s', {
 						args: {
-							date: moment( subscription.end_date ).format( 'LL' ),
+							date: endDate.format( 'LL' ),
 						},
 				  } )
 				: translate( 'Renews at %(amount)s on %(date)s', {
 						args: {
 							amount: formatCurrency( Number( subscription.renewal_price ), subscription.currency ),
-							date: moment( subscription.end_date ).format( 'LL' ),
+							date: endDate.format( 'LL' ),
 						},
 				  } ) }
 		</>

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -16,8 +16,8 @@ export const MembershipTerms = ( { subscription }: { subscription: MembershipSub
 		return <>{ translate( 'Never expires' ) }</>;
 	}
 
-	// Check if expired
-	const endDate = moment( subscription.end_date );
+	// Check if expired (parse as UTC since end_date is stored in UTC, then convert to local for display)
+	const endDate = moment.utc( subscription.end_date ).local();
 	const isExpired = endDate.isBefore( moment() );
 
 	if ( isExpired ) {


### PR DESCRIPTION
Resolves #MON-63

  ## Proposed changes

- Add expiry date check to MonetizeSubscriptionTerms component in the Hosting Dashboard
- Add expiry date check to MembershipTerms component in legacy Calypso
- Use calendar day comparison (`isToday()` / `moment().isSame(day)`) instead of 24-hour window for "Expired today" detection
- Return "Expired today" or "Expired X ago" status with error styling when end_date is in the past, matching existing WPCOM purchase behavior
- Fix incorrect translator comment that referenced non-existent %(siteUrl)s placeholder

  ## Why are these changes being made?

When a monetize/membership subscription expires, the UI incorrectly displays "Renews at $X on [past date]" instead of showing "Expired". This is confusing for users who see a renewal date that has already passed. We should basically display this like we display other expired subscriptions in Calypso and the Hosting Dashboard.

The fix adds a simple date comparison before rendering the renewal/expiry text. If the end_date is in the past, we now show "Expired today" or "Expired X ago" with error styling, matching how other expired subscriptions are displayed.


<h2 class="unchanged rich-diff-level-one" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(61, 68, 77, 0.7); color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Technical context</h2><p class="unchanged rich-diff-level-one" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Monetize/membership subscriptions use a different data model than WPCOM purchases (plans, domains):</p><markdown-accessiblity-table class="rich-diff-level-one" data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

Aspect | WPCOM Purchases | Monetize Subscriptions
-- | -- | --
API | /upgrades | /me/memberships/subscriptions
Expiry handling | Calculated expiryStatus field | Database status + end_date fields
Expired items | Returned with expiryStatus='expired' | Still returned if status='active'

</markdown-accessiblity-table><p class="unchanged rich-diff-level-one" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">For WPCOM purchases, the backend calculates and returns an expiryStatus field that the frontend uses directly. For monetize subscriptions, items with status='active' are returned regardless of whether end_date has passed - the frontend was not checking for this condition.</p><p class="unchanged rich-diff-level-one" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(240, 246, 252); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This fix adds a frontend date comparison to handle the case where status='active' but end_date is in the past. A backend change to calculate an expiryStatus equivalent could be considered for future consistency, but this frontend fix is sufficient for correct display.</p>


  ## Testing instructions

  ### Manual Testing

  #### Prerequisites
  - A WordPress.com account with an expired monetize subscription, OR
      - make a post with paid content block: /wp-admin/post-new.php
      - have secondary user susbscribe to content (open post and subscribe)


Find a Site with Existing Expired Subscription and/or Manipulate data on sandbox:
 - wpcom/public_html/wp-content/lib/billingdaddy/src/api/connected-accounts-namespace.php
     - get_user_subscriptions
 ```
      "subscriptions": [
     {
         "ID": "12510333",
         "site_id": "243362578",
         "status": "active",
         "start_date": "2025-01-23 22:52:11",
         "end_date": "2025-12-23 22:52:11",
         "is_renewable": true,
         "renew_interval": "1 month",
         "renewal_price": "5",
         "currency": "USD",
         "product_id": "4088",
         "title": "Monthly Subscription",
         "site_url": "gt7IS-p2",
         "site_title": "Site Title"
     }
     ],
 ```

change the following to hard coded values:
 - 'start_date' => '2025-01-23 22:52:11',
 - 'start_date' => '2025-01-23 22:52:11',
 
Navigate to Hosting Dashboard billing: http://calypso.localhost:3000/me/purchases
 - Scroll to the "Monetize" section
 - Look for subscriptions with dates in the past
 
Load /me/billing/monetize-subscriptions and validate the same


Before Fix

  - Subscription with past end_date shows: "Renews at $10.00 on January 15, 2024" 
  - ![a](https://github.com/user-attachments/assets/8d91a567-a27e-42aa-8f80-348647f3ae6d)

  After Fix

  - Same subscription now shows: "Expired today" or "Expired 3 days ago" (in red)
  - ![b](https://github.com/user-attachments/assets/d207da8c-1b34-400c-b4d3-b33efc13260d)
  - ![d](https://github.com/user-attachments/assets/c94ed32f-04dc-4134-96c0-155b6e8485c0)
  

  Test Cases to Verify

   | Scenario                    | end_date    | Viewed      | Before PR                    | After PR                     |
  |-----------------------------|-------------|-------------|------------------------------|------------------------------|
  | Expired today               | Jan 5, 1am  | Jan 5, 11pm | "Renews at $10 on Jan 5" ❌  | "Expired today" ✅           |
  | Expired yesterday (<24h)    | Jan 4, 11pm | Jan 5, 10am | "Renews at $10 on Jan 4" ❌  | "Expired 1 day ago" ✅       |
  | Expired yesterday (>24h)    | Jan 4, 3pm  | Jan 5, 6pm  | "Renews at $10 on Jan 4" ❌  | "Expired 1 day ago" ✅       |
  | Expired days ago            | Jan 1, 5pm  | Jan 5, 10am | "Renews at $10 on Jan 1" ❌  | "Expired 4 days ago" ✅      |
  | Expired (no renew_interval) | Jan 4, 3pm  | Jan 5, 10am | "Expires on Jan 4" ❌        | "Expired 1 day ago" ✅       |
  | Future + renew_interval     | Feb 15, 5pm | Jan 5, 10am | "Renews at $10 on Feb 15" ✅ | "Renews at $10 on Feb 15" ✅ |
  | Future (no renew_interval)  | Feb 15, 5pm | Jan 5, 10am | "Expires on Feb 15" ✅       | "Expires on Feb 15" ✅       |
  | Never expires               | null        | Jan 5, 10am | "Never expires" ✅           | "Never expires" ✅           |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
