### PR TITLE
MSD CIAB: Remove irrelevant screens

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -45,6 +45,12 @@ boot( {
 		help: true,
 		notifications: false,
 		me: {
+			billing: {
+				monetizeSubscriptions: false,
+			},
+			security: {
+				sshKey: false,
+			},
 			privacy: false,
 			apps: false,
 		},

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -45,6 +45,12 @@ boot( {
 		help: true,
 		notifications: true,
 		me: {
+			billing: {
+				monetizeSubscriptions: true,
+			},
+			security: {
+				sshKey: true,
+			},
 			privacy: true,
 			apps: true,
 		},

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -35,8 +35,18 @@ export type SiteFeatureSupports = {
 	settings: SiteSettingsSupports | false;
 };
 
+export type MeBillingSupports = {
+	monetizeSubscriptions: boolean;
+};
+
+export type MeSecuritySupports = {
+	sshKey: boolean;
+};
+
 export type MeSupports = {
+	billing: MeBillingSupports | false;
 	privacy: boolean;
+	security: MeSecuritySupports | false;
 	apps: boolean;
 };
 

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -805,10 +805,14 @@ export const createMeRoutes = ( config: AppConfig ) => {
 		billingRoute.addChildren( [
 			billingIndexRoute,
 			billingHistoryRoute.addChildren( [ billingHistoryIndexRoute, receiptRoute ] ),
-			monetizeSubscriptionsRoute.addChildren( [
-				monetizeSubscriptionsIndexRoute,
-				monetizeSubscriptionRoute,
-			] ),
+			...( config.supports.me.billing && config.supports.me.billing.monetizeSubscriptions
+				? [
+						monetizeSubscriptionsRoute.addChildren( [
+							monetizeSubscriptionsIndexRoute,
+							monetizeSubscriptionRoute,
+						] ),
+				  ]
+				: [] ),
 			purchasesRoute.addChildren( [
 				purchasesIndexRoute,
 				purchaseSettingsRoute.addChildren( [
@@ -833,7 +837,9 @@ export const createMeRoutes = ( config: AppConfig ) => {
 				securityTwoStepAuthSMSRoute,
 				securityTwoStepAuthBackupCodesRoute,
 			] ),
-			securitySshKeyRoute,
+			...( config.supports.me.security && config.supports.me.security.sshKey
+				? [ securitySshKeyRoute ]
+				: [] ),
 			securityConnectedAppsRoute,
 			securitySocialLoginsRoute,
 		] )

--- a/client/dashboard/me/billing/index.tsx
+++ b/client/dashboard/me/billing/index.tsx
@@ -1,6 +1,7 @@
 import { __experimentalVStack as VStack, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { backup, payment, receipt, institution, currencyDollar } from '@wordpress/icons';
+import { useAppContext } from '../../app/context';
 import {
 	purchasesRoute,
 	billingHistoryRoute,
@@ -14,6 +15,13 @@ import RouterLinkSummaryButton from '../../components/router-link-summary-button
 import { getMonetizeSubscriptionsPageTitle } from '../billing-monetize-subscriptions/title';
 
 function Billing() {
+	const { supports } = useAppContext();
+	const supportsBilling = supports.me && supports.me.billing;
+
+	if ( ! supportsBilling ) {
+		return null;
+	}
+
 	return (
 		<PageLayout
 			size="small"
@@ -39,12 +47,14 @@ function Billing() {
 					decoration={ <Icon icon={ backup } /> }
 					to={ billingHistoryRoute.to }
 				/>
-				<RouterLinkSummaryButton
-					title={ getMonetizeSubscriptionsPageTitle() }
-					description={ __( 'Manage Monetize subscriptions.' ) }
-					decoration={ <Icon icon={ currencyDollar } /> }
-					to={ monetizeSubscriptionsRoute.to }
-				/>
+				{ supportsBilling.monetizeSubscriptions && (
+					<RouterLinkSummaryButton
+						title={ getMonetizeSubscriptionsPageTitle() }
+						description={ __( 'Manage Monetize subscriptions.' ) }
+						decoration={ <Icon icon={ currencyDollar } /> }
+						to={ monetizeSubscriptionsRoute.to }
+					/>
+				) }
 				<RouterLinkSummaryButton
 					title={ __( 'Payment methods' ) }
 					description={ __( 'Manage credit cards saved to your account.' ) }

--- a/client/dashboard/me/security/index.tsx
+++ b/client/dashboard/me/security/index.tsx
@@ -1,5 +1,6 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useAppContext } from '../../app/context';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import SecurityAccountRecoverySummary from '../security-account-recovery/summary';
@@ -10,6 +11,13 @@ import SecuritySshKeySummary from '../security-ssh-key/summary';
 import SecurityTwoStepAuthSummary from '../security-two-step-auth/summary';
 
 function Security() {
+	const { supports } = useAppContext();
+	const supportsSecurity = supports.me && supports.me.security;
+
+	if ( ! supportsSecurity ) {
+		return null;
+	}
+
 	return (
 		<PageLayout
 			size="small"
@@ -24,7 +32,7 @@ function Security() {
 				<SecurityPasswordSummary />
 				<SecurityAccountRecoverySummary />
 				<SecurityTwoStepAuthSummary />
-				<SecuritySshKeySummary />
+				{ supportsSecurity.sshKey && <SecuritySshKeySummary /> }
 				<SecurityConnectedAppsSummary />
 				<SecuritySocialLoginsSummary />
 			</VStack>

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -92,7 +92,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 					</SummaryButtonList>
 				</VStack>
 			) }
-			{ config.isEnabled( 'wordpress-ai-assistant' ) && (
+			{ supportsSettings.experimental && config.isEnabled( 'wordpress-ai-assistant' ) && (
 				<VStack spacing={ 3 }>
 					<SectionHeader title={ __( 'Experimental (Staging)' ) } level={ 3 } />
 					<SummaryButtonList>


### PR DESCRIPTION
## Proposed Changes

Some of the MSD screens doesn't make sense for CIAB, so this PR removes them:

- Billing > Monetize
- Security > SSH Key
- Site Settings > Experimental section (for this one the route was already disabled but the section was still available)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the CIAB MSD
* Ensure that the entry points to the screens listed above are no longer available
* Head to the WP.com MSD
* Ensure that the entry points to the screens listed above are still available

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
