### PR TITLE
Fix crash when running jest e2e test locally

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -1,7 +1,9 @@
-import { Page, Locator, expect } from 'playwright/test';
+import { Page, Locator } from 'playwright';
 import { clickNavTab } from '../../element-helper';
 
 export type PeoplePageTabs = 'Users' | 'Followers' | 'Email Followers' | 'Invites';
+
+type PWExpect = ( typeof import('@playwright/test') )[ 'expect' ];
 
 /**
  * Represents the Users > All Users page.
@@ -77,8 +79,9 @@ export class PeoplePage {
 	/**
 	 * Waits for an invitation to appear in the pending invites list. Reloads the page until the invitation is found or the timeout is reached.
 	 * @param emailaddress Email address of the invited user.
+	 * @param expect Playwright expect function.
 	 */
-	async expectInvitation( emailaddress: string ): Promise< void > {
+	async expectInvitationAndAssert( emailaddress: string, expect: PWExpect ): Promise< void > {
 		await this.clickViewAllIfAvailable();
 		await expect( async () => {
 			await this.page.reload();
@@ -97,8 +100,9 @@ export class PeoplePage {
 
 	/**
 	 * Clear the invitation of a user from site.
+	 * @param expect Playwright expect function.
 	 */
-	async clearUserInvitation(): Promise< void > {
+	async clearUserInvitationAndAssert( expect: PWExpect ): Promise< void > {
 		await this.clearUserButton.click();
 		await expect(
 			this.page.getByText( 'Invite deleted' ),
@@ -108,8 +112,10 @@ export class PeoplePage {
 
 	/**
 	 * Removes a user from site.
+	 * @param username Username of the user to remove.
+	 * @param expect Playwright expect function.
 	 */
-	async removeUserFromSite( username: string ): Promise< void > {
+	async removeUserFromSiteAndAssert( username: string, expect: PWExpect ): Promise< void > {
 		await this.page.getByRole( 'button', { name: `Remove ${ username }` } ).click();
 		await this.page.getByRole( 'button', { name: 'Remove', exact: true } ).click();
 		await expect(
@@ -134,8 +140,9 @@ export class PeoplePage {
 
 	/**
 	 * Revokes the pending invite.
+	 * @param expect Playwright expect function.
 	 */
-	async revokeInvite(): Promise< void > {
+	async revokeInviteAndAssert( expect: PWExpect ): Promise< void > {
 		await this.revokeInviteButton.click();
 		await expect(
 			this.page.getByText( 'Invite deleted' ),
@@ -149,10 +156,11 @@ export class PeoplePage {
 	 * @param siteURL User's primary site URL.
 	 * @param username Username of the team member.
 	 */
-	async visitTeamMemberUserDetails(
+	async visitTeamMemberUserDetailsAndAssert(
 		baseURL: string,
 		siteURL: string,
-		username: string
+		username: string,
+		expect: PWExpect
 	): Promise< void > {
 		expect( baseURL, 'Base URL should be defined' ).toBeDefined();
 		expect( siteURL, 'Site URL should be defined' ).toBeDefined();

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -103,10 +103,11 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 		await test.step( 'Then I can see the invited user part of the team', async function () {
 			// Use direct navigation to avoid finding the user when there are over 100 team members piled up.
-			await pagePeople.visitTeamMemberUserDetails(
+			await pagePeople.visitTeamMemberUserDetailsAndAssert(
 				helperData.getCalypsoURL(),
 				accountPreRelease.credentials.testSites?.primary?.url as string,
-				signedUpUsername
+				signedUpUsername,
+				expect
 			);
 		} );
 

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -64,7 +64,7 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 		} );
 
 		await test.step( 'Then I can see the invite is pending', async function () {
-			await pagePeople.expectInvitation( testUser.email );
+			await pagePeople.expectInvitationAndAssert( testUser.email, expect );
 		} );
 
 		await test.step( 'When the invited user checks their email', async function () {
@@ -111,7 +111,7 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 		} );
 
 		await test.step( 'Then I can remove the team member from the site', async function () {
-			await pagePeople.removeUserFromSite( signedUpUsername );
+			await pagePeople.removeUserFromSiteAndAssert( signedUpUsername, expect );
 		} );
 
 		await test.step( 'And the invited user closes their account', async function () {

--- a/test/e2e/specs/users/invite__revoke.spec.ts
+++ b/test/e2e/specs/users/invite__revoke.spec.ts
@@ -62,7 +62,7 @@ test.describe(
 			} );
 
 			await test.step( 'Then I can see the invite is pending', async function () {
-				await pagePeople.expectInvitation( testEmailAddress );
+				await pagePeople.expectInvitationAndAssert( testEmailAddress, expect );
 			} );
 
 			await test.step( 'When I select the invited user', async function () {
@@ -70,7 +70,7 @@ test.describe(
 			} );
 
 			await test.step( 'And I revoke the invite', async function () {
-				await pagePeople.revokeInvite();
+				await pagePeople.revokeInviteAndAssert( expect );
 			} );
 
 			await test.step( 'Then the invite link is no longer valid', async function () {


### PR DESCRIPTION
## Proposed Changes

* Inject `expect` via dependency injection in PeoplePage methods instead of importing from `@playwright/test`

## Why are these changes being made?

I currently can't run the e2e tests locally.

Jest crashes when trying to import `@playwright/test` (I think `playwright` is supposed to be ok, but not `@playwright/test`). The "People" page object imports the offending module so that it can run assertions inside the page object methods.

tbh I'm not sure whether page objects doing assertions is even a very nice pattern 🤔 CC @adimoldovan. How can we be sure the failures it sees aren't part of the test? Seems like assertions generally belong in the test files.

Anyway, I've injected the `expect` dependency into the page object methods. Now they are `doThingAndAssert()` methods, so that it is clear the these page object methods aren't just dumb button clickers.

See also this attempt at fixing the issue #107940.

## Testing Instructions

* Run a jest test locally - should no longer crash
  * e.g. `CALYPSO_BASE_URL=https://wordpress.com yarn workspace wp-e2e-tests build && yarn workspace wp-e2e-tests test test/e2e/specs/i18n/i18n__logged-out-redirect.ts`
* CI should pass

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)