### PR TITLE
Add dashboard-review skill and command for Claude Code

### DIFF
--- a/.claude/commands/dashboard-review.md
+++ b/.claude/commands/dashboard-review.md
@@ -1,0 +1,35 @@
+# Dashboard Code Review
+
+Review the provided code for WordPress.com Dashboard compliance.
+
+## Checklist
+
+### 1. External Link Handling
+- [ ] All URLs linking to non-Dashboard routes use `wpcomLink()` from `client/dashboard/utils/link`
+- [ ] `/checkout` links have `redirect_to` and `cancel_to` params
+- [ ] `/setup/plan-upgrade` links have `cancel_to` param
+
+### 2. Mutation Callbacks
+- [ ] `onSuccess`/`onError` are on `mutate()` call, not `useMutation()`
+- [ ] Query option callbacks are not overridden
+
+### 3. Typography and Copy
+- [ ] Buttons/labels use sentence case (not Title Case)
+- [ ] Sentences end with periods; buttons/labels do not
+- [ ] Curly quotes and proper apostrophes used
+- [ ] "Hosting Dashboard" capitalized as proper noun
+
+### 4. Snackbar Messages
+- [ ] Follow pattern: `Action completed.` or `Failed to do action.`
+
+## Instructions
+
+1. Search the provided files for hardcoded WordPress.com URLs
+2. Check mutation patterns against the documented approach
+3. Review all user-facing copy for typography compliance
+4. Report findings with specific file:line references
+
+Reference docs if needed:
+- client/dashboard/docs/data-library.md
+- client/dashboard/docs/ui-components.md
+- client/dashboard/docs/typography-and-copy.md

