### PR TITLE
A4A: Port Migration support form to Help center.

### DIFF
--- a/client/a8c-for-agencies/hooks/use-help-center.ts
+++ b/client/a8c-for-agencies/hooks/use-help-center.ts
@@ -46,8 +46,13 @@ export default function useHelpCenter() {
 		// If it does, we need to set the show help center to true and set the navigate to route to the contact form.
 		const handleHashChange = () => {
 			if ( hasSupportFormHash && isEnabled( 'a4a-help-center' ) ) {
+				const isMigrationRequest =
+					window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
+
 				setShowHelpCenter( true );
-				setNavigateToRoute( '/contact-form' );
+				setNavigateToRoute(
+					isMigrationRequest ? '/contact-form?migration-request=1' : '/contact-form'
+				);
 				history.pushState( null, '', window.location.pathname + window.location.search );
 			}
 		};

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -101,7 +101,7 @@ export const HelpCenterA4AContactForm = () => {
 									label={ field.label }
 									value={ getValue( { item: data } ) }
 									onChange={ ( value ) => {
-										return onChange( { [ id ]: value ?? '' } );
+										return onChange( { [ id ]: value ? Number( value ) : '' } );
 									} }
 								/>
 							);

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -8,11 +8,12 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 	Notice,
+	TextControl,
 } from '@wordpress/components';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useState, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useCallback, useMemo } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 /**
  * Internal Dependencies
  */
@@ -28,123 +29,19 @@ type FormData = {
 	product: string;
 	message: string;
 	pressable_contact: string;
+	no_of_sites: number;
 };
 
 const FORM_CONFIG = {
 	layout: { type: 'regular' as const },
-	fields: [ 'name', 'email', 'site', 'product', 'pressable_contact', 'message' ],
+	fields: [ 'name', 'email', 'site', 'no_of_sites', 'product', 'pressable_contact', 'message' ],
 };
