### PR TITLE
Fix past-date display bug for purchases in grace period 

### DIFF
--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -137,7 +137,8 @@ export function PurchaseExpiryStatus( {
 	if (
 		purchase.introductory_offer?.is_within_period &&
 		isIntroductoryOfferFreeTrial &&
-		isRenewing( purchase )
+		isRenewing( purchase ) &&
+		! isInExpirationGracePeriod( purchase )
 	) {
 		return createInterpolateElement(
 			sprintf(
@@ -161,7 +162,11 @@ export function PurchaseExpiryStatus( {
 		);
 	}
 
-	if ( purchase.introductory_offer?.is_within_period && isIntroductoryOfferFreeTrial ) {
+	if (
+		purchase.introductory_offer?.is_within_period &&
+		isIntroductoryOfferFreeTrial &&
+		! isInExpirationGracePeriod( purchase )
+	) {
 		return (
 			<span>
 				{
@@ -197,17 +202,7 @@ export function PurchaseExpiryStatus( {
 	if ( isInExpirationGracePeriod( purchase ) ) {
 		if ( isRenewing( purchase ) ) {
 			// Auto-renew ON, renewal failing
-			return (
-				<Text intent="error">
-					{ sprintf(
-						// translators: expiry is relative to the present time and already localized, e.g. "3 days ago"
-						__( 'Expired %(expiry)s: Pending renewal' ),
-						{
-							expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
-						}
-					) }
-				</Text>
-			);
+			return <Text intent="error">{ __( 'Pending renewal' ) }</Text>;
 		}
 
 		// Auto-renew OFF (isExpiring)

--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -24,6 +24,7 @@ import {
 	isAkismetFreeProduct,
 	creditCardHasAlreadyExpired,
 	creditCardExpiresBeforeSubscription,
+	isInExpirationGracePeriod,
 } from '../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
@@ -189,6 +190,37 @@ export function PurchaseExpiryStatus( {
 					}
 				) }
 			</span>
+		);
+	}
+
+	// Check if expired within the grace period (not actually expired)
+	if ( isInExpirationGracePeriod( purchase ) ) {
+		if ( isRenewing( purchase ) ) {
+			// Auto-renew ON, renewal failing
+			return (
+				<Text intent="error">
+					{ sprintf(
+						// translators: expiry is relative to the present time and already localized, e.g. "3 days ago"
+						__( 'Expired %(expiry)s: Pending renewal' ),
+						{
+							expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+						}
+					) }
+				</Text>
+			);
+		}
+
+		// Auto-renew OFF (isExpiring)
+		return (
+			<Text intent="error">
+				{ sprintf(
+					// translators: timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"
+					__( 'Expired %(timeSinceExpiry)s' ),
+					{
+						timeSinceExpiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+					}
+				) }
+			</Text>
 		);
 	}
 

--- a/client/dashboard/me/billing-payment-methods/payment-method-delete-dialog.tsx
+++ b/client/dashboard/me/billing-payment-methods/payment-method-delete-dialog.tsx
@@ -10,7 +10,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { useLocale } from '../../app/locale';
 import { Notice } from '../../components/notice';
 import { Text } from '../../components/text';
-import { formatDate, getRelativeTimeString } from '../../utils/datetime';
+import { formatDate } from '../../utils/datetime';
 import { isInExpirationGracePeriod } from '../../utils/purchase';
 import { PaymentMethodDetails } from './payment-method-details';
 import type { Purchase, StoredPaymentMethod } from '@automattic/api-core';
@@ -87,13 +87,7 @@ export const PaymentMethodDeleteDialog = ( {
 									</VStack>
 									<Text>
 										{ isInExpirationGracePeriod( purchase )
-											? sprintf(
-													// translators: "expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"
-													__( 'Expired %(expiry)s: Pending renewal' ),
-													{
-														expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
-													}
-											  )
+											? __( 'Pending renewal' )
 											: sprintf(
 													// translators: date is a formatted renewal date
 													__( 'Renews on %(date)s' ),

--- a/client/dashboard/me/billing-payment-methods/payment-method-delete-dialog.tsx
+++ b/client/dashboard/me/billing-payment-methods/payment-method-delete-dialog.tsx
@@ -10,7 +10,8 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { useLocale } from '../../app/locale';
 import { Notice } from '../../components/notice';
 import { Text } from '../../components/text';
-import { formatDate } from '../../utils/datetime';
+import { formatDate, getRelativeTimeString } from '../../utils/datetime';
+import { isInExpirationGracePeriod } from '../../utils/purchase';
 import { PaymentMethodDetails } from './payment-method-details';
 import type { Purchase, StoredPaymentMethod } from '@automattic/api-core';
 
@@ -85,15 +86,23 @@ export const PaymentMethodDeleteDialog = ( {
 										<Text>{ purchase.meta || purchase.domain }</Text>
 									</VStack>
 									<Text>
-										{ sprintf(
-											// translators: date is a formatted renewal date
-											__( 'Renews on %(date)s' ),
-											{
-												date: formatDate( new Date( purchase.renew_date ), locale, {
-													dateStyle: 'long',
-												} ),
-											}
-										) }
+										{ isInExpirationGracePeriod( purchase )
+											? sprintf(
+													// translators: "expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"
+													__( 'Expired %(expiry)s: Pending renewal' ),
+													{
+														expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+													}
+											  )
+											: sprintf(
+													// translators: date is a formatted renewal date
+													__( 'Renews on %(date)s' ),
+													{
+														date: formatDate( new Date( purchase.renew_date ), locale, {
+															dateStyle: 'long',
+														} ),
+													}
+											  ) }
 									</Text>
 								</HStack>
 							) ) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -59,7 +59,7 @@ import PageLayout from '../../../components/page-layout';
 import SiteIcon from '../../../components/site-icon';
 import SiteBandwidthStat from '../../../sites/overview-plan-card/site-bandwidth-stat';
 import SiteStorageStat from '../../../sites/overview-plan-card/site-storage-stat';
-import { formatDate } from '../../../utils/datetime';
+import { formatDate, getRelativeTimeString } from '../../../utils/datetime';
 import { getCurrentDashboard, redirectToDashboardLink, wpcomLink } from '../../../utils/link';
 import {
 	getBillPeriodLabel,
@@ -82,6 +82,8 @@ import {
 	isJetpackT1SecurityPlan,
 	isTemporarySitePurchase,
 	isWpcomFlexSubscription,
+	isAkismetFreeProduct,
+	isInExpirationGracePeriod,
 } from '../../../utils/purchase';
 import BillingFlexUsageCard from '../../billing-flex-usage';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
@@ -556,6 +558,13 @@ function getFields( {
 						Boolean( purchase.renew_date ) &&
 						isRenewing( purchase )
 					) {
+						if ( isInExpirationGracePeriod( purchase ) ) {
+							return sprintf(
+								// translators: expiry is relative time like "3 days ago"
+								__( 'Expired %(expiry)s: Pending renewal' ),
+								{ expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ) }
+							);
+						}
 						// translators: date is a formatted date string
 						return sprintf( __( 'You will be billed on %(date)s' ), {
 							date: formatDate( new Date( purchase.renew_date ), locale, { dateStyle: 'long' } ),
@@ -1100,6 +1109,9 @@ export default function PurchaseSettings() {
 		if ( isExpired( purchase ) ) {
 			return __( 'Expired' );
 		}
+		if ( isInExpirationGracePeriod( purchase ) ) {
+			return __( 'Expired' );
+		}
 		if ( purchase.bill_period_days === SubscriptionBillPeriod.PLAN_CENTENNIAL_PERIOD ) {
 			return __( 'Paid until' );
 		}
@@ -1160,8 +1172,11 @@ export default function PurchaseSettings() {
 						icon={ calendar }
 						title={ expiryDateTitle }
 						heading={ ( () => {
-							if ( isOneTimePurchase( purchase ) ) {
+							if ( isOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) {
 								return __( 'Never expires' );
+							}
+							if ( isInExpirationGracePeriod( purchase ) ) {
+								return formattedExpiry;
 							}
 							if ( willRenew ) {
 								return formattedRenewal;
@@ -1172,6 +1187,9 @@ export default function PurchaseSettings() {
 							return formattedExpiry;
 						} )() }
 						description={ ( () => {
+							if ( purchase.is_auto_renew_enabled && isInExpirationGracePeriod( purchase ) ) {
+								return __( 'Pending renewal' );
+							}
 							if ( purchase.is_auto_renew_enabled && isRenewing( purchase ) ) {
 								return __( 'Auto-renew is enabled' );
 							}
@@ -1185,7 +1203,7 @@ export default function PurchaseSettings() {
 									</Link>
 								);
 							}
-							if ( purchase.is_trial_plan ) {
+							if ( purchase.is_trial_plan || isAkismetFreeProduct( purchase ) ) {
 								return undefined;
 							}
 							if ( purchase.is_auto_renew_enabled ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -59,7 +59,7 @@ import PageLayout from '../../../components/page-layout';
 import SiteIcon from '../../../components/site-icon';
 import SiteBandwidthStat from '../../../sites/overview-plan-card/site-bandwidth-stat';
 import SiteStorageStat from '../../../sites/overview-plan-card/site-storage-stat';
-import { formatDate, getRelativeTimeString } from '../../../utils/datetime';
+import { formatDate } from '../../../utils/datetime';
 import { getCurrentDashboard, redirectToDashboardLink, wpcomLink } from '../../../utils/link';
 import {
 	getBillPeriodLabel,
@@ -559,11 +559,7 @@ function getFields( {
 						isRenewing( purchase )
 					) {
 						if ( isInExpirationGracePeriod( purchase ) ) {
-							return sprintf(
-								// translators: expiry is relative time like "3 days ago"
-								__( 'Expired %(expiry)s: Pending renewal' ),
-								{ expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ) }
-							);
+							return __( 'Pending renewal' );
 						}
 						// translators: date is a formatted date string
 						return sprintf( __( 'You will be billed on %(date)s' ), {

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -13,8 +13,8 @@ import {
 	isCloseToExpiration,
 	isRecentMonthlyPurchase,
 	isTemporarySitePurchase,
-	isAkismetFreeProduct,
 	getRenewalUrlFromPurchase,
+	isInExpirationGracePeriod,
 } from '../../../utils/purchase';
 import { RenewNoticeAction, shouldShowRenewNoticeAction } from './renew-notice-action';
 import type { Purchase } from '@automattic/api-core';
@@ -33,11 +33,10 @@ export function shouldShowExpiringNotice(
 	);
 	const currentPurchase: Purchase =
 		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
-
 	if (
 		! isExpiring( currentPurchase ) ||
 		currentPurchase?.is_trial_plan ||
-		isAkismetFreeProduct( currentPurchase )
+		isInExpirationGracePeriod( currentPurchase )
 	) {
 		return false;
 	}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../../../app/auth';
 import { changePaymentMethodRoute, purchaseSettingsRoute } from '../../../app/router/me';
 import Notice from '../../../components/notice';
 import { getCurrentDashboard, wpcomLink } from '../../../utils/link';
+import { getRelativeTimeString } from '../../../utils/datetime';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -22,6 +23,8 @@ import {
 	creditCardExpiresBeforeSubscription,
 	creditCardHasAlreadyExpired,
 	getRenewalUrlFromPurchase,
+	isInExpirationGracePeriod,
+	isAkismetFreeProduct,
 } from '../../../utils/purchase';
 import {
 	OtherRenewablePurchasesNotice,
@@ -111,7 +114,11 @@ function shouldShowExpiredRenewNotice(
 	const currentPurchase: Purchase =
 		usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
 
-	if ( ! isExpired( currentPurchase ) ) {
+	if ( ! isExpired( currentPurchase ) && ! isInExpirationGracePeriod( currentPurchase ) ) {
+		return false;
+	}
+
+	if ( isAkismetFreeProduct( currentPurchase ) ) {
 		return false;
 	}
 
@@ -150,6 +157,23 @@ function ExpiredRenewNotice( {
 	const includedPurchase = purchase;
 
 	if ( purchase.is_renewable ) {
+		const noticeText = ( () => {
+			if ( isExpired( currentPurchase ) ) {
+				return __( 'This purchase has expired and is no longer in use.' );
+			}
+			const purchaseName = currentPurchase.is_domain
+				? currentPurchase.meta ?? ''
+				: currentPurchase.product_name;
+			const expiry = getRelativeTimeString( new Date( currentPurchase.expiry_date ) );
+			return sprintf(
+				// translators: purchaseName is the name of the product, expiry is a string like "3 days ago"
+				__(
+					'Your %(purchaseName)s subscription expired %(expiry)s and will be removed soon unless you take action.'
+				),
+				{ purchaseName, expiry }
+			);
+		} )();
+
 		return (
 			<Notice
 				variant="error"
@@ -164,7 +188,7 @@ function ExpiredRenewNotice( {
 					) : undefined
 				}
 			>
-				{ __( 'This purchase has expired and is no longer in use.' ) }
+				{ noticeText }
 			</Notice>
 		);
 	}
@@ -278,9 +302,10 @@ function TrialNotice( { purchase }: { purchase: Purchase } ) {
 		return;
 	};
 
-	const daysToExpiry = isExpired( purchase )
-		? 0
-		: differenceInCalendarDays( new Date( purchase.expiry_date ), new Date() );
+	const daysToExpiry =
+		isExpired( purchase ) || isInExpirationGracePeriod( purchase )
+			? 0
+			: differenceInCalendarDays( new Date( purchase.expiry_date ), new Date() );
 	const productType =
 		purchase.product_slug === DotcomPlans.ECOMMERCE_TRIAL_MONTHLY ||
 		purchase.product_slug === WooHostedPlans.WOO_HOSTED_FREE_TRIAL_PLAN_MONTHLY

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -11,8 +11,8 @@ import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import { changePaymentMethodRoute, purchaseSettingsRoute } from '../../../app/router/me';
 import Notice from '../../../components/notice';
-import { getCurrentDashboard, wpcomLink } from '../../../utils/link';
 import { getRelativeTimeString } from '../../../utils/datetime';
+import { getCurrentDashboard, wpcomLink } from '../../../utils/link';
 import {
 	isExpired,
 	isIncludedWithPlan,

--- a/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/renew-notice-action.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { changePaymentMethodRoute } from '../../../app/router/me';
-import { isCloseToExpiration } from '../../../utils/purchase';
+import { isCloseToExpiration, isInExpirationGracePeriod } from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
 /**
@@ -38,6 +38,11 @@ export function shouldShowRenewNoticeAction( purchase: Purchase ): boolean {
 	}
 
 	if ( ! purchase.is_rechargeable ) {
+		return true;
+	}
+
+	// Show renew action for purchases in grace period that can be renewed.
+	if ( purchase.can_explicit_renew && isInExpirationGracePeriod( purchase ) ) {
 		return true;
 	}
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -33,10 +33,7 @@ interface Props {
 function ExpiresText( { purchase }: { purchase: Purchase } ) {
 	if ( isRenewing( purchase ) ) {
 		if ( isInExpirationGracePeriod( purchase ) ) {
-			// translators: "expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"
-			return sprintf( __( 'Expired %(expiry)s: Pending renewal' ), {
-				expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
-			} );
+			return __( 'pending renewal' );
 		}
 		// translators: "renewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"
 		return sprintf( __( 'renews %(renewDate)s' ), {

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -12,7 +12,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useMemo } from 'react';
 import { purchaseSettingsRoute } from '../../../app/router/me';
 import { getRelativeTimeString } from '../../../utils/datetime';
-import { getSubtitleForDisplay, isExpired, isRenewing } from '../../../utils/purchase';
+import {
+	getSubtitleForDisplay,
+	isExpired,
+	isRenewing,
+	isInExpirationGracePeriod,
+} from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 import type { Field, View, Action } from '@wordpress/dataviews';
 
@@ -27,12 +32,18 @@ interface Props {
 
 function ExpiresText( { purchase }: { purchase: Purchase } ) {
 	if ( isRenewing( purchase ) ) {
+		if ( isInExpirationGracePeriod( purchase ) ) {
+			// translators: "expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"
+			return sprintf( __( 'Expired %(expiry)s: Pending renewal' ), {
+				expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+			} );
+		}
 		// translators: "renewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"
 		return sprintf( __( 'renews %(renewDate)s' ), {
 			renewDate: getRelativeTimeString( new Date( purchase.renew_date ) ),
 		} );
 	}
-	if ( isExpired( purchase ) ) {
+	if ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
 		// translators: "expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"
 		return sprintf( __( 'expired %(expiry)s' ), {
 			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -51,6 +51,10 @@ export function isExpired( purchase: Purchase ) {
 }
 
 export function isInExpirationGracePeriod( purchase: Purchase ): boolean {
+	if ( ! purchase.expiry_date ) {
+		return false;
+	}
+
 	if ( new Date( purchase.expiry_date ) >= new Date() ) {
 		return false;
 	}

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -50,6 +50,23 @@ export function isExpired( purchase: Purchase ) {
 	return 'expired' === purchase.expiry_status;
 }
 
+export function isInExpirationGracePeriod( purchase: Purchase ): boolean {
+	if ( new Date( purchase.expiry_date ) >= new Date() ) {
+		return false;
+	}
+	if ( isExpired( purchase ) ) {
+		return false;
+	}
+	if ( ! isRenewing( purchase ) && ! isExpiring( purchase ) ) {
+		return false;
+	}
+	if ( isAkismetFreeProduct( purchase ) ) {
+		return false;
+	}
+
+	return true;
+}
+
 export function isIncludedWithPlan( purchase: Purchase ) {
 	return 'included' === purchase.expiry_status;
 }
@@ -509,7 +526,9 @@ export function needsToRenewSoon( purchase: Purchase ): boolean {
 	) {
 		return false;
 	}
-	return isCloseToExpiration( purchase );
+	// Include purchases past expiry (grace period) that are still renewable
+	const isPastExpiry = new Date( purchase.expiry_date ) < new Date();
+	return isCloseToExpiration( purchase ) || isPastExpiry;
 }
 
 export function isPartnerPurchase(

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -27,6 +27,7 @@ import {
 	isJetpackStatsPaidProductSlug,
 	isAkismetPro500,
 	getAkismetPro500ProductDisplayName,
+	isAkismetFreeProduct,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { formatCurrency, formatNumber } from '@automattic/number-formatters';
@@ -527,6 +528,26 @@ export function isExpiring( purchase: Purchase ) {
 	return [ 'manualRenew', 'expiring' ].includes( purchase.expiryStatus );
 }
 
+export function isInExpirationGracePeriod( purchase: Purchase ): boolean {
+	if ( ! moment( purchase.expiryDate ).isBefore( moment() ) ) {
+		return false;
+	}
+
+	if ( isExpired( purchase ) ) {
+		return false;
+	}
+
+	if ( ! isRenewing( purchase ) && ! isExpiring( purchase ) ) {
+		return false;
+	}
+
+	if ( isAkismetFreeProduct( purchase ) ) {
+		return false;
+	}
+
+	return true;
+}
+
 export function isIncludedWithPlan( purchase: Purchase ) {
 	return 'included' === purchase.expiryStatus;
 }
@@ -611,7 +632,9 @@ export function needsToRenewSoon( purchase: Purchase ): boolean {
 		return false;
 	}
 
-	return isCloseToExpiration( purchase );
+	// Include purchases past expiry (grace period) that are still renewable
+	const isPastExpiry = new Date( purchase.expiryDate ) < new Date();
+	return isCloseToExpiration( purchase ) || isPastExpiry;
 }
 
 /**

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -529,6 +529,10 @@ export function isExpiring( purchase: Purchase ) {
 }
 
 export function isInExpirationGracePeriod( purchase: Purchase ): boolean {
+	if ( ! purchase.expiryDate ) {
+		return false;
+	}
+
 	if ( ! moment( purchase.expiryDate ).isBefore( moment() ) ) {
 		return false;
 	}

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -257,11 +257,14 @@ class PurchaseNotice extends Component<
 			);
 		}
 
-		return (
-			! isRechargeable( purchase ) && (
-				<NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>
-			)
-		);
+		if (
+			! isRechargeable( purchase ) ||
+			( canExplicitRenew( purchase ) && isInExpirationGracePeriod( purchase ) )
+		) {
+			return <NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>;
+		}
+
+		return null;
 	}
 
 	trackImpression( warning: string ) {

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -44,6 +44,7 @@ import {
 	isPaidWithCredits,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
 	isMonthlyPurchase,
+	isInExpirationGracePeriod,
 } from 'calypso/lib/purchases';
 import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { managePurchase } from 'calypso/me/purchases/paths';
@@ -342,7 +343,8 @@ class PurchaseNotice extends Component<
 		if (
 			! isExpiring( currentPurchase ) ||
 			EXCLUDED_PRODUCTS.includes( currentPurchase?.productSlug ) ||
-			isAkismetFreeProduct( currentPurchase )
+			isAkismetFreeProduct( currentPurchase ) ||
+			isInExpirationGracePeriod( currentPurchase )
 		) {
 			return null;
 		}
@@ -452,9 +454,15 @@ class PurchaseNotice extends Component<
 		const currentPurchaseNeedsToRenewSoon = needsToRenewSoon( currentPurchase );
 		const currentPurchaseCreditCardExpiresBeforeSubscription =
 			isRenewing( currentPurchase ) && creditCardExpiresBeforeSubscription( currentPurchase );
-		const currentPurchaseIsExpiring = isExpiring( currentPurchase ) || isExpired( currentPurchase );
+		const currentPurchaseIsExpiring =
+			isExpiring( currentPurchase ) ||
+			isExpired( currentPurchase ) ||
+			isInExpirationGracePeriod( currentPurchase );
 		const anotherPurchaseIsExpiring = otherRenewableSitePurchases.some(
-			( otherPurchase ) => isExpiring( otherPurchase ) || isExpired( otherPurchase )
+			( otherPurchase ) =>
+				isExpiring( otherPurchase ) ||
+				isExpired( otherPurchase ) ||
+				isInExpirationGracePeriod( otherPurchase )
 		);
 
 		// Other information needed by some of the messages.
@@ -466,10 +474,15 @@ class PurchaseNotice extends Component<
 		const anotherPurchaseIsCloseToExpiration = otherRenewableSitePurchases.some(
 			( otherPurchase ) => moment( otherPurchase.expiryDate ).diff( Date.now(), 'months' ) < 1
 		);
-		const anotherPurchaseIsExpired = otherRenewableSitePurchases.some( isExpired );
+		const anotherPurchaseIsExpired = otherRenewableSitePurchases.some(
+			( otherPurchase ) => isExpired( otherPurchase ) || isInExpirationGracePeriod( otherPurchase )
+		);
 		const earliestOtherExpiringPurchase = minBy(
 			otherRenewableSitePurchases.filter(
-				( otherPurchase ) => isExpiring( otherPurchase ) || isExpired( otherPurchase )
+				( otherPurchase ) =>
+					isExpiring( otherPurchase ) ||
+					isExpired( otherPurchase ) ||
+					isInExpirationGracePeriod( otherPurchase )
 			),
 			( otherPurchase ) => moment( otherPurchase.expiryDate ).format( 'X' )
 		);
@@ -519,7 +532,7 @@ class PurchaseNotice extends Component<
 			noticeActionText = translate( 'Renew all' );
 			noticeImpressionName = 'current-expires-soon-others-expire-soon';
 
-			if ( isExpired( currentPurchase ) ) {
+			if ( isInExpirationGracePeriod( currentPurchase ) ) {
 				if ( isDomainRegistration( currentPurchase ) ) {
 					noticeText = translate(
 						'Your %(purchaseName)s domain expired %(expiry)s, and you have {{link}}other upgrades{{/link}} on this site that will also be removed soon unless you take action.',
@@ -601,7 +614,7 @@ class PurchaseNotice extends Component<
 			noticeStatus = suppressErrorStylingForCurrentPurchase ? 'is-info' : 'is-error';
 			noticeImpressionName = 'current-expires-soon-others-renew-soon';
 
-			if ( isExpired( currentPurchase ) ) {
+			if ( isInExpirationGracePeriod( currentPurchase ) ) {
 				if ( isDomainRegistration( currentPurchase ) ) {
 					noticeText = translate(
 						'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
@@ -717,7 +730,7 @@ class PurchaseNotice extends Component<
 			! anotherPurchaseIsExpiring
 		) {
 			if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
-				noticeStatus = 'is-success';
+				noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
 				noticeIcon = 'info';
 				noticeImpressionName = 'current-renews-soon-others-renew-soon';
 				noticeText = translate(
@@ -779,7 +792,33 @@ class PurchaseNotice extends Component<
 			noticeStatus = 'is-info';
 			noticeImpressionName = 'current-expires-later-others-renew-soon';
 
-			if ( isPlan( currentPurchase ) && purchaseIsIncludedInPlan ) {
+			if ( isInExpirationGracePeriod( currentPurchase ) ) {
+				noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
+
+				if ( isDomainRegistration( currentPurchase ) ) {
+					noticeText = translate(
+						'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+						translateOptions
+					);
+				} else if ( isPlan( currentPurchase ) ) {
+					if ( purchaseIsIncludedInPlan ) {
+						noticeText = translate(
+							'Your {{managePurchase}}%(purchaseName)s plan{{/managePurchase}} (which includes your %(includedPurchaseName)s subscription) expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+							translateOptions
+						);
+					} else {
+						noticeText = translate(
+							'Your %(purchaseName)s plan expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+							translateOptions
+						);
+					}
+				} else {
+					noticeText = translate(
+						'Your %(purchaseName)s subscription expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+						translateOptions
+					);
+				}
+			} else if ( isPlan( currentPurchase ) && purchaseIsIncludedInPlan ) {
 				noticeText = translate(
 					'You have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
 					translateOptions
@@ -990,12 +1029,31 @@ class PurchaseNotice extends Component<
 			usePlanInsteadOfIncludedPurchase && purchaseAttachedTo ? purchaseAttachedTo : purchase;
 		const includedPurchase = purchase;
 
-		if ( ! isExpired( currentPurchase ) ) {
+		if ( ! isExpired( currentPurchase ) && ! isInExpirationGracePeriod( currentPurchase ) ) {
+			return null;
+		}
+
+		if ( isAkismetFreeProduct( currentPurchase ) ) {
 			return null;
 		}
 
 		if ( isRenewable( purchase ) ) {
-			const noticeText = translate( 'This purchase has expired and is no longer in use.' );
+			const noticeText = ( () => {
+				if ( isInExpirationGracePeriod( purchase ) ) {
+					const purchaseName = getName( purchase );
+					const expiry = moment( purchase.expiryDate ).fromNow();
+					return translate(
+						'Your %(purchaseName)s subscription expired %(expiry)s and will be removed soon unless you take action.',
+						{
+							args: { purchaseName, expiry },
+							comment:
+								'expiry is a relative time string like "3 days ago", purchaseName is the name of the product',
+						}
+					);
+				}
+				return translate( 'This purchase has expired and is no longer in use.' );
+			} )();
+
 			return (
 				<Notice showDismiss={ false } status="is-error" text={ noticeText }>
 					{ this.renderRenewNoticeAction( this.handleExpiredNoticeRenewal ) }
@@ -1126,9 +1184,10 @@ class PurchaseNotice extends Component<
 		};
 
 		const expiry = moment.utc( purchase.expiryDate );
-		const daysToExpiry = isExpired( purchase )
-			? 0
-			: Math.floor( expiry.diff( moment().utc(), 'days', true ) );
+		const daysToExpiry =
+			isExpired( purchase ) || isInExpirationGracePeriod( purchase )
+				? 0
+				: Math.floor( expiry.diff( moment().utc(), 'days', true ) );
 		const productType =
 			productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY
 				? translate( 'ecommerce' )

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.tsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.tsx
@@ -16,6 +16,7 @@ import {
 	isExpiring,
 	isRenewing,
 	showCreditCardExpiringWarning,
+	isInExpirationGracePeriod,
 } from 'calypso/lib/purchases';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isTemporarySitePurchase } from '../../utils';
@@ -67,7 +68,7 @@ export class PlanBillingPeriod extends Component<
 			return translate( 'Billed yearly, credit card expiring soon' );
 		}
 
-		if ( isRenewing( purchase ) && purchase.renewDate ) {
+		if ( isRenewing( purchase ) && purchase.renewDate && ! isInExpirationGracePeriod( purchase ) ) {
 			const renewDate = moment( purchase.renewDate );
 			return translate( 'Billed yearly, renews on %s', {
 				args: renewDate.format( 'LL' ),
@@ -75,7 +76,11 @@ export class PlanBillingPeriod extends Component<
 			} );
 		}
 
-		if ( isExpiring( purchase ) && purchase.expiryDate ) {
+		if (
+			isExpiring( purchase ) &&
+			purchase.expiryDate &&
+			! isInExpirationGracePeriod( purchase )
+		) {
 			return translate( 'Billed yearly, expires on %s', {
 				args: moment( purchase.expiryDate ).format( 'LL' ),
 				comment: '%s is the expiration date in format M DD, Y, for example: June 10, 2019',

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -114,14 +114,16 @@ describe( 'PlanBillingPeriod', () => {
 
 		describe( 'when plan is expiring', () => {
 			it( 'should display a warning to the user', () => {
+				// Use a future date - expiring plans should have a future expiry date
+				const futureDate = moment().add( 1, 'month' );
 				const purchase = {
 					...annualPlanProps.purchase,
-					expiryDate: moment( '2020-01-01' ).format(),
+					expiryDate: futureDate.format(),
 					expiryStatus: 'expiring',
 				};
 				render( <PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } /> );
 				expect( screen.getByText( /billed yearly/i ) ).toHaveTextContent(
-					'Billed yearly, expires on January 1, 2020'
+					`Billed yearly, expires on ${ futureDate.format( 'MMMM D, YYYY' ) }`
 				);
 			} );
 		} );

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -19,6 +19,7 @@ import {
 	isCloseToExpiration,
 	isRenewable,
 	isExpired,
+	isInExpirationGracePeriod,
 } from 'calypso/lib/purchases';
 import { isAkismetTemporarySitePurchase } from 'calypso/me/purchases/utils';
 import { useSelector } from 'calypso/state';
@@ -125,7 +126,8 @@ function PurchaseMetaExpiration( {
 			isAutorenewalEnabled &&
 			! hideAutoRenew &&
 			hasPaymentMethod( purchase ) &&
-			isRechargeable( purchase )
+			isRechargeable( purchase ) &&
+			! isInExpirationGracePeriod( purchase )
 		) {
 			subsBillingText = translate( 'You will be billed on {{dateSpan}}%(renewDate)s{{/dateSpan}}', {
 				args: {
@@ -134,6 +136,16 @@ function PurchaseMetaExpiration( {
 				components: {
 					dateSpan,
 				},
+			} );
+		} else if ( isInExpirationGracePeriod( purchase ) ) {
+			subsBillingText = translate( 'Expired on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
+				args: {
+					expireDate: moment( purchase.expiryDate ).format( 'LL' ),
+				},
+				components: {
+					dateSpan,
+				},
+				comment: 'expireDate is a formatted date like "January 15, 2026"',
 			} );
 		} else {
 			subsBillingText = translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -25,6 +25,7 @@ import {
 	isOneTimePurchase,
 	isRenewing,
 	isSubscription,
+	isInExpirationGracePeriod,
 } from 'calypso/lib/purchases';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -170,7 +171,7 @@ function renderRenewsOrExpiresOnLabel( {
 	domainDetails?: ResponseDomain | null;
 	translate: ReturnType< typeof useTranslate >;
 } ): string | null {
-	if ( isExpiring( purchase ) ) {
+	if ( isExpiring( purchase ) && ! isInExpirationGracePeriod( purchase ) ) {
 		if ( isDomainRegistration( purchase ) ) {
 			if ( domainDetails?.isHundredYearDomain ) {
 				return translate( 'Paid until' );
@@ -187,7 +188,7 @@ function renderRenewsOrExpiresOnLabel( {
 		}
 	}
 
-	if ( isExpired( purchase ) ) {
+	if ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
 		if ( isDomainRegistration( purchase ) ) {
 			return translate( 'Domain expired on' );
 		}
@@ -246,7 +247,7 @@ function renderRenewsOrExpiresOn( {
 		);
 	}
 
-	if ( isExpiring( purchase ) || isExpired( purchase ) ) {
+	if ( isExpiring( purchase ) || isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
 		return <>{ moment( purchase.expiryDate ).format( 'LL' ) }</>;
 	}
 

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -194,7 +194,8 @@ describe( 'Purchase Management Buttons', () => {
 			</QueryClientProvider>
 		);
 
-		expect( await screen.findByText( /remove/ ) ).toBeInTheDocument();
+		// Multiple elements may contain "remove" text (button + notice), so use findAllByText
+		expect( ( await screen.findAllByText( /remove/i ) ).length ).toBeGreaterThan( 0 );
 		expect( await screen.findByText( /Cancel/ ) ).toBeInTheDocument();
 	} );
 

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -47,6 +47,7 @@ import {
 	isIntroductoryOfferFreeTrial,
 	hasPaymentMethod,
 	isPaidWithCredits,
+	isInExpirationGracePeriod,
 } from 'calypso/lib/purchases';
 import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
 import getSiteIconUrl from 'calypso/state/selectors/get-site-icon-url';
@@ -492,6 +493,20 @@ export function PurchaseItemStatus( {
 			);
 		}
 
+		if ( isInExpirationGracePeriod( purchase ) ) {
+			return (
+				<span className="purchase-item__is-error">
+					{ translate( 'Expired %(expiry)s: Pending renewal', {
+						args: {
+							expiry: expiry.fromNow(),
+						},
+						comment:
+							'expiry is relative to the present time and already localized, e.g. "3 days ago"',
+					} ) }
+				</span>
+			);
+		}
+
 		if ( purchase.billPeriodDays ) {
 			const translateOptions = {
 				args: {
@@ -550,7 +565,11 @@ export function PurchaseItemStatus( {
 		);
 	}
 
-	if ( isExpiring( purchase ) && ! isAkismetFreeProduct( purchase ) ) {
+	if (
+		isExpiring( purchase ) &&
+		! isInExpirationGracePeriod( purchase ) &&
+		! isAkismetFreeProduct( purchase )
+	) {
 		if ( expiry < moment().add( 30, 'days' ) && ! isRecentMonthlyPurchase( purchase ) ) {
 			const expiryClass =
 				expiry < moment().add( 7, 'days' )
@@ -581,7 +600,7 @@ export function PurchaseItemStatus( {
 		} );
 	}
 
-	if ( isExpired( purchase ) ) {
+	if ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
 		if ( isConciergeSession( purchase ) ) {
 			return translate( 'Session used on %s', {
 				args: expiry.format( 'LL' ),

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -423,7 +423,11 @@ export function PurchaseItemStatus( {
 		);
 	}
 
-	if ( isWithinIntroductoryOfferPeriod( purchase ) && isIntroductoryOfferFreeTrial( purchase ) ) {
+	if (
+		isWithinIntroductoryOfferPeriod( purchase ) &&
+		isIntroductoryOfferFreeTrial( purchase ) &&
+		! isInExpirationGracePeriod( purchase )
+	) {
 		if ( isRenewing( purchase ) ) {
 			return translate(
 				'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}}',
@@ -494,17 +498,7 @@ export function PurchaseItemStatus( {
 		}
 
 		if ( isInExpirationGracePeriod( purchase ) ) {
-			return (
-				<span className="purchase-item__is-error">
-					{ translate( 'Expired %(expiry)s: Pending renewal', {
-						args: {
-							expiry: expiry.fromNow(),
-						},
-						comment:
-							'expiry is relative to the present time and already localized, e.g. "3 days ago"',
-					} ) }
-				</span>
-			);
+			return <span className="purchase-item__is-error">{ translate( 'Pending renewal' ) }</span>;
 		}
 
 		if ( purchase.billPeriodDays ) {

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -11,6 +11,7 @@ import {
 	purchaseType,
 	isExpired,
 	isRenewing,
+	isInExpirationGracePeriod,
 } from 'calypso/lib/purchases';
 import { managePurchase } from '../paths';
 import type { Purchase } from 'calypso/lib/purchases/types';
@@ -39,13 +40,21 @@ function getExpiresText(
 	purchase: Purchase
 ): TranslateResult {
 	if ( isRenewing( purchase ) ) {
+		if ( isInExpirationGracePeriod( purchase ) ) {
+			return translate( 'Expired %(expiry)s: Pending renewal', {
+				comment:
+					'"expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"',
+				args: { expiry: moment( purchase.expiryDate ).fromNow() },
+			} );
+		}
+
 		return translate( 'renews %(renewDate)s', {
 			comment:
 				'"renewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"',
 			args: { renewDate: moment( purchase.renewDate ).fromNow() },
 		} );
 	}
-	if ( isExpired( purchase ) ) {
+	if ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
 		return translate( 'expired %(expiry)s', {
 			comment:
 				'"expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"',

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -41,11 +41,7 @@ function getExpiresText(
 ): TranslateResult {
 	if ( isRenewing( purchase ) ) {
 		if ( isInExpirationGracePeriod( purchase ) ) {
-			return translate( 'Expired %(expiry)s: Pending renewal', {
-				comment:
-					'"expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"',
-				args: { expiry: moment( purchase.expiryDate ).fromNow() },
-			} );
+			return translate( 'pending renewal' );
 		}
 
 		return translate( 'renews %(renewDate)s', {

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -8,7 +8,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import SectionHeader from 'calypso/components/section-header';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getRenewalItemFromProduct } from 'calypso/lib/cart-values/cart-items';
-import { getName, isExpired, isRenewing } from 'calypso/lib/purchases';
+import { getName, isExpired, isRenewing, isInExpirationGracePeriod } from 'calypso/lib/purchases';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 import { PartialCart } from 'calypso/my-sites/checkout/src/components/secondary-cart-promotions';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -227,7 +227,7 @@ function getMessages( {
 		},
 	};
 
-	if ( isExpired( purchase ) ) {
+	if ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
 		if ( isDomainRegistration( purchase ) ) {
 			message = translate(
 				'Your %(purchaseName)s domain expired %(expiry)s. Would you like to renew it now?',


### PR DESCRIPTION
Part of #https://linear.app/a8c/issue/SHILL-912
Related to 198919-ghe-Automattic/wpcom

## Proposed Changes
  * Add date-based past-expiry checks in `purchase-expiry-status/index.tsx` to show "Expired X days ago" instead of "Expires on [past date]"
  * Add `FormattedExpiredStatus` component following existing `FormattedExpiryDate` pattern
  * Add past-expiry checks in `purchase-expiring-notice.tsx` for main notice, included-plan notice, and manual-renew notices
  * Add past-expiry checks in `other-renewable-purchases-notice.tsx` to handle expired current purchase and expired other purchases messaging


  * Add `isInExpirationGracePeriod()` helper function to detect purchases that are past their expiry date but not yet fully expired (still in grace period)                                                                                                                                                           
  * Update expiration notices to use past tense ("expired X days ago") instead of future tense ("will expire") when the purchase is in the grace period             
  * Change notice styling from `is-success` to `is-error` for grace period purchases to convey appropriate urgency                                                  
  * Update `needsToRenewSoon()` to include past-expiry purchases that are still renewable                                                                           
  * Fix date display in purchase meta to show "Expired on" instead of "You will be billed on" for grace period purchases                                            
  * Update purchase item status to show "Expired X ago: Pending renewal" for grace period purchases                                                                 
  * Apply changes across both dashboard (React Query) and classic (Redux) 


## Why are these changes being made?
After the backend fix in wpcom PR #198919, active subscriptions with past expiry dates return `expiry_status: 'expiring'` or `'auto-renewing'` instead of `'expired'`. This is correct behavior—the subscription is still active, just past its expiry date with renewal pending.
However, Calypso's messaging logic assumed these statuses meant the expiry date was in the future, producing awkward messages like:
  - "Your WordPress.com Premium plan will expire 3 days ago"
  - "You have other upgrades on this site that will expire 5 days ago"

This PR adds date-based checks to use past-tense messaging when the expiry date is in the past:
  - "Your WordPress.com Premium plan expired 3 days ago"
  - "You have other upgrades on this site that expired 5 days ago"


**Deployment order**: This Calypso PR should be merged first, as it handles past-expiry dates gracefully regardless of the backend. Then merge wpcom PR #198919.  Merging out of order should not cause anything to break, but the messages will be strange until it is.

## Translations <a href="#user-content-translations" id="new_translations">#</a>
There are 3 new translation strings:

1.     `Expired %(expiry)s: Pending renewal`
      - /me/purchases (list item)                                                                                                                                   
      - /dashboard/me/billing/purchases (list)
      - /me/billing/purchases/:id  (Help text under "Enable auto-renew" toggle )                                                                                                                      
      - /dashboard/me/billing/payment-methods (delete dialog)       
      - "expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"
      - <img width="1497" height="864" alt="image" src="https://github.com/user-attachments/assets/93e508d7-552b-4a55-b439-31fe8ce87078" />




2.   `Your %(purchaseName)s subscription expired %(expiry)s and will be removed soon unless you take action.`
      - /me/purchases/{site}/{id}                                                                                                                                   
      - /dashboard/me/billing/purchases/{id}        
      - purchaseName is the name of the product, expiry is a string like "3 days ago               
      - <img width="1499" height="860" alt="image" src="https://github.com/user-attachments/assets/4cc128a3-b7b1-409f-b7c8-1dff19005554" />
      - <img width="1254" height="852" alt="image" src="https://github.com/user-attachments/assets/5531150a-6360-4b60-9f56-1593acf481ec" />



3.   `Expired on {{dateSpan}}%(expireDate)s{{/dateSpan}}`
     - /me/purchases/{site}/{id} (meta section)  
     - expireDate is a formatted date like "January 15, 2026"                                                                                                   
     - <img width="1254" height="852" alt="image" src="https://github.com/user-attachments/assets/955dd8dd-d3d4-4065-b9d7-75048ca2de95" />





## Testing Instructions

  ### Manual Testing

  #### Prerequisites
  - Sandbox with billing write mode enabled
  ```php                                                                                                                                                            
  define( 'USE_STORE_SANDBOX', true );                                                                                                                              
  define( 'USE_BILLING_SANDBOX', true );                                                                                                                            
  define( 'BILLINGDADDY_SANDBOX', rtrim( 'https://' . `hostname` ) );      
  ```
  - Sandbox with wpcom PR #198919 applied
  - local Calypso with branch loaded
  - A test site with expired subscriptions in grace period (see Manual Data Setup to mock)

  #### Manual Data Setup

on your wpcom sandbox, modify store-subscription.php temporarily):                                                                               
  // In Store_Subscription::to_billing_upgrade() around line 4648                    
  // Manipulate: expiry, auto_renew, bill_period, subscription_status and renew_date
```
// TEST SCENARIOS - uncomment ONE line at a time:
		$this->expiry = gmdate( 'Y-m-d', time() + 30*DAY_IN_SECONDS ); $this->auto_renew = 1;  // Future 30d, auto ON (A1) 
//		$this->expiry = gmdate( 'Y-m-d', time() + 30*DAY_IN_SECONDS ); $this->auto_renew = 0;  // Future 30d, auto OFF (A2/H) <-- ACTIVE
//		$this->expiry = gmdate( 'Y-m-d', time() + 5*DAY_IN_SECONDS ); $this->auto_renew = 1;  // 5 days until expiry, auto ON (B1)
//		$this->expiry = gmdate( 'Y-m-d', time() + 5*DAY_IN_SECONDS ); $this->auto_renew = 0;  // 5 days until expiry, auto OFF (B1)
//		$this->expiry = gmdate( 'Y-m-d' ); $this->auto_renew = 1;  // Day 0, auto ON
//		$this->expiry = gmdate( 'Y-m-d' ); $this->auto_renew = 0;  /// Day 0, auto OFF (B2)
//		$this->expiry = gmdate( 'Y-m-d', time() - 3*DAY_IN_SECONDS ); $this->auto_renew = 1;  // Days 1-6, auto ON (C1) //
//		$this->expiry = gmdate( 'Y-m-d', time() - 3*DAY_IN_SECONDS ); $this->auto_renew = 0;  // Days 1-6, auto OFF (D1)/
//		$this->expiry = gmdate( 'Y-m-d', time() - 8*DAY_IN_SECONDS ); $this->auto_renew = 1;  // Days 7-10, auto ON (C2)
//		$this->expiry = gmdate( 'Y-m-d', time() - 35*DAY_IN_SECONDS ); $this->auto_renew = 1;  // Days 30+, auto ON 
//		$this->expiry = gmdate( 'Y-m-d', time() - 35*DAY_IN_SECONDS ); $this->auto_renew = 0;  // Days 30+, auto OFF
//		$this->expiry = gmdate( 'Y-m-d', time() - 15*DAY_IN_SECONDS ); $this->auto_renew = 0; $this->subscription_status = 'inactive';  // Day 11+ (Cancelled) (E1) 
//		$this->expiry = gmdate( 'Y-m-d', time() - 15*DAY_IN_SECONDS ); $this->auto_renew = 1; $this->subscription_status = 'inactive';  // Day 11+ (Cancelled) (E1)
//		$this->expiry = gmdate( 'Y-m-d', time() - 3*DAY_IN_SECONDS ); $this->auto_renew = 0; $this->bill_period = 31;  // Expired monthly (G1) 
//		$this->expiry = gmdate( 'Y-m-d', time() - 3*DAY_IN_SECONDS ); $this->auto_renew = 1; $this->bill_period = 31;  // Expired monthly (G1)
//		$this->expiry = gmdate( 'Y-m-d', time() + 25*DAY_IN_SECONDS ); $this->auto_renew = 0; $this->bill_period = 31;  // Future monthly 25d (G2)
//		$this->expiry = gmdate( 'Y-m-d', time() + 25*DAY_IN_SECONDS ); $this->auto_renew = 1; $this->bill_period = 31;  // Future monthly 25d (G2)
//		$this->expiry = gmdate( 'Y-m-d', time() - 35*DAY_IN_SECONDS ); $this->auto_renew = 0; $this->bill_period = 31;  $this->subscription_status = 'inactive';
//		$this->expiry = gmdate( 'Y-m-d', time() - 35*DAY_IN_SECONDS ); $this->auto_renew = 1; $this->bill_period = 31;  $this->subscription_status = 'inactive';
```

  //  
  //         note: renew_date must be edited after it is set later in the method: $purchase->renew_date = $this->get_date_as_ISO_8601
```
  $purchase->renew_date = $this->get_date_as_ISO_8601( '@' . ( strtotime( $this->expiry ) - DAY_IN_SECONDS*3 ) ); // TEST HACK: renew 1 day before expiry
```


  #### Steps

 1. Load Purchases lists:
     - /me/purchases
     - /me/billing/purchases 
     - Check Expires/Renews on column 
 3. Click on Purchases to load Detail Views
     - /me/purchases/{site-slug}/{purchase-id}
     - /me/billing/purchases/1199598
     - Check notification message
         - Upcoming renewals
         - Other purchases
     - Check expiry message: Expires/Renews/Expired 
     - Check expiration/renewal date
 3. Checkout with a purchase in grace period (set mock data ?shill912=c1)                                                                                             
   -  Go to checkout to buy something else on that same site (e.g., add a domain)                                                                                    
   - URL: /checkout/{site-slug} with items in cart                                                                                                                  
   - The "Upcoming Renewals" reminder should appear offering to also renew the grace period purchase   
  5. Payment Method Delete Dialog /dashboard/me/billing/payment-methods
 - Prerequisites:                                                                                                                                                    
    - User has a stored payment method (credit card)                                                                                                                
    - A subscription purchased with that payment method (stored_details_id matches)                                                                                 
    - Subscription has is_auto_renew_enabled = true                                                                                                                 
    - Subscription is in grace period (mock case C1 only - C2 won't show because auto-renew is off)                                                                                                                                                                                                  
 -   Steps:                                                                                                                                                            
    1. Go to /dashboard/me/billing/payment-methods                                                                                                                  
    2. Find a payment method with an associated subscription                                                                                                        
    3. Click the menu → "Remove payment method"                                                                                                                     
    5. Dialog opens with "Associated subscriptions" section    

Genereal scenarios to validate:
  1. Expired (inactive) - fully expired, subscription removed                                                                                                       
  2. Grace period + auto-renew ON - past expiry, pending renewal                                                                                                    
  3. Grace period + auto-renew OFF - past expiry, needs action                                                                                                      
  4. Expiring soon - future expiry, auto-renew OFF                                                                                                                  
  6. Renewing soon - future expiry, auto-renew ON                                                                                                                   
  7. Active - not expiring soon     
  8. Never expires

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?