### PR TITLE
Use store actions instead of direct REST calls to persist the router state

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -1,4 +1,4 @@
-import { default as apiFetchPromise } from '@wordpress/api-fetch';
+import apiFetch, { default as apiFetchPromise } from '@wordpress/api-fetch';
 import { select } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { Location } from 'history';
@@ -6,6 +6,7 @@ import { default as wpcomRequestPromise, canAccessWpcomApis } from 'wpcom-proxy-
 import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
 import { isE2ETest, isLoggedInHCUser } from '../utils';
+import { wpcomRequest } from '../wpcom-request-controls';
 import { STORE_KEY } from './constants';
 import type { HelpCenterOptions, HelpCenterSelect, HelpCenterShowOptions } from './types';
 import type { APIFetchOptions } from '../shared-types';
@@ -53,9 +54,31 @@ export const saveOpenState = ( isShown: boolean | undefined, isMinimized: boolea
 	}
 };
 
-export function setHelpCenterRouterHistory(
+export function* setHelpCenterRouterHistory(
 	history: { entries: Location[]; index: number } | undefined
 ) {
+	if ( canAccessWpcomApis() ) {
+		yield wpcomRequest( {
+			path: '/me/preferences',
+			apiNamespace: 'wpcom/v2',
+			method: 'PUT',
+			body: {
+				calypso_preferences: {
+					help_center_router_history: history,
+				},
+			},
+		} );
+	} else {
+		apiFetch( {
+			global: true,
+			path: '/help-center/open-state',
+			method: 'PUT',
+			data: {
+				help_center_router_history: history,
+			},
+		} as Parameters< typeof apiFetch >[ 0 ] ).catch( () => {} );
+	}
+
 	return {
 		type: 'HELP_CENTER_SET_HELP_CENTER_ROUTER_HISTORY',
 		history,

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -322,7 +322,6 @@ export type HelpCenterAction =
 			| typeof setUserDeclaredSite
 			| typeof setUserDeclaredSiteUrl
 			| typeof setUnreadCount
-			| typeof setHelpCenterRouterHistory
 			| typeof setIsChatLoaded
 			| typeof setAreSoundNotificationsEnabled
 			| typeof setZendeskClientId
@@ -336,4 +335,5 @@ export type HelpCenterAction =
 			| typeof setHelpCenterOptions
 	  >
 	| GeneratorReturnType< typeof setShowHelpCenter >
+	| GeneratorReturnType< typeof setHelpCenterRouterHistory >
 	| GeneratorReturnType< typeof setIsMinimized >;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -5,7 +5,7 @@ import { Location } from 'history';
 import { default as wpcomRequestPromise, canAccessWpcomApis } from 'wpcom-proxy-request';
 import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
-import { isE2ETest, isLoggedInHCUser } from '../utils';
+import { isE2ETest } from '../utils';
 import { wpcomRequest } from '../wpcom-request-controls';
 import { STORE_KEY } from './constants';
 import type { HelpCenterOptions, HelpCenterSelect, HelpCenterShowOptions } from './types';
@@ -17,10 +17,6 @@ import type { APIFetchOptions } from '../shared-types';
  * @param isMinimized - Whether the help center is minimized.
  */
 export const saveOpenState = ( isShown: boolean | undefined, isMinimized: boolean | undefined ) => {
-	if ( ! isLoggedInHCUser() ) {
-		return null;
-	}
-
 	const saveState: Record< string, boolean | null > = {};
 
 	if ( typeof isShown === 'boolean' ) {

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -29,9 +29,6 @@ export function register(): typeof STORE_KEY {
 				'userDeclaredSiteUrl',
 				'subject',
 				'loggedOutOdieChat',
-				// ...( ! isLoggedInHCUser()
-				// 	? [ 'helpCenterRouterHistory', 'helpCenterMinimized', 'showHelpCenter' ]
-				// 	: [] ),
 			],
 			// Don't persist the open state for e2e users, because parallel tests will start interfering with each other.
 			resolvers: enabledPersistedOpenState ? { isHelpCenterShown } : undefined,

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -1,7 +1,7 @@
 import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 import { registerPlugins } from '../plugins';
-import { isE2ETest, isInSupportSession, isLoggedInHCUser } from '../utils';
+import { isE2ETest, isInSupportSession } from '../utils';
 import { controls as wpcomRequestControls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
@@ -13,7 +13,7 @@ export type { State };
 let isRegistered = false;
 
 export function register(): typeof STORE_KEY {
-	const enabledPersistedOpenState = ! isE2ETest() && ! isInSupportSession() && isLoggedInHCUser();
+	const enabledPersistedOpenState = ! isE2ETest() && ! isInSupportSession();
 
 	registerPlugins();
 
@@ -29,9 +29,9 @@ export function register(): typeof STORE_KEY {
 				'userDeclaredSiteUrl',
 				'subject',
 				'loggedOutOdieChat',
-				...( ! isLoggedInHCUser()
-					? [ 'helpCenterRouterHistory', 'helpCenterMinimized', 'showHelpCenter' ]
-					: [] ),
+				// ...( ! isLoggedInHCUser()
+				// 	? [ 'helpCenterRouterHistory', 'helpCenterMinimized', 'showHelpCenter' ]
+				// 	: [] ),
 			],
 			// Don't persist the open state for e2e users, because parallel tests will start interfering with each other.
 			resolvers: enabledPersistedOpenState ? { isHelpCenterShown } : undefined,

--- a/packages/data-stores/src/utils.ts
+++ b/packages/data-stores/src/utils.ts
@@ -34,7 +34,7 @@ export const isInSupportSession = () => {
 };
 
 /**
- * Check if the user is logged in in a synchronous way. Works in wp-admin and Calypso.
+ * [This only works in production] Check if the user is logged in in a synchronous way. Works in wp-admin and Calypso.
  * @returns True if the user is logged in, false otherwise.
  */
 export const isLoggedInHCUser = () => {

--- a/packages/data-stores/src/utils.ts
+++ b/packages/data-stores/src/utils.ts
@@ -32,16 +32,3 @@ export const isInSupportSession = () => {
 	}
 	return false;
 };
-
-/**
- * [This only works in production] Check if the user is logged in in a synchronous way. Works in wp-admin and Calypso.
- * @returns True if the user is logged in, false otherwise.
- */
-export const isLoggedInHCUser = () => {
-	return (
-		// Calypso
-		( typeof window !== 'undefined' && !! window.currentUser?.ID ) ||
-		// wp-admin and Gutenberg
-		( typeof helpCenterData !== 'undefined' && !! helpCenterData?.currentUser?.ID )
-	);
-};

--- a/packages/help-center/src/hooks/use-persisted-history.ts
+++ b/packages/help-center/src/hooks/use-persisted-history.ts
@@ -1,9 +1,7 @@
-import { HelpCenterSelect } from '@automattic/data-stores';
-import apiFetch from '@wordpress/api-fetch';
-import { useSelect } from '@wordpress/data';
+import { HelpCenterDispatch, HelpCenterSelect } from '@automattic/data-stores';
+import { dispatch, useSelect } from '@wordpress/data';
 import { Action, Location } from 'history';
 import { useState, useEffect, useLayoutEffect } from 'react';
-import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { HELP_CENTER_STORE } from '../stores';
 export interface HistoryEvent {
 	action: Action;
@@ -118,27 +116,12 @@ class MemoryHistory {
 		const event = { action, location: this.location };
 		this.listeners.forEach( ( listener ) => listener( event ) );
 
-		if ( canAccessWpcomApis() ) {
-			wpcomRequest( {
-				path: '/me/preferences',
-				apiNamespace: 'wpcom/v2',
-				method: 'PUT',
-				body: {
-					calypso_preferences: {
-						help_center_router_history: { entries: this.entries, index: this.index },
-					},
-				},
-			} ).catch( () => {} );
-		} else {
-			apiFetch( {
-				global: true,
-				path: '/help-center/open-state',
-				method: 'PUT',
-				data: {
-					help_center_router_history: { entries: this.entries, index: this.index },
-				},
-			} as Parameters< typeof apiFetch >[ 0 ] ).catch( () => {} );
-		}
+		(
+			dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch[ 'dispatch' ]
+		 ).setHelpCenterRouterHistory( {
+			entries: this.entries,
+			index: this.index,
+		} );
 	}
 }
 


### PR DESCRIPTION
Fixes DOTCOM-15650

## Proposed Changes

Delegate persistence to the state instead of the router to centralize state management and make extending persistence options easier.

## Why are these changes being made?
Janitorial.

## Testing Instructions
1. Open the HC.
2. Navigate to a page.
3. Refresh the page.
4. HC should reopen on that page.