### PR TITLE
A4A > Marketplace: Implement term pricing for Hosting, Products & Cart

### DIFF
--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { TitanOrder } from 'calypso/state/a8c-for-agencies/types';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/data/client/use-fetch-client-products.ts
+++ b/client/a8c-for-agencies/data/client/use-fetch-client-products.ts
@@ -1,7 +1,10 @@
 import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import { selectAlphabeticallySortedProductOptions } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
 import wpcom from 'calypso/lib/wp';
-import { APIProductFamily, APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type {
+	APIProductFamily,
+	APIProductFamilyProduct,
+} from 'calypso/a8c-for-agencies/types/products';
 
 function queryClientProducts(): Promise< APIProductFamily[] > {
 	return wpcom.req

--- a/client/a8c-for-agencies/data/client/use-fetch-client-products.ts
+++ b/client/a8c-for-agencies/data/client/use-fetch-client-products.ts
@@ -36,6 +36,10 @@ function queryClientProducts(): Promise< APIProductFamily[] > {
 							.map( ( product ) => ( {
 								...product,
 								family_slug: family.slug,
+								alternative_product_id:
+									product.alternative_product_id ||
+									product.monthly_alternative_product_id ||
+									product.yearly_alternative_product_id,
 							} ) ),
 					};
 				} )

