### PR TITLE
show credits expiration date in advertising section

### DIFF
--- a/client/data/promote-post/use-promote-post-credit-balance-query.ts
+++ b/client/data/promote-post/use-promote-post-credit-balance-query.ts
@@ -10,11 +10,14 @@ const useCreditBalanceQuery = ( queryOptions = {} ) => {
 		queryKey: [ 'promote-post-credit-balance-siteid', selectedSiteId ],
 		queryFn: async () => {
 			if ( selectedSiteId ) {
-				const { balance } = await requestDSP< { balance: string } >(
+				const { balance, history } = await requestDSP< { balance: string } >(
 					selectedSiteId,
 					'/credits/balance'
 				);
-				return balance ? parseFloat( balance ).toFixed( 2 ) : undefined;
+				return {
+					balance: balance ? parseFloat( balance ).toFixed( 2 ) : undefined,
+					history: history,
+				};
 			}
 			throw new Error( 'wpcomUserId is undefined' );
 		},

--- a/client/data/promote-post/use-promote-post-credit-balance-query.ts
+++ b/client/data/promote-post/use-promote-post-credit-balance-query.ts
@@ -10,10 +10,10 @@ const useCreditBalanceQuery = ( queryOptions = {} ) => {
 		queryKey: [ 'promote-post-credit-balance-siteid', selectedSiteId ],
 		queryFn: async () => {
 			if ( selectedSiteId ) {
-				const { balance, history } = await requestDSP< { balance: string } >(
-					selectedSiteId,
-					'/credits/balance'
-				);
+				const { balance, history } = await requestDSP< {
+					balance: string;
+					history: Array< { amount: number; expires: string } >;
+				} >( selectedSiteId, '/credits/balance' );
 				return {
 					balance: balance ? parseFloat( balance ).toFixed( 2 ) : undefined,
 					history: history,

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -8,6 +8,7 @@ import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import cookie from 'cookie';
 import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import React, { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
@@ -121,7 +122,44 @@ export default function PromotedPosts( { tab, receiptId }: Props ) {
 		isJetpackSite( state, selectedSiteId, { treatAtomicAsJetpackSite: false } )
 	);
 
-	const { data: creditBalance = '0.00' } = useCreditBalanceQuery();
+	const { data: { balance: creditBalance = '0.00', history: creditsHistory = [] } = {} } =
+		useCreditBalanceQuery();
+
+	const getExpirationText = ( history: Array< { amount: number; expires: string } > ) => {
+		if ( ! history || history.length === 0 ) {
+			return '';
+		}
+
+		const firstItem = history[ 0 ];
+		const firstDate = moment( firstItem.expires ).format( 'LL' );
+
+		if ( history.length === 1 ) {
+			return translate( 'Your credits will expire on %(date)s', {
+				args: { date: firstDate },
+			} );
+		}
+
+		const firstAmount = '$' + formatNumber( firstItem.amount / 100, { decimals: 2 } );
+		const lastItem = history[ history.length - 1 ];
+		const lastDate = moment( lastItem.expires ).format( 'LL' );
+
+		return (
+			<>
+				{ translate( 'You have %(amount)s in credits expiring on %(firstDate)s.', {
+					args: {
+						amount: firstAmount,
+						firstDate,
+					},
+				} ) }
+				<br />
+				{ translate( 'Your remaining credits will expire on %(lastDate)s', {
+					args: {
+						lastDate,
+					},
+				} ) }
+			</>
+		);
+	};
 
 	/* query for campaigns */
 	const [ campaignsSearchOptions, setCampaignsSearchOptions ] = useState< SearchOptions >( {} );
@@ -386,6 +424,9 @@ export default function PromotedPosts( { tab, receiptId }: Props ) {
 						</div>
 						<div className="blaze-credits-container__result">
 							{ '$' + formatNumber( parseFloat( creditBalance ), { decimals: 2 } ) }
+						</div>
+						<div className="blaze-credits-container__credits-notice">
+							{ getExpirationText( creditsHistory ) }
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -130,17 +130,21 @@ export default function PromotedPosts( { tab, receiptId }: Props ) {
 			return '';
 		}
 
-		const firstItem = history[ 0 ];
+		const sortedHistory = [ ...history ].sort( ( a, b ) =>
+			moment( a.expires ).diff( moment( b.expires ) )
+		);
+
+		const firstItem = sortedHistory[ 0 ];
 		const firstDate = moment( firstItem.expires ).format( 'LL' );
 
-		if ( history.length === 1 ) {
+		if ( sortedHistory.length === 1 ) {
 			return translate( 'Your credits will expire on %(date)s', {
 				args: { date: firstDate },
 			} );
 		}
 
 		const firstAmount = '$' + formatNumber( firstItem.amount / 100, { decimals: 2 } );
-		const lastItem = history[ history.length - 1 ];
+		const lastItem = sortedHistory[ sortedHistory.length - 1 ];
 		const lastDate = moment( lastItem.expires ).format( 'LL' );
 
 		return (

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -763,6 +763,13 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 		margin-top: 34px;
 	}
 
+	&__credits-notice {
+		font-size: 0.875rem;
+		color: $studio-gray-100;
+		font-family: $font-sf-pro-text;
+		font-weight: 500;
+	}
+
 	&__item {
 		font-size: 1.75rem;
 		color: $studio-gray-100;


### PR DESCRIPTION

## Proposed Changes

- Add credits expiration date in advertising panel

## Why are these changes being made?
*  We are improving the UX experience of credits, and we want to give some insights for the user to know when the credits will expire.

## Testing Instructions

- Grant some blaze credits if you don't have them
- Open the advertising section. Below the credits you should see the expiration date of them

If you have multiple assignments of credits you should see something like this:

<img width="453" height="125" alt="image" src="https://github.com/user-attachments/assets/70950de1-52ca-44b7-b4ae-e52742623313" />

If you only have one assignment, you should see this:

<img width="357" height="110" alt="image" src="https://github.com/user-attachments/assets/6894d854-9449-4d92-a168-e95c6f98a4d3" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
