### PR TITLE
MSD: Handle is_launched status for ES site list

### DIFF
--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -6,7 +6,6 @@ import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import SiteIcon, { SiteIconRenderer } from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
-import { isSiteStatusBadge } from '../../utils/site-badge';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName, getSitePlanDisplayName__ES } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
@@ -36,7 +35,6 @@ import {
 	Visibility,
 } from '../site-fields';
 import type { AppConfig } from '../../app/context';
-import type { SiteStatus } from '../../types';
 import type { Site, DashboardSiteListSite } from '@automattic/api-core';
 import type { Field, Operator, View } from '@wordpress/dataviews';
 
@@ -361,15 +359,11 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 				operators: [ 'isAny' as Operator ],
 			},
 			render: ( { item, field } ) => {
-				// Convert the badge to status.
-				const badge = item.badge ?? null;
-				const status = isSiteStatusBadge( badge ) ? badge : null;
-
 				return (
 					<Visibility
 						siteSlug={ item.slug }
 						visibility={ field.getValue( { item } ) }
-						status={ status as SiteStatus }
+						status={ item.status ?? null }
 						isLaunched={ item.wpcom_status?.is_launched == null || item.wpcom_status?.is_launched }
 					/>
 				);

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -6,9 +6,11 @@ import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import SiteIcon, { SiteIconRenderer } from '../../components/site-icon';
 import TimeSince from '../../components/time-since';
+import { isSiteStatusBadge } from '../../utils/site-badge';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName, getSitePlanDisplayName__ES } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
+import { getSiteStatus } from '../../utils/site-status';
 import {
 	isSelfHostedJetpackConnected,
 	isSelfHostedJetpackConnected__ES,
@@ -34,6 +36,7 @@ import {
 	Visibility,
 } from '../site-fields';
 import type { AppConfig } from '../../app/context';
+import type { SiteStatus } from '../../types';
 import type { Site, DashboardSiteListSite } from '@automattic/api-core';
 import type { Field, Operator, View } from '@wordpress/dataviews';
 
@@ -130,7 +133,14 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 			filterBy: {
 				operators: [ 'isAny' as Operator ],
 			},
-			render: ( { item } ) => <Visibility site={ item } />,
+			render: ( { item, field } ) => (
+				<Visibility
+					siteSlug={ item.slug }
+					visibility={ field.getValue( { item } ) }
+					status={ getSiteStatus( item ) }
+					isLaunched={ item.launch_status === 'launched' || item.launch_status === false }
+				/>
+			),
 		},
 		{
 			id: 'wp_version',
@@ -330,8 +340,10 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 			id: 'visibility',
 			label: __( 'Visibility' ),
 			getValue: ( { item } ) => {
-				// TODO: Handle `unlaunched` status
-				if ( item.wpcom_status?.is_coming_soon ) {
+				if (
+					item.wpcom_status?.is_coming_soon ||
+					( item.private && ! item.wpcom_status?.is_launched )
+				) {
 					return 'coming_soon';
 				}
 
@@ -349,8 +361,18 @@ function getDefaultFields__ES( queries: AppConfig[ 'queries' ] ): Field< Dashboa
 				operators: [ 'isAny' as Operator ],
 			},
 			render: ( { item, field } ) => {
-				const value = field.getValue( { item } );
-				return visibilityLabels[ value as keyof typeof visibilityLabels ];
+				// Convert the badge to status.
+				const badge = item.badge ?? null;
+				const status = isSiteStatusBadge( badge ) ? badge : null;
+
+				return (
+					<Visibility
+						siteSlug={ item.slug }
+						visibility={ field.getValue( { item } ) }
+						status={ status as SiteStatus }
+						isLaunched={ item.wpcom_status?.is_launched == null || item.wpcom_status?.is_launched }
+					/>
+				);
 			},
 			enableSorting: false,
 		},

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -108,7 +108,7 @@ function getFetchSiteListParams(
 		name: [ 'badge' ],
 		plan: [ 'owner_id' ],
 		preview: [ 'name', 'icon', 'url', 'private' ],
-		visibility: [ 'wpcom_status', 'private' ],
+		visibility: [ 'wpcom_status', 'private', 'status' ],
 	};
 
 	// Always include ID and slug (for navigation), deleted (for styling), is_a8c (for included a8c owned) and other (for vip & self hosted jetpack)

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -28,14 +28,13 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { getSiteBadge } from '../../utils/site-badge';
 import { hasHostingFeature, hasJetpackModule } from '../../utils/site-features';
-import { getSiteStatus } from '../../utils/site-status';
 import { getSiteFormattedUrl } from '../../utils/site-url';
-import { getSiteVisibilityLabel } from '../../utils/site-visibility';
+import { getVisibilityLabels } from '../../utils/site-visibility';
 import { canManageSite, canManageSite__ES } from '../features';
 import { isSitePlanTrial } from '../plans';
 import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
-import type { SiteBadge } from '../../types';
+import type { SiteBadge, SiteStatus, SiteVisibility } from '../../types';
 import type { DashboardSiteListSite, Site } from '@automattic/api-core';
 import type { ComponentProps } from 'react';
 
@@ -418,7 +417,7 @@ export function MediaStorage( { site }: { site?: Site } ) {
 	return <span ref={ ref }>{ renderContent() }</span>;
 }
 
-function SiteLaunchNag( { site }: { site: Site } ) {
+function SiteLaunchNag( { siteSlug }: { siteSlug: string } ) {
 	const { recordTracksEvent } = useAnalytics();
 
 	// TODO: We have to fix the obscured focus ring issue as the dataview's field value container
@@ -427,7 +426,7 @@ function SiteLaunchNag( { site }: { site: Site } ) {
 		<>
 			<ComponentViewTracker eventName="calypso_dashboard_sites_site_launch_nag_impression" />
 			<ExternalLink
-				href={ wpcomLink( `/home/${ site.slug }` ) }
+				href={ wpcomLink( `/home/${ siteSlug }` ) }
 				onClick={ () => {
 					recordTracksEvent( 'calypso_dashboard_sites_site_launch_nag_click' );
 				} }
@@ -467,13 +466,23 @@ function PlanRenewNag( { site, source }: { site: Pick< Site, 'slug' | 'plan' >; 
 	);
 }
 
-export function Visibility( { site }: { site: Site } ) {
-	const status = getSiteStatus( site );
+export function Visibility( {
+	siteSlug,
+	visibility,
+	status,
+	isLaunched,
+}: {
+	siteSlug: string;
+	visibility: SiteVisibility;
+	status: SiteStatus;
+	isLaunched?: boolean;
+} ) {
+	const visibilityLabels = getVisibilityLabels();
 	return (
 		<VStack spacing={ 1 }>
-			<span>{ getSiteVisibilityLabel( site ) }</span>
+			<span>{ visibilityLabels[ visibility ] }</span>
 			{ /* We don't want to show LaunchNag if there is any pending status. */ }
-			{ ! status && site.launch_status === 'unlaunched' && <SiteLaunchNag site={ site } /> }
+			{ ! status && ! isLaunched && <SiteLaunchNag siteSlug={ siteSlug } /> }
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -34,8 +34,8 @@ import { canManageSite, canManageSite__ES } from '../features';
 import { isSitePlanTrial } from '../plans';
 import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
-import type { SiteBadge, SiteStatus, SiteVisibility } from '../../types';
-import type { DashboardSiteListSite, Site } from '@automattic/api-core';
+import type { SiteVisibility } from '../../types';
+import type { DashboardSiteListSite, Site, SiteBadge, SiteStatus } from '@automattic/api-core';
 import type { ComponentProps } from 'react';
 
 function IneligibleIndicator() {

--- a/client/dashboard/sites/site-fields/test/visibility.tsx
+++ b/client/dashboard/sites/site-fields/test/visibility.tsx
@@ -4,17 +4,17 @@
 import { render } from '../../../test-utils';
 import { wpcomLink } from '../../../utils/link';
 import { Visibility } from '../index';
-import type { Site } from '@automattic/api-core';
 
 describe( '<Visibility>', () => {
 	test( 'for unlaunched sites, it renders "Coming soon" with a "Finish setup" link', () => {
-		const site = {
-			slug: 'test.wordpress.com',
-			site_migration: {},
-			launch_status: 'unlaunched',
-			is_private: true,
-		} as Site;
-		const { container, getByRole } = render( <Visibility site={ site } /> );
+		const { container, getByRole } = render(
+			<Visibility
+				siteSlug="test.wordpress.com"
+				visibility="private"
+				status={ null }
+				isLaunched={ false }
+			/>
+		);
 		expect( container ).toHaveTextContent( 'Finish setup↗' );
 		expect( getByRole( 'link', { name: /Finish setup/ } ) ).toHaveAttribute(
 			'href',
@@ -23,29 +23,28 @@ describe( '<Visibility>', () => {
 	} );
 
 	test( 'for coming soon sites, it renders "Coming soon"', () => {
-		const site = {
-			site_migration: {},
-			is_coming_soon: true,
-		} as Site;
-		const { container } = render( <Visibility site={ site } /> );
+		const { container } = render(
+			<Visibility
+				siteSlug="test.wordpress.com"
+				visibility="coming_soon"
+				status={ null }
+				isLaunched
+			/>
+		);
 		expect( container.textContent ).toBe( 'Coming soon' );
 	} );
 
 	test( 'for private sites, it renders "Private"', () => {
-		const site = {
-			site_migration: {},
-			is_private: true,
-		} as Site;
-		const { container } = render( <Visibility site={ site } /> );
+		const { container } = render(
+			<Visibility siteSlug="test.wordpress.com" visibility="private" status={ null } isLaunched />
+		);
 		expect( container.textContent ).toBe( 'Private' );
 	} );
 
 	test( 'for public sites, it renders "Public"', () => {
-		const site = {
-			site_migration: {},
-			is_private: false,
-		} as Site;
-		const { container } = render( <Visibility site={ site } /> );
+		const { container } = render(
+			<Visibility siteSlug="test.wordpress.com" visibility="public" status={ null } isLaunched />
+		);
 		expect( container.textContent ).toBe( 'Public' );
 	} );
 } );

--- a/client/dashboard/types/site.ts
+++ b/client/dashboard/types/site.ts
@@ -1,12 +1,3 @@
-export type SiteStatus =
-	| 'deleted'
-	| 'migration_pending'
-	| 'migration_started'
-	| 'difm_lite_in_progress'
-	| null;
-
-export type SiteBadge = SiteStatus | 'staging' | 'p2' | 'trial' | null;
-
 export interface SiteMigrationStatus {
 	status: 'pending' | 'started' | 'completed';
 	type: 'difm' | 'diy' | 'ssh';

--- a/client/dashboard/types/site.ts
+++ b/client/dashboard/types/site.ts
@@ -11,3 +11,5 @@ export interface SiteMigrationStatus {
 	status: 'pending' | 'started' | 'completed';
 	type: 'difm' | 'diy' | 'ssh';
 }
+
+export type SiteVisibility = 'public' | 'private' | 'coming_soon';

--- a/client/dashboard/utils/site-badge.ts
+++ b/client/dashboard/utils/site-badge.ts
@@ -22,3 +22,14 @@ export function getSiteBadge( site: Site ): SiteBadge {
 
 	return null;
 }
+
+export function isSiteStatusBadge( badge: SiteBadge ): boolean {
+	const statusBadges = [
+		'deleted',
+		'migration_pending',
+		'migration_started',
+		'difm_lite_in_progress',
+	];
+
+	return statusBadges.includes( badge ?? '' );
+}

--- a/client/dashboard/utils/site-badge.ts
+++ b/client/dashboard/utils/site-badge.ts
@@ -1,8 +1,7 @@
 import { isSitePlanTrial } from '../sites/plans';
 import { getSiteStatus } from './site-status';
 import { isP2 } from './site-types';
-import type { SiteBadge } from '../types';
-import type { Site } from '@automattic/api-core';
+import type { Site, SiteBadge } from '@automattic/api-core';
 
 export function getSiteBadge( site: Site ): SiteBadge {
 	const status = getSiteStatus( site );
@@ -21,15 +20,4 @@ export function getSiteBadge( site: Site ): SiteBadge {
 	}
 
 	return null;
-}
-
-export function isSiteStatusBadge( badge: SiteBadge ): boolean {
-	const statusBadges = [
-		'deleted',
-		'migration_pending',
-		'migration_started',
-		'difm_lite_in_progress',
-	];
-
-	return statusBadges.includes( badge ?? '' );
 }

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -1,5 +1,5 @@
-import type { SiteStatus, SiteMigrationStatus } from '../types';
-import type { Site } from '@automattic/api-core';
+import type { SiteMigrationStatus } from '../types';
+import type { Site, SiteStatus } from '@automattic/api-core';
 
 const MIGRATION_STATUSES: SiteMigrationStatus[ 'status' ][] = [ 'pending', 'started', 'completed' ];
 const MIGRATION_TYPES: SiteMigrationStatus[ 'type' ][] = [ 'difm', 'diy', 'ssh' ];

--- a/client/dashboard/utils/site-visibility.ts
+++ b/client/dashboard/utils/site-visibility.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import type { SiteVisibility } from '../types/site';
 import type { Site } from '@automattic/api-core';
 
 export function getVisibilityLabels() {
@@ -9,7 +10,7 @@ export function getVisibilityLabels() {
 	};
 }
 
-export function getSiteVisibility( item: Site ) {
+export function getSiteVisibility( item: Site ): SiteVisibility {
 	if ( item.is_coming_soon || ( item.is_private && item.launch_status === 'unlaunched' ) ) {
 		return 'coming_soon';
 	}

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -1,13 +1,14 @@
+export type SiteStatus =
+	| 'deleted'
+	| 'migration_pending'
+	| 'migration_started'
+	| 'difm_lite_in_progress'
+	| null;
+
+export type SiteBadge = 'staging' | 'trial' | 'p2' | SiteStatus;
+
 export interface DashboardSiteListSite {
-	badge?:
-		| null
-		| 'staging'
-		| 'trial'
-		| 'p2'
-		| 'deleted'
-		| 'migration_pending'
-		| 'migration_started'
-		| 'difm_lite_in_progress';
+	badge?: SiteBadge;
 	blog_id: number; // Site ID is always fetched
 	capabilities?: {
 		manage_options: boolean;
@@ -43,6 +44,7 @@ export interface DashboardSiteListSite {
 	owner_id?: number;
 	php_version?: string;
 	slug: string; // Slug is always fetched
+	status?: SiteStatus;
 	views?: null | number;
 	visitors?: null | number;
 	total_wpcom_subscribers?: number;

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -1,5 +1,13 @@
 export interface DashboardSiteListSite {
-	badge?: null | 'staging' | 'trial' | 'p2';
+	badge?:
+		| null
+		| 'staging'
+		| 'trial'
+		| 'p2'
+		| 'deleted'
+		| 'migration_pending'
+		| 'migration_started'
+		| 'difm_lite_in_progress';
 	blog_id: number; // Site ID is always fetched
 	capabilities?: {
 		manage_options: boolean;
@@ -44,6 +52,7 @@ export interface DashboardSiteListSite {
 		is_staging: boolean;
 		is_coming_soon: boolean;
 		is_redirect: boolean;
+		is_launched?: boolean;
 	};
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-986

## Proposed Changes

* Introduce `wpcom_status.is_launched` for ES site
* Refactor `Visibility` component to accept following props so it can be shared between site and ES site
  * siteSlug - The site slug
  * visibility - `prviate`, `public`, `coming_soon`
  * status - `deleted`, `migration_pending`, `migration_started`, `difm_lite_in_progress`
  * isLaunched - Whether the site is launched
* The only trick is we need to convert the badge of the site into status for ES site as the endpoint doesn't return the site status 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to show "Finish setup" link on Visibility column if the site is not launched

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Ensure it works as before
* Go to /sites?flags=dashboard/v2/es-site-list
* Ensure you can see the Visibility column is `Coming soon` with the `Finish setup` link for ES site.
  * It would be better to create a new site for testing as the `wpcom_status.is_launched` may not be backfilled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
