### PR TITLE
Make sure isDevelopmentAsset identifies .map assets as dev mode.

### DIFF
--- a/build-tools/webpack/assets-writer-plugin.js
+++ b/build-tools/webpack/assets-writer-plugin.js
@@ -47,7 +47,7 @@ Object.assign( AssetsWriter.prototype, {
 			}
 
 			// Exclude hot update files (info.hotModuleReplacement) and source maps.
-			// Relying solely on `asset.info.development` is brittle across webpack versions,
+			// Relying solely on `asset.info.development` as we use hidden-source-map for production builds,
 			// so we also explicitly filter out any `.map` assets by filename.
 			function isDevelopmentAsset( name ) {
 				// Treat all source map files as development-only so they are never inlined into HTML.

--- a/build-tools/webpack/assets-writer-plugin.js
+++ b/build-tools/webpack/assets-writer-plugin.js
@@ -46,8 +46,15 @@ Object.assign( AssetsWriter.prototype, {
 				return path.join( stats.publicPath, f );
 			}
 
-			// Exclude hot update files (info.hotModuleReplacement) and source maps (info.development)
+			// Exclude hot update files (info.hotModuleReplacement) and source maps.
+			// Relying solely on `asset.info.development` is brittle across webpack versions,
+			// so we also explicitly filter out any `.map` assets by filename.
 			function isDevelopmentAsset( name ) {
+				// Treat all source map files as development-only so they are never inlined into HTML.
+				if ( name.endsWith( '.map' ) ) {
+					return true;
+				}
+
 				const asset = stats.assets.find( ( a ) => a.name === name );
 				if ( ! asset ) {
 					return false;

--- a/build-tools/webpack/assets-writer-plugin.js
+++ b/build-tools/webpack/assets-writer-plugin.js
@@ -47,7 +47,7 @@ Object.assign( AssetsWriter.prototype, {
 			}
 
 			// Exclude hot update files (info.hotModuleReplacement) and source maps.
-			// Relying solely on `asset.info.development` as we use hidden-source-map for production builds,
+			// `asset.info.development` is false when using hidden-source-map,
 			// so we also explicitly filter out any `.map` assets by filename.
 			function isDevelopmentAsset( name ) {
 				// Treat all source map files as development-only so they are never inlined into HTML.


### PR DESCRIPTION
## Proposed Changes

We're receiving a console error in production `Uncaught SyntaxError: Unexpected token ':'` on the multi-site dashboard.

This PR adds code to explicitely return `.map` files as development. We currently inject scripts in [client/document](https://github.com/Automattic/wp-calypso/blob/512345e67c7d91327fcd33e31e7897e9f21c1cdb/client/document/index.jsx#L227). Provided the file is in the manifest, it will inject it. 

The problem in this case, is that a .map object exists in the manifest list and once it prints the `json` in the console you get Javascript errors.

Webpack is set to use `hidden-source-map` in production so we can send [sourcemaps to Sentry](https://github.com/Automattic/wp-calypso/blob/512345e67c7d91327fcd33e31e7897e9f21c1cdb/client/webpack.config.js#L390).

The problem is that by using  `hidden-source-map`, `asset.info.development` is false so the map doesn't get removed from the manifest list.

https://github.com/Automattic/wp-calypso/blob/c2e78695a016fb5c9476cc1f3ace66fcfbc153d3/build-tools/webpack/assets-writer-plugin.js#L63

**Note:**
`hidden-source-maps` are [not considered development](https://webpack.js.org/configuration/devtool/#:~:text=hidden%2Dsource%2Dmap%20%2D%20Same%20as%20source%2Dmap%2C%20but%20doesn%27t%20add%20a%20reference%20comment%20to%20the%20bundle.%20Useful%20if%20you%20only%20want%20SourceMaps%20to%20map%20error%20stack%20traces%20from%20error%20reports%2C%20but%20don%27t%20want%20to%20expose%20your%20SourceMap%20for%20the%20browser%20development%20tools.).

> hidden-source-map - Same as source-map, but doesn't add a reference comment to the bundle. Useful if you only want SourceMaps to map error stack traces from error reports, but don't want to expose your SourceMap for the browser development tools.


## Considerations

This hasn't aways been the case. I haven't been able to track what has changed to introduce this.


## Testing Instructions

I haven't found a way to test this.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
