### PR TITLE
[Draft] Update Simple → Atomic modal

### DIFF
--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -83,6 +83,7 @@
 			margin: unset;
 			border-top: 1px solid var(--studio-gray-5);
 		}
+
 		.eligibility-warnings__message:last-of-type {
 			padding-bottom: 0;
 		}
@@ -118,7 +119,7 @@
 	font-weight: 400;
 }
 
-.eligibility-warnings__primary-text {	
+.eligibility-warnings__primary-text {
 	font-size: 1rem;
 	margin-top: 16px;
 }
@@ -137,6 +138,7 @@
 		color: var(--color-neutral-0);
 		background-color: var(--color-neutral-0);
 	}
+
 	.eligibility-warnings__message {
 		height: 24px;
 	}
@@ -154,6 +156,7 @@
 
 .eligibility-warnings .banner {
 	margin-bottom: 16px;
+
 	.banner__icon-circle {
 		line-height: 32px;
 		padding: 4px;
@@ -173,11 +176,11 @@
 }
 
 .eligibility-warnings__hold .gridicon {
-	color: var(--color-neutral-10);
+	color: currentColor;
 }
 
 .eligibility-warnings__warning .gridicon {
-	color: var(--color-warning-10);
+	color: currentColor;
 }
 
 .eligibility-warnings__message {
@@ -185,6 +188,7 @@
 	line-height: 24px;
 	padding: 0;
 	margin-bottom: 10px;
+	font-size: 13px;
 }
 
 .eligibility-warnings__inline-link {
@@ -194,9 +198,11 @@
 .eligibility-warnings__action a,
 .eligibility-warnings__hold-action a {
 	text-wrap: nowrap;
+
 	.gridicons-help-outline {
 		color: var(--color-neutral-light);
 	}
+
 	&:hover .gridicons-help-outline {
 		color: var(--color-primary);
 	}
@@ -210,9 +216,10 @@
 	align-items: center;
 	display: flex;
 
-	.gridicon {		
+	.gridicon {
 		flex-shrink: 0;
 	}
+
 	span {
 		display: block;
 		flex-grow: 1;


### PR DESCRIPTION
# Currently WIP 🚧

## Proposed changes

Fixes some visual issues in the current modal:
- [x]  (?) icon is yellow, should be Blueberry
- [ ] `Learn more` and `Need help?` have a different colour and only one is underlined
- [ ] Paragraph font-size and line-height isn't consistent with Dotcom/Core.

<img width="804" height="506" alt="Screenshot 2025-12-24 at 16 56 58" src="https://github.com/user-attachments/assets/5b065880-506b-4558-a6c6-dc0533778ba3" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Product quality

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site and add a plugin to transform it into an Atomic site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
