### PR TITLE
Revert "MSD: also send backported screen events to Sentry with identifiable tag (#107959)"

### DIFF
--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -61,11 +61,13 @@ export function handleOnCatch(
 		},
 	} );
 
-	captureException( error, {
-		tags: {
-			calypso_section: options.calypso_section,
-			...( options.dashboard_backport ? { dashboard_backport: true } : {} ),
-			...routeParams,
-		},
-	} );
+	// Dashboard backport has its mechanism to send error log to sentry.
+	if ( ! options.dashboard_backport ) {
+		captureException( error, {
+			tags: {
+				calypso_section: options.calypso_section,
+				...routeParams,
+			},
+		} );
+	}
 }

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -91,7 +91,7 @@ describe( 'handleOnCatch', () => {
 		} );
 	} );
 
-	it( 'logs when dashboard_backport is true', () => {
+	it( 'logs but does not capture when dashboard_backport is true', () => {
 		const error = new Error( 'Backport-only error' );
 		const errorInfo = createErrorInfo();
 		const router = createRouter( { siteSlug: 'my-site' } );
@@ -103,12 +103,6 @@ describe( 'handleOnCatch', () => {
 		} );
 
 		expect( mockedLogToLogstash ).toHaveBeenCalledTimes( 1 );
-		expect( mockedCaptureException ).toHaveBeenCalledWith( error, {
-			tags: {
-				calypso_section: 'dashboard',
-				dashboard_backport: true,
-				site_slug: 'my-site',
-			},
-		} );
+		expect( mockedCaptureException ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
This reverts commit #107959.

## Proposed Changes

It turns out we can use Sentry's `handled is yes` filter, to view only events which we explicitly called `captureException()`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
