### PR TITLE
Jetpack Cloud: Exclude garden sites from Jetpack Cloud

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -120,14 +120,15 @@ export function requestSites() {
 					const isJetpack =
 						site?.jetpack || Boolean( site?.options?.jetpack_connection_active_plugins?.length );
 
-					// Filter Jetpack Cloud sites to exclude P2 and Simple non-Classic sites by default.
+					// Filter Jetpack Cloud sites to exclude P2, Simple non-Classic, and Garden sites by default.
 					const isP2 = site?.options?.is_wpforteams_site;
 					const isSimpleClassic =
 						! isJetpack &&
 						! site?.is_wpcom_atomic &&
 						site?.options?.wpcom_admin_interface !== 'wp-admin';
+					const isGarden = site?.is_garden;
 
-					return ! isP2 && ! isSimpleClassic;
+					return ! isP2 && ! isSimpleClassic && ! isGarden;
 				} );
 				dispatch( receiveSites( isJetpackCloud() ? jetpackCloudSites : response.sites ) );
 				dispatch( {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of ARC-1243

## Proposed Changes

* Exclude garden sites from Jetpack Cloud

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* ARC-1243

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run Jetpack Cloud locally
* Create a garden site ( or ask the Avalon team how to do it )
* Go to http://jetpack.cloud.localhost:3000
* The garden site should not show on your list of sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
