### PR TITLE
[MSD Billing] Add AutoRenewDisablingDialog to PurchaseSettings

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
@@ -208,6 +208,9 @@ class AutoRenewDisablingDialog extends Component<
 	};
 
 	closeAndCleanup = () => {
+		if ( this.state.surveyHasShown ) {
+			this.props.onConfirm();
+		}
 		this.props.onClose();
 
 		// It is intentional that we don't reset `surveyHasShown` flag here.
@@ -251,8 +254,6 @@ class AutoRenewDisablingDialog extends Component<
 			return;
 		}
 
-		this.props.onConfirm();
-
 		if ( this.state.surveyHasShown ) {
 			return this.closeAndCleanup();
 		}
@@ -275,6 +276,7 @@ class AutoRenewDisablingDialog extends Component<
 			<ConfirmDialog
 				onCancel={ this.closeAndCleanup }
 				onConfirm={ this.onClickGeneralConfirm }
+				size="large"
 				cancelButtonText={ __( 'Keep auto-renew on' ) }
 				confirmButtonText={ __( 'Turn off auto-renew' ) }
 			>

--- a/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
@@ -6,6 +6,7 @@ import { formatDate } from '../../../utils/datetime';
 import { wpcomLink } from '../../../utils/link';
 import { isAkismetTemporarySitePurchase } from '../../../utils/purchase';
 import CancelAutoRenewalForm from './cancel-auto-renewal-form';
+import PrecancellationChatButton from './precancellation-chat-button';
 import type { Purchase } from '@automattic/api-core';
 import type { FC } from 'react';
 
@@ -279,7 +280,17 @@ const AutoRenewDisablingDialog: FC< AutoRenewDisablingDialogProps > = ( {
 				cancelButtonText={ __( 'Keep auto-renew on' ) }
 				confirmButtonText={ __( 'Turn off auto-renew' ) }
 			>
-				<SectionHeader title={ __( 'Turn off auto-renew' ) } description={ description } />
+				<SectionHeader
+					title={ __( 'Turn off auto-renew' ) }
+					description={ description }
+					actions={
+						<PrecancellationChatButton
+							purchase={ purchase }
+							onClick={ onClose }
+							className="cancel-auto-renewal-form__chat-button"
+						/>
+					}
+				/>
 			</ConfirmDialog>
 		);
 	};

