### PR TITLE
MSD: Add site_slug to upgrade billing page subtitle.

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1058,7 +1058,7 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 
 	if ( purchase.is_plan ) {
 		title = sprintf(
-			// translators: subtitle is the type of purchase (e.g. "Site plan"), site is the domain or slug of the site the plan applies to.
+			// translators: subtitle is the type of purchase (e.g. "Site plan"), site is the slug of the site the plan applies to.
 			__( '%(subtitle)s for %(site)s.' ),
 			{
 				subtitle,

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1050,7 +1050,6 @@ function PurchaseSecondSubtitle( { purchase }: { purchase: Purchase } ) {
 
 function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 	const subtitle = getSubtitleForDisplay( purchase );
-
 	if ( ! subtitle ) {
 		return null;
 	}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1058,18 +1058,14 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 	let title = subtitle;
 
 	if ( purchase.is_plan ) {
-		const siteLabel = purchase.site_slug || purchase.domain;
-
-		if ( siteLabel ) {
-			title = sprintf(
-				// translators: subtitle is the type of purchase (e.g. "Site plan"), site is the domain or slug of the site the plan applies to.
-				__( '%(subtitle)s for %(site)s.' ),
-				{
-					subtitle,
-					site: siteLabel,
-				}
-			);
-		}
+		title = sprintf(
+			// translators: subtitle is the type of purchase (e.g. "Site plan"), site is the domain or slug of the site the plan applies to.
+			__( '%(subtitle)s for %(site)s.' ),
+			{
+				subtitle,
+				site: purchase.site_slug,
+			}
+		);
 	}
 
 	return <MetadataItem title={ title } />;

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -1050,11 +1050,29 @@ function PurchaseSecondSubtitle( { purchase }: { purchase: Purchase } ) {
 
 function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 	const subtitle = getSubtitleForDisplay( purchase );
+
 	if ( ! subtitle ) {
 		return null;
 	}
 
-	return <MetadataItem title={ subtitle } />;
+	let title = subtitle;
+
+	if ( purchase.is_plan ) {
+		const siteLabel = purchase.site_slug || purchase.domain;
+
+		if ( siteLabel ) {
+			title = sprintf(
+				// translators: subtitle is the type of purchase (e.g. "Site plan"), site is the domain or slug of the site the plan applies to.
+				__( '%(subtitle)s for %(site)s.' ),
+				{
+					subtitle,
+					site: siteLabel,
+				}
+			);
+		}
+	}
+
+	return <MetadataItem title={ title } />;
 }
 
 export default function PurchaseSettings() {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -306,13 +306,7 @@ export function getSubtitleForDisplay( purchase: Purchase ): string | null {
 	}
 
 	if ( purchase.is_plan ) {
-		return sprintf(
-			// translators: site is the domain of the site the plan applies to.
-			__( 'Site plan for %(site)s' ),
-			{
-				site: purchase.site_slug || purchase.domain,
-			}
-		);
+		return __( 'Site plan' );
 	}
 
 	if ( purchase.is_domain_registration ) {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -306,7 +306,13 @@ export function getSubtitleForDisplay( purchase: Purchase ): string | null {
 	}
 
 	if ( purchase.is_plan ) {
-		return __( 'Site Plan' );
+		return sprintf(
+			// translators: site is the domain of the site the plan applies to.
+			__( 'Site plan for %(site)s' ),
+			{
+				site: purchase.site_slug || purchase.domain,
+			}
+		);
 	}
 
 	if ( purchase.is_domain_registration ) {


### PR DESCRIPTION
## Proposed Changes

This PR adds the site slug to `Site plan` in the subtitle.

On previous Active Upgrades DataView row, we show "Site plan for X". This PR aligns the upgrade single page with that experience to help users identify which plan they are viewing more easily. I didn't add for "Site Title ({url})". I don't see how that's a primary action for this billing page.

| Before | After |
|--------|--------|
| <img width="695" height="167" alt="Screenshot 2026-01-02 at 2 18 08 PM" src="https://github.com/user-attachments/assets/92a41c10-a59e-4ff6-a4fb-69581e02fba2" /> | <img width="697" height="161" alt="Screenshot 2026-01-02 at 2 18 32 PM" src="https://github.com/user-attachments/assets/4e3eaec7-0fcb-40af-827f-1bf974a7a27c" /> |
| <img width="1239" height="965" alt="Screenshot 2026-01-02 at 2 13 34 PM" src="https://github.com/user-attachments/assets/96f2d662-4bdd-46e2-91c7-387e4ee6d69e" /> | <img width="1236" height="969" alt="Screenshot 2026-01-02 at 2 12 17 PM" src="https://github.com/user-attachments/assets/d03374ef-e8ad-4106-8ced-46afa4079faa" /> |  



### Preceding Active upgrades page
<img width="1358" height="915" alt="Screenshot 2026-01-05 at 2 19 35 PM" src="https://github.com/user-attachments/assets/789d6a0b-1a69-4da0-9d9e-8212d0f681b5" />




## Why are these changes being made?

I have multiple "WordPress.com Business" and I've found it hard to identify which one I'm looking at since the page titles are the same and the tiles are in a different place.



## Testing Instructions

1. Select a plan in your Active upgrades list.
2. Confirm that the subtitle include the site_slug or domain.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
