### PR TITLE
Profile menu: Fix overflow styles

### DIFF
--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -299,8 +299,12 @@ function UserProfile() {
 			/>
 			<Menu.Popover style={ { minWidth: '250px' } }>
 				<VStack style={ { gridColumn: '1 / -1', padding: '8px 12px' } } spacing={ 1 }>
-					<Text>{ user.display_name }</Text>
-					<Text variant="muted">@{ user.username }</Text>
+					<Text truncate numberOfLines={ 1 } title={ user.display_name }>
+						{ user.display_name }
+					</Text>
+					<Text truncate numberOfLines={ 1 } title={ user.username } variant="muted">
+						@{ user.username }
+					</Text>
 				</VStack>
 				<Menu.Separator />
 				<Menu.Group>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -655,8 +655,12 @@ class MasterbarLoggedIn extends Component {
 							size={ 64 }
 						/>
 						<div className="masterbar__item-howdy-account-details">
-							<span className="display-name">{ user.display_name }</span>
-							<span className="username">{ user.username }</span>
+							<span className="display-name" title={ user.display_name }>
+								{ user.display_name }
+							</span>
+							<span className="username" title={ user.username }>
+								{ user.username }
+							</span>
 							<span className="display-name edit-profile">
 								{ isGlobalSidebarVisible ? translate( 'My Profile' ) : translate( 'Edit Profile' ) }
 							</span>

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -821,15 +821,20 @@ body.is-mobile-app-view {
 
 			.masterbar__item-howdy-account-details {
 				flex-basis: auto;
-				flex-grow: 0;
-				flex-shrink: 0;
-				max-width: 50%;
+				flex-grow: 1;
 				display: flex;
 				flex-direction: column;
 				align-items: flex-start;
 				padding: 3px 5px;
 				margin: 0;
 				line-height: 18px;
+				overflow: hidden;
+
+				.display-name, .username {
+					width: 100%;
+					 overflow: hidden;
+					 text-overflow: ellipsis;
+				}
 
 				.username {
 					font-size: 11px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTSITE-58

## Proposed Changes

* Fix overflow styles on profile menu

| Before | After |
| - | - |
|<img width="435" height="214" alt="image" src="https://github.com/user-attachments/assets/c32439aa-1cb6-4be8-b232-2a30a32faf93" />|<img width="439" height="217" alt="image" src="https://github.com/user-attachments/assets/8099d1e4-3508-44aa-be51-f8bdd3800860" />|
|<img width="358" height="131" alt="image" src="https://github.com/user-attachments/assets/eaaac754-c4b0-44b0-81a9-f674759dd286" />|<img width="362" height="131" alt="image" src="https://github.com/user-attachments/assets/407fd977-902c-4db1-8116-202441a8145d" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me
* Update your display name
* Ensure the profile menu on the masterbar looks good
* Hover on the profile menu
* Ensure the content looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
