### PR TITLE
Add property-level editing to preferences helper

### DIFF
--- a/client/dashboard/app/dev-tools/helpers/deep-merge.ts
+++ b/client/dashboard/app/dev-tools/helpers/deep-merge.ts
@@ -1,0 +1,17 @@
+/**
+ * Builds a partial update object from a path and value.
+ * Example: buildPartialUpdate(['settings', 'theme'], 'dark') returns { settings: { theme: 'dark' } }
+ * @param path - Array of keys representing the path
+ * @param value - The value to set
+ * @returns A partial object representing the update
+ */
+export function buildPartialUpdate( path: readonly string[], value: unknown ): object {
+	if ( path.length === 0 ) {
+		return value as object;
+	}
+
+	const [ first, ...rest ] = path;
+	return {
+		[ first ]: rest.length === 0 ? value : buildPartialUpdate( rest, value ),
+	};
+}

--- a/client/dashboard/app/dev-tools/helpers/test/deep-merge.test.ts
+++ b/client/dashboard/app/dev-tools/helpers/test/deep-merge.test.ts
@@ -1,0 +1,29 @@
+import { buildPartialUpdate } from '../deep-merge';
+
+describe( 'buildPartialUpdate', () => {
+	it( 'should build a single-level object', () => {
+		const result = buildPartialUpdate( [ 'a' ], 10 );
+
+		expect( result ).toEqual( { a: 10 } );
+	} );
+
+	it( 'should build a nested object from path', () => {
+		const result = buildPartialUpdate( [ 'a', 'b', 'c' ], 10 );
+
+		expect( result ).toEqual( { a: { b: { c: 10 } } } );
+	} );
+
+	it( 'should handle empty path by returning the value', () => {
+		const result = buildPartialUpdate( [], { a: 1 } );
+
+		expect( result ).toEqual( { a: 1 } );
+	} );
+
+	it( 'should handle various value types', () => {
+		expect( buildPartialUpdate( [ 'str' ], 'hello' ) ).toEqual( { str: 'hello' } );
+		expect( buildPartialUpdate( [ 'num' ], 42 ) ).toEqual( { num: 42 } );
+		expect( buildPartialUpdate( [ 'bool' ], true ) ).toEqual( { bool: true } );
+		expect( buildPartialUpdate( [ 'arr' ], [ 1, 2 ] ) ).toEqual( { arr: [ 1, 2 ] } );
+		expect( buildPartialUpdate( [ 'obj' ], { x: 1 } ) ).toEqual( { obj: { x: 1 } } );
+	} );
+} );

--- a/client/dashboard/app/dev-tools/preferences.scss
+++ b/client/dashboard/app/dev-tools/preferences.scss
@@ -32,3 +32,22 @@
 	bottom: 100%;
 	margin: 0;
 }
+
+.preferences-helper__object {
+	width: 100%;
+}
+
+.preferences-helper__property-row {
+	width: 100%;
+}
+
+.preferences-helper__property-label {
+	min-width: 100px;
+	font-weight: 500;
+	color: var( --color-neutral-60 );
+}
+
+.preferences-helper__nested-object {
+	padding-inline-start: $grid-unit-20;
+	border-inline-start: 2px solid var( --color-neutral-10 );
+}

