### PR TITLE
MSD: Remove border from IconListItem, add density.

### DIFF
--- a/client/dashboard/components/icon-list/icon-list-item.scss
+++ b/client/dashboard/components/icon-list/icon-list-item.scss
@@ -7,8 +7,6 @@
 		flex-shrink: 0;
 
 		svg {
-			width: $grid-unit-30;
-			height: $grid-unit-30;
 			flex-shrink: 0;
 			fill: $gray-700;
 		}

--- a/client/dashboard/components/icon-list/icon-list-item.scss
+++ b/client/dashboard/components/icon-list/icon-list-item.scss
@@ -2,34 +2,15 @@
 @import "@wordpress/base-styles/variables";
 
 .icon-list-item {
-	padding: $grid-unit-05 0;
-
 	.icon-list-item__decoration {
 		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		width: $grid-unit-50;
-		height: $grid-unit-50;
 		flex-shrink: 0;
-		border-radius: $radius-small;
-		overflow: hidden;
-
-		&:has(svg) {
-			border: 1px solid $gray-200;
-		}
 
 		svg {
 			width: $grid-unit-30;
 			height: $grid-unit-30;
 			flex-shrink: 0;
 			fill: $gray-700;
-		}
-
-		img {
-			width: 100%;
-			height: 100%;
-			flex-shrink: 0;
-			object-fit: cover;
 		}
 	}
 

--- a/client/dashboard/components/icon-list/icon-list-item.stories.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.stories.tsx
@@ -28,14 +28,6 @@ export const WithIcon: Story = {
 	},
 };
 
