### PR TITLE
E2E Tests: Remove redundant clickContinue step in domain flow tests

### DIFF
--- a/test/e2e/specs/flows/setup-domain__connect-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__connect-domain.ts
@@ -53,7 +53,6 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Connect a domain to a site'
 
 	it( 'Click the connect button', async function () {
 		const useADomainIOwnPage = new UseADomainIOwnPage( page );
-		await useADomainIOwnPage.clickContinue();
 		await useADomainIOwnPage.clickButtonToConnectDomain();
 	} );
 

--- a/test/e2e/specs/flows/setup-domain__transfer-domain.ts
+++ b/test/e2e/specs/flows/setup-domain__transfer-domain.ts
@@ -53,7 +53,6 @@ describe( DataHelper.createSuiteTitle( 'Domain flow: Transfer a domain to a site
 
 	it( 'Click the transfer button', async function () {
 		const useADomainIOwnPage = new UseADomainIOwnPage( page );
-		await useADomainIOwnPage.clickContinue();
 		await useADomainIOwnPage.clickButtonToTransferDomain();
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/107969.

## Summary
- Removes redundant `clickContinue()` call in connect domain E2E test
- Removes redundant `clickContinue()` call in transfer domain E2E test

These calls are no longer necessary, as the step submits automatically when there's a prefilled domain name.

## Test plan
- Verify tests pass without the redundant step