### PR TITLE
Domain Contact Editing: Use ExternalLink and InlineSupportLink in info notice

### DIFF
--- a/client/dashboard/components/domain-contact-details-form/contact-form.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form.tsx
@@ -149,25 +149,16 @@ export default function ContactForm( {
 							),
 							{
 								external: (
-									<Button
-										variant="link"
-										target="_blank"
-										href="https://www.icann.org/resources/pages/contact-verification-2013-05-03-en"
-									>
+									<ExternalLink href="https://www.icann.org/resources/pages/contact-verification-2013-05-03-en">
 										ICANN
-									</Button>
+									</ExternalLink>
 								),
 							}
 						) }
 					</Text>
 					<Text as="p">
 						{ __( 'Domain privacy service is included for free on applicable domains.' ) }{ ' ' }
-						<ExternalLink
-							// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
-							href="https://wordpress.com/support/domains/private-domain-registration/#what-is-privacy-protection"
-						>
-							{ __( 'Learn more' ) }
-						</ExternalLink>
+						<InlineSupportLink supportContext="domain-registrations-and-privacy" />
 					</Text>
 				</VStack>
 			</Notice>


### PR DESCRIPTION
Closes DOMAINS-1810.

## Proposed Changes

Update info notice within the domain contact editing form (`/domains/%s/contact-info`) so the links are reflected with their correct nature:

1. ICANN link is external so it should have the arrow icon next to it
2. "Learn more" opens the support popup instead of linking externally

<img width="1176" height="273" alt="image" src="https://github.com/user-attachments/assets/392a891c-7589-49bd-9e9e-d9dc7b057fe4" />

## Testing Instructions

Enter a domain contact info editing form in the MSD and verify that the changes are reflected in the links.