### PR TITLE
DNS Import Dialog: Improve UI when no valid records found

### DIFF
--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -168,7 +168,7 @@ export default function DnsImportDialog( {
 						</VStack>
 					</>
 				) : (
-					<Text>{ __( "We couldn't find valid DNS records in the selected BIND file." ) }</Text>
+					<Text>{ __( 'We couldn’t find valid DNS records in the selected BIND file.' ) }</Text>
 				) }
 
 				<ButtonStack justify="flex-end">

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -154,40 +154,49 @@ export default function DnsImportDialog( {
 	return (
 		<Modal title={ __( 'Import DNS records' ) } onRequestClose={ onCancel }>
 			<VStack spacing={ 6 }>
-				<Text>
-					{ __(
-						'Select the DNS records you want to import. Please review them before confirming.'
-					) }
-				</Text>
-
 				{ records.length > 0 ? (
-					<VStack spacing={ 2 }>
-						{ renderHeader() }
-						<Divider />
-						{ records.map( ( record, index ) => renderRecordRow( record, index ) ) }
-					</VStack>
+					<>
+						<Text>
+							{ __(
+								'Select the DNS records you want to import. Please review them before confirming.'
+							) }
+						</Text>
+						<VStack spacing={ 2 }>
+							{ renderHeader() }
+							<Divider />
+							{ records.map( ( record, index ) => renderRecordRow( record, index ) ) }
+						</VStack>
+					</>
 				) : (
-					<Text>{ __( 'We couldn’t find valid DNS records to import.' ) }</Text>
+					<Text>{ __( "We couldn't find valid DNS records in the selected BIND file." ) }</Text>
 				) }
 
 				<ButtonStack justify="flex-end">
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ onCancel }
-						disabled={ updateDnsMutation.isPending }
-					>
-						{ __( 'Cancel' ) }
-					</Button>
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						isBusy={ updateDnsMutation.isPending }
-						onClick={ handleConfirm }
-						disabled={ numberOfSelectedRecords === 0 || updateDnsMutation.isPending }
-					>
-						{ __( 'Import selected records' ) }
-					</Button>
+					{ records.length > 0 ? (
+						<>
+							<Button
+								__next40pxDefaultSize
+								variant="tertiary"
+								onClick={ onCancel }
+								disabled={ updateDnsMutation.isPending }
+							>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								isBusy={ updateDnsMutation.isPending }
+								onClick={ handleConfirm }
+								disabled={ numberOfSelectedRecords === 0 || updateDnsMutation.isPending }
+							>
+								{ __( 'Import selected records' ) }
+							</Button>
+						</>
+					) : (
+						<Button __next40pxDefaultSize variant="primary" onClick={ onCancel }>
+							{ __( 'Ok' ) }
+						</Button>
+					) }
 				</ButtonStack>
 			</VStack>
 		</Modal>

--- a/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
+++ b/client/dashboard/domains/domain-dns/dns-import-dialog.tsx
@@ -140,7 +140,7 @@ export default function DnsImportDialog( {
 		const isSelected = selectedRecords.has( recordId );
 
 		return (
-			<div key={ index } style={ { marginBottom: '8px' } }>
+			<div key={ index } style={ { marginBottom: '8px', wordBreak: 'break-all' } }>
 				<CheckboxControl
 					__nextHasNoMarginBottom
 					checked={ isSelected }


### PR DESCRIPTION
fixes [DOMENG-316](https://linear.app/a8c/issue/DOMENG-316/domains-dns-records-import-invalid-bind-file-modal-message-adjustment)

## Proposed Changes

- When no valid DNS records are found in the BIND file, show a single "Ok" button instead of both "Cancel" and "Import selected records" buttons
- Update the error message to be more specific: "We couldn't find valid DNS records in the selected BIND file."
- Hide the instruction text ("Select the DNS records you want to import...") when there are no records to display

## Why are these changes being made?

The current UI shows both "Cancel" and "Import selected records" buttons even when there are no records to import, which is confusing for users. The "Import selected records" button is disabled but still visible, making the UI feel broken. This change provides a cleaner, more intuitive experience by showing only a single "Ok" button to dismiss the dialog when no records are found.

## Testing Instructions

1. Go to a domain's DNS management page in the Dashboard
2. Click the menu (three dots) and select "Import BIND file"
3. Select a BIND file that contains no valid DNS records (or an invalid file)
4. Verify the dialog shows:
   - Message: "We couldn't find valid DNS records in the selected BIND file."
   - Only an "Ok" button (no "Cancel" or "Import selected records" buttons)

### Before

| No records found |
|:--:|
| <img width="681" height="348" alt="image" src="https://github.com/user-attachments/assets/4cd25e35-3c5d-4566-93e4-6545d988a25d" /> |
| Shows both "Cancel" and disabled "Import selected records" buttons |

### After

| No records found |
|:--:|
| <img width="754" height="393" alt="image" src="https://github.com/user-attachments/assets/090975c1-4122-43ad-9dd5-845a649b4e8b" /> |
| Shows only "Ok" button with clearer message |


I also fixed this UI issue:

| Before | After |
|--------|--------|
| <img width="1922" height="1218" alt="image" src="https://github.com/user-attachments/assets/796ba275-6917-4e18-bb97-dd9002638644" /> | <img width="665" height="569" alt="image" src="https://github.com/user-attachments/assets/8710b2f3-3c83-4b02-80c4-438647facc46" /> | 




## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?