### PR TITLE
Add track events to ai-assistant-form

### DIFF
--- a/client/dashboard/sites/settings-ai-assistant/ai-assistant-form.tsx
+++ b/client/dashboard/sites/settings-ai-assistant/ai-assistant-form.tsx
@@ -12,6 +12,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import ConfirmModal from '../../components/confirm-modal';
@@ -93,6 +94,7 @@ export function AIAssistantForm( { site }: { site: Site } ) {
 	const [ showDisableConfirm, setShowDisableConfirm ] = useState( false );
 	const [ lastAction, setLastAction ] = useState< 'enable' | 'disable' | null >( null );
 
+	const { recordTracksEvent } = useAnalytics();
 	const { data: pluginStatus } = useQuery( bigSkyPluginQuery( site.ID ) );
 
 	const mutation = useMutation( {
@@ -137,6 +139,11 @@ export function AIAssistantForm( { site }: { site: Site } ) {
 
 		const pluginUpdate = toBigSkyPluginUpdate( { bigSkyEnabled: true } );
 
+		recordTracksEvent( 'calypso_dashboard_ai_assistant_enable_click', {
+			selected_use_cases: Array.from( selectedUseCases ).join( ',' ),
+			other_text: selectedUseCases.has( 'other' ) ? otherText : undefined,
+		} );
+
 		setLastAction( 'enable' );
 		mutation.mutate( pluginUpdate );
 	};
@@ -158,6 +165,8 @@ export function AIAssistantForm( { site }: { site: Site } ) {
 
 	const performDisable = () => {
 		const pluginUpdate = toBigSkyPluginUpdate( { bigSkyEnabled: false } );
+
+		recordTracksEvent( 'calypso_dashboard_ai_assistant_disable_click' );
 
 		setLastAction( 'disable' );
 		mutation.mutate( pluginUpdate, {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes AI-810

## Proposed Changes

Add track events for WordPress AI Assistant enable/disable actions in the Dashboard.
* Track `calypso_dashboard_ai_assistant_enable_click` when enabling, with properties:
  * `selected_use_cases`: Comma-separated list of selected options (e.g., "questions,content,redesign")
  * `other_text`: Custom text entered by the user when "Other" is selected
* Track `calypso_dashboard_ai_assistant_disable_click` when disabling


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We are enabling this soon and we need to track usage

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to a site's AI Assistant settings page in the Dashboard (`/sites/[YOUR_SITE]/settings/ai-assistant`)
1. Select one or more use cases from the poll
1. Click "Enable WordPress AI Assistant"
1. Verify `calypso_dashboard_ai_assistant_enable_click` event fires with:
   * `selected_use_cases`: comma-separated list of selected options
   * `other_text`: custom text if "Other" was selected
1. Click "Disable WordPress AI Assistant"
1. Verify `calypso_dashboard_ai_assistant_disable_click` event fires

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
