### PR TITLE
MSD: use useSuspenseQuery in /sites/:slug/settings to avoid layout shift

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -571,12 +571,13 @@ export const siteSettingsRoute = createRoute( {
 	path: 'settings',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		queryClient.prefetchQuery( siteSettingsQuery( site.ID ) );
 
-		if ( hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ) ) {
-			// This impacts layout so we must wait for this to load
-			await queryClient.ensureQueryData( sitePrimaryDataCenterQuery( site.ID ) );
-		}
+		queryClient.prefetchQuery( siteCurrentPlanQuery( site.ID ) );
+		await Promise.all( [
+			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
+			hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ) &&
+				queryClient.ensureQueryData( sitePrimaryDataCenterQuery( site.ID ) ),
+		] );
 	},
 } );
 
@@ -663,7 +664,7 @@ export const siteSettingsSubscriptionGiftingRoute = createRoute( {
 	path: 'subscription-gifting',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		queryClient.prefetchQuery( siteSettingsQuery( site.ID ) );
+		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
 	},
 } ).lazy( () =>
 	import( '../../sites/settings-subscription-gifting' ).then( ( d ) =>

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -1,5 +1,5 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -11,11 +11,7 @@ import LockedModeForm from './locked-mode-form';
 
 export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
-
-	if ( ! site || ! settings ) {
-		return null;
-	}
+	const { data: settings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
 
 	if ( ! canViewHundredYearPlanSettings( site ) ) {
 		throw notFound();

--- a/client/dashboard/sites/settings-hundred-year-plan/summary.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/summary.tsx
@@ -12,7 +12,7 @@ export default function HundredYearPlanSummary( {
 	density,
 }: {
 	site: Site;
-	settings?: SiteSettings;
+	settings: SiteSettings;
 	density?: Density;
 } ) {
 	if ( ! canViewHundredYearPlanSettings( site ) ) {
@@ -26,9 +26,7 @@ export default function HundredYearPlanSummary( {
 			density={ density }
 			decoration={ <Icon icon={ institution } /> }
 			badges={
-				settings?.wpcom_locked_mode
-					? [ { text: __( 'Site locked' ), intent: 'info' as const } ]
-					: []
+				settings.wpcom_locked_mode ? [ { text: __( 'Site locked' ), intent: 'info' as const } ] : []
 			}
 		/>
 	);

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -1,5 +1,5 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useSearch } from '@tanstack/react-router';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -17,14 +17,10 @@ import { ShareSiteForm } from './share-site-form';
 
 export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
+	const { data: settings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
 	const { back_to } = useSearch( {
 		from: siteSettingsSiteVisibilityRoute.fullPath,
 	} );
-
-	if ( ! settings ) {
-		return null;
-	}
 
 	const renderContent = () => {
 		if ( site.launch_status === 'unlaunched' ) {

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -1,6 +1,6 @@
 import { DotcomFeatures } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsMutation, siteSettingsQuery } from '@automattic/api-queries';
-import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
 import { __experimentalVStack as VStack, Button, CheckboxControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -48,16 +48,12 @@ const form = {
 export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: string } ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { data } = useQuery( siteSettingsQuery( site.ID ) );
+	const { data } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
 	const mutation = useMutation( siteSettingsMutation( site.ID ) );
 
 	const [ formData, setFormData ] = useState( {
-		wpcom_gifting_subscription: data?.wpcom_gifting_subscription,
+		wpcom_gifting_subscription: data.wpcom_gifting_subscription,
 	} );
-
-	if ( ! data ) {
-		return null;
-	}
 
 	if ( ! hasPlanFeature( site, DotcomFeatures.SUBSCRIPTION_GIFTING ) ) {
 		throw notFound();

--- a/client/dashboard/sites/settings-subscription-gifting/summary.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/summary.tsx
@@ -13,19 +13,17 @@ export default function SubscriptionGiftingSettingsSummary( {
 	density,
 }: {
 	site: Site;
-	settings?: SiteSettings;
+	settings: SiteSettings;
 	density?: Density;
 } ) {
 	if ( ! hasPlanFeature( site, DotcomFeatures.SUBSCRIPTION_GIFTING ) ) {
 		return null;
 	}
 
-	let badges;
-	if ( settings ) {
-		badges = settings.wpcom_gifting_subscription
-			? [ { text: __( 'Enabled' ), intent: 'success' as const } ]
-			: [ { text: __( 'Disabled' ) } ];
-	}
+	const badges = settings.wpcom_gifting_subscription
+		? [ { text: __( 'Enabled' ), intent: 'success' as const } ]
+		: [ { text: __( 'Disabled' ) } ];
+
 	return (
 		<RouterLinkSummaryButton
 			to={ `/sites/${ site.slug }/settings/subscription-gifting` }

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -1,6 +1,6 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAppContext } from '../../app/context';
@@ -32,7 +32,7 @@ import type { SiteSettings } from '@automattic/api-core';
 
 export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
-	const { data: settings } = useQuery( siteSettingsQuery( site.ID ) );
+	const { data: settings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
 	const { supports } = useAppContext();
 	const supportsSettings = supports.sites && supports.sites.settings;
 


### PR DESCRIPTION

## Proposed Changes

Use `useSuspenseQuery()` when loading settings in MSD `/sites/:slug/settings`.

## Why are these changes being made?

Currently the page has layout shift if we use site switcher to switch between sites.

## Testing Instructions

1. Go to MSD /sites/:siteSlug/settings.
2. Verify the page (summaries) load correctly as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