--- a/.claude/skills/dashboard-review/SKILL.md
+++ b/.claude/skills/dashboard-review/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: dashboard-review
+description: Review code for WordPress.com Dashboard compliance. Use when reviewing dashboard code, checking for wpcomLink() usage, mutation callback patterns, typography standards, or when asked to review dashboard PRs.
+allowed-tools: Read, Grep, Glob
+---
+
+# Dashboard Code Review
+
+Review code in `client/dashboard/` for compliance with dashboard coding standards.
+
+## Review Checklist
+
+### 1. External Link Handling
+
+All URLs linking to non-Dashboard routes MUST use `wpcomLink()` from `client/dashboard/utils/link`.
+
+**Checkout and upgrade links** (always use `wpcomLink()`):
+- `/checkout` must have `redirect_to` and `cancel_to` query params
+- `/setup/plan-upgrade` must have `cancel_to` query param
+
+### 2. Mutation Callback Handling
+
+Component-specific `onSuccess`/`onError` callbacks belong on the `mutate()` call, NOT `useMutation()`:
+
+```typescript
+// Correct - callback on mutate call
+const { mutate: saveSetting } = useMutation( saveSettingMutation() );
+
+const handleSave = () => {
+  saveSetting( newValue, {
+    onSuccess: () => setShowSuccessMessage( true ),
+    onError: ( error ) => setError( error.message ),
+  } );
+};
+
+// Incorrect - overrides query option callbacks, breaks cache updates
+const { mutate: saveSetting } = useMutation( {
+  ...saveSettingMutation(),
+  onSuccess: () => setShowSuccessMessage( true ),
+} );
+```
+
+### 3. Typography and Copy
+
+- **Sentence case**: Buttons, labels, and headings use sentence case (not Title Case)
+- **Periods**: Sentences end with periods; buttons and labels do not
+- **Quotes**: Use curly quotes ("like this") and proper apostrophes (it's)
+- **Product names**: "Hosting Dashboard" is capitalized as a proper noun
+
+```typescript
+// Correct
+<Button>Save changes</Button>
+<p>Your settings have been saved.</p>
+
+// Incorrect
+<Button>Save Changes.</Button>  // Title case + period
+<p>Your settings have been saved</p>  // Missing period
+```
+
+### 4. Snackbar Message Patterns
+
+```typescript
+// Success messages
+`SSH access enabled.`
+`Settings saved.`
+
+// Error messages
+`Failed to save PHP version.`
+`Could not enable SSH access.`
+```
+
+## Reference Documentation
+
+For detailed implementation guidance, consult:
+- [Data Library](client/dashboard/docs/data-library.md) - TanStack Query usage, loaders, caching
+- [UI Components](client/dashboard/docs/ui-components.md) - WordPress components, placeholders, DataViews
+- [Router](client/dashboard/docs/router.md) - TanStack Router patterns, lazy loading
+- [Internationalization](client/dashboard/docs/i18n.md) - Translation patterns, CSS logical properties
+- [Typography and Copy](client/dashboard/docs/typography-and-copy.md) - Capitalization, snackbar messages
+- [Testing](client/dashboard/docs/testing.md) - Testing strategies
+
+## Review Process
+
+1. **Grep for potential issues**: Search for hardcoded WordPress.com URLs, `useMutation` with inline callbacks
+2. **Check imports**: Verify `wpcomLink` is imported where external links are used
+3. **Review copy**: Check button text, labels, and messages for sentence case and proper punctuation
+4. **Validate patterns**: Compare mutation usage against documented patterns

--- a/.rules/dashboard-rules.mdc
+++ b/.rules/dashboard-rules.mdc
@@ -18,83 +18,43 @@ For detailed implementation guidance, refer to:
 - [Typography and Copy](mdc:client/dashboard/docs/typography-and-copy.md) - Capitalization, snackbar messages
 - [Testing](mdc:client/dashboard/docs/testing.md) - Testing strategies
 
-## Code Review Guidelines
+## Writing Guidelines
 
-When reviewing dashboard code, watch for these specific patterns and potential issues:
+When writing dashboard code, follow these patterns:
 
-### External Link Handling
+### External Links
 
-- All URLs linking to old WordPress.com/Calypso MUST use `wpcomLink()` function
-	- **Import**: Use `import { wpcomLink } from '@automattic/dashboard/utils/link'`
-	- **Purpose**: Ensures proper environment configuration (dev vs production hostnames)
-- Every link to `/checkout` must have `redirect_to` and `cancel_to` query param
-	- **Purpose**: Ensures correct behaviour when exiting the checkout screen
-- Every link to `/setup/plan-upgrade` must have a `cancel_to` query param
-	- **Purpose**: Ensures correct behaviour when exiting the upgrade screen
+Use `wpcomLink()` for all WordPress.com/Calypso URLs:
 
 ```typescript
-// ✅ Correct - wrapped with wpcomLink()
+import { wpcomLink } from '@automattic/dashboard/utils/link';
+
 <a href={ wpcomLink( '/me/security' ) }>Security Settings</a>
-
-// ❌ Incorrect - hardcoded WordPress.com URL
-<a href="https://wordpress.com/me/security">Security Settings</a>
-
-// ❌ Incorrect - relative URL to old dashboard
-<a href="/me/security">Security Settings</a>
 ```
 
-### Mutation Callback Handling
+- `/checkout` links: include `redirect_to` and `cancel_to` query params
+- `/setup/plan-upgrade` links: include `cancel_to` query param
 
-- **Component-specific Callbacks**: Attach `onSuccess`/`onError` to the `mutate()` call, not `useMutation()`
-- **Query Options**: Don't override callbacks defined in api-queries mutation options
-- **Cache Updates**: Query option callbacks handle cache invalidation and updates
+### Mutations
+
+Attach component-specific callbacks to `mutate()`, not `useMutation()`:
 
 ```typescript
-// ✅ Correct - callback on mutate call
 const { mutate: saveSetting } = useMutation( saveSettingMutation() );
 
-const handleSave = () => {
-  saveSetting( newValue, {
-    onSuccess: () => {
-      // Component-specific success handling
-      setShowSuccessMessage( true );
-    },
-    onError: ( error ) => {
-      // Component-specific error handling
-      setError( error.message );
-    },
-  } );
-};
-
-// ❌ Incorrect - overrides query option callbacks
-const { mutate: saveSetting } = useMutation( {
-  ...saveSettingMutation(),
-  onSuccess: () => setShowSuccessMessage( true ), // Breaks cache updates!
+saveSetting( newValue, {
+  onSuccess: () => setShowSuccessMessage( true ),
   onError: ( error ) => setError( error.message ),
 } );
 ```
 
-### Typography and Copy Compliance
+### Copy Standards
 
-- **Sentence Case**: Verify buttons, labels, and headings use sentence case (not title case)
-- **Periods**: Check sentences end with periods; buttons and labels do not
-- **Curly Quotes**: Ensure proper curly quotes (“like this”) and apostrophes (it’s) are used
-- **Product Names**: "Hosting Dashboard" should be capitalized as proper noun
-- **Snackbar Patterns**: Follow established patterns for success/error messages
+- Sentence case for buttons, labels, headings
+- Periods end sentences, not buttons/labels
+- Use curly quotes ("like this") and proper apostrophes (it's)
+- Snackbar format: `Action completed.` or `Failed to do action.`
 
-```typescript
-// ✅ Correct copy patterns
-<Button>Save changes</Button>  // No period, sentence case
-<p>Your settings have been saved.</p>  // Period, curly quotes if needed
+## Code Review
 
-// Snackbar messages
-`SSH access enabled.`
-`Failed to save PHP version.`
-
-// ❌ Incorrect patterns  
-<Button>Save Changes.</Button>  // Has period, title case
-<p>Your settings have been saved</p>  // Missing period
-`SSH Access Enabled`  // Title case, missing period
-```
-
-Remember: This dashboard represents modern React patterns. Prioritize performance, accessibility, and maintainability while leveraging the WordPress ecosystem.
+For detailed code review against dashboard standards, use the `/dashboard-review` command.


### PR DESCRIPTION
## Proposed Changes

* Add `.claude/skills/dashboard-review/SKILL.md` - auto-triggered skill for reviewing dashboard code compliance
* Add `.claude/commands/dashboard-review.md` - manual `/dashboard-review` slash command
* Refactor `.rules/dashboard-rules.mdc` - simplify to focus on writing guidance, defer review details to the skill

## Why are these changes being made?

The dashboard rules file was serving two purposes: guiding code writing and providing a code review checklist. This created duplication and made the file verbose.

By separating concerns:
- **Writing guidance** stays in `.rules/dashboard-rules.mdc` (always loaded as context)
- **Review checklist** moves to the skill/command (on-demand activation)

This gives developers:
- Concise guidance while writing code
- Explicit `/dashboard-review` command to review code against dashboard standards
- Auto-triggered review when Claude detects relevant context

## Testing Instructions

* Restart Claude Code
* Type `/dashboard-review` followed by a file path - should invoke the review
* Work on dashboard code - the skill should auto-trigger when reviewing dashboard files
* Verify `.rules/dashboard-rules.mdc` still loads as context when working in `client/dashboard/`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.ai/code)