### PR TITLE
MSD: Fix plugin link in logs.

### DIFF
--- a/client/dashboard/components/logs-activity-formatted-block/index.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/index.tsx
@@ -154,7 +154,7 @@ const Plugin: BlockRenderer = ( { content, children, onClick, meta } ) => {
 
 	return (
 		<a
-			href={ `/plugins/${ pluginSlug }/${ siteSlug }` }
+			href={ `/plugins/manage/${ pluginSlug }` }
 			onClick={ onClick }
 			data-activity={ activity ?? meta.activity }
 			data-section={ section ?? meta.section ?? 'plugins' }

--- a/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
@@ -285,7 +285,7 @@ describe( 'Plugin blocks', () => {
 		} );
 
 		const link = screen.getByRole( 'link' );
-		expect( link ).toHaveAttribute( 'href', '/plugins/plugin-slug/site-slug' );
+		expect( link ).toHaveAttribute( 'href', '/plugins/manage/plugin-slug' );
 	} );
 
 	test.each( [

--- a/client/dashboard/components/logs-activity/test/activity-event.test.tsx
+++ b/client/dashboard/components/logs-activity/test/activity-event.test.tsx
@@ -236,7 +236,7 @@ describe( 'ActivityEvent', () => {
 		render( <ActivityEvent activity={ activity } /> );
 
 		const link = screen.getByRole( 'link', { name: 'Akismet' } );
-		expect( link.getAttribute( 'href' ) ).toBe( '/plugins/akismet/example.com' );
+		expect( link.getAttribute( 'href' ) ).toBe( '/plugins/manage/akismet' );
 	} );
 
 	it( 'renders theme links when themes originate from WordPress.com', () => {

--- a/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
@@ -228,6 +228,6 @@ test( 'data is properly displayed', async () => {
 	// check the link
 	expect( screen.getByRole( 'link', { name: 'Jetpack 15.1' } ) ).toHaveAttribute(
 		'href',
-		'/plugins/jetpack/testsite-slug'
+		'/plugins/manage/jetpack'
 	);
 } );


### PR DESCRIPTION
## Proposed Changes

This PR fixes broken plugin links in logs. They are currently going to a 404 page. 

## Why are these changes being made?

Broken

## Testing Instructions

- Install a new plugin on your site.
- View you logs, click on the plugin link.
- Expect to end up on the plugin's manage page.

Test, install, deactivating, deleting links.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
