### PR TITLE
MSD: use useSuspenseQuery in /me/profile to avoid flash

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -6,6 +6,7 @@ import {
 	connectedApplicationsQuery,
 	countryListQuery,
 	geoLocationQuery,
+	isAutomatticianQuery,
 	monetizeSubscriptionsQuery,
 	plansQuery,
 	productsQuery,
@@ -86,6 +87,12 @@ export const profileRoute = createRoute( {
 	} ),
 	getParentRoute: () => meRoute,
 	path: 'profile',
+	loader: async () => {
+		await Promise.all( [
+			queryClient.ensureQueryData( userSettingsQuery() ),
+			queryClient.ensureQueryData( isAutomatticianQuery() ),
+		] );
+	},
 } ).lazy( () =>
 	import( '../../me/profile' ).then( ( d ) =>
 		createLazyRoute( 'profile' )( {

--- a/client/dashboard/me/profile-gravatar/index.tsx
+++ b/client/dashboard/me/profile-gravatar/index.tsx
@@ -1,5 +1,5 @@
-import { userSettingsMutation } from '@automattic/api-queries';
-import { useMutation } from '@tanstack/react-query';
+import { userSettingsMutation, userSettingsQuery } from '@automattic/api-queries';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	Button,
 	ExternalLink,
@@ -23,10 +23,6 @@ import EditGravatar from './edit-gravatar';
 import GravatarLogo from './gravatar-logo';
 import type { UserSettings } from '@automattic/api-core';
 import type { Field, Form } from '@wordpress/dataviews';
-
-interface GravatarProfileSectionProps {
-	profile: UserSettings;
-}
 
 const fields: Field< UserSettings >[] = [
 	{
@@ -98,16 +94,16 @@ const controlledKeys = fields
 	.filter( ( field ) => field.id !== 'avatar_URL' )
 	.map( ( field ) => field.id );
 
-export default function GravatarProfileSection( {
-	profile: serverProfile,
-}: GravatarProfileSectionProps ) {
+export default function GravatarProfileSection() {
+	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+
 	const [ edits, setEdits ] = useState< Partial< UserSettings > >( {} );
-	const data = useMemo( () => ( { ...serverProfile, ...edits } ), [ serverProfile, edits ] );
+	const data = useMemo( () => ( { ...userSettings, ...edits } ), [ userSettings, edits ] );
 	const mutation = useMutation( userSettingsMutation() );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const isSaving = mutation.isPending;
 	const isDirty = controlledKeys.some(
-		( key ) => data[ key as keyof UserSettings ] !== serverProfile[ key as keyof UserSettings ]
+		( key ) => data[ key as keyof UserSettings ] !== userSettings[ key as keyof UserSettings ]
 	);
 	const { validity, isValid } = useFormValidity( data, fields, form );
 

--- a/client/dashboard/me/profile-gravatar/test/validation.test.tsx
+++ b/client/dashboard/me/profile-gravatar/test/validation.test.tsx
@@ -8,13 +8,28 @@ import { render } from '../../../test-utils';
 import { mockUserSettings } from '../../profile/__mocks__/user-settings';
 import GravatarProfileSection from '../index';
 
+jest.mock( '@automattic/api-queries', () => ( {
+	...jest.requireActual( '@automattic/api-queries' ),
+	userSettingsQuery: jest.fn(),
+} ) );
+
 describe( 'GravatarProfileSection Form Validation', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		const { userSettingsQuery } = require( '@automattic/api-queries' );
+		userSettingsQuery.mockReturnValue( {
+			queryKey: [ 'me', 'settings' ],
+			queryFn: () => Promise.resolve( mockUserSettings ),
+		} );
+	} );
+
 	describe( 'Display Name Validation', () => {
 		it( 'should show validation error for display names longer than 250 characters', async () => {
 			const user = userEvent.setup();
-			render( <GravatarProfileSection profile={ mockUserSettings } /> );
+			render( <GravatarProfileSection /> );
 
-			const displayNameInput = screen.getByDisplayValue( 'Test User' );
+			const displayNameInput = await screen.findByDisplayValue( 'Test User' );
 			const longName = 'a'.repeat( 251 );
 
 			await user.clear( displayNameInput );
@@ -28,9 +43,9 @@ describe( 'GravatarProfileSection Form Validation', () => {
 
 		it( 'should accept display names at the character limit', async () => {
 			const user = userEvent.setup();
-			render( <GravatarProfileSection profile={ mockUserSettings } /> );
+			render( <GravatarProfileSection /> );
 
-			const displayNameInput = screen.getByDisplayValue( 'Test User' );
+			const displayNameInput = await screen.findByDisplayValue( 'Test User' );
 			const maxLengthName = 'a'.repeat( 250 );
 
 			await user.clear( displayNameInput );
@@ -44,9 +59,9 @@ describe( 'GravatarProfileSection Form Validation', () => {
 
 		it( 'should disable save button when display name validation fails', async () => {
 			const user = userEvent.setup();
-			render( <GravatarProfileSection profile={ mockUserSettings } /> );
+			render( <GravatarProfileSection /> );
 
-			const displayNameInput = screen.getByDisplayValue( 'Test User' );
+			const displayNameInput = await screen.findByDisplayValue( 'Test User' );
 			const longName = 'a'.repeat( 251 );
 
 			await user.clear( displayNameInput );
@@ -60,9 +75,9 @@ describe( 'GravatarProfileSection Form Validation', () => {
 	describe( 'URL Validation', () => {
 		it( 'should show validation error for invalid URLs', async () => {
 			const user = userEvent.setup();
-			render( <GravatarProfileSection profile={ mockUserSettings } /> );
+			render( <GravatarProfileSection /> );
 
-			const urlInput = screen.getByDisplayValue( 'https://example.com' );
+			const urlInput = await screen.findByDisplayValue( 'https://example.com' );
 
 			await user.clear( urlInput );
 			await user.type( urlInput, 'not-a-url' );
@@ -73,9 +88,9 @@ describe( 'GravatarProfileSection Form Validation', () => {
 
 		it( 'should accept valid URLs', async () => {
 			const user = userEvent.setup();
-			render( <GravatarProfileSection profile={ mockUserSettings } /> );
+			render( <GravatarProfileSection /> );
 
-			const urlInput = screen.getByDisplayValue( 'https://example.com' );
+			const urlInput = await screen.findByDisplayValue( 'https://example.com' );
 
 			await user.clear( urlInput );
 			await user.type( urlInput, 'https://valid-url.com' );
@@ -86,9 +101,9 @@ describe( 'GravatarProfileSection Form Validation', () => {
 
 		it( 'should allow empty URLs (optional field)', async () => {
 			const user = userEvent.setup();
-			render( <GravatarProfileSection profile={ mockUserSettings } /> );
+			render( <GravatarProfileSection /> );
 
-			const urlInput = screen.getByDisplayValue( 'https://example.com' );
+			const urlInput = await screen.findByDisplayValue( 'https://example.com' );
 
 			await user.clear( urlInput );
 			fireEvent.blur( urlInput );
@@ -98,9 +113,9 @@ describe( 'GravatarProfileSection Form Validation', () => {
 
 		it( 'should disable save button when URL validation fails', async () => {
 			const user = userEvent.setup();
-			render( <GravatarProfileSection profile={ mockUserSettings } /> );
+			render( <GravatarProfileSection /> );
 
-			const urlInput = screen.getByDisplayValue( 'https://example.com' );
+			const urlInput = await screen.findByDisplayValue( 'https://example.com' );
 
 			await user.clear( urlInput );
 			await user.type( urlInput, 'invalid-url' );

--- a/client/dashboard/me/profile-personal-details/index.tsx
+++ b/client/dashboard/me/profile-personal-details/index.tsx
@@ -24,13 +24,7 @@ import UsernameSection from './username-section';
 import type { UserSettings } from '@automattic/api-core';
 import './style.scss';
 
-interface PersonalDetailsSectionProps {
-	profile: UserSettings;
-}
-
-export default function PersonalDetailsSection( {
-	profile: serverProfile,
-}: PersonalDetailsSectionProps ) {
+export default function PersonalDetailsSection() {
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
 	const isMobile = useViewportMatch( 'small', '<' );
@@ -48,11 +42,11 @@ export default function PersonalDetailsSection( {
 		},
 	} );
 
-	const data = useMemo( () => ( { ...serverProfile, ...edits } ), [ serverProfile, edits ] );
+	const data = useMemo( () => ( { ...userSettings, ...edits } ), [ userSettings, edits ] );
 
-	const currentUsername = userSettings?.user_login || '';
-	const isEmailVerified = userSettings?.email_verified ?? true;
-	const canChangeUsername = userSettings?.user_login_can_be_changed ?? true;
+	const currentUsername = userSettings.user_login || '';
+	const isEmailVerified = userSettings.email_verified ?? true;
+	const canChangeUsername = userSettings.user_login_can_be_changed ?? true;
 
 	// Form event handlers
 	const handleFieldChange = ( partial: Partial< UserSettings > ) => {
@@ -88,7 +82,7 @@ export default function PersonalDetailsSection( {
 		if ( key === 'user_login' ) {
 			return false;
 		}
-		return data?.[ key as keyof UserSettings ] !== serverProfile?.[ key as keyof UserSettings ];
+		return data[ key as keyof UserSettings ] !== userSettings[ key as keyof UserSettings ];
 	} );
 
 	const isSaving = mutation.isPending;

--- a/client/dashboard/me/profile-personal-details/test/index.test.tsx
+++ b/client/dashboard/me/profile-personal-details/test/index.test.tsx
@@ -79,7 +79,7 @@ const renderWithUserData = ( userData = mockUserSettings ) => {
 		queryFn: () => Promise.resolve( userData.user_email?.includes( 'automattic.com' ) || false ),
 	} );
 
-	const result = render( <PersonalDetailsSection profile={ userData } /> );
+	const result = render( <PersonalDetailsSection /> );
 
 	return result;
 };

--- a/client/dashboard/me/profile/index.tsx
+++ b/client/dashboard/me/profile/index.tsx
@@ -1,5 +1,3 @@
-import { userSettingsQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
@@ -9,12 +7,6 @@ import GravatarProfileSection from '../profile-gravatar';
 import PersonalDetailsSection from '../profile-personal-details';
 
 export default function Profile() {
-	const { data: serverData } = useQuery( userSettingsQuery() );
-
-	if ( ! serverData ) {
-		return null;
-	}
-
 	return (
 		<PageLayout
 			size="small"
@@ -30,10 +22,8 @@ export default function Profile() {
 				/>
 			}
 		>
-			<PersonalDetailsSection profile={ serverData } />
-
-			<GravatarProfileSection profile={ serverData } />
-
+			<PersonalDetailsSection />
+			<GravatarProfileSection />
 			<AccountDeletionSection />
 		</PageLayout>
 	);


### PR DESCRIPTION

## Proposed Changes

Use `useSuspenseQuery()` in MSD /me/profile to avoid flash 

## Why are these changes being made?

MSD `/me/profile` page currently flashes while the settings is not fully fetched.

## Testing Instructions

- Go to MSD /me/profile
- Smoke-test the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
