### PR TITLE
MSD: fix useSuspenseQuery() usages around billing routes

### DIFF
--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -1,5 +1,5 @@
 import { userReceiptsQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useResizeObserver } from '@wordpress/compose';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -24,8 +24,7 @@ import type { Receipt } from '@automattic/api-core';
 const emptyReceipts: Receipt[] = [];
 
 export default function BillingHistory() {
-	const { data } = useSuspenseQuery( userReceiptsQuery() );
-	const receipts = data ?? emptyReceipts;
+	const { data: receipts = emptyReceipts, isLoading } = useQuery( userReceiptsQuery() );
 
 	const searchParams = billingHistoryRoute.useSearch();
 	const [ defaultView, setDefaultView ] = useState( DEFAULT_VIEW );
@@ -83,6 +82,7 @@ export default function BillingHistory() {
 						actions={ actions }
 						getItemId={ getItemId }
 						paginationInfo={ paginationInfo }
+						isLoading={ isLoading }
 					/>
 				</DataViewsCard>
 			</div>

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -5,7 +5,7 @@ import {
 	userTaxDetailsQuery,
 } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
-import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
 	Button,
@@ -58,7 +58,7 @@ export interface LineItemCostOverrideForDisplay {
 
 export default function Receipt() {
 	const params = receiptRoute.useParams();
-	const receiptId = params.receiptId;
+	const receiptId = parseInt( params.receiptId );
 	const { data: receipt } = useSuspenseQuery( receiptQuery( receiptId ) );
 
 	const handlePrint = () => {
@@ -185,7 +185,7 @@ function ReceiptDetails( { receipt }: { receipt: Receipt } ) {
 }
 
 function UserVatDetails( { receipt }: { receipt: Receipt } ) {
-	const { data: vatDetails, isLoading, error } = useQuery( userTaxDetailsQuery() );
+	const { data: vatDetails } = useSuspenseQuery( userTaxDetailsQuery() );
 	const sendEmailMutation = useMutation( {
 		...sendReceiptEmailMutation(),
 		meta: {
@@ -203,7 +203,7 @@ function UserVatDetails( { receipt }: { receipt: Receipt } ) {
 		sendEmailMutation.mutate( String( receipt.id ) );
 	};
 
-	if ( isLoading || error || ! vatDetails?.id ) {
+	if ( ! vatDetails.id ) {
 		return null;
 	}
 

--- a/client/dashboard/me/billing-purchases/change-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/change-payment-method.tsx
@@ -34,16 +34,15 @@ function ChangePaymentMethod() {
 	if ( isNaN( numericId ) ) {
 		throw new Error( 'Invalid purchase ID' );
 	}
-	const { data: purchase, isLoading: isLoadingPurchase } = useSuspenseQuery(
-		purchaseQuery( numericId )
-	);
+	const { data: purchase } = useSuspenseQuery( purchaseQuery( numericId ) );
+
 	const { isLoading: isLoadingStoredCards } = useQuery(
 		userPaymentMethodsQuery( { type: 'card' } )
 	);
 	const { isStripeLoading } = useStripe();
 
 	const paymentMethods = useCreateAssignablePaymentMethods( purchase );
-	const isDataLoading = isLoadingStoredCards || isStripeLoading || isLoadingPurchase;
+	const isDataLoading = isLoadingStoredCards || isStripeLoading;
 
 	useEffect( () => {
 		if ( ! isDataLoading && ! purchase ) {


### PR DESCRIPTION
## Proposed Changes

Standardize the usages of `useQuery()` / `useSuspenseQuery()` in the following routes:

- `/me/billing/history`
   - use `useQuery()`
   - render loading state in the DataViews
   - speed up with `prefetchQuery()` in the loader
- `/me/billing/history/:receiptId`
   - use `useSuspenseQuery()` for receipt and tax details (and fixed the type mismatch from the string param, which caused the cache mismatch)
- `/me/billing/purchases/:receiptId/payment-method/change`
   - prefetch the payment method-related queries
- `/me/billing/payment-methods`
   - prefetch the payment method-related queries
- `/me/billing/monetize-subscriptions`
   - prefetch the DataViews query
- `/me/billing/tax-details`
   - use `useSuspenseQuery()` for all required queries

I feel like these "rules" could be encoded in a Claude / agent rule or something xD

## Why are these changes being made?

MSD loading audit.

## Testing Instructions

Smoke-test the above routes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
