### PR TITLE
Help Center: Update article images

### DIFF
--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -238,8 +238,19 @@
 				}
 			}
 
-			.wp-block-image figure figcaption {
+			figure.wp-block-image {
+				border: 1px solid $gray-200;
+				border-radius: 4px;
+				padding: 16px;
+
+				img {
+					border-radius: 2px;
+				}
+			}
+
+			figure.wp-block-image figcaption {
 				display: block;
+				padding: 12px 0 0;
 			}
 
 			color: var( --color-neutral-70 );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-15496/update-images-in-help-center

## Before

<img width="491" height="702" alt="image" src="https://github.com/user-attachments/assets/da93812e-f427-4613-b579-ec1742bf59b9" />

## After

<img width="485" height="664" alt="image" src="https://github.com/user-attachments/assets/d0ace5fc-1ec2-4685-9e3e-97f831ee0c08" />
