### PR TITLE
Help Center: Improve Zendesk escalation

### DIFF
--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -68,7 +68,7 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		const buttons: ButtonConfig[] = [];
 
 		if ( isPaidUser ) {
-			if ( isEmailForced || ! isChatLoaded ) {
+			if ( isEmailForced || ( ! isChatLoaded && ! forceAIConversation ) ) {
 				buttons.push( {
 					text: __( 'Send an email', __i18n_text_domain__ ),
 					action: async () => {
@@ -111,13 +111,9 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 						},
 					} );
 				} else if ( hasZendeskAccess ) {
-					const startNewConversationText = translationExists( 'No, connect me with someone new' )
-						? __( 'No, connect me with someone new', __i18n_text_domain__ )
-						: __( 'No thanks, let’s keep it here', __i18n_text_domain__ );
-
 					buttons.push( {
 						text: supportInteraction
-							? startNewConversationText
+							? __( 'No, connect me with someone new', __i18n_text_domain__ )
 							: __( 'Get support', __i18n_text_domain__ ),
 						action: async () => {
 							onClickAdditionalEvent?.( 'chat' );

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -5,7 +5,7 @@ import {
 	getOdieEmailFallbackMessageContent,
 	getOdieErrorMessage,
 	getOdieErrorMessageNonEligible,
-	getOdieZendeskConnectionErrorMessage,
+	getOdieZendeskConnectionErrorMessageContent,
 } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { useCurrentSupportInteraction } from '../../data/use-current-support-interaction';
@@ -53,7 +53,7 @@ const getDisplayMessage = (
 	}
 
 	if ( isUserEligibleForPaidSupport && ! isChatLoaded ) {
-		return getOdieZendeskConnectionErrorMessage().content;
+		return getOdieZendeskConnectionErrorMessageContent();
 	}
 
 	return forwardMessage;

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -283,19 +283,43 @@ export const getErrorMessageUnknownError = (): Message => {
 	};
 };
 
-export const getOdieZendeskConnectionErrorMessage = (): Message => {
+export const getErrorTryAgainLaterMessage = (): Message => {
 	return {
 		content: __(
-			"Sorry, I couldn't connect you to our support team right now. Please try again later or use the button below to reach out via email.",
+			"Sorry, I couldn't connect you to our support team right now. Please try again later.",
 			__i18n_text_domain__
 		),
+		role: 'bot',
+		type: 'message',
+		message_id: Math.floor( Math.random() * 1000 ),
+		context: {
+			site_id: null,
+			flags: {
+				is_error_message: true,
+				forward_to_human_support: false,
+			},
+			question_tags: {
+				inquiry_type: 'request-for-human-support',
+			},
+		},
+	};
+};
+
+export const getOdieZendeskConnectionErrorMessageContent = (): string => {
+	return __(
+		"Sorry, I couldn't connect you to our support team right now. Please try again later or use the button below to reach out via email.",
+		__i18n_text_domain__
+	);
+};
+
+export const getOdieZendeskConnectionErrorMessage = (): Message => {
+	return {
+		content: getOdieZendeskConnectionErrorMessageContent(),
 		role: 'bot',
 		type: 'message',
 		context: {
 			site_id: null,
 			flags: {
-				show_ai_avatar: true,
-				failed_zendesk_connection: true,
 				is_error_message: false,
 				forward_to_human_support: true,
 			},

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -30,6 +30,9 @@ export const useCreateZendeskConversation = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 
+	const getErrorMessage = ( error: unknown ) =>
+		error instanceof Error ? error.message : error?.toString?.() ?? 'Unknown error';
+
 	const createConversation = async ( {
 		createdFrom = '',
 		isFromError = false,
@@ -43,7 +46,7 @@ export const useCreateZendeskConversation = () => {
 	} ) => {
 		let activeInteractionId = currentSupportInteraction?.uuid;
 
-		trackEvent( 'create_zendesk_conversation', {
+		trackEvent( 'creating_zendesk_conversation', {
 			is_submitting_zendesk_user_fields: isSubmittingZendeskUserFields,
 			chat_conversation_id: chat.conversationId,
 			chat_status: chat.status,
@@ -69,6 +72,27 @@ export const useCreateZendeskConversation = () => {
 		const previousMessages = [ ...chat.messages ];
 		const previousProvider = chat.provider;
 		const previousConversationId = chat.conversationId;
+
+		const handleErrorCreatingZendeskConversation = ( errorType: string, error?: unknown ) => {
+			trackEvent( errorType, {
+				error_message: getErrorMessage( error ),
+				created_from: createdFrom,
+				escalation_on_second_attempt: escalationOnSecondAttempt,
+				active_interaction_id: activeInteractionId || null,
+				is_chat_loaded: isChatLoaded,
+			} );
+			const errorMessageObj = getOdieZendeskConnectionErrorMessage();
+
+			setChat( {
+				messages: [ ...previousMessages, errorMessageObj ],
+				status: 'loaded',
+				provider: previousProvider,
+				conversationId: previousConversationId,
+				odieId: chat.odieId,
+				wpcomUserId: chat.wpcomUserId,
+				clientId: chat.clientId,
+			} );
+		};
 
 		// Get transfer messages to identify and remove them on error
 		const transferMessages = isFromError
@@ -102,10 +126,8 @@ export const useCreateZendeskConversation = () => {
 
 			trackEvent( 'submitted_zendesk_user_fields' );
 		} catch ( error ) {
-			trackEvent( 'error_submitting_zendesk_user_fields', {
-				error_message:
-					error instanceof Error ? error.message : error?.toString?.() ?? 'Unknown error',
-			} );
+			handleErrorCreatingZendeskConversation( 'error_submitting_zendesk_user_fields', error );
+			return;
 		}
 
 		let conversation: ZendeskConversation | null = null;
@@ -119,7 +141,12 @@ export const useCreateZendeskConversation = () => {
 					...( chatId ? { odieChatId: chatId } : {} ),
 				},
 			} );
+		} catch ( error ) {
+			handleErrorCreatingZendeskConversation( 'error_creating_zendesk_conversation', error );
+			return;
+		}
 
+		try {
 			if ( activeInteractionId ) {
 				interaction = await addEventToInteraction( {
 					interactionId: activeInteractionId,
@@ -131,7 +158,12 @@ export const useCreateZendeskConversation = () => {
 					event_external_id: conversation.id,
 				} );
 			}
+		} catch ( error ) {
+			handleErrorCreatingZendeskConversation( 'error_updating_interaction', error );
+			return;
+		}
 
+		try {
 			if ( interaction.uuid !== activeInteractionId ) {
 				await Smooch.updateConversation( conversation.id, {
 					metadata: {
@@ -177,33 +209,8 @@ export const useCreateZendeskConversation = () => {
 
 			return conversationId;
 		} catch ( error ) {
-			const errorMessage =
-				error instanceof Error ? error.message : error?.toString?.() ?? 'Unknown error';
-
-			// Track error event
-			trackEvent( 'error_creating_zendesk_conversation', {
-				error_message: errorMessage,
-				error_type: conversation ? 'interaction_update_failed' : 'conversation_creation_failed',
-				created_from: createdFrom,
-				escalation_on_second_attempt: escalationOnSecondAttempt,
-				active_interaction_id: activeInteractionId || null,
-				conversation_id: conversation?.id || null,
-				is_chat_loaded: isChatLoaded,
-			} );
-
-			// Add error message to inform user and show GetSupport button
-			const errorMessageObj = getOdieZendeskConnectionErrorMessage();
-
-			// Restore previous chat state and add error message
-			setChat( {
-				messages: [ ...previousMessages, errorMessageObj ],
-				status: 'loaded',
-				provider: previousProvider,
-				conversationId: previousConversationId,
-				odieId: chat.odieId,
-				wpcomUserId: chat.wpcomUserId,
-				clientId: chat.clientId,
-			} );
+			handleErrorCreatingZendeskConversation( 'error_finalizing_zendesk_conversation', error );
+			return;
 		}
 	};
 

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -4,7 +4,7 @@ import Smooch from 'smooch';
 import {
 	getOdieOnErrorTransferMessage,
 	getOdieTransferMessage,
-	getOdieZendeskConnectionErrorMessage,
+	getErrorTryAgainLaterMessage,
 } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
@@ -81,7 +81,7 @@ export const useCreateZendeskConversation = () => {
 				active_interaction_id: activeInteractionId || null,
 				is_chat_loaded: isChatLoaded,
 			} );
-			const errorMessageObj = getOdieZendeskConnectionErrorMessage();
+			const errorMessageObj = getErrorTryAgainLaterMessage();
 
 			setChat( {
 				messages: [ ...previousMessages, errorMessageObj ],


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-390/duplicate-zendesk-chats-and-messaging-not-working-in-duplicates

## Changes

1. The `try catch` has been improved to know what caused the error.
2. Refactored the code to improve readability.
3. We block the escalation if we fail in updating the user fields.

