### PR TITLE
Domain Search: Do not persist free suggestion query

### DIFF
--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -38,12 +38,14 @@ export const freeSuggestionQuery = (
 	queryOptions( {
 		queryKey: [ 'free-suggestion', query, params ],
 		queryFn: () => fetchFreeDomainSuggestion( query, params ),
+		meta: { persist: false },
 	} );
 
 export const availableTldsQuery = ( query?: string, vendor?: string ) =>
 	queryOptions( {
 		queryKey: [ 'available-tlds', query, vendor ],
 		queryFn: () => fetchAvailableTlds( query, vendor ),
+		meta: { persist: false },
 	} );
 
 export const bulkDomainUpdateStatusQuery = () =>


### PR DESCRIPTION
Addresses https://github.com/Automattic/wp-calypso/pull/107948#pullrequestreview-3640258436.

## Proposed Changes

* Add `meta: { persist: false }` to `freeSuggestionQuery` to prevent persisting free domain suggestions
* Add `meta: { persist: false }` to `availableTldsQuery` to prevent persisting available TLD data

## Why are these changes being made?

Free domain suggestions and available TLD lists were being persisted to storage via TanStack Query's dehydration mechanism. This caused users to see stale domain names that may no longer be available or valid, leading to a poor user experience.

By marking these queries with `meta: { persist: false }`, we ensure that:
* Free domain suggestions are always fresh and reflect current availability
* Available TLD lists are up-to-date with the latest offerings
* Users don't encounter errors when trying to claim domains that appear available but are actually already taken

This follows the same pattern already used for `domainSuggestionsQuery` and other time-sensitive queries in the codebase.

## Testing Instructions

### In production

1. Enter `/setup` and search for a domain
2. Go through onboarding
3. Enter `/setup` again
4. Verify the domain query is the same (i.e., the same keyword is being searched. It should be prefilled.)

Assert that the free domain name matches the domain of the site just created, and that this fails when creating a new free site.

### In this branch

Go through the same steps, but this time assert that the free suggestion is different even if you don't change the domain query.
