### PR TITLE
MSD: Add an empty state component.

### DIFF
--- a/client/dashboard/components/empty-state/empty-state-action-item.tsx
+++ b/client/dashboard/components/empty-state/empty-state-action-item.tsx
@@ -1,0 +1,6 @@
+import { ActionList } from '../action-list';
+import type { ActionItemProps } from '../action-list/types';
+
+export default function EmptyStateActionItem( props: ActionItemProps ) {
+	return <ActionList.ActionItem { ...props } />;
+}

--- a/client/dashboard/components/empty-state/empty-state-action-list.tsx
+++ b/client/dashboard/components/empty-state/empty-state-action-list.tsx
@@ -1,0 +1,14 @@
+import { ActionList } from '../action-list';
+import type { ReactNode } from 'react';
+
+type EmptyStateActionListProps = {
+	children?: ReactNode;
+};
+
+export default function EmptyStateActionList( { children }: EmptyStateActionListProps ) {
+	if ( ! children ) {
+		return null;
+	}
+
+	return <ActionList>{ children }</ActionList>;
+}

--- a/client/dashboard/components/empty-state/empty-state-action-list.tsx
+++ b/client/dashboard/components/empty-state/empty-state-action-list.tsx
@@ -6,9 +6,5 @@ type EmptyStateActionListProps = {
 };
 
 export default function EmptyStateActionList( { children }: EmptyStateActionListProps ) {
-	if ( ! children ) {
-		return null;
-	}
-
 	return <ActionList>{ children }</ActionList>;
 }

--- a/client/dashboard/components/empty-state/index.stories.tsx
+++ b/client/dashboard/components/empty-state/index.stories.tsx
@@ -117,7 +117,7 @@ export const WithIconsAndActions: Story = {
 					}
 				/>
 				<EmptyState.ActionItem
-					title="Fine‑tune settings"
+					title="Settings"
 					description="Adjust advanced options as your site grows."
 					decoration={ <Icon icon={ cog } /> }
 					actions={

--- a/client/dashboard/components/empty-state/index.stories.tsx
+++ b/client/dashboard/components/empty-state/index.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Button } from '@wordpress/components';
+import { Button, Icon } from '@wordpress/components';
+import { cog, layout, page } from '@wordpress/icons';
 import EmptyState from './index';
 
 const meta: Meta< typeof EmptyState > = {
@@ -85,6 +86,47 @@ export const WithContentBelowActions: Story = {
 					You can always change this later in your settings.
 				</p>
 			</>
+		),
+	},
+};
+
+export const WithIconsInActions: Story = {
+	args: {
+		title: 'Set up your site',
+		description: 'Choose an option below to start customizing your site.',
+		children: (
+			<EmptyState.ActionList>
+				<EmptyState.ActionItem
+					title="Pick a design"
+					description="Browse themes and layouts that fit your brand."
+					decoration={ <Icon icon={ layout } /> }
+					actions={
+						<Button variant="secondary" size="compact">
+							Browse designs
+						</Button>
+					}
+				/>
+				<EmptyState.ActionItem
+					title="Create a page"
+					description="Start with a new page and add your content."
+					decoration={ <Icon icon={ page } /> }
+					actions={
+						<Button variant="secondary" size="compact">
+							New page
+						</Button>
+					}
+				/>
+				<EmptyState.ActionItem
+					title="Fine‑tune settings"
+					description="Adjust advanced options as your site grows."
+					decoration={ <Icon icon={ cog } /> }
+					actions={
+						<Button variant="secondary" size="compact">
+							Open settings
+						</Button>
+					}
+				/>
+			</EmptyState.ActionList>
 		),
 	},
 };

--- a/client/dashboard/components/empty-state/index.stories.tsx
+++ b/client/dashboard/components/empty-state/index.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta< typeof EmptyState > = {
 	title: 'client/dashboard/EmptyState',
 	component: EmptyState,
 	parameters: {
-		layout: 'centered',
+		layout: 'padded',
 	},
 	tags: [ 'autodocs' ],
 };

