### PR TITLE
MSD Active Upgrades: Update help link to open help center

### DIFF
--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -1,8 +1,9 @@
 import { SubscriptionBillPeriod } from '@automattic/api-core';
 import { formatCurrency } from '@automattic/number-formatters';
-import { ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { useHelpCenter } from '../../app/help-center';
 import { useLocale } from '../../app/locale';
 import { Text } from '../../components/text';
 import {
@@ -46,6 +47,7 @@ export function PurchaseExpiryStatus( {
 	isDisconnectedSite?: boolean;
 } ) {
 	const locale = useLocale();
+	const { setShowHelpCenter } = useHelpCenter();
 
 	// @todo: There isn't currently a way to get the taxName based on the
 	// country. The country is not included in the purchase information
@@ -101,11 +103,18 @@ export function PurchaseExpiryStatus( {
 		return (
 			<span>
 				{ createInterpolateElement(
-					__(
-						'You no longer have access to this site and its purchases. <button>Contact support</button>'
-					),
+					__( 'You no longer have access to this site and its purchases. <contactSupportLink/>' ),
 					{
-						button: <a href="/help/contact" />,
+						contactSupportLink: (
+							<Button
+								variant="link"
+								onClick={ () => {
+									setShowHelpCenter( true );
+								} }
+							>
+								{ __( 'Contact support' ) }
+							</Button>
+						),
 					}
 				) }
 			</span>


### PR DESCRIPTION
## Proposed Changes

Currently, the "Contact support" link in Active Upgrades opens https://my.wordpress.com/help/contact which is invalid.

<img width="1200" height="517" alt="SCR-20251230-mxzu" src="https://github.com/user-attachments/assets/b9bea71c-0b06-45ee-a98e-e7c344c9fb11" />

This PR updates the link so that it opens the Help Center instead.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Active Upgrades screen
* Find the "Contact support" link
* Click it and ensure it opens the Help Center

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
