### PR TITLE
Agenttic: Put in devdocs so for REST endpoint testing

### DIFF
--- a/client/devdocs/agenttic-test/index.tsx
+++ b/client/devdocs/agenttic-test/index.tsx
@@ -1,0 +1,483 @@
+/**
+ * Agenttic Test Component
+ *
+ * A test harness for @automattic/agenttic-client in Calypso.
+ */
+
+import '@automattic/agenttic-ui/index.css';
+
+import {
+	useAgentChat,
+	createOdieBotId,
+	type ContextProvider,
+	type UIMessage,
+	type AuthProvider,
+} from '@automattic/agenttic-client';
+import {
+	AgentUI,
+	createMessageRenderer,
+	createFeedbackActions,
+	EmptyView,
+	ThumbsDownIcon,
+	ThumbsUpIcon,
+} from '@automattic/agenttic-ui';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useSelector } from 'react-redux';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+const JWT_TOKEN_CACHE_KEY = 'agenttic-devdocs-jwt-token';
+const JWT_TOKEN_EXPIRATION_TIME = 30 * 60 * 1000; // 30 minutes
+
+interface TokenData {
+	token: string;
+	expire: number;
+}
+
+/**
+ * Get cached JWT token from sessionStorage
+ */
+function getCachedJwtToken(): TokenData | null {
+	try {
+		const cached = sessionStorage.getItem( JWT_TOKEN_CACHE_KEY );
+		if ( cached ) {
+			const tokenData = JSON.parse( cached ) as TokenData;
+			if ( tokenData?.token && tokenData?.expire && tokenData.expire > Date.now() ) {
+				return tokenData;
+			}
+		}
+	} catch {
+		// Invalid cached token
+	}
+	return null;
+}
+
+/**
+ * Cache JWT token in sessionStorage
+ */
+function setCachedJwtToken( tokenData: TokenData ): void {
+	try {
+		sessionStorage.setItem( JWT_TOKEN_CACHE_KEY, JSON.stringify( tokenData ) );
+	} catch {
+		// Continue without caching
+	}
+}
+
+/**
+ * Request a JWT token via wpcomRequest
+ */
+async function requestJWTToken( siteId: number ): Promise< string | null > {
+	const cached = getCachedJwtToken();
+	if ( cached ) {
+		return cached.token;
+	}
+
+	try {
+		const data = ( await wpcomRequest( {
+			path: `/sites/${ siteId }/jetpack-openai-query/jwt`,
+			apiNamespace: 'wpcom/v2',
+			method: 'POST',
+		} ) ) as { token?: string; jwt?: string };
+
+		const token = data?.token || data?.jwt;
+
+		if ( token ) {
+			setCachedJwtToken( {
+				token,
+				expire: Date.now() + JWT_TOKEN_EXPIRATION_TIME,
+			} );
+		}
+
+		return token || null;
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Failed to get JWT token:', error );
+		return null;
+	}
+}
+
+/**
+ * Create auth provider for Calypso using JWT tokens via wpcomRequest.
+ */
+function createCalypsoAuthProvider( siteId?: number ): AuthProvider {
+	return async () => {
+		const headers: Record< string, string > = {
+			'Content-Type': 'application/json',
+		};
+
+		if ( ! canAccessWpcomApis() ) {
+			// eslint-disable-next-line no-console
+			console.warn( '[AgentticTest Auth] Cannot access WPCOM APIs - check origin is allowlisted' );
+			return headers;
+		}
+
+		if ( siteId ) {
+			try {
+				const jwtToken = await requestJWTToken( siteId );
+				if ( jwtToken ) {
+					headers.Authorization = `Bearer ${ jwtToken }`;
+					return headers;
+				}
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( '[AgentticTest Auth] JWT request failed:', error );
+			}
+		}
+
+		return headers;
+	};
+}
+
+const AGENT_URL = 'https://public-api.wordpress.com/wpcom/v2/ai/agent';
+const DEFAULT_AGENT_ID = 'wpcom-support-chat';
+
+// Helper function to get URL parameter
+const getUrlParam = ( key: string ): string => {
+	if ( typeof window === 'undefined' ) {
+		return '';
+	}
+	const params = new URLSearchParams( window.location.search );
+	return params.get( key ) || '';
+};
+
+// Generate a unique session ID using UUID v4
+const generateSessionId = () => {
+	if ( typeof crypto !== 'undefined' && crypto.randomUUID ) {
+		return crypto.randomUUID();
+	}
+	// Fallback for older browsers
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace( /[xy]/g, ( c ) => {
+		const r = ( Math.random() * 16 ) | 0;
+		const v = c === 'x' ? r : ( r & 0x3 ) | 0x8;
+		return v.toString( 16 );
+	} );
+};
+
+// Sample suggestions
+const sampleSuggestions = [
+	{
+		id: '1',
+		label: 'Help with my site',
+		prompt: 'Can you help me with my WordPress.com site?',
+	},
+	{
+		id: '2',
+		label: 'Billing question',
+		prompt: 'I have a question about my billing',
+	},
+	{
+		id: '3',
+		label: 'Technical issue',
+		prompt: "I'm experiencing a technical issue",
+	},
+];
+
+interface ChatConfig {
+	agentId: string;
+	sessionId: string;
+	parsedBlogId?: number;
+}
+
+/**
+ * Chat component that contains the useAgentChat hook.
+ * Remounting this component (via key change) will reset the conversation.
+ */
+const AgentticChat: React.FC< ChatConfig > = ( { agentId, sessionId, parsedBlogId } ) => {
+	// Simple context provider
+	const contextProvider = useMemo< ContextProvider >(
+		() => ( {
+			getClientContext: () => ( {
+				environment: 'calypso-devdocs',
+				timestamp: Date.now(),
+				url: window.location.href,
+				blog_id: parsedBlogId,
+			} ),
+		} ),
+		[ parsedBlogId ]
+	);
+
+	// Create odieBotId for server-based conversation storage
+	const odieBotId = useMemo( () => createOdieBotId( agentId ), [ agentId ] );
+
+	// Create auth provider using Calypso's JWT mechanism
+	const authProvider = useMemo( () => createCalypsoAuthProvider( parsedBlogId ), [ parsedBlogId ] );
+
+	const {
+		messages,
+		isProcessing,
+		error,
+		onSubmit,
+		suggestions,
+		registerSuggestions,
+		clearSuggestions,
+		registerMessageActions,
+		abortCurrentRequest,
+	} = useAgentChat( {
+		agentId,
+		agentUrl: AGENT_URL,
+		sessionId,
+		contextProvider,
+		authProvider,
+		enableStreaming: false,
+		odieBotId,
+	} );
+
+	// Register suggestions on mount
+	useEffect( () => {
+		registerSuggestions( sampleSuggestions );
+	}, [ registerSuggestions ] );
+
+	// Custom markdown components
+	const customMarkdownComponents = useMemo(
+		() => ( {
+			blockquote: ( { children, ...props }: React.ComponentProps< 'blockquote' > ) => (
+				<blockquote
+					{ ...props }
+					style={ {
+						borderLeft: '4px solid #007cba',
+						backgroundColor: '#f0f8ff',
+						margin: '16px 0',
+						padding: '12px 16px',
+						fontStyle: 'italic',
+						borderRadius: '0 4px 4px 0',
+					} }
+				>
+					{ children }
+				</blockquote>
+			),
+		} ),
+		[]
+	);
+
+	// Create message renderer
+	const messageRenderer = useMemo(
+		() =>
+			createMessageRenderer( {
+				components: customMarkdownComponents,
+				extensions: {
+					gfm: { enabled: true },
+				},
+				enableStreaming: false,
+			} ),
+		[ customMarkdownComponents ]
+	);
+
+	const handleSubmit = useCallback(
+		async ( message: string ) => {
+			await onSubmit( message );
+			clearSuggestions();
+		},
+		[ onSubmit, clearSuggestions ]
+	);
+
+	const handleFeedback = useCallback( async ( messageId: string, feedback: 'up' | 'down' ) => {
+		// eslint-disable-next-line no-console
+		console.log( `Feedback for message ${ messageId }: ${ feedback }` );
+	}, [] );
+
+	// Register feedback actions
+	const hasRegistered = useRef( false );
+	useEffect( () => {
+		if ( hasRegistered.current ) {
+			return;
+		}
+
+		const feedbackManager = createFeedbackActions( {
+			onFeedback: handleFeedback,
+			condition: ( message: UIMessage ) => message.role === 'agent',
+			icons: {
+				up: <ThumbsUpIcon />,
+				down: <ThumbsDownIcon />,
+			},
+		} );
+
+		registerMessageActions( {
+			id: 'devdocs-feedback',
+			actions: ( message: UIMessage ) => feedbackManager.getActionsForMessage( message ),
+		} );
+
+		hasRegistered.current = true;
+	}, [ registerMessageActions, handleFeedback ] );
+
+	return (
+		<AgentUI.Container
+			messages={ messages }
+			isProcessing={ isProcessing }
+			error={ error }
+			onSubmit={ handleSubmit }
+			onStop={ abortCurrentRequest }
+			variant="embedded"
+			suggestions={ suggestions }
+			clearSuggestions={ clearSuggestions }
+			messageRenderer={ messageRenderer }
+			className="agenttic"
+			placeholder={ [
+				__( 'Ask me anything…' ),
+				__( 'How can I help you today?' ),
+				__( 'What would you like to know?' ),
+			] }
+			emptyView={
+				<EmptyView
+					heading={ __( 'Agenttic Test' ) }
+					help={ __( 'Test the agenttic-client integration in Calypso.' ) }
+					suggestions={ suggestions }
+				/>
+			}
+		>
+			<AgentUI.ConversationView showHeader={ false }>
+				<AgentUI.Messages />
+				<AgentUI.Footer>
+					<AgentUI.Notice />
+					<AgentUI.Input />
+				</AgentUI.Footer>
+				<AgentUI.Suggestions />
+			</AgentUI.ConversationView>
+		</AgentUI.Container>
+	);
+};
+
+/**
+ * Main test page component that manages config and controls conversation reset.
+ */
+const AgentticTest: React.FC = () => {
+	// Try to get selected site from Calypso state (may be null in devdocs)
+	const selectedSiteId = useSelector( getSelectedSiteId );
+
+	// Initialize state from URL parameters
+	const [ agentId, setAgentId ] = useState< string >(
+		() => getUrlParam( 'slug' ) || DEFAULT_AGENT_ID
+	);
+	const [ blogIdInput, setBlogIdInput ] = useState< string >(
+		() => getUrlParam( 'blog_id' ) || ( selectedSiteId ? String( selectedSiteId ) : '' )
+	);
+
+	// Key to force remount of chat component (resets conversation)
+	const [ chatKey, setChatKey ] = useState< number >( 0 );
+	const [ sessionId, setSessionId ] = useState< string >( generateSessionId );
+
+	// Parse blog ID from input
+	const blogId = useMemo( () => {
+		if ( blogIdInput.trim() ) {
+			const parsed = parseInt( blogIdInput.trim(), 10 );
+			if ( ! Number.isNaN( parsed ) ) {
+				return parsed;
+			}
+		}
+		return undefined;
+	}, [ blogIdInput ] );
+
+	// Update URL when parameters change
+	useEffect( () => {
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+
+		const params = new URLSearchParams( window.location.search );
+
+		if ( agentId.trim() && agentId !== DEFAULT_AGENT_ID ) {
+			params.set( 'slug', agentId.trim() );
+		} else {
+			params.delete( 'slug' );
+		}
+
+		if ( blogIdInput.trim() ) {
+			params.set( 'blog_id', blogIdInput.trim() );
+		} else {
+			params.delete( 'blog_id' );
+		}
+
+		const newUrl = params.toString()
+			? `${ window.location.pathname }?${ params.toString() }`
+			: window.location.pathname;
+		window.history.replaceState( {}, '', newUrl );
+	}, [ agentId, blogIdInput ] );
+
+	// Create odieBotId for display in debug
+	const odieBotId = useMemo( () => createOdieBotId( agentId ), [ agentId ] );
+
+	// New Conversation: generate new session ID and increment key to remount chat
+	const handleNewConversation = useCallback( () => {
+		setSessionId( generateSessionId() );
+		setChatKey( ( prev ) => prev + 1 );
+	}, [] );
+
+	return (
+		<div className="agenttic-test">
+			<div className="agenttic-test__sidebar">
+				<h3>{ __( 'Agent Configuration' ) }</h3>
+
+				<div className="agenttic-test__field">
+					<label htmlFor="agent-id">
+						{ __( 'Agent Slug' ) } <span className="required">*</span>
+					</label>
+					<input
+						id="agent-id"
+						type="text"
+						value={ agentId }
+						onChange={ ( e ) => setAgentId( e.target.value ) }
+						placeholder="e.g., wpcom-support-chat"
+					/>
+				</div>
+
+				<div className="agenttic-test__field">
+					<label htmlFor="blog-id">
+						{ __( 'Blog ID' ) } <span className="required">*</span>
+					</label>
+					<input
+						id="blog-id"
+						type="number"
+						value={ blogIdInput }
+						onChange={ ( e ) => setBlogIdInput( e.target.value ) }
+						placeholder="Send blog id to the agent"
+					/>
+					{ ! blogId && (
+						<p className="agenttic-test__field-hint agenttic-test__field-hint--error">
+							{ __( 'Blog ID is required for accurate context.' ) }
+						</p>
+					) }
+				</div>
+
+				<div className="agenttic-test__actions">
+					<button type="button" className="agenttic-test__button" onClick={ handleNewConversation }>
+						{ __( 'New Conversation' ) }
+					</button>
+				</div>
+
+				<div className="agenttic-test__info">
+					<h4>{ __( 'Auth Info' ) }</h4>
+					<p>
+						{ __(
+							'Using JWT auth via wpcom-proxy-request. Make sure you are logged in to WordPress.com and a valid Blog ID is set.'
+						) }
+					</p>
+				</div>
+
+				<div className="agenttic-test__debug">
+					<h4>{ __( 'Debug' ) }</h4>
+					<dl>
+						<dt>{ __( 'Session ID' ) }</dt>
+						<dd>{ sessionId }</dd>
+						<dt>{ __( 'Odie Bot ID' ) }</dt>
+						<dd>{ odieBotId }</dd>
+						<dt>{ __( 'Blog ID' ) }</dt>
+						<dd>{ blogId ?? __( 'not set (context missing)' ) }</dd>
+					</dl>
+				</div>
+			</div>
+
+			<div className="agenttic-test__chat">
+				<AgentticChat
+					key={ chatKey }
+					agentId={ agentId }
+					sessionId={ sessionId }
+					parsedBlogId={ blogId }
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default AgentticTest;

--- a/client/devdocs/agenttic-test/style.scss
+++ b/client/devdocs/agenttic-test/style.scss
@@ -1,0 +1,188 @@
+.agenttic-test {
+	display: flex;
+	height: calc( 100vh - 80px );
+	margin: 0;
+	padding: 0;
+	gap: 0;
+}
+
+.agenttic-test__sidebar {
+	width: 280px;
+	background: #fff;
+	padding: 24px;
+	border-inline-end: 1px solid #ddd;
+	overflow-y: auto;
+	flex-shrink: 0;
+
+	h3 {
+		margin: 0 0 24px;
+		font-size: 16px;
+		font-weight: 600;
+		color: #1e1e1e;
+	}
+
+	h4 {
+		margin: 0 0 8px;
+		font-size: 13px;
+		font-weight: 600;
+		color: #1e1e1e;
+	}
+}
+
+.agenttic-test__field {
+	margin-bottom: 16px;
+
+	label {
+		display: block;
+		font-size: 12px;
+		font-weight: 600;
+		margin-bottom: 6px;
+		color: #1e1e1e;
+
+		.required {
+			color: #d63638;
+		}
+	}
+
+	input[type="text"],
+	input[type="number"],
+	input[type="password"] {
+		width: 100%;
+		padding: 8px 12px;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		font-size: 13px;
+		box-sizing: border-box;
+
+		&:focus {
+			outline: none;
+			border-color: #007cba;
+			box-shadow: 0 0 0 1px #007cba;
+		}
+	}
+
+}
+
+
+.agenttic-test__field-hint {
+	margin: 6px 0 0;
+	font-size: 11px;
+	color: #50575e;
+
+	&--error {
+		color: #d63638;
+	}
+}
+
+.agenttic-test__actions {
+	margin-top: 24px;
+	margin-bottom: 24px;
+}
+
+.agenttic-test__button {
+	width: 100%;
+	padding: 10px 16px;
+	background: #007cba;
+	color: #fff;
+	border: none;
+	border-radius: 4px;
+	font-size: 13px;
+	font-weight: 600;
+	cursor: pointer;
+	transition: background 0.15s ease;
+
+	&:hover {
+		background: #005a87;
+	}
+
+	&:focus {
+		outline: 2px solid #007cba;
+		outline-offset: 2px;
+	}
+
+}
+
+.agenttic-test__info {
+	margin-top: 24px;
+	padding: 16px;
+	background: #f0f6fc;
+	border-radius: 4px;
+	border-inline-start: 3px solid #007cba;
+
+	p {
+		margin: 0;
+		font-size: 12px;
+		color: #50575e;
+		line-height: 1.5;
+	}
+}
+
+.agenttic-test__debug {
+	margin-top: 16px;
+	padding: 12px;
+	background: #f9f9f9;
+	border-radius: 4px;
+	border: 1px solid #ddd;
+	font-size: 11px;
+
+	h4 {
+		margin: 0 0 8px;
+		font-size: 11px;
+		font-weight: 600;
+		color: #757575;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+	}
+
+	dl {
+		margin: 0;
+	}
+
+	dt {
+		font-weight: 600;
+		color: #50575e;
+		margin-top: 6px;
+
+		&:first-of-type {
+			margin-top: 0;
+		}
+	}
+
+	dd {
+		margin: 2px 0 0;
+		color: #757575;
+		word-break: break-all;
+
+		code {
+			background: #eee;
+			padding: 2px 4px;
+			border-radius: 2px;
+			font-size: 10px;
+		}
+	}
+}
+
+.agenttic-test__chat {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	background: #f6f7f7;
+	min-width: 0;
+
+	// AgentUI container fills the space
+	.agenttic {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+	}
+}
+
+// Override some agenttic-ui defaults to fit better in devdocs
+.agenttic-test .agenttic {
+	--color-background: #f6f7f7;
+	--color-foreground: #1e1e1e;
+	--color-primary: #007cba;
+	--color-primary-foreground: #fff;
+}
+

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -10,6 +10,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 // `props.component`-aware placeholder. It still needs to be imported as
 // `AsyncLoad` though–see https://github.com/Automattic/babel-plugin-transform-wpcalypso-async/blob/HEAD/index.js#L12
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import AgentticTest from './agenttic-test';
 import AsyncLoad from './devdocs-async-load';
 import SingleDocComponent from './doc';
 import DocsComponent from './main';
@@ -153,6 +154,12 @@ const devdocs = {
 	// Welcome screen
 	welcome: function ( context, next ) {
 		context.primary = createElement( DevWelcome, {} );
+		next();
+	},
+
+	// Agenttic test
+	agenttic: function ( context, next ) {
+		context.primary = createElement( AgentticTest, {} );
 		next();
 	},
 };

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -68,6 +68,7 @@ export default function () {
 		);
 		page( '/devdocs/start', controller.pleaseLogIn, makeLayout, clientRender );
 		page( '/devdocs/welcome', controller.sidebar, controller.welcome, makeLayout, clientRender );
+		page( '/devdocs/agenttic', controller.sidebar, controller.agenttic, makeLayout, clientRender );
 		page( '/devdocs/:path*', controller.sidebar, controller.singleDoc, makeLayout, clientRender );
 	}
 }

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
+		"@automattic/agenttic-client": "^0.1.32",
 		"@automattic/agenttic-ui": "^0.1.31",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,9 +329,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.31":
-  version: 0.1.31
-  resolution: "@automattic/agenttic-client@npm:0.1.31"
+"@automattic/agenttic-client@npm:^0.1.31, @automattic/agenttic-client@npm:^0.1.32":
+  version: 0.1.32
+  resolution: "@automattic/agenttic-client@npm:0.1.32"
   dependencies:
     "@types/react": "npm:^18.0.0"
     marked: "npm:^16.2.1"
@@ -345,13 +345,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: e1996db7be1370843d42b0cf721e8c0e9be0e2481103460c1baa81e6927a250352ac072873a807d6122d8b3584dc74a43140758e148609f18994267a40a98b9b
+  checksum: 7c79b8ab0fc0c0db64b16ec31e59f8a5fb46dfa4a86ef5f8dd1fc62e402ea17c59c8176d4bc47fb1b947319e43f04857a8c35689539a1327639bb0a90c97aea4
   languageName: node
   linkType: hard
 
 "@automattic/agenttic-ui@npm:^0.1.31":
-  version: 0.1.31
-  resolution: "@automattic/agenttic-ui@npm:0.1.31"
+  version: 0.1.32
+  resolution: "@automattic/agenttic-ui@npm:0.1.32"
   dependencies:
     "@automattic/charts": "npm:>=0.14.0 <1.0.0"
     "@radix-ui/react-scroll-area": "npm:^1.2.9"
@@ -376,7 +376,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: e16ce9dcf6574d64ddc0ebf7e86261836fcee987d3aae3453dcf7e7dc4223e70922b0f9bcb0a6dfd692b52280831ec9d565a885d5637f499eb0ef4aa234fb7e0
+  checksum: a0bf5af5cc3d79a02bbe4e44bb0b4cf6bad4dce68c7515d1d1c8d845b436dc81d8462ce5d950a376d89498cb6cb5a60649b91fbbbc711e25f1afee3e24b0c8c7
   languageName: node
   linkType: hard
 
@@ -888,43 +888,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/charts@npm:>=0.14.0 <1.0.0, @automattic/charts@npm:^0.50.0":
-  version: 0.50.2
-  resolution: "@automattic/charts@npm:0.50.2"
-  dependencies:
-    "@automattic/number-formatters": "npm:^1.0.15"
-    "@babel/runtime": "npm:7.28.4"
-    "@react-spring/web": "npm:9.7.5"
-    "@visx/annotation": "npm:^3.12.0"
-    "@visx/axis": "npm:^3.12.0"
-    "@visx/curve": "npm:^3.12.0"
-    "@visx/event": "npm:^3.12.0"
-    "@visx/gradient": "npm:^3.12.0"
-    "@visx/grid": "npm:^3.12.0"
-    "@visx/group": "npm:^3.12.0"
-    "@visx/legend": "npm:^3.12.0"
-    "@visx/pattern": "npm:^3.12.0"
-    "@visx/responsive": "npm:^3.12.0"
-    "@visx/scale": "npm:^3.12.0"
-    "@visx/shape": "npm:^3.12.0"
-    "@visx/text": "npm:^3.12.0"
-    "@visx/tooltip": "npm:^3.12.0"
-    "@visx/xychart": "npm:^3.12.0"
-    "@wordpress/i18n": "npm:^6.0.0"
-    clsx: "npm:2.1.1"
-    date-fns: "npm:^4.1.0"
-    deepmerge: "npm:4.3.1"
-    fast-deep-equal: "npm:3.1.3"
-    gridicons: "npm:3.4.2"
-    tslib: "npm:2.8.1"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-  checksum: e0bdce896e10910973c422eb9626e86375731abd53223f06f77daa717da30fb04457d5ed71d54d51c323a037518c722d947d8b50b869cc65a3bcd4c0c690d76d
-  languageName: node
-  linkType: hard
-
-"@automattic/charts@npm:^0.46.1":
+"@automattic/charts@npm:>=0.14.0 <1.0.0, @automattic/charts@npm:^0.46.1":
   version: 0.46.1
   resolution: "@automattic/charts@npm:0.46.1"
   dependencies:
@@ -957,6 +921,42 @@ __metadata:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
   checksum: 0c986843d1ce366fe6bd0556f097ed278b39f6bdd1bd5e70ac665aac4ef4c3b5a5823f4ba9ecab6c277fe0e4ba5a6e6179664e05d933eb517fa91d24000f66bd
+  languageName: node
+  linkType: hard
+
+"@automattic/charts@npm:^0.50.0":
+  version: 0.50.2
+  resolution: "@automattic/charts@npm:0.50.2"
+  dependencies:
+    "@automattic/number-formatters": "npm:^1.0.15"
+    "@babel/runtime": "npm:7.28.4"
+    "@react-spring/web": "npm:9.7.5"
+    "@visx/annotation": "npm:^3.12.0"
+    "@visx/axis": "npm:^3.12.0"
+    "@visx/curve": "npm:^3.12.0"
+    "@visx/event": "npm:^3.12.0"
+    "@visx/gradient": "npm:^3.12.0"
+    "@visx/grid": "npm:^3.12.0"
+    "@visx/group": "npm:^3.12.0"
+    "@visx/legend": "npm:^3.12.0"
+    "@visx/pattern": "npm:^3.12.0"
+    "@visx/responsive": "npm:^3.12.0"
+    "@visx/scale": "npm:^3.12.0"
+    "@visx/shape": "npm:^3.12.0"
+    "@visx/text": "npm:^3.12.0"
+    "@visx/tooltip": "npm:^3.12.0"
+    "@visx/xychart": "npm:^3.12.0"
+    "@wordpress/i18n": "npm:^6.0.0"
+    clsx: "npm:2.1.1"
+    date-fns: "npm:^4.1.0"
+    deepmerge: "npm:4.3.1"
+    fast-deep-equal: "npm:3.1.3"
+    gridicons: "npm:3.4.2"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: e0bdce896e10910973c422eb9626e86375731abd53223f06f77daa717da30fb04457d5ed71d54d51c323a037518c722d947d8b50b869cc65a3bcd4c0c690d76d
   languageName: node
   linkType: hard
 
@@ -1840,7 +1840,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.0.1, @automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15":
+"@automattic/number-formatters@npm:^1.0.1, @automattic/number-formatters@npm:^1.0.14":
+  version: 1.0.14
+  resolution: "@automattic/number-formatters@npm:1.0.14"
+  dependencies:
+    "@wordpress/date": "npm:^5.19.0"
+    debug: "npm:^4.4.0"
+    tslib: "npm:^2.5.0"
+  checksum: 271214c5a2b5363a5e85b12f4773ec02d52fcd214d41e6877f780287684f279e8c194128c7f4a57e66fde51f37f4243579666216ef437a4ed4b69e2229abfe8b
+  languageName: node
+  linkType: hard
+
+"@automattic/number-formatters@npm:^1.0.15":
   version: 1.0.15
   resolution: "@automattic/number-formatters@npm:1.0.15"
   dependencies:
@@ -15305,6 +15316,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
+    "@automattic/agenttic-client": "npm:^0.1.32"
     "@automattic/agenttic-ui": "npm:^0.1.31"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"


### PR DESCRIPTION
Add a new test harness in devdocs for @automattic/agenttic-client that allows us to test authenticated requests (kind of).

- JWT authentication via wpcom-proxy-request
- Use UUID-based session IDs for conversation tracking

