### PR TITLE
MSD: Stop retrying on DashboardDataError problem.

### DIFF
--- a/client/dashboard/sites/site/error.tsx
+++ b/client/dashboard/sites/site/error.tsx
@@ -1,4 +1,4 @@
-import { DashboardDataError } from '@automattic/api-core';
+import { DashboardDataError, INACCESSIBLE_JETPACK_ERROR_CODE } from '@automattic/api-core';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import UnknownError from '../../app/500';
@@ -10,7 +10,7 @@ import RouterLinkButton from '../../components/router-link-button';
 
 export default function Error( { error }: { error: Error } ) {
 	switch ( error instanceof DashboardDataError && error.code ) {
-		case 'inaccessible_jetpack':
+		case INACCESSIBLE_JETPACK_ERROR_CODE:
 			return <InaccessibleJetpackError error={ error } />;
 		default:
 			return <UnknownError error={ error } />;

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -2,6 +2,8 @@ import { isWpError, DashboardDataError } from '../error';
 import { wpcom } from '../wpcom-fetcher';
 import type { Site } from './types';
 
+export const INACCESSIBLE_JETPACK_ERROR_CODE = 'inaccessible_jetpack' as const;
+
 export const SITE_FIELDS = [
 	'ID',
 	'slug',
@@ -70,7 +72,7 @@ export async function fetchSite( siteIdOrSlug: number | string ): Promise< Site 
 		);
 	} catch ( error ) {
 		if ( isWpError( error ) && error.message.startsWith( 'The Jetpack site is inaccessible' ) ) {
-			throw new DashboardDataError( 'inaccessible_jetpack', error );
+			throw new DashboardDataError( INACCESSIBLE_JETPACK_ERROR_CODE, error );
 		}
 		throw error;
 	}

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -1,5 +1,6 @@
 import {
 	isWpError,
+	DashboardDataError,
 	fetchSite,
 	deleteSite,
 	launchSite,
@@ -44,6 +45,10 @@ export function siteBySlugQuery( siteSlug: string ) {
 			}
 		},
 		retry: ( failureCount, e: { data?: string } ) => {
+			if ( e instanceof DashboardDataError && e.code === 'inaccessible_jetpack' ) {
+				return false;
+			}
+
 			if ( e.data && KNOWN_ERRORS.includes( e.data ) ) {
 				return false;
 			}
@@ -87,6 +92,10 @@ export function siteByIdQuery( siteId: number ) {
 			}
 		},
 		retry: ( failureCount, e: { data?: string } ) => {
+			if ( e instanceof DashboardDataError && e.code === 'inaccessible_jetpack' ) {
+				return false;
+			}
+
 			if ( e.data && KNOWN_ERRORS.includes( e.data ) ) {
 				return false;
 			}

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -1,6 +1,7 @@
 import {
 	isWpError,
 	DashboardDataError,
+	INACCESSIBLE_JETPACK_ERROR_CODE,
 	fetchSite,
 	deleteSite,
 	launchSite,
@@ -45,7 +46,7 @@ export function siteBySlugQuery( siteSlug: string ) {
 			}
 		},
 		retry: ( failureCount, e: { data?: string } ) => {
-			if ( e instanceof DashboardDataError && e.code === 'inaccessible_jetpack' ) {
+			if ( e instanceof DashboardDataError && e.code === INACCESSIBLE_JETPACK_ERROR_CODE ) {
 				return false;
 			}
 
@@ -92,7 +93,7 @@ export function siteByIdQuery( siteId: number ) {
 			}
 		},
 		retry: ( failureCount, e: { data?: string } ) => {
-			if ( e instanceof DashboardDataError && e.code === 'inaccessible_jetpack' ) {
+			if ( e instanceof DashboardDataError && e.code === INACCESSIBLE_JETPACK_ERROR_CODE ) {
 				return false;
 			}
 


### PR DESCRIPTION
Part of #107845

## Proposed Changes

This PR updates `siteBySlugQuery`  and `siteByIdQuery` to stop retrying if we encounter a DashboardDataError of type `inaccessible_jetpack`. The connection will not recover. The user should not wait.

## Why are these changes being made?

We don't need to continue to request the site data. It will always return broken.

## Testing Instructions

Patch your sandbox the following from `rest/v1.1/sites/{url}`:
```
"body": {
        "error": "method_not_allowed",
        "message": "The Jetpack site is inaccessible or returned an error: transport error - HTTP status code was not 200 (405)"
    }
```

- Load your site overview. 
- Look at your network search, for `rest/v1.1/sites/`
- Expect that to only be called _twice_ 
  - It's called twice because we don't propagate preloading errors. 
  - We can't handle the error there, otherwise the loading state will always be pending. See #107344.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
