### PR TITLE
Dashboard: fix crashes around async RTL css handling

### DIFF
--- a/client/dashboard/app/i18n.tsx
+++ b/client/dashboard/app/i18n.tsx
@@ -96,7 +96,10 @@ function loadCSS(
 			setTimeout( () => resolve( link ), 500 );
 		}
 
-		document.head.insertBefore( link, currentLink ? currentLink.nextSibling : null );
+		document.head.insertBefore(
+			link,
+			currentLink?.nextSibling?.parentElement === document.head ? currentLink.nextSibling : null
+		);
 	} );
 }
 
@@ -124,7 +127,9 @@ async function switchWebpackCSS( isRTL: boolean ) {
 
 		if ( newLink ) {
 			newLink.setAttribute( 'data-webpack', 'true' );
-			currentLink.parentElement?.removeChild( currentLink );
+			if ( currentLink.isConnected ) {
+				currentLink.parentElement?.removeChild( currentLink );
+			}
 		}
 	}
 }


### PR DESCRIPTION

## Proposed Changes

Attempts to fix the following ongoing Sentry errors:

> Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.

and 

> Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.

After some debugging session with ChatGPT, I conclude that these errors were caused by race condition in DOM manipulation when we swap CSS for RTL languages, added in https://github.com/Automattic/wp-calypso/pull/106016.

## Why are these changes being made?

Fixing Sentry errors.

## Testing Instructions

Sanity check: verify you can switch to RTL language and dashboard still works (see instructions on https://github.com/Automattic/wp-calypso/pull/106016).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
