### PR TITLE
Domains: Auto-submit use-my-domain form when domain is prefilled

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -440,11 +440,11 @@ function UseMyDomain( props ) {
 		}
 
 		initialValidation.current = true;
-		initialQuery &&
-			! initialMode &&
-			! getDomainNameValidationErrorMessage( initialQuery ) &&
+		// Auto-submit if there's an initial query, we're in domain input mode, and validation passes
+		if ( mode === inputMode.domainInput && ! getDomainNameValidationErrorMessage( initialQuery ) ) {
 			onNext();
-	}, [ initialMode, initialQuery, onNext ] );
+		}
+	}, [ mode, initialQuery, onNext ] );
 
 	useEffect( () => {
 		if ( inputMode.transferDomain === mode && inputMode.transferDomain === initialMode ) {


### PR DESCRIPTION
Closes DOMAINS-1680.

## Proposed Changes

* Updated the auto-submission logic in the `use-my-domain` component to automatically submit the form when a domain is prefilled from the "Bring it over" button in domain search results

## Why are these changes being made?

When users search for a domain and see it's unavailable, they can click the "Bring it over" button to transfer or connect that domain. Currently, this redirects them to the use-my-domain flow with the domain name prefilled in the input box, but they still need to manually click submit again.

This is a poor user experience because the user has already entered the domain name in the previous step. They shouldn't need to submit it again when it's already prefilled.

This change improves the user flow by automatically submitting the form when there's a prefilled domain query, taking users directly to the transfer-or-connect options screen. This eliminates an unnecessary click and provides a smoother, more intuitive experience.

## Testing Instructions

### Prerequisites
- Ensure the local development server is running (`yarn start`)
- Navigate to `http://my.localhost:3000/setup/onboarding`

### Test Steps
1. In the domain search field, enter a domain you own or any domain that is already registered (e.g., `zaguini.me`, `google.com`, etc.)
2. Click "Search domains"
3. You should see an unavailability notice that says "[domain] is already registered"
4. Click the "Bring it over" button

### Expected Result
- ✅ You should be **automatically taken to the transfer-or-connect screen** showing options to "Transfer your domain name" or "Connect your site address"
- ✅ The URL should show: `/setup/onboarding/use-my-domain?initialQuery=[domain]&step=transfer-or-connect`
- ✅ You should **NOT** see the domain input screen with a prefilled field requiring manual submission

### Before/After

**Before:** Click "Bring it over" → see domain input screen with prefilled domain → manually click submit → see transfer-or-connect options

**After:** Click "Bring it over" → automatically see transfer-or-connect options (domain input step is skipped)

### Additional Test Cases
1. Test with various domain names (different TLDs)
2. Verify the fix works in different flows (onboarding, domain-only, etc.)
3. Ensure entering a domain manually (without clicking "Bring it over") still works correctly

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?