### PR TITLE
Use wpcomLink() for plans URL in plugin upgrade action

### DIFF
--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -12,9 +12,10 @@ import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs } from '@wordpress/url';
 import { useMemo, useState } from 'react';
 import { Plan } from '../../sites/site-fields';
-import { wpcomLink } from '../../utils/link';
+import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { hasPlanFeature } from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName } from '../../utils/site-plan';
@@ -248,7 +249,11 @@ export const SitesWithoutThisPlugin = ( {
 					}
 
 					if ( site.slug ) {
-						window.open( wpcomLink( `/plans/${ site.slug }` ), '_blank' );
+						const backUrl = redirectToDashboardLink();
+						window.location.href = addQueryArgs( wpcomLink( '/setup/plan-upgrade' ), {
+							siteSlug: site.slug,
+							cancel_to: backUrl,
+						} );
 					}
 				},
 				isEligible: ( item: Site ) => ! hasPlanFeature( item, DotcomFeatures.INSTALL_PLUGINS ),

--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -14,6 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
 import { Plan } from '../../sites/site-fields';
+import { wpcomLink } from '../../utils/link';
 import { hasPlanFeature } from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName } from '../../utils/site-plan';
@@ -247,7 +248,7 @@ export const SitesWithoutThisPlugin = ( {
 					}
 
 					if ( site.slug ) {
-						window.open( `https://wordpress.com/plans/${ site.slug }`, '_blank' );
+						window.open( wpcomLink( `/plans/${ site.slug }` ), '_blank' );
 					}
 				},
 				isEligible: ( item: Site ) => ! hasPlanFeature( item, DotcomFeatures.INSTALL_PLUGINS ),


### PR DESCRIPTION
## Proposed Changes

* Use `wpcomLink()` helper for hardcoded WordPress.com URL in plugin upgrade action

## Why are these changes being made?

Hardcoded `https://wordpress.com/plans/` URL doesn't adapt to environment (dev vs production). Dashboard code review guideline requires all WordPress.com/Calypso links use `wpcomLink()` for proper hostname configuration.

## Testing Instructions

### Prerequisites
* Site without Creator plan or higher (cannot install plugins)
* Plugin that requires Creator plan+

### Steps
1. Navigate to Dashboard → Plugins → [Any Plugin]
2. Scroll to "Sites without this plugin" section
3. Find site without required plan
4. Click "Upgrade to install" action
5. Verify opens plans page in new tab with correct environment URL:
   - Dev: `https://wpcalypso.wordpress.com/plans/{site-slug}`
   - Prod: `https://wordpress.com/plans/{site-slug}`

### Edge Cases
* Test with site that has expired plan
* Test with Jetpack connected self-hosted site (action should not appear)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?