-
-const fields: Field< FormData >[] = [
-	{
-		id: 'name',
-		label: __( 'Name', __i18n_text_domain__ ),
-		type: 'text' as const,
-		placeholder: __( 'Your name', __i18n_text_domain__ ),
-		isValid: {
-			required: true,
-		},
-	},
-	{
-		id: 'email',
-		label: __( 'Email address', __i18n_text_domain__ ),
-		type: 'text' as const,
-		placeholder: __( 'Your email', __i18n_text_domain__ ),
-		isValid: {
-			required: true,
-		},
-	},
-	{
-		id: 'site',
-		label: __( 'Related site', __i18n_text_domain__ ),
-		type: 'text' as const,
-		placeholder: __( 'Add site if necessary', __i18n_text_domain__ ),
-	},
-	{
-		id: 'product',
-		label: __( 'What product would you like help with?', __i18n_text_domain__ ),
-		type: 'text' as const,
-		Edit: 'select',
-		elements: [
-			{
-				label: __( 'Choose a product', __i18n_text_domain__ ),
-				value: '',
-			},
-			{
-				label: __( 'Automattic for Agencies', __i18n_text_domain__ ),
-				value: 'a4a',
-			},
-			{
-				label: __( 'Woo', __i18n_text_domain__ ),
-				value: 'woo',
-			},
-			{
-				label: __( 'WordPress.com', __i18n_text_domain__ ),
-				value: 'wpcom',
-			},
-			{
-				label: __( 'Jetpack', __i18n_text_domain__ ),
-				value: 'jetpack',
-			},
-			{
-				label: __( 'Pressable', __i18n_text_domain__ ),
-				value: 'pressable',
-			},
-		],
-		isValid: {
-			required: true,
-		},
-	},
-	{
-		id: 'pressable_contact',
-		label: __( 'Would you like help with Pressable sales or support?', __i18n_text_domain__ ),
-		type: 'text' as const,
-		Edit: 'select',
-		elements: [
-			{
-				label: __( 'Sales', __i18n_text_domain__ ),
-				value: 'sales',
-			},
-			{
-				label: __( 'Support', __i18n_text_domain__ ),
-				value: 'support',
-			},
-		],
-		isVisible: ( item: FormData ) => item.product === 'pressable',
-	},
-	{
-		id: 'message',
-		label: __( 'How can we help?', __i18n_text_domain__ ),
-		type: 'text' as const,
-		Edit: ( { field, data, onChange } ) => {
-			const { id, getValue } = field;
-			const placeholder =
-				data.product === 'pressable'
-					? __(
-							"Please provide the team with a detailed explanation of the issue you're facing, including steps to reproduce the issue on our end and/or URLs. Providing these details will greatly help us with your support request.",
-							__i18n_text_domain__
-					  )
-					: __( 'Add your message here', __i18n_text_domain__ );
-			return (
-				<TextareaControl
-					__nextHasNoMarginBottom
-					label={ field.label }
-					placeholder={ placeholder }
-					value={ getValue( { item: data } ) }
-					onChange={ ( value ) => {
-						return onChange( { [ id ]: value ?? '' } );
-					} }
-				/>
-			);
-		},
-		isValid: {
-			required: true,
-		},
-	},
-];
 
 export const HelpCenterA4AContactForm = () => {
 	const { currentUser, agency } = useHelpCenterContext();
+	const [ searchParams ] = useSearchParams();
+	const isMigrationRequest = !! searchParams.get( 'migration-request' );
+
 	const navigate = useNavigate();
 
 	const [ formData, setFormData ] = useState< FormData >( {
@@ -152,7 +49,12 @@ export const HelpCenterA4AContactForm = () => {
 		email: currentUser?.email ?? '',
 		site: '',
 		product: '',
-		message: '',
+		message: isMigrationRequest
+			? __( "I'd like to chat more about the migration offer.", __i18n_text_domain__ ) +
+			  '\n\n' +
+			  __( '[your message here]', __i18n_text_domain__ )
+			: '',
+		no_of_sites: 1,
 		pressable_contact: 'sales',
 	} );
 
@@ -163,6 +65,163 @@ export const HelpCenterA4AContactForm = () => {
 	} = useSubmitA4ATicketMutation();
 
 	const isPressableSelected = formData.product === 'pressable';
+
+	const fields: Field< FormData >[] = useMemo(
+		() => [
+			{
+				id: 'name',
+				label: __( 'Name', __i18n_text_domain__ ),
+				type: 'text' as const,
+				placeholder: __( 'Your name', __i18n_text_domain__ ),
+				isValid: {
+					required: true,
+				},
+			},
+			{
+				id: 'email',
+				label: __( 'Email address', __i18n_text_domain__ ),
+				type: 'text' as const,
+				placeholder: __( 'Your email', __i18n_text_domain__ ),
+				isValid: {
+					required: true,
+				},
+			},
+			isMigrationRequest
+				? {
+						id: 'no_of_sites',
+						label: __( 'Number of sites', __i18n_text_domain__ ),
+						type: 'number' as const,
+						Edit: ( { field, data, onChange } ) => {
+							const { id, getValue } = field;
+							return (
+								<TextControl
+									__nextHasNoMarginBottom
+									type="number"
+									min="1"
+									label={ field.label }
+									value={ getValue( { item: data } ) }
+									onChange={ ( value ) => {
+										return onChange( { [ id ]: value ?? '' } );
+									} }
+								/>
+							);
+						},
+						placeholder: __( 'Add number of sites you plan to migrate', __i18n_text_domain__ ),
+						isValid: {
+							required: true,
+						},
+				  }
+				: {
+						id: 'site',
+						label: __( 'Related site', __i18n_text_domain__ ),
+						type: 'text' as const,
+						placeholder: __( 'Add site if necessary', __i18n_text_domain__ ),
+				  },
+			{
+				id: 'product',
+				label: isMigrationRequest
+					? __( 'What hosting product are you considering?', __i18n_text_domain__ )
+					: __( 'What product would you like help with?', __i18n_text_domain__ ),
+				type: 'text' as const,
+				Edit: 'select',
+				elements: isMigrationRequest
+					? [
+							{
+								label: __( 'Choose a product', __i18n_text_domain__ ),
+								value: '',
+							},
+							{
+								label: __( 'WordPress.com', __i18n_text_domain__ ),
+								value: 'wpcom',
+							},
+							{
+								label: __( 'Pressable', __i18n_text_domain__ ),
+								value: 'pressable',
+							},
+							{
+								label: __( "Don't know", __i18n_text_domain__ ),
+								value: 'dont-know',
+							},
+					  ]
+					: [
+							{
+								label: __( 'Choose a product', __i18n_text_domain__ ),
+								value: '',
+							},
+							{
+								label: __( 'Automattic for Agencies', __i18n_text_domain__ ),
+								value: 'a4a',
+							},
+							{
+								label: __( 'Woo', __i18n_text_domain__ ),
+								value: 'woo',
+							},
+							{
+								label: __( 'WordPress.com', __i18n_text_domain__ ),
+								value: 'wpcom',
+							},
+							{
+								label: __( 'Jetpack', __i18n_text_domain__ ),
+								value: 'jetpack',
+							},
+							{
+								label: __( 'Pressable', __i18n_text_domain__ ),
+								value: 'pressable',
+							},
+					  ],
+				isValid: {
+					required: true,
+				},
+			},
+			{
+				id: 'pressable_contact',
+				label: __( 'Would you like help with Pressable sales or support?', __i18n_text_domain__ ),
+				type: 'text' as const,
+				Edit: 'select',
+				elements: [
+					{
+						label: __( 'Sales', __i18n_text_domain__ ),
+						value: 'sales',
+					},
+					{
+						label: __( 'Support', __i18n_text_domain__ ),
+						value: 'support',
+					},
+				],
+				isVisible: ( item: FormData ) => item.product === 'pressable',
+			},
+			{
+				id: 'message',
+				label: __( 'How can we help?', __i18n_text_domain__ ),
+				type: 'text' as const,
+				Edit: ( { field, data, onChange } ) => {
+					const { id, getValue } = field;
+					const placeholder =
+						data.product === 'pressable'
+							? __(
+									"Please provide the team with a detailed explanation of the issue you're facing, including steps to reproduce the issue on our end and/or URLs. Providing these details will greatly help us with your support request.",
+									__i18n_text_domain__
+							  )
+							: __( 'Add your message here', __i18n_text_domain__ );
+					return (
+						<TextareaControl
+							__nextHasNoMarginBottom
+							label={ field.label }
+							placeholder={ placeholder }
+							value={ getValue( { item: data } ) }
+							onChange={ ( value ) => {
+								return onChange( { [ id ]: value ?? '' } );
+							} }
+						/>
+					);
+				},
+				isValid: {
+					required: true,
+				},
+			},
+		],
+		[ isMigrationRequest ]
+	);
 
 	const { validity } = useFormValidity( formData, fields, FORM_CONFIG );
 
@@ -182,7 +241,9 @@ export const HelpCenterA4AContactForm = () => {
 					agency_id: agency?.id,
 					pressable_id: agency?.pressableId,
 					site: formData.site || undefined,
+					no_of_sites: isMigrationRequest ? formData.no_of_sites : undefined,
 					contact_type: isPressableSelected ? formData.pressable_contact : undefined,
+					tags: isMigrationRequest ? [ 'a4a_form_dash_migration' ] : undefined,
 				},
 				{
 					onSuccess: () => {
@@ -191,7 +252,21 @@ export const HelpCenterA4AContactForm = () => {
 				}
 			);
 		},
-		[ formData, submitA4ATicket, agency?.id, agency?.pressableId, isPressableSelected, navigate ]
+		[
+			formData.message,
+			formData.name,
+			formData.email,
+			formData.product,
+			formData.site,
+			formData.no_of_sites,
+			formData.pressable_contact,
+			submitA4ATicket,
+			agency?.id,
+			agency?.pressableId,
+			isMigrationRequest,
+			isPressableSelected,
+			navigate,
+		]
 	);
 
 	const isValidForm = ! validity;

--- a/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
+++ b/packages/help-center/src/data/use-submit-a4a-support-ticket.ts
@@ -8,8 +8,10 @@ type Ticket = {
 	product: string;
 	agency_id: number | undefined;
 	site?: string;
+	no_of_sites?: number;
 	contact_type?: string;
 	pressable_id?: number;
+	tags?: string[];
 };
 
 export function useSubmitA4ATicketMutation() {


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1967/a4a-migration-form-regression

## Proposed Changes

This pull request enhances the Help Center contact form to better support agency migration requests. The main improvements include dynamically adjusting form fields and submission payloads based on a migration request parameter, allowing users to specify the number of sites, and tagging migration-related tickets for easier identification.

**Migration request support and form enhancements:**

* The Help Center now detects a special hash in the URL and, if present, navigates users to the contact form with a `migration-request` parameter, ensuring the form is tailored for migration inquiries.
* The contact form dynamically adds a "Number of sites" field and changes the product selection options and labels when accessed as a migration request. The message field is also pre-filled with a migration-specific template. [[1]](diffhunk://#diff-0d5731e675b77983cee175e110e33345defcfaad57975a54616692fede3cdc97R32-R70) [[2]](diffhunk://#diff-0d5731e675b77983cee175e110e33345defcfaad57975a54616692fede3cdc97L57-R146)
* The form submission logic now includes `no_of_sites` and a `tags` array (with a migration tag) in the payload when it's a migration request, supporting better ticket categorization and handling. [[1]](diffhunk://#diff-0d5731e675b77983cee175e110e33345defcfaad57975a54616692fede3cdc97R244-R246) [[2]](diffhunk://#diff-37e869efb4c61d2cce200a61f74e1cfcb1850d05594c9dc36ecef5cc9f8f3064R11-R14)
* The form's React hook dependencies and field configuration are updated to support the new dynamic behavior and ensure correct reactivity. [[1]](diffhunk://#diff-0d5731e675b77983cee175e110e33345defcfaad57975a54616692fede3cdc97L144-R224) [[2]](diffhunk://#diff-0d5731e675b77983cee175e110e33345defcfaad57975a54616692fede3cdc97L194-R269)
* Additional React and routing hooks are imported to enable reading search parameters and conditionally rendering fields.

<img width="438" height="833" alt="Screenshot 2026-01-01 at 3 19 18 PM" src="https://github.com/user-attachments/assets/4cc36f37-f6ed-4a7b-a617-87ec5a6b7d7b" />


## Why are these changes being made?

* This was a regression introduced when we added the new Contact form via the Help center. This PR fixes the missing functionality.

## Testing Instructions

* Use the A4A live link and navigate to the `/migrations/overview` page
* Click the `Migrate your Site > Concierge service` dropdown menu.
   <img width="460" height="363" alt="Screenshot 2026-01-01 at 3 23 39 PM" src="https://github.com/user-attachments/assets/36d926d5-fee1-4a75-80fc-c47377443ecf" />

* Verify that the form is tailored for migration inquiry. Verify that the form is submitting properly.
* Verify that the regular contact support form is working properly without regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
