### PR TITLE
Login: Fix localized magic login browser freeze

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -3,7 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { localize, fixMe } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { useSelector, connect } from 'react-redux';
+import { connect } from 'react-redux';
 import AppPromo from 'calypso/blocks/app-promo';
 import { shouldUseMagicCode } from 'calypso/blocks/login/utils/should-use-magic-code';
 import GlobalNotices from 'calypso/components/global-notices';
@@ -48,15 +48,15 @@ import {
 } from './utils/heading-utils';
 import './style.scss';
 
-export const MagicLoginLocaleSuggestions = ( { path, showCheckYourEmail } ) => {
-	const locale = useSelector( getCurrentLocaleSlug );
-
+const MagicLoginLocaleSuggestionsBase = ( { locale, path, showCheckYourEmail } ) => {
 	if ( showCheckYourEmail ) {
 		return null;
 	}
 
 	return <LocaleSuggestions locale={ locale } path={ path } />;
 };
+
+export const MagicLoginLocaleSuggestions = localize( MagicLoginLocaleSuggestionsBase );
 
 export const buildEnterPasswordLoginParameters = (
 	{


### PR DESCRIPTION
Closes DOTOBRD-373.

## Proposed Changes

Fixes an [infinite loop](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/locale-suggestions/index.jsx#L48-L52) caused by [reading the locale from the wrong source](https://github.com/Automattic/wp-calypso/blob/trunk/client/login/magic-login/index.jsx#L52).

The problem here was that the Redux selector is out of sync with the i18n library, so once we change the locale, the UI thinks it's in the previous locale, creating the infinite loop.

Reading it directly from the library via the `localize` HOC fixes the problem. There are other issues on this page, but they aren't related to the freeze and can be addressed later.

## Testing Instructions

- Enter `/log-in/link/fr` in WPCOM and verify the page freezes;
- Enter the same page in the Calypso Live link from the PR and verify you can proceed with the login.