### PR TITLE
Create a new data-store field to persist logged out sessions

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -5,7 +5,7 @@ import { Location } from 'history';
 import { default as wpcomRequestPromise, canAccessWpcomApis } from 'wpcom-proxy-request';
 import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
-import { isE2ETest } from '../utils';
+import { isE2ETest, isLoggedInHCUser } from '../utils';
 import { STORE_KEY } from './constants';
 import type { HelpCenterOptions, HelpCenterSelect, HelpCenterShowOptions } from './types';
 import type { APIFetchOptions } from '../shared-types';
@@ -16,6 +16,10 @@ import type { APIFetchOptions } from '../shared-types';
  * @param isMinimized - Whether the help center is minimized.
  */
 export const saveOpenState = ( isShown: boolean | undefined, isMinimized: boolean | undefined ) => {
+	if ( ! isLoggedInHCUser() ) {
+		return null;
+	}
+
 	const saveState: Record< string, boolean | null > = {};
 
 	if ( typeof isShown === 'boolean' ) {
@@ -89,6 +93,14 @@ export const setIsMinimized = function* ( minimized: boolean ) {
 		minimized,
 	} as const;
 };
+
+export const setLoggedOutOdieChat = (
+	session: { odieId: number; sessionId: string; botSlug: string } | undefined
+) =>
+	( {
+		type: 'HELP_CENTER_SET_LOGGED_OUT_ODIE_CHAT',
+		session,
+	} ) as const;
 
 export const setIsChatLoaded = ( isChatLoaded: boolean ) =>
 	( {
@@ -286,6 +298,7 @@ export type HelpCenterAction =
 			| typeof setSubject
 			| typeof resetStore
 			| typeof setMessage
+			| typeof setLoggedOutOdieChat
 			| typeof setContextTerm
 			| typeof setUserDeclaredSite
 			| typeof setUserDeclaredSiteUrl
@@ -294,6 +307,7 @@ export type HelpCenterAction =
 			| typeof setIsChatLoaded
 			| typeof setAreSoundNotificationsEnabled
 			| typeof setZendeskClientId
+			| typeof setLoggedOutOdieChat
 			| typeof setSupportTypingStatus
 			| typeof setZendeskConnectionStatus
 			| typeof setNavigateToRoute

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -1,7 +1,7 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 import { registerPlugins } from '../plugins';
-import { isE2ETest, isInSupportSession } from '../utils';
+import { isE2ETest, isInSupportSession, isLoggedInHCUser } from '../utils';
 import { controls as wpcomRequestControls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
@@ -13,7 +13,7 @@ export type { State };
 let isRegistered = false;
 
 export function register(): typeof STORE_KEY {
-	const enabledPersistedOpenState = ! isE2ETest() && ! isInSupportSession();
+	const enabledPersistedOpenState = ! isE2ETest() && ! isInSupportSession() && isLoggedInHCUser();
 
 	registerPlugins();
 
@@ -23,7 +23,17 @@ export function register(): typeof STORE_KEY {
 			reducer,
 			controls: { ...controls, ...wpcomRequestControls },
 			selectors,
-			persist: [ 'message', 'userDeclaredSite', 'userDeclaredSiteUrl', 'subject' ],
+			persist: [
+				'message',
+				'userDeclaredSite',
+				'userDeclaredSiteUrl',
+				'subject',
+				'loggedOutOdieChat',
+				// TODO: only persist these if the user is logged out
+				'helpCenterRouterHistory',
+				'helpCenterMinimized',
+				'showHelpCenter',
+			],
 			// Don't persist the open state for e2e users, because parallel tests will start interfering with each other.
 			resolvers: enabledPersistedOpenState ? { isHelpCenterShown } : undefined,
 		} );

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -29,10 +29,9 @@ export function register(): typeof STORE_KEY {
 				'userDeclaredSiteUrl',
 				'subject',
 				'loggedOutOdieChat',
-				// TODO: only persist these if the user is logged out
-				'helpCenterRouterHistory',
-				'helpCenterMinimized',
-				'showHelpCenter',
+				...( ! isLoggedInHCUser()
+					? [ 'helpCenterRouterHistory', 'helpCenterMinimized', 'showHelpCenter' ]
+					: [] ),
 			],
 			// Don't persist the open state for e2e users, because parallel tests will start interfering with each other.
 			resolvers: enabledPersistedOpenState ? { isHelpCenterShown } : undefined,

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -57,6 +57,17 @@ const helpCenterRouterHistory: Reducer<
 	return state;
 };
 
+const loggedOutOdieChat: Reducer<
+	{ odieId: number; sessionId: string; botSlug: string } | undefined,
+	HelpCenterAction
+> = ( state = undefined, action ) => {
+	switch ( action.type ) {
+		case 'HELP_CENTER_SET_LOGGED_OUT_ODIE_CHAT':
+			return action.session;
+	}
+	return state;
+};
+
 const showMessagingWidget: Reducer< boolean | undefined, HelpCenterAction > = ( state, action ) => {
 	switch ( action.type ) {
 		case 'HELP_CENTER_SET_SHOW_MESSAGING_WIDGET':
@@ -216,6 +227,7 @@ const reducer = combineReducers( {
 	odieInitialPromptText,
 	odieBotNameSlug,
 	helpCenterRouterHistory,
+	loggedOutOdieChat,
 	hasPremiumSupport,
 	contextTerm,
 	helpCenterOptions,

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -11,6 +11,7 @@ export const getUnreadCount = ( state: State ) => state.unreadCount;
 export const getZendeskConnectionStatus = ( state: State ) => state.zendeskConnectionStatus;
 export const getIsMinimized = ( state: State ) => state.isMinimized;
 export const getIsChatLoaded = ( state: State ) => state.isChatLoaded;
+export const getLoggedOutOdieChat = ( state: State ) => state.loggedOutOdieChat;
 export const getAreSoundNotificationsEnabled = ( state: State ) =>
 	state.areSoundNotificationsEnabled;
 export const getZendeskClientId = ( state: State ) => state.zendeskClientId;

--- a/packages/data-stores/src/utils.ts
+++ b/packages/data-stores/src/utils.ts
@@ -2,7 +2,9 @@
  * Utility functions shared across data stores
  */
 
-declare const helpCenterData: { isProxied: boolean; isSU: boolean; isSSP: boolean } | undefined;
+declare const helpCenterData:
+	| { isProxied: boolean; isSU: boolean; isSSP: boolean; currentUser: { ID: number } }
+	| undefined;
 declare const isSupportSession: boolean;
 declare const isSSP: boolean;
 
@@ -29,4 +31,17 @@ export const isInSupportSession = () => {
 		);
 	}
 	return false;
+};
+
+/**
+ * Check if the user is logged in in a synchronous way. Works in wp-admin and Calypso.
+ * @returns True if the user is logged in, false otherwise.
+ */
+export const isLoggedInHCUser = () => {
+	return (
+		// Calypso
+		( typeof window !== 'undefined' && !! window.currentUser?.ID ) ||
+		// wp-admin and Gutenberg
+		( typeof helpCenterData !== 'undefined' && !! helpCenterData?.currentUser?.ID )
+	);
 };


### PR DESCRIPTION
Fixes DOTCOM-15636

## Proposed Changes

Add a new field to store logged out Odie sessions in the Help Center. 

## Why are these changes being made?
To make https://github.com/Automattic/wp-calypso/pull/107902 smaller.

## Testing Instructions
1. Unit tests passing.
