### PR TITLE
Don't override the Help Center location when auto-opening

### DIFF
--- a/packages/data-stores/src/help-center/types.ts
+++ b/packages/data-stores/src/help-center/types.ts
@@ -38,7 +38,9 @@ export interface Dispatch {
 	dispatch: DispatchFromMap< typeof actions >;
 }
 
-export type HelpCenterSelect = SelectFromMap< typeof selectors >;
+export type HelpCenterSelect = SelectFromMap< typeof selectors > & {
+	isResolving: ( key: string ) => boolean;
+};
 
 export interface HelpCenterOptions {
 	hideBackButton?: boolean;

--- a/packages/odie-client/src/data/use-current-support-interaction.ts
+++ b/packages/odie-client/src/data/use-current-support-interaction.ts
@@ -20,7 +20,7 @@ export const useCurrentSupportInteraction = () => {
 		if ( id && query.status === 'error' ) {
 			navigate( '/odie' );
 		}
-	}, [ query, navigate, id ] );
+	}, [ query.status, navigate, id ] );
 
 	return query;
 };


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/92899

Part of HAL-557

## Proposed Changes

- Opening a link from Odie adds the query param help-center=wapuu. Which is meant to open the Help Center on landing. But this overrides the persisted state and derails the user's support session. 
- This makes sure the location is `undefined` before overwriting it.

## Why are these changes being made?
To keep the user session intact.

## Testing Instructions
1. Go to /sites?version=1.2.2
2. Ask "how do I edit my homepage?".
3. Click the link in the answer.
4. The destination page should re-open the Help Center in the same location.
