### PR TITLE
MSD: Open the admin link from the site switcher if the user cannot manage the site

### DIFF
--- a/client/dashboard/sites/site-switcher/base.tsx
+++ b/client/dashboard/sites/site-switcher/base.tsx
@@ -10,6 +10,7 @@ import Switcher from '../../components/switcher';
 import { Text } from '../../components/text';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSiteDisplayUrl } from '../../utils/site-url';
+import { canManageSite } from '../features';
 import type { SwitcherProps } from '../../components/switcher';
 import type { Site } from '@automattic/api-core';
 
@@ -39,7 +40,12 @@ export const SiteSwitcherBase = ( props: Pick< SwitcherProps< Site >, 'children'
 			items={ sites }
 			value={ site }
 			searchableFields={ searchableFields }
-			getItemUrl={ ( site ) => buildCurrentRouteLink( { params: { siteSlug: site.slug } } ) }
+			getItemUrl={ ( site ) => {
+				if ( canManageSite( site ) ) {
+					return buildCurrentRouteLink( { params: { siteSlug: site.slug } } );
+				}
+				return site.options?.admin_url ?? '';
+			} }
 			renderItemMedia={ ( { item, size } ) => <SiteIcon site={ item } size={ size } /> }
 			renderItemTitle={ ( { item } ) => (
 				<span


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-998

## Proposed Changes

* Open the admin link from the site switcher if the user cannot manage the site

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If the user cannot manage the site, the page will show 404 after the user select the site

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site
* Open the site switcher
* Select the site that cannot be managed
* Ensure it opens the WP Admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
