### PR TITLE
Badge: Support custom icon

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- `Badge`: Support custom icon to display inside the badge ([107955](https://github.com/Automattic/wp-calypso/pull/107955)).
+
 ## 1.0.2
 
 ### Enhancements

--- a/packages/ui/src/badge/index.stories.tsx
+++ b/packages/ui/src/badge/index.stories.tsx
@@ -1,3 +1,4 @@
+import { starEmpty } from '@wordpress/icons';
 import { Badge } from '.';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -41,5 +42,13 @@ export const Error: Story = {
 	args: {
 		...Default.args,
 		intent: 'error',
+	},
+};
+
+export const CustomIcon: Story = {
+	args: {
+		...Default.args,
+		intent: 'success',
+		icon: starEmpty,
 	},
 };

--- a/packages/ui/src/badge/index.tsx
+++ b/packages/ui/src/badge/index.tsx
@@ -3,6 +3,7 @@
  *
  * - Converted styles to CSS module.
  * - Added theme color support to `info` variant.
+ * - Supported the `icon` props to make it controllable.
  */
 
 import { info, caution, error, published } from '@wordpress/icons';
@@ -36,7 +37,7 @@ export function Badge( {
 	children,
 	...props
 }: BadgeProps & React.ComponentPropsWithoutRef< 'span' > ) {
-	const icon = contextBasedIcon( intent );
+	const icon = typeof props.icon !== 'undefined' ? props.icon : contextBasedIcon( intent );
 	const hasIcon = !! icon;
 
 	return (

--- a/packages/ui/src/badge/types.ts
+++ b/packages/ui/src/badge/types.ts
@@ -9,4 +9,8 @@ export type BadgeProps = {
 	 * Text to display inside the badge.
 	 */
 	children: string;
+	/**
+	 * Custom icon to display inside the badge. Use `null` to hide the icon.
+	 */
+	icon?: JSX.Element | null;
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/107925

## Proposed Changes

* Support custom icon so we can display different icons for the same intent or hide the icons for certain intent.

<img width="128" height="40" alt="image" src="https://github.com/user-attachments/assets/7f2cf1d6-34b8-4c2f-bf00-8eaf30df788b" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Sometimes we want the badge component to display different colors without an icon, and other times we want to display different icons with the same intent.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the storybook
* Go to /?path=/story/wordpress-core-badge--custom-icon
* Ensure you can see the custom icon with the success intent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