--- a/client/dashboard/app/dev-tools/preferences.tsx
+++ b/client/dashboard/app/dev-tools/preferences.tsx
@@ -14,15 +14,28 @@ import {
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
+import deepmerge from 'deepmerge';
 import { Fragment, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Card, CardBody, CardDivider } from '../../components/card';
 import { Text } from '../../components/text';
+import { buildPartialUpdate } from './helpers/deep-merge';
 import type { UserPreferences } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
+
 import './preferences.scss';
 
-type InputType = 'string' | 'number' | 'checkbox';
+type InputType = 'text' | 'number' | 'checkbox';
+
+function getInputType( value: unknown ): InputType {
+	if ( typeof value === 'boolean' ) {
+		return 'checkbox';
+	}
+	if ( typeof value === 'number' ) {
+		return 'number';
+	}
+	return 'text';
+}
 
 const formattedValue = ( inputType: InputType, value?: unknown ) => {
 	if ( inputType === 'number' ) {
@@ -38,7 +51,7 @@ const formattedValue = ( inputType: InputType, value?: unknown ) => {
 
 const renderPreference = ( name: string, value: unknown ) => {
 	if ( typeof value === 'string' ) {
-		return <EditablePreference inputType="string" name={ name } value={ value } />;
+		return <EditablePreference inputType="text" name={ name } value={ value } />;
 	}
 
 	if ( typeof value === 'boolean' ) {
@@ -53,6 +66,10 @@ const renderPreference = ( name: string, value: unknown ) => {
 		return <ArrayPreference value={ value } />;
 	}
 
+	if ( typeof value === 'object' && value !== null ) {
+		return <ObjectPreference name={ name } value={ value as Record< string, unknown > } />;
+	}
+
 	return null;
 };
 
@@ -63,6 +80,132 @@ function ArrayPreference( { value }: { value: unknown[] } ) {
 				<li key={ index }>{ JSON.stringify( preference ) }</li>
 			) ) }
 		</ul>
+	);
+}
+
+function ObjectPreference( { name, value }: { name: string; value: Record< string, unknown > } ) {
+	return (
+		<VStack spacing={ 2 } className="preferences-helper__object">
+			{ Object.entries( value ).map( ( [ propertyKey, propertyValue ] ) => (
+				<ObjectPropertyField
+					key={ propertyKey }
+					preferenceName={ name }
+					propertyPath={ [ propertyKey ] }
+					propertyKey={ propertyKey }
+					propertyValue={ propertyValue }
+				/>
+			) ) }
+		</VStack>
+	);
+}
+
+function ObjectPropertyField( {
+	preferenceName,
+	propertyPath,
+	propertyKey,
+	propertyValue,
+}: {
+	preferenceName: string;
+	propertyPath: string[];
+	propertyKey: string;
+	propertyValue: unknown;
+} ) {
+	const { mutate: savePreference, isPending } = useMutation(
+		userPreferenceMutation( preferenceName as keyof UserPreferences )
+	);
+	const [ localValue, setLocalValue ] = useState( propertyValue );
+
+	// Handle nested objects recursively
+	if (
+		typeof propertyValue === 'object' &&
+		propertyValue !== null &&
+		! Array.isArray( propertyValue )
+	) {
+		return (
+			<VStack spacing={ 1 } alignment="flex-start">
+				<Text className="preferences-helper__property-label">{ propertyKey }:</Text>
+				<div className="preferences-helper__nested-object">
+					{ Object.entries( propertyValue as Record< string, unknown > ).map(
+						( [ nestedKey, nestedValue ] ) => (
+							<ObjectPropertyField
+								key={ nestedKey }
+								preferenceName={ preferenceName }
+								propertyPath={ [ ...propertyPath, nestedKey ] }
+								propertyKey={ nestedKey }
+								propertyValue={ nestedValue }
+							/>
+						)
+					) }
+				</div>
+			</VStack>
+		);
+	}
+
+	const handleSave = () => {
+		const currentPreferences = queryClient.getQueryData< UserPreferences >(
+			rawUserPreferencesQuery().queryKey
+		);
+		const currentPreference = currentPreferences?.[ preferenceName as keyof UserPreferences ];
+		const partialUpdate = buildPartialUpdate( propertyPath, localValue );
+		const mergedPreference = currentPreference
+			? deepmerge( currentPreference as object, partialUpdate )
+			: partialUpdate;
+
+		// @ts-expect-error - mergedPreference type is dynamic
+		savePreference( mergedPreference );
+	};
+
+	const handleReset = () => {
+		setLocalValue( propertyValue );
+	};
+
+	const isDirty = localValue !== propertyValue;
+	const inputType = getInputType( propertyValue );
+
+	const handleChange = ( newValue: string | undefined ) => {
+		setLocalValue( formattedValue( inputType, newValue ) );
+	};
+
+	return (
+		<HStack spacing={ 2 } alignment="top" className="preferences-helper__property-row">
+			<Text className="preferences-helper__property-label">{ propertyKey }:</Text>
+			<VStack spacing={ 1 } expanded alignment="flex-start">
+				{ inputType === 'checkbox' ? (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						checked={ localValue as boolean }
+						onChange={ setLocalValue }
+						disabled={ isPending }
+					/>
+				) : (
+					<InputControl
+						type={ inputType }
+						value={ String( localValue ?? '' ) }
+						size="small"
+						onChange={ handleChange }
+						disabled={ isPending }
+					/>
+				) }
+				<HStack justify="flex-start" spacing={ 1 }>
+					<Button
+						variant="primary"
+						size="small"
+						disabled={ ! isDirty || isPending }
+						onClick={ handleSave }
+					>
+						{ __( 'Save' ) }
+					</Button>
+					<Button
+						variant="secondary"
+						size="small"
+						disabled={ ! isDirty || isPending }
+						onClick={ handleReset }
+					>
+						{ __( 'Reset' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</HStack>
 	);
 }
 


### PR DESCRIPTION
## Summary

Adds the ability to edit individual properties within preference objects in the dev-tools preferences panel.

- Add `buildPartialUpdate` helper to build nested objects from a path
- Add `ObjectPreference` component for editing object preferences  
- Uses `deepmerge` package for merging partial updates with existing values
- Supports nested object properties recursively

## Test plan

- [x] Unit tests pass for `buildPartialUpdate` helper (4 tests)
- [ ] Verify object preferences render in dev-tools preferences panel
- [ ] Verify property-level editing saves correctly
- [ ] Verify other properties are preserved when updating one property

🤖 Generated with [Claude Code](https://claude.com/claude-code)