### PR TITLE
DIFM Onboarding: Pass siteId when redirecting to site-content-collection flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -365,6 +365,7 @@ function addDIFMLiteProductToCart( callback, dependencies, step, reduxStore ) {
 		selectedSiteCategory,
 		isLetUsChooseSelected,
 		siteSlug,
+		siteId: selectedSiteId,
 		cartItem,
 	};
 	const newCartItems = [ cartItem ];

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -811,8 +811,15 @@ export function generateSteps( {
 				'isLetUsChooseSelected',
 				'cartItem',
 				'siteSlug',
+				'siteId',
 			],
-			optionalDependencies: [ 'selectedDesign', 'isLetUsChooseSelected', 'cartItem', 'siteSlug' ],
+			optionalDependencies: [
+				'selectedDesign',
+				'isLetUsChooseSelected',
+				'cartItem',
+				'siteSlug',
+				'siteId',
+			],
 			props: {
 				hideSkip: true,
 				hideExternalPreview: true,


### PR DESCRIPTION
Fixes DOTOBRD-382.

## Proposed Changes

If the user selects "**new site**" in the DIFM site picker, we were not forwarding the newly created site ID to the post-checkout flow, resulting in a broken experience despite the site being created.

## Testing Instructions

1. Enter `/start/do-it-for-me`
2. Click "new site" in the site picker's step subtitle
3. Enter a site title, skip the socials step
4. Pick "Let us choose" in the designs step
5. Click "Go to checkout" in the page picker step

Pay at checkout, then verify you're redirected to the content-gathering step. Production currently shows a broken page after paying.