### PR TITLE
Dashboard: Hide "Change site address" action for non-simple sites

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../app/router/domains';
 import { isDomainRenewable, canSetAsPrimary, getDomainRenewalUrl } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
+import { isSimple } from '../../utils/site-types';
 import { AutoRenewModal } from './auto-renew-modal';
 import type { DomainSummary, Site, User } from '@automattic/api-core';
 import type { Action } from '@wordpress/dataviews';
@@ -247,9 +248,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				callback: () => {},
 				isEligible: ( item: DomainSummary ) => {
 					const site = sitesByBlogId[ item.blog_id ];
-					return (
-						!! site && ! site?.is_wpcom_atomic && item.subtype.id === DomainSubtype.DEFAULT_ADDRESS
-					);
+					return !! site && isSimple( site ) && item.subtype.id === DomainSubtype.DEFAULT_ADDRESS;
 				},
 				RenderModal: ( { items, closeModal = noop } ) => {
 					const site = sitesByBlogId[ items[ 0 ].blog_id ];


### PR DESCRIPTION
## Proposed changes

Hide the "Change site address" action in the domains DataViews for non-simple sites (Jetpack-connected, Atomic, and garden sites). The action now uses the existing `isSimple()` utility instead of only checking for Atomic sites.

<img width="1247" height="186" alt="CleanShot 2026-01-07 at 10 52 35" src="https://github.com/user-attachments/assets/252c2967-7c3e-4021-ab5b-491d2c69fe02" />


## Why are these changes being made?

The change site address API endpoint doesn't support Jetpack sites, returning the error "This WP REST API endpoint is not implemented for Jetpack sites". Garden sites are also Jetpack-connected, so users would see the action but get an error when trying to use it.

By using `isSimple()`, we correctly hide the action for all site types where the feature isn't supported, providing a better user experience.

## Testing instructions

1. Navigate to the hosting dashboard (/v2 or /ciab)
2. For a **simple WordPress.com site**: verify the "Change site address" action appears in the domains list
3. For a **garden site** (e.g., commerce-garden.com domain): verify the action is hidden
4. For an **Atomic site**: verify the action is hidden
5. For a **Jetpack-connected site**: verify the action is hidden