### PR TITLE
Newsletter importer: Fix subscriber import reset button for Stepper flow

### DIFF
--- a/client/blocks/importer/substack/index.tsx
+++ b/client/blocks/importer/substack/index.tsx
@@ -221,6 +221,9 @@ export const SubstackImporter: React.FunctionComponent< ImporterBaseProps > = ( 
 							selectedSite={ selectedSite }
 							fromSite={ fromSite }
 							onViewSummaryClick={ () => setStep( nextStepSlug ) }
+							onReset={ () => {
+								setStep( stepSlugs[ 0 ] );
+							} }
 							skipNextStep={ () => {
 								setStep( nextStepSlug );
 								skipNextStep( selectedSite.ID, engine, nextStepSlug, step );

--- a/client/my-sites/importer/newsletter/subscribers/step-done.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-done.tsx
@@ -18,11 +18,17 @@ export default function StepDone( {
 	engine,
 	siteSlug,
 	actionButton,
+	onReset,
 }: StepDoneProps ) {
 	const { __, _n } = useI18n();
 	const { resetPaidNewsletter, isPending } = useResetMutation( {
 		onSuccess: () => {
-			page.redirect( `/import/newsletter/${ engine }/${ siteSlug }/content` );
+			if ( onReset ) {
+				onReset();
+			} else {
+				// Fallback for traditional flow
+				page.redirect( `/import/newsletter/${ engine }/${ siteSlug }/content` );
+			}
 		},
 	} );
 	const subscribedCount = parseInt( cardData?.meta?.email_count || '0' );

--- a/client/my-sites/importer/newsletter/types.ts
+++ b/client/my-sites/importer/newsletter/types.ts
@@ -13,6 +13,7 @@ export interface SubscribersStepProps {
 	fromSite: string;
 	nextStepUrl?: string;
 	onViewSummaryClick?: () => void;
+	onReset?: () => void;
 	selectedSite: SiteDetails;
 	setAutoFetchData: Dispatch< SetStateAction< boolean > >;
 	siteSlug: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/107876

## Proposed Changes

* Add the correct "Start over" functionality for when subscribers imports fail, for the Stepper flow. I previously addressed this for the /import/newsletter/substack flow only.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the fix in both flows. Post about eliminating one here: pe7F0s-3sV-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes locally.
* Import subscribers from Substack to a new site (on /import/newsletter/substack/).
* You should see a success message. To see the failure message, open React dev tools and manually change the cardData meta status to "failed" in the stepDone component.
* Click Start Over.
* Check that you are redirected to the content step.
* Skip or complete the content step, then check that you can complete the subscribers step.
* On another new site, import from Substack by going to Tools > Import > Substack. Repeat the testing steps using this flow. Start Over should redirect you to the initial URL step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?