### PR TITLE
A4A: Move Learn menu item under Exclusive Offers

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -110,6 +110,20 @@ const useMainMenuItems = ( path: string ) => {
 					menu_item: 'Automattic for Agencies / Exclusive offers',
 				},
 			},
+			...( isSectionNameEnabled( 'a8c-for-agencies-learn' )
+				? [
+						{
+							icon: pages,
+							path: A4A_LEARN_LINK,
+							link: A4A_LEARN_RESOURCE_CENTER_LINK,
+							title: translate( 'Learn' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Learn',
+							},
+							withChevron: true,
+						},
+				  ]
+				: [] ),
 			{
 				icon: category,
 				path: '/',
@@ -190,20 +204,6 @@ const useMainMenuItems = ( path: string ) => {
 				},
 				withChevron: true,
 			},
-			...( isSectionNameEnabled( 'a8c-for-agencies-learn' )
-				? [
-						{
-							icon: pages,
-							path: A4A_LEARN_LINK,
-							link: A4A_LEARN_RESOURCE_CENTER_LINK,
-							title: translate( 'Learn' ),
-							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Learn',
-							},
-							withChevron: true,
-						},
-				  ]
-				: [] ),
 			...( isSectionNameEnabled( 'a8c-for-agencies-settings' )
 				? [
 						{


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/A4A-1651/implement-resource-center-into-product

## Proposed Changes

* Moves the item from the bottom of the menu to under Exclusive Offers

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live link
* Confirm the menu item is under Exclusive Offers.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
