### PR TITLE
MSD: don't send to logstash for (re)authorization_required

### DIFF
--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -65,7 +65,8 @@ export const getRouter = ( config: AppConfig ) => {
 		defaultErrorComponent: UnknownError,
 		defaultNotFoundComponent: NotFound,
 		defaultOnCatch: ( error: Error, errorInfo: ErrorInfo ) => {
-			if ( ( error as any ).error === 'reauthorization_error' ) {
+			const code = ( error as any ).error;
+			if ( code === 'authorization_required' || code === 'reauthorization_required' ) {
 				return;
 			}
 

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -65,6 +65,10 @@ export const getRouter = ( config: AppConfig ) => {
 		defaultErrorComponent: UnknownError,
 		defaultNotFoundComponent: NotFound,
 		defaultOnCatch: ( error: Error, errorInfo: ErrorInfo ) => {
+			if ( ( error as any ).error === 'reauthorization_error' ) {
+				return;
+			}
+
 			logToLogstash( {
 				feature: 'calypso_client',
 				message: error.message,

--- a/client/sites/v2/utils/router.ts
+++ b/client/sites/v2/utils/router.ts
@@ -14,7 +14,8 @@ export function getRouterOptions( config: AppConfig ) {
 			config,
 		},
 		defaultOnCatch: ( error: Error, errorInfo: ErrorInfo ) => {
-			if ( ( error as any ).error === 'reauthorization_error' ) {
+			const code = ( error as any ).error;
+			if ( code === 'authorization_required' || code === 'reauthorization_required' ) {
 				return;
 			}
 

--- a/client/sites/v2/utils/router.ts
+++ b/client/sites/v2/utils/router.ts
@@ -14,6 +14,10 @@ export function getRouterOptions( config: AppConfig ) {
 			config,
 		},
 		defaultOnCatch: ( error: Error, errorInfo: ErrorInfo ) => {
+			if ( ( error as any ).error === 'reauthorization_error' ) {
+				return;
+			}
+
 			logToLogstash( {
 				feature: 'calypso_client',
 				message: error.message,


### PR DESCRIPTION
## Proposed Changes

Don't send `(re)authorization_required` to logstash:

<img width="910" height="318" alt="Screenshot 2025-12-24 at 15 13 47" src="https://github.com/user-attachments/assets/6a2d81e0-aa05-4437-9f1f-41fe5e6d163b" />


## Why are these changes being made?

It's not really an error and just adds noise to the logs

## Testing Instructions

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
