### PR TITLE
Fix Titan mailbox 404 redirect

### DIFF
--- a/client/dashboard/utils/email-utils.ts
+++ b/client/dashboard/utils/email-utils.ts
@@ -1,4 +1,5 @@
 import { EmailAccount } from '@automattic/api-core';
+import { dashboardLink } from './link';
 
 export type EmailWarningType =
 	| 'google_pending_tos_acceptance'
@@ -65,7 +66,7 @@ export function buildGoogleManageWorkspaceLink( email: string, domainName: strin
 export function buildTitanMailboxLink( email: string ) {
 	const titanMailUrl = new URL( 'https://wp.titan.email/mail/' );
 	titanMailUrl.searchParams.append( 'email_account', email );
-	titanMailUrl.searchParams.append( 'topbar.redirect_url', 'https://wordpress.com/emails' );
+	titanMailUrl.searchParams.append( 'topbar.redirect_url', dashboardLink( '/emails' ) );
 
 	return titanMailUrl.href;
 }


### PR DESCRIPTION
Part of #

## Proposed Changes

* Replace hardcoded `https://wordpress.com/emails` URL in `buildTitanMailboxLink()` with `dashboardLink('/emails')`
* Add import for `dashboardLink` utility function

## Why are these changes being made?

The `buildTitanMailboxLink()` function builds a URL to open Titan webmail with a redirect parameter that should return users to the dashboard after they're done. However, it was hardcoded to `https://wordpress.com/emails`, which doesn't exist and results in a 404 error in production.

<img width="3136" height="1780" alt="CleanShot 2026-01-09 at 12 01 43@2x" src="https://github.com/user-attachments/assets/37578d2e-b04b-46bb-af58-c1475107971a" />


By using `dashboardLink('/emails')`, the redirect now correctly points to:
- Development: `http://my.localhost:3000/emails`
- Production: `https://my.wordpress.com/emails`

This ensures users are properly returned to the dashboard emails page after accessing their Titan mailbox.

## Testing Instructions

### Prerequisites
Need a Titan email. If you don't have one: go to `/emails` and attach one to one of your existing test sites with a custom domain, make sure to choose Titan as the provider
* At least one Titan mailbox created

### Steps to test

1. Navigate to dashboard emails page (`/emails`)
2. Locate a Titan mailbox in the list
3. Click the "View mailbox" action (or open mailbox link)
4. Observe that Titan webmail opens in new tab
5. In the Titan webmail interface, click the "My Mailboxes" link in the topbar to return to dashboard
6. **Expected**: You are redirected to `https://my.wordpress.com/emails` or the equivalent page given the environment you're testing in (not a 404 page)

<img width="2134" height="1020" alt="CleanShot 2026-01-09 at 12 02 09@2x" src="https://github.com/user-attachments/assets/4fc2dd4e-db93-46d8-9c3c-c11422a4c1a2" />

<img width="2144" height="678" alt="CleanShot 2026-01-09 at 12 01 57@2x" src="https://github.com/user-attachments/assets/493cc3c2-bdf5-4d64-95ae-6498f2661f26" />


### Alternative test location
* From mailboxes ready view (after setting up Titan email)
* Click any "Open mailbox" button for Titan accounts
* Follow steps 5-6 above

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? *(N/A - utility function fix, no logic change)*
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors? *(No errors)*
- [x] Have you tested accessibility for your changes? *(N/A - no UI changes)*
- [x] Have you used memoizing on expensive computations? *(N/A - no computations added)*
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? *(N/A - no strings changed)*
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)? *(N/A - no tracking changes)*