### PR TITLE
Test: make test runner work from local

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -78,7 +78,7 @@ export class AllFormFieldsFlow implements BlockFlow {
 		// And we just wrap up labeling the auto-added blocks.
 		const otherBlocksToLabel = isRefactor
 			? [
-					[ 'Button', 'Add text…' ],
+					[ 'Button', 'Button text' ],
 					[ 'Option', 'Add option…', 'Single choice (radio)' ],
 					[ 'Option', 'Add option…', 'Multiple choice (checkbox)' ],
 			  ]


### PR DESCRIPTION


## Proposed Changes
Change expected aria-label for submit button after the core/button replacement.


## Why are these changes being made?
Failing tests on "Configure the block" with Jetpack Forms blocks.

## Testing Instructions

Run with 
```
yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts
```
and
```
yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace -- wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts
```

Or any other variant/viewport. The script should trigger the tests and the tests should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
