### PR TITLE
Cancel flow: Add AtomicRevertChanges to renderProductRevertContent

### DIFF
--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -684,15 +684,15 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					cancellationFeatures={ cancellationFeatures }
 				/>
 
-				{ ! cancellationFeatures.length
-					? this.renderProductRevertContent()
-					: this.renderPlanRevertContent() }
+				{ cancellationFeatures.length
+					? this.renderPlanRevertContent()
+					: this.renderProductRevertContent() }
 			</>
 		);
 	};
 
 	renderProductRevertContent = () => {
-		const { purchase, isDomainRegistrationPurchase } = this.props;
+		const { purchase, isDomainRegistrationPurchase, atomicTransfer } = this.props;
 		const purchaseName = getName( purchase );
 		const plan = getPlan( purchase?.productSlug );
 		const planDescription = plan?.getPlanCancellationDescription?.();
@@ -706,6 +706,16 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						<div className="cancel-purchase__plan-description">{ planDescription }</div>
 					) }
 					<ProductLink purchase={ purchase } selectedSite={ this.props.site } />
+
+					<AtomicRevertChanges
+						atomicTransfer={ atomicTransfer }
+						purchase={ purchase }
+						onConfirmationChange={ this.onAtomicRevertConfirmationChange }
+						needsAtomicRevertConfirmation={ Boolean(
+							atomicTransfer?.created_at && ! isRefundable( purchase )
+						) }
+						isLoading={ this.state.isLoading }
+					/>
 				</CompactCard>
 
 				<CompactCard className="cancel-purchase__footer">


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1488/fix-wordpresscom-pro-plan-cancellation-button-being-inactive-in

## Proposed Changes

In this PR we add the Atomic revert warning and checkbox to `renderProductRevertContent` in the calypso cancel flow. It will only render if the an Atomic revert is likely. With the checkbox available, it will be possible to make the "Cancel subscription" button active.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1142" height="494" alt="Screenshot 2026-01-07 at 12 35 48 PM" src="https://github.com/user-attachments/assets/3b0c27cc-8e15-4875-81bd-7fd4bd6e4290" /> | <img width="1132" height="650" alt="Screenshot 2026-01-07 at 12 54 39 PM" src="https://github.com/user-attachments/assets/1b3fac09-bfb1-48f6-b64a-bf37ed78e259" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There are two distinct views in the "main" part of the calypso cancel flow: `renderProductRevertContent` and `renderPlanRevertContent`. 

The first one is used when there are cancellation features (`getCancellationFeatures`) configured for a plan in packages/calypso-products/src/plans-list.tsx and also lists the Atomic revert warning and checkbox if the site will be reverted from Atomic to Simple when the subscription is cancelled. It does not display any text from the `getPlanCancellationDescription` function that is part of the configuration of some plans (eg: the legacy Pro plan).

The second one is used when there are no cancellation features and *does* display the text from `getPlanCancellationDescription` but it does *not* have the Atomic revert warning or checkbox.

This is a problem because the "Cancel subscription" button that allows you to continue the cancellation flow will only be active if the Atomic revert checkbox has been checked (or is not needed). As a result, the button will always be disabled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use Store Admin to add a legacy Pro plan to your account.
- Take an action which makes the site Atomic.
- Visit `/me/purchases/` and click on your Pro plan.
- Click "Cancel" to begin the cancellation process.
- Verify that you can successfully cancel the plan.
