### PR TITLE
Docs: Fix typos in dashboard documentation

### DIFF
--- a/client/dashboard/README.md
+++ b/client/dashboard/README.md
@@ -1,6 +1,6 @@
 # Hosting Dashboard
 
-Build a new Hosting Dashboard for WordPress.com based on the new design. The same dashboard with different entry points is used for different products (WordPress.com, Jetpack Clound and a4a).
+Build a new Hosting Dashboard for WordPress.com based on the new design. The same dashboard with different entry points is used for different products (WordPress.com, Jetpack Cloud and a4a).
 
 ## Some principles
 

--- a/client/dashboard/docs/entry-points.md
+++ b/client/dashboard/docs/entry-points.md
@@ -144,7 +144,7 @@ This configuration:
 
 ## Limitations
 
-The customization options are intentionaly limited at the moment. We need further input and explorations to ensure the following questions:
+The customization options are intentionally limited at the moment. We need further input and explorations to ensure the following questions:
 
 - Does the content of each route aim to be different? For example, would the sites table contain different fields/interactions depending on the application / logged in user role (agency, regular user…)?
 - What kind of branding differences do we expect per dashboard? Do design tokens provide enough local variance (colors, spacing, fonts, etc.) or do we expect each property to be modified entirely (navigation, menu reordering, etc.)?

--- a/client/dashboard/docs/router.md
+++ b/client/dashboard/docs/router.md
@@ -6,7 +6,7 @@ The dashboard uses the [@tanstack/react-router](https://tanstack.router.dev/) li
 
 ## Architecture
 
-The router is follows these key principles:
+The router follows these key principles:
 
 1. **Configuration-based**: Routes are created based on the `AppConfig` that's passed to the router
 2. **Lazy-loaded**: Each route is lazy-loaded using dynamic imports to optimize performance

--- a/client/dashboard/docs/typography-and-copy.md
+++ b/client/dashboard/docs/typography-and-copy.md
@@ -2,7 +2,7 @@
 
 ## General
 
-End sentences with a period. Even short ones. Button and form labels do not end in periods, and neither to headings.
+End sentences with a period. Even short ones. Button and form labels do not end in periods, and neither do headings.
 
 Use curly quotes and apostrophes.
 e.g. “like this” instead of "like this"

--- a/client/dashboard/docs/ui-components.md
+++ b/client/dashboard/docs/ui-components.md
@@ -24,7 +24,7 @@ See this post on loaders: p58i-kIo-p2
 
 The dashboard relies heavily on two core components for data display and interaction:
 
-- **DataViews**: A component for displaying lists a tabular, grid or list format, allowing for sorting, filtering, and pagination.
+- **DataViews**: A component for displaying lists in a tabular, grid or list format, allowing for sorting, filtering, and pagination.
 - **DataForm**: A component for creating and editing data, providing a form-based interface for user input.
 
 These components are part of the design system, if changes are required to implement specific pages, consider checking with the design team first. The solution could be either to adapt the design or implement a generic solution at the component level.


### PR DESCRIPTION
## Proposed Changes

- Fix "neither to headings" → "neither do headings" in `typography-and-copy.md`
- Fix "The router is follows" → "The router follows" in `router.md`
- Fix "Jetpack Clound" → "Jetpack Cloud" in `README.md`
- Fix "intentionaly" → "intentionally" in `entry-points.md`
- Fix "displaying lists a tabular" → "displaying lists in a tabular" in `ui-components.md`

## Why are these changes being made?

These are minor typo corrections in the dashboard documentation to improve readability and professionalism.

## Testing Instructions

No testing required - documentation-only changes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~Have you written new tests for your changes?~~ N/A - docs only
- [ ] ~~Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?~~ N/A - docs only
- [x] Have you checked for TypeScript, React or other console errors? N/A - docs only
- [ ] ~~Have you tested accessibility for your changes?~~ N/A - docs only
- [ ] ~~Have you used memoizing on expensive computations?~~ N/A - docs only
- [ ] ~~Have we added the "[Status] String Freeze" label?~~ N/A - no translatable strings
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?~~ N/A

🤖 Generated with [Claude Code](https://claude.ai/code)