### PR TITLE
Add HC in logged out page for easier testing

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -114,11 +114,15 @@ const LayoutLoggedOut = ( {
 		! isWooOAuth2Client( oauth2Client );
 
 	const loadHelpCenter =
-		isLoggedIn &&
-		// we want to show only the Help center in my home and the help section (but not the FAB)
-		( [ 'home', 'help' ].includes( sectionName ) ||
-			currentRoute?.startsWith( '/start/do-it-for-me/' ) ) &&
-		userAllowedToHelpCenter;
+		// Load for all logged out users only on the devdocs page.
+		( isLoggedIn === false &&
+			isEnabled( 'help-center/logged-out' ) &&
+			'devdocs' === sectionName ) ||
+		( isLoggedIn &&
+			// we want to show only the Help center in my home and the help section (but not the FAB)
+			( [ 'home', 'help' ].includes( sectionName ) ||
+				currentRoute?.startsWith( '/start/do-it-for-me/' ) ) &&
+			userAllowedToHelpCenter );
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { WordPressWordmark, WordPressLogo } from '@automattic/components';
 import {
 	isDefaultLocale,
@@ -111,6 +112,23 @@ class MasterbarLoggedOut extends Component {
 					comment: 'Should be shorter than ~12 chars',
 				} ) }
 			</Item>
+		);
+	}
+
+	renderHelpCenter() {
+		if ( ! isEnabled( 'help-center/logged-out' ) ) {
+			return null;
+		}
+
+		const { siteId, translate } = this.props;
+
+		return (
+			<AsyncLoad
+				require="./masterbar-help-center"
+				siteId={ siteId }
+				tooltip={ translate( 'Help' ) }
+				placeholder={ null }
+			/>
 		);
 	}
 
@@ -243,6 +261,7 @@ class MasterbarLoggedOut extends Component {
 				) }
 				{ sectionName !== 'reader' && (
 					<div className="masterbar__login-links">
+						{ this.renderHelpCenter() }
 						{ this.renderLoginItem() }
 						{ this.renderSignupItem() }
 					</div>

--- a/config/development.json
+++ b/config/development.json
@@ -73,6 +73,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help/gpt-response": true,
+		"help-center/logged-out": true,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
 		"hosting/datacenter-picker": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -47,6 +47,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help/gpt-response": true,
+		"help-center/logged-out": true,
 		"hosting-server-settings-enhancements": true,
 		"summer-special-2025": true,
 		"summer-special-2025-banner": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -31,6 +31,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/checkout-version": true,
+		"help-center/logged-out": true,
 		"ciab/allow-domain-features": true,
 		"checkout/razorpay": true,
 		"checkout/vgs-ebanx": true,


### PR DESCRIPTION
Fixes DOTCOM-15637

## Proposed Changes

Registers the HC in devdocs page when logged out. In dev and staging (not prod).

## Why are these changes being made?
Easier dev.

## Testing Instructions

1. Visit the live link while incognito.
2. Devdocs should have the HC.