### PR TITLE
MSD: remove redundant cache warmup in backported site settings

### DIFF
--- a/client/sites/v2/site-settings/index.tsx
+++ b/client/sites/v2/site-settings/index.tsx
@@ -1,9 +1,4 @@
-import {
-	siteBySlugQuery,
-	siteSettingsQuery,
-	queryClient,
-	persistQueryClientPromise,
-} from '@automattic/api-queries';
+import { siteSettingsQuery, queryClient, persistQueryClientPromise } from '@automattic/api-queries';
 import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AUTH_QUERY_KEY } from 'calypso/dashboard/app/auth';
@@ -76,12 +71,6 @@ export default function DashboardBackportSiteSettingsRenderer( {
 	useEffect( () => {
 		if ( user ) {
 			queryClient.setQueryData( AUTH_QUERY_KEY, user );
-		}
-
-		if ( site ) {
-			// The site type used by the Hosting Dashboard is slightly different, but _mostly_ compatible,
-			// so this is safe to copy in to the cache.
-			queryClient.setQueryData( siteBySlugQuery( site.slug ).queryKey, site as any ); // eslint-disable-line @typescript-eslint/no-explicit-any
 		}
 
 		if ( site && siteSettings ) {


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/107848

## Proposed Changes

We forgot to remove the redundant cache warmup in Site Settings, similar to what we did in Site Overview in the linked PR above.

## Why are these changes being made?

Fixing logstash errors.

The old approach warms up the cache using the site data from the old redux store, which contains incomplete fields such as `slug`. This caused race condition, where sometimes that version of cache is used, resulting crash in some places where it expects a defined `site.slug`.

The cache is now populated via:

- https://github.com/Automattic/wp-calypso/pull/106002

## Testing Instructions

1. Go to <Calypso live link>/sites (v1).
2. Click a site.
3. Click Settings tab.
4. Verify you don't experience performance regression compared to production.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
