### PR TITLE
E2E: Add welcome modal dismissal to dashboard visit()

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/dashboard-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/dashboard-page.ts
@@ -30,11 +30,28 @@ export class DashboardPage {
 
 	/**
 	 * Visits the dashboard entry page.
+	 * Dismisses the welcome modal if it appears because it hides the "main" content.
 	 *
 	 * @returns Promise that resolves when navigation is complete.
 	 */
 	async visit(): Promise< void > {
 		await this.page.goto( getDashboardURL() );
+
+		try {
+			await this.page
+				.getByRole( 'heading', {
+					name: 'Meet the new WordPress.com Hosting Dashboard',
+				} )
+				.waitFor( { state: 'visible', timeout: 3000 } );
+			await this.page
+				.getByRole( 'button', {
+					name: 'Try it out',
+				} )
+				.click();
+		} catch {
+			// Modal didn't appear, continue
+		}
+
 		// Wait for the main content to be visible
 		await this.page.getByRole( 'main' ).waitFor();
 	}


### PR DESCRIPTION
Part of DOTMSD-983

## Proposed Changes

* Add logic to `DashboardPage.visit()` to detect and dismiss welcome modal
* Add JSDoc explaining modal blocks main content

## Why are these changes being made?

The `DashboardPage.visit()` method was missing logic to handle the dashboard welcome modal. While the button locator was defined, there was no code to check for the modal or click the dismiss button. This caused E2E tests to hang when waiting for main content because the modal was blocking it.

## Testing Instructions

### Prerequisites
* Ensure you have a test account that triggers the welcome modal on first dashboard visit
* Clear any browser state/cookies that would prevent modal from appearing

### Test Cases

   ```bash
   yarn playwright test --project=chrome specs/dashboard/dashboard__basic-and-routing.spec.ts
   ```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?