### PR TITLE
MSD: Improve Add SSH key button UX

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -589,6 +589,11 @@ export const securitySshKeyRoute = createRoute( {
 		] );
 	},
 	path: '/ssh-key',
+	validateSearch: ( search ): { back_to?: 'site-settings-sftp-ssh' } => {
+		return {
+			back_to: search.back_to === 'site-settings-sftp-ssh' ? 'site-settings-sftp-ssh' : undefined,
+		};
+	},
 } ).lazy( () =>
 	import( '../../me/security-ssh-key' ).then( ( d ) =>
 		createLazyRoute( 'security-ssh-key' )( {

--- a/client/dashboard/components/snackbar-back-button/index.tsx
+++ b/client/dashboard/components/snackbar-back-button/index.tsx
@@ -7,7 +7,7 @@ import { ReactNode } from 'react';
 import './style.scss';
 
 export function getSnackbarBackButtonText(
-	to: 'site-overview' | 'site-domains' | 'site-deployments'
+	to: 'site-overview' | 'site-domains' | 'site-deployments' | 'site-settings-sftp-ssh'
 ) {
 	switch ( to ) {
 		case 'site-overview':
@@ -16,6 +16,8 @@ export function getSnackbarBackButtonText(
 			return __( 'Back to Site Deployments' );
 		case 'site-domains':
 			return __( 'Back to Site Domain Names' );
+		case 'site-settings-sftp-ssh':
+			return __( 'Back to SFTP/SSH settings' );
 		default:
 			return null;
 	}

--- a/client/dashboard/me/security-ssh-key/index.tsx
+++ b/client/dashboard/me/security-ssh-key/index.tsx
@@ -6,9 +6,13 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { securitySshKeyRoute } from '../../app/router/me';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import SnackbarBackButton, {
+	getSnackbarBackButtonText,
+} from '../../components/snackbar-back-button';
 import SshKey from './ssh-key';
 import SshKeyForm from './ssh-key-form';
 
@@ -54,27 +58,35 @@ export default function SecuritySshKey() {
 		);
 	}
 
+	const search = securitySshKeyRoute.useSearch();
+	const snackbarBackButtonText = getSnackbarBackButtonText( search?.back_to );
+
 	return (
-		<PageLayout
-			size="small"
-			header={
-				<PageHeader
-					prefix={ <Breadcrumbs length={ 2 } /> }
-					title={ isEditing ? __( 'Update SSH key' ) : __( 'SSH key' ) }
-					description={ description }
-				/>
-			}
-		>
-			{ sshKey && ! isEditing ? (
-				<SshKey sshKey={ sshKey } setIsEditing={ setIsEditing } username={ username } />
-			) : (
-				<SshKeyForm
-					sshKey={ sshKey }
-					isEditing={ isEditing }
-					setIsEditing={ setIsEditing }
-					username={ username }
-				/>
+		<>
+			<PageLayout
+				size="small"
+				header={
+					<PageHeader
+						prefix={ <Breadcrumbs length={ 2 } /> }
+						title={ isEditing ? __( 'Update SSH key' ) : __( 'SSH key' ) }
+						description={ description }
+					/>
+				}
+			>
+				{ sshKey && ! isEditing ? (
+					<SshKey sshKey={ sshKey } setIsEditing={ setIsEditing } username={ username } />
+				) : (
+					<SshKeyForm
+						sshKey={ sshKey }
+						isEditing={ isEditing }
+						setIsEditing={ setIsEditing }
+						username={ username }
+					/>
+				) }
+			</PageLayout>
+			{ snackbarBackButtonText && (
+				<SnackbarBackButton>{ snackbarBackButtonText }</SnackbarBackButton>
 			) }
-		</PageLayout>
+		</>
 	);
 }

--- a/client/dashboard/sites/settings-sftp-ssh/index.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/index.tsx
@@ -67,7 +67,6 @@ export default function SftpSshSettings( { siteSlug }: { siteSlug: string } ) {
 				{ sftpEnabled && hasSshFeature && (
 					<SshCard
 						siteId={ site.ID }
-						siteSlug={ site.slug }
 						sftpUsers={ sftpUsers }
 						sshEnabled={ sshAccessStatus?.setting === 'ssh' }
 					/>

--- a/client/dashboard/sites/settings-sftp-ssh/index.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/index.tsx
@@ -67,6 +67,7 @@ export default function SftpSshSettings( { siteSlug }: { siteSlug: string } ) {
 				{ sftpEnabled && hasSshFeature && (
 					<SshCard
 						siteId={ site.ID }
+						siteSlug={ site.slug }
 						sftpUsers={ sftpUsers }
 						sshEnabled={ sshAccessStatus?.setting === 'ssh' }
 					/>

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -27,11 +27,14 @@ import { trash } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { useAuth } from '../../app/auth';
+import { securitySshKeyRoute } from '../../app/router/me';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import ClipboardInputControl from '../../components/clipboard-input-control';
 import InlineSupportLink from '../../components/inline-support-link';
+import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { reauthRequiredLink } from '../../utils/link';
 import type { SftpUser, SiteSshKey, UserSshKey } from '@automattic/api-core';
 import type { DataFormControlProps, Field } from '@wordpress/dataviews';
@@ -85,12 +88,35 @@ const SshKeyCard = ( {
 	);
 };
 
+const AddSshKeyButton = ( { siteSlug }: { siteSlug: string } ) => {
+	if ( isDashboardBackport() ) {
+		return (
+			<Button variant="secondary" target="_blank" href="/me/security/ssh-key" rel="noreferrer">
+				{ __( 'Add new SSH key ↗' ) }
+			</Button>
+		);
+	}
+
+	return (
+		<RouterLinkButton
+			to={ securitySshKeyRoute.fullPath }
+			params={ { siteSlug } }
+			search={ { back_to: 'site-settings-sftp-ssh' } }
+			variant="secondary"
+		>
+			{ __( 'Add new SSH key' ) }
+		</RouterLinkButton>
+	);
+};
+
 export default function SshCard( {
 	siteId,
+	siteSlug,
 	sftpUsers,
 	sshEnabled,
 }: {
 	siteId: number;
+	siteSlug: string;
 	sftpUsers: SftpUser[];
 	sshEnabled: boolean;
 } ) {
@@ -329,14 +355,7 @@ export default function SshCard( {
 							>
 								{ __( 'Attach SSH key to site' ) }
 							</Button>
-							<Button
-								variant="secondary"
-								target="_blank"
-								href="/me/security/ssh-key"
-								rel="noreferrer"
-							>
-								{ __( 'Add new SSH key ↗' ) }
-							</Button>
+							<AddSshKeyButton siteSlug={ siteSlug } />
 						</ButtonStack>
 					) }
 				</VStack>

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -88,7 +88,7 @@ const SshKeyCard = ( {
 	);
 };
 
-const AddSshKeyButton = ( { siteSlug }: { siteSlug: string } ) => {
+const AddSshKeyButton = () => {
 	if ( isDashboardBackport() ) {
 		return (
 			<Button variant="secondary" target="_blank" href="/me/security/ssh-key" rel="noreferrer">
@@ -100,7 +100,6 @@ const AddSshKeyButton = ( { siteSlug }: { siteSlug: string } ) => {
 	return (
 		<RouterLinkButton
 			to={ securitySshKeyRoute.fullPath }
-			params={ { siteSlug } }
 			search={ { back_to: 'site-settings-sftp-ssh' } }
 			variant="secondary"
 		>
@@ -111,12 +110,10 @@ const AddSshKeyButton = ( { siteSlug }: { siteSlug: string } ) => {
 
 export default function SshCard( {
 	siteId,
-	siteSlug,
 	sftpUsers,
 	sshEnabled,
 }: {
 	siteId: number;
-	siteSlug: string;
 	sftpUsers: SftpUser[];
 	sshEnabled: boolean;
 } ) {
@@ -355,7 +352,7 @@ export default function SshCard( {
 							>
 								{ __( 'Attach SSH key to site' ) }
 							</Button>
-							<AddSshKeyButton siteSlug={ siteSlug } />
+							<AddSshKeyButton />
 						</ButtonStack>
 					) }
 				</VStack>


### PR DESCRIPTION
## Proposed Changes

Improve the "Add SSH key" button so that:

- It uses TanStack router to navigate to /me/security/ssh-key
- Add a Back button to return to the site SFTP/SSH settings

<img width="1239" height="1186" alt="SCR-20251229-krfb" src="https://github.com/user-attachments/assets/30e6488d-0390-4870-a23a-7a61da86e0db" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the MSD /sites
* Select a Business site
* Head to Settings > SFTP/SSH
* In the SSH section, find the "Add new SSH key" (only available if a SSH has not yet been attached to the site)
* Ensure that clicking the button routes to the SSH screen
* Ensure that you see the back button as shown on the screenshot above
* Repeat the steps for the v1 /sites
* Ensure that you see "Add new SSH key" button with an external arrow
* Ensure that clicking the button opens the v1 SSH screen in a new tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
