### PR TITLE
MSD: check for inaccessible jetpack error more flexibly

### DIFF
--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -1,4 +1,4 @@
-import { DashboardDataError, INACCESSIBLE_JETPACK_ERROR_CODE } from '@automattic/api-core';
+import { isInaccessibleJetpackError } from '@automattic/api-core';
 import calypsoConfig from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { camelToSnakeCase } from '@automattic/js-utils';
@@ -17,7 +17,7 @@ function isBenignError( error: Error ) {
 
 	// Ignore errors related to inaccessible Jetpack sites.
 	// The user is expected to debug their Jetpack sites.
-	if ( error instanceof DashboardDataError && error.code === INACCESSIBLE_JETPACK_ERROR_CODE ) {
+	if ( isInaccessibleJetpackError( error ) ) {
 		return true;
 	}
 

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -5,7 +5,6 @@
 import { captureException } from '@automattic/calypso-sentry';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { handleOnCatch } from '../index';
-import type { WPError } from '@automattic/api-core';
 import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
 
@@ -37,10 +36,8 @@ describe( 'handleOnCatch', () => {
 	} );
 
 	it( 'does not log or capture benign inaccessible Jetpack error', () => {
-		const error = new Error( 'The Jetpack site is inaccessible or returned an error' ) as WPError;
+		const error = new Error( 'The Jetpack site is inaccessible or returned an error' );
 		error.name = 'ParseError';
-		error.status = 403;
-		error.statusCode = 403;
 
 		const errorInfo = createErrorInfo();
 		const router = createRouter( { siteSlug: 'my-site' } );

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { DashboardDataError, INACCESSIBLE_JETPACK_ERROR_CODE } from '@automattic/api-core';
 import { captureException } from '@automattic/calypso-sentry';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { handleOnCatch } from '../index';
@@ -36,8 +35,8 @@ describe( 'handleOnCatch', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'does not log or capture benign DashboardDataError (inaccessible Jetpack site)', () => {
-		const error = new DashboardDataError( INACCESSIBLE_JETPACK_ERROR_CODE );
+	it( 'does not log or capture benign inaccessible Jetpack error', () => {
+		const error = new Error( 'The Jetpack site is inaccessible or returned an error' );
 		const errorInfo = createErrorInfo();
 		const router = createRouter( { siteSlug: 'my-site' } );
 

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -5,6 +5,7 @@
 import { captureException } from '@automattic/calypso-sentry';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { handleOnCatch } from '../index';
+import type { WPError } from '@automattic/api-core';
 import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
 
@@ -36,7 +37,11 @@ describe( 'handleOnCatch', () => {
 	} );
 
 	it( 'does not log or capture benign inaccessible Jetpack error', () => {
-		const error = new Error( 'The Jetpack site is inaccessible or returned an error' );
+		const error = new Error( 'The Jetpack site is inaccessible or returned an error' ) as WPError;
+		error.name = 'ParseError';
+		error.status = 403;
+		error.statusCode = 403;
+
 		const errorInfo = createErrorInfo();
 		const router = createRouter( { siteSlug: 'my-site' } );
 

--- a/client/dashboard/sites/site/error.tsx
+++ b/client/dashboard/sites/site/error.tsx
@@ -1,4 +1,4 @@
-import { DashboardDataError, INACCESSIBLE_JETPACK_ERROR_CODE } from '@automattic/api-core';
+import { isInaccessibleJetpackError } from '@automattic/api-core';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import UnknownError from '../../app/500';
@@ -9,12 +9,10 @@ import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
 
 export default function Error( { error }: { error: Error } ) {
-	switch ( error instanceof DashboardDataError && error.code ) {
-		case INACCESSIBLE_JETPACK_ERROR_CODE:
-			return <InaccessibleJetpackError error={ error } />;
-		default:
-			return <UnknownError error={ error } />;
+	if ( isInaccessibleJetpackError( error ) ) {
+		return <InaccessibleJetpackError error={ error } />;
 	}
+	return <UnknownError error={ error } />;
 }
 
 function InaccessibleJetpackError( { error }: { error: Error } ) {

--- a/packages/api-core/src/error.ts
+++ b/packages/api-core/src/error.ts
@@ -17,7 +17,7 @@ export function isWpError( error: unknown ): error is WPError {
 }
 
 export function isInaccessibleJetpackError( error: unknown ): boolean {
-	if ( error instanceof Error ) {
+	if ( isWpError( error ) ) {
 		if ( error.message.startsWith( 'The Jetpack site is inaccessible' ) ) {
 			return true;
 		}

--- a/packages/api-core/src/error.ts
+++ b/packages/api-core/src/error.ts
@@ -1,17 +1,3 @@
-export class DashboardDataError extends Error {
-	constructor(
-		public code: string,
-		cause?: unknown
-	) {
-		const message = cause instanceof Error ? cause.message : `Error: ${ cause }`;
-		super( message, { cause } );
-		this.name = 'DashboardDataError';
-
-		// Fix prototype chain (important for instanceof to work reliably)
-		Object.setPrototypeOf( this, new.target.prototype );
-	}
-}
-
 export interface WPError extends Error {
 	status: number;
 	statusCode: number;
@@ -28,4 +14,8 @@ export function isWpError( error: unknown ): error is WPError {
 		typeof error.statusCode === 'number' &&
 		( 'error' in error ? typeof error.error === 'string' : true )
 	);
+}
+
+export function isInaccessibleJetpackError( error: unknown ): boolean {
+	return error instanceof Error && error.message.startsWith( 'The Jetpack site is inaccessible' );
 }

--- a/packages/api-core/src/error.ts
+++ b/packages/api-core/src/error.ts
@@ -17,5 +17,16 @@ export function isWpError( error: unknown ): error is WPError {
 }
 
 export function isInaccessibleJetpackError( error: unknown ): boolean {
-	return error instanceof Error && error.message.startsWith( 'The Jetpack site is inaccessible' );
+	if ( error instanceof Error ) {
+		if ( error.message.startsWith( 'The Jetpack site is inaccessible' ) ) {
+			return true;
+		}
+		if (
+			error.name === 'UnauthorizedError' &&
+			error.message.startsWith( 'API calls to this blog have been disabled' )
+		) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/api-core/src/error.ts
+++ b/packages/api-core/src/error.ts
@@ -17,7 +17,7 @@ export function isWpError( error: unknown ): error is WPError {
 }
 
 export function isInaccessibleJetpackError( error: unknown ): boolean {
-	if ( isWpError( error ) ) {
+	if ( error instanceof Error ) {
 		if ( error.message.startsWith( 'The Jetpack site is inaccessible' ) ) {
 			return true;
 		}

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -1,8 +1,5 @@
-import { isWpError, DashboardDataError } from '../error';
 import { wpcom } from '../wpcom-fetcher';
 import type { Site } from './types';
-
-export const INACCESSIBLE_JETPACK_ERROR_CODE = 'inaccessible_jetpack' as const;
 
 export const SITE_FIELDS = [
 	'ID',
@@ -65,15 +62,8 @@ export const SITE_OPTIONS = [
 export const JOINED_SITE_OPTIONS = SITE_OPTIONS.join( ',' );
 
 export async function fetchSite( siteIdOrSlug: number | string ): Promise< Site > {
-	try {
-		return await wpcom.req.get(
-			{ path: `/sites/${ siteIdOrSlug }` },
-			{ fields: JOINED_SITE_FIELDS, options: JOINED_SITE_OPTIONS }
-		);
-	} catch ( error ) {
-		if ( isWpError( error ) && error.message.startsWith( 'The Jetpack site is inaccessible' ) ) {
-			throw new DashboardDataError( INACCESSIBLE_JETPACK_ERROR_CODE, error );
-		}
-		throw error;
-	}
+	return await wpcom.req.get(
+		{ path: `/sites/${ siteIdOrSlug }` },
+		{ fields: JOINED_SITE_FIELDS, options: JOINED_SITE_OPTIONS }
+	);
 }

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -1,5 +1,4 @@
 import {
-	isWpError,
 	isInaccessibleJetpackError,
 	fetchSite,
 	deleteSite,
@@ -16,7 +15,9 @@ import type { Site } from '@automattic/api-core';
 import type { Query } from '@tanstack/react-query';
 
 function isSiteNotFoundError( error: unknown ) {
-	return isWpError( error ) && [ 'UnknownBlogError', 'UnauthorizedError' ].includes( error.name );
+	return (
+		error instanceof Error && [ 'UnknownBlogError', 'UnauthorizedError' ].includes( error.name )
+	);
 }
 
 export function siteBySlugQuery( siteSlug: string ) {

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -1,7 +1,6 @@
 import {
 	isWpError,
-	DashboardDataError,
-	INACCESSIBLE_JETPACK_ERROR_CODE,
+	isInaccessibleJetpackError,
 	fetchSite,
 	deleteSite,
 	launchSite,
@@ -46,7 +45,7 @@ export function siteBySlugQuery( siteSlug: string ) {
 			}
 		},
 		retry: ( failureCount, e: { data?: string } ) => {
-			if ( e instanceof DashboardDataError && e.code === INACCESSIBLE_JETPACK_ERROR_CODE ) {
+			if ( isInaccessibleJetpackError( e ) ) {
 				return false;
 			}
 
@@ -93,7 +92,7 @@ export function siteByIdQuery( siteId: number ) {
 			}
 		},
 		retry: ( failureCount, e: { data?: string } ) => {
-			if ( e instanceof DashboardDataError && e.code === INACCESSIBLE_JETPACK_ERROR_CODE ) {
+			if ( isInaccessibleJetpackError( e ) ) {
 				return false;
 			}
 

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -15,7 +15,9 @@ import { queryClient } from './query-client';
 import type { Site } from '@automattic/api-core';
 import type { Query } from '@tanstack/react-query';
 
-const KNOWN_ERRORS = [ 'unknown_blog', 'unauthorized' ];
+function isSiteNotFoundError( error: unknown ) {
+	return isWpError( error ) && [ 'UnknownBlogError', 'UnauthorizedError' ].includes( error.name );
+}
 
 export function siteBySlugQuery( siteSlug: string ) {
 	// Used to find an existing Site object which is already in the `site-by-id` cache.
@@ -38,18 +40,14 @@ export function siteBySlugQuery( siteSlug: string ) {
 			try {
 				return await fetchSite( siteSlug );
 			} catch ( e ) {
-				if ( isWpError( e ) && e.error && KNOWN_ERRORS.includes( e.error ) ) {
-					throw notFound( { data: e.error } );
+				if ( isSiteNotFoundError( e ) && ! isInaccessibleJetpackError( e ) ) {
+					throw notFound();
 				}
 				throw e;
 			}
 		},
-		retry: ( failureCount, e: { data?: string } ) => {
-			if ( isInaccessibleJetpackError( e ) ) {
-				return false;
-			}
-
-			if ( e.data && KNOWN_ERRORS.includes( e.data ) ) {
+		retry: ( failureCount, e: { isNotFound?: boolean } ) => {
+			if ( e.isNotFound || isInaccessibleJetpackError( e ) ) {
 				return false;
 			}
 			return failureCount < 3; // default retry count
@@ -85,18 +83,14 @@ export function siteByIdQuery( siteId: number ) {
 			try {
 				return await fetchSite( siteId );
 			} catch ( e ) {
-				if ( isWpError( e ) && e.error && KNOWN_ERRORS.includes( e.error ) ) {
-					throw notFound( { data: e.error } );
+				if ( isSiteNotFoundError( e ) && ! isInaccessibleJetpackError( e ) ) {
+					throw notFound();
 				}
 				throw e;
 			}
 		},
-		retry: ( failureCount, e: { data?: string } ) => {
-			if ( isInaccessibleJetpackError( e ) ) {
-				return false;
-			}
-
-			if ( e.data && KNOWN_ERRORS.includes( e.data ) ) {
+		retry: ( failureCount, e: { isNotFound?: boolean } ) => {
+			if ( e.isNotFound || isInaccessibleJetpackError( e ) ) {
 				return false;
 			}
 			return failureCount < 3; // default retry count


### PR DESCRIPTION
Suppress error in Sentry CALYPSO-2854
Suppress error in Sentry CALYPSO-31X
Suppress error in p1768290838229989/1768241666.357019-slack-C08JZTRS6NA
Part of DOTMSD-1014

## Proposed Changes

Treats inaccessible Jetpack error as benign error from all endpoints, not just from `fetchSite()` endpoint.

## Why are these changes being made?

We're still seeing Sentry events of inaccessible Jetpack error even though we have suppressed them. It turns out that the error can also happen when the user opens a subroute, e.g. `/sites/:siteSlug/settings`, where the `fetchSiteSettings()` throws the error. But we're only wrapping it with `DashboardDataError` in `fetchSite()`. So it will not be counted as benign and will be sent to Sentry.

The solution here is to not wrap with `DashboardDataError` at all, and instead create a utility `isInaccessibleJetpack()` function, which is then used everywhere.

## Note

It's unfortunate that we're checking for message prefix. But there is really no way to identify inaccessible Jetpack error reliably other than this...

## Testing Instructions

We need to produce an inaccessible Jetpack site. One approach:

1. Create a new Jurassic Ninja site.
2. Open the wp-admin, then connect it to Jetpack.
3. SSH to the site.
4. Delete its wp-config.php
5. Go to /sites/:siteSlug/settings
6. Verify you see the `Your Jetpack site can not be reached at this time.` banner as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?