### PR TITLE
MSD Activity Logs: Use external links

### DIFF
--- a/client/dashboard/components/logs-activity-formatted-block/index.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/index.tsx
@@ -13,6 +13,7 @@
  * });
  * // Renders: Updated <a href="/reader/blogs/123/posts/456">Hello World</a>
  */
+import { ExternalLink } from '@wordpress/components';
 import { Fragment, type MouseEvent, type ReactNode } from 'react';
 import isA8CForAgencies from '../../../lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from '../../../lib/jetpack/is-jetpack-cloud';
@@ -40,48 +41,27 @@ const Emphasis = ( { children }: { children: ReactNode } ) => <em>{ children }</
 
 const Preformatted = ( { children }: { children: ReactNode } ) => <pre>{ children }</pre>;
 
-const isWordPressDotComUrl = ( url?: string | null ) =>
-	!! url && url.startsWith( 'https://wordpress.com/' ); // we want the extra slash at the end because other subdomains could be used to trick this check (e.g. wordpress.com.malicious-site.com)
-
-const relativizeWordPressUrl = ( url: string ) => url.replace( /^https:\/\/wordpress\.com/, '' );
-
 const Link: BlockRenderer = ( { content, children, onClick, meta } ) => {
-	const { url: originalUrl, activity, section, intent } = content;
+	const { url, activity, section, intent } = content;
 
-	if ( ! originalUrl ) {
+	if ( ! url ) {
 		return <Fragment>{ children }</Fragment>;
 	}
 
-	if ( isWordPressDotComUrl( originalUrl ) ) {
-		if ( isJetpackCloud() || isA8CForAgencies() ) {
-			return <Fragment>{ children }</Fragment>;
-		}
-
-		return (
-			<a
-				href={ relativizeWordPressUrl( originalUrl ) }
-				onClick={ onClick }
-				data-activity={ activity ?? meta.activity }
-				data-section={ section ?? meta.section }
-				data-intent={ intent ?? meta.intent }
-			>
-				{ children }
-			</a>
-		);
+	if ( isJetpackCloud() || isA8CForAgencies() ) {
+		return <Fragment>{ children }</Fragment>;
 	}
 
 	return (
-		<a
-			href={ originalUrl }
+		<ExternalLink
+			href={ url }
 			onClick={ onClick }
 			data-activity={ activity ?? meta.activity }
 			data-section={ section ?? meta.section }
 			data-intent={ intent ?? meta.intent }
-			target="_blank"
-			rel="noopener noreferrer"
 		>
 			{ children }
-		</a>
+		</ExternalLink>
 	);
 };
 

--- a/client/dashboard/components/logs-activity-formatted-block/index.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/index.tsx
@@ -41,6 +41,9 @@ const Emphasis = ( { children }: { children: ReactNode } ) => <em>{ children }</
 
 const Preformatted = ( { children }: { children: ReactNode } ) => <pre>{ children }</pre>;
 
+const isWordPressDotComUrl = ( url?: string | null ) =>
+	!! url && url.startsWith( 'https://wordpress.com/' ); // we want the extra slash at the end because other subdomains could be used to trick this check (e.g. wordpress.com.malicious-site.com)
+
 const Link: BlockRenderer = ( { content, children, onClick, meta } ) => {
 	const { url, activity, section, intent } = content;
 
@@ -48,7 +51,7 @@ const Link: BlockRenderer = ( { content, children, onClick, meta } ) => {
 		return <Fragment>{ children }</Fragment>;
 	}
 
-	if ( isJetpackCloud() || isA8CForAgencies() ) {
+	if ( isWordPressDotComUrl( url ) && ( isJetpackCloud() || isA8CForAgencies() ) ) {
 		return <Fragment>{ children }</Fragment>;
 	}
 

--- a/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
@@ -99,18 +99,6 @@ describe( 'Link blocks', () => {
 		jest.clearAllMocks();
 	} );
 
-	test( 'relativizes wordpress.com links when not in Jetpack or A4A', () => {
-		renderFormatted( {
-			type: 'link',
-			url: 'https://wordpress.com/path/to/resource',
-			children: [ 'My link' ],
-		} );
-
-		const link = screen.getByRole( 'link' );
-		expect( link ).toHaveAttribute( 'href', '/path/to/resource' );
-		expect( link ).toHaveTextContent( 'My link' );
-	} );
-
 	test.each( [
 		[ 'Jetpack Cloud', true, false ],
 		[ 'A4A', false, true ],
@@ -143,7 +131,7 @@ describe( 'Link blocks', () => {
 			const link = screen.getByRole( 'link' );
 			expect( link ).toHaveAttribute( 'href', 'https://example.com/path' );
 			expect( link ).toHaveAttribute( 'target', '_blank' );
-			expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+			expect( link ).toHaveAttribute( 'rel', 'external noopener noreferrer' );
 		}
 	);
 } );

--- a/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
@@ -131,7 +131,7 @@ describe( 'Link blocks', () => {
 			const link = screen.getByRole( 'link' );
 			expect( link ).toHaveAttribute( 'href', 'https://example.com/path' );
 			expect( link ).toHaveAttribute( 'target', '_blank' );
-			expect( link ).toHaveAttribute( 'rel', 'external noopener noreferrer' );
+			expect( link ).toHaveAttribute( 'rel', 'external noreferrer noopener' );
 		}
 	);
 } );

--- a/client/dashboard/components/logs-activity/activity-event.scss
+++ b/client/dashboard/components/logs-activity/activity-event.scss
@@ -15,7 +15,8 @@
 .site-activity-logs__event-content {
 	flex: 1 0 0;
 	flex-wrap: wrap;
-	span {
+
+	> span {
 		color: $gray-700;
 	}
 }

--- a/client/dashboard/components/logs-activity/test/activity-event.test.tsx
+++ b/client/dashboard/components/logs-activity/test/activity-event.test.tsx
@@ -86,7 +86,7 @@ describe( 'ActivityEvent', () => {
 
 		render( <ActivityEvent activity={ activity } /> );
 
-		const link = screen.getByRole( 'link', { name: 'View' } );
+		const link = screen.getByRole( 'link', { name: 'View (opens in a new tab)' } );
 		expect( link ).toBeInTheDocument();
 		expect( link.getAttribute( 'href' ) ).toBe( 'https://wordpress.com/post/example' );
 	} );
@@ -212,7 +212,7 @@ describe( 'ActivityEvent', () => {
 
 		render( <ActivityEvent activity={ activity } /> );
 
-		const link = screen.getByRole( 'link', { name: 'Comment' } );
+		const link = screen.getByRole( 'link', { name: 'Comment (opens in a new tab)' } );
 		expect( link.getAttribute( 'href' ) ).toBe( 'https://wordpress.com/comment/2/1' );
 	} );
 

--- a/client/dashboard/components/logs-activity/test/activity-event.test.tsx
+++ b/client/dashboard/components/logs-activity/test/activity-event.test.tsx
@@ -88,7 +88,7 @@ describe( 'ActivityEvent', () => {
 
 		const link = screen.getByRole( 'link', { name: 'View' } );
 		expect( link ).toBeInTheDocument();
-		expect( link.getAttribute( 'href' ) ).toBe( '/post/example' );
+		expect( link.getAttribute( 'href' ) ).toBe( 'https://wordpress.com/post/example' );
 	} );
 
 	it( 'renders strong ranges as bold text', () => {
@@ -213,7 +213,7 @@ describe( 'ActivityEvent', () => {
 		render( <ActivityEvent activity={ activity } /> );
 
 		const link = screen.getByRole( 'link', { name: 'Comment' } );
-		expect( link.getAttribute( 'href' ) ).toBe( '/comment/2/1' );
+		expect( link.getAttribute( 'href' ) ).toBe( 'https://wordpress.com/comment/2/1' );
 	} );
 
 	it( 'renders plugin links for plugin ranges', () => {


### PR DESCRIPTION
## Proposed Changes

Currently, activity log links are converted to relative urls if the origin is wordpress.com.

https://github.com/Automattic/wp-calypso/blob/85c03ac6be6e897187aa1b4fe959e0207ee17129/client/dashboard/components/logs-activity-formatted-block/index.tsx#L55-L71

This approach no longer works with the MSD subdomain, as these paths do not exist in the Dashboard environment. This PR updates links to open externally instead.

I considered replacing wordpress.com with the MSD subdomain for paths that exist in the Dashboard environment (e.g.: wordpress.com/plugins/${plugin_slug} → my.wordpress.com/plugins/${plugin_slug}) , but ultimately decided against it since the routing paths might not be the same after all. For instance, wordpress.com/plugins/plugin/${plugin_slug} vs my.wordpress.com/plugins/${plugin_slug}.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to MSD /sites
* Select a site
* Click on the Logs tab
* Ensure that the links in the Activity Logs are now external

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
