### PR TITLE
Help Center: Add loading state when transferring to Zendesk

### DIFF
--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import cx from 'clsx';
+import { Fragment } from 'react';
 import ChatMessage from '..';
 import { useOdieAssistantContext } from '../../../context';
 import { isCSATMessage } from '../../../utils';
@@ -114,24 +115,6 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 		const startingHumanSupport = group.messages.some( isZendeskChatStartedMessage );
 		const endingHumanSupport = group.messages.some( isCSATMessage );
 
-		if ( startingHumanSupport ) {
-			return (
-				<ChatWithSupportLabel
-					labelText={ __( 'Chat with support team started', __i18n_text_domain__ ) }
-					key={ group.id }
-				/>
-			);
-		}
-
-		if ( endingHumanSupport ) {
-			return (
-				<ChatWithSupportLabel
-					labelText={ __( 'Chat with support team ended', __i18n_text_domain__ ) }
-					key={ group.id }
-				/>
-			);
-		}
-
 		const messageHeader = () => {
 			// Only business messages have a header.
 			if ( group.role === 'business' ) {
@@ -145,19 +128,28 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 		};
 
 		return (
-			<div
-				className={ cx( 'odie-chatbox-messages-cluster', `role-${ group.role }` ) }
-				key={ group.id }
-			>
-				{ group.messages.map( ( message, index ) => (
-					<ChatMessage
-						key={ getMessageUniqueIdentifier( message, `${ group.id }-${ index }` ) }
-						message={ message }
-						currentUser={ currentUser }
-						header={ index === 0 ? messageHeader() : undefined }
+			<Fragment key={ group.id }>
+				{ endingHumanSupport && (
+					<ChatWithSupportLabel
+						labelText={ __( 'Chat with support team ended', __i18n_text_domain__ ) }
 					/>
-				) ) }
-			</div>
+				) }
+				<div className={ cx( 'odie-chatbox-messages-cluster', `role-${ group.role }` ) }>
+					{ group.messages.map( ( message, index ) => (
+						<ChatMessage
+							key={ getMessageUniqueIdentifier( message, `${ group.id }-${ index }` ) }
+							message={ message }
+							currentUser={ currentUser }
+							header={ index === 0 ? messageHeader() : undefined }
+						/>
+					) ) }
+				</div>
+				{ startingHumanSupport && (
+					<ChatWithSupportLabel
+						labelText={ __( 'Chat with support team started', __i18n_text_domain__ ) }
+					/>
+				) }
+			</Fragment>
 		);
 	} );
 }

--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -1,13 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import cx from 'clsx';
-import { Fragment } from 'react';
 import ChatMessage from '..';
 import { useOdieAssistantContext } from '../../../context';
 import { isCSATMessage } from '../../../utils';
 import {
 	hasFeedbackForm,
 	isAttachment,
-	isTransitionToSupportMessage,
+	isZendeskChatStartedMessage,
 	isZendeskIntroMessage,
 } from '../../../utils/csat';
 import ChatWithSupportLabel from '../../chat-with-support';