-export const WithImage: Story = {
-	args: {
-		title: 'Icon list item title',
-		description: 'Icon list item description',
-		decoration: <Icon icon={ <img src="https://placecats.com/300/200" alt="Cat" /> } />,
-	},
-};
-
 export const WithoutDescription: Story = {
 	args: {
 		title: 'Icon list item title',

--- a/client/dashboard/components/icon-list/icon-list-item.stories.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.stories.tsx
@@ -34,3 +34,30 @@ export const WithoutDescription: Story = {
 		decoration: <Icon icon={ cog } />,
 	},
 };
+
+export const DensityLow: Story = {
+	args: {
+		title: 'Low density item',
+		description: 'More spacing between elements',
+		decoration: <Icon icon={ cog } />,
+		density: 'low',
+	},
+};
+
+export const DensityMedium: Story = {
+	args: {
+		title: 'Medium density item',
+		description: 'Default spacing between elements',
+		decoration: <Icon icon={ cog } />,
+		density: 'medium',
+	},
+};
+
+export const DensityHigh: Story = {
+	args: {
+		title: 'High density item',
+		description: 'Tighter spacing between elements',
+		decoration: <Icon icon={ cog } />,
+		density: 'high',
+	},
+};

--- a/client/dashboard/components/icon-list/icon-list-item.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.tsx
@@ -21,6 +21,7 @@ function UnforwardedIconListItem(
 
 	const iconSpacing = densitySpacingMap[ density ];
 	const textSpacing = densitySpacingMap[ density ] / 2;
+	const suffixSpacing = densitySpacingMap[ density ];
 	const titleSize = density === 'low' ? '15px' : undefined;
 	const alignment = description ? 'flex-start' : 'center';
 
@@ -28,7 +29,7 @@ function UnforwardedIconListItem(
 		<VStack className={ clsx( 'icon-list-item', className ) } ref={ ref } as="span">
 			<HStack spacing={ iconSpacing } alignment={ alignment } as="span">
 				{ !! decoration && <span className="icon-list-item__decoration">{ decoration }</span> }
-				<HStack spacing={ 3 } as="span">
+				<HStack spacing={ suffixSpacing } as="span">
 					<VStack spacing={ textSpacing } as="span">
 						<Text weight={ 500 } lineHeight="24px" size={ titleSize }>
 							{ title }

--- a/client/dashboard/components/icon-list/icon-list-item.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.tsx
@@ -10,23 +10,30 @@ import type { IconListItemProps } from './types';
 import './icon-list-item.scss';
 
 function UnforwardedIconListItem(
-	{ title, description, decoration, suffix, className }: IconListItemProps,
+	{ title, description, decoration, suffix, className, density = 'medium' }: IconListItemProps,
 	ref: React.ForwardedRef< HTMLSpanElement >
 ) {
+	const densitySpacingMap = {
+		low: 3,
+		medium: 2,
+		high: 1,
+	};
+
+	const iconSpacing = densitySpacingMap[ density ];
+	const textSpacing = densitySpacingMap[ density ] / 2;
+	const titleSize = density === 'low' ? '15px' : undefined;
+	const alignment = description ? 'flex-start' : 'center';
+
 	return (
 		<VStack className={ clsx( 'icon-list-item', className ) } ref={ ref } as="span">
-			<HStack spacing={ 4 } justify="flex-start" alignment="center" as="span">
+			<HStack spacing={ iconSpacing } alignment={ alignment } as="span">
 				{ !! decoration && <span className="icon-list-item__decoration">{ decoration }</span> }
 				<HStack spacing={ 3 } as="span">
-					<VStack spacing={ 1 } as="span">
-						<Text weight={ 500 } lineHeight="20px">
+					<VStack spacing={ textSpacing } as="span">
+						<Text weight={ 500 } size={ titleSize }>
 							{ title }
 						</Text>
-						{ description && (
-							<Text variant="muted" lineHeight="20px">
-								{ description }
-							</Text>
-						) }
+						{ description && <Text variant="muted">{ description }</Text> }
 					</VStack>
 					{ suffix }
 				</HStack>

--- a/client/dashboard/components/icon-list/icon-list-item.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.tsx
@@ -30,7 +30,7 @@ function UnforwardedIconListItem(
 				{ !! decoration && <span className="icon-list-item__decoration">{ decoration }</span> }
 				<HStack spacing={ 3 } as="span">
 					<VStack spacing={ textSpacing } as="span">
-						<Text weight={ 500 } size={ titleSize }>
+						<Text weight={ 500 } lineHeight="24px" size={ titleSize }>
 							{ title }
 						</Text>
 						{ description && <Text variant="muted">{ description }</Text> }

--- a/client/dashboard/components/icon-list/types.ts
+++ b/client/dashboard/components/icon-list/types.ts
@@ -24,7 +24,11 @@ export interface IconListItemProps {
 	 */
 	className?: string;
 	/**
-	 * Controls the spacing between the icon and the content.
+	 * Controls the overall visual density of the item, including spacing
+	 * between the decoration/icon and the content, as well as the spacing
+	 * between the title and description text. When set to `'low'`, it also
+	 * adjusts the title typography (e.g., a smaller title font size) to
+	 * match the denser layout.
 	 * @default 'medium'
 	 */
 	density?: 'low' | 'medium' | 'high';

--- a/client/dashboard/components/icon-list/types.ts
+++ b/client/dashboard/components/icon-list/types.ts
@@ -23,6 +23,11 @@ export interface IconListItemProps {
 	 * Optional CSS class name(s) to apply to the item.
 	 */
 	className?: string;
+	/**
+	 * Controls the spacing between the icon and the content.
+	 * @default 'medium'
+	 */
+	density?: 'low' | 'medium' | 'high';
 }
 
 export interface IconListProps {

--- a/client/dashboard/domains/domain-connection-setup/style.scss
+++ b/client/dashboard/domains/domain-connection-setup/style.scss
@@ -8,9 +8,7 @@
 			fill: var(--dashboard__background-color-success);
 		}
 	}
-	.dashboard-domain-connection-verification__title {
-		@include body-large;
-	}
+
 	.summary-button.components-button .summary-button-title {
 		font-weight: 500;
 	}

--- a/client/dashboard/domains/domain-connection-setup/verification-in-progress-next-steps.stories.tsx
+++ b/client/dashboard/domains/domain-connection-setup/verification-in-progress-next-steps.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from '@storybook/react';
+import VerificationInProgressNextSteps from './verification-in-progress-next-steps';
+
+const meta: Meta< typeof VerificationInProgressNextSteps > = {
+	title: 'client/dashboard/Domains/VerificationInProgressNextSteps',
+	component: VerificationInProgressNextSteps,
+	tags: [ 'autodocs' ],
+};
+
+export default meta;
+
+type Story = StoryObj< typeof VerificationInProgressNextSteps >;
+
+export const Default: Story = {};
+
+export const DensityLow: Story = {
+	args: {
+		density: 'low',
+	},
+};
+
+export const DensityMedium: Story = {
+	args: {
+		density: 'medium',
+	},
+};
+
+export const DensityHigh: Story = {
+	args: {
+		density: 'high',
+	},
+};

--- a/client/dashboard/domains/domain-connection-setup/verification-in-progress-next-steps.tsx
+++ b/client/dashboard/domains/domain-connection-setup/verification-in-progress-next-steps.tsx
@@ -49,6 +49,7 @@ export default function VerificationInProgressNextSteps() {
 					title={ item.title }
 					description={ item.description }
 					decoration={ <Icon icon={ item.icon } /> }
+					density="medium"
 				/>
 			) ) }
 		</CollapsibleCard>


### PR DESCRIPTION
Part DOTMSD-995.
Fixes DOTMSD-996.

## Proposed Changes

This PR removes the border and padding around the icon. 

## Screenshot

<img width="1103" height="833" alt="Screenshot 2026-01-09 at 11 50 16 AM" src="https://github.com/user-attachments/assets/29453409-ae98-41d6-bd4b-a6a83e3f92ca" />


**Production changes**

| Before | After |
|--------|--------|
| <img width="703" height="111" alt="Screenshot 2026-01-09 at 11 02 09 AM" src="https://github.com/user-attachments/assets/6e03c18f-551d-42e3-9190-6edbd31d0e64" /> | <img width="695" height="112" alt="Screenshot 2026-01-09 at 11 01 56 AM" src="https://github.com/user-attachments/assets/e76d944f-935c-48a5-acb6-13a1b6458d02" /> |
| <img width="605" height="210" alt="Screenshot 2026-01-09 at 11 06 38 AM" src="https://github.com/user-attachments/assets/3455ca5e-0cf3-4a61-a386-6713d76e5fe7" /> | <img width="568" height="197" alt="Screenshot 2026-01-09 at 11 09 59 AM" src="https://github.com/user-attachments/assets/49288cc3-c2b4-4335-b97a-c7beab7d1436" /> | 

## Why are these changes being made?

While this icon matches [the figma](https://www.figma.com/design/rykv85Ii9RkvP504dtqqaW/DS-Experimental?node-id=1698-8535&p=f&m=dev), we aren't using these styles meaningfully and we want to unifying styles in the dashboard. 

You can read more context: p9Jlb4-glF-p2#comment-15531

## Considerations

This does remove `img` support as well. That's a nice feature, although I don't see any uses of that and it's not trivial to support that. I think we can re-add it if we need it.

## Testing Instructions

### Check out the stories
* `yarn storybook:start`
* Check out the stories

### Verify the impacted views
#### Delete account
- Navigate to `/me/profile`
- Scroll to the bottom. 
- Verify layout of "Delete your account permanently"

### Domain connection setup
It's a bit tricky to test this locally. The PR that implement the component is here: https://github.com/Automattic/wp-calypso/pull/106628.

I create a custom story to test myself.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