--- a/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
@@ -1,5 +1,5 @@
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
-import { createInterpolateElement, Component } from '@wordpress/element';
+import { createInterpolateElement, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { SectionHeader } from '../../../components/section-header';
 import { formatDate } from '../../../utils/datetime';
@@ -7,6 +7,7 @@ import { wpcomLink } from '../../../utils/link';
 import { isAkismetTemporarySitePurchase } from '../../../utils/purchase';
 import CancelAutoRenewalForm from './cancel-auto-renewal-form';
 import type { Purchase } from '@automattic/api-core';
+import type { FC } from 'react';
 
 const DIALOG = {
 	GENERAL: 'general',
@@ -15,10 +16,6 @@ const DIALOG = {
 } as const;
 
 type DialogType = typeof DIALOG.GENERAL | typeof DIALOG.ATOMIC | typeof DIALOG.SURVEY;
-
-interface AutoRenewDisablingDialogConnectedProps {
-	isAtomicSite: boolean;
-}
 
 interface AutoRenewDisablingDialogProps {
 	isVisible: boolean;
@@ -36,20 +33,22 @@ interface AutoRenewDisablingDialogState {
 	surveyHasShown: boolean;
 }
 
-type AutoRenewDisablingDialogAllProps = AutoRenewDisablingDialogProps &
-	AutoRenewDisablingDialogConnectedProps;
-
-class AutoRenewDisablingDialog extends Component<
-	AutoRenewDisablingDialogAllProps,
-	AutoRenewDisablingDialogState
-> {
-	state: AutoRenewDisablingDialogState = {
+const AutoRenewDisablingDialog: FC< AutoRenewDisablingDialogProps > = ( {
+	isVisible,
+	planName,
+	siteDomain,
+	purchase,
+	isAtomicSite,
+	locale,
+	onConfirm,
+	onClose,
+} ) => {
+	const [ state, setState ] = useState< AutoRenewDisablingDialogState >( {
 		dialogType: DIALOG.GENERAL,
 		surveyHasShown: false,
-	};
+	} );
 
-	getVariation() {
-		const { purchase, isAtomicSite } = this.props;
+	const getVariation = () => {
 		if ( purchase.is_domain_registration ) {
 			return 'domain';
 		}
@@ -71,10 +70,9 @@ class AutoRenewDisablingDialog extends Component<
 		}
 
 		return null;
-	}
+	};
 
-	getCopy( variation: string ) {
-		const { planName, siteDomain, purchase, locale } = this.props;
+	const getCopy = ( variation: string ) => {
 		const expiryDate = formatDate( new Date( purchase.expiry_date ), locale, {
 			year: 'numeric',
 			month: 'long',
@@ -198,31 +196,32 @@ class AutoRenewDisablingDialog extends Component<
 					}
 				);
 		}
-	}
-
-	onClickAtomicFollowUpConfirm = () => {
-		this.props.onConfirm();
-		this.setState( {
-			dialogType: DIALOG.SURVEY,
-		} );
 	};
 
-	closeAndCleanup = () => {
-		if ( this.state.surveyHasShown ) {
-			this.props.onConfirm();
+	const onClickAtomicFollowUpConfirm = () => {
+		onConfirm();
+		setState( ( previousState ) => ( {
+			...previousState,
+			dialogType: DIALOG.SURVEY,
+		} ) );
+	};
+
+	const closeAndCleanup = () => {
+		if ( state.surveyHasShown ) {
+			onConfirm();
 		}
-		this.props.onClose();
+		onClose();
 
 		// It is intentional that we don't reset `surveyHasShown` flag here.
 		// That state is for preventing the survey from showing excessively.
 		// The current behavior is that it won't show up until this component has been unmounted and then remounted.
-		this.setState( {
+		setState( ( previousState ) => ( {
+			...previousState,
 			dialogType: DIALOG.GENERAL,
-		} );
+		} ) );
 	};
 
-	renderAtomicFollowUpDialog = () => {
-		const { isVisible, siteDomain } = this.props;
+	const renderAtomicFollowUpDialog = () => {
 		const exportPath = wpcomLink( `/backup/${ siteDomain }` );
 
 		if ( ! isVisible ) {
@@ -232,7 +231,7 @@ class AutoRenewDisablingDialog extends Component<
 		return (
 			<ConfirmDialog
 				onCancel={ () => ( window.location.href = exportPath ) }
-				onConfirm={ this.onClickAtomicFollowUpConfirm }
+				onConfirm={ onClickAtomicFollowUpConfirm }
 				cancelButtonText={ __( 'Download content' ) }
 				confirmButtonText={ __( 'Turn off auto-renew' ) }
 			>
@@ -246,27 +245,27 @@ class AutoRenewDisablingDialog extends Component<
 		);
 	};
 
-	onClickGeneralConfirm = () => {
-		if ( 'atomic' === this.getVariation() ) {
-			this.setState( {
+	const onClickGeneralConfirm = () => {
+		if ( 'atomic' === getVariation() ) {
+			setState( ( previousState ) => ( {
+				...previousState,
 				dialogType: DIALOG.ATOMIC,
-			} );
+			} ) );
 			return;
 		}
 
-		if ( this.state.surveyHasShown ) {
-			return this.closeAndCleanup();
+		if ( state.surveyHasShown ) {
+			return closeAndCleanup();
 		}
 
-		this.setState( {
+		setState( {
 			dialogType: DIALOG.SURVEY,
 			surveyHasShown: true,
 		} );
 	};
 
-	renderGeneralDialog = () => {
-		const { isVisible } = this.props;
-		const description = this.getCopy( this.getVariation() ?? '' );
+	const renderGeneralDialog = () => {
+		const description = getCopy( getVariation() ?? '' );
 
 		if ( ! isVisible ) {
 			return null;
@@ -274,8 +273,8 @@ class AutoRenewDisablingDialog extends Component<
 
 		return (
 			<ConfirmDialog
-				onCancel={ this.closeAndCleanup }
-				onConfirm={ this.onClickGeneralConfirm }
+				onCancel={ closeAndCleanup }
+				onConfirm={ onClickGeneralConfirm }
 				size="large"
 				cancelButtonText={ __( 'Keep auto-renew on' ) }
 				confirmButtonText={ __( 'Turn off auto-renew' ) }
@@ -285,29 +284,25 @@ class AutoRenewDisablingDialog extends Component<
 		);
 	};
 
-	renderSurvey = () => {
-		const { purchase, isVisible } = this.props;
-
+	const renderSurvey = () => {
 		return (
 			<CancelAutoRenewalForm
 				purchase={ purchase }
 				selectedSiteId={ purchase.blog_id }
 				isVisible={ isVisible }
-				onClose={ this.closeAndCleanup }
+				onClose={ closeAndCleanup }
 			/>
 		);
 	};
 
-	render() {
-		switch ( this.state.dialogType ) {
-			case DIALOG.GENERAL:
-				return this.renderGeneralDialog();
-			case DIALOG.ATOMIC:
-				return this.renderAtomicFollowUpDialog();
-			case DIALOG.SURVEY:
-				return this.renderSurvey();
-		}
+	switch ( state.dialogType ) {
+		case DIALOG.GENERAL:
+			return renderGeneralDialog();
+		case DIALOG.ATOMIC:
+			return renderAtomicFollowUpDialog();
+		case DIALOG.SURVEY:
+			return renderSurvey();
 	}
-}
+};
 
 export default AutoRenewDisablingDialog;

--- a/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
@@ -1,0 +1,311 @@
+import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from 'react';
+import { SectionHeader } from '../../../components/section-header';
+import { formatDate } from '../../../utils/datetime';
+import { isAkismetTemporarySitePurchase } from '../../../utils/purchase';
+import CancelAutoRenewalForm from './cancel-auto-renewal-form';
+import type { Purchase } from '@automattic/api-core';
+
+const DIALOG = {
+	GENERAL: 'general',
+	ATOMIC: 'atomic',
+	SURVEY: 'survey',
+} as const;
+
+type DialogType = typeof DIALOG.GENERAL | typeof DIALOG.ATOMIC | typeof DIALOG.SURVEY;
+
+interface AutoRenewDisablingDialogConnectedProps {
+	isAtomicSite: boolean;
+}
+
+interface AutoRenewDisablingDialogProps {
+	isVisible: boolean;
+	planName: string;
+	siteDomain: string;
+	purchase: Purchase;
+	isAtomicSite: boolean;
+	locale: string;
+	onConfirm: () => void;
+	onClose: () => void;
+}
+
+interface AutoRenewDisablingDialogState {
+	dialogType: DialogType;
+	surveyHasShown: boolean;
+}
+
+type AutoRenewDisablingDialogAllProps = AutoRenewDisablingDialogProps &
+	AutoRenewDisablingDialogConnectedProps;
+
+class AutoRenewDisablingDialog extends Component<
+	AutoRenewDisablingDialogAllProps,
+	AutoRenewDisablingDialogState
+> {
+	state: AutoRenewDisablingDialogState = {
+		dialogType: DIALOG.GENERAL,
+		surveyHasShown: false,
+	};
+
+	getVariation() {
+		const { purchase, isAtomicSite } = this.props;
+		if ( purchase.is_domain_registration ) {
+			return 'domain';
+		}
+
+		if ( purchase.is_plan && isAtomicSite ) {
+			return 'atomic';
+		}
+
+		if ( purchase.is_plan ) {
+			return 'plan';
+		}
+
+		if ( purchase.is_google_workspace_product || purchase.is_titan_mail_product ) {
+			return 'email';
+		}
+
+		if ( isAkismetTemporarySitePurchase( purchase ) ) {
+			return 'siteless';
+		}
+
+		return null;
+	}
+
+	getCopy( variation: string ) {
+		const { planName, siteDomain, purchase, locale } = this.props;
+		const expiryDate = formatDate( new Date( purchase.expiry_date ), locale, {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric',
+		} );
+
+		switch ( variation ) {
+			case 'plan':
+				return createInterpolateElement(
+					sprintf(
+						/* translators: %(planName)s is the name of a WordPress.com plan, e.g. Personal, Premium, Business. %(siteDomain)s is a domain name, e.g. example.com, example.wordpress.com. %(expiryDate)s is a date string, e.g. May 14, 2020 */
+						__(
+							'By canceling auto-renewal, your <strong>%(planName)s</strong> plan for <strong>%(siteDomain)s</strong> will expire on <strong>%(expiryDate)s</strong>. ' +
+								"When it does, you'll lose access to key features you may be using on your site. " +
+								'To avoid that, turn auto-renewal back on or manually renew your plan before the expiration date.'
+						),
+						{
+							planName,
+							siteDomain,
+							expiryDate,
+						}
+					),
+					{
+						strong: <strong />,
+					}
+				);
+			case 'domain':
+				return createInterpolateElement(
+					sprintf(
+						/* translators: %(domain)s is a domain name, e.g. example.com, example.wordpress.com. %(expiryDate)s is a date string, e.g. May 14, 2020 */
+						__(
+							'By canceling auto-renewal, your domain <strong>%(domain)s</strong> will expire on <strong>%(expiryDate)s</strong>. ' +
+								"Once your domain expires, there is no guarantee that you'll be able to get it back – " +
+								'it could become unavailable and be impossible to purchase here, or at any other domain registrar. ' +
+								'To avoid that, turn auto-renewal back on or manually renew your domain before the expiration date.'
+						),
+						{
+							// in case of a domain registration, we need the actual domain bound to this purchase instead of the primary domain bound to the site.
+							domain: purchase.meta ?? '',
+							expiryDate,
+						}
+					),
+					{
+						strong: <strong />,
+					}
+				);
+			case 'atomic':
+				return createInterpolateElement(
+					sprintf(
+						/* translators: %(planName)s is the name of a WordPress.com plan, e.g. Personal, Premium, Business. %(siteDomain)s is a domain name, e.g. example.com, example.wordpress.com. %(expiryDate)s is a date string, e.g. May 14, 2020 */
+						__(
+							'By canceling auto-renewal, your <strong>%(planName)s</strong> plan for <strong>%(siteDomain)s</strong> will expire on <strong>%(expiryDate)s</strong>. ' +
+								'When it expires, plugins, themes and design customizations will be deactivated. ' +
+								'To avoid that, turn auto-renewal back on or manually renew your plan before the expiration date.'
+						),
+						{
+							planName,
+							siteDomain,
+							expiryDate,
+						}
+					),
+					{
+						strong: <strong />,
+					}
+				);
+			case 'email':
+				return createInterpolateElement(
+					sprintf(
+						/* translators: %(emailProductName)s is the name of an email product, e.g. Email, Titan Mail, Google Workspace. %(domainName)s is a domain name, e.g. example.com. %(expiryDate)s is a date string, e.g. May 14, 2020 */
+						__(
+							'By canceling auto-renewal, your <strong>%(emailProductName)s</strong> subscription for <strong>%(domainName)s</strong> will expire on <strong>%(expiryDate)s</strong>. ' +
+								'After it expires, you will not be able to send and receive emails for this domain. ' +
+								'To avoid that, turn auto-renewal back on or manually renew your subscription before the expiration date.'
+						),
+						{
+							domainName: purchase.meta ?? '',
+							// Use the purchased product name to make sure it's correct
+							emailProductName: purchase.product_name,
+							expiryDate,
+						}
+					),
+					{
+						strong: <strong />,
+					}
+				);
+			case 'siteless':
+				return createInterpolateElement(
+					sprintf(
+						/* translators: %(productName)s is the name of an Akismet plan/ product. %(expiryDate)s is a date string, e.g. May 14, 2020 */
+						__(
+							'By canceling auto-renewal, your <strong>%(productName)s</strong> subscription will expire on <strong>%(expiryDate)s</strong>. ' +
+								"When it does, you'll lose access to key features you may be using on your site. " +
+								'To avoid that, turn auto-renewal back on or manually renew your subscription before the expiration date.'
+						),
+						{
+							productName: purchase.product_name,
+							expiryDate,
+						}
+					),
+					{
+						strong: <strong />,
+					}
+				);
+			default:
+				return createInterpolateElement(
+					sprintf(
+						/* translators: %(productName)s is the name of a WordPress.com product. %(siteDomain)s is a domain name, e.g. example.com, example.wordpress.com. %(expiryDate)s is a date string, e.g. May 14, 2020 */
+						__(
+							'By canceling auto-renewal, your <strong>%(productName)s</strong> subscription for <strong>%(siteDomain)s</strong> will expire on <strong>%(expiryDate)s</strong>. ' +
+								"When it does, you'll lose access to key features you may be using on your site. " +
+								'To avoid that, turn auto-renewal back on or manually renew your subscription before the expiration date.'
+						),
+						{
+							productName: purchase.product_name,
+							siteDomain,
+							expiryDate,
+						}
+					),
+					{
+						strong: <strong />,
+					}
+				);
+		}
+	}
+
+	onClickAtomicFollowUpConfirm = () => {
+		this.props.onConfirm();
+		this.setState( {
+			dialogType: DIALOG.SURVEY,
+		} );
+	};
+
+	closeAndCleanup = () => {
+		this.props.onClose();
+
+		// It is intentional that we don't reset `surveyHasShown` flag here.
+		// That state is for preventing the survey from showing excessively.
+		// The current behavior is that it won't show up until this component has been unmounted and then remounted.
+		this.setState( {
+			dialogType: DIALOG.GENERAL,
+		} );
+	};
+
+	renderAtomicFollowUpDialog = () => {
+		const { isVisible, siteDomain } = this.props;
+		const exportPath = '/backup/' + siteDomain;
+
+		if ( ! isVisible ) {
+			return null;
+		}
+
+		return (
+			<ConfirmDialog
+				onCancel={ () => ( window.location.href = exportPath ) }
+				onConfirm={ this.onClickAtomicFollowUpConfirm }
+				cancelButtonText={ __( 'Download content' ) }
+				confirmButtonText={ __( 'Turn off auto-renew' ) }
+			>
+				<SectionHeader
+					title={ __( 'Download your content' ) }
+					description={ __(
+						'Before you continue, we recommend downloading a backup of your site—that way, you’ll have your content to use on any future websites.'
+					) }
+				/>
+			</ConfirmDialog>
+		);
+	};
+
+	onClickGeneralConfirm = () => {
+		if ( 'atomic' === this.getVariation() ) {
+			this.setState( {
+				dialogType: DIALOG.ATOMIC,
+			} );
+			return;
+		}
+
+		this.props.onConfirm();
+
+		if ( this.state.surveyHasShown ) {
+			return this.closeAndCleanup();
+		}
+
+		this.setState( {
+			dialogType: DIALOG.SURVEY,
+			surveyHasShown: true,
+		} );
+	};
+
+	renderGeneralDialog = () => {
+		const { isVisible } = this.props;
+		const description = this.getCopy( this.getVariation() ?? '' );
+
+		if ( ! isVisible ) {
+			return null;
+		}
+
+		return (
+			<ConfirmDialog
+				onCancel={ this.closeAndCleanup }
+				onConfirm={ this.onClickGeneralConfirm }
+				cancelButtonText={ __( 'Keep auto-renew on' ) }
+				confirmButtonText={ __( 'Turn off auto-renew' ) }
+			>
+				<SectionHeader title={ __( 'Turn off auto-renew' ) } description={ description } />
+			</ConfirmDialog>
+		);
+	};
+
+	renderSurvey = () => {
+		const { purchase, isVisible } = this.props;
+
+		return (
+			<CancelAutoRenewalForm
+				purchase={ purchase }
+				selectedSiteId={ purchase.blog_id }
+				isVisible={ isVisible }
+				onClose={ this.closeAndCleanup }
+			/>
+		);
+	};
+
+	render() {
+		switch ( this.state.dialogType ) {
+			case DIALOG.GENERAL:
+				return this.renderGeneralDialog();
+			case DIALOG.ATOMIC:
+				return this.renderAtomicFollowUpDialog();
+			case DIALOG.SURVEY:
+				return this.renderSurvey();
+		}
+	}
+}
+
+export default AutoRenewDisablingDialog;

--- a/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
@@ -3,7 +3,7 @@ import { createInterpolateElement, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { SectionHeader } from '../../../components/section-header';
 import { formatDate } from '../../../utils/datetime';
-import { wpcomLink } from '../../../utils/link';
+import { dashboardLink } from '../../../utils/link';
 import { isAkismetTemporarySitePurchase } from '../../../utils/purchase';
 import CancelAutoRenewalForm from './cancel-auto-renewal-form';
 import PrecancellationChatButton from './precancellation-chat-button';
@@ -24,6 +24,7 @@ interface AutoRenewDisablingDialogProps {
 	siteDomain: string;
 	purchase: Purchase;
 	isAtomicSite: boolean;
+	dialogSize: string;
 	locale: string;
 	onConfirm: () => void;
 	onClose: () => void;
@@ -40,6 +41,7 @@ const AutoRenewDisablingDialog: FC< AutoRenewDisablingDialogProps > = ( {
 	siteDomain,
 	purchase,
 	isAtomicSite,
+	dialogSize,
 	locale,
 	onConfirm,
 	onClose,
@@ -200,10 +202,10 @@ const AutoRenewDisablingDialog: FC< AutoRenewDisablingDialogProps > = ( {
 	};
 
 	const onClickAtomicFollowUpConfirm = () => {
-		onConfirm();
 		setState( ( previousState ) => ( {
 			...previousState,
 			dialogType: DIALOG.SURVEY,
+			surveyHasShown: true,
 		} ) );
 	};
 
@@ -223,26 +225,31 @@ const AutoRenewDisablingDialog: FC< AutoRenewDisablingDialogProps > = ( {
 	};
 
 	const renderAtomicFollowUpDialog = () => {
-		const exportPath = wpcomLink( `/backup/${ siteDomain }` );
+		const exportPath = dashboardLink( `/sites/${ siteDomain }/backups` );
 
 		if ( ! isVisible ) {
 			return null;
 		}
 
 		return (
-			<ConfirmDialog
-				onCancel={ () => ( window.location.href = exportPath ) }
-				onConfirm={ onClickAtomicFollowUpConfirm }
-				cancelButtonText={ __( 'Download content' ) }
-				confirmButtonText={ __( 'Turn off auto-renew' ) }
-			>
-				<SectionHeader
-					title={ __( 'Download your content' ) }
-					description={ __(
-						'Before you continue, we recommend downloading a backup of your site—that way, you’ll have your content to use on any future websites.'
-					) }
-				/>
-			</ConfirmDialog>
+			<>
+				<span>{ /* TODO: remove this workaround and fix the underlying issue */ }</span>
+				<ConfirmDialog
+					onCancel={ closeAndCleanup }
+					onConfirm={ onClickAtomicFollowUpConfirm }
+					size={ dialogSize }
+					cancelButtonText={ __( 'Keep auto-renew on' ) }
+					confirmButtonText={ __( 'Turn off auto-renew' ) }
+				>
+					<SectionHeader
+						title={ __( 'Download your content' ) }
+						description={ __(
+							'Before you continue, we recommend downloading a backup of your site—that way, you’ll have your content to use on any future websites.'
+						) }
+						actions={ <a href={ exportPath }>{ __( 'Download content' ) }</a> }
+					/>
+				</ConfirmDialog>
+			</>
 		);
 	};
 
@@ -276,7 +283,7 @@ const AutoRenewDisablingDialog: FC< AutoRenewDisablingDialogProps > = ( {
 			<ConfirmDialog
 				onCancel={ closeAndCleanup }
 				onConfirm={ onClickGeneralConfirm }
-				size="large"
+				size={ dialogSize }
 				cancelButtonText={ __( 'Keep auto-renew on' ) }
 				confirmButtonText={ __( 'Turn off auto-renew' ) }
 			>

--- a/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
@@ -3,6 +3,7 @@ import { createInterpolateElement, Component } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { SectionHeader } from '../../../components/section-header';
 import { formatDate } from '../../../utils/datetime';
+import { wpcomLink } from '../../../utils/link';
 import { isAkismetTemporarySitePurchase } from '../../../utils/purchase';
 import CancelAutoRenewalForm from './cancel-auto-renewal-form';
 import type { Purchase } from '@automattic/api-core';
@@ -222,7 +223,7 @@ class AutoRenewDisablingDialog extends Component<
 
 	renderAtomicFollowUpDialog = () => {
 		const { isVisible, siteDomain } = this.props;
-		const exportPath = '/backup/' + siteDomain;
+		const exportPath = wpcomLink( `/backup/${ siteDomain }` );
 
 		if ( ! isVisible ) {
 			return null;

--- a/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/auto-renew-disabling-dialog.tsx
@@ -1,7 +1,6 @@
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, Component } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Component } from 'react';
 import { SectionHeader } from '../../../components/section-header';
 import { formatDate } from '../../../utils/datetime';
 import { isAkismetTemporarySitePurchase } from '../../../utils/purchase';

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
@@ -1,35 +1,33 @@
+import { marketingSurveyMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
 import { RadioControl, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Component } from 'react';
+import { useState } from 'react';
 import { SectionHeader } from '../../../components/section-header';
 import { shuffleArray } from '../../../utils/collection';
 import enrichedSurveyData from '../cancel-purchase/enriched-survey-data';
 import PrecancellationChatButton from './precancellation-chat-button';
-import type { MarketingSurveyResponses, Purchase } from '@automattic/api-core';
-// import { submitSurvey } from 'calypso/lib/purchases/actions'; //TODO: port submitSurvey to mutation
+import type { MarketingSurveyDetails, Purchase } from '@automattic/api-core';
+import type { FC } from 'react';
 
 interface CancelAutoRenewFormProps {
 	purchase: Purchase;
 	selectedSiteId: number;
 	isVisible: boolean;
 	onClose: () => void;
-	submitSurvey: (
-		survey: string,
-		selectedSiteId: number,
-		surveyData: Omit< MarketingSurveyResponses, 'purchaseId' | 'purchase' >
-	) => void;
 }
 
-class CancelAutoRenewalForm extends Component< CancelAutoRenewFormProps > {
-	state = {
+const CancelAutoRenewalForm: FC< CancelAutoRenewFormProps > = ( {
+	purchase,
+	selectedSiteId,
+	isVisible,
+	onClose,
+} ) => {
+	const [ state, setState ] = useState( {
 		response: '',
-	};
+	} );
 
-	radioButtons = {};
-
-	getProductTypeString = () => {
-		const { purchase } = this.props;
-
+	const getProductTypeString = () => {
 		if ( purchase.is_domain_registration ) {
 			/* translators: as in "domain name"*/
 			return __( 'domain' );
@@ -43,108 +41,114 @@ class CancelAutoRenewalForm extends Component< CancelAutoRenewFormProps > {
 		return __( 'subscription' );
 	};
 
-	constructor( props: CancelAutoRenewFormProps ) {
-		super( props );
+	const productType = getProductTypeString();
 
-		const productType = this.getProductTypeString();
+	const radioButtons = shuffleArray( [
+		{
+			value: 'let-it-expire',
+			/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+			label: sprintf( __( "I'm going to let this %(productType)s expire." ), {
+				productType,
+			} ),
+		},
+		{
+			value: 'manual-renew',
+			/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+			label: sprintf( __( "I'm going to renew the %(productType)s, but will do it manually." ), {
+				productType,
+			} ),
+		},
+		{
+			value: 'not-sure',
+			label: __( "I'm not sure." ),
+		},
+	] );
 
-		this.radioButtons = shuffleArray( [
-			{
-				value: 'let-it-expire',
-				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
-				label: sprintf( __( "I'm going to let this %(productType)s expire." ), {
-					productType,
-				} ),
+	const marketingSurveyMutate = useMutation( marketingSurveyMutation() );
+	const submitMarketingSurvey = ( surveyDetails: MarketingSurveyDetails ) =>
+		marketingSurveyMutate.mutate( surveyDetails, {
+			onSuccess: () => {
+				setState( ( state ) => ( {
+					...state,
+					isSubmitting: false,
+				} ) );
 			},
-
-			{
-				value: 'manual-renew',
-				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
-				label: sprintf( __( "I'm going to renew the %(productType)s, but will do it manually." ), {
-					productType,
-				} ),
+			onError: () => {
+				setState( ( state ) => ( {
+					...state,
+					isSubmitting: false,
+				} ) );
 			},
-			{
-				value: 'not-sure',
-				label: __( "I'm not sure." ),
-			},
-		] );
-	}
+		} );
 
-	onSubmit = () => {
-		const { purchase, selectedSiteId } = this.props;
-		const { response } = this.state;
+	const onSubmit = () => {
+		const { response } = state;
 
 		const surveyData = {
 			response,
 		};
 
-		this.props.submitSurvey(
-			'calypso-cancel-auto-renewal',
-			selectedSiteId,
-			enrichedSurveyData( surveyData, purchase )
-		);
+		submitMarketingSurvey( {
+			survey_id: 'calypso-cancel-auto-renewal',
+			site_id: selectedSiteId,
+			survey_responses: enrichedSurveyData( surveyData, purchase ),
+		} );
 
-		this.props.onClose();
+		onClose();
 	};
 
-	onRadioChange = ( value: string ) => {
-		this.setState( {
+	const onRadioChange = ( value: string ) => {
+		setState( {
 			response: value,
 		} );
 	};
 
-	render() {
-		const { isVisible, onClose, purchase } = this.props;
-
-		const productType = this.getProductTypeString();
-
-		if ( ! isVisible ) {
-			return null;
-		}
-
-		return (
-			<ConfirmDialog
-				onCancel={ onClose }
-				onConfirm={ this.onSubmit }
-				cancelButtonText={ __( 'Skip' ) }
-				confirmButtonText={ __( 'Submit' ) }
-			>
-				<SectionHeader
-					title={ __( 'Help us improve' ) }
-					description={
-						<fieldset role="group" className="cancel-auto-renewal-form__form-fieldset">
-							<p>{ __( "You've turned off auto-renewal." ) }</p>
-							<p>
-								{ sprintf(
-									/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
-									__(
-										"Before you go, we'd love to know: " +
-											"are you letting this %(productType)s expire completely, or do you think you'll renew it manually?"
-									),
-									{ productType }
-								) }
-							</p>
-							<RadioControl
-								className="cancel-auto-renewal-form__radio-control"
-								hideLabelFromVision
-								options={ this.radioButtons }
-								selected={ this.state.response }
-								onChange={ this.onRadioChange }
-							/>
-						</fieldset>
-					}
-					actions={
-						<PrecancellationChatButton
-							purchase={ purchase }
-							onClick={ onClose }
-							className="cancel-auto-renewal-form__chat-button"
-						/>
-					}
-				/>
-			</ConfirmDialog>
-		);
+	// render
+	if ( ! isVisible ) {
+		return null;
 	}
-}
+
+	return (
+		<ConfirmDialog
+			onCancel={ onClose }
+			onConfirm={ onSubmit }
+			cancelButtonText={ __( 'Skip' ) }
+			confirmButtonText={ __( 'Submit' ) }
+		>
+			<SectionHeader
+				title={ __( 'Help us improve' ) }
+				description={
+					<fieldset role="group" className="cancel-auto-renewal-form__form-fieldset">
+						<p>{ __( "You've turned off auto-renewal." ) }</p>
+						<p>
+							{ sprintf(
+								/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+								__(
+									"Before you go, we'd love to know: " +
+										"are you letting this %(productType)s expire completely, or do you think you'll renew it manually?"
+								),
+								{ productType }
+							) }
+						</p>
+						<RadioControl
+							className="cancel-auto-renewal-form__radio-control"
+							hideLabelFromVision
+							options={ radioButtons }
+							selected={ state.response }
+							onChange={ onRadioChange }
+						/>
+					</fieldset>
+				}
+				actions={
+					<PrecancellationChatButton
+						purchase={ purchase }
+						onClick={ onClose }
+						className="cancel-auto-renewal-form__chat-button"
+					/>
+				}
+			/>
+		</ConfirmDialog>
+	);
+};
 
 export default CancelAutoRenewalForm;

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
@@ -1,8 +1,8 @@
 import { marketingSurveyMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { RadioControl, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from 'react';
 import { SectionHeader } from '../../../components/section-header';
 import { shuffleArray } from '../../../utils/collection';
 import enrichedSurveyData from '../cancel-purchase/enriched-survey-data';

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
@@ -67,20 +67,7 @@ const CancelAutoRenewalForm: FC< CancelAutoRenewFormProps > = ( {
 
 	const marketingSurveyMutate = useMutation( marketingSurveyMutation() );
 	const submitMarketingSurvey = ( surveyDetails: MarketingSurveyDetails ) =>
-		marketingSurveyMutate.mutate( surveyDetails, {
-			onSuccess: () => {
-				setState( ( state ) => ( {
-					...state,
-					isSubmitting: false,
-				} ) );
-			},
-			onError: () => {
-				setState( ( state ) => ( {
-					...state,
-					isSubmitting: false,
-				} ) );
-			},
-		} );
+		marketingSurveyMutate.mutate( surveyDetails );
 
 	const onSubmit = () => {
 		const { response } = state;

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
@@ -23,10 +23,6 @@ const CancelAutoRenewalForm: FC< CancelAutoRenewFormProps > = ( {
 	isVisible,
 	onClose,
 } ) => {
-	const [ state, setState ] = useState( {
-		response: '',
-	} );
-
 	const getProductTypeString = () => {
 		if ( purchase.is_domain_registration ) {
 			/* translators: as in "domain name"*/
@@ -43,26 +39,31 @@ const CancelAutoRenewalForm: FC< CancelAutoRenewFormProps > = ( {
 
 	const productType = getProductTypeString();
 
-	const radioButtons = shuffleArray( [
-		{
-			value: 'let-it-expire',
-			/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
-			label: sprintf( __( "I'm going to let this %(productType)s expire." ), {
-				productType,
-			} ),
-		},
-		{
-			value: 'manual-renew',
-			/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
-			label: sprintf( __( "I'm going to renew the %(productType)s, but will do it manually." ), {
-				productType,
-			} ),
-		},
-		{
-			value: 'not-sure',
-			label: __( "I'm not sure." ),
-		},
-	] );
+	const [ state, setState ] = useState( {
+		response: '',
+		radioButtons: shuffleArray( [
+			{
+				value: 'let-it-expire',
+				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+				label: sprintf( __( "I'm going to let this %(productType)s expire." ), {
+					productType,
+				} ),
+			},
+			{
+				value: 'manual-renew',
+				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+				label: sprintf( __( "I'm going to renew the %(productType)s, but will do it manually." ), {
+					productType,
+				} ),
+			},
+			{
+				value: 'not-sure',
+				label: __( "I'm not sure." ),
+			},
+		] ),
+	} );
+
+	const { radioButtons } = state;
 
 	const marketingSurveyMutate = useMutation( marketingSurveyMutation() );
 	const submitMarketingSurvey = ( surveyDetails: MarketingSurveyDetails ) =>

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
@@ -1,0 +1,176 @@
+import { RadioControl, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { SectionHeader } from '../../../components/section-header';
+import { shuffleArray } from '../../../utils/collection';
+import enrichedSurveyData from '../cancel-purchase-form/enriched-survey-data';
+// import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
+// import { submitSurvey } from 'calypso/lib/purchases/actions';
+
+class CancelAutoRenewalForm extends Component {
+	static propTypes = {
+		purchase: PropTypes.object.isRequired,
+		selectedSiteId: PropTypes.number.isRequired,
+		isVisible: PropTypes.bool,
+		onClose: PropTypes.func.isRequired,
+	};
+
+	state = {
+		response: '',
+	};
+
+	radioButtons = {};
+
+	getProductTypeString = () => {
+		const { purchase } = this.props;
+
+		if ( purchase.is_domain_registration ) {
+			/* translators: as in "domain name"*/
+			return __( 'domain' );
+		}
+
+		if ( purchase.is_plan ) {
+			/* translators: as in "Premium plan" or "Personal plan"*/
+			return __( 'plan' );
+		}
+
+		return __( 'subscription' );
+	};
+
+	constructor( props ) {
+		super( props );
+
+		const productType = this.getProductTypeString();
+
+		this.radioButtons = shuffleArray( [
+			{
+				value: 'let-it-expire',
+				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+				label: __( "I'm going to let this %(productType)s expire.", {
+					args: { productType },
+				} ),
+			},
+
+			{
+				value: 'manual-renew',
+				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+				label: __( "I'm going to renew the %(productType)s, but will do it manually.", {
+					args: { productType },
+				} ),
+			},
+			{
+				value: 'not-sure',
+				label: __( "I'm not sure." ),
+			},
+		] );
+	}
+
+	onSubmit = () => {
+		const { purchase, selectedSiteId } = this.props;
+		const { response } = this.state;
+
+		const surveyData = {
+			response,
+		};
+
+		this.props.submitSurvey(
+			'calypso-cancel-auto-renewal',
+			selectedSiteId,
+			enrichedSurveyData( surveyData, purchase )
+		);
+
+		this.props.onClose();
+	};
+
+	onRadioChange = ( value ) => {
+		this.setState( {
+			response: value,
+		} );
+	};
+
+	// renderButtons = () => {
+	// 	const { purchase, onClose } = this.props;
+	// 	const { response } = this.state;
+	// 	const disableSubmit = ! response;
+
+	// 	const skip = {
+	// 		action: 'skip',
+	// 		disabled: false,
+	// 		label: __( 'Skip' ),
+	// 		onClick: onClose,
+	// 	};
+
+	// 	const submit = {
+	// 		action: 'submit',
+	// 		isPrimary: true,
+	// 		disabled: disableSubmit,
+	// 		label: __( 'Submit' ),
+	// 		onClick: this.onSubmit,
+	// 	};
+
+	// 	const chat = (
+	// 		<PrecancellationChatButton
+	// 			purchase={ purchase }
+	// 			onClick={ onClose }
+	// 			className="cancel-auto-renewal-form__chat-button"
+	// 		/>
+	// 	);
+
+	// 	return [ skip, submit, chat ];
+	// };
+
+	render() {
+		const { isVisible, onClose } = this.props;
+
+		const productType = this.getProductTypeString();
+
+		if ( ! isVisible ) {
+			return null;
+		}
+
+		return (
+			<ConfirmDialog
+				onCancel={ onClose }
+				onConfirm={ this.onSubmit }
+				cancelButtonText={ __( 'Skip' ) }
+				confirmButtonText={ __( 'Submit' ) }
+			>
+				<SectionHeader
+					title={ __( 'Help us improve' ) }
+					description={
+						<fieldset role="group" class="cancel-auto-renewal-form__form-fieldset">
+							<p>{ __( "You've turned off auto-renewal." ) }</p>
+							<p>
+								{ sprintf(
+									/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+									__(
+										"Before you go, we'd love to know: " +
+											"are you letting this %(productType)s expire completely, or do you think you'll renew it manually?"
+									),
+									{ productType }
+								) }
+							</p>
+							<RadioControl
+								className="cancel-auto-renewal-form__radio-control"
+								hideLabelFromVision
+								options={ this.radioButtons }
+								selected={ this.state.response }
+								onChange={ this.onRadioChange }
+							/>
+						</fieldset>
+					}
+					// actions={
+					// 	<PrecancellationChatButton
+					// 		purchase={ purchase }
+					// 		onClick={ onClose }
+					// 		className="cancel-auto-renewal-form__chat-button"
+					// 	/>
+					// }
+				/>
+			</ConfirmDialog>
+		);
+	}
+}
+
+export default CancelAutoRenewalForm;

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
@@ -1,21 +1,26 @@
 import { RadioControl, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { SectionHeader } from '../../../components/section-header';
 import { shuffleArray } from '../../../utils/collection';
-import enrichedSurveyData from '../cancel-purchase-form/enriched-survey-data';
-// import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
-// import { submitSurvey } from 'calypso/lib/purchases/actions';
+import enrichedSurveyData from '../cancel-purchase/enriched-survey-data';
+import PrecancellationChatButton from './precancellation-chat-button';
+import type { MarketingSurveyResponses, Purchase } from '@automattic/api-core';
+// import { submitSurvey } from 'calypso/lib/purchases/actions'; //TODO: port submitSurvey to mutation
 
-class CancelAutoRenewalForm extends Component {
-	static propTypes = {
-		purchase: PropTypes.object.isRequired,
-		selectedSiteId: PropTypes.number.isRequired,
-		isVisible: PropTypes.bool,
-		onClose: PropTypes.func.isRequired,
-	};
+interface CancelAutoRenewFormProps {
+	purchase: Purchase;
+	selectedSiteId: number;
+	isVisible: boolean;
+	onClose: () => void;
+	submitSurvey: (
+		survey: string,
+		selectedSiteId: number,
+		surveyData: Omit< MarketingSurveyResponses, 'purchaseId' | 'purchase' >
+	) => void;
+}
 
+class CancelAutoRenewalForm extends Component< CancelAutoRenewFormProps > {
 	state = {
 		response: '',
 	};
@@ -38,7 +43,7 @@ class CancelAutoRenewalForm extends Component {
 		return __( 'subscription' );
 	};
 
-	constructor( props ) {
+	constructor( props: CancelAutoRenewFormProps ) {
 		super( props );
 
 		const productType = this.getProductTypeString();
@@ -47,16 +52,16 @@ class CancelAutoRenewalForm extends Component {
 			{
 				value: 'let-it-expire',
 				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
-				label: __( "I'm going to let this %(productType)s expire.", {
-					args: { productType },
+				label: sprintf( __( "I'm going to let this %(productType)s expire." ), {
+					productType,
 				} ),
 			},
 
 			{
 				value: 'manual-renew',
 				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
-				label: __( "I'm going to renew the %(productType)s, but will do it manually.", {
-					args: { productType },
+				label: sprintf( __( "I'm going to renew the %(productType)s, but will do it manually." ), {
+					productType,
 				} ),
 			},
 			{
@@ -83,45 +88,14 @@ class CancelAutoRenewalForm extends Component {
 		this.props.onClose();
 	};
 
-	onRadioChange = ( value ) => {
+	onRadioChange = ( value: string ) => {
 		this.setState( {
 			response: value,
 		} );
 	};
 
-	// renderButtons = () => {
-	// 	const { purchase, onClose } = this.props;
-	// 	const { response } = this.state;
-	// 	const disableSubmit = ! response;
-
-	// 	const skip = {
-	// 		action: 'skip',
-	// 		disabled: false,
-	// 		label: __( 'Skip' ),
-	// 		onClick: onClose,
-	// 	};
-
-	// 	const submit = {
-	// 		action: 'submit',
-	// 		isPrimary: true,
-	// 		disabled: disableSubmit,
-	// 		label: __( 'Submit' ),
-	// 		onClick: this.onSubmit,
-	// 	};
-
-	// 	const chat = (
-	// 		<PrecancellationChatButton
-	// 			purchase={ purchase }
-	// 			onClick={ onClose }
-	// 			className="cancel-auto-renewal-form__chat-button"
-	// 		/>
-	// 	);
-
-	// 	return [ skip, submit, chat ];
-	// };
-
 	render() {
-		const { isVisible, onClose } = this.props;
+		const { isVisible, onClose, purchase } = this.props;
 
 		const productType = this.getProductTypeString();
 
@@ -139,7 +113,7 @@ class CancelAutoRenewalForm extends Component {
 				<SectionHeader
 					title={ __( 'Help us improve' ) }
 					description={
-						<fieldset role="group" class="cancel-auto-renewal-form__form-fieldset">
+						<fieldset role="group" className="cancel-auto-renewal-form__form-fieldset">
 							<p>{ __( "You've turned off auto-renewal." ) }</p>
 							<p>
 								{ sprintf(
@@ -160,13 +134,13 @@ class CancelAutoRenewalForm extends Component {
 							/>
 						</fieldset>
 					}
-					// actions={
-					// 	<PrecancellationChatButton
-					// 		purchase={ purchase }
-					// 		onClick={ onClose }
-					// 		className="cancel-auto-renewal-form__chat-button"
-					// 	/>
-					// }
+					actions={
+						<PrecancellationChatButton
+							purchase={ purchase }
+							onClick={ onClose }
+							className="cancel-auto-renewal-form__chat-button"
+						/>
+					}
 				/>
 			</ConfirmDialog>
 		);

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancel-auto-renewal-form.tsx
@@ -99,9 +99,10 @@ const CancelAutoRenewalForm: FC< CancelAutoRenewFormProps > = ( {
 	};
 
 	const onRadioChange = ( value: string ) => {
-		setState( {
+		setState( ( state ) => ( {
+			...state,
 			response: value,
-		} );
+		} ) );
 	};
 
 	// render
@@ -119,26 +120,28 @@ const CancelAutoRenewalForm: FC< CancelAutoRenewFormProps > = ( {
 			<SectionHeader
 				title={ __( 'Help us improve' ) }
 				description={
-					<fieldset role="group" className="cancel-auto-renewal-form__form-fieldset">
-						<p>{ __( "You've turned off auto-renewal." ) }</p>
-						<p>
-							{ sprintf(
-								/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
-								__(
-									"Before you go, we'd love to know: " +
-										"are you letting this %(productType)s expire completely, or do you think you'll renew it manually?"
-								),
-								{ productType }
-							) }
-						</p>
-						<RadioControl
-							className="cancel-auto-renewal-form__radio-control"
-							hideLabelFromVision
-							options={ radioButtons }
-							selected={ state.response }
-							onChange={ onRadioChange }
-						/>
-					</fieldset>
+					<>
+						<fieldset role="group" style={ { border: 0 } }>
+							<p>{ __( "You've turned off auto-renewal." ) }</p>
+							<p>
+								{ sprintf(
+									/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+									__(
+										"Before you go, we'd love to know: " +
+											"are you letting this %(productType)s expire completely, or do you think you'll renew it manually?"
+									),
+									{ productType }
+								) }
+							</p>
+							<RadioControl
+								className="cancel-auto-renewal-form__radio-control"
+								hideLabelFromVision
+								options={ radioButtons }
+								selected={ state.response }
+								onChange={ onRadioChange }
+							/>
+						</fieldset>
+					</>
 				}
 				actions={
 					<PrecancellationChatButton

--- a/client/dashboard/me/billing-purchases/purchase-settings/chat-button.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/chat-button.tsx
@@ -179,8 +179,8 @@ const ChatButton: FC< Props > = ( {
 	const handleClick = () => {
 		if ( canConnectToZendesk && initialMessage ) {
 			onClick?.();
-			// setNewMessagingChat( { initialMessage, section, siteUrl, siteId } );
 			setSubject( initialMessage );
+			setShowHelpCenter( true );
 		} else {
 			setNavigateToRoute( '/odie' );
 			setShowHelpCenter( true );

--- a/client/dashboard/me/billing-purchases/purchase-settings/chat-button.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/chat-button.tsx
@@ -3,7 +3,7 @@ import { useChatStatus } from '@automattic/help-center/src/hooks';
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { Icon, comment } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';

--- a/client/dashboard/me/billing-purchases/purchase-settings/chat-button.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/chat-button.tsx
@@ -98,6 +98,7 @@ function useCanConnectToZendeskMessaging( enabled = true ) {
 		select: ( data ) => !! data,
 	} );
 
+	const sentTracksEvent = useRef< boolean >( false );
 	useEffect( () => {
 		// Leaving for backwards compatibility. This event is no longer needed. The one below is more general.
 		if ( ! query.data && query.status !== 'pending' ) {
@@ -107,12 +108,22 @@ function useCanConnectToZendeskMessaging( enabled = true ) {
 			} );
 		}
 
-		recordTracksEvent( 'calypso_helpcenter_zendesk_config_request', {
-			status: query.status,
-			status_text: query.error?.message,
-			failure_count: query.failureCount,
-		} );
-	}, [ recordTracksEvent, query.data, query.error?.message, query.status, query.failureCount ] );
+		if ( ! sentTracksEvent.current ) {
+			recordTracksEvent( 'calypso_helpcenter_zendesk_config_request', {
+				status: query.status,
+				status_text: query.error?.message,
+				failure_count: query.failureCount,
+			} );
+			sentTracksEvent.current = true;
+		}
+	}, [
+		sentTracksEvent,
+		recordTracksEvent,
+		query.data,
+		query.error?.message,
+		query.status,
+		query.failureCount,
+	] );
 
 	return query;
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/chat-button.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/chat-button.tsx
@@ -1,0 +1,214 @@
+import config from '@automattic/calypso-config';
+import { useChatStatus } from '@automattic/help-center/src/hooks';
+import { useQuery } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { Button } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
+import { Icon, comment } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
+import clsx from 'clsx';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { useAnalytics } from '../../../app/analytics';
+import { useHelpCenter } from '../../../app/help-center';
+import type { FC } from 'react';
+
+type APIFetchOptions = {
+	global: boolean;
+	path: string;
+};
+type MessagingAvailability = {
+	is_available: boolean;
+};
+type MessagingGroup = 'jp_presales' | 'wpcom_messaging' | 'wpcom_presales';
+
+type ChatIntent = 'SUPPORT' | 'PRESALES' | 'PRECANCELLATION';
+
+type Props = {
+	chatIntent?: ChatIntent;
+	className?: string;
+	initialMessage: string;
+	onClick?: () => void;
+	onError?: () => void;
+	primary?: boolean;
+	siteUrl?: string;
+	siteId?: string | number;
+	children?: React.ReactNode;
+	withHelpCenter?: boolean;
+	section?: string;
+};
+
+function useZendeskMessagingAvailability( group: MessagingGroup, enabled = true ) {
+	return useQuery< MessagingAvailability >( {
+		queryKey: [ 'zendeskMessagingAvailability', group ],
+		queryFn: () => {
+			const currentEnvironment = config( 'env_id' );
+			const params = {
+				group: group as string,
+				environment: currentEnvironment === 'development' ? 'development' : 'production',
+			};
+			const wpcomParams = new URLSearchParams( params );
+
+			return canAccessWpcomApis()
+				? wpcomRequest< MessagingAvailability >( {
+						path: '/help/support-status/messaging',
+						apiNamespace: 'wpcom/v2',
+						query: wpcomParams.toString(),
+						method: 'GET',
+				  } )
+				: apiFetch< MessagingAvailability >( {
+						path: addQueryArgs( '/help-center/support-status/messaging', params ),
+						method: 'GET',
+						global: true,
+				  } as APIFetchOptions );
+		},
+		staleTime: 60 * 1000, // 1 minute
+		meta: {
+			persist: false,
+		},
+		enabled,
+	} );
+}
+
+function fetchZendeskConfig() {
+	// Parse the JSON to throw errors for all non-success responses
+	return fetch( 'https://wpcom.zendesk.com/embeddable/config' ).then( ( res ) => res.json() );
+}
+
+/**
+ * This hook verifies connectivity to Zendesk's messaging service by making a config request and manages automatic retries with error tracking.
+ */
+function useCanConnectToZendeskMessaging( enabled = true ) {
+	const { recordTracksEvent } = useAnalytics();
+	const query = useQuery< boolean, Error >( {
+		queryKey: [ 'canConnectToZendesk' ],
+		queryFn: fetchZendeskConfig,
+		staleTime: Infinity,
+		// Retry 3 times with a 1 second delay between each retry
+		retry: 3,
+		retryDelay: 1000,
+		refetchOnMount: false,
+		retryOnMount: false,
+		refetchOnWindowFocus: false,
+		meta: {
+			persist: false,
+		},
+		enabled,
+		// Cast down to boolean.
+		select: ( data ) => !! data,
+	} );
+
+	useEffect( () => {
+		// Leaving for backwards compatibility. This event is no longer needed. The one below is more general.
+		if ( ! query.data && query.status !== 'pending' ) {
+			recordTracksEvent( 'calypso_helpcenter_zendesk_config_error', {
+				status: query.status,
+				status_text: query.error?.message,
+			} );
+		}
+
+		recordTracksEvent( 'calypso_helpcenter_zendesk_config_request', {
+			status: query.status,
+			status_text: query.error?.message,
+			failure_count: query.failureCount,
+		} );
+	}, [ recordTracksEvent, query.data, query.error?.message, query.status, query.failureCount ] );
+
+	return query;
+}
+
+function getMessagingGroupForIntent( chatIntent: ChatIntent ): MessagingGroup {
+	switch ( chatIntent ) {
+		case 'PRESALES':
+			return 'wpcom_presales';
+
+		case 'PRECANCELLATION':
+		case 'SUPPORT':
+		default:
+			return 'wpcom_messaging';
+	}
+}
+const ChatButton: FC< Props > = ( {
+	chatIntent = 'SUPPORT',
+	children,
+	className = '',
+	initialMessage,
+	onClick,
+	primary = false,
+	withHelpCenter = true,
+} ) => {
+	const { __ } = useI18n();
+	const { hasActiveChats, isEligibleForChat, isPrecancellationChatOpen, isPresalesChatOpen } =
+		useChatStatus();
+	const messagingGroup = getMessagingGroupForIntent( chatIntent );
+	const { data: isMessagingAvailable } = useZendeskMessagingAvailability(
+		messagingGroup,
+		isEligibleForChat
+	);
+	const { setNavigateToRoute, setSubject, setShowHelpCenter } = useHelpCenter();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
+
+	function shouldShowChatButton(): boolean {
+		if ( isEligibleForChat && hasActiveChats && canConnectToZendesk ) {
+			return true;
+		}
+
+		switch ( chatIntent ) {
+			case 'PRESALES':
+				if ( ! isPresalesChatOpen ) {
+					return false;
+				}
+				break;
+
+			case 'PRECANCELLATION':
+				if ( ! isPrecancellationChatOpen ) {
+					return false;
+				}
+				break;
+			default:
+				break;
+		}
+
+		if ( isEligibleForChat && isMessagingAvailable && ( canConnectToZendesk || withHelpCenter ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	const handleClick = () => {
+		if ( canConnectToZendesk && initialMessage ) {
+			onClick?.();
+			// setNewMessagingChat( { initialMessage, section, siteUrl, siteId } );
+			setSubject( initialMessage );
+		} else {
+			setNavigateToRoute( '/odie' );
+			setShowHelpCenter( true );
+			onClick?.();
+		}
+	};
+
+	const classes = clsx( 'chat-button', className );
+
+	if ( ! shouldShowChatButton() ) {
+		return null;
+	}
+
+	function getChildren() {
+		return children || <Icon icon={ comment } />;
+	}
+
+	return (
+		<Button
+			className={ classes }
+			variant={ primary ? 'primary' : 'link' }
+			onClick={ handleClick }
+			title={ __( 'Contact us' ) }
+			size="compact"
+		>
+			{ getChildren() }
+		</Button>
+	);
+};
+
+export default ChatButton;

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -640,10 +640,9 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 		isPending: isMutationPending,
 	} = useMutation( userPurchaseSetAutoRenewQuery() );
 	const { user } = useAuth();
-	const [ state, setState ] = useState( ( previousState ) => ( {
-		...previousState,
+	const [ state, setState ] = useState( {
 		showAutoRenewDisablingDialog: false,
-	} ) );
+	} );
 	const { showAutoRenewDisablingDialog } = state;
 	const openAutoRenewDisablingDialog = () => setState( { showAutoRenewDisablingDialog: true } );
 	const closeAutoRenewDisablingDialog = () => setState( { showAutoRenewDisablingDialog: false } );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -587,17 +587,13 @@ function getFields( {
 							disabled={ isMutationPending || isAutoRenewToggleDisabled( purchase, user ) }
 							onChange={ ( enabled: boolean ) => {
 								if ( enabled ) {
-									if ( showAutoRenewDisablingDialog ) {
-										closeAutoRenewDisablingDialog();
-									}
 									onChange( { is_auto_renew_enabled: enabled } );
 									return;
 								}
-								if ( ! enabled && ! showAutoRenewDisablingDialog ) {
+								if ( ! enabled ) {
 									openAutoRenewDisablingDialog();
 								}
 							} }
-							// onChange={ ( value: boolean ) => onChange( { is_auto_renew_enabled: value } ) }
 							help={ helpText }
 						/>
 						<AutoRenewDisablingDialog
@@ -647,12 +643,8 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const [ state, setState ] = useState( { showAutoRenewDisablingDialog: false } );
 	const { showAutoRenewDisablingDialog } = state;
-	const openAutoRenewDisablingDialog = () => {
-		setState( { showAutoRenewDisablingDialog: true } );
-	};
-	const closeAutoRenewDisablingDialog = () => {
-		setState( { showAutoRenewDisablingDialog: false } );
-	};
+	const openAutoRenewDisablingDialog = () => setState( { showAutoRenewDisablingDialog: true } );
+	const closeAutoRenewDisablingDialog = () => setState( { showAutoRenewDisablingDialog: false } );
 	return (
 		<Card>
 			<CardBody>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -37,11 +37,10 @@ import {
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { DataForm } from '@wordpress/dataviews';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { moreVertical, calendar, currencyDollar, commentAuthorAvatar } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import { useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Breadcrumbs from '../../../app/breadcrumbs';

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -41,6 +41,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { moreVertical, calendar, currencyDollar, commentAuthorAvatar } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
+import { useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Breadcrumbs from '../../../app/breadcrumbs';
@@ -85,6 +86,7 @@ import {
 } from '../../../utils/purchase';
 import BillingFlexUsageCard from '../../billing-flex-usage';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
+import AutoRenewDisablingDialog from './auto-renew-disabling-dialog';
 import { PurchaseNotice } from './purchase-notice';
 import type { User, Purchase, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -528,9 +530,15 @@ function WPComResourceMeters( { purchase, site }: { purchase: Purchase; site: Si
 function getFields( {
 	isMutationPending,
 	user,
+	showAutoRenewDisablingDialog,
+	openAutoRenewDisablingDialog,
+	closeAutoRenewDisablingDialog,
 }: {
 	isMutationPending?: boolean;
 	user: User;
+	showAutoRenewDisablingDialog: boolean;
+	openAutoRenewDisablingDialog: () => void;
+	closeAutoRenewDisablingDialog: () => void;
 } ): Field< Purchase >[] {
 	return [
 		{
@@ -566,19 +574,45 @@ function getFields( {
 					return undefined;
 				} )();
 				return (
-					<ToggleControl
-						__nextHasNoMarginBottom
-						className="purchase-settings__toggle-control"
-						label={
-							shouldAllowExpiredAutoRenewToggle( purchase )
-								? __( 'Re-activate subscription' )
-								: field.label
-						}
-						checked={ getValue( { item: purchase } ) }
-						disabled={ isMutationPending || isAutoRenewToggleDisabled( purchase, user ) }
-						onChange={ ( value: boolean ) => onChange( { is_auto_renew_enabled: value } ) }
-						help={ helpText }
-					/>
+					<>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							className="purchase-settings__toggle-control"
+							label={
+								shouldAllowExpiredAutoRenewToggle( purchase )
+									? __( 'Re-activate subscription' )
+									: field.label
+							}
+							checked={ getValue( { item: purchase } ) }
+							disabled={ isMutationPending || isAutoRenewToggleDisabled( purchase, user ) }
+							onChange={ ( enabled: boolean ) => {
+								if ( enabled ) {
+									if ( showAutoRenewDisablingDialog ) {
+										closeAutoRenewDisablingDialog();
+									}
+									onChange( { is_auto_renew_enabled: enabled } );
+									return;
+								}
+								if ( ! enabled && ! showAutoRenewDisablingDialog ) {
+									openAutoRenewDisablingDialog();
+								}
+							} }
+							// onChange={ ( value: boolean ) => onChange( { is_auto_renew_enabled: value } ) }
+							help={ helpText }
+						/>
+						<AutoRenewDisablingDialog
+							isVisible={ showAutoRenewDisablingDialog }
+							planName={ purchase.product_name }
+							purchase={ purchase }
+							siteDomain={ purchase.site_slug }
+							isAtomicSite={ false }
+							locale={ locale }
+							onClose={ closeAutoRenewDisablingDialog }
+							onConfirm={ () => {
+								onChange( { is_auto_renew_enabled: false } );
+							} }
+						/>
+					</>
 				);
 			},
 		},
@@ -611,12 +645,26 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 		isPending: isMutationPending,
 	} = useMutation( userPurchaseSetAutoRenewQuery() );
 	const { user } = useAuth();
+	const [ state, setState ] = useState( { showAutoRenewDisablingDialog: false } );
+	const { showAutoRenewDisablingDialog } = state;
+	const openAutoRenewDisablingDialog = () => {
+		setState( { showAutoRenewDisablingDialog: true } );
+	};
+	const closeAutoRenewDisablingDialog = () => {
+		setState( { showAutoRenewDisablingDialog: false } );
+	};
 	return (
 		<Card>
 			<CardBody>
 				<DataForm< Purchase >
 					data={ purchase }
-					fields={ getFields( { isMutationPending, user } ) }
+					fields={ getFields( {
+						isMutationPending,
+						user,
+						showAutoRenewDisablingDialog,
+						openAutoRenewDisablingDialog,
+						closeAutoRenewDisablingDialog,
+					} ) }
 					form={ form }
 					onChange={ ( newData ) => {
 						if ( newData.is_auto_renew_enabled !== purchase.is_auto_renew_enabled ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -640,7 +640,10 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 		isPending: isMutationPending,
 	} = useMutation( userPurchaseSetAutoRenewQuery() );
 	const { user } = useAuth();
-	const [ state, setState ] = useState( { showAutoRenewDisablingDialog: false } );
+	const [ state, setState ] = useState( ( previousState ) => ( {
+		...previousState,
+		showAutoRenewDisablingDialog: false,
+	} ) );
 	const { showAutoRenewDisablingDialog } = state;
 	const openAutoRenewDisablingDialog = () => setState( { showAutoRenewDisablingDialog: true } );
 	const closeAutoRenewDisablingDialog = () => setState( { showAutoRenewDisablingDialog: false } );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -16,6 +16,7 @@ import {
 	siteJetpackKeysQuery,
 	reinstallMarketplacePluginsQuery,
 	siteBySlugQuery,
+	siteLatestAtomicTransferQuery,
 } from '@automattic/api-queries';
 import { domainManagementEdit, domainUseMyDomain } from '@automattic/domains-table/src/utils/paths';
 import { formatCurrency } from '@automattic/number-formatters';
@@ -532,12 +533,16 @@ function getFields( {
 	showAutoRenewDisablingDialog,
 	openAutoRenewDisablingDialog,
 	closeAutoRenewDisablingDialog,
+	isAtomicSite,
+	dialogSize,
 }: {
 	isMutationPending?: boolean;
 	user: User;
 	showAutoRenewDisablingDialog: boolean;
 	openAutoRenewDisablingDialog: () => void;
 	closeAutoRenewDisablingDialog: () => void;
+	isAtomicSite: boolean;
+	dialogSize: string;
 } ): Field< Purchase >[] {
 	return [
 		{
@@ -600,7 +605,8 @@ function getFields( {
 							planName={ purchase.product_name }
 							purchase={ purchase }
 							siteDomain={ purchase.site_slug }
-							isAtomicSite={ false }
+							isAtomicSite={ isAtomicSite }
+							dialogSize={ dialogSize }
 							locale={ locale }
 							onClose={ closeAutoRenewDisablingDialog }
 							onConfirm={ () => {
@@ -633,7 +639,15 @@ const form = {
 	],
 };
 
-function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
+function ManageSubscriptionCard( {
+	purchase,
+	isAtomicSite,
+	dialogSize,
+}: {
+	purchase: Purchase;
+	isAtomicSite: boolean;
+	dialogSize: string;
+} ) {
 	const {
 		mutate: setAutoRenew,
 		error,
@@ -644,8 +658,12 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 		showAutoRenewDisablingDialog: false,
 	} );
 	const { showAutoRenewDisablingDialog } = state;
-	const openAutoRenewDisablingDialog = () => setState( { showAutoRenewDisablingDialog: true } );
-	const closeAutoRenewDisablingDialog = () => setState( { showAutoRenewDisablingDialog: false } );
+	const openAutoRenewDisablingDialog = () => {
+		setState( { showAutoRenewDisablingDialog: true } );
+	};
+	const closeAutoRenewDisablingDialog = () => {
+		setState( { showAutoRenewDisablingDialog: false } );
+	};
 	return (
 		<Card>
 			<CardBody>
@@ -657,6 +675,8 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 						showAutoRenewDisablingDialog,
 						openAutoRenewDisablingDialog,
 						closeAutoRenewDisablingDialog,
+						isAtomicSite,
+						dialogSize,
 					} ) }
 					form={ form }
 					onChange={ ( newData ) => {
@@ -1107,6 +1127,8 @@ export default function PurchaseSettings() {
 		...siteBySlugQuery( purchase.site_slug ?? '' ),
 		enabled: Boolean( purchase.site_slug ) && ! isTemporarySitePurchase( purchase ),
 	} );
+	const { data: atomicTransfer } = useQuery( siteLatestAtomicTransferQuery( purchase.blog_id ) );
+	const isAtomicSite = atomicTransfer?.created_at;
 	const formattedExpiry = useFormattedTime( purchase.expiry_date ?? '' );
 	const formattedRenewal = useFormattedTime( purchase.renew_date ?? '' );
 	const upgradeUrl = getUpgradeUrl( purchase );
@@ -1129,6 +1151,7 @@ export default function PurchaseSettings() {
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const columns = isSmallViewport ? 1 : 2;
 	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
+	const dialogSize = isSmallViewport ? 'medium' : 'large';
 
 	return (
 		<PageLayout
@@ -1241,7 +1264,11 @@ export default function PurchaseSettings() {
 					<BillingFlexUsageCard purchaseId={ purchase.ID } />
 				) }
 				{ ! purchase.is_trial_plan && purchase.subscription_status === 'active' && (
-					<ManageSubscriptionCard purchase={ purchase } />
+					<ManageSubscriptionCard
+						purchase={ purchase }
+						isAtomicSite={ isAtomicSite }
+						dialogSize={ dialogSize }
+					/>
 				) }
 				<PurchaseSettingsActions purchase={ purchase } />
 			</VStack>

--- a/client/dashboard/me/billing-purchases/purchase-settings/precancellation-chat-button.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/precancellation-chat-button.tsx
@@ -1,0 +1,57 @@
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useAnalytics } from '../../../app/analytics';
+import ChatButton from './chat-button';
+import type { Purchase } from '@automattic/api-core';
+import type { FC } from 'react';
+
+type Props = {
+	icon?: string;
+	purchase: Purchase;
+	surveyStep?: string;
+	onClick: () => void;
+	className?: string;
+};
+
+const PrecancellationChatButton: FC< Props > = ( {
+	purchase,
+	surveyStep = '',
+	onClick,
+	className,
+} ) => {
+	const { recordTracksEvent } = useAnalytics();
+
+	const handleClick = () => {
+		recordTracksEvent( 'calypso_precancellation_chat_click', {
+			survey_step: surveyStep,
+			purchase: purchase.product_slug,
+			is_plan: purchase.is_plan,
+			is_domain_registration: purchase.is_domain_registration,
+			has_included_domain: purchase.included_domain,
+		} );
+
+		onClick();
+	};
+
+	const purchaseDomain = purchase.is_domain
+		? `domain: ${ purchase.meta }`
+		: `site: ${ purchase.domain }`;
+	const initialMessage =
+		'User is contacting us from the pre-cancellation flow.\n' +
+		"Product they're attempting to cancel: " +
+		`${ purchase.product_name } (slug: ${ purchase.product_slug }, ${ purchaseDomain })`;
+
+	return (
+		<ChatButton
+			chatIntent="PRECANCELLATION"
+			initialMessage={ initialMessage }
+			className={ clsx( 'precancellation-chat-button__main-button', className ) }
+			onClick={ handleClick }
+			section="pre-cancellation"
+		>
+			{ __( 'Need help?' ) }
+		</ChatButton>
+	);
+};
+
+export default PrecancellationChatButton;

--- a/client/dashboard/utils/collection.ts
+++ b/client/dashboard/utils/collection.ts
@@ -10,6 +10,7 @@ export function shuffleArray< T >( collection: T[] ): T[] {
 		newArray[ randomPointer ] = newArray[ pointer ];
 		newArray[ pointer ] = valueAtRandomPointer;
 	} );
+	collection = collection.filter( ( val ) => val );
 	return newArray;
 }
 

--- a/client/dashboard/utils/collection.ts
+++ b/client/dashboard/utils/collection.ts
@@ -1,9 +1,9 @@
 const randomInt = ( lower: number, upper: number ): number =>
 	Math.floor( Math.random() * ( upper - lower + 1 ) );
 
-export function shuffleArray< T >( collection: T[] ): T[] {
 export function shuffleArray< T >( collection: readonly T[] ): T[] {
 	let pointer = -1;
+	const newArray = structuredClone( collection );
 	collection.forEach( () => {
 		const randomPointer = randomInt( ++pointer, collection.length - 1 );
 		const valueAtRandomPointer = newArray[ randomPointer ];

--- a/client/dashboard/utils/collection.ts
+++ b/client/dashboard/utils/collection.ts
@@ -10,8 +10,7 @@ export function shuffleArray< T >( collection: T[] ): T[] {
 		newArray[ randomPointer ] = newArray[ pointer ];
 		newArray[ pointer ] = valueAtRandomPointer;
 	} );
-	collection = collection.filter( ( val ) => val );
-	return newArray;
+	return newArray.filter( ( val ) => val );
 }
 
 export function mostCommonValueInArray< T >( arr: T[] ): T | undefined {

--- a/client/dashboard/utils/collection.ts
+++ b/client/dashboard/utils/collection.ts
@@ -2,7 +2,7 @@ const randomInt = ( lower: number, upper: number ): number =>
 	Math.floor( Math.random() * ( upper - lower + 1 ) );
 
 export function shuffleArray< T >( collection: T[] ): T[] {
-	const newArray = structuredClone( collection );
+export function shuffleArray< T >( collection: readonly T[] ): T[] {
 	let pointer = -1;
 	collection.forEach( () => {
 		const randomPointer = randomInt( ++pointer, collection.length - 1 );

--- a/client/dashboard/utils/collection.ts
+++ b/client/dashboard/utils/collection.ts
@@ -3,7 +3,7 @@ const randomInt = ( lower: number, upper: number ): number =>
 
 export function shuffleArray< T >( collection: readonly T[] ): T[] {
 	let pointer = -1;
-	const newArray = structuredClone( collection );
+	const newArray = [ ...collection ];
 	collection.forEach( () => {
 		const randomPointer = randomInt( ++pointer, collection.length - 1 );
 		const valueAtRandomPointer = newArray[ randomPointer ];

--- a/client/dashboard/utils/collection.ts
+++ b/client/dashboard/utils/collection.ts
@@ -2,15 +2,15 @@ const randomInt = ( lower: number, upper: number ): number =>
 	Math.floor( Math.random() * ( upper - lower + 1 ) );
 
 export function shuffleArray< T >( collection: T[] ): T[] {
-	const newArray = collection;
+	const newArray = structuredClone( collection );
 	let pointer = -1;
 	collection.forEach( () => {
-		const randomPointer = randomInt( ++pointer, collection.length );
+		const randomPointer = randomInt( ++pointer, collection.length - 1 );
 		const valueAtRandomPointer = newArray[ randomPointer ];
 		newArray[ randomPointer ] = newArray[ pointer ];
 		newArray[ pointer ] = valueAtRandomPointer;
 	} );
-	return newArray.filter( ( val ) => val );
+	return newArray;
 }
 
 export function mostCommonValueInArray< T >( arr: T[] ): T | undefined {

--- a/client/dashboard/utils/collection.ts
+++ b/client/dashboard/utils/collection.ts
@@ -1,7 +1,7 @@
 const randomInt = ( lower: number, upper: number ): number =>
 	Math.floor( Math.random() * ( upper - lower + 1 ) );
 
-export function shuffleArray( collection: string[] ) {
+export function shuffleArray< T >( collection: T[] ): T[] {
 	const newArray = collection;
 	let pointer = -1;
 	collection.forEach( () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [SHILL-1253](https://linear.app/a8c/issue/SHILL-1253/multi-site-dashboard-do-we-need-autorenewdisablingdialog)

## Proposed Changes

* Add `AutoRenewDisablingDialog` back into the auto-renew toggle on the purchase settings page in the MSD.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This functionality was not ported over previously, which means people are able to disable auto renew without being first warned about possible consequences of doing so (e.g., losing domain, losing atomic features unless they manually renew).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try to disable auto-renew in the MSD for domains, atomic site plans and email products.
* When the dialog pops up, click "Need help?" and observe: 1. the dialog closes 2. the help center pops up 3. auto renew remains enabled.
* Try to disable auto-renew again. When the dialog pops up, click "keep auto renew on". observe 1. the dialog closes, 2. auto renew remains enabled.
* Try to disable auto-renew again. When the dialog pops up, click "turn off auto renew". Click outside of the dialog box. observe: 1. the dialog closes, 2. auto renew is disabled.
* Enable auto renew. Observe that it is now enabled.
* Try to disable auto-renew again. When the dialog pops up, click "turn off auto renew". Click "need help?" and observe: 1. the dialog closes, 2. the help center pops up, 3. auto renew is disabled.
* Enable auto renew. Observe that it is now enabled.
* Try to disable auto-renew again. When the dialog pops up, click "turn off auto renew" then click "Skip". Observe: 1. the dialog closes, 2. auto renew is disabled.
* Enable auto renew. Observe that it is now enabled.
* Open the network tab in developer tools. Try to disable auto-renew again. When the dialog pops up, click "turn off auto renew" and complete the survey, clicking submit when finished. Observe: 1. the dialog closes, 2. network tab in developer tools shows a request to submit the survey 3. auto renew is disabled.

Repeat the steps above for an atomic site and make sure that you see a dialog which provides a link to download content from your site. Confirm that auto renewal is disable only after clicking "Turn off auto-renew" twice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