@@ -112,8 +111,26 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 	const { currentUser } = useOdieAssistantContext();
 
 	return groups.map( ( group ) => {
-		const startingHumanSupport = group.messages.some( isTransitionToSupportMessage );
+		const startingHumanSupport = group.messages.some( isZendeskChatStartedMessage );
 		const endingHumanSupport = group.messages.some( isCSATMessage );
+
+		if ( startingHumanSupport ) {
+			return (
+				<ChatWithSupportLabel
+					labelText={ __( 'Chat with support team started', __i18n_text_domain__ ) }
+					key={ group.id }
+				/>
+			);
+		}
+
+		if ( endingHumanSupport ) {
+			return (
+				<ChatWithSupportLabel
+					labelText={ __( 'Chat with support team ended', __i18n_text_domain__ ) }
+					key={ group.id }
+				/>
+			);
+		}
 
 		const messageHeader = () => {
 			// Only business messages have a header.
@@ -128,28 +145,19 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 		};
 
 		return (
-			<Fragment key={ group.id }>
-				{ endingHumanSupport && (
-					<ChatWithSupportLabel
-						labelText={ __( 'Chat with support team ended', __i18n_text_domain__ ) }
+			<div
+				className={ cx( 'odie-chatbox-messages-cluster', `role-${ group.role }` ) }
+				key={ group.id }
+			>
+				{ group.messages.map( ( message, index ) => (
+					<ChatMessage
+						key={ getMessageUniqueIdentifier( message, `${ group.id }-${ index }` ) }
+						message={ message }
+						currentUser={ currentUser }
+						header={ index === 0 ? messageHeader() : undefined }
 					/>
-				) }
-				<div className={ cx( 'odie-chatbox-messages-cluster', `role-${ group.role }` ) }>
-					{ group.messages.map( ( message, index ) => (
-						<ChatMessage
-							key={ getMessageUniqueIdentifier( message, `${ group.id }-${ index }` ) }
-							message={ message }
-							currentUser={ currentUser }
-							header={ index === 0 ? messageHeader() : undefined }
-						/>
-					) ) }
-				</div>
-				{ startingHumanSupport && (
-					<ChatWithSupportLabel
-						labelText={ __( 'Chat with support team started', __i18n_text_domain__ ) }
-					/>
-				) }
-			</Fragment>
+				) ) }
+			</div>
 		);
 	} );
 }

--- a/packages/odie-client/src/components/message/messages-cluster/style.scss
+++ b/packages/odie-client/src/components/message/messages-cluster/style.scss
@@ -40,6 +40,10 @@
 		.odie-chatbox-message {
 			margin-bottom: 16px;
 		}
