### PR TITLE
Disable SSH migration feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -130,7 +130,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration/ssh-migration": true,
+		"migration/ssh-migration": false,
 		"oauth": false,
 		"oauth/unified-experience": true,
 		"onboarding/create-course": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,7 @@
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration/ssh-migration": true,
+		"migration/ssh-migration": false,
 		"oauth/unified-experience": false,
 		"onboarding/create-course": false,
 		"onboarding/post-checkout-ai-step": false,

--- a/config/production.json
+++ b/config/production.json
@@ -100,7 +100,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration/ssh-migration": true,
+		"migration/ssh-migration": false,
 		"oauth/unified-experience": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -99,7 +99,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration/ssh-migration": true,
+		"migration/ssh-migration": false,
 		"oauth/unified-experience": true,
 		"onboarding/create-course": false,
 		"onboarding/import": true,

--- a/config/test.json
+++ b/config/test.json
@@ -73,7 +73,7 @@
 		"marketplace-redesign": false,
 		"me/account-close": true,
 		"migration-flow/introductory-offer": true,
-		"migration/ssh-migration": true,
+		"migration/ssh-migration": false,
 		"oauth/unified-experience": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,7 +105,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"migration-flow/introductory-offer": true,
-		"migration/ssh-migration": true,
+		"migration/ssh-migration": false,
 		"oauth/unified-experience": true,
 		"onboarding/create-course": false,
 		"onboarding/import": true,


### PR DESCRIPTION
Related to DOTCOM-15623

pgDwfM-no-p2

## Proposed changes

Disables the `migration/ssh-migration` feature flag across all config environments (production, stage, development, wpcalypso, horizon, and test).

## Why are these changes being made?

Some users were being unexpectedly redirected into an SSH migration flow based on their source site's hosting provider. This change disables the feature to prevent that behavior while the underlying issue is investigated.

## Testing Instructions

Run `yarn feature-search migration/ssh-migration` to verify the flag is set to `false` in all config files