### PR TITLE
MSD: Revert Browse plugins link to open in new tab

### DIFF
--- a/client/dashboard/plugins/plugins-menu/index.tsx
+++ b/client/dashboard/plugins/plugins-menu/index.tsx
@@ -1,37 +1,22 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 import { wpcomLink } from '../../utils/link';
 
 const PluginsMenu = () => {
-	const isRedesignEnabled = isEnabled( 'marketplace-redesign' );
-	const browsePluginsLabel = __( 'Browse plugins' );
-
 	return (
 		<ResponsiveMenu prefix={ <MenuDivider /> }>
 			<ResponsiveMenu.Item to="/plugins/manage">{ __( 'Manage plugins' ) }</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to="/plugins/scheduled-updates">
 				{ __( 'Scheduled updates' ) }
 			</ResponsiveMenu.Item>
-			{ isRedesignEnabled ? (
-				<Button
-					className="dashboard-menu__item"
-					variant="tertiary"
-					href={ wpcomLink( '/plugins' ) }
-				>
-					{ browsePluginsLabel }
-				</Button>
-			) : (
-				<ResponsiveMenu.Item
-					href={ wpcomLink( '/plugins' ) }
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					{ browsePluginsLabel }
-				</ResponsiveMenu.Item>
-			) }
+			<ResponsiveMenu.Item
+				href={ wpcomLink( '/plugins' ) }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ __( 'Browse plugins' ) }
+			</ResponsiveMenu.Item>
 		</ResponsiveMenu>
 	);
 };


### PR DESCRIPTION
Part of #107585

## Proposed Changes

* Revert the Browse plugins link in the multi-site dashboard to open in a new tab instead of the same tab.

## Why are these changes being made?

Opening in the same tab from the MSD leaves users with no way to get back to the dashboard except using the browser's back button. Until we have a contextually aware "Back" control to return to the multi-site dashboard, opening in a separate tab is more appropriate.

## Testing Instructions

* Enable the v2 dashboard (plugins menu is only visible on the v2 dashboard)
* Navigate to the multi-site dashboard
* Click on "Plugins" in the sidebar to expand the menu
* Click on "Browse plugins"
* Verify that the plugins page opens in a new tab

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
