### PR TITLE
MSD: test sending dashboard-* env to Sentry

### DIFF
--- a/packages/calypso-sentry/src/index.ts
+++ b/packages/calypso-sentry/src/index.ts
@@ -203,8 +203,8 @@ export async function initSentry( parameters?: SentryOptions ) {
 			// wpcalypso (calypso.live) runs on PRs, which doesn't really map to a
 			// release we need to track. Horizon is just a different flavor of trunk,
 			// so it can be mapped to a trunk release.
-			const environment = config< string >( 'env_id' ).replace( 'dashboard-', '' );
-			const release = [ 'production', 'horizon' ].includes( environment )
+			const environment = config< string >( 'env_id' );
+			const release = [ 'production', 'dashboard-production', 'horizon' ].includes( environment )
 				? `calypso_${ window.COMMIT_SHA }`
 				: undefined;
 


### PR DESCRIPTION
Ref: p1767580658999769-slack-CRWCHQGUB

## Proposed Changes

We want to send `my.wordpress.com` errors to Sentry with proper `dashboard-production` environment, because it's the actual environment.

## Why are these changes being made?

Easier to do filtering / view in Sentry.

## Testing Instructions

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?