### PR TITLE
i18n: Fix typo in transfer completed label

### DIFF
--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -200,7 +200,7 @@ export const useFields = ( {
 					{ value: DomainStatus.PENDING_REGISTRATION, label: __( 'Pending registration' ) },
 					{ value: DomainStatus.PENDING_TRANSFER, label: __( 'Outgoing transfer pending' ) },
 					{ value: DomainStatus.IN_PROGRESS, label: __( 'Incoming transfer in progress' ) },
-					{ value: DomainStatus.TRANSFER_COMPLETED, label: __( 'Incoming trnasfer completed' ) },
+					{ value: DomainStatus.TRANSFER_COMPLETED, label: __( 'Incoming transfer completed' ) },
 					{ value: DomainStatus.TRANSFER_ERROR, label: __( 'Incoming transfer failed' ) },
 					{ value: DomainStatus.TRANSFER_PENDING, label: __( 'Incoming transfer pending' ) },
 					{ value: DomainStatus.CONNECTION_ERROR, label: __( 'Connection error' ) },


### PR DESCRIPTION
Update "trnasfer" to "transfer"

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* The translators reported a typo here in #18n-reviewers on Slack.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the code that I spelled "transfer" correctly :) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