--- a/client/dashboard/components/empty-state/index.stories.tsx
+++ b/client/dashboard/components/empty-state/index.stories.tsx
@@ -1,0 +1,90 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Button } from '@wordpress/components';
+import EmptyState from './index';
+
+const meta: Meta< typeof EmptyState > = {
+	title: 'client/dashboard/EmptyState',
+	component: EmptyState,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: [ 'autodocs' ],
+};
+
+export default meta;
+
+type Story = StoryObj< typeof EmptyState >;
+
+export const Default: Story = {
+	args: {
+		title: 'No items yet',
+		description: 'Get started by creating your first item.',
+		children: (
+			<EmptyState.ActionList>
+				<EmptyState.ActionItem
+					title="Create item"
+					description="Set up a new item to see it appear here."
+					actions={
+						<Button __next40pxDefaultSize variant="primary">
+							Create item
+						</Button>
+					}
+				/>
+			</EmptyState.ActionList>
+		),
+	},
+};
+
+export const WithMultipleActions: Story = {
+	args: {
+		title: 'Nothing here yet',
+		description: 'Choose one of the options below to get started.',
+		children: (
+			<EmptyState.ActionList>
+				<EmptyState.ActionItem
+					title="Create item"
+					description="Set up a new item to see it appear here."
+					actions={
+						<Button __next40pxDefaultSize variant="primary">
+							Create item
+						</Button>
+					}
+				/>
+				<EmptyState.ActionItem
+					title="Learn more"
+					description="Read the documentation to understand how this works."
+					actions={
+						<Button variant="secondary" size="compact">
+							View docs
+						</Button>
+					}
+				/>
+			</EmptyState.ActionList>
+		),
+	},
+};
+
+export const WithContentBelowActions: Story = {
+	args: {
+		title: 'No items yet',
+		description: 'Get started by creating your first item.',
+		children: (
+			<>
+				<EmptyState.ActionList>
+					<EmptyState.ActionItem
+						title="Create item"
+						description="Set up a new item to see it appear here."
+						actions={
+							<Button __next40pxDefaultSize variant="primary">
+								Create item
+							</Button>
+						}
+					/>
+				</EmptyState.ActionList>
+				<p style={ { textAlign: 'center', margin: 0 } }>
+					You can always change this later in your settings.
+				</p>
+			</>
+		),
+	},
+};

--- a/client/dashboard/components/empty-state/index.stories.tsx
+++ b/client/dashboard/components/empty-state/index.stories.tsx
@@ -90,7 +90,7 @@ export const WithContentBelowActions: Story = {
 	},
 };
 
