### PR TITLE
MSD: Fix incorrect unsaved changes popup that shows when reloading the page after changes are saved

### DIFF
--- a/client/dashboard/me/preferences-language/index.tsx
+++ b/client/dashboard/me/preferences-language/index.tsx
@@ -2,6 +2,7 @@ import { userSettingsMutation, userSettingsQuery } from '@automattic/api-queries
 import config from '@automattic/calypso-config';
 import { getLanguage, isDefaultLocale, isTranslatedIncompletely } from '@automattic/i18n-utils';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import {
 	Notice,
 	Button,
@@ -36,6 +37,7 @@ export default function PreferencesLanguageForm() {
 	} );
 	const [ formData, setFormData ] = useState< Partial< UserSettings > | undefined >();
 	const mutation = useMutation( userSettingsMutation() );
+	const router = useRouter();
 
 	/**
 	 * When we save the language, in case we're using a locale_variant (a language without an official locale)
@@ -67,6 +69,7 @@ export default function PreferencesLanguageForm() {
 		const mutationData = formData;
 		mutation.mutate( mutationData, {
 			onSuccess: () => {
+				router.history.destroy(); // Ignore any navigation blocker
 				reloadWithFlashMessage( 'language' );
 			},
 			onError: ( error ) => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-977

## Proposed Changes

* `NavigationBlockerRegistry` uses the `useBlocker` hook to block navigation when any blocker is active. However, when unsaved changes are saved and the page needs to be reloaded immediately, the `shouldBlock` value can still be true. This happens because the `isDirty` value registered by `NavigationBlocker` may not have been updated yet. As a result, the confirmation popup is shown when the `beforeunload` event is fired, even though there are no longer unsaved changes.
* This PR proposes a quick fix to destroy the current history before reload.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's confusing as the popup shows after the user saves the changes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /me/preferences
2. Change your languages
3. Save
4. Ensure you won't see the confirmation popup

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
