### PR TITLE
Fix/cancellation flow page title

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -453,7 +453,7 @@ export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
 	return (
 		props.isVisible && (
 			<VStack spacing={ 6 }>
-				<SectionHeader title={ getSurveyTitle( props.surveyStep ) } level={ 3 } />
+				<SectionHeader title={ getSurveyTitle( props.surveyStep ?? '' ) } level={ 3 } />
 				<SurveyContent { ...props } />
 				<StepButtons { ...props } canGoNext={ canGoToNextStep( props ) } />
 			</VStack>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -441,14 +441,19 @@ function canGoToNextStep( {
 	return ! disableButtons && ! isSubmitting;
 }
 
+function getSurveyTitle( surveyStep: string ) {
+	if ( surveyStep !== UPSELL_STEP ) {
+		return __( 'Before you go, please answer a few quick questions to help us improve.' );
+	}
+
+	return __( 'Here is an idea' );
+}
+
 export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {
 	return (
 		props.isVisible && (
 			<VStack spacing={ 6 }>
-				<SectionHeader
-					title={ __( 'Before you go, please answer a few quick questions to help us improve.' ) }
-					level={ 3 }
-				/>
+				<SectionHeader title={ getSurveyTitle( props.surveyStep ) } level={ 3 } />
 				<SurveyContent { ...props } />
 				<StepButtons { ...props } canGoNext={ canGoToNextStep( props ) } />
 			</VStack>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -442,11 +442,11 @@ function canGoToNextStep( {
 }
 
 function getSurveyTitle( surveyStep: string ) {
-	if ( surveyStep !== UPSELL_STEP ) {
-		return __( 'Before you go, please answer a few quick questions to help us improve.' );
+	if ( surveyStep === UPSELL_STEP ) {
+		return __( 'Here is an idea' );
 	}
 
-	return __( 'Here is an idea' );
+	return __( 'Before you go, please answer a few quick questions to help us improve.' );
 }
 
 export default function CancelPurchaseForm( props: CancelPurchaseFormProps ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -30,7 +30,6 @@ function Upsell( { ...props }: UpsellProps ) {
 	return (
 		<VStack spacing={ 6 }>
 			<VStack>
-				<div className="cancel-purchase-form__upsell-subheader">{ __( 'Here is an idea' ) }</div>
 				<Heading>{ props.title }</Heading>
 				<div className="cancel-purchase-form__upsell-text">{ props.children }</div>
 			</VStack>


### PR DESCRIPTION
## Proposed Changes

Update card title for intervention step of the cancellation flow.

## Why are these changes being made?
We have some nonsensical copy on the intervention step of the cancellation flow. 

**Before**
<img width="1898" height="1522" alt="image" src="https://github.com/user-attachments/assets/683b2060-2fe3-4560-a1ea-c486d59744ab" />

**After**
<img width="1898" height="1522" alt="image" src="https://github.com/user-attachments/assets/2f6f7801-0b79-442e-a8ce-c35515fd8726" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/me/billing/purchases`. 
* Cancel a plan purchase
* Navigate to the intervention step by saying the plan is too expensive && `The plan is too expensive for the features offered.`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
