### PR TITLE
Revert "Webpack: Make sure isDevelopmentAsset identifies .map assets …

### DIFF
--- a/build-tools/webpack/assets-writer-plugin.js
+++ b/build-tools/webpack/assets-writer-plugin.js
@@ -46,15 +46,8 @@ Object.assign( AssetsWriter.prototype, {
 				return path.join( stats.publicPath, f );
 			}
 
-			// Exclude hot update files (info.hotModuleReplacement) and source maps.
-			// `asset.info.development` is false when using hidden-source-map,
-			// so we also explicitly filter out any `.map` assets by filename.
+			// Exclude hot update files (info.hotModuleReplacement) and source maps (info.development)
 			function isDevelopmentAsset( name ) {
-				// Treat all source map files as development-only so they are never inlined into HTML.
-				if ( name.endsWith( '.map' ) ) {
-					return true;
-				}
-
 				const asset = stats.assets.find( ( a ) => a.name === name );
 				if ( ! asset ) {
 					return false;


### PR DESCRIPTION
This reverts commit c2e78695a016fb5c9476cc1f3ace66fcfbc153d3.

## Proposed Changes

Just in case.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
