### PR TITLE
Agents Manager: add to onboarding screen

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -201,6 +201,11 @@ async function main() {
 							sectionName="stepper"
 						/>
 					) }
+					<AsyncLoad
+						require="calypso/layout/agents-manager-loader"
+						placeholder={ null }
+						sectionName={ flowName }
+					/>
 					{ 'development' === process.env.NODE_ENV && (
 						<AsyncLoad require="calypso/components/webpack-build-monitor" placeholder={ null } />
 					) }

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -196,16 +196,18 @@ async function main() {
 						/>
 					</BrowserRouter>
 					{ ! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) && (
-						<AsyncHelpCenterApp
-							currentUser={ user as UserStore.CurrentUser }
-							sectionName="stepper"
-						/>
+						<>
+							<AsyncHelpCenterApp
+								currentUser={ user as UserStore.CurrentUser }
+								sectionName="stepper"
+							/>
+							<AsyncLoad
+								require="calypso/layout/agents-manager-loader"
+								placeholder={ null }
+								sectionName={ flowName }
+							/>
+						</>
 					) }
-					<AsyncLoad
-						require="calypso/layout/agents-manager-loader"
-						placeholder={ null }
-						sectionName={ flowName }
-					/>
 					{ 'development' === process.env.NODE_ENV && (
 						<AsyncLoad require="calypso/components/webpack-build-monitor" placeholder={ null } />
 					) }

--- a/client/layout/agents-manager-loader.tsx
+++ b/client/layout/agents-manager-loader.tsx
@@ -9,10 +9,10 @@ import { shouldLoadInlineHelp } from './utils';
 
 export default function AgentsManagerLoader( {
 	sectionName,
-	currentRoute,
+	currentRoute = window.location.pathname,
 }: {
 	sectionName: string;
-	currentRoute: string;
+	currentRoute?: string;
 } ) {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 	const user = useSelector( getCurrentUser );


### PR DESCRIPTION
Adds the agents manager loader to the onboarding pages.

Fixes AI-777

## Why are these changes being made?

We need to load the agents manager during the onboarding steps so the new AI sidebar can be displayed.

## Testing Instructions

* Ensure unified chat is enabled (you may need to wait a while for caches to update)
* Visit a variety of onboarding pages and confirm the agents manager is loaded
  * http://calypso.localhost:3000/setup/onboarding/plans?source=sites-dashboard&ref=new-site-popover
  * http://calypso.localhost:3000/setup/onboarding/domains
  * http://calypso.localhost:3000/setup/ai-site-builder/plans?flow=plan-domain
* Disable unified chat, wait for caches to clear
* Visit the same pages and confirm no agents manager is loaded. Also check that the only JS loaded is `async-load-calypos-layout-agents-manager-loader.js`, and not the full agents manager JS/CSS

Note that the style of the agents manager may appear broken. This is dealt with in #107816

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
