### PR TITLE
Framework: Swallow service worker registration errors

### DIFF
--- a/client/document/domains-landing.jsx
+++ b/client/document/domains-landing.jsx
@@ -103,7 +103,11 @@ function DomainsLanding( {
 						__html: `
 							if ('serviceWorker' in navigator) {
 								window.addEventListener('load', function() {
-									navigator.serviceWorker.register('/service-worker.js');
+									try {
+										navigator.serviceWorker.register('/service-worker.js');
+									} catch ( err ) {
+										console.error( 'Error registering service worker', err );
+									}
 								});
 							}
 						 `,

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -282,7 +282,11 @@ class Document extends Component {
 							__html: `
 							if ('serviceWorker' in navigator) {
 								window.addEventListener('load', function() {
-									navigator.serviceWorker.register('/service-worker.js');
+									try {
+										navigator.serviceWorker.register('/service-worker.js');
+									} catch ( err ) {
+										console.error( 'Error registering service worker', err );
+									}
 								});
 							}
 						 `,


### PR DESCRIPTION
## Proposed Changes

Swallow the service worker registration errors. 

See CALYPSO-14F3 in Sentry (issue 4235644623)

## Why are these changes being made?

On Windows we're receiving a bunch of errors when service worker registration fails. 

## Testing Instructions

Verify service worker registration still works.