### PR TITLE
Purchases: fix incorrect usage of plan expiration

### DIFF
--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -22,7 +22,7 @@ export function hostingFeatures( context: PageJSContext, next: () => void ) {
 
 	let content;
 	if ( site ) {
-		const hasAtomicFeature = ! site.plan?.expired && hasPlanFeature( site, DotcomFeatures.ATOMIC );
+		const hasAtomicFeature = hasPlanFeature( site, DotcomFeatures.ATOMIC );
 		const shouldShowActivationCallout = ! site.is_wpcom_atomic && hasAtomicFeature;
 
 		let redirectUrl = context.query.redirect_to;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1537/

## Proposed Changes

This updates some of the incorrect instances where a subscription's expiration date, instead of feature support or subscription status (active/inactive), is used for feature gating.

## Why are these changes being made?

Almost all products have a grace period after a subscription expires, where the subscription is still active and the user still has access to the product and its features. Because of this, we shouldn't be using a subscription's expiration date for feature gating - instead, we should be using methods that check if a site supports a feature or we should check the subscription's status (active or inactive) directly. 

See: p1767943462110459-slack-C03TY6J1A

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*