### PR TITLE
Onboarding: Streamline post-checkout destinations

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding-unified/onboarding-unified.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding-unified/onboarding-unified.ts
@@ -13,8 +13,6 @@ import {
 	persistSignupDestination,
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
-import { useSelector } from 'calypso/state';
-import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE, USER_STORE } from '../../../stores';
 import { getOnboardingPostCheckoutDestination } from '../../helpers/get-onboarding-post-checkout-destination';
@@ -52,7 +50,6 @@ const onboardingUnifiedFlow: FlowV2< typeof initialize > = {
 		const locale = useFlowLocale();
 		const { setSignupDomainOrigin } = dispatch( ONBOARD_STORE ) as OnboardActions;
 		const { setShouldShowNotification } = usePurchasePlanNotification();
-		const dashboardOptIn = useSelector( hasDashboardOptIn );
 		/**
 		 * Handle step submissions for the onboarding unified flow
 		 */
@@ -144,7 +141,6 @@ const onboardingUnifiedFlow: FlowV2< typeof initialize > = {
 					) {
 						// Handle final redirect after site setup is complete
 						const [ destination ] = getOnboardingPostCheckoutDestination( {
-							shouldRedirectToMultiSiteDashboard: dashboardOptIn,
 							flowName,
 							locale,
 							siteSlug: providedDependencies.siteSlug,

--- a/client/landing/stepper/declarative-flow/flows/onboarding-unified/onboarding-unified.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding-unified/onboarding-unified.ts
@@ -13,6 +13,8 @@ import {
 	persistSignupDestination,
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
+import { useSelector } from 'calypso/state';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE, USER_STORE } from '../../../stores';
 import { getOnboardingPostCheckoutDestination } from '../../helpers/get-onboarding-post-checkout-destination';
@@ -50,6 +52,7 @@ const onboardingUnifiedFlow: FlowV2< typeof initialize > = {
 		const locale = useFlowLocale();
 		const { setSignupDomainOrigin } = dispatch( ONBOARD_STORE ) as OnboardActions;
 		const { setShouldShowNotification } = usePurchasePlanNotification();
+		const dashboardOptIn = useSelector( hasDashboardOptIn );
 		/**
 		 * Handle step submissions for the onboarding unified flow
 		 */
@@ -141,6 +144,7 @@ const onboardingUnifiedFlow: FlowV2< typeof initialize > = {
 					) {
 						// Handle final redirect after site setup is complete
 						const [ destination ] = getOnboardingPostCheckoutDestination( {
+							shouldRedirectToMultiSiteDashboard: dashboardOptIn,
 							flowName,
 							locale,
 							siteSlug: providedDependencies.siteSlug,

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -10,7 +10,6 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
-import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { addSurvicate } from 'calypso/lib/analytics/survicate';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
@@ -33,15 +32,13 @@ import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
+import { getOnboardingPostCheckoutDestination } from '../../helpers/get-onboarding-post-checkout-destination';
+import { withLocale } from '../../helpers/with-locale';
 import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../../internals/types';
 import type { DomainSuggestion } from '@automattic/api-core';
-
-const withLocale = ( url: string, locale: string ) => {
-	return locale && locale !== 'en' ? `${ url }/${ locale }` : url;
-};
 
 function initialize() {
 	const steps = [
@@ -121,29 +118,11 @@ const onboarding: FlowV2< typeof initialize > = {
 				];
 			}
 
-			/**
-			 * If the dashboard/v2/onboarding feature flag is enabled, we'll redirect the user to the new Multi-site Dashboard.
-			 * We aren't using the dashboard/v2 FF because it's enabled by default on wpcalypso.json which would break e2e tests.
-			 * Since we're aiming to remove steps after the isMvpOnboarding experiment ends,
-			 * we'll redirect the user to the new Dashboard here.
-			 */
-			if ( isEnabled( 'dashboard/v2/onboarding' ) ) {
-				return [
-					addQueryArgs( dashboardLink( `/sites/${ providedDependencies.siteSlug }` ), {
-						ref: flowName,
-					} ),
-					addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
-						siteSlug: providedDependencies.siteSlug,
-					} ),
-				];
-			}
-
-			return [
-				addQueryArgs( `/home/${ providedDependencies.siteSlug }`, { ref: flowName } ),
-				addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
-					siteSlug: providedDependencies.siteSlug,
-				} ),
-			];
+			return getOnboardingPostCheckoutDestination( {
+				flowName,
+				locale,
+				siteSlug: providedDependencies.siteSlug as string,
+			} );
 		};
 
 		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -25,7 +25,6 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch as useReduxDispatch } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { State } from '../../../../../../packages/data-stores/src/plans/reducer';
 import { isPlanProductFree } from '../../../../../../packages/data-stores/src/plans/selectors';
@@ -74,7 +73,6 @@ const onboarding: FlowV2< typeof initialize > = {
 			setHideFreePlan,
 		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const locale = useFlowLocale();
-		const dashboardOptIn = useSelector( hasDashboardOptIn );
 		const { signupDomainOrigin, planCartItem } = useSelect(
 			( select ) => ( {
 				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
@@ -120,7 +118,6 @@ const onboarding: FlowV2< typeof initialize > = {
 			}
 
 			return getOnboardingPostCheckoutDestination( {
-				shouldRedirectToMultiSiteDashboard: dashboardOptIn,
 				flowName,
 				locale,
 				siteSlug: providedDependencies.siteSlug as string,

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -11,7 +11,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
-import { isSimplifiedOnboarding } from 'calypso/landing/stepper/hooks/use-simplified-onboarding';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { addSurvicate } from 'calypso/lib/analytics/survicate';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
@@ -102,7 +101,7 @@ const onboarding: FlowV2< typeof initialize > = {
 				return [ `/home/${ providedDependencies.siteSlug }`, null ];
 			}
 
-			if ( playgroundId && providedDependencies.siteSlug ) {
+			if ( playgroundId ) {
 				// Check if the user selected the free plan
 				const isFree =
 					! planCartItem || isPlanProductFree( {} as unknown as State, planCartItem?.product_id );
@@ -139,20 +138,12 @@ const onboarding: FlowV2< typeof initialize > = {
 				];
 			}
 
-			if ( await isSimplifiedOnboarding() ) {
-				return [
-					addQueryArgs( `/home/${ providedDependencies.siteSlug }`, { ref: flowName } ),
-					addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
-						siteSlug: providedDependencies.siteSlug,
-					} ),
-				];
-			}
-
-			const destination = addQueryArgs( withLocale( '/setup/site-setup', locale ), {
-				siteSlug: providedDependencies.siteSlug,
-			} );
-
-			return [ destination, addQueryArgs( destination, { skippedCheckout: 1 } ) ];
+			return [
+				addQueryArgs( `/home/${ providedDependencies.siteSlug }`, { ref: flowName } ),
+				addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
+					siteSlug: providedDependencies.siteSlug,
+				} ),
+			];
 		};
 
 		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -25,6 +25,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch as useReduxDispatch } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { State } from '../../../../../../packages/data-stores/src/plans/reducer';
 import { isPlanProductFree } from '../../../../../../packages/data-stores/src/plans/selectors';
@@ -73,7 +74,7 @@ const onboarding: FlowV2< typeof initialize > = {
 			setHideFreePlan,
 		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const locale = useFlowLocale();
-
+		const dashboardOptIn = useSelector( hasDashboardOptIn );
 		const { signupDomainOrigin, planCartItem } = useSelect(
 			( select ) => ( {
 				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
@@ -119,6 +120,7 @@ const onboarding: FlowV2< typeof initialize > = {
 			}
 
 			return getOnboardingPostCheckoutDestination( {
+				shouldRedirectToMultiSiteDashboard: dashboardOptIn,
 				flowName,
 				locale,
 				siteSlug: providedDependencies.siteSlug as string,

--- a/client/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination.ts
+++ b/client/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination.ts
@@ -1,24 +1,19 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { addQueryArgs } from '@wordpress/url';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { withLocale } from './with-locale';
 
 export const getOnboardingPostCheckoutDestination = ( {
+	shouldRedirectToMultiSiteDashboard,
 	flowName,
 	locale,
 	siteSlug,
 }: {
+	shouldRedirectToMultiSiteDashboard: boolean;
 	flowName: string;
 	locale: string;
 	siteSlug: string;
 } ): [ postCheckoutDestination: string, checkoutBackUrl: string ] => {
-	/**
-	 * If the dashboard/v2/onboarding feature flag is enabled, we'll redirect the user to the new Multi-site Dashboard.
-	 * We aren't using the dashboard/v2 FF because it's enabled by default on wpcalypso.json which would break e2e tests.
-	 * Since we're aiming to remove steps after the isMvpOnboarding experiment ends,
-	 * we'll redirect the user to the new Dashboard here.
-	 */
-	if ( isEnabled( 'dashboard/v2/onboarding' ) ) {
+	if ( shouldRedirectToMultiSiteDashboard ) {
 		return [
 			addQueryArgs( dashboardLink( `/sites/${ siteSlug }` ), {
 				ref: flowName,

--- a/client/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination.ts
+++ b/client/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination.ts
@@ -1,29 +1,15 @@
 import { addQueryArgs } from '@wordpress/url';
-import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { withLocale } from './with-locale';
 
 export const getOnboardingPostCheckoutDestination = ( {
-	shouldRedirectToMultiSiteDashboard,
 	flowName,
 	locale,
 	siteSlug,
 }: {
-	shouldRedirectToMultiSiteDashboard: boolean;
 	flowName: string;
 	locale: string;
 	siteSlug: string;
 } ): [ postCheckoutDestination: string, checkoutBackUrl: string ] => {
-	if ( shouldRedirectToMultiSiteDashboard ) {
-		return [
-			addQueryArgs( dashboardLink( `/sites/${ siteSlug }` ), {
-				ref: flowName,
-			} ),
-			addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
-				siteSlug,
-			} ),
-		];
-	}
-
 	return [
 		addQueryArgs( `/home/${ siteSlug }`, { ref: flowName } ),
 		addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {

--- a/client/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination.ts
+++ b/client/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination.ts
@@ -1,0 +1,38 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { addQueryArgs } from '@wordpress/url';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { withLocale } from './with-locale';
+
+export const getOnboardingPostCheckoutDestination = ( {
+	flowName,
+	locale,
+	siteSlug,
+}: {
+	flowName: string;
+	locale: string;
+	siteSlug: string;
+} ): [ postCheckoutDestination: string, checkoutBackUrl: string ] => {
+	/**
+	 * If the dashboard/v2/onboarding feature flag is enabled, we'll redirect the user to the new Multi-site Dashboard.
+	 * We aren't using the dashboard/v2 FF because it's enabled by default on wpcalypso.json which would break e2e tests.
+	 * Since we're aiming to remove steps after the isMvpOnboarding experiment ends,
+	 * we'll redirect the user to the new Dashboard here.
+	 */
+	if ( isEnabled( 'dashboard/v2/onboarding' ) ) {
+		return [
+			addQueryArgs( dashboardLink( `/sites/${ siteSlug }` ), {
+				ref: flowName,
+			} ),
+			addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
+				siteSlug,
+			} ),
+		];
+	}
+
+	return [
+		addQueryArgs( `/home/${ siteSlug }`, { ref: flowName } ),
+		addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
+			siteSlug,
+		} ),
+	];
+};

--- a/client/landing/stepper/declarative-flow/helpers/test/get-onboarding-post-checkout-destination.ts
+++ b/client/landing/stepper/declarative-flow/helpers/test/get-onboarding-post-checkout-destination.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getOnboardingPostCheckoutDestination } from '../get-onboarding-post-checkout-destination';
+
+describe( 'getOnboardingPostCheckoutDestination', () => {
+	const mockParams = {
+		flowName: 'onboarding',
+		locale: 'en',
+		siteSlug: 'example.wordpress.com',
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'when shouldRedirectToMultiSiteDashboard is true', () => {
+		it( 'should return dashboard destination with correct query args', () => {
+			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
+				...mockParams,
+				shouldRedirectToMultiSiteDashboard: true,
+			} );
+
+			expect( destination ).toBe(
+				'http://my.localhost:3000/sites/example.wordpress.com?ref=onboarding'
+			);
+			expect( backUrl ).toBe( '/setup/onboarding/plans?siteSlug=example.wordpress.com' );
+		} );
+
+		it( 'should handle different site slugs', () => {
+			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
+				...mockParams,
+				shouldRedirectToMultiSiteDashboard: true,
+				siteSlug: 'test-site.wordpress.com',
+			} );
+
+			expect( destination ).toContain( 'test-site.wordpress.com' );
+			expect( backUrl ).toContain( 'siteSlug=test-site.wordpress.com' );
+		} );
+
+		it( 'should handle different flow names', () => {
+			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
+				...mockParams,
+				shouldRedirectToMultiSiteDashboard: true,
+				flowName: 'custom-flow',
+			} );
+
+			expect( destination ).toContain( 'ref=custom-flow' );
+			expect( backUrl ).toContain( '/setup/custom-flow/plans' );
+		} );
+
+		it( 'should handle different locales', () => {
+			const [ , backUrl ] = getOnboardingPostCheckoutDestination( {
+				...mockParams,
+				shouldRedirectToMultiSiteDashboard: true,
+				locale: 'fr',
+			} );
+
+			expect( backUrl ).toContain( '/setup/onboarding/plans/fr' );
+		} );
+	} );
+
+	describe( 'when shouldRedirectToMultiSiteDashboard is false', () => {
+		it( 'should return home destination with correct query args', () => {
+			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
+				...mockParams,
+				shouldRedirectToMultiSiteDashboard: false,
+			} );
+
+			expect( destination ).toBe( '/home/example.wordpress.com?ref=onboarding' );
+			expect( backUrl ).toBe( '/setup/onboarding/plans?siteSlug=example.wordpress.com' );
+		} );
+
+		it( 'should handle different site slugs', () => {
+			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
+				...mockParams,
+				shouldRedirectToMultiSiteDashboard: false,
+				siteSlug: 'another-site.wordpress.com',
+			} );
+
+			expect( destination ).toContain( 'another-site.wordpress.com' );
+			expect( backUrl ).toContain( 'siteSlug=another-site.wordpress.com' );
+		} );
+
+		it( 'should handle different flow names', () => {
+			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
+				...mockParams,
+				shouldRedirectToMultiSiteDashboard: false,
+				flowName: 'test-flow',
+			} );
+
+			expect( destination ).toContain( 'ref=test-flow' );
+			expect( backUrl ).toContain( '/setup/test-flow/plans' );
+		} );
+
+		it( 'should handle different locales', () => {
+			const [ , backUrl ] = getOnboardingPostCheckoutDestination( {
+				...mockParams,
+				shouldRedirectToMultiSiteDashboard: false,
+				locale: 'es',
+			} );
+
+			expect( backUrl ).toContain( '/setup/onboarding/plans/es' );
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/helpers/test/get-onboarding-post-checkout-destination.ts
+++ b/client/landing/stepper/declarative-flow/helpers/test/get-onboarding-post-checkout-destination.ts
@@ -14,93 +14,39 @@ describe( 'getOnboardingPostCheckoutDestination', () => {
 		jest.clearAllMocks();
 	} );
 
-	describe( 'when shouldRedirectToMultiSiteDashboard is true', () => {
-		it( 'should return dashboard destination with correct query args', () => {
-			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
-				...mockParams,
-				shouldRedirectToMultiSiteDashboard: true,
-			} );
+	it( 'should return home destination with correct query args', () => {
+		const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( mockParams );
 
-			expect( destination ).toBe(
-				'http://my.localhost:3000/sites/example.wordpress.com?ref=onboarding'
-			);
-			expect( backUrl ).toBe( '/setup/onboarding/plans?siteSlug=example.wordpress.com' );
-		} );
-
-		it( 'should handle different site slugs', () => {
-			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
-				...mockParams,
-				shouldRedirectToMultiSiteDashboard: true,
-				siteSlug: 'test-site.wordpress.com',
-			} );
-
-			expect( destination ).toContain( 'test-site.wordpress.com' );
-			expect( backUrl ).toContain( 'siteSlug=test-site.wordpress.com' );
-		} );
-
-		it( 'should handle different flow names', () => {
-			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
-				...mockParams,
-				shouldRedirectToMultiSiteDashboard: true,
-				flowName: 'custom-flow',
-			} );
-
-			expect( destination ).toContain( 'ref=custom-flow' );
-			expect( backUrl ).toContain( '/setup/custom-flow/plans' );
-		} );
-
-		it( 'should handle different locales', () => {
-			const [ , backUrl ] = getOnboardingPostCheckoutDestination( {
-				...mockParams,
-				shouldRedirectToMultiSiteDashboard: true,
-				locale: 'fr',
-			} );
-
-			expect( backUrl ).toContain( '/setup/onboarding/plans/fr' );
-		} );
+		expect( destination ).toBe( '/home/example.wordpress.com?ref=onboarding' );
+		expect( backUrl ).toBe( '/setup/onboarding/plans?siteSlug=example.wordpress.com' );
 	} );
 
-	describe( 'when shouldRedirectToMultiSiteDashboard is false', () => {
-		it( 'should return home destination with correct query args', () => {
-			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
-				...mockParams,
-				shouldRedirectToMultiSiteDashboard: false,
-			} );
-
-			expect( destination ).toBe( '/home/example.wordpress.com?ref=onboarding' );
-			expect( backUrl ).toBe( '/setup/onboarding/plans?siteSlug=example.wordpress.com' );
+	it( 'should handle different site slugs', () => {
+		const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
+			...mockParams,
+			siteSlug: 'another-site.wordpress.com',
 		} );
 
-		it( 'should handle different site slugs', () => {
-			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
-				...mockParams,
-				shouldRedirectToMultiSiteDashboard: false,
-				siteSlug: 'another-site.wordpress.com',
-			} );
+		expect( destination ).toContain( 'another-site.wordpress.com' );
+		expect( backUrl ).toContain( 'siteSlug=another-site.wordpress.com' );
+	} );
 
-			expect( destination ).toContain( 'another-site.wordpress.com' );
-			expect( backUrl ).toContain( 'siteSlug=another-site.wordpress.com' );
+	it( 'should handle different flow names', () => {
+		const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
+			...mockParams,
+			flowName: 'test-flow',
 		} );
 
-		it( 'should handle different flow names', () => {
-			const [ destination, backUrl ] = getOnboardingPostCheckoutDestination( {
-				...mockParams,
-				shouldRedirectToMultiSiteDashboard: false,
-				flowName: 'test-flow',
-			} );
+		expect( destination ).toContain( 'ref=test-flow' );
+		expect( backUrl ).toContain( '/setup/test-flow/plans' );
+	} );
 
-			expect( destination ).toContain( 'ref=test-flow' );
-			expect( backUrl ).toContain( '/setup/test-flow/plans' );
+	it( 'should handle different locales', () => {
+		const [ , backUrl ] = getOnboardingPostCheckoutDestination( {
+			...mockParams,
+			locale: 'es',
 		} );
 
-		it( 'should handle different locales', () => {
-			const [ , backUrl ] = getOnboardingPostCheckoutDestination( {
-				...mockParams,
-				shouldRedirectToMultiSiteDashboard: false,
-				locale: 'es',
-			} );
-
-			expect( backUrl ).toContain( '/setup/onboarding/plans/es' );
-		} );
+		expect( backUrl ).toContain( '/setup/onboarding/plans/es' );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/helpers/with-locale.ts
+++ b/client/landing/stepper/declarative-flow/helpers/with-locale.ts
@@ -1,0 +1,3 @@
+export const withLocale = ( url: string, locale: string ) => {
+	return locale && locale !== 'en' ? `${ url }/${ locale }` : url;
+};

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -3,7 +3,6 @@
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
-import { addQueryArgs } from '@wordpress/url';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
@@ -98,9 +97,7 @@ describe( 'Onboarding Flow', () => {
 			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
 			expect( window.location.replace ).toHaveBeenCalledWith(
-				addQueryArgs( '/setup/site-setup', {
-					siteSlug: 'test-site.wordpress.com',
-				} )
+				'/home/test-site.wordpress.com?ref=onboarding'
 			);
 		} );
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -7,6 +7,7 @@ import {
 import { DOMAIN_FOR_GRAVATAR_FLOW, isDomainForGravatarFlow } from '@automattic/onboarding';
 import { isURL } from '@wordpress/url';
 import { get, includes, reject } from 'lodash';
+import { getOnboardingPostCheckoutDestination } from 'calypso/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { addQueryArgs, pathToUrl } from 'calypso/lib/url';
 import { generateFlows } from 'calypso/signup/config/flows-pure';
@@ -22,6 +23,13 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 
 	const isDomainOnly = [ 'domain', DOMAIN_FOR_GRAVATAR_FLOW ].includes( flowName );
 	const isGravatarDomain = isDomainForGravatarFlow( flowName );
+	const isOnboardingPmFlow = flowName === 'onboarding-pm';
+
+	const [ onboardingPmPostCheckoutDestination ] = getOnboardingPostCheckoutDestination( {
+		flowName,
+		locale: localeSlug,
+		siteSlug: dependencies.siteSlug,
+	} );
 
 	// checkoutBackUrl is required to be a complete URL, and will be further sanitized within the checkout package.
 	// Due to historical reason, `destination` can be either a path or a complete URL.
@@ -40,6 +48,8 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 		? addQueryArgs( { skippedCheckout: 1, celebrateLaunch: 'true' }, checkoutBackUrl )
 		: addQueryArgs( { skippedCheckout: 1 }, checkoutBackUrl );
 
+	const redirectTo = isOnboardingPmFlow ? onboardingPmPostCheckoutDestination : destination;
+
 	return addQueryArgs(
 		{
 			signup: 1,
@@ -47,9 +57,11 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 			...( dependencies.coupon && { coupon: dependencies.coupon } ),
 			...( isDomainOnly && { isDomainOnly: 1 } ),
 			...( isGravatarDomain && { isGravatarDomain: 1 } ),
-			checkoutBackUrl: finalCheckoutBackUrl,
+			checkoutBackUrl: isOnboardingPmFlow
+				? new URL( onboardingPmPostCheckoutDestination, window.location.origin )
+				: finalCheckoutBackUrl,
 			// Pass the final destination as redirect_to so checkout knows where to go after completion
-			...( destination && { redirect_to: destination } ),
+			...( redirectTo && { redirect_to: redirectTo } ),
 		},
 		checkoutURL
 	);

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -26,6 +26,7 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 	const isOnboardingPmFlow = flowName === 'onboarding-pm';
 
 	const [ onboardingPmPostCheckoutDestination ] = getOnboardingPostCheckoutDestination( {
+		shouldRedirectToMultiSiteDashboard: dependencies.dashboardOptIn,
 		flowName,
 		locale: localeSlug,
 		siteSlug: dependencies.siteSlug,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -15,7 +15,6 @@ import stepConfig from './steps';
 
 function getOnboardingPmUrls( dependencies, localeSlug, flowName ) {
 	const [ onboardingPmPostCheckoutDestination ] = getOnboardingPostCheckoutDestination( {
-		shouldRedirectToMultiSiteDashboard: dependencies.dashboardOptIn,
 		flowName,
 		locale: localeSlug,
 		siteSlug: dependencies.siteSlug,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -13,6 +13,24 @@ import { addQueryArgs, pathToUrl } from 'calypso/lib/url';
 import { generateFlows } from 'calypso/signup/config/flows-pure';
 import stepConfig from './steps';
 
+function getOnboardingPmUrls( dependencies, localeSlug, flowName ) {
+	const [ onboardingPmPostCheckoutDestination ] = getOnboardingPostCheckoutDestination( {
+		shouldRedirectToMultiSiteDashboard: dependencies.dashboardOptIn,
+		flowName,
+		locale: localeSlug,
+		siteSlug: dependencies.siteSlug,
+	} );
+
+	const onboardingPmPostCheckoutBackUrl = isURL( onboardingPmPostCheckoutDestination )
+		? onboardingPmPostCheckoutDestination
+		: new URL( onboardingPmPostCheckoutDestination, window.location.origin );
+
+	return {
+		redirectTo: onboardingPmPostCheckoutDestination,
+		checkoutBackUrl: onboardingPmPostCheckoutBackUrl,
+	};
+}
+
 function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 	let checkoutURL = `/checkout/${ dependencies.siteSlug }`;
 
@@ -25,12 +43,10 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 	const isGravatarDomain = isDomainForGravatarFlow( flowName );
 	const isOnboardingPmFlow = flowName === 'onboarding-pm';
 
-	const [ onboardingPmPostCheckoutDestination ] = getOnboardingPostCheckoutDestination( {
-		shouldRedirectToMultiSiteDashboard: dependencies.dashboardOptIn,
-		flowName,
-		locale: localeSlug,
-		siteSlug: dependencies.siteSlug,
-	} );
+	// Calculate onboarding PM URLs only once if needed
+	const onboardingPmUrls = isOnboardingPmFlow
+		? getOnboardingPmUrls( dependencies, localeSlug, flowName )
+		: null;
 
 	// checkoutBackUrl is required to be a complete URL, and will be further sanitized within the checkout package.
 	// Due to historical reason, `destination` can be either a path or a complete URL.
@@ -49,7 +65,7 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 		? addQueryArgs( { skippedCheckout: 1, celebrateLaunch: 'true' }, checkoutBackUrl )
 		: addQueryArgs( { skippedCheckout: 1 }, checkoutBackUrl );
 
-	const redirectTo = isOnboardingPmFlow ? onboardingPmPostCheckoutDestination : destination;
+	const redirectTo = onboardingPmUrls?.redirectTo ?? destination;
 
 	return addQueryArgs(
 		{
@@ -58,9 +74,7 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 			...( dependencies.coupon && { coupon: dependencies.coupon } ),
 			...( isDomainOnly && { isDomainOnly: 1 } ),
 			...( isGravatarDomain && { isGravatarDomain: 1 } ),
-			checkoutBackUrl: isOnboardingPmFlow
-				? new URL( onboardingPmPostCheckoutDestination, window.location.origin )
-				: finalCheckoutBackUrl,
+			checkoutBackUrl: onboardingPmUrls?.checkoutBackUrl ?? finalCheckoutBackUrl,
 			// Pass the final destination as redirect_to so checkout knows where to go after completion
 			...( redirectTo && { redirect_to: redirectTo } ),
 		},

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -11,6 +11,7 @@ import { sectionify } from 'calypso/lib/route';
 import { addQueryArgs } from 'calypso/lib/url';
 import flows from 'calypso/signup/config/flows';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
 import { updateDependencies } from 'calypso/state/signup/actions';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { setCurrentFlowName, setPreviousFlowName } from 'calypso/state/signup/flow/actions';
@@ -287,6 +288,8 @@ export default {
 			context.store.dispatch( setSelectedSiteId( null ) );
 		}
 
+		const dashboardOptIn = hasDashboardOptIn( context.store.getState() );
+
 		// Set referral parameter in signup dependency store so we can retrieve it in getSignupDestination().
 		const refParameter = query && query.ref;
 		// Set design parameters in signup depencency store so we can retrieve it in getChecklistThemeDestination().
@@ -314,6 +317,7 @@ export default {
 			...( screenParameter && { screenParameter } ),
 			...( pluginParameter && { pluginParameter } ),
 			...( pluginBillingPeriod && { pluginBillingPeriod } ),
+			dashboardOptIn,
 		};
 		if ( ! isEmpty( additionalDependencies ) ) {
 			context.store.dispatch( updateDependencies( additionalDependencies ) );


### PR DESCRIPTION
Closes DOTOBRD-364.

## Proposed Changes

- Simplify post-checkout destination logic in the shared helper `getOnboardingPostCheckoutDestination`
- All users now redirect to `/home/{siteSlug}` after onboarding checkout
- Update three onboarding flows to use the simplified redirect logic:
  - `onboarding` (stepper flow)
  - `onboarding-unified` (stepper flow)
  - `onboarding-pm` (legacy signup flow)

## Why are these changes being made?

Based on product feedback, we should always redirect users to the home page of their new site after checkout in onboarding flows. This PR simplifies the post-checkout destination logic to ensure all users have a consistent experience, redirecting them to `/home/{siteSlug}`.

## Testing Instructions

### Flow 1: `onboarding` (Stepper)

1. Navigate to `/setup/onboarding`
2. Complete the flow and proceed through checkout (or skip checkout)
3. ✅ Verify redirect to `/home/{siteSlug}?ref=onboarding`

### Flow 2: `onboarding-unified` (Stepper)

1. Navigate to `/setup/onboarding-unified`
2. Complete the flow through the processing step
3. ✅ Verify redirect to `/home/{siteSlug}?ref=onboarding-unified`

### Flow 3: `onboarding-pm` (Legacy Signup)

1. Navigate to `/start/onboarding-pm`
2. Complete the flow and proceed to checkout
3. ✅ Verify checkout `redirect_to` points to `/home/{siteSlug}`

### Additional Checks

- Verify locale suffix is correctly appended for non-English users (e.g., `/setup/onboarding/plans/es`)
- Verify Playground-based onboarding still redirects correctly based on free/paid plan selection
- Verify the `ref` query parameter is preserved in all redirect destinations
- Verify other `/start` flows (`/start/onboarding-with-email`, for example) were not affected by these changes