### PR TITLE
Help Center: Do not open Odie links in a new tab

### DIFF
--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -107,9 +107,7 @@ export const UserMessage = ( {
 				<MarkdownOrChildren
 					messageContent={ messageContent }
 					components={ {
-						a: ( props: React.ComponentProps< 'a' > ) => (
-							<CustomALink { ...props } target="_blank" />
-						),
+						a: ( props: React.ComponentProps< 'a' > ) => <CustomALink { ...props } />,
 					} }
 				/>
 			</div>


### PR DESCRIPTION
Fixes HAL-545

## Proposed Changes

Remove target="_blank" from Odie links.

## Why are these changes being made?
Smoother continuity.

## Testing Instructions
1. Go to /sites?version=1.2.2
2. Ask "how do I edit my homepage?".
3. Click the link in the answer.
4. The destination page should open the Help Center in the same tab.

