### PR TITLE
E2E: Enable Dashboard pre-release tests on TeamCity

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1142,8 +1142,6 @@ object PlaywrightTestDashboardPreReleaseMatrix : BuildType({
 			""".trimIndent()
 			triggerRules = """
 				-:**.md
-				+:client/dashboard/**
-				+:test/e2e/specs/dashboard/**
 			""".trimIndent()
 		}
 	}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1008,6 +1008,7 @@ object PlaywrightTestPreReleaseMatrix : BuildType({
 	params {
 		text("TEST_GROUP", "@calypso-release")
 		param("CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
+		param("DASHBOARD_BASE_URL", "https://my.wordpress.com")
 	}
 
 	features {
@@ -1164,13 +1165,14 @@ object PreReleaseE2ETests : BuildType({
 		root(Settings.WpCalypso)
 		cleanCheckout = true
 	}
-	
+
 	params {
 		param("env.NODE_CONFIG_ENV", "test")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
 		param("env.HEADLESS", "true")
 		param("env.LOCALE", "en")
 		param("env.CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
+		param("end.DASHBOARD_BASE_URL", "https://my.wordpress.com")
 		param("env.ALLURE_RESULTS_PATH", "allure-results")
 	}
 
@@ -1304,6 +1306,7 @@ object AuthenticationE2ETests : BuildType({
 	params {
 		param("PROJECT", "authentication")
 		param("CALYPSO_BASE_URL", "https://wordpress.com")
+		param("DASHBOARD_BASE_URL", "https://my.wordpress.com")
 	}
 
 	features {
@@ -1345,6 +1348,7 @@ object QuarantinedE2ETests: E2EBuildType(
 	buildParams = {
 		param("env.VIEWPORT_NAME", "desktop")
 		param("env.CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
+		param("env.DASHBOARD_BASE_URL", "https://my.wordpress.com")
 	},
 	buildFeatures = {
 		notifications {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -27,7 +27,7 @@ object WebApp : Project({
 	buildType(PlaywrightTestPRMatrix)
 	buildType(PlaywrightTestPreReleaseMatrix)
 	buildType(PlaywrightTestDashboardPRMatrix)
-	// buildType(PlaywrightTestDashboardPreReleaseMatrix)
+	buildType(PlaywrightTestDashboardPreReleaseMatrix)
 	buildType(PreReleaseE2ETests)
 	buildType(AuthenticationE2ETests)
 	buildType(QuarantinedE2ETests)
@@ -1107,6 +1107,7 @@ object PlaywrightTestDashboardPreReleaseMatrix : BuildType({
 
 	params {
 		param("TEST_GROUP", "@dashboard-release")
+		param("CALYPSO_BASE_URL", "https://wordpress.com")
 		param("DASHBOARD_BASE_URL", "https://my.wordpress.com")
 	}
 


### PR DESCRIPTION
Fixes #107941

## Proposed Changes

* Enable the `PlaywrightTestDashboardPreReleaseMatrix` build type (was commented out)

## Why are these changes being made?

With #107941 merged, we have dashboard pre-release tests ready. This enables them on TeamCity so they run on trunk against `my.wordpress.com` as a canary test before deploying.

## Testing Instructions

Unfortunately this has to be tested after merging 🤞 

* Verify TeamCity picks up the new build config after merge
* Monitor `#e2eflowtesting-notif` for test results