### PR TITLE
MSD: Simplify CancelPurchaseForm

### DIFF
--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -52,7 +52,6 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	flowType,
 	...props
 } ) => {
-	const shouldProvideCancellationOffer = true;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const initialCancellationStep = useMemo( () => {
@@ -180,7 +179,6 @@ const CancelJetpackForm: React.FC< Props > = ( {
 
 		if (
 			CANCEL_FLOW_TYPE.REMOVE === flowType &&
-			shouldProvideCancellationOffer &&
 			cancellationOffer &&
 			isOfferPriceSameOrLowerThanPurchasePrice &&
 			offerDiscountBasedFromPurchasePrice >= 10
@@ -194,7 +192,6 @@ const CancelJetpackForm: React.FC< Props > = ( {
 		purchase,
 		props.cancellationCompleted,
 		flowType,
-		shouldProvideCancellationOffer,
 		cancellationOffer,
 		isOfferPriceSameOrLowerThanPurchasePrice,
 		offerDiscountBasedFromPurchasePrice,
@@ -338,8 +335,8 @@ const CancelJetpackForm: React.FC< Props > = ( {
 			}
 			return translate( 'Cancel subscription' );
 		};
-		const loadingOffers = shouldProvideCancellationOffer && fetchingCancellationOffers;
-		const applyingOffer = shouldProvideCancellationOffer && applyingCancellationOffer;
+		const loadingOffers = fetchingCancellationOffers;
+		const applyingOffer = applyingCancellationOffer;
 		const close = {
 			action: 'close',
 			disabled: disabled || applyingOffer,
@@ -531,7 +528,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 
 	return (
 		<>
-			{ shouldProvideCancellationOffer && purchase.siteId && purchase.id && (
+			{ purchase.siteId && purchase.id && (
 				<QueryPurchaseCancellationOffers siteId={ purchase.siteId } purchaseId={ purchase.id } />
 			) }
 			<Dialog

--- a/client/components/marketing-survey/cancel-jetpack-form/index.tsx
+++ b/client/components/marketing-survey/cancel-jetpack-form/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button, Dialog } from '@automattic/components';
 import { BaseButton } from '@automattic/components/dist/types/dialog/button-bar';
@@ -53,7 +52,7 @@ const CancelJetpackForm: React.FC< Props > = ( {
 	flowType,
 	...props
 } ) => {
-	const shouldProvideCancellationOffer = config.isEnabled( 'cancellation-offers' );
+	const shouldProvideCancellationOffer = true;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const initialCancellationStep = useMemo( () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -339,7 +339,7 @@ function StepButtons( {
 		return (
 			<ButtonStack justify="flex-start">
 				<Button
-					disabled={ ! canGoNext || disableButtons /* || disableContinuation || applyingOffer*/ }
+					disabled={ ! canGoNext || disableButtons }
 					isBusy={ isCancelling }
 					onClick={ onSubmit }
 					variant="primary"

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -348,7 +348,7 @@ function StepButtons( {
 				</Button>
 				<Button
 					className="jetpack-cancellation-offer__accept-cta"
-					disabled={ isApplyingOffer ?? ( false || Boolean( offerApplyError ) ) ?? false }
+					disabled={ isApplyingOffer || Boolean( offerApplyError ) }
 					isBusy={ isApplyingOffer ?? false }
 					onClick={ () => {
 						onClickAcceptForCancellationOffer && onClickAcceptForCancellationOffer();

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -49,7 +49,7 @@ interface CancelPurchaseFormProps {
 	downgradePlanToPersonalPrice?: number;
 	flowType?: string;
 	freeMonthOfferClick?: () => void;
-	getAllSurveySteps?: () => string[];
+	allSteps: string[];
 	hasBackupsFeature?: boolean;
 	importQuestionRadio?: string;
 	includedDomainPurchase?: Purchase;
@@ -92,350 +92,347 @@ interface CancelPurchaseFormProps {
 	willAtomicSiteRevert?: boolean;
 }
 
-export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
-	const { purchase, siteSlug } = props;
-	/**
-	 * Get possible steps for the survey
-	 */
-	const surveyContent = () => {
-		const {
-			atomicRevertCheckOne,
-			atomicRevertCheckTwo,
-			atomicRevertOnClickCheckOne,
-			atomicRevertOnClickCheckTwo,
-			atomicTransfer,
-			cancellationOffer,
-			clickNext,
-			closeDialog,
-			downgradeClick,
-			downgradePlan,
-			flowType,
-			freeMonthOfferClick,
-			getAllSurveySteps,
-			hasBackupsFeature,
-			isImport,
-			offerDiscountBasedFromPurchasePrice,
-			onGetCancellationOffer,
-			onImportRadioChange,
-			onNextAdventureValidationChange,
-			onRadioOneChange,
-			onRadioTwoChange,
-			onSubmit,
-			onTextOneChange,
-			onTextThreeChange,
-			onTextTwoChange,
-			plans,
-			purchase,
-			questionOneOrder,
-			questionOneText,
-			questionTwoOrder,
-			refundAmount,
-			surveyStep,
-			upsell,
-		} = props;
-		const { product_name: productName } = purchase;
-		if ( surveyStep === FEEDBACK_STEP ) {
+function SurveyContent( {
+	atomicRevertCheckOne,
+	atomicRevertCheckTwo,
+	atomicRevertOnClickCheckOne,
+	atomicRevertOnClickCheckTwo,
+	atomicTransfer,
+	cancellationOffer,
+	clickNext,
+	closeDialog,
+	downgradeClick,
+	downgradePlan,
+	flowType,
+	freeMonthOfferClick,
+	allSteps,
+	hasBackupsFeature,
+	isImport,
+	offerDiscountBasedFromPurchasePrice,
+	onGetCancellationOffer,
+	onImportRadioChange,
+	onNextAdventureValidationChange,
+	onRadioOneChange,
+	onRadioTwoChange,
+	onSubmit,
+	onTextOneChange,
+	onTextThreeChange,
+	onTextTwoChange,
+	plans,
+	purchase,
+	questionOneOrder,
+	questionOneText,
+	questionTwoOrder,
+	refundAmount,
+	surveyStep,
+	upsell,
+	siteSlug,
+	cancelBundledDomain,
+	cancellationInProgress,
+	includedDomainPurchase,
+	isAkismet,
+}: CancelPurchaseFormProps ) {
+	const { product_name: productName } = purchase;
+	if ( surveyStep === FEEDBACK_STEP ) {
+		return (
+			<FeedbackStep
+				cancellationReasonCodes={ questionOneOrder }
+				isImport={ isImport ?? false }
+				onChangeCancellationReason={ onRadioOneChange }
+				onChangeCancellationReasonDetails={ onTextOneChange }
+				onChangeImportFeedback={ onImportRadioChange }
+				plans={ plans }
+				purchase={ purchase }
+			/>
+		);
+	}
+
+	if ( surveyStep === UPSELL_STEP ) {
+		const isLastStep = surveyStep === allSteps?.[ allSteps.length - 1 ];
+
+		if ( upsell?.startsWith( 'education:' ) ) {
 			return (
-				<FeedbackStep
-					cancellationReasonCodes={ questionOneOrder }
-					isImport={ isImport ?? false }
-					onChangeCancellationReason={ onRadioOneChange }
-					onChangeCancellationReasonDetails={ onTextOneChange }
-					onChangeImportFeedback={ onImportRadioChange }
-					plans={ plans }
-					purchase={ purchase }
-				/>
-			);
-		}
-
-		if ( surveyStep === UPSELL_STEP ) {
-			const allSteps = getAllSurveySteps && getAllSurveySteps();
-			const isLastStep = surveyStep === allSteps?.[ allSteps.length - 1 ];
-
-			if ( upsell?.startsWith( 'education:' ) ) {
-				return (
-					<EducationContentStep
-						cancellationReason={ questionOneText }
-						onDecline={ isLastStep ? onSubmit : clickNext }
-						siteSlug={ siteSlug }
-						type={ upsell }
-					/>
-				);
-			}
-
-			return (
-				<UpsellStep
-					cancelBundledDomain={ props.cancelBundledDomain }
-					cancellationInProgress={ props.cancellationInProgress }
+				<EducationContentStep
 					cancellationReason={ questionOneText }
-					closeDialog={ closeDialog }
-					currencyCode={ purchase.currency_code }
-					downgradePlan={ downgradePlan }
-					includedDomainPurchase={ props.includedDomainPurchase }
-					onClickDowngrade={ downgradeClick }
-					onClickFreeMonthOffer={ freeMonthOfferClick }
-					onDeclineUpsell={ isLastStep ? onSubmit : clickNext }
-					plans={ plans }
-					purchase={ purchase }
-					refundAmount={ refundAmount }
-					upsell={ upsell ?? '' }
-				/>
-			);
-		}
-
-		if ( surveyStep === NEXT_ADVENTURE_STEP ) {
-			return (
-				<NextAdventureStep
-					adventureOptions={ questionTwoOrder ?? [] }
-					isPlan={ purchase.is_plan }
-					onChangeNextAdventureDetails={ onTextTwoChange }
-					onChangeText={ onTextThreeChange }
-					onSelectNextAdventure={ onRadioTwoChange }
-					onValidationChange={ onNextAdventureValidationChange }
-				/>
-			);
-		}
-
-		if ( surveyStep === ATOMIC_REVERT_STEP ) {
-			return (
-				<AtomicRevertStep
-					atomicRevertCheckOne={ atomicRevertCheckOne ?? false }
-					atomicRevertCheckTwo={ atomicRevertCheckTwo ?? false }
-					atomicTransfer={ atomicTransfer }
-					hasBackupsFeature={ hasBackupsFeature ?? false }
-					isRemovePlan={ flowType === CANCEL_FLOW_TYPE.REMOVE && purchase.is_plan }
-					onClickCheckOne={ atomicRevertOnClickCheckOne }
-					onClickCheckTwo={ atomicRevertOnClickCheckTwo }
-					purchase={ purchase }
+					onDecline={ isLastStep ? onSubmit : clickNext }
 					siteSlug={ siteSlug }
+					type={ upsell }
 				/>
 			);
 		}
 
-		if ( surveyStep === REMOVE_PLAN_STEP ) {
-			return (
-				<>
-					<span className="cancel-purchase-form__remove-plan-text">
-						{ sprintf(
-							/* Translators: %(planName)s: name of the plan being canceled, eg: "WordPress.com Business" */
+		return (
+			<UpsellStep
+				cancelBundledDomain={ cancelBundledDomain }
+				cancellationInProgress={ cancellationInProgress }
+				cancellationReason={ questionOneText }
+				closeDialog={ closeDialog }
+				currencyCode={ purchase.currency_code }
+				downgradePlan={ downgradePlan }
+				includedDomainPurchase={ includedDomainPurchase }
+				onClickDowngrade={ downgradeClick }
+				onClickFreeMonthOffer={ freeMonthOfferClick }
+				onDeclineUpsell={ isLastStep ? onSubmit : clickNext }
+				plans={ plans }
+				purchase={ purchase }
+				refundAmount={ refundAmount }
+				upsell={ upsell ?? '' }
+			/>
+		);
+	}
+
+	if ( surveyStep === NEXT_ADVENTURE_STEP ) {
+		return (
+			<NextAdventureStep
+				adventureOptions={ questionTwoOrder ?? [] }
+				isPlan={ purchase.is_plan }
+				onChangeNextAdventureDetails={ onTextTwoChange }
+				onChangeText={ onTextThreeChange }
+				onSelectNextAdventure={ onRadioTwoChange }
+				onValidationChange={ onNextAdventureValidationChange }
+			/>
+		);
+	}
+
+	if ( surveyStep === ATOMIC_REVERT_STEP ) {
+		return (
+			<AtomicRevertStep
+				atomicRevertCheckOne={ atomicRevertCheckOne ?? false }
+				atomicRevertCheckTwo={ atomicRevertCheckTwo ?? false }
+				atomicTransfer={ atomicTransfer }
+				hasBackupsFeature={ hasBackupsFeature ?? false }
+				isRemovePlan={ flowType === CANCEL_FLOW_TYPE.REMOVE && purchase.is_plan }
+				onClickCheckOne={ atomicRevertOnClickCheckOne }
+				onClickCheckTwo={ atomicRevertOnClickCheckTwo }
+				purchase={ purchase }
+				siteSlug={ siteSlug }
+			/>
+		);
+	}
+
+	if ( surveyStep === REMOVE_PLAN_STEP ) {
+		return (
+			<>
+				<span className="cancel-purchase-form__remove-plan-text">
+					{ sprintf(
+						/* Translators: %(planName)s: name of the plan being canceled, eg: "WordPress.com Business" */
+						__(
+							'If you remove your plan, you will lose access to the features of the %(planName)s plan.'
+						),
+						{
+							planName: productName,
+						}
+					) }
+				</span>
+				<span className="cancel-purchase-form__remove-plan-text">
+					{ createInterpolateElement(
+						sprintf(
+							/* Translators: %(planName)s: name of the plan being canceled, eg: "WordPress.com Business". %(purchaseRenewalDate)s: date when the plan will expire, eg: "January 1, 2022" */
 							__(
-								'If you remove your plan, you will lose access to the features of the %(planName)s plan.'
+								'If you keep your plan, you will be able to continue using your %(planName)s plan features until <strong>%(purchaseRenewalDate)s</strong>.'
 							),
 							{
 								planName: productName,
+								purchaseRenewalDate: intlFormat( purchase.expiry_date, {
+									dateStyle: 'medium',
+								} ),
 							}
-						) }
-					</span>
-					<span className="cancel-purchase-form__remove-plan-text">
-						{ createInterpolateElement(
-							sprintf(
-								/* Translators: %(planName)s: name of the plan being canceled, eg: "WordPress.com Business". %(purchaseRenewalDate)s: date when the plan will expire, eg: "January 1, 2022" */
-								__(
-									'If you keep your plan, you will be able to continue using your %(planName)s plan features until <strong>%(purchaseRenewalDate)s</strong>.'
-								),
-								{
-									planName: productName,
-									purchaseRenewalDate: intlFormat( purchase.expiry_date, {
-										dateStyle: 'medium',
-									} ),
-								}
-							),
-							{
-								strong: <strong className="is-highlighted" />,
-							}
-						) }
-					</span>
-				</>
-			);
-		}
-		// Step 3: Offer
-		// This step is only made available after offers are checked for/ loaded.
-		if ( surveyStep === CANCELLATION_OFFER_STEP && cancellationOffer ) {
-			// Show an offer, the user can accept it or go ahead with the cancellation.
-			return (
-				<JetpackCancellationOfferStep
-					isAkismet={ props?.isAkismet }
-					offer={ cancellationOffer }
-					onGetCancellationOffer={ onGetCancellationOffer }
-					percentDiscount={ offerDiscountBasedFromPurchasePrice }
-					purchase={ purchase }
-				/>
-			);
-		}
-
-		// Step 4: Offer Accepted
-		if ( surveyStep === OFFER_ACCEPTED_STEP ) {
-			// Show after an offer discount has been accepted
-			return (
-				<JetpackCancellationOfferAcceptedStep
-					isAkismet={ props?.isAkismet }
-					percentDiscount={ offerDiscountBasedFromPurchasePrice }
-					productName={ productName }
-				/>
-			);
-		}
-	};
-
-	const canGoNext = () => {
-		const {
-			atomicRevertCheckOne,
-			atomicRevertCheckTwo,
-			disableButtons,
-			importQuestionRadio,
-			isImport,
-			isNextAdventureValid,
-			isSubmitting,
-			questionOneRadio,
-			questionOneText,
-			questionTwoRadio,
-			questionTwoText,
-			surveyStep,
-		} = props;
-
-		if ( disableButtons || isSubmitting ) {
-			return false;
-		}
-
-		if ( surveyStep === FEEDBACK_STEP ) {
-			if ( isImport && ! importQuestionRadio ) {
-				return false;
-			}
-
-			return Boolean(
-				questionOneRadio &&
-					( purchase.is_jetpack_plan_or_product || ! purchase.is_plan || questionOneText )
-			);
-		}
-
-		if ( surveyStep === ATOMIC_REVERT_STEP ) {
-			return Boolean( atomicRevertCheckOne && atomicRevertCheckTwo );
-		}
-
-		if ( surveyStep === NEXT_ADVENTURE_STEP ) {
-			if ( questionTwoRadio === 'anotherReasonTwo' && ! questionTwoText ) {
-				return false;
-			}
-
-			// For plan cancellations, require a valid selection from the adventure dropdown
-			if ( purchase.is_plan && ! isNextAdventureValid ) {
-				return false;
-			}
-
-			return true;
-		}
-
-		return ! disableButtons && ! isSubmitting;
-	};
-
-	const renderStepButtons = () => {
-		const {
-			clickNext,
-			closeDialog,
-			disableButtons,
-			getAllSurveySteps,
-			isApplyingOffer,
-			isSubmitting,
-			offerApplyError,
-			onClickAcceptForCancellationOffer,
-			onSubmit,
-			solution,
-			surveyStep,
-		} = props;
-		const isCancelling = ( disableButtons || isSubmitting ) && ! solution;
-
-		const allSteps = getAllSurveySteps && getAllSurveySteps();
-		const isLastStep = surveyStep === allSteps?.[ allSteps.length - 1 ];
-
-		if ( surveyStep === UPSELL_STEP ) {
-			return null;
-		}
-
-		if ( ! isLastStep ) {
-			return (
-				<ButtonStack justify="flex-start">
-					<Button variant="primary" disabled={ ! canGoNext() } onClick={ clickNext }>
-						{ __( 'Continue' ) }
-					</Button>
-					<Button variant="tertiary" onClick={ onSubmit }>
-						{ __( 'Skip' ) }
-					</Button>
-				</ButtonStack>
-			);
-		}
-
-		if ( surveyStep === REMOVE_PLAN_STEP ) {
-			return (
-				<ButtonStack justify="flex-start">
-					<Button
-						className="cancel-purchase-form__remove-plan-button"
-						disabled={ ! canGoNext() }
-						isBusy={ isCancelling }
-						onClick={ onSubmit }
-						variant="primary"
-					>
-						{ __( 'Continue' ) }
-					</Button>
-					<Button
-						disabled={ ! canGoNext() }
-						isBusy={ isCancelling }
-						onClick={ closeDialog }
-						variant="secondary"
-					>
-						{ __( 'Keep plan' ) }
-					</Button>
-				</ButtonStack>
-			);
-		}
-
-		if ( surveyStep === CANCELLATION_OFFER_STEP ) {
-			return (
-				<ButtonStack justify="flex-start">
-					<Button
-						disabled={
-							! canGoNext() || disableButtons /* || disableContinuation || applyingOffer*/
+						),
+						{
+							strong: <strong className="is-highlighted" />,
 						}
-						isBusy={ isCancelling }
-						onClick={ onSubmit }
-						variant="primary"
-					>
-						{ __( 'No, thanks' ) }
-					</Button>
-					<Button
-						className="jetpack-cancellation-offer__accept-cta"
-						disabled={ isApplyingOffer ?? ( false || Boolean( offerApplyError ) ) ?? false }
-						isBusy={ isApplyingOffer ?? false }
-						onClick={ () => {
-							onClickAcceptForCancellationOffer && onClickAcceptForCancellationOffer();
-						} }
-						variant="primary"
-					>
-						{ isApplyingOffer ? __( 'Getting Discount' ) : __( 'Get discount' ) }
-					</Button>
-				</ButtonStack>
-			);
-		}
+					) }
+				</span>
+			</>
+		);
+	}
+	// Step 3: Offer
+	// This step is only made available after offers are checked for/ loaded.
+	if ( surveyStep === CANCELLATION_OFFER_STEP && cancellationOffer ) {
+		// Show an offer, the user can accept it or go ahead with the cancellation.
+		return (
+			<JetpackCancellationOfferStep
+				isAkismet={ isAkismet }
+				offer={ cancellationOffer }
+				onGetCancellationOffer={ onGetCancellationOffer }
+				percentDiscount={ offerDiscountBasedFromPurchasePrice }
+				purchase={ purchase }
+			/>
+		);
+	}
 
-		const variant = surveyStep !== UPSELL_STEP ? 'primary' : 'secondary';
+	// Step 4: Offer Accepted
+	if ( surveyStep === OFFER_ACCEPTED_STEP ) {
+		// Show after an offer discount has been accepted
+		return (
+			<JetpackCancellationOfferAcceptedStep
+				isAkismet={ isAkismet }
+				percentDiscount={ offerDiscountBasedFromPurchasePrice }
+				productName={ productName }
+			/>
+		);
+	}
+}
 
+function StepButtons( {
+	canGoNext,
+	clickNext,
+	closeDialog,
+	disableButtons,
+	isApplyingOffer,
+	isSubmitting,
+	offerApplyError,
+	onClickAcceptForCancellationOffer,
+	onSubmit,
+	solution,
+	surveyStep,
+	allSteps,
+}: {
+	canGoNext: boolean;
+} & CancelPurchaseFormProps ) {
+	const isCancelling = ( disableButtons || isSubmitting ) && ! solution;
+
+	const isLastStep = surveyStep === allSteps?.[ allSteps.length - 1 ];
+
+	if ( surveyStep === UPSELL_STEP ) {
+		return null;
+	}
+
+	if ( ! isLastStep ) {
+		return (
+			<ButtonStack justify="flex-start">
+				<Button variant="primary" disabled={ ! canGoNext } onClick={ clickNext }>
+					{ __( 'Continue' ) }
+				</Button>
+				<Button variant="tertiary" onClick={ onSubmit }>
+					{ __( 'Skip' ) }
+				</Button>
+			</ButtonStack>
+		);
+	}
+
+	if ( surveyStep === REMOVE_PLAN_STEP ) {
 		return (
 			<ButtonStack justify="flex-start">
 				<Button
-					disabled={ ! canGoNext() }
+					className="cancel-purchase-form__remove-plan-button"
+					disabled={ ! canGoNext }
 					isBusy={ isCancelling }
 					onClick={ onSubmit }
-					variant={ variant }
+					variant="primary"
 				>
-					{ __( 'Submit' ) }
+					{ __( 'Continue' ) }
 				</Button>
-				{ ! canGoNext() && ! isCancelling && (
-					<Button variant="tertiary" onClick={ onSubmit }>
-						{ __( 'Skip' ) }
-					</Button>
-				) }
+				<Button
+					disabled={ ! canGoNext }
+					isBusy={ isCancelling }
+					onClick={ closeDialog }
+					variant="secondary"
+				>
+					{ __( 'Keep plan' ) }
+				</Button>
 			</ButtonStack>
 		);
-	};
+	}
 
+	if ( surveyStep === CANCELLATION_OFFER_STEP ) {
+		return (
+			<ButtonStack justify="flex-start">
+				<Button
+					disabled={ ! canGoNext || disableButtons /* || disableContinuation || applyingOffer*/ }
+					isBusy={ isCancelling }
+					onClick={ onSubmit }
+					variant="primary"
+				>
+					{ __( 'No, thanks' ) }
+				</Button>
+				<Button
+					className="jetpack-cancellation-offer__accept-cta"
+					disabled={ isApplyingOffer ?? ( false || Boolean( offerApplyError ) ) ?? false }
+					isBusy={ isApplyingOffer ?? false }
+					onClick={ () => {
+						onClickAcceptForCancellationOffer && onClickAcceptForCancellationOffer();
+					} }
+					variant="primary"
+				>
+					{ isApplyingOffer ? __( 'Getting Discount' ) : __( 'Get discount' ) }
+				</Button>
+			</ButtonStack>
+		);
+	}
+
+	const variant = surveyStep !== UPSELL_STEP ? 'primary' : 'secondary';
+
+	return (
+		<ButtonStack justify="flex-start">
+			<Button
+				disabled={ ! canGoNext }
+				isBusy={ isCancelling }
+				onClick={ onSubmit }
+				variant={ variant }
+			>
+				{ __( 'Submit' ) }
+			</Button>
+			{ ! canGoNext && ! isCancelling && (
+				<Button variant="tertiary" onClick={ onSubmit }>
+					{ __( 'Skip' ) }
+				</Button>
+			) }
+		</ButtonStack>
+	);
+}
+
+function canGoToNextStep( {
+	atomicRevertCheckOne,
+	atomicRevertCheckTwo,
+	disableButtons,
+	importQuestionRadio,
+	isImport,
+	isNextAdventureValid,
+	isSubmitting,
+	questionOneRadio,
+	questionOneText,
+	questionTwoRadio,
+	questionTwoText,
+	surveyStep,
+	purchase,
+}: CancelPurchaseFormProps ): boolean {
+	if ( disableButtons || isSubmitting ) {
+		return false;
+	}
+
+	if ( surveyStep === FEEDBACK_STEP ) {
+		if ( isImport && ! importQuestionRadio ) {
+			return false;
+		}
+
+		return Boolean(
+			questionOneRadio &&
+				( purchase.is_jetpack_plan_or_product || ! purchase.is_plan || questionOneText )
+		);
+	}
+
+	if ( surveyStep === ATOMIC_REVERT_STEP ) {
+		return Boolean( atomicRevertCheckOne && atomicRevertCheckTwo );
+	}
+
+	if ( surveyStep === NEXT_ADVENTURE_STEP ) {
+		if ( questionTwoRadio === 'anotherReasonTwo' && ! questionTwoText ) {
+			return false;
+		}
+
+		// For plan cancellations, require a valid selection from the adventure dropdown
+		if ( purchase.is_plan && ! isNextAdventureValid ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	return ! disableButtons && ! isSubmitting;
+}
+
+export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
 	return (
 		props.isVisible && (
 			<VStack spacing={ 6 }>
@@ -443,8 +440,8 @@ export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
 					title={ __( 'Before you go, please answer a few quick questions to help us improve.' ) }
 					level={ 3 }
 				/>
-				{ surveyContent() }
-				{ renderStepButtons() }
+				<SurveyContent { ...props } />
+				<StepButtons { ...props } canGoNext={ canGoToNextStep( props ) } />
 			</VStack>
 		)
 	);

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -272,6 +272,8 @@ function SurveyContent( {
 			/>
 		);
 	}
+
+	return null;
 }
 
 function StepButtons( {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -660,19 +660,7 @@ export default function CancelPurchase() {
 	};
 
 	const clickNext = () => {
-		changeSurveyStep(
-			nextStep(
-				state.surveyStep ?? '',
-				getAllSurveySteps( {
-					purchase,
-					upsell: state.upsell,
-					cancellationOffer,
-					hasQuestionTwo: Boolean( questionTwoOrder.length ),
-					plans,
-					userHasCompletedCancelSurveyForPurchase,
-				} )
-			)
-		);
+		changeSurveyStep( nextStep( state.surveyStep ?? '', allSteps ) );
 	};
 
 	const closeDialog = () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -219,7 +219,8 @@ function getBasicSurveySteps( {
 	if ( upsell && ! isDowngradePlan ) {
 		return [ FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP ];
 	}
-	if ( downgradePlan ) {
+	// NOTE: downgradePlan only ever exists if upsell is true (see getDowngradePlanForPurchase).
+	if ( upsell && downgradePlan ) {
 		return [ FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP ];
 	}
 	if ( hasQuestionTwo ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1,4 +1,8 @@
-import { DomainProductSlugs, SubscriptionBillPeriod } from '@automattic/api-core';
+import {
+	DomainProductSlugs,
+	SubscriptionBillPeriod,
+	CancellationOffer,
+} from '@automattic/api-core';
 import {
 	applyCancellationOfferMutation,
 	cancelAndRefundPurchaseMutation,
@@ -20,7 +24,6 @@ import {
 	removePurchaseMutation,
 	userPreferenceQuery,
 } from '@automattic/api-queries';
-import config from '@automattic/calypso-config';
 import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
@@ -28,7 +31,7 @@ import { useDispatch } from '@wordpress/data';
 import { _n, sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { intlFormat } from 'date-fns';
-import { useCallback, useEffect, useRef, useMemo, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import Breadcrumbs from '../../../app/breadcrumbs';
 import { cancelPurchaseRoute, purchaseSettingsRoute, purchasesRoute } from '../../../app/router/me';
@@ -49,7 +52,6 @@ import {
 	isJetpackTemporarySitePurchase,
 	isAkismetProduct,
 	isPartnerPurchase,
-	willAtomicSiteRevertAfterPurchaseDeactivation,
 	isOneTimePurchase,
 } from '../../../utils/purchase';
 import CancelHeaderTitle from './cancel-header-title';
@@ -128,6 +130,143 @@ const getDowngradePlanForPurchase = (
 	}
 };
 
+function getOfferDiscountBasedOnPurchasePrice(
+	purchase: Purchase,
+	cancellationOffer: CancellationOffer | undefined
+): number {
+	if ( ! cancellationOffer ) {
+		return 0;
+	}
+	const offerDiscountPercentage = ( 1 - cancellationOffer.raw_price / purchase.amount ) * 100;
+	// Round the cancellation offer discount percentage to the nearest whole number
+	return Math.round( offerDiscountPercentage );
+}
+
+function availableJetpackSurveySteps(
+	purchase: Purchase,
+	flowType: string,
+	cancellationOffer: CancellationOffer | undefined
+): string[] {
+	const availableSteps = [];
+
+	// If the plan is already expired or is a temporary Jetpack purchase (license),
+	// we only need one "confirm" step for the survey is the removal confirmation
+	// A product that is not in use does not need to collect the survey or show benefits
+	if ( isExpired( purchase ) || isJetpackTemporarySitePurchase( purchase ) ) {
+		return [ CANCEL_CONFIRM_STEP ];
+	}
+
+	// Always include the survey step if it's a normal cancellation flow
+	if (
+		CANCEL_FLOW_TYPE.CANCEL_AUTORENEW === flowType ||
+		CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND === flowType
+	) {
+		availableSteps.push( FEEDBACK_STEP );
+	}
+
+	if ( CANCEL_FLOW_TYPE.REMOVE === flowType ) {
+		const isOfferPriceSameOrLowerThanPurchasePrice = cancellationOffer
+			? purchase.amount >= cancellationOffer.original_price
+			: false;
+		const offerDiscountBasedFromPurchasePrice = getOfferDiscountBasedOnPurchasePrice(
+			purchase,
+			cancellationOffer
+		);
+
+		availableSteps.push( FEEDBACK_STEP );
+		if ( isOfferPriceSameOrLowerThanPurchasePrice && offerDiscountBasedFromPurchasePrice >= 10 ) {
+			availableSteps.push( CANCELLATION_OFFER_STEP );
+		}
+	}
+
+	return availableSteps;
+}
+
+function getBasicSurveySteps( {
+	purchase,
+	upsell,
+	cancellationOffer,
+	hasQuestionTwo,
+	plans,
+}: {
+	purchase: Purchase;
+	upsell: CancelPurchaseState[ 'upsell' ];
+	cancellationOffer: CancellationOffer | undefined;
+	hasQuestionTwo: boolean;
+	plans: PlanProduct[];
+} ): string[] {
+	const flowType = getPurchaseCancellationFlowType( purchase );
+	const isJetpack = purchase.is_jetpack_plan_or_product;
+	const downgradePlan = getDowngradePlanForPurchase( plans, purchase, upsell );
+	const isDowngradePlan = [ 'downgrade-monthly', 'downgrade-personal' ].includes( upsell ?? '' );
+
+	if (
+		isPartnerPurchase( purchase ) &&
+		purchase.partner_type &&
+		isAgencyPartnerType( purchase.partner_type )
+	) {
+		return [];
+	}
+	if ( isJetpack ) {
+		return availableJetpackSurveySteps( purchase, flowType, cancellationOffer );
+	}
+	if ( purchase.is_domain_registration ) {
+		return [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
+	}
+	if ( ! isGSuiteOrGoogleWorkspaceProductSlug( purchase.product_slug ) && ! purchase.is_plan ) {
+		return [ NEXT_ADVENTURE_STEP ];
+	}
+	if ( upsell && ! isDowngradePlan ) {
+		return [ FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP ];
+	}
+	if ( downgradePlan ) {
+		return [ FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP ];
+	}
+	if ( hasQuestionTwo ) {
+		return [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
+	}
+	return [ FEEDBACK_STEP ];
+}
+
+function getAllSurveySteps( {
+	purchase,
+	upsell,
+	cancellationOffer,
+	hasQuestionTwo,
+	plans,
+	userHasCompletedCancelSurveyForPurchase,
+}: {
+	purchase: Purchase;
+	upsell: CancelPurchaseState[ 'upsell' ];
+	cancellationOffer: CancellationOffer | undefined;
+	hasQuestionTwo: boolean;
+	plans: PlanProduct[];
+	userHasCompletedCancelSurveyForPurchase: boolean;
+} ): string[] {
+	let steps = getBasicSurveySteps( {
+		purchase,
+		upsell,
+		cancellationOffer,
+		hasQuestionTwo,
+		plans,
+	} );
+	const skipRemovePlanSurvey = purchase.is_plan && userHasCompletedCancelSurveyForPurchase;
+	const flowType = getPurchaseCancellationFlowType( purchase );
+
+	if ( purchase.will_atomic_revert_after_removal && flowType === CANCEL_FLOW_TYPE.REMOVE ) {
+		steps.push( ATOMIC_REVERT_STEP );
+	}
+
+	// If the survey has already been completed, then remove certain steps and make `REMOVE_PLAN_STEP` the first step.
+	if ( skipRemovePlanSurvey ) {
+		const stepsToRemove = [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
+		steps = steps.filter( ( step ) => ! stepsToRemove.includes( step ) );
+		steps = [ REMOVE_PLAN_STEP, ...steps ];
+	}
+
+	return steps;
+}
+
 export default function CancelPurchase() {
 	const { createSuccessNotice, removeNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
@@ -147,7 +286,6 @@ export default function CancelPurchase() {
 		purchaseQuery( parseInt( purchaseId ) )
 	);
 	const { data: sitePurchases } = useSuspenseQuery( sitePurchasesQuery( purchase.blog_id ) );
-	const { data: products } = useSuspenseQuery( productsQuery() );
 	const { data: siteFeatures, isPending: siteFeaturesQueryIsPending } = useSuspenseQuery(
 		siteFeaturesQuery( purchase.blog_id )
 	);
@@ -178,12 +316,9 @@ export default function CancelPurchase() {
 	const { data: cancellationOffers } = useQuery(
 		cancellationOffersQuery( purchase.blog_id, purchase.ID )
 	);
-	const {
-		data: userHasCompletedCancelSurveyForPurchase,
-		isPending: userPreferencesQueryIsPending,
-	} = useQuery(
-		userPreferenceQuery( getCancelPurchaseSurveyCompletedPreferenceKey( purchase.ID ) )
-	);
+	const { data: userPreferenceForSurveyComplete, isPending: userPreferencesQueryIsPending } =
+		useQuery( userPreferenceQuery( getCancelPurchaseSurveyCompletedPreferenceKey( purchase.ID ) ) );
+	const userHasCompletedCancelSurveyForPurchase = Boolean( userPreferenceForSurveyComplete );
 
 	// Mutations
 	const cancelAndRefundPurchaseMutate = useMutation( cancelAndRefundPurchaseMutation() );
@@ -237,122 +372,12 @@ export default function CancelPurchase() {
 	};
 	const flowType = getPurchaseCancellationFlowType( purchase );
 
-	const shouldProvideCancellationOffer = config.isEnabled( 'cancellation-offers' );
-
 	const cancellationOffer = cancellationOffers?.length ? cancellationOffers[ 0 ] : undefined;
-	const isOfferPriceSameOrLowerThanPurchasePrice = cancellationOffer
-		? purchase.amount >= cancellationOffer.original_price
-		: false;
-	const offerDiscountBasedFromPurchasePrice = useMemo( () => {
-		if ( cancellationOffer ) {
-			const offerDiscountPercentage = ( 1 - cancellationOffer.raw_price / purchase.amount ) * 100;
-
-			// Round the cancellation offer discount percentage to the nearest whole number
-			return Math.round( offerDiscountPercentage );
-		}
-		return 0;
-	}, [ cancellationOffer, purchase ] );
-
-	const availableJetpackSurveySteps = useCallback( () => {
-		const availableSteps = [];
-
-		// If the plan is already expired or is a temporary Jetpack purchase (license),
-		// we only need one "confirm" step for the survey is the removal confirmation
-		// A product that is not in use does not need to collect the survey or show benefits
-		if ( isExpired( purchase ) || isJetpackTemporarySitePurchase( purchase ) ) {
-			return [ CANCEL_CONFIRM_STEP ];
-		}
-
-		// Always include the survey step if cancellation is completed, or if it's a normal cancellation flow
-		if (
-			// props.cancellationCompleted ||
-			CANCEL_FLOW_TYPE.CANCEL_AUTORENEW === flowType ||
-			CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND === flowType
-		) {
-			availableSteps.push( FEEDBACK_STEP );
-		}
-
-		if ( CANCEL_FLOW_TYPE.REMOVE === flowType ) {
-			availableSteps.push( FEEDBACK_STEP );
-			if (
-				shouldProvideCancellationOffer &&
-				cancellationOffer &&
-				isOfferPriceSameOrLowerThanPurchasePrice &&
-				offerDiscountBasedFromPurchasePrice >= 10
-			) {
-				availableSteps.push( CANCELLATION_OFFER_STEP );
-			}
-		}
-
-		return availableSteps;
-	}, [
-		cancellationOffer,
-		flowType,
-		isOfferPriceSameOrLowerThanPurchasePrice,
-		offerDiscountBasedFromPurchasePrice,
-		purchase,
-		shouldProvideCancellationOffer,
-	] );
 
 	let questionOneOrder = [];
 	let questionTwoOrder = [];
 
 	const downgradePlan = getDowngradePlanForPurchase( plans, purchase, state.upsell );
-
-	const getAllSurveySteps = useCallback( () => {
-		let steps = [ FEEDBACK_STEP ];
-		const isJetpack = purchase.is_jetpack_plan_or_product;
-		const skipRemovePlanSurvey = purchase.is_plan && userHasCompletedCancelSurveyForPurchase;
-		const isDowngradePlan = [ 'downgrade-monthly', 'downgrade-personal' ].includes(
-			state.upsell ?? ''
-		);
-
-		if (
-			isPartnerPurchase( purchase ) &&
-			purchase.partner_type &&
-			isAgencyPartnerType( purchase.partner_type )
-		) {
-			steps = [];
-		} else if ( isJetpack ) {
-			steps = availableJetpackSurveySteps();
-		} else if ( purchase.is_domain_registration ) {
-			steps = [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
-		} else if (
-			! isGSuiteOrGoogleWorkspaceProductSlug( purchase.product_slug ) &&
-			! purchase.is_plan
-		) {
-			steps = [ NEXT_ADVENTURE_STEP ];
-		} else if ( state.upsell && ( ! isDowngradePlan || ( isDowngradePlan && downgradePlan ) ) ) {
-			steps = [ FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP ];
-		} else if ( questionTwoOrder?.length ) {
-			steps = [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
-		}
-
-		if ( state.willAtomicSiteRevert && flowType === CANCEL_FLOW_TYPE.REMOVE ) {
-			steps.push( ATOMIC_REVERT_STEP );
-		}
-
-		if ( skipRemovePlanSurvey ) {
-			if ( steps.includes( FEEDBACK_STEP ) ) {
-				steps = steps.filter( ( step ) => step !== FEEDBACK_STEP );
-			}
-			if ( steps.includes( NEXT_ADVENTURE_STEP ) ) {
-				steps = steps.filter( ( step ) => step !== NEXT_ADVENTURE_STEP );
-			}
-			steps = [ REMOVE_PLAN_STEP, ...steps ];
-		}
-
-		return steps;
-	}, [
-		downgradePlan,
-		userHasCompletedCancelSurveyForPurchase,
-		purchase,
-		availableJetpackSurveySteps,
-		flowType,
-		questionTwoOrder?.length,
-		state.upsell,
-		state.willAtomicSiteRevert,
-	] );
 
 	const getActiveMarketplaceSubscriptions = (): Purchase[] => {
 		if ( ! purchase.is_plan || ! productsList ) {
@@ -365,6 +390,15 @@ export default function CancelPurchase() {
 			) ?? [];
 		return subs;
 	};
+
+	const allSteps = getAllSurveySteps( {
+		purchase,
+		upsell: state.upsell,
+		cancellationOffer,
+		hasQuestionTwo: Boolean( questionTwoOrder.length ),
+		plans,
+		userHasCompletedCancelSurveyForPurchase,
+	} );
 
 	const initSurveyState = () => {
 		if ( state.initialized ) {
@@ -379,10 +413,7 @@ export default function CancelPurchase() {
 			questionTwoOrder.push( 'anotherReasonTwo' );
 		}
 
-		const allSteps = getAllSurveySteps();
 		const [ firstStep ] = allSteps;
-
-		const linkedPurchases: Purchase[] = getActiveMarketplaceSubscriptions();
 
 		const newState: CancelPurchaseState = {
 			...initialSurveyState(),
@@ -411,13 +442,6 @@ export default function CancelPurchase() {
 			surveyShown: REMOVE_PLAN_STEP === firstStep,
 			surveyStep: firstStep,
 			upsell: '',
-			willAtomicSiteRevert: willAtomicSiteRevertAfterPurchaseDeactivation(
-				purchase,
-				sitePurchases,
-				site,
-				Object.values( products ),
-				linkedPurchases
-			),
 		};
 		if ( JSON.stringify( state ) !== JSON.stringify( newState ) ) {
 			setState( newState );
@@ -636,7 +660,19 @@ export default function CancelPurchase() {
 	};
 
 	const clickNext = () => {
-		changeSurveyStep( nextStep( state.surveyStep ?? '', getAllSurveySteps() ) );
+		changeSurveyStep(
+			nextStep(
+				state.surveyStep ?? '',
+				getAllSurveySteps( {
+					purchase,
+					upsell: state.upsell,
+					cancellationOffer,
+					hasQuestionTwo: Boolean( questionTwoOrder.length ),
+					plans,
+					userHasCompletedCancelSurveyForPurchase,
+				} )
+			)
+		);
 	};
 
 	const closeDialog = () => {
@@ -1184,6 +1220,10 @@ export default function CancelPurchase() {
 		);
 	}
 
+	const offerDiscountBasedFromPurchasePrice = getOfferDiscountBasedOnPurchasePrice(
+		purchase,
+		cancellationOffer
+	);
 	return (
 		<PageLayout
 			size="small"
@@ -1214,7 +1254,6 @@ export default function CancelPurchase() {
 							downgradePlan={ downgradePlan }
 							flowType={ flowType }
 							freeMonthOfferClick={ freeMonthOfferClick }
-							getAllSurveySteps={ getAllSurveySteps }
 							hasBackupsFeature={ hasBackupsFeature }
 							importQuestionRadio={ state.importQuestionRadio }
 							includedDomainPurchase={ includedDomainPurchase }
@@ -1249,6 +1288,7 @@ export default function CancelPurchase() {
 							siteSlug={ siteSlug }
 							solution={ state.solution }
 							surveyStep={ state.surveyStep }
+							allSteps={ allSteps }
 							upsell={ state.upsell }
 						/>
 						{ ! state.surveyShown && (

--- a/config/development.json
+++ b/config/development.json
@@ -43,7 +43,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"cancellation-offers": true,
 		"checkout/checkout-version": true,
 		"ciab/allow-domain-features": true,
 		"checkout/ebanx-pix": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -17,7 +17,6 @@
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"ciab/allow-domain-features": true,

--- a/config/production.json
+++ b/config/production.json
@@ -29,7 +29,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"ciab/allow-domain-features": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -27,7 +27,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": true,
 		"ciab/allow-domain-features": true,

--- a/config/test.json
+++ b/config/test.json
@@ -27,7 +27,6 @@
 		"akismet/checkout-quantity-dropdown": true,
 		"calypso/all-domain-management": true,
 		"calypso/domains-dataviews": true,
-		"cancellation-offers": true,
 		"catch-js-errors": false,
 		"checkout/checkout-version": false,
 		"checkout/ebanx-pix": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,7 +27,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"cancellation-offers": true,
 		"catch-js-errors": false,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -364,6 +364,14 @@ export interface Purchase {
 	 * a product directly to the cart, also set `upgrade_product_slug`.
 	 */
 	is_upgradable: boolean;
+
+	/**
+	 * True if deactivating this subscription will cause the site to be reverted
+	 * from an Atomic site to a Simple site. This is only true if the site is
+	 * currently on the Atomic architecture and removing this subscription would
+	 * leave the site with no other products that provide the ATOMIC feature.
+	 */
+	will_atomic_revert_after_removal: boolean;
 }
 
 export type RawPurchase = Purchase & {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1451/the-remove-plan-view-has-a-skip-button-and-is-missing-plan
Fixes https://linear.app/a8c/issue/SHILL-1480/msd-simplify-cancelpurchaseform

## Proposed Changes

This PR refactors `CancelPurchaseForm` and `CancelPurchase` to make it slightly easier to follow the logic in those two components.

**This should not change any behavior of the components.**

The main changes are as follows:

- Remove the `'cancellation-offers'` config option since it is always true.
- Remove `willAtomicSiteRevertAfterPurchaseDeactivation()` since it's not always accurate and replace it with a parameter on the purchase.
- Move all the render functions out of `CancelPurchaseForm` and into their own components.
- Move all the memoized functions out of `CancelPurchase` to make dependencies clear and derive a lot of variables closer to where they are used to reduce the number of things being passed around.

Depends on 198946-ghe-Automattic/wpcom

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The logic in `CancelPurchaseForm` and `CancelPurchase` is difficult to follow since the components are so large. It makes fixing bugs much harder to do.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is tricky to test because there's so many flows. I think the best way to test it is to try some common cancel flows and make sure they appear the same before and after this PR. 
