### PR TITLE
MSD: check route permission on beforeLoad + show snackbar

### DIFF
--- a/client/dashboard/app/root/error.tsx
+++ b/client/dashboard/app/root/error.tsx
@@ -1,0 +1,21 @@
+import NotFound from '../404';
+import Header from '../header';
+
+/**
+ * When notFound() is called within a beforeLoad, TanStack Router will skip rendering the root route,
+ * and instead render the notFoundComponent directly.
+ *
+ * The current workaround is to recreate the layout.
+ *
+ * See: https://github.com/TanStack/router/issues/2139
+ */
+export default function NotFoundRoot() {
+	return (
+		<div className="dashboard-root__layout">
+			<Header />
+			<main>
+				<NotFound />
+			</main>
+		</div>
+	);
+}

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -1,9 +1,13 @@
 import { createRootRouteWithContext } from '@tanstack/react-router';
 import Root from '../root';
+import NotFoundRoot from '../root/error';
 import type { AppConfig } from '../context';
 
 export type RootRouterContext = {
 	config: AppConfig;
 };
 
-export const rootRoute = createRootRouteWithContext< RootRouterContext >()( { component: Root } );
+export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
+	component: Root,
+	notFoundComponent: NotFoundRoot,
+} );

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -38,9 +38,17 @@ import {
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
-import { createRoute, redirect, createLazyRoute, lazyRouteComponent } from '@tanstack/react-router';
+import {
+	createLazyRoute,
+	createRoute,
+	lazyRouteComponent,
+	notFound,
+	redirect,
+} from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import {
+	canManageSite,
+	canTransferSite,
 	canViewHundredYearPlanSettings,
 	canViewSiteVisibilitySettings,
 	canViewWordPressSettings,
@@ -50,9 +58,10 @@ import { getSiteDisplayName } from '../../utils/site-name';
 import { isSiteMigrationInProgress, getSiteMigrationState } from '../../utils/site-status';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { isCommerceGarden, isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { AUTH_QUERY_KEY } from '../auth';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
-import type { DifmWebsiteContentResponse, Site } from '@automattic/api-core';
+import type { DifmWebsiteContentResponse, Site, User } from '@automattic/api-core';
 import type { AnyRoute } from '@tanstack/react-router';
 
 export const sitesRoute = createRoute( {
@@ -89,6 +98,10 @@ export const siteRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites/$siteSlug',
 	beforeLoad: async ( { cause, params: { siteSlug }, location, matches } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
 		let site;
 		try {
 			site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
@@ -97,18 +110,18 @@ export const siteRoute = createRoute( {
 			return;
 		}
 
-		const overviewUrl = `/sites/${ siteSlug }`;
-		if ( isSelfHostedJetpackConnected( site ) && ! location.pathname.endsWith( overviewUrl ) ) {
-			throw redirect( { to: overviewUrl } );
+		if ( ! canManageSite( site ) ) {
+			throw notFound();
 		}
 
-		if ( cause !== 'enter' ) {
-			return;
+		const overviewUrl = `/sites/${ siteSlug }`;
+		if ( isSelfHostedJetpackConnected( site ) && ! location.pathname.endsWith( overviewUrl ) ) {
+			throw redirectAsNotAllowed( { to: overviewUrl } );
 		}
 
 		const trialExpiredUrl = `/sites/${ siteSlug }/trial-ended`;
 		if ( hasSiteTrialEnded( site ) && ! location.pathname.includes( trialExpiredUrl ) ) {
-			throw redirect( { to: trialExpiredUrl } );
+			throw redirectAsNotAllowed( { to: trialExpiredUrl } );
 		}
 
 		const difmUrl = `/sites/${ siteSlug }/site-building-in-progress`;
@@ -118,12 +131,12 @@ export const siteRoute = createRoute( {
 			! isSupportSession() &&
 			! matches.some( ( match ) => difmAllowedRoutes.includes( match.routeId ) )
 		) {
-			throw redirect( { to: difmUrl } );
+			throw redirectAsNotAllowed( { to: difmUrl } );
 		}
 
 		const migrationUrl = `/sites/${ siteSlug }/migration-overview`;
 		if ( isSiteMigrationInProgress( site ) && ! location.pathname.includes( migrationUrl ) ) {
-			throw redirect( { to: migrationUrl } );
+			throw redirectAsNotAllowed( { to: migrationUrl } );
 		}
 	},
 	loader: async ( { params: { siteSlug } } ) => {
@@ -192,10 +205,14 @@ export const siteDeploymentsRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'deployments',
-	beforeLoad: async ( { params: { siteSlug } } ) => {
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( isCommerceGarden( site ) ) {
-			throw redirect( { to: `/sites/${ siteSlug }` } );
+			throw redirectAsNotAllowed( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 } ).lazy( () =>
@@ -231,10 +248,14 @@ export const siteMonitoringRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'monitoring',
-	beforeLoad: async ( { params: { siteSlug } } ) => {
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( isCommerceGarden( site ) ) {
-			throw redirect( { to: `/sites/${ siteSlug }` } );
+			throw redirectAsNotAllowed( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 } ).lazy( () =>
@@ -255,10 +276,14 @@ export const siteLogsRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'logs',
-	beforeLoad: async ( { params: { siteSlug } } ) => {
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( isCommerceGarden( site ) ) {
-			throw redirect( { to: `/sites/${ siteSlug }` } );
+			throw redirectAsNotAllowed( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 } );
@@ -347,10 +372,14 @@ export const siteScanRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'scan',
-	beforeLoad: async ( { params: { siteSlug } } ) => {
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( isCommerceGarden( site ) ) {
-			throw redirect( { to: `/sites/${ siteSlug }` } );
+			throw redirectAsNotAllowed( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 	loader: async ( { params: { siteSlug } } ) => {
@@ -420,7 +449,7 @@ export const siteBackupsRoute = createRoute( {
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( isCommerceGarden( site ) ) {
-			throw redirect( { to: `/sites/${ siteSlug }` } );
+			throw redirectAsNotAllowed( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 	loader: async ( { params: { siteSlug } } ) => {
@@ -548,7 +577,7 @@ export const sitePerformanceRoute = createRoute( {
 	beforeLoad: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( isCommerceGarden( site ) ) {
-			throw redirect( { to: `/sites/${ siteSlug }` } );
+			throw redirectAsNotAllowed( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 } ).lazy( () =>
@@ -602,10 +631,14 @@ export const siteSettingsSiteVisibilityRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'site-visibility',
-	beforeLoad: async ( { params: { siteSlug } } ) => {
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( ! canViewSiteVisibilitySettings( site ) ) {
-			throw redirect( { to: `/sites/${ siteSlug }/settings` } );
+			throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 	loader: async ( { params: { siteSlug } } ) => {
@@ -662,6 +695,16 @@ export const siteSettingsSubscriptionGiftingRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'subscription-gifting',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! hasPlanFeature( site, DotcomFeatures.SUBSCRIPTION_GIFTING ) ) {
+			throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
+		}
+	},
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
@@ -750,6 +793,19 @@ export const siteSettingsAgencyRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'agency',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( site.is_wpcom_atomic ) {
+			const agencyBlog = await queryClient.ensureQueryData( siteAgencyBlogQuery( site.ID ) );
+			if ( ! agencyBlog ) {
+				throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
+			}
+		}
+	},
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( site.is_wpcom_atomic ) {
@@ -774,11 +830,19 @@ export const siteSettingsHundredYearPlanRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'hundred-year-plan',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! canViewHundredYearPlanSettings( site ) ) {
+			throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
+		}
+	},
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( canViewHundredYearPlanSettings( site ) ) {
-			await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
-		}
+		await queryClient.ensureQueryData( siteSettingsQuery( site.ID ) );
 	},
 } ).lazy( () =>
 	import( '../../sites/settings-hundred-year-plan' ).then( ( d ) =>
@@ -799,7 +863,7 @@ export const siteSettingsPrimaryDataCenterRoute = createRoute( {
 	getParentRoute: () => siteSettingsRoute,
 	path: 'primary-data-center',
 	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
-		if ( cause !== 'enter' ) {
+		if ( cause === 'preload' ) {
 			return;
 		}
 
@@ -813,13 +877,11 @@ export const siteSettingsPrimaryDataCenterRoute = createRoute( {
 			}
 		}
 
-		throw redirect( { to: `/sites/${ siteSlug }/settings` } );
+		throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
 	},
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ) ) {
-			await queryClient.ensureQueryData( sitePrimaryDataCenterQuery( site.ID ) );
-		}
+		await queryClient.ensureQueryData( sitePrimaryDataCenterQuery( site.ID ) );
 	},
 } ).lazy( () =>
 	import( '../../sites/settings-primary-data-center' ).then( ( d ) =>
@@ -938,6 +1000,17 @@ export const siteSettingsTransferSiteRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteSettingsRoute,
 	path: 'transfer-site',
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		if ( ! user || ! canTransferSite( site, user ) ) {
+			throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
+		}
+	},
 } ).lazy( () =>
 	import( '../../sites/settings-transfer-site' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-transfer-site' )( {
@@ -1117,13 +1190,13 @@ export const siteTrialEndedRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'trial-ended',
 	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
-		if ( cause !== 'enter' ) {
+		if ( cause === 'preload' ) {
 			return;
 		}
 
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( ! hasSiteTrialEnded( site ) ) {
-			throw redirect( { to: `/sites/${ siteSlug }` } );
+			throw redirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 } ).lazy( () =>
@@ -1147,13 +1220,13 @@ export const siteDifmLiteInProgressRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'site-building-in-progress',
 	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
-		if ( cause !== 'enter' ) {
+		if ( cause === 'preload' ) {
 			return;
 		}
 
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( ! site.options?.is_difm_lite_in_progress ) {
-			throw redirect( { to: `/sites/${ siteSlug }` } );
+			throw redirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 	},
 	loader: async ( { params: { siteSlug } } ) => {
@@ -1201,13 +1274,13 @@ export const siteMigrationOverviewRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'migration-overview',
 	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
-		if ( cause !== 'enter' ) {
+		if ( cause === 'preload' ) {
 			return;
 		}
 
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( ! isSiteMigrationInProgress( site ) ) {
-			throw redirect( { to: `/sites/${ siteSlug }` } );
+			throw redirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
 		}
 
 		return {
@@ -1392,4 +1465,18 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 // Defined as a `function` so that routes defined earlier can reference routes defined later.
 function getDifmLiteAllowedRoutes() {
 	return [ siteDifmLiteInProgressRoute.id, siteDomainsRoute.id ];
+}
+
+function redirectAsNotAllowed( options: {
+	to: string;
+	params?: Record< string, string >;
+	search?: Record< string, unknown >;
+} ) {
+	return redirect( {
+		...options,
+		search: {
+			...options.search,
+			flash: 'route-not-allowed',
+		},
+	} );
 }

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -102,14 +102,7 @@ export const siteRoute = createRoute( {
 			return;
 		}
 
-		let site;
-		try {
-			site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		} catch ( e ) {
-			// Do nothing and propagate the error through the loader function.
-			return;
-		}
-
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( ! canManageSite( site ) ) {
 			throw notFound();
 		}

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -102,7 +102,14 @@ export const siteRoute = createRoute( {
 			return;
 		}
 
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		let site;
+		try {
+			site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		} catch ( e ) {
+			// Do nothing and propagate the error through the loader function.
+			return;
+		}
+
 		if ( ! canManageSite( site ) ) {
 			throw notFound();
 		}

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -439,7 +439,11 @@ export const siteBackupsRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'backups',
-	beforeLoad: async ( { params: { siteSlug } } ) => {
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( isCommerceGarden( site ) ) {
 			throw redirectAsNotAllowed( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
@@ -567,7 +571,11 @@ export const sitePerformanceRoute = createRoute( {
 	} ),
 	getParentRoute: () => siteRoute,
 	path: 'performance',
-	beforeLoad: async ( { params: { siteSlug } } ) => {
+	beforeLoad: async ( { cause, params: { siteSlug } } ) => {
+		if ( cause === 'preload' ) {
+			return;
+		}
+
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( isCommerceGarden( site ) ) {
 			throw redirectAsNotAllowed( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );

--- a/client/dashboard/components/flash-message/index.tsx
+++ b/client/dashboard/components/flash-message/index.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 
 interface FlashMessageProps {
 	id: string;
+	refreshKey?: string;
 	message: string;
 	type?: 'success' | 'error';
 }
@@ -20,7 +21,12 @@ export function reloadWithFlashMessage( messageId: string ) {
  * Allows a snackbar to be shown on page load based on a query parameter.
  * Clears the query parameter when done.
  */
-export default function FlashMessage( { id, message, type = 'success' }: FlashMessageProps ) {
+export default function FlashMessage( {
+	id,
+	refreshKey = id,
+	message,
+	type = 'success',
+}: FlashMessageProps ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	useEffect( () => {
@@ -45,9 +51,9 @@ export default function FlashMessage( { id, message, type = 'success' }: FlashMe
 		}
 
 		// This effect has side effects, like editing the URL. We only ever
-		// want to run it once on mount.
+		// want to run it once on mount or when the `refreshKey` prop changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ refreshKey ] );
 
 	return null;
 }

--- a/client/dashboard/components/flash-message/index.tsx
+++ b/client/dashboard/components/flash-message/index.tsx
@@ -5,7 +5,6 @@ import { useEffect } from 'react';
 
 interface FlashMessageProps {
 	id: string;
-	refreshKey?: string;
 	message: string;
 	type?: 'success' | 'error';
 }
@@ -21,12 +20,7 @@ export function reloadWithFlashMessage( messageId: string ) {
  * Allows a snackbar to be shown on page load based on a query parameter.
  * Clears the query parameter when done.
  */
-export default function FlashMessage( {
-	id,
-	refreshKey = id,
-	message,
-	type = 'success',
-}: FlashMessageProps ) {
+export default function FlashMessage( { id, message, type = 'success' }: FlashMessageProps ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	useEffect( () => {
@@ -51,9 +45,9 @@ export default function FlashMessage( {
 		}
 
 		// This effect has side effects, like editing the URL. We only ever
-		// want to run it once on mount or when the `refreshKey` prop changes.
+		// want to run it once on mount.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ refreshKey ] );
+	}, [] );
 
 	return null;
 }

--- a/client/dashboard/sites/settings-agency/index.tsx
+++ b/client/dashboard/sites/settings-agency/index.tsx
@@ -1,11 +1,5 @@
-import {
-	siteAgencyBlogQuery,
-	siteBySlugQuery,
-	siteSettingsMutation,
-	siteSettingsQuery,
-} from '@automattic/api-queries';
+import { siteBySlugQuery, siteSettingsMutation, siteSettingsQuery } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { notFound } from '@tanstack/react-router';
 import {
 	__experimentalVStack as VStack,
 	Button,
@@ -61,10 +55,6 @@ const form = {
 export default function SettingsAgency( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: siteSettings } = useQuery( siteSettingsQuery( site.ID ) );
-	const { data: agencyBlog, isLoading: isLoadingAgencyBlog } = useQuery( {
-		...siteAgencyBlogQuery( site.ID ),
-		enabled: site.is_wpcom_atomic,
-	} );
 	const mutation = useMutation( {
 		...siteSettingsMutation( site.ID ),
 		meta: {
@@ -78,10 +68,6 @@ export default function SettingsAgency( { siteSlug }: { siteSlug: string } ) {
 	const [ formData, setFormData ] = useState( {
 		is_fully_managed_agency_site: siteSettings?.is_fully_managed_agency_site,
 	} );
-
-	if ( ! agencyBlog && ! isLoadingAgencyBlog ) {
-		throw notFound();
-	}
 
 	const isAgencyDevelopmentSite = site.is_a4a_dev_site;
 	const renderContent = () => {

--- a/client/dashboard/sites/settings-hundred-year-plan/index.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/index.tsx
@@ -1,21 +1,15 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { notFound } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { canViewHundredYearPlanSettings } from '../features';
 import ContactForm from './contact-form';
 import LockedModeForm from './locked-mode-form';
 
 export default function HundredYearPlanSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: settings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
-
-	if ( ! canViewHundredYearPlanSettings( site ) ) {
-		throw notFound();
-	}
 
 	return (
 		<PageLayout

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -1,7 +1,5 @@
-import { DotcomFeatures } from '@automattic/api-core';
 import { siteBySlugQuery, siteSettingsMutation, siteSettingsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import { notFound } from '@tanstack/react-router';
 import { __experimentalVStack as VStack, Button, CheckboxControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
@@ -16,7 +14,6 @@ import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { hasPlanFeature } from '../../utils/site-features';
 import type { SiteSettings } from '@automattic/api-core';
 import type { Field, FormField } from '@wordpress/dataviews';
 
@@ -54,10 +51,6 @@ export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: s
 	const [ formData, setFormData ] = useState( {
 		wpcom_gifting_subscription: data.wpcom_gifting_subscription,
 	} );
-
-	if ( ! hasPlanFeature( site, DotcomFeatures.SUBSCRIPTION_GIFTING ) ) {
-		throw notFound();
-	}
 
 	const isDirty = Object.entries( formData ).some(
 		( [ key, value ] ) => data[ key as keyof SiteSettings ] !== value

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -1,6 +1,5 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { notFound } from '@tanstack/react-router';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getQueryArg } from '@wordpress/url';
@@ -11,7 +10,6 @@ import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { canTransferSite } from '../features';
 import { ConfirmNewOwnerForm, ConfirmNewOwnerFormData } from './confirm-new-owner-form';
 import { EmailConfirmation } from './email-confirmation';
 import { InvitationEmailSent } from './invitation-email-sent';
@@ -72,10 +70,6 @@ export default function SettingsTransferSite( {
 	const handleStartSiteTransfer = () => {
 		handleForward();
 	};
-
-	if ( ! canTransferSite( site, user ) ) {
-		throw notFound();
-	}
 
 	if ( confirmationHash ) {
 		return (

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -1,16 +1,18 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Outlet, notFound } from '@tanstack/react-router';
+import { Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { Suspense, useMemo, lazy } from 'react';
 import { useAppContext } from '../../app/context';
 import { siteRoute } from '../../app/router/sites';
 import StagingSiteSyncMonitor from '../../app/staging-site-sync-monitor';
+import FlashMessage from '../../components/flash-message';
 import HeaderBar from '../../components/header-bar';
 import MenuDivider from '../../components/menu-divider';
 import { hasStagingSite } from '../../utils/site-staging-site';
 import { isSiteMigrationInProgress } from '../../utils/site-status';
-import { canManageSite, canSwitchEnvironment } from '../features';
+import { canSwitchEnvironment } from '../features';
 import SiteMenu from '../site-menu';
 import EnvironmentSwitcher from './environment-switcher';
 
@@ -22,10 +24,6 @@ function Site() {
 
 	if ( isError ) {
 		throw error;
-	}
-
-	if ( ! canManageSite( site ) ) {
-		throw notFound();
 	}
 
 	return (
@@ -46,6 +44,12 @@ function Site() {
 				</HStack>
 			</HeaderBar>
 			<Suspense fallback={ null }>
+				<FlashMessage
+					id="route-not-allowed"
+					refreshKey={ siteSlug }
+					type="error"
+					message={ __( 'Route not found or not allowed.' ) }
+				/>
 				<Outlet />
 			</Suspense>
 		</Suspense>

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -48,7 +48,7 @@ function Site() {
 					id="route-not-allowed"
 					key={ siteSlug }
 					type="error"
-					message={ __( 'Page not found or not allowed.' ) }
+					message={ __( 'You don’t have permission to view the page.' ) }
 				/>
 				<Outlet />
 			</Suspense>

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -46,7 +46,7 @@ function Site() {
 			<Suspense fallback={ null }>
 				<FlashMessage
 					id="route-not-allowed"
-					refreshKey={ siteSlug }
+					key={ siteSlug }
 					type="error"
 					message={ __( 'Page not found or not allowed.' ) }
 				/>

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -48,7 +48,7 @@ function Site() {
 					id="route-not-allowed"
 					refreshKey={ siteSlug }
 					type="error"
-					message={ __( 'Route not found or not allowed.' ) }
+					message={ __( 'Page not found or not allowed.' ) }
 				/>
 				<Outlet />
 			</Suspense>

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -48,7 +48,7 @@ function Site() {
 					id="route-not-allowed"
 					key={ siteSlug }
 					type="error"
-					message={ __( 'You don’t have permission to view the page.' ) }
+					message={ __( 'You don’t have permission to view the requested page.' ) }
 				/>
 				<Outlet />
 			</Suspense>


### PR DESCRIPTION
Part of DOTMSD-741
A bit related to DOMENG-319

## Proposed Changes

This PR's motivation is to establish a definite pattern in MSD on how to do route permission checks. Right now, each team does differently. For example, in domain-related routes, we throw errors, which caused alerts in DOMENG-319.

This PR proposes a pattern, and applies it in site routes. We can then expand to more routes later.

- Check for permission in `beforeLoad`. This is actually TanStack's preferred approach.
   - We can then remove redundant check in the components.
- Update `if ( cause !== 'enter' )` to `if ( cause === 'preload' )`. This is because when we use site switcher, the cause is `stay`, not `enter`, because the route is the same, only the param changes. 🥹 
- Show snackbar when redirecting. I used `<FlashMessage>` but I don't know if that's correct pattern here 🥹 

## Testing Instructions

1. Need humans to visually check the code changes.
2. Smoke check some of the routes. For example:
    - Open `/sites/:site/logs`
    - From site switcher, change to a CIAB site
    - Observe it redirects to overview and with the snackbar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
