### PR TITLE
MSD Cancel flow: Use CancelFlowType for flowType variable

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-header-title.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-header-title.tsx
@@ -1,9 +1,9 @@
 import { __ } from '@wordpress/i18n';
-import { CANCEL_FLOW_TYPE } from '../../../utils/purchase';
+import { CANCEL_FLOW_TYPE, CancelFlowType } from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
 interface CancelHeaderTitleProps {
-	flowType: string;
+	flowType: CancelFlowType;
 	purchase: Purchase;
 }
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -4,7 +4,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { intlFormat } from 'date-fns';
 import { ButtonStack } from '../../../../components/button-stack';
 import { SectionHeader } from '../../../../components/section-header';
-import { CANCEL_FLOW_TYPE } from '../../../../utils/purchase';
+import { CANCEL_FLOW_TYPE, CancelFlowType } from '../../../../utils/purchase';
 import { AtomicRevertStep } from './step-components/atomic-revert-step';
 import EducationContentStep from './step-components/educational-content-step';
 import FeedbackStep from './step-components/feedback-step';
@@ -47,7 +47,7 @@ interface CancelPurchaseFormProps {
 	downgradePlan?: PlanProduct;
 	downgradePlanToMonthlyPrice?: number;
 	downgradePlanToPersonalPrice?: number;
-	flowType?: string;
+	flowType?: CancelFlowType;
 	freeMonthOfferClick?: () => void;
 	allSteps: string[];
 	hasBackupsFeature?: boolean;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -41,6 +41,7 @@ import PageLayout from '../../../components/page-layout';
 import { shuffleArray } from '../../../utils/collection';
 import {
 	CANCEL_FLOW_TYPE,
+	CancelFlowType,
 	getIncludedDomainPurchase,
 	getPurchaseCancellationFlowType,
 	hasAmountAvailableToRefund,
@@ -144,7 +145,7 @@ function getOfferDiscountBasedOnPurchasePrice(
 
 function availableJetpackSurveySteps(
 	purchase: Purchase,
-	flowType: string,
+	flowType: CancelFlowType,
 	cancellationOffer: CancellationOffer | undefined
 ): string[] {
 	const availableSteps = [];

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -25,7 +25,8 @@ export const CANCEL_FLOW_TYPE = {
 	// When users effectively cancelling the auto-renewal by
 	// cancelling a subscription out of the refund window
 	CANCEL_AUTORENEW: 'cancel_autorenew',
-};
+} as const;
+export type CancelFlowType = ( typeof CANCEL_FLOW_TYPE )[ keyof typeof CANCEL_FLOW_TYPE ];
 
 export function isTemporarySitePurchase( purchase: Purchase ): boolean {
 	const { domain } = purchase;
@@ -580,7 +581,7 @@ export function hasAmountAvailableToRefund( purchase: Purchase ) {
 /**
  * Returns the purchase cancellation flow.
  */
-export function getPurchaseCancellationFlowType( purchase: Purchase ): string {
+export function getPurchaseCancellationFlowType( purchase: Purchase ): CancelFlowType {
 	const isPlanRefundable = purchase.is_refundable;
 	const isPlanAutoRenewing = purchase.is_auto_renew_enabled;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1502/msd-cancel-flow-flowtype-should-have-a-typescript-type

## Proposed Changes

This PR adds a new TypeScript type, `CancelFlowType` to the MSD (Multi Site Dashboard) cancel flow and uses it to replace `string` for every instance of the `flowType` variable.

> [!NOTE]
> After this is merged, we'll need to rebase https://github.com/Automattic/wp-calypso/pull/107983 on top of it and update that branch to use this type.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

`flowType` is very important to the cancel flow and it can only be one of three values, but the type system currently doesn't enforce that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The Type checker will cover this change.
