### PR TITLE
Localize tax support URL in billing tax details

### DIFF
--- a/client/dashboard/me/billing-tax-details/user-tax-form.tsx
+++ b/client/dashboard/me/billing-tax-details/user-tax-form.tsx
@@ -5,8 +5,8 @@ import {
 	userTaxDetailsQuery,
 	userTaxDetailsMutation,
 } from '@automattic/api-queries';
-import { CALYPSO_CONTACT } from '@automattic/urls';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { CALYPSO_CONTACT } from '@automattic/urls';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
 	Button,

--- a/client/dashboard/me/billing-tax-details/user-tax-form.tsx
+++ b/client/dashboard/me/billing-tax-details/user-tax-form.tsx
@@ -6,6 +6,7 @@ import {
 	userTaxDetailsMutation,
 } from '@automattic/api-queries';
 import { CALYPSO_CONTACT } from '@automattic/urls';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
 	Button,
@@ -263,8 +264,7 @@ export default function UserTaxForm() {
 	/* This is a call to action for contacting support */
 	const contactSupportLinkTitle = __( 'Contact Happiness Engineers' );
 
-	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
-	const taxSupportPageURL = 'https://wordpress.com/support/vat-gst-other-taxes/'; // TODO: Replace with localized URL.
+	const taxSupportPageURL = localizeUrl( 'https://wordpress.com/support/vat-gst-other-taxes/' );
 
 	/* This is the title of the support page from https://wordpress.com/support/vat-gst-other-taxes/ */
 	const taxSupportPageLinkTitle = __( 'VAT, GST, and other taxes' );


### PR DESCRIPTION
## Proposed Changes

* Wrap tax support URL with `localizeUrl()` to enable multi-language support

## Why are these changes being made?

This is probably a relic of when `localiseUrl` wasn't available in MSD.
The locale-specific versions (e.g., [German](https://wordpress.com/de/support/ust-gst-und-sonstige-steuern/), [Russian](https://wordpress.com/ru/support/vat-gst-other-taxes/)) appear to be available.

## Testing Instructions

### Setup
1. Navigate to Dashboard → Billing → Tax Details (`/me/billing/tax-details`)

<img width="1466" height="1252" alt="CleanShot 2026-01-09 at 15 14 41@2x" src="https://github.com/user-attachments/assets/e6481924-ab47-4395-b130-c4f37533c061" />


### Test Cases

**English locale (default):**
1. Click the "click here" link in the "For more information about taxes" section
2. Verify it opens `https://wordpress.com/support/vat-gst-other-taxes/`

**German locale:**
1. Change locale to German (de)
2. Navigate to `/me/billing-tax-details`
3. Click the "click here" link
4. Verify it opens `https://wordpress.com/de/support/ust-gst-und-sonstige-steuern/`

**Russian locale:**
1. Change locale to Russian (ru)
2. Navigate to `/me/billing-tax-details`
3. Click the "click here" link
4. Verify it opens `https://wordpress.com/ru/support/vat-gst-other-taxes/`

**Unsupported locale:**
1. Change to a locale not in `supportSiteLocales` (e.g., Swahili)
2. Navigate to `/me/billing-tax-details`
3. Click the "click here" link
4. Verify it falls back to English version

**Smoke test:**
1. Verify no console errors
2. Verify page renders correctly
3. Verify form submission still works
4. Verify all other links on the page work correctly

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?