### PR TITLE
Pricing Differentiation: Pass assignment to the backend

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -154,6 +154,7 @@ function useGenerateActionCallback( {
 	sitePlanSlug,
 	siteId,
 	coupon,
+	isGatingBusinessQ1,
 }: {
 	currentPlan: Plans.SitePlan | undefined;
 	eligibleForFreeHostingTrial: boolean;
@@ -164,6 +165,11 @@ function useGenerateActionCallback( {
 	sitePlanSlug?: PlanSlug | null;
 	siteId?: number | null;
 	coupon?: string;
+	/**
+	 * When true, adds `is_gating_business_q1` to the plan cart item extra data.
+	 * Used for the pricing differentiation experiment (calypso_plans_differentiators_20251210).
+	 */
+	isGatingBusinessQ1?: boolean;
 } ): UseActionCallback {
 	const siteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
 	const siteUrl = useSelector( ( state: IAppState ) => siteId && getSiteUrl( state, siteId ) );
@@ -258,8 +264,22 @@ function useGenerateActionCallback( {
 					saw_free_trial_offer: !! freeTrialPlanSlug,
 				} );
 			}
+
+			// Augment the cart item with pricing differentiation experiment data if applicable.
+			let augmentedCartItemForPlan = cartItemForPlan;
+
+			if ( cartItemForPlan && isGatingBusinessQ1 ) {
+				augmentedCartItemForPlan = {
+					...cartItemForPlan,
+					extra: {
+						...cartItemForPlan.extra,
+						is_gating_business_q1: true,
+					},
+				};
+			}
+
 			handleUpgradeClick( {
-				cartItemForPlan,
+				cartItemForPlan: augmentedCartItemForPlan,
 				selectedStorageAddOn,
 			} );
 			return;

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -75,6 +75,7 @@ export default function useGenerateActionHook( {
 	showBillingDescriptionForIncreasedRenewalPrice,
 	enableCategorisedFeatures,
 	reflectStorageSelectionInPlanPrices,
+	isGatingBusinessQ1,
 }: {
 	siteId?: number | null;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
@@ -88,6 +89,11 @@ export default function useGenerateActionHook( {
 	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
 	enableCategorisedFeatures?: boolean;
 	reflectStorageSelectionInPlanPrices?: boolean;
+	/**
+	 * When true, adds `is_gating_business_q1` to the plan cart item extra data.
+	 * Used for the pricing differentiation experiment (calypso_plans_differentiators_20251210).
+	 */
+	isGatingBusinessQ1?: boolean;
 } ): UseAction {
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
@@ -118,6 +124,7 @@ export default function useGenerateActionHook( {
 		sitePlanSlug,
 		siteId,
 		coupon,
+		isGatingBusinessQ1,
 	} );
 
 	const useActionHook = ( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -385,6 +385,7 @@ const PlansFeaturesMain = ( {
 		isLongSet,
 		isShortSet,
 		showDifferentiatorHeader,
+		variant: differentiatorsVariant,
 	} = usePlanDifferentiatorsExperiment( { flowName, intent, isInSignup } );
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
@@ -425,6 +426,7 @@ const PlansFeaturesMain = ( {
 		showBillingDescriptionForIncreasedRenewalPrice: renewalPricingVariation,
 		enableCategorisedFeatures: showSimplifiedFeatures,
 		reflectStorageSelectionInPlanPrices: true,
+		isGatingBusinessQ1: !! differentiatorsVariant,
 	} );
 
 	const isDomainOnlySite = useSelector( ( state: IAppState ) =>

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -976,6 +976,13 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	 *
 	 */
 	hosting_intent?: string;
+
+	/**
+	 * Indicates the user was in a treatment variation of the pricing
+	 * differentiation experiment (calypso_plans_differentiators_20251210).
+	 * Used to add the `gating-business-q1` blog sticker on purchase.
+	 */
+	is_gating_business_q1?: boolean;
 }
 
 export interface GSuiteProductUser {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOTCOM-15460](https://linear.app/a8c/issue/DOTCOM-15460/design-for-the-pricing-grids-for-all-variants-incl-comparison-view)
## Proposed Changes

* passes a `is_gating_business_q1` extra prop to the backend Store if the user is assigned one of the treatment variations of the `calypso_plans_differentiators_20251210`. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* this is needed by the Store to determine wether to add the corresponding `gating-business-q1` blog sticker which will be used for feature gating.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself any treatment variation of the `calypso_plans_differentiators_20251210` experiment
* You may need to clean the `explat-experiment--calypso_plans_differentiators_20251210` localStorage in Calypso
* Go `/setup/onboarding`
* Create a Personal/Premiu/Business plan site
* Check that the `rest/v1.1/me/transactions` request that is sent after submitting on Checkout contains the `is_gating_business_q1` extra prop on the product

<img width="480" alt="Screenshot 2025-12-24 at 13 02 15" src="https://github.com/user-attachments/assets/7799739c-c362-4f89-9e7a-4d040c49a6b1" />

* Follow instructions from 198785-ghe-Automattic/wpcom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?