### PR TITLE
Jetpack Cloud: Add padding to top wrapper when viewing plugin list.

### DIFF
--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -376,6 +376,11 @@
 
 body.is-section-plugins .hosting-dashboard-layout,
 .is-section-jetpack-cloud-plugin-management .hosting-dashboard-layout {
+
+	.hosting-dashboard-layout__top-wrapper:not( .preview-hidden ) {
+		padding-inline: 24px;
+	}
+
 	.hosting-dashboard-layout-with-columns__container {
 		background-color: var( --color-main-background );
 	}

--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -376,15 +376,6 @@
 
 body.is-section-plugins .hosting-dashboard-layout,
 .is-section-jetpack-cloud-plugin-management .hosting-dashboard-layout {
-
-	.hosting-dashboard-layout__top-wrapper:not( .preview-hidden ) {
-		padding-inline: 24px;
-	}
-
-	&:has( .dataviews-view-table ) .hosting-dashboard-layout__top-wrapper:not( .preview-hidden ) {
-		padding-inline: 48px;
-	}
-
 	.hosting-dashboard-layout-with-columns__container {
 		background-color: var( --color-main-background );
 	}
@@ -415,5 +406,15 @@ body.is-section-plugins .hosting-dashboard-layout,
 		padding: 0;
 		text-align: start;
 		height: auto;
+	}
+}
+
+.is-section-jetpack-cloud-plugin-management .hosting-dashboard-layout {
+	.hosting-dashboard-layout__top-wrapper:not( .preview-hidden ) {
+		padding-inline: 24px;
+	}
+
+	&:has( .dataviews-view-table ) .hosting-dashboard-layout__top-wrapper:not( .preview-hidden ) {
+		padding-inline: 48px;
 	}
 }

--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -381,6 +381,10 @@ body.is-section-plugins .hosting-dashboard-layout,
 		padding-inline: 24px;
 	}
 
+	&:has( .dataviews-view-table ) .hosting-dashboard-layout__top-wrapper:not( .preview-hidden ) {
+		padding-inline: 48px;
+	}
+
 	.hosting-dashboard-layout-with-columns__container {
 		background-color: var( --color-main-background );
 	}


### PR DESCRIPTION
## Proposed Changes

Add some padding to plugin list title.

| Before | After |
|--------|--------|
| <img width="2374" height="1926" alt="cloud jetpack com_" src="https://github.com/user-attachments/assets/2863cca1-338d-4469-b17c-f9828b4a7cfb" /> |  <img width="2374" height="1926" alt="jetpack cloud localhost_3001_plugins_manage_sites (1)" src="https://github.com/user-attachments/assets/afcce891-ed44-4ca8-a655-60f2560325eb" /> |
| <img width="1502" height="1926" alt="cloud jetpack com_ (1)" src="https://github.com/user-attachments/assets/01a0e58b-b1be-4e9d-b6dc-8302253de432" /> | <img width="1388" height="1926" alt="jetpack cloud localhost_3001_plugins_manage_sites" src="https://github.com/user-attachments/assets/d8d4521d-fd0d-4f28-abec-3921f66ed9c6" /> | 

## Why are these changes being made?

Looks broken.

## Testing Instructions

- Visit Jetpack cloud plugin list, expect to see padding around the heading (`/plugins/manage/sites`)
- Visit WP.com plugin list, expect the padding to be even (`plugins/manage/sites`)
- Visit A4A plugin list, , expect the padding to be even (`/plugins/manage/sites`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
