### PR TITLE
MSD: set dashboard-production env logs as error severity

### DIFF
--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -68,10 +68,9 @@ export const getRouter = ( config: AppConfig ) => {
 			logToLogstash( {
 				feature: 'calypso_client',
 				message: error.message,
-				severity: calypsoConfig( 'env_id' ) === 'production' ? 'error' : 'debug',
+				severity: calypsoConfig( 'env_id' ) === 'dashboard-production' ? 'error' : 'debug',
 				tags: [ 'dashboard' ],
 				properties: {
-					dashboard_backport: false,
 					env: calypsoConfig( 'env_id' ),
 					message: error.message,
 					stack: errorInfo.componentStack,


### PR DESCRIPTION

## Proposed Changes

Fix logstash logging so that we log error logs as ERROR severity in the launched `dashboard-production` env 🥲 

See the other code reference for backported MSD logging:

https://github.com/Automattic/wp-calypso/blob/fb5aa78e58f7bb657785167001c708cc54aeda01/client/sites/v2/utils/router.ts#L17-L29

## Why are these changes being made?

We only log errors for backported MSD currently; this PR fixes it.

## Testing Instructions

~Trust me bro~ Check whether the code makes sense.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
