### PR TITLE
Grid: properly re-render when the `layout` prop changes dynamically.

### DIFF
--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -1,7 +1,7 @@
 import { DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { useResizeObserver, useDebounce, useEvent } from '@wordpress/compose';
-import { useMemo, Children, isValidElement, useState, useEffect } from 'react';
+import { useMemo, Children, isValidElement, useState } from 'react';
 import { GridItem } from './grid-item';
 import type { GridLayoutItem, GridProps } from './types';
 import type { DragOverEvent } from '@dnd-kit/core';
@@ -23,14 +23,6 @@ export function Grid( {
 	 */
 	const [ temporaryLayout, setTemporaryLayout ] = useState< GridLayoutItem[] | undefined >();
 	const activeLayout = temporaryLayout ?? layout;
-
-	/*
-	 * Clear temporary state when parent updates layout e.g., switching pages,
-	 * loading data to avoid showing stale pending changes from previous layouts
-	 */
-	useEffect( () => {
-		setTemporaryLayout( undefined );
-	}, [ layout ] );
 
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const resizeObserverRef = useResizeObserver( ( [ { contentRect } ] ) => {

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -1,7 +1,7 @@
 import { DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { useResizeObserver, useDebounce, useEvent } from '@wordpress/compose';
-import { useMemo, Children, isValidElement, useState } from 'react';
+import { useMemo, Children, isValidElement, useState, useEffect } from 'react';
 import { GridItem } from './grid-item';
 import type { GridLayoutItem, GridProps } from './types';
 import type { DragOverEvent } from '@dnd-kit/core';
@@ -17,9 +17,21 @@ export function Grid( {
 	editMode = false,
 	onChangeLayout,
 }: GridProps ) {
-	// Temporary layout to avoid updating the layout while dragging
+	/*
+	 * Temporary layout holds pending changes during drag/resize
+	 * to show preview without triggering parent re-renders
+	 */
 	const [ temporaryLayout, setTemporaryLayout ] = useState< GridLayoutItem[] | undefined >();
 	const activeLayout = temporaryLayout ?? layout;
+
+	/*
+	 * Clear temporary state when parent updates layout e.g., switching pages,
+	 * loading data to avoid showing stale pending changes from previous layouts
+	 */
+	useEffect( () => {
+		setTemporaryLayout( undefined );
+	}, [ layout ] );
+
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const resizeObserverRef = useResizeObserver( ( [ { contentRect } ] ) => {
 		setContainerWidth( contentRect.width );
@@ -107,6 +119,10 @@ export function Grid( {
 	} );
 	const debouncedHandleDragOver = useDebounce( handleDragOver, 100 );
 
+	/*
+	 * Commit temporary changes to parent and clear local state
+	 * Called when user finishes drag/resize on mouse up
+	 */
 	function persistTemporaryLayout() {
 		if ( ! onChangeLayout || ! temporaryLayout ) {
 			return;

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -17,11 +17,9 @@ export function Grid( {
 	editMode = false,
 	onChangeLayout,
 }: GridProps ) {
-	// Temporary layout to avoid updaing the layout while dragging
-	const [ temporaryLayout, setTemporaryLayout ] = useState< GridLayoutItem[] | undefined >(
-		layout
-	);
-	const activeLayout = temporaryLayout || layout;
+	// Temporary layout to avoid updating the layout while dragging
+	const [ temporaryLayout, setTemporaryLayout ] = useState< GridLayoutItem[] | undefined >();
+	const activeLayout = temporaryLayout ?? layout;
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const resizeObserverRef = useResizeObserver( ( [ { contentRect } ] ) => {
 		setContainerWidth( contentRect.width );

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -312,3 +312,165 @@ export const WithActionableArea: StoryObj< typeof Grid > = {
 		layout: '',
 	},
 };
+
+/**
+ * Demonstrates the bug where Grid tiles don't re-render when layout prop changes dynamically.
+ * This story shows the issue described in ARC-1330.
+ *
+ * BUG: When you add, remove, or switch layouts, the Grid doesn't update properly.
+ * Expected: Tiles should appear/disappear/change immediately
+ * Actual: Grid retains old tile instances
+ *
+ * Current workaround: Use a `key` prop on Grid to force re-mount when layout changes
+ */
+export const DynamicLayoutChange: StoryObj< typeof Grid > = {
+	render: function DynamicLayoutChange() {
+		const colors = [
+			'#f44336',
+			'#2196f3',
+			'#4caf50',
+			'#ff9800',
+			'#9c27b0',
+			'#607d8b',
+			'#3f51b5',
+			'#8bc34a',
+			'#cddc39',
+			'#ffeb3b',
+		];
+
+		const layoutA: GridLayoutItem[] = [
+			{ key: 'tile-1', width: 2, height: 1 },
+			{ key: 'tile-2', width: 2, height: 1 },
+			{ key: 'tile-3', width: 2, height: 1 },
+		];
+
+		const layoutB: GridLayoutItem[] = [
+			{ key: 'tile-a', width: 3, height: 1 },
+			{ key: 'tile-b', width: 3, height: 1 },
+		];
+
+		const [ layout, setLayout ] = useState< GridLayoutItem[] >( layoutA );
+		const [ currentLayoutName, setCurrentLayoutName ] = useState( 'A' );
+		const [ nextTileId, setNextTileId ] = useState( 4 );
+
+		const addTile = () => {
+			const newLayout = [ ...layout, { key: `tile-${ nextTileId }`, width: 2, height: 1 } ];
+			setLayout( newLayout );
+			setNextTileId( nextTileId + 1 );
+		};
+
+		const removeLastTile = () => {
+			if ( layout.length > 0 ) {
+				setLayout( layout.slice( 0, -1 ) );
+			}
+		};
+
+		const switchLayout = () => {
+			if ( currentLayoutName === 'A' ) {
+				setLayout( layoutB );
+				setCurrentLayoutName( 'B' );
+			} else {
+				setLayout( layoutA );
+				setCurrentLayoutName( 'A' );
+			}
+		};
+
+		const getTileNumber = ( key: string ) => {
+			const match = key.match( /\d+/ );
+			return match ? parseInt( match[ 0 ], 10 ) : key.charCodeAt( key.length - 1 ) - 96;
+		};
+
+		return (
+			<div style={ { width: '800px' } }>
+				<div
+					style={ {
+						marginBottom: '20px',
+						padding: '20px',
+						background: '#f5f5f5',
+						borderRadius: '4px',
+					} }
+				>
+					<h3 style={ { marginTop: 0 } }>Layout Controls</h3>
+					<div style={ { display: 'flex', gap: '10px', marginBottom: '15px' } }>
+						<button
+							onClick={ addTile }
+							style={ {
+								padding: '8px 16px',
+								background: '#2196f3',
+								color: 'white',
+								border: 'none',
+								borderRadius: '4px',
+								cursor: 'pointer',
+							} }
+						>
+							Add Tile
+						</button>
+						<button
+							onClick={ removeLastTile }
+							disabled={ layout.length === 0 }
+							style={ {
+								padding: '8px 16px',
+								background: layout.length === 0 ? '#ccc' : '#f44336',
+								color: 'white',
+								border: 'none',
+								borderRadius: '4px',
+								cursor: layout.length === 0 ? 'not-allowed' : 'pointer',
+							} }
+						>
+							Remove Last Tile
+						</button>
+						<button
+							onClick={ switchLayout }
+							style={ {
+								padding: '8px 16px',
+								background: '#4caf50',
+								color: 'white',
+								border: 'none',
+								borderRadius: '4px',
+								cursor: 'pointer',
+							} }
+						>
+							Switch to Layout { currentLayoutName === 'A' ? 'B' : 'A' }
+						</button>
+					</div>
+					<div style={ { fontSize: '14px', color: '#666' } }>
+						<strong>Current Layout:</strong> { currentLayoutName } | <strong>Tiles:</strong>{ ' ' }
+						{ layout.length }
+					</div>
+					<div
+						style={ {
+							marginTop: '10px',
+							padding: '10px',
+							background: '#fff3cd',
+							borderRadius: '4px',
+							fontSize: '13px',
+						} }
+					>
+						<strong>BUG:</strong> When you add/remove tiles or switch layouts, the Grid doesn't
+						update properly. The tiles remain from the previous layout state.
+					</div>
+				</div>
+				<Grid layout={ layout } minColumnWidth={ 160 } rowHeight={ 100 } spacing={ 2 }>
+					{ layout.map( ( item ) => {
+						const tileNum = getTileNumber( item.key );
+						const colorIndex = tileNum % colors.length;
+						return (
+							<Card key={ item.key } color={ colors[ colorIndex ] }>
+								{ item.key }
+							</Card>
+						);
+					} ) }
+				</Grid>
+			</div>
+		);
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"This story demonstrates the bug where Grid tiles don't re-render when the layout prop changes dynamically. Try adding tiles, removing tiles, or switching between layouts - you'll see that the Grid doesn't update correctly. This is the issue described in ARC-1330.",
+			},
+		},
+		layout: '',
+	},
+};

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -447,7 +447,9 @@ export const InteractiveGrid: StoryObj< typeof Grid > = {
 							<Card
 								key={ item.key }
 								color={ colors[ colorIndex ] }
-								actionableArea={ <WidgetActions onClose={ () => removeTile( item.key ) } /> }
+								actionableArea={
+									editMode ? <WidgetActions onClose={ () => removeTile( item.key ) } /> : undefined
+								}
 							>
 								{ item.key }
 							</Card>

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -314,17 +314,11 @@ export const WithActionableArea: StoryObj< typeof Grid > = {
 };
 
 /**
- * Demonstrates the bug where Grid tiles don't re-render when layout prop changes dynamically.
- * This story shows the issue described in ARC-1330.
- *
- * BUG: When you add, remove, or switch layouts, the Grid doesn't update properly.
- * Expected: Tiles should appear/disappear/change immediately
- * Actual: Grid retains old tile instances
- *
- * Current workaround: Use a `key` prop on Grid to force re-mount when layout changes
+ * Interactive grid example showing dynamic layout changes.
+ * Add, remove, and switch layouts on the fly. Enable edit mode to drag and resize tiles.
  */
-export const DynamicLayoutChange: StoryObj< typeof Grid > = {
-	render: function DynamicLayoutChange() {
+export const InteractiveGrid: StoryObj< typeof Grid > = {
+	render: function InteractiveGrid() {
 		const colors = [
 			'#f44336',
 			'#2196f3',
@@ -352,6 +346,7 @@ export const DynamicLayoutChange: StoryObj< typeof Grid > = {
 		const [ layout, setLayout ] = useState< GridLayoutItem[] >( layoutA );
 		const [ currentLayoutName, setCurrentLayoutName ] = useState( 'A' );
 		const [ nextTileId, setNextTileId ] = useState( 4 );
+		const [ editMode, setEditMode ] = useState( false );
 
 		const addTile = () => {
 			const newLayout = [ ...layout, { key: `tile-${ nextTileId }`, width: 2, height: 1 } ];
@@ -359,19 +354,19 @@ export const DynamicLayoutChange: StoryObj< typeof Grid > = {
 			setNextTileId( nextTileId + 1 );
 		};
 
-		const removeLastTile = () => {
-			if ( layout.length > 0 ) {
-				setLayout( layout.slice( 0, -1 ) );
-			}
+		const removeTile = ( key: string ) => {
+			setLayout( layout.filter( ( item ) => item.key !== key ) );
 		};
 
 		const switchLayout = () => {
 			if ( currentLayoutName === 'A' ) {
 				setLayout( layoutB );
 				setCurrentLayoutName( 'B' );
+				setNextTileId( 4 );
 			} else {
 				setLayout( layoutA );
 				setCurrentLayoutName( 'A' );
+				setNextTileId( 4 );
 			}
 		};
 
@@ -390,7 +385,7 @@ export const DynamicLayoutChange: StoryObj< typeof Grid > = {
 						borderRadius: '4px',
 					} }
 				>
-					<h3 style={ { marginTop: 0 } }>Layout Controls</h3>
+					<h3 style={ { marginTop: 0 } }>Grid Controls</h3>
 					<div style={ { display: 'flex', gap: '10px', marginBottom: '15px' } }>
 						<button
 							onClick={ addTile }
@@ -406,20 +401,6 @@ export const DynamicLayoutChange: StoryObj< typeof Grid > = {
 							Add Tile
 						</button>
 						<button
-							onClick={ removeLastTile }
-							disabled={ layout.length === 0 }
-							style={ {
-								padding: '8px 16px',
-								background: layout.length === 0 ? '#ccc' : '#f44336',
-								color: 'white',
-								border: 'none',
-								borderRadius: '4px',
-								cursor: layout.length === 0 ? 'not-allowed' : 'pointer',
-							} }
-						>
-							Remove Last Tile
-						</button>
-						<button
 							onClick={ switchLayout }
 							style={ {
 								padding: '8px 16px',
@@ -432,30 +413,42 @@ export const DynamicLayoutChange: StoryObj< typeof Grid > = {
 						>
 							Switch to Layout { currentLayoutName === 'A' ? 'B' : 'A' }
 						</button>
+						<button
+							onClick={ () => setEditMode( ! editMode ) }
+							style={ {
+								padding: '8px 16px',
+								background: editMode ? '#ff9800' : '#666',
+								color: 'white',
+								border: 'none',
+								borderRadius: '4px',
+								cursor: 'pointer',
+							} }
+						>
+							{ editMode ? 'Disable' : 'Enable' } Edit Mode
+						</button>
 					</div>
 					<div style={ { fontSize: '14px', color: '#666' } }>
-						<strong>Current Layout:</strong> { currentLayoutName } | <strong>Tiles:</strong>{ ' ' }
-						{ layout.length }
-					</div>
-					<div
-						style={ {
-							marginTop: '10px',
-							padding: '10px',
-							background: '#fff3cd',
-							borderRadius: '4px',
-							fontSize: '13px',
-						} }
-					>
-						<strong>BUG:</strong> When you add/remove tiles or switch layouts, the Grid doesn't
-						update properly. The tiles remain from the previous layout state.
+						<strong>Layout:</strong> { currentLayoutName } | <strong>Tiles:</strong>{ ' ' }
+						{ layout.length } | <strong>Edit Mode:</strong> { editMode ? 'ON' : 'OFF' }
 					</div>
 				</div>
-				<Grid layout={ layout } minColumnWidth={ 160 } rowHeight={ 100 } spacing={ 2 }>
+				<Grid
+					layout={ layout }
+					minColumnWidth={ 160 }
+					rowHeight={ 100 }
+					spacing={ 2 }
+					editMode={ editMode }
+					onChangeLayout={ setLayout }
+				>
 					{ layout.map( ( item ) => {
 						const tileNum = getTileNumber( item.key );
 						const colorIndex = tileNum % colors.length;
 						return (
-							<Card key={ item.key } color={ colors[ colorIndex ] }>
+							<Card
+								key={ item.key }
+								color={ colors[ colorIndex ] }
+								actionableArea={ <WidgetActions onClose={ () => removeTile( item.key ) } /> }
+							>
 								{ item.key }
 							</Card>
 						);
@@ -468,7 +461,7 @@ export const DynamicLayoutChange: StoryObj< typeof Grid > = {
 		docs: {
 			description: {
 				story:
-					"This story demonstrates the bug where Grid tiles don't re-render when the layout prop changes dynamically. Try adding tiles, removing tiles, or switching between layouts - you'll see that the Grid doesn't update correctly. This is the issue described in ARC-1330.",
+					'Interactive example showing dynamic layout management. Add tiles, switch between predefined layouts, and enable edit mode to drag and resize tiles. Each tile has a close button to remove it individually.',
 			},
 		},
 		layout: '',


### PR DESCRIPTION
Related to ARC-1330

## Why?
The Grid component wasn't responding to external layout changes. When the layout prop was updated (e.g., adding/removing tiles or switching to a different layout), the Grid would retain old tile instances instead of updating to reflect the new layout.

This forced users to use workarounds like adding a `key` prop to force re-mounting.

## How?
**Root cause:** The `temporaryLayout` state was initialized with the `layout` prop value but never synchronized when the prop changed externally.

**Solution:** Remove the initial value from `temporaryLayout` state, so it starts as `undefined` and only gets populated during drag/resize operations:

This ensures:
- `temporaryLayout` only exists during active drag/resize operations
- When `layout` prop changes externally, `activeLayout` immediately uses the new value
- No functionality is lost (there's no cancel/revert feature)

## Testing
Added an interactive Storybook story (`InteractiveGrid`) that demonstrates:
- Adding tiles dynamically
- Removing tiles individually
- Switching between different layouts
- Edit mode with drag & drop and resize

Before the fix, these operations wouldn't update the grid. After the fix, all dynamic layout changes work correctly.

## Additional Changes
- Improved the interactive story with edit mode toggle and per-tile removal
- Fixed typo in comment: "updaing" → "updating"

https://github.com/user-attachments/assets/e5ee3644-66a8-48f4-9aec-1c6595714bd1