+
+		.odie-chatbox-message-meta {
+			margin-bottom: 0;
+		}
 	}
 
 	&.role-business {

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -144,24 +144,11 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				{ chat.messages?.length > 0 && <MessagesClusterizer messages={ chat.messages } /> }
 				<JumpToRecent containerReference={ messagesContainerRef } />
 
-				{ chat.provider === 'odie' && chat.status === 'sending' && (
-					<div
-						className="odie-chatbox__action-message"
-						ref={ ( div ) => div?.scrollIntoView( { behavior: 'smooth', block: 'end' } ) }
-					>
-						<ThinkingPlaceholder />
-					</div>
-				) }
+				{ chat.provider === 'odie' && chat.status === 'sending' && <ThinkingPlaceholder /> }
 				{ chat.provider === 'odie' && chat.status === 'transfer' && (
-					<div
-						className="odie-chatbox__action-message"
-						ref={ ( div ) => div?.scrollIntoView( { behavior: 'smooth', block: 'end' } ) }
-					>
-						<div className="odie-chatbox__action-message-content" aria-live="polite">
-							<Spinner />
-							<span>{ __( 'Connecting to a live agent…', __i18n_text_domain__ ) }</span>
-						</div>
-					</div>
+					<ThinkingPlaceholder
+						content={ __( 'Connecting to a live agent…', __i18n_text_domain__ ) }
+					/>
 				) }
 				{ chat.provider.startsWith( 'zendesk' ) && (
 					<ZendeskTypingIndicator conversationId={ chat.conversationId } />

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -1,4 +1,5 @@
 import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import clx from 'classnames';
 import { useEffect, useRef, useState } from 'react';
 import { NavigationType, useNavigate, useNavigationType, useSearchParams } from 'react-router-dom';
@@ -149,6 +150,17 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 						ref={ ( div ) => div?.scrollIntoView( { behavior: 'smooth', block: 'end' } ) }
 					>
 						<ThinkingPlaceholder />
+					</div>
+				) }
+				{ chat.provider === 'odie' && chat.status === 'transfer' && (
+					<div
+						className="odie-chatbox__action-message"
+						ref={ ( div ) => div?.scrollIntoView( { behavior: 'smooth', block: 'end' } ) }
+					>
+						<div className="odie-chatbox__action-message-content" aria-live="polite">
+							<Spinner />
+							<span>{ __( 'Connecting to a live agent…', __i18n_text_domain__ ) }</span>
+						</div>
 					</div>
 				) }
 				{ chat.provider.startsWith( 'zendesk' ) && (

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -150,7 +150,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				{ chat.provider === 'odie' && chat.status === 'transfer' && (
 					<ThinkingPlaceholder
 						content={
-							__( 'Connecting to the support team', __i18n_text_domain__ ) +
+							__( 'Requesting human support', __i18n_text_domain__ ) +
 							( isTestMode ? '… (ZENDESK STAGING)' : '…' )
 						}
 					/>

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -1,3 +1,4 @@
+import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clx from 'classnames';
@@ -28,6 +29,7 @@ interface ChatMessagesProps {
 export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	const { chat, isChatLoaded, isUserEligibleForPaidSupport, forceEmailSupport } =
 		useOdieAssistantContext();
+	const isTestMode = isTestModeEnvironment();
 	const createZendeskConversation = useCreateZendeskConversation();
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const navigate = useNavigate();
@@ -147,7 +149,10 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				{ chat.provider === 'odie' && chat.status === 'sending' && <ThinkingPlaceholder /> }
 				{ chat.provider === 'odie' && chat.status === 'transfer' && (
 					<ThinkingPlaceholder
-						content={ __( 'Connecting to a live agent…', __i18n_text_domain__ ) }
+						content={
+							__( 'Connecting to a live agent…', __i18n_text_domain__ ) +
+							( isTestMode ? ' (ZENDESK STAGING)' : '' )
+						}
 					/>
 				) }
 				{ chat.provider.startsWith( 'zendesk' ) && (

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -150,8 +150,8 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				{ chat.provider === 'odie' && chat.status === 'transfer' && (
 					<ThinkingPlaceholder
 						content={
-							__( 'Connecting to the support team…', __i18n_text_domain__ ) +
-							( isTestMode ? ' (ZENDESK STAGING)' : '' )
+							__( 'Connecting to the support team', __i18n_text_domain__ ) +
+							( isTestMode ? '… (ZENDESK STAGING)' : '…' )
 						}
 					/>
 				) }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -150,7 +150,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 				{ chat.provider === 'odie' && chat.status === 'transfer' && (
 					<ThinkingPlaceholder
 						content={
-							__( 'Connecting to a live agent…', __i18n_text_domain__ ) +
+							__( 'Connecting to the support team…', __i18n_text_domain__ ) +
 							( isTestMode ? ' (ZENDESK STAGING)' : '' )
 						}
 					/>

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -54,6 +54,10 @@ $blueberry-color: #3858e9;
 			display: none;
 		}
 	}
+
+	.odie-chatbox-thinking-placeholder {
+		align-items: center;
+	}
 }
 
 .odie-chatbox-message {

--- a/packages/odie-client/src/components/message/thinking-placeholder.tsx
+++ b/packages/odie-client/src/components/message/thinking-placeholder.tsx
@@ -1,9 +1,14 @@
 import { ThinkingMessage } from '@automattic/agenttic-ui';
 
-export const ThinkingPlaceholder = () => {
+export const ThinkingPlaceholder = ( { content }: { content?: string } ) => {
 	return (
-		<div className="agenttic">
-			<ThinkingMessage />
+		<div
+			className="odie-chatbox__action-message"
+			ref={ ( div ) => div?.scrollIntoView( { behavior: 'smooth', block: 'end' } ) }
+		>
+			<div className="odie-chatbox-thinking-placeholder agenttic">
+				<ThinkingMessage content={ content } />
+			</div>
 		</div>
 	);
 };

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -87,25 +87,31 @@ export const UserMessage = ( {
 	const showGetSupport = isLastBotMessage && ( isRequestingHumanSupport || isErrorMessage );
 	const showActionButtons = ! isRequestingHumanSupport && ! isErrorMessage;
 
-	const shouldOverrideWithForwardMessage = isRequestingHumanSupport && chat.provider !== 'zendesk';
+	const messageContent = () => {
+		if ( ! isRequestingHumanSupport ) {
+			return message.content;
+		}
 
-	const messageContent = shouldOverrideWithForwardMessage
-		? getDisplayMessage(
-				!! hasRecentOpenConversation,
-				isUserEligibleForPaidSupport,
-				canConnectToZendesk,
-				forceEmailSupport,
-				isChatRestricted,
-				message?.context?.flags?.is_error_message,
-				isChatLoaded
-		  )
-		: message.content;
+		if ( chat.provider === 'zendesk' ) {
+			return '';
+		}
+
+		return getDisplayMessage(
+			!! hasRecentOpenConversation,
+			isUserEligibleForPaidSupport,
+			canConnectToZendesk,
+			forceEmailSupport,
+			isChatRestricted,
+			message?.context?.flags?.is_error_message,
+			isChatLoaded
+		);
+	};
 
 	return (
 		<>
 			<div className="odie-chatbox-message__content">
 				<MarkdownOrChildren
-					messageContent={ messageContent }
+					messageContent={ messageContent() }
 					components={ {
 						a: ( props: React.ComponentProps< 'a' > ) => (
 							<CustomALink { ...props } target="_blank" />

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,3 +1,4 @@
+import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { __, sprintf } from '@wordpress/i18n';
 import type { Context, Message, OdieAllowedBots, OdieAllBotSlugs } from './types';
 declare const __i18n_text_domain__: string;
@@ -53,6 +54,104 @@ export function getFlowFromBotSlug( botSlug?: OdieAllBotSlugs ): string {
 	return 'wpcom';
 }
 
+export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] => {
+	const isTestMode = isTestModeEnvironment();
+	const flow = getFlowFromBotSlug( botSlug );
+
+	// Commerce garden has a simplified, single-message flow
+	if ( flow === 'commerce-garden' ) {
+		return [
+			{
+				content:
+					( isTestMode ? '(STAGING VERSION OF ZENDESK) ' : '' ) +
+					__(
+						"Yes, of course! A Happiness Engineer is jumping in to help you now. They can see your chat with our assistant, so feel free to share any extra details; we'll take it from there.",
+						__i18n_text_domain__
+					),
+				role: 'bot' as const,
+				type: 'message' as const,
+				context: {
+					flags: {
+						hide_disclaimer_content: true,
+						show_ai_avatar: false,
+					},
+					site_id: null,
+				},
+			},
+		];
+	}
+
+	const baseMessage = {
+		content:
+			__( 'No problem. Help is on the way!', __i18n_text_domain__ ) +
+			( isTestMode ? ' (staging)' : '' ),
+		role: 'bot' as const,
+		type: 'message' as const,
+		context: {
+			flags: {
+				hide_disclaimer_content: true,
+				show_ai_avatar: false,
+			},
+			site_id: null,
+		},
+	};
+
+	if ( isTestMode ) {
+		return [
+			baseMessage,
+			{
+				content: __(
+					'This is the Sandbox version of Zendesk. You will not be redirected to a support agent. If you want to test the real experience and be connected to a support agent, you need to be unproxied.',
+					__i18n_text_domain__
+				),
+				role: 'bot' as const,
+				type: 'message' as const,
+				context: {
+					flags: {
+						hide_disclaimer_content: true,
+						show_ai_avatar: false,
+					},
+					site_id: null,
+				},
+			},
+		];
+	}
+
+	return [
+		baseMessage,
+		{
+			content: __(
+				"We're connecting you with our support team. A Happiness Engineer will join the chat as soon as they're available.",
+				__i18n_text_domain__
+			),
+			role: 'bot' as const,
+			type: 'message' as const,
+			context: {
+				flags: {
+					hide_disclaimer_content: true,
+					show_ai_avatar: false,
+				},
+				site_id: null,
+			},
+		},
+		{
+			content: __(
+				'They can see your chat with our AI assistant but please share any extra details while you wait so we can assist you better.',
+				__i18n_text_domain__
+			),
+			role: 'bot' as const,
+			type: 'message' as const,
+			context: {
+				flags: {
+					hide_disclaimer_content: true,
+					show_ai_avatar: false,
+				},
+				site_id: null,
+			},
+		},
+	];
+};
+
 export const getOdieThirdPartyMessageContent = (): string =>
 	`${ __(
 		'I’m happy to connect you to a human! However, it looks like 3rd party cookies are disabled in your browser. Please turn them on for our live chat to work properly. [Use our guide](https://wordpress.com/support/third-party-cookies/)',
@@ -83,7 +182,6 @@ export const getOdieEmailFallbackMessage = (): Message => ( {
 	type: 'message',
 	context: {
 		flags: {
-			show_contact_support_msg: false,
 			forward_to_human_support: true,
 		},
 		question_tags: {
@@ -219,7 +317,6 @@ export const getZendeskChatStartedMetaMessage = (): Message => ( {
 		site_id: null,
 		flags: {
 			hide_disclaimer_content: true,
-			show_contact_support_msg: true,
 			show_ai_avatar: false,
 		},
 	},

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,4 +1,3 @@
-import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { __, sprintf } from '@wordpress/i18n';
 import type { Context, Message, OdieAllowedBots, OdieAllBotSlugs } from './types';
 declare const __i18n_text_domain__: string;
@@ -53,125 +52,6 @@ export function getFlowFromBotSlug( botSlug?: OdieAllBotSlugs ): string {
 	}
 	return 'wpcom';
 }
-
-export const getOdieTransferMessage = ( botSlug?: OdieAllBotSlugs ): Message[] => {
-	const isTestMode = isTestModeEnvironment();
-	const flow = getFlowFromBotSlug( botSlug );
-
-	// Commerce garden has a simplified, single-message flow
-	if ( flow === 'commerce-garden' ) {
-		return [
-			{
-				content:
-					( isTestMode ? '(STAGING VERSION OF ZENDESK) ' : '' ) +
-					__(
-						"Yes, of course! A Happiness Engineer is jumping in to help you now. They can see your chat with our assistant, so feel free to share any extra details; we'll take it from there.",
-						__i18n_text_domain__
-					),
-				role: 'bot' as const,
-				type: 'message' as const,
-				context: {
-					flags: {
-						hide_disclaimer_content: true,
-						show_contact_support_msg: true,
-						show_ai_avatar: false,
-					},
-					site_id: null,
-				},
-			},
-		];
-	}
-
-	const baseMessage = {
-		content:
-			__( 'No problem. Help is on the way!', __i18n_text_domain__ ) +
-			( isTestMode ? ' (staging)' : '' ),
-		role: 'bot' as const,
-		type: 'message' as const,
-		context: {
-			flags: {
-				hide_disclaimer_content: true,
-				show_contact_support_msg: false,
-				show_ai_avatar: false,
-			},
-			site_id: null,
-		},
-	};
-
-	if ( isTestMode ) {
-		return [
-			baseMessage,
-			{
-				content: __(
-					'This is the Sandbox version of Zendesk. You will not be redirected to a support agent. If you want to test the real experience and be connected to a support agent, you need to be unproxied.',
-					__i18n_text_domain__
-				),
-				role: 'bot' as const,
-				type: 'message' as const,
-				context: {
-					flags: {
-						hide_disclaimer_content: true,
-						show_contact_support_msg: true,
-						show_ai_avatar: false,
-					},
-					site_id: null,
-				},
-			},
-		];
-	}
-
-	return [
-		baseMessage,
-		{
-			content: __(
-				"We're connecting you with our support team. A Happiness Engineer will join the chat as soon as they're available.",
-				__i18n_text_domain__
-			),
-			role: 'bot' as const,
-			type: 'message' as const,
-			context: {
-				flags: {
-					hide_disclaimer_content: true,
-					show_contact_support_msg: true,
-					show_ai_avatar: false,
-				},
-				site_id: null,
-			},
-		},
-		{
-			content: __(
-				'They can see your chat with our AI assistant but please share any extra details while you wait so we can assist you better.',
-				__i18n_text_domain__
-			),
-			role: 'bot' as const,
-			type: 'message' as const,
-			context: {
-				flags: {
-					hide_disclaimer_content: true,
-					show_contact_support_msg: true,
-					show_ai_avatar: false,
-				},
-				site_id: null,
-			},
-		},
-	];
-};
-
-export const getOdieOnErrorTransferMessage = (): Message[] => [
-	{
-		content: getOdieErrorMessage(),
-		role: 'bot',
-		type: 'message',
-		context: {
-			flags: {
-				hide_disclaimer_content: true,
-				show_contact_support_msg: false,
-				show_ai_avatar: true,
-			},
-			site_id: null,
-		},
-	},
-];
 
 export const getOdieThirdPartyMessageContent = (): string =>
 	`${ __(
@@ -329,6 +209,21 @@ export const getOdieZendeskConnectionErrorMessage = (): Message => {
 		},
 	};
 };
+
+export const getZendeskChatStartedMetaMessage = (): Message => ( {
+	content: null,
+	role: 'bot',
+	type: 'meta',
+	internal_message_id: 'zendesk-chat-started',
+	context: {
+		site_id: null,
+		flags: {
+			hide_disclaimer_content: true,
+			show_contact_support_msg: true,
+			show_ai_avatar: false,
+		},
+	},
+} );
 
 export const ODIE_THUMBS_DOWN_RATING_VALUE = 0;
 export const ODIE_THUMBS_UP_RATING_VALUE = 1;

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -48,7 +48,6 @@ const getErrorMessageForSiteIdAndInternalMessageId = (
 			flags: {
 				forward_to_human_support: true,
 				hide_disclaimer_content: false,
-				show_contact_support_msg: true,
 				show_ai_avatar: true,
 				is_error_message: true,
 			},

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -77,10 +77,9 @@ export const useCreateZendeskConversation = () => {
 				active_interaction_id: activeInteractionId || null,
 				is_chat_loaded: isChatLoaded,
 			} );
-			const errorMessageObj = getErrorTryAgainLaterMessage();
 
 			setChat( {
-				messages: [ ...previousMessages, errorMessageObj ],
+				messages: [ ...previousMessages, getErrorTryAgainLaterMessage() ],
 				status: 'loaded',
 				provider: previousProvider,
 				conversationId: previousConversationId,

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -1,11 +1,10 @@
 import { useUpdateZendeskUserFields, type ZendeskConversation } from '@automattic/zendesk-client';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Smooch from 'smooch';
-import { getErrorTryAgainLaterMessage } from '../constants';
+import { getErrorTryAgainLaterMessage, getZendeskChatStartedMetaMessage } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
-import type { Message } from '../types';
 
 export const useCreateZendeskConversation = () => {
 	const {
@@ -172,23 +171,7 @@ export const useCreateZendeskConversation = () => {
 			// We need to load the conversation to get typing events. Load simply means "focus on"..
 			Smooch.loadConversation( conversationId );
 
-			const transitionToSupportMessage: Message = {
-				content: null,
-				role: 'bot',
-				type: 'meta',
-				internal_message_id: 'zendesk-chat-started',
-				context: {
-					site_id: selectedSiteId ?? null,
-					flags: {
-						hide_disclaimer_content: true,
-						show_contact_support_msg: true,
-						show_ai_avatar: false,
-					},
-				},
-				metadata: {
-					local_timestamp: Date.now(),
-				},
-			};
+			const transitionToSupportMessage = getZendeskChatStartedMetaMessage();
 
 			setChat( ( prevChat ) => ( {
 				...prevChat,

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -1,15 +1,11 @@
 import { useUpdateZendeskUserFields, type ZendeskConversation } from '@automattic/zendesk-client';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Smooch from 'smooch';
-import {
-	getOdieOnErrorTransferMessage,
-	getOdieTransferMessage,
-	getErrorTryAgainLaterMessage,
-} from '../constants';
+import { getErrorTryAgainLaterMessage } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
-import type { OdieAllBotSlugs } from '../types';
+import type { Message } from '../types';
 
 export const useCreateZendeskConversation = () => {
 	const {
@@ -94,14 +90,8 @@ export const useCreateZendeskConversation = () => {
 			} );
 		};
 
-		// Get transfer messages to identify and remove them on error
-		const transferMessages = isFromError
-			? getOdieOnErrorTransferMessage()
-			: getOdieTransferMessage( currentSupportInteraction?.bot_slug as OdieAllBotSlugs );
-
 		setChat( ( prevChat ) => ( {
 			...prevChat,
-			messages: [ ...prevChat.messages, ...transferMessages ],
 			status: 'transfer',
 		} ) );
 
@@ -183,9 +173,32 @@ export const useCreateZendeskConversation = () => {
 			// We need to load the conversation to get typing events. Load simply means "focus on"..
 			Smooch.loadConversation( conversationId );
 
+			const transitionToSupportMessage: Message = {
+				content: null,
+				role: 'bot',
+				type: 'meta',
+				internal_message_id: 'zendesk-chat-started',
+				context: {
+					site_id: selectedSiteId ?? null,
+					flags: {
+						hide_disclaimer_content: true,
+						show_contact_support_msg: true,
+						show_ai_avatar: false,
+					},
+				},
+				metadata: {
+					local_timestamp: Date.now(),
+				},
+			};
+
 			setChat( ( prevChat ) => ( {
 				...prevChat,
 				conversationId: conversationId,
+				messages: prevChat.messages.some(
+					( message ) => !! message?.context?.flags?.show_contact_support_msg
+				)
+					? prevChat.messages
+					: [ ...prevChat.messages, transitionToSupportMessage ],
 				provider: 'zendesk',
 				status: 'loaded',
 			} ) );

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -1,7 +1,11 @@
 import { useUpdateZendeskUserFields, type ZendeskConversation } from '@automattic/zendesk-client';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Smooch from 'smooch';
-import { getErrorTryAgainLaterMessage, getZendeskChatStartedMetaMessage } from '../constants';
+import {
+	getErrorTryAgainLaterMessage,
+	getOdieTransferMessages,
+	getZendeskChatStartedMetaMessage,
+} from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
@@ -171,16 +175,14 @@ export const useCreateZendeskConversation = () => {
 			// We need to load the conversation to get typing events. Load simply means "focus on"..
 			Smooch.loadConversation( conversationId );
 
-			const transitionToSupportMessage = getZendeskChatStartedMetaMessage();
-
 			setChat( ( prevChat ) => ( {
 				...prevChat,
 				conversationId: conversationId,
-				messages: prevChat.messages.some(
-					( message ) => !! message?.context?.flags?.show_contact_support_msg
-				)
-					? prevChat.messages
-					: [ ...prevChat.messages, transitionToSupportMessage ],
+				messages: [
+					...prevChat.messages,
+					...getOdieTransferMessages( currentSupportInteraction?.bot_slug ),
+					getZendeskChatStartedMetaMessage(),
+				],
 				provider: 'zendesk',
 				status: 'loaded',
 			} ) );

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -5,7 +5,6 @@ import { useIsMutating } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { getMessageUniqueIdentifier } from '../components/message/utils/get-message-unique-identifier';
-import { getOdieTransferMessage } from '../constants';
 import { emptyChat } from '../context';
 import { useGetZendeskConversation, useManageSupportInteraction, useOdieChat } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
@@ -14,7 +13,7 @@ import {
 	getOdieIdFromInteraction,
 	getIsRequestingHumanSupport,
 } from '../utils';
-import type { Chat, Message, OdieAllBotSlugs } from '../types';
+import type { Chat, Message } from '../types';
 
 function isEqual( message1: Message, message2: Message ) {
 	const message1Id = getMessageUniqueIdentifier( message1 );
@@ -142,9 +141,6 @@ export const useGetCombinedChat = (
 								conversationId: conversation.id,
 								messages: [
 									...( odieChat ? filteredOdieMessages : [] ),
-									...getOdieTransferMessage(
-										currentSupportInteraction?.bot_slug as OdieAllBotSlugs
-									),
 									...( deduplicateZDMessages( [
 										// During connection recovery, the user queued messages can be deleted. This ensure they remain. And `deduplicateZDMessages` takes of duplication.
 										...( isSameConversation

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -5,7 +5,7 @@ import { useIsMutating } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { getMessageUniqueIdentifier } from '../components/message/utils/get-message-unique-identifier';
-import { getZendeskChatStartedMetaMessage } from '../constants';
+import { getOdieTransferMessages, getZendeskChatStartedMetaMessage } from '../constants';
 import { emptyChat } from '../context';
 import { useGetZendeskConversation, useManageSupportInteraction, useOdieChat } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
@@ -142,6 +142,7 @@ export const useGetCombinedChat = (
 								conversationId: conversation.id,
 								messages: [
 									...( odieChat ? filteredOdieMessages : [] ),
+									...getOdieTransferMessages( currentSupportInteraction?.bot_slug ),
 									getZendeskChatStartedMetaMessage(),
 									...( deduplicateZDMessages( [
 										// During connection recovery, the user queued messages can be deleted. This ensure they remain. And `deduplicateZDMessages` takes of duplication.

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -5,6 +5,7 @@ import { useIsMutating } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { getMessageUniqueIdentifier } from '../components/message/utils/get-message-unique-identifier';
+import { getZendeskChatStartedMetaMessage } from '../constants';
 import { emptyChat } from '../context';
 import { useGetZendeskConversation, useManageSupportInteraction, useOdieChat } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
@@ -141,6 +142,7 @@ export const useGetCombinedChat = (
 								conversationId: conversation.id,
 								messages: [
 									...( odieChat ? filteredOdieMessages : [] ),
+									getZendeskChatStartedMetaMessage(),
 									...( deduplicateZDMessages( [
 										// During connection recovery, the user queued messages can be deleted. This ensure they remain. And `deduplicateZDMessages` takes of duplication.
 										...( isSameConversation

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -114,7 +114,6 @@ export type Context = {
 		failed_zendesk_connection?: boolean;
 		forward_to_human_support?: boolean;
 		hide_disclaimer_content?: boolean;
-		show_contact_support_msg?: boolean;
 		show_ai_avatar?: boolean;
 		is_error_message?: boolean;
 	};

--- a/packages/odie-client/src/utils/csat.ts
+++ b/packages/odie-client/src/utils/csat.ts
@@ -12,8 +12,8 @@ export const isAttachment = ( message: Message ) =>
 export const isZendeskIntroMessage = ( message: Message | ZendeskMessage ) =>
 	'source' in message && message.source?.type === 'zd:answerBot';
 
-export const isTransitionToSupportMessage = ( message: Message ) =>
-	!! message?.context?.flags?.show_contact_support_msg;
+export const isZendeskChatStartedMessage = ( message: Message ) =>
+	message?.internal_message_id === 'zendesk-chat-started';
 
 export const hasCSATMessage = ( chat: Chat ) => {
 	return chat?.messages.some( isCSATMessage );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-15539/add-loader-odie-thinking-when-creating-conversation

## Proposed Changes

- Do not add the transfer messages right away. They would be changed if an error occurs.
<img width="420" height="171" alt="image" src="https://github.com/user-attachments/assets/0ea88aea-f140-47a7-9782-99b61b4aca21" />

- Add a "Thinking" message where we say that we're transferring to live chat.
- Add the transfer messages only if the escalation succeeds.

https://github.com/user-attachments/assets/110baef9-7e28-456c-ab8e-6d9950c284a8

**NEXT**:  https://linear.app/a8c/issue/DOTSUP-381/improve-odie-human-handoff

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this locally
* Ask to talk with a human
* Ask to talk with a human when you already have an open conversation
