### PR TITLE
Release @automattic/grid@0.1.3

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.1.3
+
+### Bug Fixes
+
+- Fix Grid not re-rendering when layout prop changes dynamically
+
 ## 0.1.2
 
 - Add actionableArea grid item property

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/grid",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "Grid component for Automattic projects.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Summary

- Bump `@automattic/grid` package version to `0.1.3`
- Update CHANGELOG with bug fix entry

### Changes included in this release

- Fix Grid not re-rendering when layout prop changes dynamically (https://github.com/Automattic/wp-calypso/pull/107871)

## Test plan

- [ ] Verify package version is updated in `package.json`
- [ ] Verify CHANGELOG entry is correct
- [ ] After merge: publish to npm and create git tag