### PR TITLE
Help Center: Disable auth-dependant requests for logged out users

### DIFF
--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -25,7 +25,9 @@ export function HelpCenterChat( {
 	const preventOdieAccess = ! shouldUseWapuu && ! isUserEligibleForPaidSupport && ! isLoadingStatus;
 	const { currentUser, site, isCommerceGarden, newInteractionsBotSlug, newInteractionsBotVersion } =
 		useHelpCenterContext();
-	const { data: canConnectToZendesk, isLoading } = useCanConnectToZendeskMessaging();
+	const { data: canConnectToZendesk, isLoading } = useCanConnectToZendeskMessaging(
+		!! currentUser?.ID
+	);
 	const { search } = useLocation();
 	const { data } = useSupportStatus( ! isCommerceGarden );
 	const params = new URLSearchParams( search );

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -15,6 +15,7 @@ import { useQueryClient, QueryClient } from '@tanstack/react-query';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import Smooch from 'smooch';
+import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useChatStatus } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
 import { getClientId, getZendeskConversations } from './utils';
@@ -92,8 +93,9 @@ const playNotificationSound = () => {
 const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } ) => {
 	const { isEligibleForChat } = useChatStatus();
 	const queryClient = useQueryClient();
+	const { currentUser } = useHelpCenterContext();
 	const smoochRef = useRef< HTMLDivElement >( null );
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
 	const {
 		isHelpCenterShown,
 		isChatLoaded,

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -38,7 +38,7 @@ const HelpCenter: React.FC< Container > = ( {
 	}, [] );
 	const { currentUser, site, sectionName } = useHelpCenterContext();
 	const { isEligibleForChat } = useChatStatus();
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
 	const { data: supportInteractionsOpen, isLoading: isLoadingOpenInteractions } =
 		useGetSupportInteractions( 'zendesk' );
 	const hasOpenZendeskConversations =

--- a/packages/help-center/src/components/notices.tsx
+++ b/packages/help-center/src/components/notices.tsx
@@ -15,8 +15,8 @@ import './notices.scss';
 import { HELP_CENTER_STORE } from '../stores';
 
 export const BlockedZendeskNotice: React.FC = () => {
-	const { sectionName } = useHelpCenterContext();
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
+	const { currentUser, sectionName } = useHelpCenterContext();
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
 	const { isEligibleForChat } = useChatStatus();
 	const { setShowSupportDoc } = useDispatch( HELP_CENTER_STORE );
 


### PR DESCRIPTION
Fixes DOTCOM-15395

## Proposed Changes

Currently, logged-out users get a lot of 403 responses because the HC attempts to fetch some privileged data. This disables these cases.

## Why are these changes being made?
Save on requests and 403s.

## Testing Instructions

1. Smoke test the HC while logged out.
2. Most importantly, starting a chat with Odie and then going back to the HC homepage should show the interaction as a recent convo.
3. Going to support history should show all the interactions.
