### PR TITLE
Fix TypeError when DNS record is undefined in getProcessedRecord

### DIFF
--- a/client/dashboard/domains/dns/utils.ts
+++ b/client/dashboard/domains/dns/utils.ts
@@ -95,6 +95,12 @@ export const getNormalizedName = ( name: string, type: DnsRecordType, domainName
  * @returns
  */
 export const getProcessedRecord = ( record: DnsRecord ): DnsRecord => {
+	// Safety check: if record is undefined or null, return it as-is
+	// This can happen if a record is deleted while the page is loading
+	if ( ! record ) {
+		return record;
+	}
+
 	const isRootDomainRecord = record.name === `${ record.domain }.`;
 	if ( isRootDomainRecord ) {
 		record.name = '';


### PR DESCRIPTION
Part of DOMENG-318

## Proposed Changes

* Added a safety check in the `getProcessedRecord` function to handle undefined/null DNS records gracefully

## Why are these changes being made?

A Sentry error (CALYPSO-2GNC) was reported where users encountered a `TypeError: undefined is not an object (evaluating 'e.name')` in the DNS record editing flow. This occurred due to a race condition between the route's `beforeLoad` check and component rendering. When a DNS record is deleted or becomes unavailable after the initial check but before the component renders, the `find()` operation returns `undefined`, which then causes a TypeError when trying to access `record.name`.

This fix prevents the application from crashing in this edge case by adding a defensive check at the beginning of `getProcessedRecord`. The router's existing redirect logic will handle navigating away from invalid records appropriately.

## Testing Instructions

1. Navigate to a domain's DNS settings page
2. Open the edit page for a DNS record
3. While the page is loading, delete that DNS record via API or another browser tab
4. Verify that the page doesn't crash with a TypeError
5. Verify that the application handles the missing record gracefully (e.g., redirects to DNS overview)

**Note:** This is difficult to reproduce manually due to timing. The fix is defensive in nature to prevent the crash reported in Sentry.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?