### PR TITLE
Notifications v2: Display the summary of liked post and comment

### DIFF
--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -119,12 +119,8 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 			</CardHeader>
 			<CardBody size="small" style={ { maxHeight: 'unset' } }>
 				<VStack justify="flex-start" spacing={ 4 }>
-					{ note.type !== 'like' && note.type !== 'comment_like' && (
-						<>
-							<NoteSummary note={ note } />
-							<Divider style={ { color: '#f0f0f0' } } />
-						</>
-					) }
+					<NoteSummary note={ note } />
+					<Divider style={ { color: '#f0f0f0' } } />
 					<div className={ getClasses( { note, isApproved, isRead } ) }>
 						<NoteBody note={ note } />
 					</div>

--- a/apps/notifications/src/app/templates/note-summary.tsx
+++ b/apps/notifications/src/app/templates/note-summary.tsx
@@ -9,8 +9,9 @@ import type { Note } from '../types';
 import type { CSSProperties } from 'react';
 
 const getNoteIconLink = ( note: Note ) => {
-	if ( note.header?.[ 0 ].ranges?.[ 0 ].type === 'user' ) {
-		const { id: userId, site_id: siteId, url } = note.header[ 0 ].ranges[ 0 ];
+	const user = ( note.subject?.[ 0 ].ranges || [] ).find( ( { type } ) => type === 'user' );
+	if ( user ) {
+		const { id: userId, site_id: siteId, url } = user;
 		// Some site notifications populate id with the siteId, so consider the userId falsy in this
 		// case.
 		return userId && userId !== siteId ? `https://wordpress.com/reader/users/id/${ userId }` : url;
@@ -21,7 +22,7 @@ const getNoteIconLink = ( note: Note ) => {
 
 const NoteSummaryIcon = ( { note }: { note: Note } ) => {
 	const link = getNoteIconLink( note );
-	const style: CSSProperties = { flexShrink: 0 };
+	const style: CSSProperties = { display: 'flex', flexShrink: 0 };
 	const content = <NoteIcon icon={ note.icon } size={ 32 } />;
 
 	if ( ! link ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-981

## Proposed Changes

* Display the summary of liked post and comment
* Fix the profile link on the summary is incorrect
* Fix the profile height on the summary is incorrect

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users can see an option to view the post or comment that's been liked in v1, so we should also port the feature to v2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Dashboard
* Open Notifications
* Switch to Likes tab
* Select any notification
* Ensure you can see the summary of the notification

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
