### PR TITLE
Renewal pricing experiment: add a period at the end of the sentence

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -883,7 +883,7 @@ export function LineItemSublabelAndPrice( {
 				<>
 					<LineItemSublabelTitle>
 						{ isRenewalPricingExperiment
-							? translate( 'Auto-renews at %(price)s/month. Billed every month', {
+							? translate( 'Auto-renews at %(price)s/month. Billed every month.', {
 									args: { price: actualMonthlyPrice },
 							  } )
 							: translate( 'Billed every month' ) }
@@ -902,7 +902,7 @@ export function LineItemSublabelAndPrice( {
 				<>
 					<LineItemSublabelTitle>
 						{ isRenewalPricingExperiment
-							? translate( 'Auto-renews at %(price)s/month. Billed every 12 months', {
+							? translate( 'Auto-renews at %(price)s/month. Billed every 12 months.', {
 									args: { price: actualMonthlyPrice },
 							  } )
 							: translate( 'Billed every year' ) }
@@ -921,7 +921,7 @@ export function LineItemSublabelAndPrice( {
 				<>
 					<LineItemSublabelTitle>
 						{ isRenewalPricingExperiment
-							? translate( 'Auto-renews at %(price)s/month. Billed every 24 months', {
+							? translate( 'Auto-renews at %(price)s/month. Billed every 24 months.', {
 									args: { price: actualMonthlyPrice },
 							  } )
 							: translate( 'Billed every 2 years' ) }
@@ -940,7 +940,7 @@ export function LineItemSublabelAndPrice( {
 				<>
 					<LineItemSublabelTitle>
 						{ isRenewalPricingExperiment
-							? translate( 'Auto-renews at %(price)s/month. Billed every 36 months', {
+							? translate( 'Auto-renews at %(price)s/month. Billed every 36 months.', {
 									args: { price: actualMonthlyPrice },
 							  } )
 							: translate( 'Billed every 3 years' ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMART-79

## Proposed Changes

* Add a period at the end of the sentence.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match the proposed designs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
