### PR TITLE
POC: Reader testing cleaned layout

### DIFF
--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -3,7 +3,6 @@ import page, { Context } from '@automattic/calypso-router';
 import { getAnyLanguageRouteParam, getLanguageRouteParam } from '@automattic/i18n-utils';
 import { addMiddleware } from 'redux-dynamic-middlewares';
 import {
-	makeLayout,
 	redirectLoggedOut,
 	redirectLoggedOutToSignup,
 	render as clientRender,
@@ -28,6 +27,7 @@ import {
 	setupReadRoutes,
 	setBeforePrimary,
 } from './controller';
+import { makeLayout } from './middleware';
 import { userProfile } from './user-profile/controller';
 
 import './style.scss';

--- a/client/reader/middleware/index.tsx
+++ b/client/reader/middleware/index.tsx
@@ -1,0 +1,77 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { Provider as ReduxProvider } from 'react-redux';
+import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
+import { RouteProvider } from 'calypso/components/route';
+import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
+import Layout from './layout';
+
+export { render, hydrate } from 'calypso/controller/web-util';
+
+export const ProviderWrappedLayout = ( {
+	store,
+	queryClient,
+	currentSection,
+	currentRoute,
+	currentQuery,
+	primary,
+	secondary,
+	redirectUri,
+} ) => {
+	return (
+		<CalypsoI18nProvider>
+			<RouteProvider
+				currentSection={ currentSection }
+				currentRoute={ currentRoute }
+				currentQuery={ currentQuery }
+			>
+				<QueryClientProvider client={ queryClient }>
+					<ReduxProvider store={ store }>
+						<Layout
+							primary={ primary }
+							secondary={ secondary }
+							redirectUri={ redirectUri }
+							sectionName="promote-post-i2"
+							groupName="sites"
+						/>
+					</ReduxProvider>
+					<CalypsoReactQueryDevtools />
+				</QueryClientProvider>
+			</RouteProvider>
+		</CalypsoI18nProvider>
+	);
+};
+
+export function makeLayoutMiddleware( LayoutComponent ) {
+	return ( context, next ) => {
+		const {
+			i18n,
+			store,
+			queryClient,
+			section,
+			pathname,
+			query,
+			primary,
+			secondary,
+			showGdprBanner,
+		} = context;
+
+		// On server, only render LoggedOutLayout when logged-out.
+		context.layout = (
+			<LayoutComponent
+				i18n={ i18n }
+				store={ store }
+				queryClient={ queryClient }
+				currentSection={ section }
+				currentRoute={ pathname }
+				currentQuery={ query }
+				primary={ primary }
+				secondary={ secondary }
+				redirectUri={ context.originalUrl }
+				showGdprBanner={ showGdprBanner }
+			/>
+		);
+		next();
+	};
+}
+
+export const makeLayout = makeLayoutMiddleware( ProviderWrappedLayout );

--- a/client/reader/middleware/layout.tsx
+++ b/client/reader/middleware/layout.tsx
@@ -1,0 +1,208 @@
+import config from '@automattic/calypso-config';
+import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import { Component, useEffect } from 'react';
+import { connect } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
+import DocumentHead from 'calypso/components/data/document-head';
+import QuerySites from 'calypso/components/data/query-sites';
+import { withCurrentRoute } from 'calypso/components/route';
+import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
+import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
+import { isWcMobileApp } from 'calypso/lib/mobile-app';
+import { isCrowdsignalOAuth2Client } from 'calypso/lib/oauth2-clients';
+import UserVerificationChecker from 'calypso/lib/user/verification-checker';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import { isReaderMSDEnabled } from 'calypso/state/reader-ui/selectors';
+import { isSupportSession } from 'calypso/state/support/selectors';
+import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+function SidebarOverflowDelay( { layoutFocus } ) {
+	const setSidebarOverflowClass = ( overflow ) => {
+		const classList = document.querySelector( 'body' ).classList;
+		if ( overflow ) {
+			classList.add( 'is-sidebar-overflow' );
+		} else {
+			classList.remove( 'is-sidebar-overflow' );
+		}
+	};
+
+	useEffect( () => {
+		if ( layoutFocus !== 'sites' ) {
+			// The sidebar menu uses a flyout design that requires the overflowing content
+			// to be visible. However, `overflow` isn't an animatable CSS property, so we
+			// need to set it after the sliding transition finishes. We wait for 150ms (the
+			// CSS transition time) + a grace period of 350ms (since the sidebar menu is
+			// rendered asynchronously).
+			// @see https://github.com/Automattic/wp-calypso/issues/47019
+			setTimeout( () => {
+				setSidebarOverflowClass( true );
+			}, 500 );
+		} else {
+			setSidebarOverflowClass( false );
+		}
+	}, [ layoutFocus ] );
+
+	return null;
+}
+
+class Layout extends Component {
+	static propTypes = {
+		primary: PropTypes.element,
+		secondary: PropTypes.element,
+		beforePrimary: PropTypes.element,
+		focus: PropTypes.object,
+		// connected props
+		masterbarIsHidden: PropTypes.bool,
+		isSupportSession: PropTypes.bool,
+		sectionGroup: PropTypes.string,
+		sectionName: PropTypes.string,
+		colorScheme: PropTypes.string,
+		isGravatarDomain: PropTypes.bool,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isDesktop: isWithinBreakpoint( '>=782px' ),
+		};
+	}
+
+	componentDidMount() {
+		this.unsubscribe = subscribeIsWithinBreakpoint( '>=782px', ( isDesktop ) => {
+			this.setState( { isDesktop } );
+		} );
+	}
+
+	render() {
+		const sectionClass = clsx( 'layout', `focus-${ this.props.currentLayoutFocus }`, {
+			[ 'is-group-' + this.props.sectionGroup ]: this.props.sectionGroup,
+			[ 'is-section-' + this.props.sectionName ]: this.props.sectionName,
+			crowdsignal: isCrowdsignalOAuth2Client( this.props.oauth2Client ),
+			'is-support-session': this.props.isSupportSession,
+			'has-universal-header': this.props.hasUniversalHeader,
+			'is-logged-in': this.props.isLoggedIn,
+			'is-global-sidebar-visible': this.props.isGlobalSidebarVisible,
+			'is-global-sidebar-collapsed': this.props.isGlobalSidebarCollapsed,
+			'is-reader-msd-enabled': this.props.isMSDEnabledForReader,
+		} );
+
+		const shouldEnableCommandPalette =
+			// There is a custom command palette in the "Switch site" page, so we disable it.
+			config.isEnabled( 'yolo/command-palette' ) && this.props.currentRoute !== '/switch-site';
+
+		return (
+			<div className={ sectionClass }>
+				<SidebarOverflowDelay layoutFocus={ this.props.currentLayoutFocus } />
+				<DocumentHead />
+				{ this.props.shouldQueryAllSites ? (
+					<QuerySites allSites />
+				) : (
+					<QuerySites primaryAndRecent={ ! config.isEnabled( 'jetpack-cloud' ) } />
+				) }
+				<UserVerificationChecker />
+				{ config.isEnabled( 'layout/guided-tours' ) && (
+					<AsyncLoad require="calypso/layout/guided-tours" placeholder={ null } />
+				) }
+				<div className="layout__header-section">
+					<AsyncLoad require="calypso/reader/components/header" placeholder={ null } />;
+				</div>
+				<div id="content" className="layout__content">
+					<AsyncLoad
+						require="calypso/components/global-notices"
+						placeholder={ null }
+						id="notices"
+					/>
+
+					<div id="secondary" className="layout__secondary" role="navigation">
+						{ this.props.secondary }
+					</div>
+					{ this.props.beforePrimary }
+					<div id="primary" className="layout__primary">
+						{ this.props.primary }
+					</div>
+				</div>
+				<AsyncLoad require="calypso/layout/community-translator" placeholder={ null } />
+				{ 'development' === process.env.NODE_ENV && (
+					<>
+						<SympathyDevWarning />
+						<AsyncLoad require="calypso/components/webpack-build-monitor" placeholder={ null } />
+					</>
+				) }
+				{ config.isEnabled( 'layout/support-article-dialog' ) && (
+					<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
+				) }
+				{ config.isEnabled( 'cookie-banner' ) && (
+					<AsyncLoad require="calypso/blocks/cookie-banner" placeholder={ null } />
+				) }
+				{ config.isEnabled( 'layout/app-banner' ) && (
+					<AsyncLoad require="calypso/blocks/app-banner" placeholder={ null } />
+				) }
+				{ config.isEnabled( 'legal-updates-banner' ) && (
+					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
+				) }
+
+				{ shouldEnableCommandPalette && (
+					<AsyncLoad require="calypso/layout/command-palette" placeholder={ null } />
+				) }
+			</div>
+		);
+	}
+}
+
+export default withCurrentRoute(
+	connect( ( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
+		const sectionGroup = currentSection?.group ?? null;
+		const sectionName = currentSection?.name ?? null;
+		const siteId = getSelectedSiteId( state );
+		const isMSDEnabledForReader = currentSection?.name === 'reader' && isReaderMSDEnabled( state );
+
+		const sidebarType = getSidebarType( {
+			state,
+			siteId,
+			section: currentSection,
+			route: currentRoute,
+		} );
+
+		const shouldShowGlobalSidebar =
+			sidebarType === SidebarType.Global || sidebarType === SidebarType.GlobalCollapsed;
+		const shouldShowCollapsedGlobalSidebar = sidebarType === SidebarType.GlobalCollapsed;
+		const shouldShowUnifiedSiteSidebar = sidebarType === SidebarType.UnifiedSiteClassic;
+
+		const isFromAutomatticForAgenciesPlugin =
+			'automattic-for-agencies-client' === currentQuery?.from;
+
+		const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
+		const oauth2Client = getCurrentOAuth2Client( state );
+		const wccomFrom = currentQuery?.[ 'wccom-from' ];
+		const sidebarIsHidden = ! secondary || isWcMobileApp();
+		const isGlobalSidebarVisible = shouldShowGlobalSidebar && ! sidebarIsHidden;
+
+		const isLoggedIn = isUserLoggedIn( state );
+
+		return {
+			sidebarIsHidden,
+			isJetpackMobileFlow,
+			isFromAutomatticForAgenciesPlugin,
+			isMSDEnabledForReader,
+			oauth2Client,
+			wccomFrom,
+			isLoggedIn,
+			isSupportSession: isSupportSession( state ),
+			sectionGroup,
+			sectionName,
+			currentLayoutFocus: getCurrentLayoutFocus( state ),
+			siteId,
+			currentRoute,
+			isGlobalSidebarVisible,
+			isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar && ! sidebarIsHidden,
+			isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
+		};
+	} )( Layout )
+);

