### PR TITLE
Domains in MSD: Hide transfer button if domain can't be transferred

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.utils.ts
+++ b/client/dashboard/domains/domain-overview/actions.utils.ts
@@ -33,6 +33,11 @@ export const shouldShowTransferAction = ( domain: Domain ) => {
 		return false;
 	}
 
+	// If the domain cannot be transferred to any user or another site, we shouldn't show the transfer action
+	if ( ! domain.can_transfer_to_any_user && ! domain.can_transfer_to_other_site ) {
+		return false;
+	}
+
 	return true;
 };
 

--- a/client/dashboard/domains/domain-overview/test/actions.utils.test.ts
+++ b/client/dashboard/domains/domain-overview/test/actions.utils.test.ts
@@ -28,8 +28,8 @@ describe( 'shouldShowTransferAction', () => {
 
 	it( 'returns true when domain can be transferred to any user', () => {
 		const domain = createDomain( {
-			can_transfer_to_any_user: false,
-			can_transfer_to_other_site: true,
+			can_transfer_to_any_user: true,
+			can_transfer_to_other_site: false,
 		} );
 
 		expect( shouldShowTransferAction( domain ) ).toBe( true );

--- a/client/dashboard/domains/domain-overview/test/actions.utils.test.ts
+++ b/client/dashboard/domains/domain-overview/test/actions.utils.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+import { DomainSubtype, type Domain } from '@automattic/api-core';
+import { shouldShowTransferAction } from '../actions.utils';
+
+const createDomain = ( overrides: Partial< Domain > = {} ): Domain =>
+	( {
+		domain: 'example.com',
+		current_user_is_owner: true,
+		is_redeemable: false,
+		pending_registration: false,
+		pending_registration_at_registry: false,
+		move_to_new_site_pending: false,
+		aftermarket_auction: false,
+		can_transfer_to_any_user: true,
+		can_transfer_to_other_site: true,
+		subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
+		...overrides,
+	} ) as Domain;
+
+describe( 'shouldShowTransferAction', () => {
+	it( 'returns false when domain cannot be transferred to any user or another site', () => {
+		const domain = createDomain( {
+			can_transfer_to_any_user: false,
+			can_transfer_to_other_site: false,
+		} );
+
+		expect( shouldShowTransferAction( domain ) ).toBe( false );
+	} );
+
+	it( 'returns true when domain can be transferred to any user', () => {
+		const domain = createDomain( {
+			can_transfer_to_any_user: false,
+			can_transfer_to_other_site: true,
+		} );
+
+		expect( shouldShowTransferAction( domain ) ).toBe( true );
+	} );
+
+	it( 'returns true when domain can be transferred to another site', () => {
+		const domain = createDomain( {
+			can_transfer_to_any_user: false,
+			can_transfer_to_other_site: true,
+		} );
+
+		expect( shouldShowTransferAction( domain ) ).toBe( true );
+	} );
+} );

--- a/client/dashboard/domains/domain-overview/test/actions.utils.test.ts
+++ b/client/dashboard/domains/domain-overview/test/actions.utils.test.ts
@@ -1,10 +1,3 @@
-/**
- * @jest-environment node
- */
-jest.mock( '@wordpress/i18n', () => ( {
-	__: ( text: string ) => text,
-} ) );
-
 import { DomainSubtype, type Domain } from '@automattic/api-core';
 import { shouldShowTransferAction } from '../actions.utils';
 

--- a/client/dashboard/utils/domain-permissions.ts
+++ b/client/dashboard/utils/domain-permissions.ts
@@ -29,6 +29,12 @@ const checkNotAftermarketAuction: DomainCheckFunction = ( domain: Domain ) =>
 const checkCanTransferToAnyUser: DomainCheckFunction = ( domain: Domain ) =>
 	!! domain.can_transfer_to_any_user;
 
+const checkCanTransferToOtherSite: DomainCheckFunction = ( domain: Domain ) =>
+	!! domain.can_transfer_to_other_site;
+
+const checkCanTransfer: DomainCheckFunction = ( domain: Domain ) =>
+	checkCanTransferToAnyUser( domain ) || checkCanTransferToOtherSite( domain );
+
 const checkCanManageNameServers: DomainCheckFunction = ( domain: Domain ) =>
 	!! domain.can_manage_name_servers;
 
@@ -123,7 +129,7 @@ const DOMAIN_PERMISSION_CHECKS = {
 				),
 		},
 		{
-			check: checkCanTransferToAnyUser,
+			check: checkCanTransfer,
 			getErrorMessage: () => __( 'You do not have permission to transfer this domain.' ),
 		},
 	],


### PR DESCRIPTION
Part of [DOMENG-319](https://linear.app/a8c/issue/DOMENG-319)

## Proposed Changes

This PR hides the domain transfer action in the domain overview page if the domain cannot be transferred.

### Screenshots

| Before | After |
| --- | --- |
|  <img width="690" height="383" alt="Screenshot 2026-01-09 at 15 16 03" src="https://github.com/user-attachments/assets/43099c63-7d05-42fc-8879-371b1c7fb072" /> | <img width="696" height="306" alt="Screenshot 2026-01-09 at 15 16 35" src="https://github.com/user-attachments/assets/19568a6e-78a9-4e66-990b-5d19fb94d557" /> |

## Why are these changes being made?

We shouldn't allow users to access the outbound domain transfer page if the domain cannot be transferred. More specifically, we're showing the transfer action if `can_transfer_to_any_user` or `can_transfer_to_other_site` domain properties are true.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to the domain overview page for a domain you own
- The domain should not be transferrable to other sites or users - alternatively, hack the backend to make the `can_transfer_to_other_site` and `can_transfer_to_other_site` properties false
- Ensure the transfer action is not shown

I've also added unit tests for the `shouldShowTransferAction` function:

```
yarn test-client client/dashboard/domains/domain-overview/test/actions.utils.test.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
