### PR TITLE
Woo Hosted Upgrade Flow: add `isWooHostedFreePlan()` to avoid plan class collisions

### DIFF
--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -14,6 +14,8 @@ import {
 	PLAN_WOOEXPRESS_PLUS,
 	PLAN_WOOEXPRESS_SMALL,
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
+	PLAN_WOO_HOSTED_FREE,
+	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
 	TERM_CENTENNIALLY,
@@ -184,6 +186,10 @@ export function getPlanClass( planKey: string ): string {
 
 	if ( isEcommercePlan( planKey ) ) {
 		return 'is-ecommerce-plan';
+	}
+
+	if ( isWooHostedFreePlan( planKey ) ) {
+		return 'is-woo-hosted-trial';
 	}
 
 	if ( isWooHostedPlan( planKey ) ) {
@@ -418,6 +424,10 @@ export function isWooExpressSmallPlan( planSlug: string ): boolean {
 
 export function isWooExpressPlan( planSlug: string ): boolean {
 	return ( WOO_EXPRESS_PLANS as ReadonlyArray< string > ).includes( planSlug );
+}
+
+export function isWooHostedFreePlan( planSlug: string ): boolean {
+	return [ PLAN_WOO_HOSTED_FREE, PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY ].includes( planSlug );
 }
 
 export function isWooHostedPlan( planSlug: string ): boolean {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1475/woo-hosted-plans-cant-purchase-a-plan-from-the-plans-page

## Proposed Changes

This adds the `isWooHostedFreePlan()` helper to avoid plan class collisions in the plans grid for the upgrade flow.

## Why are these changes being made?

Since the Woo Hosted Free Trial is technically an active plan, the plans grid in the Woo Hosted upgrade flow is misidentifying it as the same "plan class" as other Woo Hosted plans, making it impossible to select a paid plan. This adds a new helper to distinguish paid Woo Hosted plans from free Woo Hosted plans.

## Testing Instructions

- visit my.localhost:3000/ciab/sites
- either create a new site or use an existing site with a free trial
- visit the site's purchase management page or the site's admin, and click an upgrade nudge (e.g. "Upgrade Now" from the purchase management page)
- verify that you're taken to the Woo Hosted upgrade flow
- verify that you can select a paid plan
- verify that you can complete checkout with the paid plan