--- a/client/reader/middleware/layout.tsx
+++ b/client/reader/middleware/layout.tsx
@@ -2,17 +2,17 @@ import config from '@automattic/calypso-config';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { Component, useEffect } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
-import QuerySites from 'calypso/components/data/query-sites';
 import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
 import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { isCrowdsignalOAuth2Client } from 'calypso/lib/oauth2-clients';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
+import Header from 'calypso/reader/components/header';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -22,35 +22,6 @@ import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
-
-function SidebarOverflowDelay( { layoutFocus } ) {
-	const setSidebarOverflowClass = ( overflow ) => {
-		const classList = document.querySelector( 'body' ).classList;
-		if ( overflow ) {
-			classList.add( 'is-sidebar-overflow' );
-		} else {
-			classList.remove( 'is-sidebar-overflow' );
-		}
-	};
-
-	useEffect( () => {
-		if ( layoutFocus !== 'sites' ) {
-			// The sidebar menu uses a flyout design that requires the overflowing content
-			// to be visible. However, `overflow` isn't an animatable CSS property, so we
-			// need to set it after the sliding transition finishes. We wait for 150ms (the
-			// CSS transition time) + a grace period of 350ms (since the sidebar menu is
-			// rendered asynchronously).
-			// @see https://github.com/Automattic/wp-calypso/issues/47019
-			setTimeout( () => {
-				setSidebarOverflowClass( true );
-			}, 500 );
-		} else {
-			setSidebarOverflowClass( false );
-		}
-	}, [ layoutFocus ] );
-
-	return null;
-}
 
 class Layout extends Component {
 	static propTypes = {
@@ -93,25 +64,13 @@ class Layout extends Component {
 			'is-reader-msd-enabled': this.props.isMSDEnabledForReader,
 		} );
 
-		const shouldEnableCommandPalette =
-			// There is a custom command palette in the "Switch site" page, so we disable it.
-			config.isEnabled( 'yolo/command-palette' ) && this.props.currentRoute !== '/switch-site';
-
 		return (
 			<div className={ sectionClass }>
-				<SidebarOverflowDelay layoutFocus={ this.props.currentLayoutFocus } />
 				<DocumentHead />
-				{ this.props.shouldQueryAllSites ? (
-					<QuerySites allSites />
-				) : (
-					<QuerySites primaryAndRecent={ ! config.isEnabled( 'jetpack-cloud' ) } />
-				) }
 				<UserVerificationChecker />
-				{ config.isEnabled( 'layout/guided-tours' ) && (
-					<AsyncLoad require="calypso/layout/guided-tours" placeholder={ null } />
-				) }
+
 				<div className="layout__header-section">
-					<AsyncLoad require="calypso/reader/components/header" placeholder={ null } />;
+					<Header />
 				</div>
 				<div id="content" className="layout__content">
 					<AsyncLoad
@@ -128,7 +87,7 @@ class Layout extends Component {
 						{ this.props.primary }
 					</div>
 				</div>
-				<AsyncLoad require="calypso/layout/community-translator" placeholder={ null } />
+				{ /* <AsyncLoad require="calypso/layout/community-translator" placeholder={ null } /> */ }
 				{ 'development' === process.env.NODE_ENV && (
 					<>
 						<SympathyDevWarning />
@@ -146,10 +105,6 @@ class Layout extends Component {
 				) }
 				{ config.isEnabled( 'legal-updates-banner' ) && (
 					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
-				) }
-
-				{ shouldEnableCommandPalette && (
-					<AsyncLoad require="calypso/layout/command-palette" placeholder={ null } />
 				) }
 			</div>
 		);

--- a/client/reader/middleware/style.scss
+++ b/client/reader/middleware/style.scss
@@ -1,0 +1,528 @@
+
+html.command-palette-modal-open {
+	overflow: visible;
+}
+body.command-palette-modal-open {
+	overflow: hidden;
+}
+
+/**
+ * /*
+ * 	Layout Elements
+ * 	.layout__loading - Displays when loading Calypso
+ * 	.layout__content - Contains primary and secondary elements
+ * 		.layout__primary - Where the main content lives
+ * 		.layout__secondary - Contains the site selector and sidebar elements
+ * 			.sidebar
+ * 			.site-selector
+ *
+ */
+
+// Set transitons for layout elements
+.layout__primary .main,
+.layout__secondary,
+.layout__secondary .sidebar,
+.layout__secondary .site-selector {
+	transition: transform 0.15s ease-in-out, opacity 0.15s ease-out;
+}
+
+.layout__header-section-content {
+	box-sizing: border-box;
+	padding: 79px 32px 32px 32px;
+
+	@include breakpoint-deprecated( "<960px" ) {
+		padding: 71px 24px 24px 24px;
+	}
+}
+
+// Setup the content element to adapt to the sidebar,
+// lack of sidebar, or the WebPreview component.
+.layout__content {
+	@include clear-fix;
+	position: relative;
+	margin: 0;
+	padding: 79px 32px 32px calc(var(--sidebar-width-max) + 32px + 1px);
+	box-sizing: border-box;
+	overflow: hidden;
+
+	// Various screens dont use a sidebar.
+	.has-no-sidebar & {
+		padding-left: 32px;
+	}
+
+	// Checkout sets it own padding/margin
+	.is-section-checkout &,
+	.is-section-checkout.has-no-sidebar & {
+		padding: 0;
+		margin: 0;
+	}
+	// Note that we have to use a 0,0,3,1 specificity selector to override the
+	// one in `client/my-sites/sidebar/style.scss` which has 0,0,3,0 in case it
+	// loads second, which happens if checkout is not the first page of calypso
+	// to load.
+	.theme-default.is-section-checkout div.is-section-checkout.focus-content & {
+		padding: 0;
+		margin: 0;
+	}
+
+	// Themes sets its own padding/margin when there is no sidebar
+	.is-section-theme.has-no-sidebar &,
+	.is-section-themes.has-no-sidebar &,
+	.theme-default .layout.is-section-theme.has-no-sidebar &,
+	.theme-default .layout.is-section-themes.has-no-sidebar &,
+	.theme-default .layout.is-section-themes:not(.is-logged-in) & {
+		padding: 0;
+		margin: 0;
+	}
+
+	.is-section-marketplace.has-no-sidebar & {
+		padding: 0;
+		margin: 0;
+	}
+
+	.is-section-theme & {
+		.sites.main {
+			padding-top: calc(79px - var(--masterbar-height));
+		}
+	}
+
+	.is-section-plugins.is-logged-in & {
+		// The plugins site view needs the header to be full width, so the padding
+		// is added on the header and .plugins-browser__content-wrapper instead
+		padding: 47px 0 32px calc(var(--sidebar-width-max) + 1px);
+	}
+
+	.is-section-plugins.is-logged-in.has-no-sidebar & {
+		padding: 79px 32px 32px;
+	}
+
+	// Tablets
+	@include breakpoint-deprecated( "<960px" ) {
+		padding: 71px 24px 24px calc(var(--sidebar-width-min) + 24px + 1px);
+
+		.has-no-sidebar & {
+			padding-left: 24px;
+		}
+
+		.is-section-theme.has-no-sidebar &,
+		.is-section-themes.has-no-sidebar & {
+			padding: 0;
+			margin: 0;
+		}
+
+		.is-section-themes.has-no-sidebar.is-logged-in & {
+			padding: 47px 0 0;
+		}
+
+		.is-section-plugins.has-no-sidebar.is-logged-in & {
+			padding: 71px 24px 24px;
+		}
+	}
+
+	// Mobile (Full Width)
+	@include breakpoint-deprecated( "<660px" ) {
+		margin-left: 0;
+		padding: 0;
+		padding-top: calc(var(--masterbar-height) + 1px);
+
+		.has-no-sidebar & {
+			padding-left: 0;
+		}
+
+		.is-section-plugins.has-no-sidebar.is-logged-in & {
+			padding: calc(var(--masterbar-height) + 1px) 0 0;
+		}
+	}
+}
+
+// Add extra bottom padding for smaller screens to prevent
+// floating inline help from overlapping content.
+.layout__primary .main {
+	// The height is set to 100% in /sites page so we want to ensure that padding doesn't take us over 100% total height.
+	box-sizing: border-box;
+	padding-bottom: 88px;
+	@include breakpoint-deprecated( ">1400px" ) {
+		padding-bottom: 0;
+	}
+}
+body.is-mobile-app-view {
+	/* We are ignoring these lines because without the px value the calc function does not work as expected */
+	/* stylelint-disable length-zero-no-unit */
+	--sidebar-width-max: 0px;
+	--sidebar-width-min: 0px;
+	/* stylelint-enable length-zero-no-unit */
+	.layout__secondary {
+		display: none;
+	}
+}
+// Setup the secondary element, which contains the sidebar and
+// the site-selector elements.
+.layout__secondary {
+	position: fixed;
+	top: var(--masterbar-height);
+	left: 0;
+	bottom: 0;
+	color: var(--color-sidebar-text);
+	// background: var(--color-sidebar-background);
+	width: var(--sidebar-width-max);
+	overflow: hidden;
+	// Ensure that the sidebar always remains on top.
+	// Related issue: https://github.com/Automattic/wp-calypso/issues/53504
+	z-index: z-index("root", ".layout__secondary");
+
+	@include breakpoint-deprecated( "<960px" ) {
+		width: var(--sidebar-width-min);
+	}
+
+	@include breakpoint-deprecated( "<660px" ) {
+		width: 100%;
+	}
+
+	// The editor has its own sidebar which doesnt
+	// use the secondary element.
+	.is-section-gutenberg-editor &,
+	// Some screens (like /theme/) simply dont have
+	// a sidebar.
+	.has-no-sidebar & {
+		display: none;
+	}
+
+	// Secondary Layout overrides
+	.site__title {
+		color: var(--color-sidebar-text);
+	}
+
+	.site__domain {
+		color: var(--color-sidebar-text-alternative);
+	}
+
+	.site__title::after,
+	.site__domain::after {
+		@include long-content-fade( $color: var( --color-sidebar-background ) );
+	}
+
+	.site-selector {
+		// Setup the site-selector element. Its default
+		// position is off screen.
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		pointer-events: none;
+		transform: translateX(calc(-1 * var(--sidebar-width-max)));
+		height: calc(100vh - var(--masterbar-height));
+
+		&.is-large .site-selector__sites {
+			border-color: var(--color-sidebar-border);
+		}
+
+		&__sites {
+			background: var(--color-sidebar-background);
+		}
+
+		&__add-new-site {
+			border-color: var(--color-sidebar-border);
+
+			.button {
+				color: var(--color-sidebar-text-alternative);
+				&:hover {
+					color: var(--color-sidebar-text);
+				}
+			}
+		}
+
+		&__recent {
+			border-color: var(--color-sidebar-border);
+		}
+
+		&__no-results {
+			color: var(--color-sidebar-text-alternative);
+		}
+
+		&__list-bottom-adornment {
+			color: var(--color-sidebar-text);
+		}
+
+		.all-sites {
+			border-color: var(--color-sidebar-border);
+		}
+
+		.site,
+		.all-sites {
+			.site__title,
+			.site__domain {
+				&::after {
+					@include long-content-fade( $color: var( --color-sidebar-background ) );
+				}
+			}
+		}
+
+		@include breakpoint-deprecated( "<660px" ) {
+			-webkit-overflow-scrolling: touch;
+			transform: translateX(-100%);
+			height: auto;
+		}
+	}
+
+	.all-sites .count {
+		color: var(--color-sidebar-text);
+		border-color: var(--color-sidebar-text);
+	}
+
+	.app-promo {
+		box-shadow: 0 0 0 1px var(--color-sidebar-border), 0 1px 2px var(--color-sidebar-border);
+	}
+}
+
+/*
+	Focus States
+	Sites - Site Selector for those with multiple sites
+	Sidebar - The sidebar is the current focus
+	Content - The content is the furrent focus
+*/
+
+// Adjust the content as needed when focused on the site selector or sidebar.
+.layout.focus-sites,
+.layout.focus-sidebar {
+	.layout__primary .main {
+		@include breakpoint-deprecated( "<660px" ) {
+			pointer-events: none;
+			overflow: hidden;
+			max-height: calc(100vh - 47px);
+
+			// Removing this transform could have unintended side-affects
+			// related to z-index and elements showing through on mobile.
+			transform: translateX(100%);
+		}
+	}
+}
+
+// Adjust elements when the site-selector is visible.
+.layout.focus-sites {
+	.layout__secondary .site-selector {
+		pointer-events: auto;
+		transform: translateX(0);
+	}
+
+	.layout__secondary .sidebar {
+		pointer-events: none;
+		transform: translateX(var(--sidebar-width-max));
+
+		@include breakpoint-deprecated( "<660px" ) {
+			transform: translateX(100%);
+		}
+	}
+
+	.layout__primary .main {
+		@include breakpoint-deprecated( ">660px" ) {
+			pointer-events: none;
+			opacity: 0.25;
+		}
+	}
+}
+
+// Move the secondary element off screen when focused
+// on the content. This only applies to small screens.
+.layout.focus-content .layout__secondary {
+	@media only screen and (max-width: 781px) {
+		transform: translateX(-100%);
+	}
+}
+
+// Display sidebar as a panel under a main payment component in mobile checkout
+.layout.is-section-checkout {
+	@include breakpoint-deprecated( "<660px" ) {
+		.layout__content {
+			display: flex;
+			flex-flow: column;
+		}
+		.layout__primary {
+			order: 1;
+		}
+		.layout__secondary {
+			order: 2;
+			position: relative;
+			transform: none;
+			top: 10px;
+		}
+	}
+}
+
+.layout {
+	.global-notices {
+		padding: 8px;
+
+		/* This is the breakpoint we're using in client/components/global-notices/style.scss */
+		@include breakpoint-deprecated( ">660px" ) {
+			padding: 0;
+		}
+	}
+
+	// Try to clean things up a bit when printing.
+	.masterbar,
+	.layout__secondary {
+		@media print {
+			display: none;
+		}
+	}
+
+	.layout__content {
+		@media print {
+			padding: 0;
+		}
+	}
+}
+// Only apply the no-masterbar rule to logged in sections
+// This is done since most has-no-masterbar section have their own padding set already that we don't want to overwrite
+.layout.has-no-masterbar.is-group-me,
+.layout.has-no-masterbar.is-group-sites,
+.layout.has-no-masterbar.is-section-reader {
+	/* We are ignoring these lines because without the px value the calc function does not work as expected */
+	/* stylelint-disable-next-line length-zero-no-unit */
+	--masterbar-height: 0px;
+
+	.layout__content {
+		padding-top: 32px;
+	}
+	&.has-no-sidebar .layout__content {
+		padding-top: 0;
+	}
+}
+
+// Ensure sidebar is visually separate from the content in the Contrast color scheme
+.theme-default.is-contrast {
+	.layout__secondary {
+		outline: 1px solid var(--color-sidebar-border);
+	}
+}
+
+// Ensure reader streams have the neutral background.
+.layout.is-section-reader {
+	min-height: 100vh;
+
+	&.has-header-section {
+		background: var(--studio-white);
+	}
+	.section-header.card {
+		box-shadow: none;
+		margin-bottom: 24px;
+		padding: 0;
+
+		.section-header__label-text {
+			font-size: 1.25rem;
+			font-weight: 500;
+			line-height: 26px;
+		}
+
+		@include breakpoint-deprecated( "<660px" ) {
+			margin: 0 16px;
+		}
+	}
+}
+
+// Handle Gravatar domain flow styles
+.layout.is-domain-for-gravatar {
+	* {
+		font-family:
+			'SF Pro Text',
+			-apple-system,
+			BlinkMacSystemFont,
+			'Segoe UI',
+			Roboto,
+			Oxygen-Sans,
+			Ubuntu,
+			Cantarell,
+			'Helvetica Neue',
+			sans-serif !important;
+	}
+
+	.masterbar__secure-checkout {
+		column-gap: 8px;
+	}
+
+	.gravatar-text-logo {
+		width: 119px;
+		height: 22px;
+	}
+
+	h1.formatted-header__title,
+	.checkout-title,
+	h1.thank-you__header-title {
+		font-family:
+			'SF Pro Display',
+			-apple-system,
+			BlinkMacSystemFont,
+			'Segoe UI',
+			Roboto,
+			Oxygen-Sans,
+			Ubuntu,
+			Cantarell,
+			'Helvetica Neue',
+			sans-serif !important;
+	}
+
+	h1.formatted-header__title,
+	h1.thank-you__header-title {
+		font-weight: 700 !important;
+	}
+
+	.domain-suggestion__action.is-primary:not( :disabled ),
+	.checkout-modal__button.is-status-primary,
+	.thank-you__product-actions .components-button.is-primary:not( :disabled ) {
+		background-color: #1d4fc4;
+		border-color: #1d4fc4;
+
+		&:hover,
+		&:focus {
+			background-color: #002e9b;
+			border-color: #002e9b;
+		}
+	}
+
+	// Domain pages
+	&.is-section-signup {
+		.gravatar-text-logo {
+			position: absolute;
+			top: 20px;
+			left: 24px;
+			width: 130px;
+			height: 24px;
+		}
+	}
+
+	&.is-section-checkout,
+	&.is-section-checkout-pending {
+		.gravatar-text-logo {
+			margin-bottom: 3px;
+		}
+	}
+
+	&.is-section-checkout {
+		.cost-overrides-list-item__reason--is-discount {
+			color: #1d4fc4;;
+		}
+
+		.checkout-payment-methods .is-checked:not( .has-highlight ) {
+			border: #c3c4c7 1px solid;
+		}
+	}
+
+	&.is-section-checkout-pending {
+		.gravatar-text-logo {
+			margin-left: 19.5px;
+		}
+	}
+
+	&.is-section-checkout-thank-you {
+		.gravatar-text-logo {
+			margin-left: 24px;
+			align-self: center;
+		}
+	}
+}
+
+// Universal header
+.layout.has-universal-header .lpc-header-nav-wrapper {
+	padding-top: var(--masterbar-height);
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
