### PR TITLE
MSD: restore auth error logging suppression

### DIFF
--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -7,6 +7,14 @@ import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
 
 function isBenignError( error: Error ) {
+	// Ignore errors related to missing auth tokens.
+	// The user will get redirected to the login page / second auth factor.
+	switch ( error.name ) {
+		case 'AuthorizationRequiredError':
+		case 'ReauthorizationRequiredError':
+			return true;
+	}
+
 	// Ignore errors related to inaccessible Jetpack sites.
 	// The user is expected to debug their Jetpack sites.
 	if ( error instanceof DashboardDataError && error.code === INACCESSIBLE_JETPACK_ERROR_CODE ) {


### PR DESCRIPTION
Partially reverts:

- https://github.com/Automattic/wp-calypso/pull/107949

## Proposed Changes

Sorry for the back-and-forth... I just double checked, and it seems the auth error is still being sent to Logstash/Sentry. So I was wrong in the previous PR 🤔 

So I added back the suppression. Note that this error is thrown by `wpcom-proxy-request`, so it's impossible to catch this error earlier (otherwise we need to try-catch all queries), so the easiest way is to treat this as benign error.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
