### PR TITLE
Update support history UI and recent conversations to support logged out chats

### DIFF
--- a/packages/help-center/src/components/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/help-center-recent-conversations.tsx
@@ -1,14 +1,27 @@
-import { calculateUnread } from '@automattic/zendesk-client';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { TimeSince } from '@automattic/components';
+import SummaryButton from '@automattic/components/src/summary-button';
+import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/icons';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useGetHistoryChats } from '../hooks';
-import { HelpCenterSupportChatMessage } from './help-center-support-chat-message';
-import { getLastMessage } from './utils';
-import type { ZendeskConversation } from '@automattic/odie-client';
-
+import { getChatLinkFromConversation, getLastMessage } from './utils';
 import './help-center-recent-conversations.scss';
+
+const trackContactButtonClicked = ( sectionName: string ) => {
+	recordTracksEvent( 'calypso_inlinehelp_support_chat_message_click', {
+		force_site_id: true,
+		location: 'help-center',
+		section: sectionName,
+	} );
+};
 
 const HelpCenterRecentConversations: React.FC = () => {
 	const { recentConversations } = useGetHistoryChats();
+	const navigate = useNavigate();
+	const { sectionName } = useHelpCenterContext();
 
 	if ( ! recentConversations?.length ) {
 		return null;
@@ -23,19 +36,48 @@ const HelpCenterRecentConversations: React.FC = () => {
 	if ( ! lastMessage ) {
 		return null;
 	}
+	const messageDisplayName = lastMessage
+		? __( 'Happiness chat', __i18n_text_domain__ )
+		: __( 'Support assistant chat', __i18n_text_domain__ );
 
-	const { numberOfUnreadMessages } = calculateUnread( [
-		recentConversation as ZendeskConversation,
-	] );
+	const receivedDateISO = (
+		! lastMessage.received ? new Date() : new Date( lastMessage.received * 1000 )
+	).toISOString();
+
+	const chatLink = getChatLinkFromConversation( recentConversation );
 
 	return (
-		<HelpCenterSupportChatMessage
-			numberOfUnreadMessages={ numberOfUnreadMessages }
-			sectionName="recent_conversations"
-			key={ recentConversation.id }
-			message={ lastMessage }
-			conversation={ recentConversation }
-			homePageVersion
+		<SummaryButton
+			strapline={ __( 'Recent Conversation', __i18n_text_domain__ ) }
+			title={ lastMessage.text || '' }
+			description={
+				<div className="help-center-support-chat__conversation-sub-information">
+					<span className="help-center-support-chat__conversation-information-name">
+						{ messageDisplayName }
+					</span>
+					<Icon
+						size={ 2 }
+						icon={
+							<svg
+								width="2"
+								height="2"
+								viewBox="0 0 2 2"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<circle cx="1" cy="1" r="1" fill="#787C82" />
+							</svg>
+						}
+					/>
+					<span className="help-center-support-chat__conversation-information-time">
+						<TimeSince date={ receivedDateISO } dateFormat="lll" />
+					</span>
+				</div>
+			}
+			onClick={ () => {
+				trackContactButtonClicked( sectionName );
+				navigate( chatLink );
+			} }
 		/>
 	);
 };

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
 import { Link } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useGetHistoryChats } from '../hooks';
+import { getChatLinkFromConversation } from './utils';
 import type { OdieConversation, OdieMessage } from '@automattic/odie-client';
 import type { ZendeskConversation, ZendeskMessage } from '@automattic/zendesk-client';
 
@@ -129,10 +130,7 @@ export const HelpCenterSupportChatMessage = ( {
 		);
 	}
 
-	const chatLink =
-		conversation.metadata && 'sessionId' in conversation.metadata
-			? `/odie?chatId=${ conversation.id }&sessionId=${ conversation.metadata?.sessionId }&botSlug=${ conversation.metadata?.botSlug }`
-			: `/odie?id=${ conversation.metadata?.supportInteractionId }`;
+	const chatLink = getChatLinkFromConversation( conversation );
 
 	return (
 		<Link

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -1,12 +1,11 @@
 /* eslint-disable no-restricted-imports */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gravatar, TimeSince, WordPressLogo } from '@automattic/components';
-import SummaryButton from '@automattic/components/src/summary-button';
 import { WapuuAvatar } from '@automattic/odie-client/src/assets';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useGetHistoryChats } from '../hooks';
 import type { OdieConversation, OdieMessage } from '@automattic/odie-client';
