### PR TITLE
MSD Cancel: Show Skip button only for surveys

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -296,6 +296,11 @@ function StepButtons( {
 
 	const isLastStep = surveyStep === allSteps?.[ allSteps.length - 1 ];
 
+	// Check if ANY step in the flow is a warning/confirmation step
+	// If so, we should not show Skip button at all to avoid bypassing warnings
+	const hasWarningStep =
+		allSteps?.includes( ATOMIC_REVERT_STEP ) || allSteps?.includes( REMOVE_PLAN_STEP );
+
 	if ( surveyStep === UPSELL_STEP ) {
 		return null;
 	}
@@ -306,9 +311,11 @@ function StepButtons( {
 				<Button variant="primary" disabled={ ! canGoNext } onClick={ clickNext }>
 					{ __( 'Continue' ) }
 				</Button>
-				<Button variant="tertiary" onClick={ onSubmit }>
-					{ __( 'Skip' ) }
-				</Button>
+				{ ! hasWarningStep && (
+					<Button variant="tertiary" onClick={ onSubmit }>
+						{ __( 'Skip' ) }
+					</Button>
+				) }
 			</ButtonStack>
 		);
 	}
@@ -375,7 +382,7 @@ function StepButtons( {
 			>
 				{ __( 'Submit' ) }
 			</Button>
-			{ ! canGoNext && ! isCancelling && (
+			{ ! canGoNext && ! isCancelling && ! hasWarningStep && (
 				<Button variant="tertiary" onClick={ onSubmit }>
 					{ __( 'Skip' ) }
 				</Button>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1451/the-remove-plan-view-has-a-skip-button-and-is-missing-plan

## Proposed Changes

This PR modifies the Multi Site Dashboard (MSD) cancel flow so that if the steps of the form contain any "warning" steps (steps that are not just survey questions), the "Skip" button (a new feature of the MSD cancel flow) will not be displayed.

Before             |  After
:-------------------------:|:-------------------------:
<img width="697" height="450" alt="Screenshot 2026-01-05 at 12 21 26 PM" src="https://github.com/user-attachments/assets/ce4a4970-9286-4c9b-9d43-a993d76f4581" /> | <img width="687" height="436" alt="Screenshot 2026-01-05 at 12 21 34 PM" src="https://github.com/user-attachments/assets/9aad85b3-bac5-4870-83fd-51a016d3968e" />
<img width="710" height="631" alt="Screenshot 2026-01-05 at 12 28 43 PM" src="https://github.com/user-attachments/assets/62cfcc1b-8700-4fb7-85fc-25f5ea2ee333" /> | <img width="709" height="642" alt="Screenshot 2026-01-05 at 12 36 26 PM" src="https://github.com/user-attachments/assets/696ec0c6-d9de-415c-b5ce-f6212f1984d0" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There's a bug with the cancel flow for Atomic sites: the user is offered a "Skip" button (a new feature of the MSD cancel flow) which allows skipping ATOMIC_REVERT_STEP entirely. ATOMIC_REVERT_STEP is critical because it warns the user about what will happen when they revert from Atomic to Simple so we must not allow it to be skipped.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Purchase a WordPress.com Business plan and switch the site to Atomic. **NOTE: this is not trivial to do in a test environment.** See P9o2xV-30n-p2 for some information.
- Wait until the plan is outside its refund period. (Or simulate this by changing `is_refundable` to false on the server response for the upgrades endpoint.)
- Visit https://my.wordpress.com/me/billing/purchases and select the plan.
- Turn off auto-renew on that plan.
- Click the "Remove" button. (If you see "Cancel", you cannot reproduce this bug.)
- Check the box on the first page (the page will read "Your plan will expire on XXX and you’ll lose access to…") and press "Cancel plan".
- On the second page (the page will read "Before you go, please answer a few quick questions to help us improve.") verify that there's no "Skip" button.
- Select some answers to the survey and click "Continue".
- Verify that the next step is the Atomic revert warning step (the page will read "Proceed with caution").
- Verify there's  no "Skip" button.