### PR TITLE
WIP: update copy on /plugins to reflect plugins available on all plans

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -552,15 +552,7 @@ function FreePrice( { shouldUpgrade } ) {
 		<>
 			{ translate( 'Free' ) }
 			{ ( ! isLoggedIn || ! selectedSite || shouldUpgrade ) && (
-				<span className="plugin-details-cta__notice">
-					{ translate(
-						// Translators: %(planName)s is the name of a plan (e.g. Creator or Business)
-						'on %(planName)s plan',
-						{
-							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-						}
-					) }
-				</span>
+				<span className="plugin-details-cta__notice">{ translate( 'on paid plans' ) }</span>
 			) }
 		</>
 	);

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -5,14 +5,12 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_MONTHLY,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
-	getPlan,
 } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { Icon, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
-import usePluginsSupportText from 'calypso/my-sites/plugins/use-plugins-support-text';
 import { useSelector } from 'calypso/state';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
@@ -128,10 +126,11 @@ export const PlanUSPS: React.FC< Props > = ( {
 	const isPreInstalledPlugin = ! isJetpack && PREINSTALLED_PLUGINS.includes( pluginSlug );
 
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
-	const supportText = usePluginsSupportText();
 	const requiredPlan = useRequiredPlan( shouldUpgrade );
 	const planDisplayCost = useSelector( ( state ) => {
-		return getProductDisplayCost( state, requiredPlan || '' );
+		// Always use Personal plan for the "starting at" price
+		const personalPlan = isAnnualPeriod ? PLAN_PERSONAL : PLAN_PERSONAL_MONTHLY;
+		return getProductDisplayCost( state, personalPlan );
 	} );
 	const monthlyLabel = translate( 'month' );
 	const annualLabel = translate( 'year' );
@@ -142,36 +141,15 @@ export const PlanUSPS: React.FC< Props > = ( {
 	}
 
 	let planText;
-	switch ( requiredPlan ) {
-		case PLAN_PERSONAL:
-		case PLAN_PERSONAL_MONTHLY:
-			planText = translate(
-				'Included in the %(personalPlanName)s plan (%(cost)s/%(periodicity)s):',
-				{
-					args: {
-						personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() as string,
-						cost: planDisplayCost as string,
-						periodicity: periodicityLabel,
-					},
-				}
-			);
-			break;
-		case PLAN_BUSINESS:
-		case PLAN_BUSINESS_MONTHLY:
-			planText = translate(
-				'Included in the %(businessPlanName)s plan (%(cost)s/%(periodicity)s):',
-				{
-					args: {
-						businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() as string,
-						cost: planDisplayCost as string,
-						periodicity: periodicityLabel,
-					},
-				}
-			);
-			break;
-		case PLAN_ECOMMERCE_TRIAL_MONTHLY:
-			planText = translate( 'Included in ecommerce plans:' );
-			break;
+	if ( requiredPlan === PLAN_ECOMMERCE_TRIAL_MONTHLY ) {
+		planText = translate( 'Included in ecommerce plans:' );
+	} else {
+		planText = translate( 'Included on all paid plans (starting at %(cost)s/%(periodicity)s):', {
+			args: {
+				cost: planDisplayCost as string,
+				periodicity: periodicityLabel,
+			},
+		} );
 	}
 
 	const preInstalledPluginUSPS = [
@@ -187,7 +165,8 @@ export const PlanUSPS: React.FC< Props > = ( {
 	const filteredUSPS = [
 		...( isFreePlan && isAnnualPeriod ? [ translate( 'Free domain for one year' ) ] : [] ),
 		translate( 'Best-in-class hosting' ),
-		supportText,
+		translate( 'Access to thousands of plugins' ),
+		translate( 'Expert support' ),
 		...( isPreInstalledPlugin ? preInstalledPluginUSPS : [] ),
 		...( requiredPlan === PLAN_ECOMMERCE_TRIAL_MONTHLY
 			? [ translate( 'Tools for store management and growth' ) ]


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15537

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