@@ -27,7 +26,6 @@ export const HelpCenterSupportChatMessage = ( {
 	sectionName,
 	conversation,
 	numberOfUnreadMessages = 0,
-	homePageVersion = false,
 }: {
 	message: OdieMessage | ZendeskMessage;
 	sectionName?: string;
@@ -38,7 +36,6 @@ export const HelpCenterSupportChatMessage = ( {
 	const { __ } = useI18n();
 	const { currentUser } = useHelpCenterContext();
 	const { received, role, text, altText } = message;
-	const navigate = useNavigate();
 	const messageText =
 		'metadata' in message && message.metadata?.type === 'csat'
 			? __(
@@ -132,46 +129,14 @@ export const HelpCenterSupportChatMessage = ( {
 		);
 	}
 
-	if ( homePageVersion ) {
-		return (
-			<SummaryButton
-				strapline={ __( 'Recent Conversation', __i18n_text_domain__ ) }
-				title={ messageText || altText || '' }
-				description={
-					<div className="help-center-support-chat__conversation-sub-information">
-						<span className="help-center-support-chat__conversation-information-name">
-							{ messageDisplayName }
-						</span>
-						<Icon
-							size={ 2 }
-							icon={
-								<svg
-									width="2"
-									height="2"
-									viewBox="0 0 2 2"
-									fill="none"
-									xmlns="http://www.w3.org/2000/svg"
-								>
-									<circle cx="1" cy="1" r="1" fill="#787C82" />
-								</svg>
-							}
-						/>
-						<span className="help-center-support-chat__conversation-information-time">
-							<TimeSince date={ receivedDateISO } dateFormat="lll" />
-						</span>
-					</div>
-				}
-				onClick={ () => {
-					trackContactButtonClicked( sectionName || helpCenterContextSectionName );
-					navigate( `/odie?id=${ supportInteraction?.uuid }` );
-				} }
-			/>
-		);
-	}
+	const chatLink =
+		conversation.metadata && 'sessionId' in conversation.metadata
+			? `/odie?chatId=${ conversation.id }&sessionId=${ conversation.metadata?.sessionId }&botSlug=${ conversation.metadata?.botSlug }`
+			: `/odie?id=${ conversation.metadata?.supportInteractionId }`;
 
 	return (
 		<Link
-			to={ `/odie?id=${ supportInteraction?.uuid }` }
+			to={ chatLink }
 			onClick={ () => {
 				trackContactButtonClicked( sectionName || helpCenterContextSectionName );
 			} }

--- a/packages/help-center/src/components/utils.tsx
+++ b/packages/help-center/src/components/utils.tsx
@@ -40,6 +40,30 @@ export const getLastMessage = ( {
 	return filteredMessages.length > 0 ? filteredMessages[ filteredMessages.length - 1 ] : null;
 };
 
+export const getChatLinkFromConversation = (
+	conversation: OdieConversation | ZendeskConversation
+): string => {
+	const chatParams = new URLSearchParams();
+	const metadata = conversation.metadata;
+
+	if ( metadata ) {
+		// Logged out chats only have a sessionId and a botSlug (not support interaction id)
+		if ( 'sessionId' in metadata && metadata.sessionId ) {
+			chatParams.set( 'sessionId', metadata.sessionId.toString() );
+		}
+
+		if ( metadata.supportInteractionId ) {
+			chatParams.set( 'id', metadata.supportInteractionId.toString() );
+		}
+
+		if ( metadata.botSlug ) {
+			chatParams.set( 'botSlug', metadata.botSlug.toString() );
+		}
+	}
+
+	return `/odie?${ chatParams.toString() }`;
+};
+
 export const getZendeskConversations = () => {
 	try {
 		const conversations = Smooch?.getConversations?.() ?? [];


### PR DESCRIPTION
Fixes DOTCOM-15641

## Proposed Changes

When available, use sessionId and botSlug from the interaction metadata as well as the interaction ID. 

## Why are these changes being made?
This allows logged out conversation to be fetched and viewed.

## Testing Instructions

1. For now, this should be regession-tested only.
2. View the history, click an item, should take you to a working convo.
3. On the homepage, click recent convo card, should work.