### PR TITLE
MSD: Remove staging sites from sites list.

### DIFF
--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -44,7 +44,13 @@ export const usePlugin = ( pluginSlug: string ) => {
 		isLoading: isLoadingSitesPlugins,
 		isFetching: isFetchingSitePlugins,
 	} = useQuery( pluginsQuery() );
-	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery(
+		queries.sitesQuery( {
+			include_staging: true,
+			include_a8c_owned: false,
+			site_visibility: 'visible',
+		} )
+	);
 	const { data: marketplacePlugins, isLoading: isLoadingMarketplacePlugins } = useQuery(
 		marketplacePluginsQuery()
 	);

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -13,6 +13,7 @@ export type FetchSiteTypes = 'all' | FetchSiteType[];
 export interface FetchSitesOptions {
 	site_visibility: 'all' | 'visible' | 'hidden' | 'deleted';
 	include_a8c_owned: boolean;
+	include_staging?: boolean;
 }
 
 export interface FetchPaginatedSitesOptions extends FetchSitesOptions {
@@ -32,7 +33,7 @@ export interface FetchPaginatedSitesResponse {
 
 export async function fetchSites(
 	site_types: FetchSiteTypes,
-	{ site_visibility, include_a8c_owned }: FetchSitesOptions
+	{ site_visibility, include_a8c_owned, include_staging = false }: FetchSitesOptions
 ): Promise< Site[] > {
 	const { sites } = await wpcom.req.get(
 		{
@@ -46,6 +47,7 @@ export async function fetchSites(
 			site_visibility,
 			include_a8c_owned,
 			include_domain_only: false,
+			include_staging,
 			filters: site_types !== 'all' ? site_types.join( ',' ) : undefined,
 		}
 	);

--- a/packages/api-queries/src/sites.ts
+++ b/packages/api-queries/src/sites.ts
@@ -10,7 +10,11 @@ export const sitesQueryKey = [ 'sites', SITE_FIELDS, SITE_OPTIONS ];
 
 export const sitesQuery = (
 	siteFilters: FetchSiteTypes,
-	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
+	fetchSitesOptions: FetchSitesOptions = {
+		site_visibility: 'visible',
+		include_a8c_owned: false,
+		include_staging: false,
+	}
 ) =>
 	queryOptions( {
 		queryKey: [ ...sitesQueryKey, siteFilters, fetchSitesOptions ],


### PR DESCRIPTION
Part of DOTMSD-220

Requires: 199429-ghe-Automattic/wpcom

> [!WARNING]
> This will affect the backport as well. Merge with caution. Give happiness a heads up first.

## Proposed Changes

This PR removes staging sites from sites list.

**Locations:**
- In the main site list
- In the Site Switcher
- In Primary site dropdown in the submenu
- In Sites notifications (notifications/sites)
- In domain transfer site selector.

## Why are these changes being made?

Staging sites are associated to main sites and make it more difficult to find your main site.

See DOTMSD-220 for more discussion.

## Considerations

There are some places that already filter out staging sites. I am on the fence as to whether they should be removed. I've left them in, in case in the future staging sites are re-added to the sites list.
- Example: https://github.com/Automattic/wp-calypso/blob/1acffd8cc4ea7077d5af9887102cb6aa2d548e1e/client/dashboard/plugins/scheduled-updates/hooks/use-eligible-sites.ts#L14

## Testing Instructions

Apply: 199429-ghe-Automattic/wpcom

Test the following places and make sure you don't see your staging sites.

**Multi-site dashboard**
- In the main site list
- In the Site Switcher
- In Primary site dropdown in the submenu
- In Sites notifications (notifications/sites)
- In domain transfer site selector.

**Hosting Dashboard v1**
- /sites

Test that you still see your staging site on:
- plugins/manage/gutenberg


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
