### PR TITLE
MSD: Don't redirect to login on reauth errors.

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -90,7 +90,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 	// out, redirect the user to the log in screen.
 	useEffect( () => {
 		const isAuthError = ( { statusCode, error = '' }: WPError ) => {
-			if ( [ 'reauthorization_required', 'authorization_required' ].includes( error ) ) {
+			if ( [ 'authorization_required' ].includes( error ) ) {
 				return true;
 			}
 


### PR DESCRIPTION
Part of #107870

## Proposed Changes

This PR removes `reauthorization_required` added in #107870 which redirects users to the log-in page when their session has expired.


## Why are these changes being made?

I was able to trigger an infinite redirect when my token expired and I was trying to visit my preferences. 

I can have a valid user session and an expired 2fa token. So we can't assume that `reauthorization_required` means a new login. The login page doesn't handle the 2fa re-auth, that is handled by `me/reauth-required`.

See this thread: p1766959813518229-slack-CRWCHQGUB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?