--- a/client/a8c-for-agencies/data/marketplace/use-products-query.ts
+++ b/client/a8c-for-agencies/data/marketplace/use-products-query.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, UseQueryResult, useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -7,16 +8,17 @@ import wpcom from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { APIProductFamily, APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type {
+	APIProductFamily,
+	APIProductFamilyProduct,
+} from 'calypso/a8c-for-agencies/types/products';
 
-function queryProducts(
-	isPublicFacing: boolean,
-	agencyId?: number
-): Promise< APIProductFamily[] > {
-	const productsAPIPath = isPublicFacing
-		? '/jetpack-licensing/public/manage-pricing'
+const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
+
+async function queryProducts( agencyId?: number ): Promise< APIProductFamily[] > {
+	const productsAPIPath = isTermPricingEnabled
+		? '/agency/products'
 		: '/jetpack-licensing/partner/product-families';
-
 	return wpcom.req
 		.get(
 			{
@@ -60,20 +62,9 @@ function queryProducts(
 		} );
 }
 
-export function usePublicProductsQuery(): UseQueryResult< APIProductFamilyProduct[], unknown > {
-	return useProductsQuery( true );
-}
-
-const getProductsQueryKey = ( isPublicFacing: boolean, agencyId?: number ) => [
-	'a4a',
-	'marketplace',
-	'products',
-	isPublicFacing,
-	agencyId,
-];
+const getProductsQueryKey = ( agencyId?: number ) => [ 'a4a', 'marketplace', 'products', agencyId ];
 
 export default function useProductsQuery(
-	isPublicFacing = false,
 	includeRawData = false,
 	useStaleData = false
 ): UseQueryResult< APIProductFamilyProduct[], unknown > {
@@ -82,7 +73,7 @@ export default function useProductsQuery(
 	const agencyId = useSelector( getActiveAgencyId );
 
 	const queryClient = useQueryClient();
-	const data = queryClient.getQueryData( getProductsQueryKey( isPublicFacing, agencyId ) );
+	const data = queryClient.getQueryData( getProductsQueryKey( agencyId ) );
 
 	let staleTime = 0;
 
@@ -92,10 +83,10 @@ export default function useProductsQuery(
 	}
 
 	const query = useQuery( {
-		queryKey: getProductsQueryKey( isPublicFacing, agencyId ),
-		queryFn: () => queryProducts( isPublicFacing, agencyId ),
+		queryKey: getProductsQueryKey( agencyId ),
+		queryFn: () => queryProducts( agencyId ),
 		select: includeRawData ? getProductsRaw : selectAlphabeticallySortedProductOptions,
-		enabled: isPublicFacing || !! agencyId,
+		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
 		staleTime,
 	} );

--- a/client/a8c-for-agencies/data/marketplace/use-products-query.ts
+++ b/client/a8c-for-agencies/data/marketplace/use-products-query.ts
@@ -52,6 +52,10 @@ async function queryProducts( agencyId?: number ): Promise< APIProductFamily[] >
 							.map( ( product ) => ( {
 								...product,
 								family_slug: family.slug,
+								alternative_product_id:
+									product.alternative_product_id ||
+									product.monthly_alternative_product_id ||
+									product.yearly_alternative_product_id,
 							} ) ),
 					};
 				} )

--- a/client/a8c-for-agencies/data/marketplace/use-products-query.ts
+++ b/client/a8c-for-agencies/data/marketplace/use-products-query.ts
@@ -13,9 +13,8 @@ import type {
 	APIProductFamilyProduct,
 } from 'calypso/a8c-for-agencies/types/products';
 
-const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
-
 async function queryProducts( agencyId?: number ): Promise< APIProductFamily[] > {
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 	const productsAPIPath = isTermPricingEnabled
 		? '/agency/products'
 		: '/jetpack-licensing/partner/product-families';

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
@@ -9,7 +9,7 @@ import {
 	SubscriptionStatus,
 } from '../field-content';
 import type { Subscription } from '../../../types';
-import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
@@ -1,19 +1,33 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { getProductCommissionPercentage } from '../../referrals/lib/commissions';
-import type { ShoppingCartItem } from '../types';
+import type { ShoppingCartItem, TermPricingType } from '../types';
 
 import './style.scss';
 
-export default function CommissionsInfo( { items }: { items: ShoppingCartItem[] } ) {
+export default function CommissionsInfo( {
+	items,
+	termPricing,
+}: {
+	items: ShoppingCartItem[];
+	termPricing?: TermPricingType;
+} ) {
 	const translate = useTranslate();
+
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 
 	const totalCommissions = items.reduce( ( acc, item ) => {
 		const product = item;
-		const commissionPercentage = getProductCommissionPercentage( product.family_slug );
-		const totalCommissions = product?.amount
-			? Number( product.amount.replace( /,/g, '' ) ) * commissionPercentage
-			: 0;
+		const commissionPercentage = getProductCommissionPercentage(
+			product.slug,
+			product.family_slug
+		);
+		const termPrice =
+			termPricing === 'yearly' ? product.yearly_price ?? 0 : product.monthly_price ?? 0;
+		const productAmount = product?.amount ? Number( product.amount.replace( /,/g, '' ) ) : 0;
+		const productPrice = isTermPricingEnabled ? termPrice : productAmount;
+		const totalCommissions = productPrice * commissionPercentage || 0;
 		return acc + totalCommissions;
 	}, 0 );
 
@@ -22,16 +36,25 @@ export default function CommissionsInfo( { items }: { items: ShoppingCartItem[] 
 		return null;
 	}
 
+	const currency = items[ 0 ]?.currency ?? 'USD';
+
+	const totalPricePerTerm =
+		isTermPricingEnabled && termPricing === 'yearly'
+			? translate( '%(total)s/yr', {
+					args: {
+						total: formatCurrency( totalCommissions, currency ),
+					},
+			  } )
+			: translate( '%(total)s/mo', {
+					args: {
+						total: formatCurrency( totalCommissions, currency ),
+					},
+			  } );
+
 	return (
 		<div className="commissions-info">
 			<span>{ translate( 'Your estimated commission:' ) }</span>
-			<span>
-				{ translate( '%(total)s/mo', {
-					args: {
-						total: formatCurrency( totalCommissions, 'USD' ),
-					},
-				} ) }
-			</span>
+			<span>{ totalPricePerTerm }</span>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/woo-product-download.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/woo-product-download.tsx
@@ -6,8 +6,8 @@ import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import useLicenseDownloadUrlMutation from '../../purchases/licenses/revoke-license-dialog/hooks/use-license-download-url-mutation';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 interface WooProductDownloadProps {
 	licenseKey: string;

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -4,7 +4,6 @@ import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-prod
 import { isProductMatch } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/filter';
 import { useSelector } from 'calypso/state';
 import { getAssignedPlanAndProductIDsForSite } from 'calypso/state/partner-portal/licenses/selectors';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import {
 	PRODUCT_TYPE_JETPACK_BACKUP_ADDON,
 	PRODUCT_TYPE_JETPACK_PLAN,
@@ -19,6 +18,7 @@ import {
 	filterProductsAndPlansByType,
 } from '../lib/product-filter';
 import type { SiteDetails } from '@automattic/data-stores';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 // Plans and Products that we can merged into 1 card.
 const MERGABLE_PLANS = [ 'jetpack-security' ];
@@ -111,9 +111,8 @@ export default function useProductAndPlans( {
 	selectedSite,
 	selectedProductFilters,
 	productSearchQuery,
-	usePublicQuery = false,
 }: Props ) {
-	const { data, isLoading: isLoadingProducts } = useProductsQuery( usePublicQuery );
+	const { data, isLoading: isLoadingProducts } = useProductsQuery();
 
 	const addedPlanAndProducts = useSelector( ( state ) =>
 		selectedSite ? getAssignedPlanAndProductIDsForSite( state, selectedSite.ID ) : null

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-categories.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-categories.ts
@@ -14,11 +14,14 @@ import {
 	MERCHANDISING_PRODUCT_SLUGS,
 	STORE_CONTENT_PRODUCT_SLUGS,
 	STORE_MANAGEMENT_PRODUCT_SLUGS,
+	BACKUP_STORAGE_FAMILY_SLUG,
+	JETPACK_PACKS_FAMILY_SLUG,
 } from '../lib/product-slugs';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type CategoryConfig = {
 	slugs: string[];
+	familySlugs?: string[];
 	label: string;
 };
 
@@ -33,7 +36,11 @@ export function useProductCategories( product: APIProductFamilyProduct ): string
 			: [];
 
 		const CATEGORIES: CategoryConfig[] = [
-			{ slugs: SECURITY_PRODUCT_SLUGS, label: translate( 'security' ) },
+			{
+				slugs: SECURITY_PRODUCT_SLUGS,
+				familySlugs: [ BACKUP_STORAGE_FAMILY_SLUG ],
+				label: translate( 'security' ),
+			},
 			{ slugs: PERFORMANCE_PRODUCT_SLUGS, label: translate( 'performance' ) },
 			{ slugs: SOCIAL_PRODUCT_SLUGS, label: translate( 'social' ) },
 			{ slugs: GROWTH_PRODUCT_SLUGS, label: translate( 'growth' ) },
@@ -48,8 +55,8 @@ export function useProductCategories( product: APIProductFamilyProduct ): string
 
 		// Add regular categories
 		categories.push(
-			...CATEGORIES.reduce( ( acc: string[], { slugs, label } ) => {
-				if ( slugs.includes( slug ) ) {
+			...CATEGORIES.reduce( ( acc: string[], { slugs, familySlugs, label } ) => {
+				if ( slugs.includes( slug ) || familySlugs?.includes( family_slug ) ) {
 					acc.push( label );
 				}
 				return acc;
@@ -57,9 +64,9 @@ export function useProductCategories( product: APIProductFamilyProduct ): string
 		);
 
 		// Add product type categories
-		if ( family_slug === 'jetpack-packs' ) {
+		if ( family_slug === JETPACK_PACKS_FAMILY_SLUG ) {
 			categories.push( translate( 'bundle' ), translate( 'plan' ) );
-		} else if ( family_slug === 'jetpack-backup-storage' ) {
+		} else if ( family_slug === BACKUP_STORAGE_FAMILY_SLUG ) {
 			categories.push( translate( 'add-on' ) );
 		} else if ( isProductType( family_slug ) ) {
 			categories.push( translate( 'product' ) );

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-categories.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-categories.ts
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { isWooCommerceProduct } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { isProductType } from '../lib/product-filter';
 import {
 	SECURITY_PRODUCT_SLUGS,
@@ -16,6 +15,7 @@ import {
 	STORE_CONTENT_PRODUCT_SLUGS,
 	STORE_MANAGEMENT_PRODUCT_SLUGS,
 } from '../lib/product-slugs';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type CategoryConfig = {
 	slugs: string[];
@@ -24,7 +24,7 @@ type CategoryConfig = {
 
 export function useProductCategories( product: APIProductFamilyProduct ): string[] {
 	const translate = useTranslate();
-	const { family_slug } = product;
+	const { family_slug, slug } = product;
 
 	return useMemo( () => {
 		// Add e-commerce category for WooCommerce products
@@ -49,7 +49,7 @@ export function useProductCategories( product: APIProductFamilyProduct ): string
 		// Add regular categories
 		categories.push(
 			...CATEGORIES.reduce( ( acc: string[], { slugs, label } ) => {
-				if ( slugs.includes( family_slug ) ) {
+				if ( slugs.includes( slug ) ) {
 					acc.push( label );
 				}
 				return acc;
@@ -68,5 +68,5 @@ export function useProductCategories( product: APIProductFamilyProduct ): string
 		}
 
 		return categories;
-	}, [ family_slug, translate ] );
+	}, [ family_slug, translate, slug ] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value.ts
@@ -1,16 +1,26 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { formatCurrency } from '@automattic/number-formatters';
+import { useTranslate } from 'i18n-calypso';
 import { useContext, useMemo } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import useWPCOMOwnedSites from 'calypso/a8c-for-agencies/hooks/use-wpcom-owned-sites';
 import wpcomBulkOptions from 'calypso/a8c-for-agencies/sections/marketplace/lib/wpcom-bulk-options';
 import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/lib/wpcom-bulk-values-utils';
 import { isWooCommerceProduct } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/woocommerce-product-slug-mapping';
-import { SelectedLicenseProp } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/types';
-import { APIProductFamily, APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
-import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import { MarketplaceTypeContext } from '../context';
+import type { TermPricingType } from '../types';
+import type {
+	APIProductFamily,
+	APIProductFamilyProduct,
+	SelectedLicenseProp,
+} from 'calypso/a8c-for-agencies/types/products';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
-export const useGetProductPricingInfo = () => {
-	const { data } = useProductsQuery( false, true );
+const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
+
+export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currency?: string ) => {
+	const translate = useTranslate();
+	const { data } = useProductsQuery( true );
 	const wpcomProducts = data?.find(
 		( product ) => product.slug === 'wpcom-hosting'
 	) as unknown as APIProductFamily;
@@ -34,13 +44,49 @@ export const useGetProductPricingInfo = () => {
 		product: SelectedLicenseProp | APIProductFamilyProduct,
 		quantity: number
 	) => {
+		const termPrice =
+			termPricing === 'yearly' ? product.yearly_price ?? 0 : product.monthly_price ?? 0;
+		const productPrice = isTermPricingEnabled ? termPrice : Number( product.amount );
+
+		const termPricingText =
+			isTermPricingEnabled && termPricing === 'yearly' ? translate( '/yr' ) : translate( '/mo' );
+
+		const productBundlePrice = productPrice * quantity;
+
 		if ( product.family_slug === 'wpcom-hosting' ) {
 			const tier = calculateTier( options, quantity + ownedPlans );
-			const actualCost = Number( product.amount ) * quantity;
+			const discountedCost = productBundlePrice * ( 1 - tier.discount );
+			return {
+				actualCost: productBundlePrice,
+				discountedCost,
+				discountPercentage: tier.discount,
+				showActualCost: productBundlePrice > discountedCost,
+				termPricingText,
+				discountedCostFormatted: formatCurrency( discountedCost, currency ?? 'USD' ),
+				actualCostFormatted: formatCurrency( productBundlePrice, currency ?? 'USD' ),
+				isFree: productBundlePrice === 0,
+			};
+		}
+
+		if ( isTermPricingEnabled ) {
+			// TODO: When we enable BD for all the agencies, we will only keep this logic for all the products, remove the rest of the logic.
+			const isDailyPricing = product.price_interval === 'day';
+			const actualCost = isDailyPricing ? productBundlePrice / 365 : productBundlePrice;
+			const discountedCost = productPrice || 0;
+
+			const discountPercentage = discountedCost
+				? Math.round( ( ( actualCost - discountedCost ) / actualCost ) * 100 )
+				: 100;
+
 			return {
 				actualCost,
-				discountedCost: actualCost * ( 1 - tier.discount ),
-				discountPercentage: tier.discount,
+				discountedCost,
+				discountPercentage,
+				discountedCostFormatted: formatCurrency( discountedCost, currency ?? 'USD' ),
+				actualCostFormatted: formatCurrency( actualCost, currency ?? 'USD' ),
+				showActualCost: actualCost > discountedCost,
+				termPricingText,
+				isFree: actualCost === 0,
 			};
 		}
 
@@ -51,6 +97,11 @@ export const useGetProductPricingInfo = () => {
 				actualCost,
 				discountedCost: actualCost,
 				discountPercentage: 0,
+				discountedCostFormatted: formatCurrency( actualCost, currency ?? 'USD' ),
+				actualCostFormatted: formatCurrency( actualCost, currency ?? 'USD' ),
+				showActualCost: false,
+				termPricingText,
+				isFree: actualCost === 0,
 			};
 		}
 
@@ -105,20 +156,32 @@ export const useGetProductPricingInfo = () => {
 				discountInfo.actualCost = actualCost;
 			}
 		}
-		return discountInfo;
+
+		return {
+			actualCost: discountInfo.actualCost,
+			discountedCost: discountInfo.discountedCost,
+			discountPercentage: discountInfo.discountPercentage,
+			discountedCostFormatted: formatCurrency( discountInfo.discountedCost, currency ?? 'USD' ),
+			actualCostFormatted: formatCurrency( discountInfo.actualCost, currency ?? 'USD' ),
+			showActualCost: discountInfo.actualCost > discountInfo.discountedCost,
+			termPricingText,
+			isFree: discountInfo.actualCost === 0,
+		};
 	};
 	return { getProductPricingInfo };
 };
 
-export const useTotalInvoiceValue = () => {
-	const { getProductPricingInfo } = useGetProductPricingInfo();
+export const useTotalInvoiceValue = ( termPricing?: TermPricingType, currency?: string ) => {
+	const translate = useTranslate();
+
+	const { getProductPricingInfo } = useGetProductPricingInfo( termPricing, currency );
 
 	const getTotalInvoiceValue = (
 		userProducts: Record< string, ProductListItem >,
 		selectedLicenses: SelectedLicenseProp[]
 	) => {
 		// Use the reduce function to calculate the total invoice value
-		return selectedLicenses.reduce(
+		const totalInvoiceValue = selectedLicenses.reduce(
 			( acc, license ) => {
 				// Get the pricing information for the current license
 				const { actualCost, discountedCost, discountPercentage } = getProductPricingInfo(
@@ -139,6 +202,24 @@ export const useTotalInvoiceValue = () => {
 				discountPercentage: 0,
 			}
 		);
+
+		const totalDiscountedCostFormatted =
+			isTermPricingEnabled && termPricing === 'yearly'
+				? translate( '%(total)s/yr', {
+						args: {
+							total: formatCurrency( totalInvoiceValue.discountedCost, currency ?? 'USD' ),
+						},
+				  } )
+				: translate( '%(total)s/mo', {
+						args: {
+							total: formatCurrency( totalInvoiceValue.discountedCost, currency ?? 'USD' ),
+						},
+				  } );
+
+		return {
+			...totalInvoiceValue,
+			totalDiscountedCostFormatted,
+		};
 	};
 
 	return { getTotalInvoiceValue };

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value.ts
@@ -44,14 +44,13 @@ export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currenc
 		product: SelectedLicenseProp | APIProductFamilyProduct,
 		quantity: number
 	) => {
-		const termPrice =
-			termPricing === 'yearly' ? product.yearly_price ?? 0 : product.monthly_price ?? 0;
+		const termPrice = termPricing === 'yearly' ? product.yearly_price : product.monthly_price;
 		const productPrice = isTermPricingEnabled ? termPrice : Number( product.amount );
 
 		const termPricingText =
 			isTermPricingEnabled && termPricing === 'yearly' ? translate( '/yr' ) : translate( '/mo' );
 
-		const productBundlePrice = productPrice * quantity;
+		const productBundlePrice = productPrice ? productPrice * quantity : 0;
 
 		if ( product.family_slug === 'wpcom-hosting' ) {
 			const tier = calculateTier( options, quantity + ownedPlans );
@@ -64,7 +63,7 @@ export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currenc
 				termPricingText,
 				discountedCostFormatted: formatCurrency( discountedCost, currency ?? 'USD' ),
 				actualCostFormatted: formatCurrency( productBundlePrice, currency ?? 'USD' ),
-				isFree: productBundlePrice === 0,
+				isFree: productPrice === 0,
 			};
 		}
 
@@ -86,7 +85,7 @@ export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currenc
 				actualCostFormatted: formatCurrency( actualCost, currency ?? 'USD' ),
 				showActualCost: actualCost > discountedCost,
 				termPricingText,
-				isFree: actualCost === 0,
+				isFree: productPrice === 0,
 			};
 		}
 

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value.ts
@@ -16,8 +16,6 @@ import type {
 } from 'calypso/a8c-for-agencies/types/products';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
-const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
-
 export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currency?: string ) => {
 	const translate = useTranslate();
 	const { data } = useProductsQuery( true );
@@ -44,6 +42,8 @@ export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currenc
 		product: SelectedLicenseProp | APIProductFamilyProduct,
 		quantity: number
 	) => {
+		const isTermPricingEnabled =
+			isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 		const termPrice = termPricing === 'yearly' ? product.yearly_price : product.monthly_price;
 		const productPrice = isTermPricingEnabled ? termPrice : Number( product.amount );
 
@@ -201,6 +201,9 @@ export const useTotalInvoiceValue = ( termPricing?: TermPricingType, currency?: 
 				discountPercentage: 0,
 			}
 		);
+
+		const isTermPricingEnabled =
+			isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 
 		const totalDiscountedCostFormatted =
 			isTermPricingEnabled && termPricing === 'yearly'

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-wpcom-discount-tiers.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-wpcom-discount-tiers.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import { APIProductFamily } from 'calypso/state/partner-portal/types';
 import wpcomBulkOptions from '../../lib/wpcom-bulk-options';
+import type { APIProductFamily } from 'calypso/a8c-for-agencies/types/products';
 
 export default function useWPCOMDiscountTiers() {
-	const { data: products } = useProductsQuery( false, true );
+	const { data: products } = useProductsQuery( true );
 
 	const wpcomProducts = products
 		? ( products.find(

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/index.tsx
@@ -1,10 +1,10 @@
 import { useContext, useMemo } from 'react';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { SectionProps } from '..';
 import { MarketplaceTypeContext } from '../../context';
 import EnterpriseAgencyHosting from './enterprise-agency-hosting';
 import PremierAgencyHosting from './premier-agency-hosting';
 import StandardAgencyHosting from './standard-agency-hosting';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = SectionProps & {
 	onAddToCart: ( plan: APIProductFamilyProduct, quantity: number ) => void;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
@@ -17,10 +17,9 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingAdditionalFeaturesSection from '../../../common/hosting-additional-features-section';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
-import { MarketplaceTypeContext } from '../../../context';
+import { MarketplaceTypeContext, TermPricingContext } from '../../../context';
 import useGetPressablePlanByProductId from '../../../pressable-overview/hooks/use-get-pressable-plan-by-product-id';
 import getPressablePlan from '../../../pressable-overview/lib/get-pressable-plan';
 import usePressableOwnershipType from '../../hooks/use-pressable-ownership-type';
@@ -28,6 +27,7 @@ import ClientRelationships from '../common/client-relationships';
 import HostingFeatures from '../common/hosting-features';
 import PressablePlanSection from './pressable-plan-section';
 import PressableUsageSection from './pressable-usage-section';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 
@@ -44,6 +44,8 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 	};
 
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const { termPricing } = useContext( TermPricingContext );
+
 	const pressableOwnership = usePressableOwnershipType();
 
 	const isReferralMode = marketplaceType === 'referral';
@@ -97,6 +99,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 				existingPlan={ agencyPressablePlan }
 				existingPlanInfo={ existingPlanInfo }
 				isFetching={ isExistingPlanFetched }
+				termPricing={ termPricing }
 			/>
 
 			<HostingFeatures

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -17,11 +17,12 @@ import getPressablePlan, {
 import PlanSelectionFilter from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingPlanSection from '../../common/hosting-plan-section';
 import CustomPlanCardContent from './custom-plan-card-content';
 import PremiumPlanSection from './premium-plan-section';
 import RegularPlanCardContent from './regular-plan-card-content';
+import type { TermPricingType } from 'calypso/a8c-for-agencies/sections/marketplace/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 
@@ -32,6 +33,7 @@ type Props = {
 	existingPlan: APIProductFamilyProduct | null;
 	existingPlanInfo: PressablePlan | null;
 	isFetching?: boolean;
+	termPricing: TermPricingType;
 };
 
 const getSelectedTab = (
@@ -67,6 +69,7 @@ export default function PressablePlanSection( {
 	existingPlan,
 	existingPlanInfo,
 	isFetching,
+	termPricing,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -210,6 +213,7 @@ export default function PressablePlanSection( {
 						onSelect={ onPlanAddToCart }
 						isReferralMode={ isReferralMode }
 						pressableOwnership={ pressableOwnership }
+						termPricing={ termPricing }
 					/>
 				) }
 			</HostingPlanSection.Card>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
@@ -1,34 +1,38 @@
-import { formatCurrency } from '@automattic/number-formatters';
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useGetProductPricingInfo } from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import { useSelector } from 'calypso/state';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import type { TermPricingType } from 'calypso/a8c-for-agencies/sections/marketplace/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
 	plan: APIProductFamilyProduct;
 	onSelect: ( plan: APIProductFamilyProduct ) => void;
 	isReferralMode?: boolean;
 	pressableOwnership?: 'agency' | 'regular' | 'none';
+	termPricing: TermPricingType;
 };
 
-export default function PressablePlanSelectorCard( {
+export default function RegularPlanCardContent( {
 	plan,
 	onSelect,
 	isReferralMode,
 	pressableOwnership,
+	termPricing,
 }: Props ) {
 	const translate = useTranslate();
+
+	const { getProductPricingInfo } = useGetProductPricingInfo( termPricing, plan.currency );
+
 	const userProducts = useSelector( getProductsList );
 
-	const { getProductPricingInfo } = useGetProductPricingInfo();
-
-	const { discountedCost } = plan
+	const { discountedCostFormatted } = plan
 		? getProductPricingInfo( userProducts, plan, 1 )
-		: { discountedCost: 0 };
+		: { discountedCostFormatted: '' };
 
 	const ctaLabel = useMemo( () => {
 		if ( isReferralMode ) {
@@ -48,6 +52,21 @@ export default function PressablePlanSelectorCard( {
 		} );
 	}, [ isReferralMode, plan.name, translate ] );
 
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
+
+	const priceInterval = () => {
+		if ( isTermPricingEnabled ) {
+			return termPricing === 'yearly' ? translate( 'per year' ) : translate( 'per month' );
+		}
+		if ( plan.price_interval === 'day' ) {
+			return translate( 'per day, billed monthly' );
+		}
+		if ( plan.price_interval === 'month' ) {
+			return translate( 'per month, billed monthly' );
+		}
+		return '';
+	};
+
 	return (
 		<div className="pressable-plan-card-content">
 			<div className="pressable-plan-card-content__top">
@@ -65,13 +84,10 @@ export default function PressablePlanSelectorCard( {
 				) : (
 					<div className="pressable-plan-card-content__price">
 						<b className="pressable-plan-card-content__price-actual-value">
-							{ formatCurrency( discountedCost, plan.currency ) }
+							{ discountedCostFormatted }
 						</b>
 
-						<div className="pressable-plan-card-content__price-interval">
-							{ plan.price_interval === 'day' && translate( 'per day, billed monthly' ) }
-							{ plan.price_interval === 'month' && translate( 'per month, billed monthly' ) }
-						</div>
+						<div className="pressable-plan-card-content__price-interval">{ priceInterval() }</div>
 					</div>
 				) }
 			</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-usage-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-usage-section/index.tsx
@@ -2,7 +2,7 @@ import { Badge } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/index.tsx
@@ -2,11 +2,11 @@ import { useTranslate } from 'i18n-calypso';
 import { BackgroundType10 } from 'calypso/a8c-for-agencies/components/page-section/backgrounds';
 import ProfileAvatar1 from 'calypso/assets/images/a8c-for-agencies/hosting/standard-testimonial-1.png';
 import ProfileAvatar2 from 'calypso/assets/images/a8c-for-agencies/hosting/standard-testimonial-2.png';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
 import ClientRelationships from '../common/client-relationships';
 import HostingFeatures from '../common/hosting-features';
 import WPCOMPlanSection from './wpcom-plan-section';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
 	onAddToCart: ( plan: APIProductFamilyProduct, quantity: number ) => void;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
@@ -7,15 +7,18 @@ import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-conf
 import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
 import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
 import useWPCOMOwnedSites from 'calypso/a8c-for-agencies/hooks/use-wpcom-owned-sites';
-import { MarketplaceTypeContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
+import {
+	MarketplaceTypeContext,
+	TermPricingContext,
+} from 'calypso/a8c-for-agencies/sections/marketplace/context';
 import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
 import { getWPCOMCreatorPlan } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingPlanSection from '../../common/hosting-plan-section';
 import WPCOMPlanSlider from '../wpcom-plan-selector/slider';
 import WPCOMPlanSelector from './wpcom-plan-selector';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 
@@ -57,6 +60,8 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const isReferralMode = marketplaceType === 'referral';
+
+	const { termPricing } = useContext( TermPricingContext );
 
 	const ownedPlans = useMemo( () => {
 		if ( isReferralMode ) {
@@ -106,6 +111,7 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 							isReferralMode={ isReferralMode }
 							quantity={ displayQuantity }
 							setQuantity={ setQuantity }
+							termPricing={ termPricing }
 						/>
 					) : (
 						<WPCOMPlanSelector.Placeholder />

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
@@ -7,8 +8,9 @@ import A4ANumberInputV2 from 'calypso/a8c-for-agencies/components/a4a-number-inp
 import useWPCOMPlanDescription from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-wpcom-plan-description';
 import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/lib/wpcom-bulk-values-utils';
 import WPCOMLogo from 'calypso/assets/images/a8c-for-agencies/wpcom-logo.svg';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import useWPCOMDiscountTiers from '../../../hooks/use-wpcom-discount-tiers';
+import type { TermPricingType } from 'calypso/a8c-for-agencies/sections/marketplace/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
 	plan: APIProductFamilyProduct;
@@ -17,6 +19,7 @@ type Props = {
 	isReferralMode?: boolean;
 	quantity: number;
 	setQuantity: ( quantity: number ) => void;
+	termPricing: TermPricingType;
 };
 
 function Placeholder() {
@@ -40,8 +43,11 @@ export default function WPCOMPlanSelector( {
 	isReferralMode,
 	quantity,
 	setQuantity,
+	termPricing,
 }: Props ) {
 	const translate = useTranslate();
+
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 
 	const discountTiers = useWPCOMDiscountTiers();
 
@@ -55,7 +61,10 @@ export default function WPCOMPlanSelector( {
 		return calculateTier( discountTiers, quantity + ownedPlans ).discount;
 	}, [ discountTiers, ownedPlans, quantity, isReferralMode ] );
 
-	const originalPrice = Number( plan?.amount ?? 0 ) * quantity;
+	const termPrice = termPricing === 'yearly' ? plan.yearly_price ?? 0 : plan.monthly_price ?? 0;
+	const productPrice = isTermPricingEnabled ? termPrice : Number( plan?.amount ?? 0 );
+
+	const originalPrice = Number( productPrice ) * quantity;
 	const actualPrice = originalPrice - originalPrice * discount;
 
 	const { name: planName } = useWPCOMPlanDescription( plan?.slug ?? '' );
@@ -93,6 +102,19 @@ export default function WPCOMPlanSelector( {
 		};
 	}, [ containerRef ] );
 
+	const priceInterval = () => {
+		if ( isTermPricingEnabled ) {
+			return termPricing === 'yearly' ? translate( 'per year' ) : translate( 'per month' );
+		}
+		if ( plan.price_interval === 'day' ) {
+			return translate( 'per day, billed monthly' );
+		}
+		if ( plan.price_interval === 'month' ) {
+			return translate( 'per month, billed monthly' );
+		}
+		return '';
+	};
+
 	return (
 		<div
 			className={ clsx( 'wpcom-plan-selector__details', { 'is-compact': isCompact } ) }
@@ -114,7 +136,6 @@ export default function WPCOMPlanSelector( {
 				<div className="wpcom-plan-selector__plan-name">
 					<img src={ WPCOMLogo } alt="WPCOM" />
 				</div>
-
 				<div className="wpcom-plan-selector__price">
 					<b className="wpcom-plan-selector__price-actual-value">
 						{ formatCurrency( actualPrice, plan.currency ) }
@@ -135,10 +156,7 @@ export default function WPCOMPlanSelector( {
 							</span>
 						</>
 					) }
-					<div className="wpcom-plan-selector__price-interval">
-						{ plan.price_interval === 'day' && translate( 'per day, billed monthly' ) }
-						{ plan.price_interval === 'month' && translate( 'per month, billed monthly' ) }
-					</div>
+					<div className="wpcom-plan-selector__price-interval">{ priceInterval() }</div>
 				</div>
 			</div>
 			<div className="wpcom-plan-selector__cta">

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-selector/slider.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-selector/slider.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import wpcomBulkOptions from 'calypso/a8c-for-agencies/sections/marketplace/lib/wpcom-bulk-options';
-import { APIProductFamily } from 'calypso/state/partner-portal/types';
+import type { APIProductFamily } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
 	ownedPlans: number;
@@ -14,7 +14,7 @@ type Props = {
 export default function WPCOMPlanSlider( { quantity, ownedPlans, onChange }: Props ) {
 	const translate = useTranslate();
 
-	const { data } = useProductsQuery( false, true );
+	const { data } = useProductsQuery( true );
 
 	const wpcomProducts = data
 		? ( data.find(

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -23,7 +23,6 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import ReferralToggle from '../common/referral-toggle';
 import TermPricingToggle from '../common/term-pricing-toggle';
 import withMarketplaceProviders from '../hoc/with-marketplace-providers';
@@ -32,6 +31,7 @@ import ShoppingCart from '../shopping-cart';
 import HeroSection from './hero-section';
 import useCompactOnScroll from './hooks/use-compact-on-scroll';
 import { HostingContent } from './hosting-content';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 
@@ -101,6 +101,8 @@ function HostingOverview( { section }: SectionProps ) {
 		}, 300 );
 	}, [ sidebarRef ] );
 
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
+
 	return (
 		<Layout
 			className="hosting-overview"
@@ -127,7 +129,7 @@ function HostingOverview( { section }: SectionProps ) {
 						hideOnMobile
 					/>
 					<Actions>
-						{ isEnabled( 'a4a-bd-term-pricing' ) && (
+						{ isTermPricingEnabled && (
 							<div className="a4a-marketplace__header-actions">
 								<TermPricingToggle />
 							</div>

--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -2,7 +2,7 @@ import { VIPLogo } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import WPCOMLogo from 'calypso/assets/images/a8c-for-agencies/wpcom-logo.svg';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 /**
  * Get the WPCOM Creator plan from a list of plans

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -2,7 +2,6 @@ import {
 	isWooCommerceProduct,
 	isWpcomHostingProduct,
 } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import {
 	PRODUCT_BRAND_FILTER_ALL,
 	PRODUCT_CATEGORY_CONVERSION,
@@ -51,6 +50,7 @@ import {
 	STORE_CONTENT_PRODUCT_SLUGS,
 	STORE_MANAGEMENT_PRODUCT_SLUGS,
 } from './product-slugs';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 export type SelectedFilters = {
 	[ PRODUCT_FILTER_KEY_BRAND ]: string;

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -49,6 +49,9 @@ import {
 	MERCHANDISING_PRODUCT_SLUGS,
 	STORE_CONTENT_PRODUCT_SLUGS,
 	STORE_MANAGEMENT_PRODUCT_SLUGS,
+	BACKUP_STORAGE_FAMILY_SLUG,
+	JETPACK_PACKS_FAMILY_SLUG,
+	JETPACK_COMPLETE_PRODUCT_SLUG,
 } from './product-slugs';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
@@ -250,8 +253,8 @@ function filterProductsAndPlansByVendors(
 
 export const isProductType = ( family_slug: string ) => {
 	return (
-		family_slug !== 'jetpack-packs' &&
-		family_slug !== 'jetpack-backup-storage' &&
+		family_slug !== JETPACK_PACKS_FAMILY_SLUG &&
+		family_slug !== BACKUP_STORAGE_FAMILY_SLUG &&
 		! isWooCommerceProduct( family_slug ) &&
 		! isWpcomHostingProduct( family_slug ) &&
 		! isPressableHostingProduct( family_slug )
@@ -278,14 +281,16 @@ export function filterProductsAndPlansByType(
 		case PRODUCT_TYPE_JETPACK_PLAN:
 		case PRODUCT_TYPE_PLAN: // Right now this is the same as jetpack plan but once we have more non-jetpack plans we can separate them.
 			return (
-				allProductsAndPlans?.filter( ( { family_slug } ) => family_slug === 'jetpack-packs' ) || []
+				allProductsAndPlans?.filter(
+					( { family_slug } ) => family_slug === JETPACK_PACKS_FAMILY_SLUG
+				) || []
 			);
 
 		case PRODUCT_TYPE_JETPACK_BACKUP_ADDON:
 		case PRODUCT_TYPE_ADDON: // Right now this is the same as jetpack backup addons but once we have more non-jetpack addons we can separate them.
 			return (
 				allProductsAndPlans
-					?.filter( ( { family_slug } ) => family_slug === 'jetpack-backup-storage' )
+					?.filter( ( { family_slug } ) => family_slug === BACKUP_STORAGE_FAMILY_SLUG )
 					.sort( ( a, b ) => a.product_id - b.product_id ) || []
 			);
 
@@ -339,52 +344,50 @@ function filterProductsAndPlansByCategory(
 				[]
 			);
 		case PRODUCT_CATEGORY_SECURITY:
-			return allProductsAndPlans.filter(
-				( { slug, family_slug } ) =>
-					SECURITY_PRODUCT_SLUGS.includes( family_slug ) || slug === 'jetpack-complete'
-			);
+			return allProductsAndPlans.filter( ( { slug, family_slug } ) => {
+				const securitySlugs = [ ...SECURITY_PRODUCT_SLUGS, JETPACK_COMPLETE_PRODUCT_SLUG ];
+				return securitySlugs.includes( slug ) || family_slug === BACKUP_STORAGE_FAMILY_SLUG;
+			} );
 		case PRODUCT_CATEGORY_PERFORMANCE:
-			return allProductsAndPlans.filter(
-				( { slug, family_slug } ) =>
-					PERFORMANCE_PRODUCT_SLUGS.includes( family_slug ) || slug === 'jetpack-complete'
-			);
+			return allProductsAndPlans.filter( ( { slug } ) => {
+				const performanceSlugs = [ ...PERFORMANCE_PRODUCT_SLUGS, JETPACK_COMPLETE_PRODUCT_SLUG ];
+				return performanceSlugs.includes( slug );
+			} );
 		case PRODUCT_CATEGORY_SOCIAL:
-			return allProductsAndPlans.filter(
-				( { slug, family_slug } ) =>
-					SOCIAL_PRODUCT_SLUGS.includes( family_slug ) || slug === 'jetpack-complete'
-			);
+			return allProductsAndPlans.filter( ( { slug } ) => {
+				const socialSlugs = [ ...SOCIAL_PRODUCT_SLUGS, JETPACK_COMPLETE_PRODUCT_SLUG ];
+				return socialSlugs.includes( slug );
+			} );
 		case PRODUCT_CATEGORY_GROWTH:
-			return allProductsAndPlans.filter(
-				( { slug, family_slug } ) =>
-					GROWTH_PRODUCT_SLUGS.includes( family_slug ) || slug === 'jetpack-complete'
-			);
+			return allProductsAndPlans.filter( ( { slug } ) => {
+				const growthSlugs = [ ...GROWTH_PRODUCT_SLUGS, JETPACK_COMPLETE_PRODUCT_SLUG ];
+				return growthSlugs.includes( slug );
+			} );
 		case PRODUCT_CATEGORY_PAYMENTS:
-			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				PAYMENTS_PRODUCT_SLUGS.includes( family_slug )
-			);
+			return allProductsAndPlans.filter( ( { slug } ) => PAYMENTS_PRODUCT_SLUGS.includes( slug ) );
 		case PRODUCT_CATEGORY_SHIPPING_DELIVERY_FULFILLMENT:
-			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				SHIPPING_DELIVERY_FULFILLMENT_PRODUCT_SLUGS.includes( family_slug )
+			return allProductsAndPlans.filter( ( { slug } ) =>
+				SHIPPING_DELIVERY_FULFILLMENT_PRODUCT_SLUGS.includes( slug )
 			);
 		case PRODUCT_CATEGORY_CONVERSION:
-			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				CONVERSION_PRODUCT_SLUGS.includes( family_slug )
+			return allProductsAndPlans.filter( ( { slug } ) =>
+				CONVERSION_PRODUCT_SLUGS.includes( slug )
 			);
 		case PRODUCT_CATEGORY_CUSTOMER_SERVICE:
-			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				CUSTOMER_SERVICE_PRODUCT_SLUGS.includes( family_slug )
+			return allProductsAndPlans.filter( ( { slug } ) =>
+				CUSTOMER_SERVICE_PRODUCT_SLUGS.includes( slug )
 			);
 		case PRODUCT_CATEGORY_MERCHANDISING:
-			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				MERCHANDISING_PRODUCT_SLUGS.includes( family_slug )
+			return allProductsAndPlans.filter( ( { slug } ) =>
+				MERCHANDISING_PRODUCT_SLUGS.includes( slug )
 			);
 		case PRODUCT_CATEGORY_STORE_CONTENT:
-			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				STORE_CONTENT_PRODUCT_SLUGS.includes( family_slug )
+			return allProductsAndPlans.filter( ( { slug } ) =>
+				STORE_CONTENT_PRODUCT_SLUGS.includes( slug )
 			);
 		case PRODUCT_CATEGORY_STORE_MANAGEMENT:
-			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				STORE_MANAGEMENT_PRODUCT_SLUGS.includes( family_slug )
+			return allProductsAndPlans.filter( ( { slug } ) =>
+				STORE_MANAGEMENT_PRODUCT_SLUGS.includes( slug )
 			);
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -56,8 +56,6 @@ import {
 } from './product-slugs';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
-const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
-
 export type SelectedFilters = {
 	[ PRODUCT_FILTER_KEY_BRAND ]: string;
 	[ PRODUCT_FILTER_KEY_CATEGORIES ]: Record< string, boolean >;
@@ -185,6 +183,7 @@ function filterProductsAndPlansByTypes(
  * @return {number} Price.
  */
 function getProductPrice( product: APIProductFamilyProduct ) {
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 	if ( isTermPricingEnabled ) {
 		return product.yearly_price || product.monthly_price || 0;
 	}

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	isWooCommerceProduct,
 	isWpcomHostingProduct,
@@ -54,6 +55,8 @@ import {
 	JETPACK_COMPLETE_PRODUCT_SLUG,
 } from './product-slugs';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
+
+const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 
 export type SelectedFilters = {
 	[ PRODUCT_FILTER_KEY_BRAND ]: string;
@@ -176,6 +179,19 @@ function filterProductsAndPlansByTypes(
 }
 
 /*
+ * Get the price of a product.
+ *
+ * @param {APIProductFamilyProduct} product - Product.
+ * @return {number} Price.
+ */
+function getProductPrice( product: APIProductFamilyProduct ) {
+	if ( isTermPricingEnabled ) {
+		return product.yearly_price || product.monthly_price || 0;
+	}
+	return Number( product.amount );
+}
+
+/*
  * Filter products and plans by prices.
  *
  * @param {APIProductFamilyProduct[]} productsAndPlans - List of products and plans.
@@ -188,11 +204,11 @@ function filterProductsAndPlansByPrices(
 ) {
 	if ( prices.length === 1 ) {
 		if ( prices[ 0 ] === PRODUCT_PRICE_FREE ) {
-			return productsAndPlans.filter( ( { amount } ) => Number( amount ) === 0 );
+			return productsAndPlans.filter( ( product ) => getProductPrice( product ) === 0 );
 		}
 
 		if ( prices[ 0 ] === PRODUCT_PRICE_PAID ) {
-			return productsAndPlans.filter( ( { amount } ) => Number( amount ) > 0 );
+			return productsAndPlans.filter( ( product ) => getProductPrice( product ) > 0 );
 		}
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-slugs.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-slugs.ts
@@ -1,9 +1,8 @@
 export const SECURITY_PRODUCT_SLUGS = [
-	'jetpack-backup',
+	'jetpack-backup-t1',
 	'jetpack-scan',
 	'jetpack-anti-spam',
 	'jetpack-monitor',
-	'jetpack-backup-storage',
 ];
 
 export const PERFORMANCE_PRODUCT_SLUGS = [
@@ -12,7 +11,7 @@ export const PERFORMANCE_PRODUCT_SLUGS = [
 	'jetpack-videopress',
 ];
 
-export const SOCIAL_PRODUCT_SLUGS = [ 'jetpack-social' ];
+export const SOCIAL_PRODUCT_SLUGS = [ 'jetpack-social-v1' ];
 
 export const GROWTH_PRODUCT_SLUGS = [ 'jetpack-creator', 'jetpack-ai', 'jetpack-stats' ];
 
@@ -89,3 +88,9 @@ export const STORE_MANAGEMENT_PRODUCT_SLUGS = [
 	'woocommerce-tax',
 	'woocommerce-woopayments',
 ];
+
+export const BACKUP_STORAGE_FAMILY_SLUG = 'jetpack-backup-storage';
+
+export const JETPACK_PACKS_FAMILY_SLUG = 'jetpack-packs';
+
+export const JETPACK_COMPLETE_PRODUCT_SLUG = 'jetpack-complete';

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -7,10 +7,10 @@ import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { useGetProductPricingInfo } from '../../hooks/use-total-invoice-value';
 import getPressablePlan from '../lib/get-pressable-plan';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
 	selectedPlan: APIProductFamilyProduct | null;

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -6,7 +6,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import {
 	FILTER_TYPE_INSTALL,
 	FILTER_TYPE_VISITS,
@@ -20,6 +19,7 @@ import {
 import getPressablePlan, { PressablePlan } from '../lib/get-pressable-plan';
 import getSliderOptions from '../lib/get-slider-options';
 import { FilterType } from '../types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
 	// Plan details for the plan that's currently selected in the UI

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hocs/with-product-lightbox.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hocs/with-product-lightbox.tsx
@@ -9,31 +9,36 @@ import { getVendorInfo } from '../lib/get-vendor-info';
 import WooCustomFooter from '../product-card/woo-custom-footer';
 import WooPaymentsCustomDescription from '../product-card/woopayments-custom-description';
 import WooPaymentsRevenueShareNotice from '../product-card/woopayments-revenue-share-notice';
+import type { TermPricingType } from '../../types';
+import type { APIProductFamilyProduct as APIProductFamilyProductA4A } from 'calypso/a8c-for-agencies/types/products';
 import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 export type WithProductLightboxProps = {
-	products: APIProductFamilyProduct[];
+	products: APIProductFamilyProductA4A[];
 	isSelected?: boolean;
 	quantity?: number;
 	onSelectProduct: (
-		value: APIProductFamilyProduct,
-		replace?: APIProductFamilyProduct
+		value: APIProductFamilyProductA4A,
+		replace?: APIProductFamilyProductA4A
 	) => void | null;
 	asReferral?: boolean;
+	termPricing: TermPricingType;
 	isDisabled?: boolean;
 	customCTALabel?: string;
 };
 
 export type ProductLightboxActivatorProps = {
-	currentProduct: APIProductFamilyProduct;
-	setCurrentProduct: ( product: APIProductFamilyProduct ) => void;
+	currentProduct: APIProductFamilyProductA4A;
+	setCurrentProduct: ( product: APIProductFamilyProductA4A ) => void;
 	onShowLightbox: ( e: React.MouseEvent< HTMLElement > ) => void;
 };
 
 function withProductLightbox< T >(
 	WrappedComponent: ComponentType< T & WithProductLightboxProps & ProductLightboxActivatorProps >
 ): ComponentType< T & WithProductLightboxProps > {
-	return ( props ) => {
+	const WithProductLightboxComponent = (
+		props: T & WithProductLightboxProps & ProductLightboxActivatorProps
+	) => {
 		const {
 			isSelected,
 			quantity,
@@ -42,6 +47,7 @@ function withProductLightbox< T >(
 			isDisabled,
 			products,
 			customCTALabel,
+			termPricing,
 		} = props;
 
 		const translate = useTranslate();
@@ -122,6 +128,13 @@ function withProductLightbox< T >(
 
 		const vendor = getVendorInfo( currentProduct.slug );
 
+		const handleActivate = useCallback(
+			( product: APIProductFamilyProduct | APIProductFamilyProductA4A ): void => {
+				onSelectProduct( product as APIProductFamilyProductA4A );
+			},
+			[ onSelectProduct ]
+		);
+
 		return (
 			<>
 				<WrappedComponent
@@ -138,16 +151,23 @@ function withProductLightbox< T >(
 						ctaLabel={ customCTALabel ?? ( ctaLightboxLabel as string ) }
 						isCTAPrimary={ ! isSelected }
 						isDisabled={ isDisabled }
-						onActivate={ onSelectProduct }
+						onActivate={ handleActivate }
 						onClose={ onHideLightbox }
 						customDescription={ customDescription }
 						customFooter={ customFooter }
 						extraAsideContent={ extraAsideContent }
+						termPricing={ termPricing }
 					/>
 				) }
 			</>
 		);
 	};
+
+	const wrappedComponentName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+	WithProductLightboxComponent.displayName = `WithProductLightbox(${ wrappedComponentName })`;
+
+	// Explicitly cast the return so TS knows it conforms to ComponentType<T & WithProductLightboxProps>
+	return WithProductLightboxComponent as React.ComponentType< T & WithProductLightboxProps >;
 }
 
 export default withProductLightbox;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-assign-licenses-to-site.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-assign-licenses-to-site.ts
@@ -5,11 +5,11 @@ import {
 	getProductTitle,
 } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
 import useAssignLicenseMutation from '../../hooks/use-assign-license-mutation';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 import type {
 	ProductInfo,
 	PurchasedProductsInfo,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
-import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 const NO_OP = () => {
 	/* Do nothing */

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-licenses.tsx
@@ -1,10 +1,7 @@
 import usePaymentMethod from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method';
-import {
-	APIError,
-	APILicense,
-	APIProductFamilyProductBundlePrice,
-} from 'calypso/state/partner-portal/types';
 import useIssueLicenseMutation from '../../hooks/use-issue-license-mutation';
+import type { APIProductFamilyProductBundlePrice } from 'calypso/a8c-for-agencies/types/products';
+import type { APIError, APILicense } from 'calypso/state/partner-portal/types';
 
 const NO_OP = () => {
 	/* Do nothing */

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-product-bundle-size.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-product-bundle-size.tsx
@@ -1,7 +1,7 @@
 import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 const BUNDLE_SIZE_PARAM_KEY = 'bundle_size';
 
@@ -24,8 +24,8 @@ export const getSupportedBundleSizes = ( products?: APIProductFamilyProduct[] ) 
 	return [ ...supported ];
 };
 
-export function useProductBundleSize( isPublicFacing = false ) {
-	const { data: products } = useProductsQuery( isPublicFacing );
+export function useProductBundleSize() {
+	const { data: products } = useProductsQuery();
 
 	const supportedBundleSizes = getSupportedBundleSizes( products );
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -25,7 +25,7 @@ import getSites from 'calypso/state/selectors/get-sites';
 import ReferralToggle from '../common/referral-toggle';
 import TermPricingToggle from '../common/term-pricing-toggle';
 import { PRODUCT_FILTER_KEY_CATEGORIES } from '../constants';
-import { MarketplaceTypeContext, ShoppingCartContext } from '../context';
+import { MarketplaceTypeContext, ShoppingCartContext, TermPricingContext } from '../context';
 import withMarketplaceProviders from '../hoc/with-marketplace-providers';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
@@ -84,6 +84,8 @@ export function ProductsOverview( { siteId, suggestedProduct, productBrand, sear
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const isReferralMode = marketplaceType === 'referral';
 
+	const { termPricing } = useContext( TermPricingContext );
+
 	const {
 		selectedSize: selectedBundleSize,
 		availableSizes: availableBundleSizes,
@@ -128,7 +130,7 @@ export function ProductsOverview( { siteId, suggestedProduct, productBrand, sear
 	const productListingStickyTopOffset =
 		actionPanelStickyTopOffset + ( actionPanelRef.current?.offsetHeight ?? 0 );
 
-	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' );
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 
 	return (
 		<Layout
@@ -229,6 +231,7 @@ export function ProductsOverview( { siteId, suggestedProduct, productBrand, sear
 						isReferralMode={ isReferralMode }
 						selectedBundleSize={ selectedBundleSize }
 						selectedFilters={ selectedFilters }
+						termPricing={ termPricing }
 					/>
 				}
 			</ShoppingCartContext.Provider>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-badges/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-badges/index.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@automattic/ui';
 import { useProductCategories } from '../../hooks/use-product-categories';
-import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/hooks/use-custom-product-card.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/hooks/use-custom-product-card.tsx
@@ -1,6 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import WooPaymentsLogo from 'calypso/assets/images/a8c-for-agencies/product-logos/woopayments.svg';
-import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type CustomProductCard = {
 	className: string;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
@@ -20,7 +20,7 @@ import withProductLightbox, {
 import ProductBadges from '../product-badges';
 import useCustomProductCard from './hooks/use-custom-product-card';
 import ProductPriceWithDiscount from './product-price-with-discount-info';
-import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 
@@ -36,6 +36,7 @@ type Props = WithProductLightboxProps &
 function ProductCard( props: Props ) {
 	const {
 		asReferral,
+		termPricing,
 		products,
 		isSelected,
 		isDisabled,
@@ -170,6 +171,7 @@ function ProductCard( props: Props ) {
 									<ProductBadges product={ currentProduct } />
 									<div className="product-card__pricing is-compact">
 										<ProductPriceWithDiscount
+											termPricing={ termPricing }
 											product={ currentProduct }
 											hideDiscount={ hideDiscount }
 											quantity={ quantity }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/index.tsx
@@ -1,22 +1,26 @@
-import { formatCurrency } from '@automattic/number-formatters';
+import { isEnabled } from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
-import { getProductPricingInfo } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
+import withMarketplaceProviders from 'calypso/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-providers';
+import { useGetProductPricingInfo } from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value';
 import { useSelector } from 'calypso/state';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { isProductsListFetching, getProductsList } from 'calypso/state/products-list/selectors';
+import type { TermPricingType } from 'calypso/a8c-for-agencies/sections/marketplace/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 
 interface Props {
+	termPricing?: TermPricingType;
 	product: APIProductFamilyProduct;
 	hideDiscount?: boolean;
 	quantity?: number;
 	compact?: boolean;
 }
 
-export default function ProductPriceWithDiscount( {
+function ProductPriceWithDiscount( {
+	termPricing,
 	product,
 	hideDiscount,
 	quantity = 1,
@@ -30,13 +34,12 @@ export default function ProductPriceWithDiscount( {
 
 	const isBundle = quantity > 1;
 
-	const { actualCost, discountedCost, discountPercentage } = getProductPricingInfo(
-		userProducts,
-		product,
-		quantity
-	);
+	const { getProductPricingInfo } = useGetProductPricingInfo( termPricing, product.currency );
 
-	const isFree = actualCost === 0;
+	const { discountedCostFormatted, actualCostFormatted, discountPercentage, isFree } =
+		getProductPricingInfo( userProducts, product, quantity );
+
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 
 	if ( isFree ) {
 		return (
@@ -50,17 +53,30 @@ export default function ProductPriceWithDiscount( {
 		);
 	}
 
+	const priceInterval = () => {
+		if ( isTermPricingEnabled ) {
+			return termPricing === 'yearly' ? translate( 'per year' ) : translate( 'per month' );
+		}
+		if ( isDailyPricing ) {
+			return isBundle ? translate( 'per bundle per day' ) : translate( 'per license per day' );
+		}
+		if ( product.price_interval === 'month' ) {
+			return isBundle ? translate( 'per bundle per month' ) : translate( 'per license per month' );
+		}
+		return '';
+	};
+
 	return (
 		<div>
 			<div className={ clsx( 'product-price-with-discount__price', { 'is-compact': compact } ) }>
-				{ formatCurrency( discountedCost, product.currency ) }
+				{ discountedCostFormatted }
 				{
 					// Display discount info only if there is a discount
 					discountPercentage > 0 && ! hideDiscount && (
 						<>
 							{ compact && (
 								<span className="product-price-with-discount__price-old">
-									{ formatCurrency( actualCost, product.currency ) }
+									{ actualCostFormatted }
 								</span>
 							) }
 
@@ -75,7 +91,7 @@ export default function ProductPriceWithDiscount( {
 							{ ! compact && (
 								<div>
 									<span className="product-price-with-discount__price-old">
-										{ formatCurrency( actualCost, product.currency ) }
+										{ actualCostFormatted }
 									</span>
 								</div>
 							) }
@@ -83,14 +99,9 @@ export default function ProductPriceWithDiscount( {
 					)
 				}
 			</div>
-			<div className="product-price-with-discount__price-interval">
-				{ isDailyPricing &&
-					( isBundle ? translate( 'per bundle per day' ) : translate( 'per license per day' ) ) }
-				{ product.price_interval === 'month' &&
-					( isBundle
-						? translate( 'per bundle per month' )
-						: translate( 'per license per month' ) ) }
-			</div>
+			<div className="product-price-with-discount__price-interval">{ priceInterval() }</div>
 		</div>
 	);
 }
+
+export default withMarketplaceProviders( ProductPriceWithDiscount );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -19,9 +19,9 @@ import useSubmitForm from '../hooks/use-submit-form';
 import ProductCard from '../product-card';
 import ProductListingEmpty from './empty';
 import ProductListingSection from './section';
-import type { ShoppingCartItem } from '../../types';
+import type { ShoppingCartItem, TermPricingType } from '../../types';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 
@@ -34,6 +34,7 @@ interface ProductListingProps {
 	selectedBundleSize: number;
 	selectedFilters: SelectedFilters;
 	stickyHeadingTopOffset?: number;
+	termPricing: TermPricingType;
 }
 
 export default function ProductListing( {
@@ -44,6 +45,7 @@ export default function ProductListing( {
 	selectedBundleSize,
 	selectedFilters,
 	stickyHeadingTopOffset,
+	termPricing,
 }: ProductListingProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -264,6 +266,7 @@ export default function ProductListing( {
 			return (
 				<ProductCard
 					asReferral={ isReferralMode }
+					termPricing={ termPricing }
 					key={ options.map( ( { slug } ) => slug ).join( ',' ) }
 					products={ options }
 					onSelectProduct={ onSelectOrReplaceProduct }

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import { formatCurrency } from '@automattic/number-formatters';
 import { Popover } from '@wordpress/components';
 import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -7,7 +6,7 @@ import { useContext } from 'react';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import CommissionsInfo from '../../commissions-info';
-import { MarketplaceTypeContext } from '../../context';
+import { MarketplaceTypeContext, TermPricingContext } from '../../context';
 import { useTotalInvoiceValue } from '../../hooks/use-total-invoice-value';
 import ShoppingCartMenuItem from './item';
 import type { ShoppingCartItem } from '../../types';
@@ -24,10 +23,15 @@ type Props = {
 export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, items }: Props ) {
 	const translate = useTranslate();
 
-	const userProducts = useSelector( getProductsList );
-	const { getTotalInvoiceValue } = useTotalInvoiceValue();
-	const { discountedCost } = getTotalInvoiceValue( userProducts, items );
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const { termPricing } = useContext( TermPricingContext );
+
+	const userProducts = useSelector( getProductsList );
+	const { getTotalInvoiceValue } = useTotalInvoiceValue(
+		termPricing,
+		items[ 0 ]?.currency ?? 'USD'
+	);
+	const { totalDiscountedCostFormatted } = getTotalInvoiceValue( userProducts, items );
 
 	return (
 		<Popover
@@ -57,6 +61,7 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 							key={ `shopping-cart-item-${ item.product_id }-${ item.quantity }` }
 							item={ item }
 							onRemoveItem={ onRemoveItem }
+							termPricing={ termPricing }
 						/>
 					) ) }
 				</ul>
@@ -68,14 +73,13 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 								? translate( 'Total:' )
 								: translate( 'Total your client will pay:' ) }
 						</span>
-						<span>
-							{ translate( '%(total)s/mo', {
-								args: { total: formatCurrency( discountedCost, items[ 0 ]?.currency ?? 'USD' ) },
-							} ) }
-						</span>
+
+						<span>{ totalDiscountedCostFormatted }</span>
 					</div>
 
-					{ marketplaceType === 'referral' && <CommissionsInfo items={ items } /> }
+					{ marketplaceType === 'referral' && (
+						<CommissionsInfo items={ items } termPricing={ termPricing } />
+					) }
 
 					<Button
 						className="shopping-cart__menu-checkout-button"

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -1,25 +1,26 @@
-import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { useGetProductPricingInfo } from '../../hooks/use-total-invoice-value';
-import type { ShoppingCartItem } from '../../types';
+import type { ShoppingCartItem, TermPricingType } from '../../types';
 
 import './style.scss';
 
 type ItemProps = {
 	item: ShoppingCartItem;
 	onRemoveItem?: ( item: ShoppingCartItem ) => void;
+	termPricing?: TermPricingType;
 };
 
-export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps ) {
+export default function ShoppingCartMenuItem( { item, onRemoveItem, termPricing }: ItemProps ) {
 	const translate = useTranslate();
 	const userProducts = useSelector( getProductsList );
 
-	const { getProductPricingInfo } = useGetProductPricingInfo();
-	const { actualCost, discountedCost } = getProductPricingInfo( userProducts, item, item.quantity );
+	const { getProductPricingInfo } = useGetProductPricingInfo( termPricing, item.currency );
+	const { showActualCost, termPricingText, discountedCostFormatted, actualCostFormatted, isFree } =
+		getProductPricingInfo( userProducts, item, item.quantity );
 	// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
 	//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
 	const productDisplayName =
@@ -30,7 +31,6 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 					args: { productName: productDisplayName, quantity: item.quantity },
 			  } )
 			: productDisplayName;
-	const isFree = actualCost === 0;
 
 	return (
 		<li className="shopping-cart__menu-list-item">
@@ -43,18 +43,14 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 					) : (
 						<>
 							<span className="shopping-cart__menu-list-item-price-discounted">
-								{ formatCurrency( discountedCost, item.currency ) }
+								{ discountedCostFormatted }
 							</span>
-							{ actualCost > discountedCost && (
+							{ showActualCost && (
 								<span className="shopping-cart__menu-list-item-price-actual">
-									{ formatCurrency( actualCost, item.currency ) }
+									{ actualCostFormatted }
 								</span>
 							) }
-							<span>
-								{ translate( '/mo', {
-									comment: 'Abbreviation for per month',
-								} ) }
-							</span>
+							<span>{ termPricingText }</span>
 						</>
 					) }
 				</div>

--- a/client/a8c-for-agencies/sections/marketplace/types.ts
+++ b/client/a8c-for-agencies/sections/marketplace/types.ts
@@ -1,4 +1,4 @@
-import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 export type ShoppingCartItem = APIProductFamilyProduct & {
 	quantity: number;

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -19,7 +19,7 @@ type ConsolidatedViewsProps = {
 
 export default function ConsolidatedViews( { referrals, totalPayouts }: ConsolidatedViewsProps ) {
 	const translate = useTranslate();
-	const { data: productsData, isFetching } = useProductsQuery( false, false, true );
+	const { data: productsData, isFetching } = useProductsQuery( false, true );
 	const { previousQuarterExpectedCommission, pendingOrders, currentQuarterExpectedCommission } =
 		useGetConsolidatedPayoutData( referrals, productsData );
 	const { showSupportGuide } = useHelpCenter();

--- a/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-consolidated-payout-data.ts
@@ -7,7 +7,7 @@ import * as getEstimatedCommission from '../../lib/get-estimated-commission';
 import * as getNextPayoutDate from '../../lib/get-next-payout-date';
 import useGetConsolidatedPayoutData from '../use-get-consolidated-payout-data';
 import type { Referral } from '../../types';
-import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 // Mock the dependencies
 jest.mock( '../../lib/get-estimated-commission' );

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getEstimatedCommission } from '../lib/get-estimated-commission';
 import {
 	getCurrentCycleActivityWindow,
 	getNextPayoutDateActivityWindow,
 } from '../lib/get-next-payout-date';
 import { Referral } from '../types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 export default function useGetConsolidatedPayoutData(
 	referrals: Referral[],

--- a/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
@@ -1,6 +1,3 @@
-import type { Referral } from '../types';
-import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
-
 export const isProductEligibleForCommission = ( slug: string ) => {
 	const thirdPartyProducts = [
 		'woocommerce-affirm',
@@ -24,29 +21,15 @@ export const isProductEligibleForCommission = ( slug: string ) => {
 	return true;
 };
 
-export const getProductCommissionPercentage = ( slug?: string ) => {
-	if ( ! slug || ! isProductEligibleForCommission( slug ) ) {
+export const getProductCommissionPercentage = ( slug?: string, familySlug?: string ) => {
+	if ( ! slug || ! familySlug || ! isProductEligibleForCommission( slug ) ) {
 		return 0;
 	}
-	if ( [ 'wpcom-hosting', 'pressable-hosting' ].includes( slug ) ) {
+	if ( [ 'wpcom-hosting', 'pressable-hosting' ].includes( familySlug ) ) {
 		return 0.2;
 	}
 	if ( slug.startsWith( 'jetpack-' ) || slug.startsWith( 'woocommerce-' ) ) {
 		return 0.5;
 	}
 	return 0;
-};
-
-export const calculateCommissions = ( referral: Referral, products: APIProductFamilyProduct[] ) => {
-	return referral.purchases
-		.filter( ( purchase ) => [ 'pending', 'active' ].includes( purchase.status ) )
-		.map( ( purchase ) => {
-			const product = products.find( ( product ) => product.product_id === purchase.product_id );
-			const commissionPercentage = getProductCommissionPercentage( product?.family_slug );
-			const totalCommissions = product?.amount
-				? Number( product.amount ) * commissionPercentage
-				: 0;
-			return totalCommissions;
-		} )
-		.reduce( ( acc, current ) => acc + current, 0 );
 };

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -79,7 +79,10 @@ export const getEstimatedCommission = (
 					const dailyPrice = getDailyPrice( product, purchase.quantity );
 
 					// Get commission percentage for the product (common for both subscription and license)
-					const commissionPercentage = getProductCommissionPercentage( product.family_slug );
+					const commissionPercentage = getProductCommissionPercentage(
+						product.slug,
+						product.family_slug
+					);
 
 					// Add commission to the total commission (in cents)
 					acc.legacyCommissionsInCents += dailyPrice * totalDays * commissionPercentage;

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
@@ -50,11 +50,11 @@ describe( 'get-estimated-commission', () => {
 		};
 		const mockProduct: APIProductFamilyProduct = {
 			product_id: 1,
-			family_slug: 'jetpack-backup',
+			family_slug: 'jetpack-scan',
 			price_per_unit: 100,
 			supported_bundles: [],
-			name: 'Mock Product',
-			slug: 'mock-product',
+			name: 'Jetpack Scan',
+			slug: 'jetpack-scan',
 			currency: 'USD',
 			amount: '100',
 			price_interval: 'month',

--- a/client/a8c-for-agencies/sections/referrals/referral-details/client-referrals.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/client-referrals.tsx
@@ -4,11 +4,11 @@ import { useMemo, ReactNode, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import ReferralProducts from './components/referral-products';
 import ReferralStatus from './components/referral-status';
 import type { ReferralAPIResponse } from '../types';
 import type { Action } from 'calypso/a8c-for-agencies/components/list-item-cards';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -10,8 +10,8 @@ import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/s
 import { useSubscriptionDetails } from 'calypso/a8c-for-agencies/hooks/use-subscription-details';
 import { isWPCOMHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import { addQueryArgs, urlToSlug } from 'calypso/lib/url';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { ReferralPurchase } from '../../types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
 	purchase: ReferralPurchase;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/product-details.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/product-details.tsx
@@ -1,6 +1,6 @@
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { ReferralPurchase } from '../../types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
 	purchase: ReferralPurchase;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/referral-products.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/referral-products.tsx
@@ -1,6 +1,6 @@
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import type { ReferralPurchase } from '../../types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 const getProductName = ( purchase: ReferralPurchase, data: APIProductFamilyProduct[] ) => {
 	const product = data.find( ( product ) => product.product_id === purchase.product_id );

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
@@ -2,8 +2,8 @@ import { Gridicon } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { ReferralPurchase } from '../../types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
 	purchase: ReferralPurchase;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
@@ -4,13 +4,14 @@ import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { ReferralPurchase } from '../../types';
-import './style.scss';
 import AssignedTo from '../components/assigned-to';
 import DateAssigned from '../components/date';
 import ProductDetails from '../components/product-details';
 import TotalAmount from '../components/total-amount';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
+
+import './style.scss';
 
 type PurchaseItemProps = {
 	purchase: ReferralPurchase;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/referrals-mobile.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/referrals-mobile.tsx
@@ -6,10 +6,10 @@ import {
 	ListItemCardActions,
 	type Action,
 } from 'calypso/a8c-for-agencies/components/list-item-cards';
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import ReferralProducts from '../components/referral-products';
 import ReferralStatus from '../components/referral-status';
 import type { ReferralAPIResponse } from '../../types';
+import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
@@ -16,7 +16,7 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { data, isFetching } = useProductsQuery( false, false, true );
+	const { data, isFetching } = useProductsQuery( false, true );
 
 	const handleAssignToSite = useCallback(
 		( url: string ) => {

--- a/client/a8c-for-agencies/sections/referrals/referral-details/referrals/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/referrals/index.tsx
@@ -26,11 +26,7 @@ const ReferralDetailsReferrals = ( { referrals }: { referrals: ReferralAPIRespon
 	const { handleResendReferralEmail, isPending: isResendingReferralEmail } =
 		useHandleReferralResend();
 
-	const { data: productsData, isFetching: isFetchingProducts } = useProductsQuery(
-		false,
-		false,
-		true
-	);
+	const { data: productsData, isFetching: isFetchingProducts } = useProductsQuery( false, true );
 
 	const referralActions = [
 		{

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
@@ -10,7 +10,7 @@ import type { Referral } from '../types';
 
 export default function CommissionsColumn( { referral }: { referral: Referral } ) {
 	const translate = useTranslate();
-	const { data, isFetching } = useProductsQuery( false, false, true );
+	const { data, isFetching } = useProductsQuery( false, true );
 	const tooltipRef = useRef< HTMLSpanElement >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -66,8 +66,7 @@ export function SitesDashboard() {
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
-	// FIXME: We should switch to a new A4A-specific endpoint when it becomes available, instead of using the public-facing endpoint for A4A
-	const { data: products } = useProductsQuery( true );
+	const { data: products } = useProductsQuery();
 
 	const {
 		data: verifiedContacts,

--- a/client/a8c-for-agencies/types/products.ts
+++ b/client/a8c-for-agencies/types/products.ts
@@ -1,0 +1,40 @@
+export interface APIProductFamilyProductBundlePrice {
+	quantity: number;
+	amount: string;
+	price_per_unit: number; // price per day in cents
+}
+
+export interface APIProductFamilyProduct {
+	name: string;
+	slug: string;
+	product_id: number;
+	monthly_product_id?: number;
+	yearly_product_id?: number;
+	alternative_product_id?: number;
+	currency: string;
+	amount: string;
+	price_interval: string;
+	price_per_unit?: number; // price per day in cents
+	price_per_unit_display?: string;
+	family_slug: string;
+	supported_bundles: APIProductFamilyProductBundlePrice[];
+	monthly_price?: number;
+	yearly_price?: number;
+}
+
+export interface APIProductFamily {
+	name: string;
+	slug: string;
+	products: APIProductFamilyProduct[];
+	discounts?: {
+		tiers: {
+			quantity: number;
+			discount_percent: number;
+		}[];
+	};
+}
+
+export type SelectedLicenseProp = APIProductFamilyProduct & {
+	quantity: number;
+	siteUrls?: string[];
+};

--- a/client/a8c-for-agencies/types/products.ts
+++ b/client/a8c-for-agencies/types/products.ts
@@ -11,6 +11,8 @@ export interface APIProductFamilyProduct {
 	monthly_product_id?: number;
 	yearly_product_id?: number;
 	alternative_product_id?: number;
+	monthly_alternative_product_id?: number;
+	yearly_alternative_product_id?: number;
 	currency: string;
 	amount: string;
 	price_interval: string;

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
@@ -13,6 +13,8 @@ import JetpackProductInfo from 'calypso/components/jetpack/jetpack-product-info'
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { useLicenseLightboxData } from './hooks/use-license-lightbox-data';
 import LicenseLightboxJetpackManageLicense from './license-lightbox-jetpack-manage-license';
+import type { TermPricingType } from 'calypso/a8c-for-agencies/sections/marketplace/types';
+import type { APIProductFamilyProduct as APIProductFamilyProductA4A } from 'calypso/a8c-for-agencies/types/products';
 
 import './style.scss';
 
@@ -20,9 +22,9 @@ export type LicenseLightBoxProps = {
 	ctaLabel: string;
 	isCTAPrimary?: boolean;
 	isDisabled?: boolean;
-	onActivate: ( product: APIProductFamilyProduct ) => void;
+	onActivate: ( product: APIProductFamilyProduct | APIProductFamilyProductA4A ) => void;
 	onClose: () => void;
-	product: APIProductFamilyProduct;
+	product: APIProductFamilyProduct | APIProductFamilyProductA4A;
 	extraAsideContent?: JSX.Element;
 	secondaryAsideContent?: JSX.Element;
 	className?: string;
@@ -34,6 +36,7 @@ export type LicenseLightBoxProps = {
 	customDescription?: ReactNode;
 	customFooter?: ReactNode;
 	vendor?: VendorInfo | null;
+	termPricing?: TermPricingType;
 };
 
 const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
@@ -54,6 +57,7 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 	customDescription,
 	customFooter,
 	vendor,
+	termPricing,
 } ) => {
 	const isLargeScreen = useBreakpoint( '>782px' );
 	const { title, product: productInfo } = useLicenseLightboxData( product );
@@ -90,7 +94,11 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 
 			<JetpackLightboxAside ref={ sidebarRef }>
 				{ showPaymentPlan && (
-					<LicenseLightboxJetpackManageLicense product={ product } quantity={ quantity } />
+					<LicenseLightboxJetpackManageLicense
+						product={ product }
+						quantity={ quantity }
+						termPricing={ termPricing }
+					/>
 				) }
 
 				<Button

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-jetpack-manage-license.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-jetpack-manage-license.tsx
@@ -1,17 +1,22 @@
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
+import ProductPriceWithDiscountA4A from 'calypso/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import ProductPriceWithDiscount from '../primary/product-price-with-discount-info';
+import type { TermPricingType } from 'calypso/a8c-for-agencies/sections/marketplace/types';
+import type { APIProductFamilyProduct as APIProductFamilyProductA4A } from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
-	product: APIProductFamilyProduct;
+	product: APIProductFamilyProduct | APIProductFamilyProductA4A;
 	quantity?: number;
+	termPricing?: TermPricingType;
 };
 
 const LicenseLightboxJetpackManageLicense: FunctionComponent< Props > = ( {
 	product,
 	quantity,
+	termPricing,
 } ) => {
 	const translate = useTranslate();
 
@@ -25,7 +30,15 @@ const LicenseLightboxJetpackManageLicense: FunctionComponent< Props > = ( {
 			</h3>
 
 			<div className="license-lightbox__pricing">
-				<ProductPriceWithDiscount product={ product } quantity={ quantity } />
+				{ isA4A ? (
+					<ProductPriceWithDiscountA4A
+						termPricing={ termPricing }
+						product={ product as APIProductFamilyProductA4A }
+						quantity={ quantity }
+					/>
+				) : (
+					<ProductPriceWithDiscount product={ product } quantity={ quantity } />
+				) }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1926/marketplace-show-monthlyearly-pricing-for-hosting-and-products

Resolves https://linear.app/a8c/issue/A4A-1929/products-display-monthlyyearly-pricing-on-cards
Resolves https://linear.app/a8c/issue/A4A-1930/hosting-display-monthlyyearly-pricing-on-cards
Resolves https://linear.app/a8c/issue/A4A-1961/cart-display-monthlyyearly-pricing
Resolves https://linear.app/a8c/issue/A4A-1962/display-term-based-pricing-on-product-details-modal-lightbox

## Proposed Changes

This PR implements term pricing for Hosting, Products & Cart.

## Why are these changes being made?

* To support term pricing on A4A Marketplace

## Testing Instructions

Note: There might be some pricing difference when the feature flag is enabled. Please ignore it now, as we will fix it later. 

* Open the A4A live link
* Use a non-BD agency > Test all the scenarios mentioned below > Verify the prices match production, and all the flows work as expected.
* Use a BD agency > Append the URL with `?flags=-a4a-bd-term-pricing`
* Test all the scenarios mentioned below > Verify the prices match production, and all the flows work as expected.

1) Marketplace > Hosting > Standard Agency Hosting > Refer mode on/off
2) Marketplace > Hosting > Premier Agency Hosting > Refer mode on/off
3) Marketplace > Products > Refer mode on/off
4) Marketplace > Products > View details for a product
5) Marketplace > Checkout

* Verify that all the filters work as expected on the Products page

* Patch 199438-ghe-Automattic/wpcom/
* Append the URL with `?flags=a4a-bd-term-pricing` > Test all the scenarios mentioned below > Verify the UI looks as displayed below for yearly and monthly billing. 

Billing term: Monthly

1) Marketplace > Hosting > Standard Agency Hosting > Refer mode off

<img width="1920" height="860" alt="Screenshot 2026-01-14 at 2 48 42 PM" src="https://github.com/user-attachments/assets/c250e1b6-4e42-42e2-a95e-3759c6720581" />

2) Marketplace > Hosting > Standard Agency Hosting > Refer mode on

<img width="1920" height="860" alt="Screenshot 2026-01-14 at 2 53 55 PM" src="https://github.com/user-attachments/assets/d0e88cf9-66b0-43bd-b9ed-0271b300083f" />

3) Marketplace > Hosting > Premier Agency Hosting > Refer mode on

<img width="1920" height="860" alt="Screenshot 2026-01-14 at 2 54 31 PM" src="https://github.com/user-attachments/assets/723526a7-3897-4ee8-8339-d2e87c988d8e" />

4) Marketplace > Hosting > Premier Agency Hosting > Refer mode off

<img width="1920" height="860" alt="Screenshot 2026-01-14 at 2 55 27 PM" src="https://github.com/user-attachments/assets/b38a12be-0310-44e0-9242-a81dbb30937c" />

5) Marketplace > Products > Refer mode off 

<img width="1920" height="860" alt="Screenshot 2026-01-14 at 2 57 19 PM" src="https://github.com/user-attachments/assets/307fef64-78c4-4e9a-96e9-736076e0020d" />

6) Marketplace > Products > Refer mode on 

<img width="1920" height="860" alt="Screenshot 2026-01-14 at 2 57 54 PM" src="https://github.com/user-attachments/assets/8e35deec-3dd5-4d89-aaa7-ae0019039a7b" />

7) Cart > Refer mode off

<img width="663" height="860" alt="Screenshot 2026-01-14 at 2 58 54 PM" src="https://github.com/user-attachments/assets/6fadfebc-ff46-4766-a8f0-241142d65eae" />

8) Cart > Refer mode on 

<img width="663" height="860" alt="Screenshot 2026-01-14 at 2 59 06 PM" src="https://github.com/user-attachments/assets/1e62dd55-539e-4fae-ae2b-3d2538bb8a14" /> 

9) View details 

<img width="1125" height="641" alt="Screenshot 2026-01-14 at 3 04 54 PM" src="https://github.com/user-attachments/assets/49f5b3be-03d6-4e87-8bc0-3bf14fa1aa7d" />


Billing term: Yearly


1) Marketplace > Hosting > Standard Agency Hosting > Refer mode off

<img width="1920" height="881" alt="Screenshot 2026-01-14 at 3 00 53 PM" src="https://github.com/user-attachments/assets/d6c3a130-eeba-4889-82b0-2ae5470ad7ff" />

2) Marketplace > Hosting > Standard Agency Hosting > Refer mode on

<img width="1920" height="881" alt="Screenshot 2026-01-14 at 3 01 04 PM" src="https://github.com/user-attachments/assets/495859fe-a22e-41f3-ac61-0c30c79efd49" />

3) Marketplace > Hosting > Premier Agency Hosting > Refer mode off

<img width="1920" height="881" alt="Screenshot 2026-01-14 at 3 01 27 PM" src="https://github.com/user-attachments/assets/ac1790d0-1d44-4566-b9f1-bcde854adaca" />

4) Marketplace > Hosting > Premier Agency Hosting > Refer mode on

<img width="1920" height="881" alt="Screenshot 2026-01-14 at 3 02 00 PM" src="https://github.com/user-attachments/assets/9ecd26fa-3b4c-4e0f-ab0d-427ed9c43cd9" />

5) Marketplace > Products > Refer mode off 

<img width="1920" height="881" alt="Screenshot 2026-01-14 at 3 03 04 PM" src="https://github.com/user-attachments/assets/7f75ef90-f48b-4acb-9cde-afe5ed4492f4" />

6) Marketplace > Products > Refer mode on 

<img width="1920" height="881" alt="Screenshot 2026-01-14 at 3 03 16 PM" src="https://github.com/user-attachments/assets/35cd0ea1-161e-4a32-a2f1-b82a1568d5a6" />

7) Cart > Refer mode off

<img width="647" height="881" alt="Screenshot 2026-01-14 at 3 03 30 PM" src="https://github.com/user-attachments/assets/9c3c8394-e02e-4642-861b-13020793344f" />

8) Cart > Refer mode on 

<img width="647" height="881" alt="Screenshot 2026-01-14 at 3 03 41 PM" src="https://github.com/user-attachments/assets/0799b283-83d5-4020-bcda-729b0e8109b3" />

9) View details

<img width="1099" height="644" alt="Screenshot 2026-01-14 at 3 04 43 PM" src="https://github.com/user-attachments/assets/e69758a7-a7d5-4f12-b610-cc586e6b1c6d" />

## Pre-merge Checklist



<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?