-export const WithIconsInActions: Story = {
+export const WithIconsAndActions: Story = {
 	args: {
 		title: 'Set up your site',
 		description: 'Choose an option below to start customizing your site.',

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -21,7 +21,7 @@ function EmptyState( {
 			<CardBody>
 				<VStack spacing={ 8 } alignment="center" className="dashboard-empty-state">
 					<VStack spacing={ 2 } alignment="center">
-						<Text as="h2" size="20px" weight={ 500 } align="center">
+						<Text as="h2" align="center" className="dashboard-empty-state__title">
 							{ title }
 						</Text>
 						<Text variant="muted" align="center" className="dashboard-empty-state__description">

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -1,10 +1,11 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { Card, CardBody } from '../card';
 import { Text } from '../text';
 import EmptyStateActionItem from './empty-state-action-item';
 import EmptyStateActionList from './empty-state-action-list';
 import type { ReactNode } from 'react';
+
+import './style.scss';
 
 function EmptyState( {
 	title,
@@ -15,25 +16,19 @@ function EmptyState( {
 	description: ReactNode;
 	children?: ReactNode;
 } ) {
-	const isMobile = useViewportMatch( 'small', '<' );
 	return (
 		<Card>
 			<CardBody>
-				<VStack
-					spacing={ 8 }
-					style={ { minHeight: ! isMobile ? 'min(70vh, 676px)' : 'auto' } }
-					justify={ isMobile ? 'flex-start' : 'center' }
-					alignment="center"
-				>
+				<VStack spacing={ 8 } alignment="center" className="dashboard-empty-state">
 					<VStack spacing={ 2 } alignment="center">
 						<Text as="h2" size="20px" weight={ 500 } align="center">
 							{ title }
 						</Text>
-						<Text style={ { width: 'min(100%, 432px)' } } variant="muted" align="center">
+						<Text variant="muted" align="center" className="dashboard-empty-state__description">
 							{ description }
 						</Text>
 					</VStack>
-					<VStack spacing={ 6 } style={ { width: 'min(100%, 660px)' } }>
+					<VStack spacing={ 6 } className="dashboard-empty-state__content">
 						{ children }
 					</VStack>
 				</VStack>

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -17,12 +17,12 @@ function EmptyState( {
 	return (
 		<Card>
 			<CardBody>
-				<VStack style={ { minHeight: 'max(60vh, 676px)' } } spacing={ 8 } alignment="center">
+				<VStack style={ { minHeight: 'min(60vh, 676px)' } } spacing={ 8 } alignment="center">
 					<VStack spacing={ 2 }>
 						<Text as="h2" size="20px" weight={ 500 } align="center">
 							{ title }
 						</Text>
-						<Text style={ { width: 'min(100%, 351px)' } } variant="muted" align="center">
+						<Text style={ { width: 'min(100%, 432px)' } } variant="muted" align="center">
 							{ description }
 						</Text>
 					</VStack>

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -20,8 +20,8 @@ function EmptyState( {
 		<Card>
 			<CardBody>
 				<VStack
-					style={ { minHeight: 'min(70vh, 676px)' } }
 					spacing={ 8 }
+					style={ { minHeight: ! isMobile ? 'min(70vh, 676px)' : 'auto' } }
 					justify={ isMobile ? 'flex-start' : 'center' }
 					alignment="center"
 				>

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -17,16 +17,16 @@ function EmptyState( {
 	return (
 		<Card>
 			<CardBody>
-				<VStack style={ { minHeight: '676px' } } spacing={ 8 } alignment="center">
+				<VStack style={ { minHeight: 'max(60vh, 676px)' } } spacing={ 8 } alignment="center">
 					<VStack spacing={ 2 }>
 						<Text as="h2" size="20px" weight={ 500 } align="center">
 							{ title }
 						</Text>
-						<Text style={ { maxWidth: '351px' } } variant="muted" align="center">
+						<Text style={ { width: 'min(100%, 351px)' } } variant="muted" align="center">
 							{ description }
 						</Text>
 					</VStack>
-					<VStack spacing={ 6 } style={ { maxWidth: '660px' } }>
+					<VStack spacing={ 6 } style={ { width: 'min(100%, 660px)' } }>
 						{ children }
 					</VStack>
 				</VStack>

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -18,7 +18,7 @@ function EmptyState( {
 		<Card>
 			<CardBody>
 				<VStack style={ { minHeight: 'min(70vh, 676px)' } } spacing={ 8 } alignment="center">
-					<VStack spacing={ 2 }>
+					<VStack spacing={ 2 } alignment="center">
 						<Text as="h2" size="20px" weight={ 500 } align="center">
 							{ title }
 						</Text>

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -11,7 +11,7 @@ function EmptyState( {
 	children,
 }: {
 	title: string;
-	description: string;
+	description: ReactNode;
 	children?: ReactNode;
 } ) {
 	return (

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -17,7 +17,7 @@ function EmptyState( {
 	return (
 		<Card>
 			<CardBody>
-				<VStack style={ { minHeight: 'min(60vh, 676px)' } } spacing={ 8 } alignment="center">
+				<VStack style={ { minHeight: 'min(70vh, 676px)' } } spacing={ 8 } alignment="center">
 					<VStack spacing={ 2 }>
 						<Text as="h2" size="20px" weight={ 500 } align="center">
 							{ title }

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -1,4 +1,5 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { Card, CardBody } from '../card';
 import { Text } from '../text';
 import EmptyStateActionItem from './empty-state-action-item';
@@ -14,10 +15,16 @@ function EmptyState( {
 	description: ReactNode;
 	children?: ReactNode;
 } ) {
+	const isMobile = useViewportMatch( 'small', '<' );
 	return (
 		<Card>
 			<CardBody>
-				<VStack style={ { minHeight: 'min(70vh, 676px)' } } spacing={ 8 } alignment="center">
+				<VStack
+					style={ { minHeight: 'min(70vh, 676px)' } }
+					spacing={ 8 }
+					justify={ isMobile ? 'flex-start' : 'center' }
+					alignment="center"
+				>
 					<VStack spacing={ 2 } alignment="center">
 						<Text as="h2" size="20px" weight={ 500 } align="center">
 							{ title }

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -1,0 +1,43 @@
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Card, CardBody } from '../card';
+import { Text } from '../text';
+import EmptyStateActionItem from './empty-state-action-item';
+import EmptyStateActionList from './empty-state-action-list';
+import type { ReactNode } from 'react';
+
+function EmptyState( {
+	title,
+	description,
+	children,
+}: {
+	title: string;
+	description: string;
+	children?: ReactNode;
+} ) {
+	return (
+		<Card>
+			<CardBody>
+				<VStack style={ { minHeight: '676px' } } spacing={ 8 } alignment="center">
+					<VStack spacing={ 2 }>
+						<Text as="h2" size="20px" weight={ 500 } align="center">
+							{ title }
+						</Text>
+						<Text style={ { maxWidth: '351px' } } variant="muted" align="center">
+							{ description }
+						</Text>
+					</VStack>
+					<VStack spacing={ 6 } style={ { maxWidth: '660px' } }>
+						{ children }
+					</VStack>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}
+
+const EmptyStateWithStatics = Object.assign( EmptyState, {
+	ActionList: EmptyStateActionList,
+	ActionItem: EmptyStateActionItem,
+} );
+
+export default EmptyStateWithStatics;

--- a/client/dashboard/components/empty-state/style.scss
+++ b/client/dashboard/components/empty-state/style.scss
@@ -1,0 +1,22 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.dashboard-empty-state {
+	justify-content: flex-start;
+
+	@include break-small {
+		justify-content: center;
+		min-height: min(70vh, 676px);
+	}
+}
+
+// Balanced wrapping works better for centered text
+// Extra specificity to override <Text> component styles
+.dashboard-empty-state__description.dashboard-empty-state__description  {
+	width: min(100%, 432px);
+    text-wrap: balance;
+}
+
+.dashboard-empty-state__content {
+	width: min(100%, 660px);   
+}

--- a/client/dashboard/components/empty-state/style.scss
+++ b/client/dashboard/components/empty-state/style.scss
@@ -13,6 +13,7 @@
 
 .dashboard-empty-state__title {
 	font-size: $font-size-x-large;
+	font-weight: 500;
 }
 
 // Balanced wrapping works better for centered text

--- a/client/dashboard/components/empty-state/style.scss
+++ b/client/dashboard/components/empty-state/style.scss
@@ -19,7 +19,7 @@
 // Extra specificity to override <Text> component styles
 .dashboard-empty-state__description.dashboard-empty-state__description  {
 	width: min(100%, 432px);
-    text-wrap: balance;
+	text-wrap: balance;
 }
 
 .dashboard-empty-state__content {

--- a/client/dashboard/components/empty-state/style.scss
+++ b/client/dashboard/components/empty-state/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 
 .dashboard-empty-state {
 	justify-content: flex-start;
@@ -8,6 +9,10 @@
 		justify-content: center;
 		min-height: min(70vh, 676px);
 	}
+}
+
+.dashboard-empty-state__title {
+	font-size: $font-size-x-large;
 }
 
 // Balanced wrapping works better for centered text


### PR DESCRIPTION
Related: DES-297
Fixes: DOTMSD-1007

## Proposed Changes

Adds `EmptyState`, `EmptyState.ActionList`, `EmptyState.ActionListItem`, components to be rendered when we don't have DataView Data.

### Usage
```js
<EmptyState
	title={ __( 'Change me' ) }
	description={ __( 'Change me' ) }
>
	<>
		<EmptyState.ActionList>
			<EmptyState.ActionItem
				title={ __( 'Change me' ) }
				description={ __( 'Change me' ) }
				actions={
					<Button>
						{ __( 'Click me' ) }
					</Button>
				}
			/>
		</EmptyState.ActionList>
		<Card isBorderless variant="secondary">
			<CardBody>
				<p>{ __( 'A card!' ) }</p>
			</CardBody>
		</Card>
	</>
</EmptyState>
```

## Screenshots

| Header |
|--------|
| <img width="1358" height="935" alt="Screenshot 2026-01-12 at 2 37 23 PM" src="https://github.com/user-attachments/assets/5e148cdd-318f-4e74-a2e8-08336d70ce3f" /> | 
| <img width="1358" height="945" alt="Screenshot 2026-01-12 at 2 37 15 PM" src="https://github.com/user-attachments/assets/003ee106-15c2-46db-8686-c773ab6fc761" /> |
| <img width="1355" height="932" alt="Screenshot 2026-01-12 at 2 37 02 PM" src="https://github.com/user-attachments/assets/de742b9b-3009-4b3b-a1bc-52497b975544" /> |
| <img width="1359" height="946" alt="Screenshot 2026-01-12 at 2 36 19 PM" src="https://github.com/user-attachments/assets/b96ee6de-ad55-4978-b05b-3066c678cc36" /> |




## Why are these changes being made?

We need this component for empty results in the multi-site dashboard.

## Considerations

### Why wrap ActionList/ActionList.ActionItem?

This view should reuse existing components and we need to keep the interface consistent across different app sections (sites, domains, emails). By wrapping the ActionList and ActionItem, we get to enforce a specific experience without exposing the underlying components making it easier to modify in the future without adding any significant overhead.
 
### We don't enforce button size?

Since the button is passed in as an action, the composer determines the `size` of the Button. This could lead to inconsistent states. Should we care about this?

### Why allow generic `children`?

It's a probability that in the future we'll want to add things under the ActionList. The current designs include an advertisement banner.


## Testing Instructions

- Run `yarn storybook:start`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
