### PR TITLE
Dashboard: fix benign error checking; can't rely on instanceof

### DIFF
--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -1,4 +1,4 @@
-import { DashboardDataError, INACCESSIBLE_JETPACK_ERROR_CODE } from '@automattic/api-core';
+import { INACCESSIBLE_JETPACK_ERROR_CODE } from '@automattic/api-core';
 import calypsoConfig from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { camelToSnakeCase } from '@automattic/js-utils';
@@ -17,18 +17,16 @@ function isBenignError( error: Error ) {
 
 	// Ignore errors related to inaccessible Jetpack sites.
 	// The user is expected to debug their Jetpack sites.
-	if ( error instanceof DashboardDataError ) {
-		return error.code === INACCESSIBLE_JETPACK_ERROR_CODE;
+	if ( 'code' in error && error.code === INACCESSIBLE_JETPACK_ERROR_CODE ) {
+		return true;
 	}
 
 	// Ignore errors related to view transitions.
 	// Those are triggered by the browser when the user tries to navigate away from a page that is still transitioning.
-	if ( error instanceof DOMException ) {
-		switch ( error.name ) {
-			case 'AbortError':
-			case 'InvalidStateError':
-				return error.message.includes( 'transition' );
-		}
+	switch ( error.name ) {
+		case 'AbortError':
+		case 'InvalidStateError':
+			return error.message.includes( 'transition' );
 	}
 
 	return false;


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/107926

## Proposed Changes

I'm still seeing the suppressed errors from the above PR on Sentry. It seems the `error instanceof X` might be failing in production. Let me try skipping that check.

## Testing Instructions

Merge and check Sentry on production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
