### PR TITLE
MSD Domains: Update TLD maintenance notice wording

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -55,6 +55,7 @@ module.exports = {
 							'!@automattic/components/src/breadcrumbs',
 							'!@automattic/components/src/breadcrumbs/types',
 							'!@automattic/components/src/logos',
+							'!@automattic/domain-search',
 							'!@automattic/domains-table',
 							'!@automattic/domains-table/src/utils/*',
 							'!@automattic/generate-password',

--- a/client/dashboard/domains/maintenance-notice.tsx
+++ b/client/dashboard/domains/maintenance-notice.tsx
@@ -1,4 +1,5 @@
 import { domainQuery } from '@automattic/api-queries';
+import { getTld } from '@automattic/domain-search';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
@@ -14,7 +15,7 @@ export const TLDMaintenanceNotice = ( { showGoBackLink = true }: { showGoBackLin
 
 	return (
 		<Notice
-			variant="error"
+			variant="warning"
 			actions={
 				showGoBackLink ? (
 					<Link to={ domainRoute.fullPath } params={ { domainName } }>
@@ -24,11 +25,12 @@ export const TLDMaintenanceNotice = ( { showGoBackLink = true }: { showGoBackLin
 			}
 		>
 			{ sprintf(
-				/* translators: %(maintenanceEnd)s is the maintenance end time */
+				/* translators: %(tld)s is the domain's TLD, %(maintenanceEnd)s is the maintenance end time */
 				__(
-					'The domain registrar is undergoing maintenance. Please try again %(maintenanceEnd)s.'
+					'The .%(tld)s TLD is under scheduled maintenance. Your domain continues to work normally, but changes to name servers, DNSSEC, contacts, or registration settings are unavailable until maintenance ends (estimated: %(maintenanceEnd)s).'
 				),
 				{
+					tld: getTld( domain.domain ),
 					maintenanceEnd: formatDistanceToNowStrict(
 						new Date( domain.tld_maintenance_end_time * 1000 ),
 						{


### PR DESCRIPTION
## Proposed Changes

Updates the wording to the proposed in https://github.com/Automattic/wp-calypso/pull/107754#issuecomment-3678081651:

<img width="702" height="250" alt="image" src="https://github.com/user-attachments/assets/3d67e8dd-8e90-487f-acea-04173035d112" />

## Testing Instructions

Follow the instructions from the original PR to simulate a maintenance window, then verify that the notice is updated according to the screenshot.
