### PR TITLE
MSD Domains: Prevent site name from breaking into new lines

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-site.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-site.tsx
@@ -7,7 +7,6 @@ import { domainTransferToOtherSiteRoute } from '../../app/router/domains';
 import { siteRoute } from '../../app/router/sites';
 import SiteIcon from '../../components/site-icon';
 import { Text } from '../../components/text';
-import { Truncate } from '../../components/truncate';
 import type { DomainSummary } from '@automattic/api-core';
 
 export const DomainSiteField = ( { domain, value }: { domain: DomainSummary; value: string } ) => {
@@ -32,10 +31,14 @@ export const DomainSiteField = ( { domain, value }: { domain: DomainSummary; val
 				params={ { siteSlug: domain?.site_slug } }
 				style={ { textDecoration: 'none' } }
 			>
-				<Text>
-					<Truncate tooltip={ value } ellipsizeMode="tail" limit={ 32 }>
-						{ value }
-					</Truncate>
+				<Text
+					title={ value }
+					ellipsizeMode="tail"
+					limit={ 32 }
+					truncate
+					style={ { whiteSpace: 'nowrap' } }
+				>
+					{ value }
 				</Text>
 			</Link>
 		</HStack>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Prevent site name from breaking into new lines

| Before | After |
| - | - |
|<img width="143" height="73" alt="image" src="https://github.com/user-attachments/assets/46448f4b-da66-41c1-af96-102a86f446ec" />|<img width="152" height="54" alt="image" src="https://github.com/user-attachments/assets/2c051a86-821c-493b-927f-01647d73216f" />|
|<img width="131" height="78" alt="image" src="https://github.com/user-attachments/assets/03166f4c-e7dc-47af-898a-177995b00253" />|<img width="258" height="45" alt="image" src="https://github.com/user-attachments/assets/f02a8e1b-bf41-41d8-bf55-b8cfb53c7202" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* UI improvement

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains
* Ensure the site name column looks better

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
