### PR TITLE
MSD: only need to suppress dashboard-related errors

### DIFF
--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -1,4 +1,4 @@
-import { INACCESSIBLE_JETPACK_ERROR_CODE } from '@automattic/api-core';
+import { DashboardDataError, INACCESSIBLE_JETPACK_ERROR_CODE } from '@automattic/api-core';
 import calypsoConfig from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { camelToSnakeCase } from '@automattic/js-utils';
@@ -7,26 +7,10 @@ import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
 
 function isBenignError( error: Error ) {
-	// Ignore errors related to missing auth tokens.
-	// The user will get redirected to the login page / second auth factor.
-	switch ( error.name ) {
-		case 'AuthorizationRequiredError':
-		case 'ReauthorizationRequiredError':
-			return true;
-	}
-
 	// Ignore errors related to inaccessible Jetpack sites.
 	// The user is expected to debug their Jetpack sites.
-	if ( 'code' in error && error.code === INACCESSIBLE_JETPACK_ERROR_CODE ) {
+	if ( error instanceof DashboardDataError && error.code === INACCESSIBLE_JETPACK_ERROR_CODE ) {
 		return true;
-	}
-
-	// Ignore errors related to view transitions.
-	// Those are triggered by the browser when the user tries to navigate away from a page that is still transitioning.
-	switch ( error.name ) {
-		case 'AbortError':
-		case 'InvalidStateError':
-			return error.message.includes( 'transition' );
 	}
 
 	return false;

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { DashboardDataError, INACCESSIBLE_JETPACK_ERROR_CODE } from '@automattic/api-core';
+import { captureException } from '@automattic/calypso-sentry';
+import { logToLogstash } from 'calypso/lib/logstash';
+import { handleOnCatch } from '../index';
+import type { AnyRouter } from '@tanstack/react-router';
+import type { ErrorInfo } from 'react';
+
+jest.mock( '@automattic/calypso-config', () => jest.fn( () => 'development' ) );
+jest.mock( '@automattic/calypso-sentry', () => ( {
+	captureException: jest.fn(),
+} ) );
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: jest.fn(),
+} ) );
+
+const mockedLogToLogstash = jest.mocked( logToLogstash );
+const mockedCaptureException = jest.mocked( captureException );
+
+const createRouter = ( params: Record< string, string > ): AnyRouter =>
+	( {
+		state: {
+			matches: [ { params } ],
+		},
+	} ) as unknown as AnyRouter;
+
+const createErrorInfo = ( stack = 'at SomeComponent' ): ErrorInfo => ( {
+	componentStack: stack,
+} );
+
+describe( 'handleOnCatch', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'does not log or capture benign DashboardDataError (inaccessible Jetpack site)', () => {
+		const error = new DashboardDataError( INACCESSIBLE_JETPACK_ERROR_CODE );
+		const errorInfo = createErrorInfo();
+		const router = createRouter( { siteSlug: 'my-site' } );
+
+		handleOnCatch( error, errorInfo, router, {
+			severity: 'error',
+			dashboard_backport: false,
+			calypso_section: 'dashboard',
+		} );
+
+		expect( mockedLogToLogstash ).not.toHaveBeenCalled();
+		expect( mockedCaptureException ).not.toHaveBeenCalled();
+	} );
+
+	it( 'logs and captures a non-benign error', () => {
+		const error = new Error( 'Boom' );
+		const errorInfo = createErrorInfo( 'at SitePage' );
+		const router = createRouter( { siteSlug: 'my-site', someId: '123' } );
+
+		handleOnCatch( error, errorInfo, router, {
+			severity: 'error',
+			dashboard_backport: false,
+			calypso_section: 'dashboard',
+		} );
+
+		expect( mockedLogToLogstash ).toHaveBeenCalledTimes( 1 );
+		expect( mockedLogToLogstash ).toHaveBeenCalledWith( {
+			feature: 'calypso_client',
+			message: 'Boom',
+			severity: 'error',
+			tags: [ 'dashboard' ],
+			properties: {
+				dashboard_backport: false,
+				env: 'development',
+				message: 'Boom',
+				stack: 'at SitePage',
+				path: 'https://example.com/',
+				params: {
+					site_slug: 'my-site',
+					some_id: '123',
+				},
+			},
+		} );
+
+		expect( mockedCaptureException ).toHaveBeenCalledTimes( 1 );
+		expect( mockedCaptureException ).toHaveBeenCalledWith( error, {
+			tags: {
+				calypso_section: 'dashboard',
+				site_slug: 'my-site',
+				some_id: '123',
+			},
+		} );
+	} );
+
+	it( 'logs but does not capture when dashboard_backport is true', () => {
+		const error = new Error( 'Backport-only error' );
+		const errorInfo = createErrorInfo();
+		const router = createRouter( { siteSlug: 'my-site' } );
+
+		handleOnCatch( error, errorInfo, router, {
+			severity: 'debug',
+			dashboard_backport: true,
+			calypso_section: 'dashboard',
+		} );
+
+		expect( mockedLogToLogstash ).toHaveBeenCalledTimes( 1 );
+		expect( mockedCaptureException ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

It turns out that we've been adding unnecessary logic to suppress errors from being sent to Sentry/Logstash:

- `(Re)AuthorizationRequired` errors: actually "fixed" already via https://github.com/Automattic/wp-calypso/pull/107870

    I checked Logstash, and the counts indeed dropped dramatically after the time the above PR is merged:

    <img width="1281" height="175" alt="image" src="https://github.com/user-attachments/assets/9716882e-eff6-4dae-ab9d-ce46e8d525c0" />

- `AbortError` / `InvalidStateError` errors: they never go past our handler. They are NOT caught by our TanStack router error handling. If we check the events, the`calypo_section` tag is not `dashboard`, confirming that it's not sent from our dashboard code, most likely from the global Calypso handler [here](https://github.com/Automattic/wp-calypso/blob/eeb209a7c9a0dc355303b0924642bf76711bce3d/client/lib/error-logger/setup-error-logger.js#L16).

This leaves `DashboardDataError`. Note that this suppression does need to happen inside `defaultOnCatch` (`handleOnCatch`) and NOT earlier, since we're using `errorComponent` to show the message for the user.

## Why are these changes being made?

We want reliable Sentry dashboard for MSD.

## Testing Instructions

Merge and YOLO.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
