### PR TITLE
Enable Global Styles on Personal

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,7 @@
 		"domain-search-rewrite": true,
 		"domain-transfer-redesign": true,
 		"email-accounts/enabled": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"google-drive": true,
 		"google-my-business": true,
 		"help": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -33,7 +33,7 @@
 		"devdocs": false,
 		"domain-search-rewrite": true,
 		"domain-transfer-redesign": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"google-my-business": false,
 		"help": true,
 		"home/layout-dev": true,

--- a/config/production.json
+++ b/config/production.json
@@ -43,7 +43,7 @@
 		"dashboard/v2/backport/site-overview": true,
 		"domain-search-rewrite": true,
 		"domain-transfer-redesign": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"google-my-business": true,
 		"help": true,
 		"help/gpt-response": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -43,7 +43,7 @@
 		"dev/store-sandbox-helper": true,
 		"domain-search-rewrite": true,
 		"domain-transfer-redesign": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"google-my-business": true,
 		"help": true,
 		"help/gpt-response": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -51,7 +51,7 @@
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/M4R73CH-1618/roll-out-treatment-1-global-styles-on-personal

## Proposed Changes

* Enabled Global Styles on Personal on all environments

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See the linked Linear issue for full context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this wpcom patch (will fill in once available)
* Use the Calypso live link
* Make sure when creating a new site, you see that the Global Styles feature is on the plans grid under the personal plan
* After creating a site on the personal plan, Global Styles should not be limited on any paid plan
* Global Styles should remain limited on Free sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
