### PR TITLE
MSD: Fix the incorrect result due to the plan filter after the user switches languages

### DIFF
--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -74,8 +74,8 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 		{
 			id: 'plan',
 			label: __( 'Plan' ),
-			getValue: ( { item } ) => getSitePlanDisplayName( item ) ?? '',
-			render: function PlanField( { field, item } ) {
+			getValue: ( { item } ) => item.plan?.product_name_en ?? '',
+			render: function PlanField( { item } ) {
 				const { user } = useAuth();
 				return (
 					<Plan
@@ -83,7 +83,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 						isSelfHostedJetpackConnected={ isSelfHostedJetpackConnected( item ) }
 						isJetpack={ item.jetpack }
 						isOwner={ item.site_owner === user.ID }
-						value={ field.getValue( { item } ) }
+						value={ getSitePlanDisplayName( item ) ?? '' }
 					/>
 				);
 			},
@@ -95,10 +95,18 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 
 				// A plan may have different product_slugs due to the period.
 				// However, a filter can only represent one value.
-				// As a result, it seems better to use the name as value for filters.
-				return Array.from( new Set( plan.map( ( plan ) => plan.name ) ) ).map( ( name ) => ( {
-					label: name,
-					value: name,
+				// As a result, it seems better to use the untranslated name as value for filters.
+				const elements = plan.reduce(
+					( acc, current ) => ( {
+						...acc,
+						[ current.name ]: current.name_en,
+					} ),
+					{}
+				);
+
+				return Object.entries( elements ).map( ( [ label, value ] ) => ( {
+					label,
+					value,
 				} ) );
 			},
 			filterBy: {
@@ -299,10 +307,18 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 
 				// A plan may have different product_slugs due to the period.
 				// However, a filter can only represent one value.
-				// As a result, it seems better to use the name as value for filters.
-				return Array.from( new Set( plan.map( ( plan ) => plan.name ) ) ).map( ( name ) => ( {
-					label: name,
-					value: name,
+				// As a result, it seems better to use the untranslated name as value for filters.
+				const elements = plan.reduce(
+					( acc, current ) => ( {
+						...acc,
+						[ current.name ]: current.name_en,
+					} ),
+					{}
+				);
+
+				return Object.entries( elements ).map( ( [ label, value ] ) => ( {
+					label,
+					value,
 				} ) );
 			},
 			filterBy: {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -157,7 +157,7 @@ function getFetchSiteListParams(
 	const planSlugsByName = siteFilters.plan?.reduce(
 		( acc, current ) => ( {
 			...acc,
-			[ current.name ]: [ ...( acc[ current.name ] || [] ), current.value ],
+			[ current.name_en ]: [ ...( acc[ current.name_en ] || [] ), current.value ],
 		} ),
 		{} as Record< string, string[] >
 	);

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -13,6 +13,7 @@ export interface DashboardSiteListSite {
 		product_id: number;
 		product_slug: string;
 		product_name_short: string;
+		product_name_en: string;
 		expired: boolean;
 		is_free: boolean;
 		features: {
@@ -69,5 +70,5 @@ export interface FetchDashboardSiteFiltersParams {
 }
 
 export interface DashboardFilters {
-	plan?: Array< { name: string; value: string } >;
+	plan?: Array< { name: string; value: string; name_en: string } >;
 }

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -3,6 +3,7 @@ interface SitePlan {
 	product_slug: string;
 	product_name?: string;
 	product_name_short: string;
+	product_name_en: string;
 	expired: boolean;
 	is_free: boolean;
 	license_key?: string;

--- a/packages/api-queries/src/me-settings.ts
+++ b/packages/api-queries/src/me-settings.ts
@@ -1,6 +1,6 @@
 import { fetchUserSettings, updateUserSettings } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
-import { queryClient } from './query-client';
+import { queryClient, clearQueryClient } from './query-client';
 
 export const userSettingsQuery = () =>
 	queryOptions( {
@@ -11,7 +11,7 @@ export const userSettingsQuery = () =>
 export const userSettingsMutation = () =>
 	mutationOptions( {
 		mutationFn: updateUserSettings,
-		onSuccess: ( newData ) => {
+		onSuccess: ( newData, variables ) => {
 			queryClient.setQueryData(
 				userSettingsQuery().queryKey,
 				( oldData ) =>
@@ -20,6 +20,10 @@ export const userSettingsMutation = () =>
 						...newData,
 					}
 			);
+
+			if ( variables.language ) {
+				clearQueryClient();
+			}
 		},
 	} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-978

## Proposed Changes

* Fix the incorrect result due to the plan filter after the user switches languages

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The result becomes incorrect after the user switches the language

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 199208-ghe-Automattic/wpcom to your sandbox and sandbox your endpoint
* Go to /sites or /sites?flags=dashboard/v2/es-site-list
* Add the plan filter
* Switch the language
* Go back to /sites
* Ensure the result is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?