### PR TITLE
A4A: Add missing Download Tier badge button.

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -9,6 +9,7 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import DownloadBadges from '../../download-badges';
 import AgencyTierOverviewContent from '../../overview-content';
 
 import './style.scss';
@@ -24,6 +25,11 @@ export default function AgencyTierOverview() {
 	const totalInfluencedRevenue = agency?.influenced_revenue ?? 0;
 	const tierStatus = agency?.tier?.status ?? undefined;
 
+	// Show download badges button for Agency Partner, Pro Agency Partner, and Premier Partner tiers
+	const showDownloadBadges =
+		currentAgencyTierId &&
+		[ 'agency-partner', 'pro-agency-partner', 'premier-partner' ].includes( currentAgencyTierId );
+
 	return (
 		<Layout title={ title } wide>
 			<LayoutTop>
@@ -31,6 +37,7 @@ export default function AgencyTierOverview() {
 					<Title>{ title }</Title>
 					<Actions>
 						<MobileSidebarNavigation />
+						{ showDownloadBadges && <DownloadBadges /> }
 					</Actions>
 				</LayoutHeader>
 			</LayoutTop>


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1971/a4a-portal-missing-badge-downloads-from-new-tiers-page

## Proposed Changes

* Revert the changes that remove the `Download badge` button. Refer here:  https://github.com/Automattic/wp-calypso/pull/107490/files#diff-ab6903b4e29f77206ddcf26a936381b1f0fa0dd4137dcdde586a3088691de9baL57
* 
## Why are these changes being made?

* The capability was mistakenly removed and needs to be reinstated.


## Testing Instructions
Before setting up, set your agencies' tier status to either a **Partner**, **Pro**, or **Premier**. Also, make sure you have a Partner Directory set up, as this is a prerequisite. 

* Use the A4A live link and navigate to the `/agency-tier` page.
* Confirm that you see the Download badge button.
<img width="1551" height="218" alt="Screenshot 2026-01-06 at 4 54 56 PM" src="https://github.com/user-attachments/assets/2dfa143b-218f-42c9-9c50-a820473477eb" />


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
