### PR TITLE
Newsletter importer: Show subscriber import failed message and start over button

### DIFF
--- a/client/my-sites/importer/newsletter/subscribers/step-done.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-done.tsx
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { Notice } from '@wordpress/components';
-import { useCallback } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useResetMutation } from 'calypso/data/paid-newsletter/use-reset-mutation';
@@ -30,45 +29,46 @@ export default function StepDone( {
 	const metaStatus = cardData?.meta?.status;
 	const isFailed = metaStatus === 'failed';
 
-	const handleStartOver = useCallback( () => {
+	const handleStartOver = () => {
 		if ( selectedSite?.ID ) {
 			resetPaidNewsletter( selectedSite.ID, engine, 'content' );
 		}
-	}, [ selectedSite?.ID, engine, resetPaidNewsletter ] );
+	};
 
 	return (
 		<Card>
 			<h2>{ __( 'Import your subscribers' ) }</h2>
 			{ isFailed ? (
-				<Notice status="warning" className="importer__notice" isDismissible={ false }>
-					{ __( 'The subscriber import failed. Please try again.' ) }
-				</Notice>
+				<>
+					<Notice status="warning" className="importer__notice" isDismissible={ false }>
+						{ __( 'The subscriber import failed. Please try again.' ) }
+					</Notice>
+					<ImporterActionButtonContainer noSpacing>
+						<ImporterActionButton
+							onClick={ handleStartOver }
+							primary
+							disabled={ isPending }
+							busy={ isPending }
+						>
+							{ __( 'Start over' ) }
+						</ImporterActionButton>
+					</ImporterActionButtonContainer>
+				</>
 			) : (
-				<Notice status="success" className="importer__notice" isDismissible={ false }>
-					{ sprintf(
-						// Translators: %d is number of subscribers.
-						_n(
-							'Success! %d subscriber has been added!',
-							'Success! %d subscribers have been added!',
+				<>
+					<Notice status="success" className="importer__notice" isDismissible={ false }>
+						{ sprintf(
+							// Translators: %d is number of subscribers.
+							_n(
+								'Success! %d subscriber has been added!',
+								'Success! %d subscribers have been added!',
+								subscribedCount
+							),
 							subscribedCount
-						),
-						subscribedCount
-					) }
-				</Notice>
-			) }
-			{ isFailed ? (
-				<ImporterActionButtonContainer noSpacing>
-					<ImporterActionButton
-						onClick={ handleStartOver }
-						primary
-						disabled={ isPending }
-						busy={ isPending }
-					>
-						{ __( 'Start over' ) }
-					</ImporterActionButton>
-				</ImporterActionButtonContainer>
-			) : (
-				actionButton
+						) }
+					</Notice>
+					{ actionButton }
+				</>
 			) }
 		</Card>
 	);

--- a/client/my-sites/importer/newsletter/subscribers/step-done.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-done.tsx
@@ -1,32 +1,75 @@
+import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { Notice } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { useResetMutation } from 'calypso/data/paid-newsletter/use-reset-mutation';
+import ImporterActionButton from '../../importer-action-buttons/action-button';
+import ImporterActionButtonContainer from '../../importer-action-buttons/container';
 import { SubscribersStepProps } from '../types';
 
 interface StepDoneProps extends SubscribersStepProps {
 	actionButton?: React.ReactNode;
 }
 
-export default function StepDone( { cardData, actionButton }: StepDoneProps ) {
+export default function StepDone( {
+	cardData,
+	selectedSite,
+	engine,
+	siteSlug,
+	actionButton,
+}: StepDoneProps ) {
 	const { __, _n } = useI18n();
+	const { resetPaidNewsletter, isPending } = useResetMutation( {
+		onSuccess: () => {
+			page.redirect( `/import/newsletter/${ engine }/${ siteSlug }/content` );
+		},
+	} );
 	const subscribedCount = parseInt( cardData?.meta?.email_count || '0' );
+	const metaStatus = cardData?.meta?.status;
+	const isFailed = metaStatus === 'failed';
+
+	const handleStartOver = useCallback( () => {
+		if ( selectedSite?.ID ) {
+			resetPaidNewsletter( selectedSite.ID, engine, 'content' );
+		}
+	}, [ selectedSite?.ID, engine, resetPaidNewsletter ] );
 
 	return (
 		<Card>
 			<h2>{ __( 'Import your subscribers' ) }</h2>
-			<Notice status="success" className="importer__notice" isDismissible={ false }>
-				{ sprintf(
-					// Translators: %d is number of subscribers.
-					_n(
-						'Success! %d subscriber has been added!',
-						'Success! %d subscribers have been added!',
+			{ isFailed ? (
+				<Notice status="warning" className="importer__notice" isDismissible={ false }>
+					{ __( 'The subscriber import failed. Please try again.' ) }
+				</Notice>
+			) : (
+				<Notice status="success" className="importer__notice" isDismissible={ false }>
+					{ sprintf(
+						// Translators: %d is number of subscribers.
+						_n(
+							'Success! %d subscriber has been added!',
+							'Success! %d subscribers have been added!',
+							subscribedCount
+						),
 						subscribedCount
-					),
-					subscribedCount
-				) }
-			</Notice>
-			{ actionButton }
+					) }
+				</Notice>
+			) }
+			{ isFailed ? (
+				<ImporterActionButtonContainer noSpacing>
+					<ImporterActionButton
+						onClick={ handleStartOver }
+						primary
+						disabled={ isPending }
+						busy={ isPending }
+					>
+						{ __( 'Start over' ) }
+					</ImporterActionButton>
+				</ImporterActionButtonContainer>
+			) : (
+				actionButton
+			) }
 		</Card>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/NL-326/substack-importer-fix-done-but-failed-subscriber-import

## Proposed Changes

* Show failed message and Start over button when subscriber import meta has a failed status. Currently it incorrectly shows a success message.

Before / Success | After / Failed
---- | ----
<img width="981" height="455" alt="Screenshot 2025-12-24 at 1 45 30 PM" src="https://github.com/user-attachments/assets/41fccb72-bcb1-4642-927b-240ad5e22322" /> | <img width="902" height="461" alt="Screenshot 2025-12-24 at 1 45 15 PM" src="https://github.com/user-attachments/assets/4b39aa84-db97-4b65-a841-3e4032ebdec9" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently the user can get stuck on this subscriber import success message with no way to start over.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With this change applied, import subscribers from Substack to a new site (on /import/newsletter/substack/).
* You should see a success message. To see the failure message, open React dev tools and manually change the `cardData` meta status to "failed" like this in the `stepDone` component:

<img width="1920" height="742" alt="Screenshot 2025-12-24 at 2 22 08 PM" src="https://github.com/user-attachments/assets/a5750e7a-354e-4b7c-9d00-45b367b4f71a" />

* Click Start Over.
* Check that you are redirected to the content step.
* Skip or complete the content step, then check that you can complete the subscribers step.
* You should see the success message again.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
