### PR TITLE
Reader: Fix secondary menu option order

### DIFF
--- a/client/reader/components/header/index.tsx
+++ b/client/reader/components/header/index.tsx
@@ -71,8 +71,8 @@ const ReaderHeader = () => {
 				</Button>
 				{ user && (
 					<>
-						<Notifications user={ user } className="dashboard-secondary-menu__item" />
 						<HelpCenter user={ user } />
+						<Notifications user={ user } className="dashboard-secondary-menu__item" />
 						<UserProfile user={ user } />
 					</>
 				) }


### PR DESCRIPTION

## Proposed Changes
* Move the help center icon to be before the notification icon to follow the same style https://my.wordpress.com/


## Before
<img width="2492" height="148" alt="CleanShot 2026-01-06 at 13 08 19@2x" src="https://github.com/user-attachments/assets/d5f02514-d13a-4f61-9a14-96bf867bf8e0" />

## After
<img width="2492" height="148" alt="CleanShot 2026-01-06 at 13 08 44@2x" src="https://github.com/user-attachments/assets/ed50bbb0-8e13-491b-9d81-d0b6fa982f09" />



## Why are these changes being made?
* Keep consistency between /reader and https://my.wordpress.com/

## Testing Instructions
* Go to /reader
* Check if the help center/notifications icons are in the correct position. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
