### PR TITLE
Framework: Async service worker registration handling

### DIFF
--- a/client/document/domains-landing.jsx
+++ b/client/document/domains-landing.jsx
@@ -102,9 +102,9 @@ function DomainsLanding( {
 					dangerouslySetInnerHTML={ {
 						__html: `
 							if ('serviceWorker' in navigator) {
-								window.addEventListener('load', function() {
+								window.addEventListener('load', async function() {
 									try {
-										navigator.serviceWorker.register('/service-worker.js');
+										await navigator.serviceWorker.register('/service-worker.js');
 									} catch ( err ) {
 										console.error( 'Error registering service worker', err );
 									}

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -281,9 +281,9 @@ class Document extends Component {
 						dangerouslySetInnerHTML={ {
 							__html: `
 							if ('serviceWorker' in navigator) {
-								window.addEventListener('load', function() {
+								window.addEventListener('load', async function() {
 									try {
-										navigator.serviceWorker.register('/service-worker.js');
+										await navigator.serviceWorker.register('/service-worker.js');
 									} catch ( err ) {
 										console.error( 'Error registering service worker', err );
 									}


### PR DESCRIPTION
## Proposed Changes

Properly swallow the service worker registration errors by awaiting the registration to finish. 

See CALYPSO-14F3 in Sentry (issue 4235644623)

## Why are these changes being made?

On Windows we're receiving a bunch of errors when service worker registration fails. 

## Testing Instructions

Verify service worker registration still works.