### PR TITLE
MSD: Rename isDashboard() to isDashboardEnv()

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -10,7 +10,7 @@ import '@wordpress/components/build-style/style.css';
 import '@wordpress/commands/build-style/style.css';
 import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import wpcom from 'calypso/lib/wp';
-import isDashboard from '../utils/is-dashboard';
+import isDashboardEnv from '../utils/is-dashboard-env';
 import { loadPreferencesHelper } from './dev-tools/preferences';
 import Layout from './layout';
 import limitTotalSnackbars from './snackbars/limit-total-snackbars';
@@ -19,7 +19,7 @@ import type { AppConfig } from './context';
 import './style.scss';
 
 function boot( config: AppConfig ) {
-	if ( ! isDashboard() && ! isEnabled( 'dashboard/v2' ) && ! isSupportSession() ) {
+	if ( ! isDashboardEnv() && ! isEnabled( 'dashboard/v2' ) && ! isSupportSession() ) {
 		throw new Error( 'Multi-site Dashboard is not enabled' );
 	}
 

--- a/client/dashboard/utils/is-dashboard-backport.ts
+++ b/client/dashboard/utils/is-dashboard-backport.ts
@@ -1,8 +1,8 @@
-import isDashboard from './is-dashboard';
+import isDashboardEnv from './is-dashboard-env';
 
 export function isDashboardBackport() {
 	// No need to check for backport if it's a dashboard Calypso environment.
-	if ( isDashboard() ) {
+	if ( isDashboardEnv() ) {
 		return false;
 	}
 

--- a/client/dashboard/utils/is-dashboard-env.ts
+++ b/client/dashboard/utils/is-dashboard-env.ts
@@ -7,6 +7,6 @@ const dashboardEnvironments = [
 	'dashboard-production',
 ];
 
-const isDashboard = (): boolean => dashboardEnvironments.includes( config( 'env_id' ) );
+const isDashboardEnv = (): boolean => dashboardEnvironments.includes( config( 'env_id' ) );
 
-export default isDashboard;
+export default isDashboardEnv;

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -23,7 +23,7 @@ import {
 	DASHBOARD_SECTION_DEFINITION,
 	DASHBOARD_CIAB_SECTION_DEFINITION,
 } from 'calypso/dashboard/section';
-import isDashboard from 'calypso/dashboard/utils/is-dashboard';
+import isDashboardEnv from 'calypso/dashboard/utils/is-dashboard-env';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { STEPPER_SECTION_DEFINITION } from 'calypso/landing/stepper/section';
 import { SUBSCRIPTIONS_SECTION_DEFINITION } from 'calypso/landing/subscriptions/section';
@@ -1048,7 +1048,7 @@ export default function pages() {
 	app.use( setupLoggedInContext );
 	app.use( middlewareUnsupportedBrowser() );
 
-	if ( ! ( isJetpackCloud() || isA8CForAgencies() || isDashboard() ) ) {
+	if ( ! ( isJetpackCloud() || isA8CForAgencies() || isDashboardEnv() ) ) {
 		wpcomPages( app );
 	}
 
@@ -1185,7 +1185,7 @@ export default function pages() {
 
 	// Multi-site Dashboard routing for my.wordpress.com.
 	// Return earlier since we don't need to set up any other routes.
-	if ( isDashboard() ) {
+	if ( isDashboardEnv() ) {
 		DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
 			handleSectionPath( DASHBOARD_SECTION_DEFINITION, route, 'entry-dashboard-dotcom' );
 		} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->


## Proposed Changes

Renamed the function and file from isDashboard/is-dashboard.ts to isDashboardEnv/is-dashboard-env.ts to clarify that this function only checks the environment ID, not the dashboard state.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->



This prevents confusion that `isDashboard()` is simply the opposite of `isDashboardBackport()`, however it also checks the URL path to determine if the user is in the dashboard backport.

The `isDashboard()` function was added in https://github.com/Automattic/wp-calypso/pull/107300, and you can see there that it was intended to be an environment checker, so I think this is a reasonable change.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test, there should be no changes to behaviour
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
