### PR TITLE
MSD Site Settings: Fix navigation blocker on site redirects screen

### DIFF
--- a/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
+++ b/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
@@ -1,5 +1,6 @@
 import { productsQuery, domainCanRedirectQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -18,6 +19,7 @@ export default function CreateSiteRedirect( {
 	siteSlug: string;
 	siteId: number;
 } ) {
+	const router = useRouter();
 	const { data: products } = useSuspenseQuery( productsQuery() );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const offsetRedirect = products?.offsite_redirect;
@@ -55,6 +57,7 @@ export default function CreateSiteRedirect( {
 				meta: formData.redirect,
 			},
 		] );
+		router.history.destroy(); // Ignore any navigation blocker
 		window.location.href = addQueryArgs( wpcomLink( `/checkout/${ siteSlug }` ), {
 			cancel_to: backUrl,
 			redirect_to: backUrl,

--- a/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
+++ b/client/dashboard/sites/settings-redirect/create-site-redirect.tsx
@@ -1,6 +1,5 @@
 import { productsQuery, domainCanRedirectQuery } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -19,7 +18,6 @@ export default function CreateSiteRedirect( {
 	siteSlug: string;
 	siteId: number;
 } ) {
-	const router = useRouter();
 	const { data: products } = useSuspenseQuery( productsQuery() );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const offsetRedirect = products?.offsite_redirect;
@@ -57,7 +55,6 @@ export default function CreateSiteRedirect( {
 				meta: formData.redirect,
 			},
 		] );
-		router.history.destroy(); // Ignore any navigation blocker
 		window.location.href = addQueryArgs( wpcomLink( `/checkout/${ siteSlug }` ), {
 			cancel_to: backUrl,
 			redirect_to: backUrl,

--- a/client/dashboard/sites/settings-redirect/site-redirect-form.tsx
+++ b/client/dashboard/sites/settings-redirect/site-redirect-form.tsx
@@ -66,8 +66,8 @@ export default function SiteRedirectForm( {
 	};
 
 	const { isValid: isFormValid } = useFormValidity( formData, fields, form );
-	const isUnchanged = disableWhenUnchanged && formData.redirect === initialValue;
-	const isDisabled = isSubmitting || ! isFormValid || isUnchanged;
+	const isUnchanged = formData.redirect === initialValue;
+	const isDisabled = isSubmitting || ! isFormValid || ( isUnchanged && disableWhenUnchanged );
 
 	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();

--- a/client/dashboard/sites/settings-redirect/site-redirect-form.tsx
+++ b/client/dashboard/sites/settings-redirect/site-redirect-form.tsx
@@ -77,7 +77,7 @@ export default function SiteRedirectForm( {
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
-				<NavigationBlocker shouldBlock={ ! isUnchanged } />
+				<NavigationBlocker shouldBlock={ ! isUnchanged && ! isSubmitting } />
 				<DataForm< SiteRedirectFormData >
 					data={ formData }
 					fields={ fields }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-1005

## Proposed Changes

* Don't show navigation blocker on site redirects screen if
  * Nothing changed
  * Saved and redirecting to checkout page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should not show navigation blocker if nothing changed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites/:site/settings/site-redirect
  * Note that it's only available on non-atomic sites
* Click browser back button
* Ensure the page doesn't show the blocker
* Add redirect URL and save
* Ensure the page doesn't show the blocker either before redirecting to the checkout page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
