### PR TITLE
Help Center: Better handoff to Happiness Engineers

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { useGetUnreadConversations } from '@automattic/odie-client/src/data';
-import { isZendeskIntroMessage } from '@automattic/odie-client/src/utils/csat';
+import { isZendeskIntroMessage } from '@automattic/odie-client/src/utils';
 import {
 	useLoadZendeskMessaging,
 	useAuthenticateZendeskMessaging,

--- a/packages/odie-client/src/components/chat-with-support/style.scss
+++ b/packages/odie-client/src/components/chat-with-support/style.scss
@@ -8,6 +8,11 @@
 	display: flex;
 	gap: 8px;
 
+	.odie-chatbox-messages-cluster & {
+		padding: 0;
+		margin-bottom: 24px;
+	}
+
 	.chat-with-support__message {
 		border-radius: 4px;
 		color: base.$gray-700;

--- a/packages/odie-client/src/components/chat-with-support/style.scss
+++ b/packages/odie-client/src/components/chat-with-support/style.scss
@@ -10,6 +10,9 @@
 
 	.odie-chatbox-messages-cluster & {
 		padding: 0;
+	}
+
+	.odie-chatbox-messages-cluster &:has( + .odie-chatbox-message ) {
 		margin-bottom: 24px;
 	}
 

--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -8,7 +8,7 @@ import {
 	isZendeskIntroMessage,
 	isAttachment,
 	hasFeedbackForm,
-	isChatWithSupportStartedLabelMessage,
+	isHappinessEngineerJoinedLabelMessage,
 } from '../../../utils';
 import ChatWithSupportLabel from '../../chat-with-support';
 import { getMessageUniqueIdentifier } from '../utils/get-message-unique-identifier';
@@ -146,7 +146,7 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 							);
 						}
 
-						if ( isChatWithSupportStartedLabelMessage( message ) ) {
+						if ( isHappinessEngineerJoinedLabelMessage( message ) ) {
 							return (
 								<ChatWithSupportLabel
 									key={ getMessageUniqueIdentifier( message, `${ group.id }-${ index }` ) }

--- a/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
+++ b/packages/odie-client/src/components/message/messages-cluster/messages-cluster.tsx
@@ -2,13 +2,14 @@ import { __ } from '@wordpress/i18n';
 import cx from 'clsx';
 import { Fragment } from 'react';
 import ChatMessage from '..';
-import { isCSATMessage } from '../../../utils';
 import {
-	hasFeedbackForm,
-	isAttachment,
-	isZendeskChatStartedMessage,
+	isCSATMessage,
+	isWaitingForHumanLabelMessage,
 	isZendeskIntroMessage,
-} from '../../../utils/csat';
+	isAttachment,
+	hasFeedbackForm,
+	isChatWithSupportStartedLabelMessage,
+} from '../../../utils';
 import ChatWithSupportLabel from '../../chat-with-support';
 import { getMessageUniqueIdentifier } from '../utils/get-message-unique-identifier';
 import type { Message, MessageRole } from '../../../types';
@@ -87,7 +88,7 @@ function clusterMessagesBySender( messages: Message[] ) {
 	const groups = [ currentGroup ];
 
 	for ( const message of sortMessagesByTimestamp( messages ) ) {
-		if ( EXCLUDED_MESSAGE_ROLES.includes( getPresentedRole( message ) as any ) ) {
+		if ( EXCLUDED_MESSAGE_ROLES.includes( getPresentedRole( message ) as 'zendesk-intro' ) ) {
 			continue;
 		}
 
@@ -110,8 +111,10 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 	const groups = clusterMessagesBySender( messages );
 
 	return groups.map( ( group ) => {
-		const startingHumanSupport = group.messages.some( isZendeskChatStartedMessage );
 		const endingHumanSupport = group.messages.some( isCSATMessage );
+		const firstNonWaitingLabelIndex = group.messages.findIndex(
+			( message ) => ! isWaitingForHumanLabelMessage( message )
+		);
 
 		const messageHeader = () => {
 			// Only business messages have a header.
@@ -133,19 +136,34 @@ export function MessagesClusterizer( { messages }: { messages: Message[] } ) {
 					/>
 				) }
 				<div className={ cx( 'odie-chatbox-messages-cluster', `role-${ group.role }` ) }>
-					{ group.messages.map( ( message, index ) => (
-						<ChatMessage
-							key={ getMessageUniqueIdentifier( message, `${ group.id }-${ index }` ) }
-							message={ message }
-							header={ index === 0 ? messageHeader() : undefined }
-						/>
-					) ) }
+					{ group.messages.map( ( message, index ) => {
+						if ( isWaitingForHumanLabelMessage( message ) ) {
+							return (
+								<ChatWithSupportLabel
+									key={ getMessageUniqueIdentifier( message, `${ group.id }-${ index }` ) }
+									labelText={ __( 'WAITING FOR HUMAN', __i18n_text_domain__ ) }
+								/>
+							);
+						}
+
+						if ( isChatWithSupportStartedLabelMessage( message ) ) {
+							return (
+								<ChatWithSupportLabel
+									key={ getMessageUniqueIdentifier( message, `${ group.id }-${ index }` ) }
+									labelText={ __( 'HAPPINESS ENGINEER JOINED', __i18n_text_domain__ ) }
+								/>
+							);
+						}
+
+						return (
+							<ChatMessage
+								key={ getMessageUniqueIdentifier( message, `${ group.id }-${ index }` ) }
+								message={ message }
+								header={ index === firstNonWaitingLabelIndex ? messageHeader() : undefined }
+							/>
+						);
+					} ) }
 				</div>
-				{ startingHumanSupport && (
-					<ChatWithSupportLabel
-						labelText={ __( 'Chat with support team started', __i18n_text_domain__ ) }
-					/>
-				) }
 			</Fragment>
 		);
 	} );

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -81,49 +81,37 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 		];
 	}
 
-	const baseMessage = {
-		content:
-			__( 'No problem. Help is on the way!', __i18n_text_domain__ ) +
-			( isTestMode ? ' (staging)' : '' ),
-		role: 'bot' as const,
-		type: 'message' as const,
-		context: {
-			flags: {
-				hide_disclaimer_content: true,
-				show_ai_avatar: false,
-			},
-			site_id: null,
-		},
-	};
-
-	if ( isTestMode ) {
-		return [
-			baseMessage,
-			{
-				content: __(
-					'This is the Sandbox version of Zendesk. You will not be redirected to a support agent. If you want to test the real experience and be connected to a support agent, you need to be unproxied.',
-					__i18n_text_domain__
-				),
-				role: 'bot' as const,
-				type: 'message' as const,
-				context: {
-					flags: {
-						hide_disclaimer_content: true,
-						show_ai_avatar: false,
-					},
-					site_id: null,
-				},
-			},
-		];
-	}
-
-	return [
-		baseMessage,
+	const messages: Message[] = [
 		{
-			content: __(
-				"We're connecting you with our support team. A Happiness Engineer will join the chat as soon as they're available.",
-				__i18n_text_domain__
-			),
+			content:
+				__( 'No problem. Help is on the way!', __i18n_text_domain__ ) +
+				( isTestMode ? ' (staging)' : '' ),
+			role: 'bot' as const,
+			type: 'message' as const,
+			context: {
+				flags: {
+					hide_disclaimer_content: true,
+					show_ai_avatar: false,
+				},
+				site_id: null,
+			},
+		},
+		{
+			content: '',
+			role: 'bot' as const,
+			type: 'meta' as const,
+			internal_message_id: 'waiting-for-human',
+			context: {
+				flags: {
+					show_waiting_for_human: true,
+				},
+				site_id: null,
+			},
+		},
+		{
+			content:
+				( isTestMode ? '(STAGING VERSION OF ZENDESK) ' : '' ) +
+				__( "I've asked for a Happiness Engineer to join this chat.", __i18n_text_domain__ ),
 			role: 'bot' as const,
 			type: 'message' as const,
 			context: {
@@ -136,7 +124,7 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 		},
 		{
 			content: __(
-				'They can see your chat with our AI assistant but please share any extra details while you wait so we can assist you better.',
+				'They can see our chat history but please share any extra details while you wait so we can help you better.',
 				__i18n_text_domain__
 			),
 			role: 'bot' as const,
@@ -146,6 +134,58 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 					hide_disclaimer_content: true,
 					show_ai_avatar: false,
 				},
+				site_id: null,
+			},
+		},
+	];
+
+	return messages;
+};
+
+export const getOdieTransferedMessage = ( {
+	conversationId,
+	conversationMessages,
+}: {
+	conversationId: string;
+	conversationMessages: Message[];
+} ): Message[] => {
+	const hasLiveChatMessages = conversationMessages.some(
+		( message ) => ( message as any )?.source?.type === 'zd:agentWorkspace'
+	);
+	return [
+		{
+			content:
+				__( 'No problem. Help is on the way!', __i18n_text_domain__ ) +
+				( isTestModeEnvironment() ? ' (staging)' : '' ),
+			role: 'bot' as const,
+			type: 'message' as const,
+			context: {
+				flags: {
+					hide_disclaimer_content: true,
+					show_ai_avatar: false,
+				},
+				site_id: null,
+			},
+		},
+		{
+			content: '',
+			role: 'bot',
+			type: 'meta',
+			internal_message_id: hasLiveChatMessages
+				? `chat-with-support-started-${ conversationId }`
+				: `waiting-for-human-${ conversationId }`,
+			context: {
+				flags: hasLiveChatMessages
+					? {
+							show_chat_with_support_started_label: true,
+							hide_disclaimer_content: true,
+							show_ai_avatar: false,
+					  }
+					: {
+							show_waiting_for_human: true,
+							hide_disclaimer_content: true,
+							show_ai_avatar: false,
+					  },
 				site_id: null,
 			},
 		},

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -73,7 +73,6 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 				context: {
 					flags: {
 						hide_disclaimer_content: true,
-						show_ai_avatar: false,
 					},
 					site_id: null,
 				},
@@ -91,7 +90,6 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 			context: {
 				flags: {
 					hide_disclaimer_content: true,
-					show_ai_avatar: false,
 				},
 				site_id: null,
 			},
@@ -117,7 +115,6 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 			context: {
 				flags: {
 					hide_disclaimer_content: true,
-					show_ai_avatar: false,
 				},
 				site_id: null,
 			},
@@ -132,7 +129,6 @@ export const getOdieTransferMessages = ( botSlug?: OdieAllBotSlugs ): Message[] 
 			context: {
 				flags: {
 					hide_disclaimer_content: true,
-					show_ai_avatar: false,
 				},
 				site_id: null,
 			},
@@ -162,7 +158,6 @@ export const getOdieTransferedMessage = ( {
 			context: {
 				flags: {
 					hide_disclaimer_content: true,
-					show_ai_avatar: false,
 				},
 				site_id: null,
 			},
@@ -177,14 +172,12 @@ export const getOdieTransferedMessage = ( {
 			context: {
 				flags: hasLiveChatMessages
 					? {
-							show_chat_with_support_started_label: true,
+							show_happiness_engineer_joined_label: true,
 							hide_disclaimer_content: true,
-							show_ai_avatar: false,
 					  }
 					: {
 							show_waiting_for_human: true,
 							hide_disclaimer_content: true,
-							show_ai_avatar: false,
 					  },
 				site_id: null,
 			},
@@ -290,7 +283,6 @@ export const getErrorMessageUnknownError = (): Message => {
 		context: {
 			site_id: null,
 			flags: {
-				show_ai_avatar: true,
 				is_error_message: true,
 				forward_to_human_support: false,
 			},
@@ -347,20 +339,6 @@ export const getOdieZendeskConnectionErrorMessage = (): Message => {
 		},
 	};
 };
-
-export const getZendeskChatStartedMetaMessage = (): Message => ( {
-	content: null,
-	role: 'bot',
-	type: 'meta',
-	internal_message_id: 'zendesk-chat-started',
-	context: {
-		site_id: null,
-		flags: {
-			hide_disclaimer_content: true,
-			show_ai_avatar: false,
-		},
-	},
-} );
 
 export const ODIE_THUMBS_DOWN_RATING_VALUE = 0;
 export const ODIE_THUMBS_UP_RATING_VALUE = 1;

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -145,7 +145,7 @@ export const getOdieTransferedMessage = ( {
 	conversationId: string;
 	conversationMessages: Message[];
 } ): Message[] => {
-	const hasLiveChatMessages = conversationMessages.some(
+	const hasLiveAgentMessages = conversationMessages.some(
 		( message ) => ( message as any )?.source?.type === 'zd:agentWorkspace'
 	);
 	return [
@@ -166,11 +166,11 @@ export const getOdieTransferedMessage = ( {
 			content: '',
 			role: 'bot',
 			type: 'meta',
-			internal_message_id: hasLiveChatMessages
+			internal_message_id: hasLiveAgentMessages
 				? `chat-with-support-started-${ conversationId }`
 				: `waiting-for-human-${ conversationId }`,
 			context: {
-				flags: hasLiveChatMessages
+				flags: hasLiveAgentMessages
 					? {
 							show_happiness_engineer_joined_label: true,
 							hide_disclaimer_content: true,

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { ODIE_NEW_INTERACTIONS_BOT_SLUG } from '../constants';
 import { useOdieBroadcastWithCallbacks } from '../data';
 import { useGetCombinedChat } from '../hooks';
-import { isOdieAllowedBot, getIsRequestingHumanSupport } from '../utils';
+import { isOdieAllowedBot } from '../utils';
 import type {
 	Chat,
 	Message,
@@ -39,7 +39,6 @@ export const OdieAssistantContext = createContext< OdieAssistantContextInterface
 	clearChat: noop,
 	currentUser: { display_name: 'Me' },
 	experimentVariationName: null,
-	hasUserEverEscalatedToHumanSupport: false,
 	isChatLoaded: false,
 	isMinimized: false,
 	isUserEligibleForPaidSupport: false,
@@ -109,13 +108,6 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	const { mainChatState, setMainChatState } = useGetCombinedChat(
 		isUserEligibleForPaidSupport && canConnectToZendesk,
 		isLoadingCanConnectToZendesk
-	);
-
-	/**
-	 * Has the user ever escalated to get human support?
-	 */
-	const hasUserEverEscalatedToHumanSupport = mainChatState?.messages.some( ( message ) =>
-		getIsRequestingHumanSupport( message )
 	);
 
 	/**
@@ -199,7 +191,6 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				isUserEligibleForPaidSupport,
 				canConnectToZendesk,
 				isLoadingCanConnectToZendesk,
-				hasUserEverEscalatedToHumanSupport,
 				odieBroadcastClientId,
 				selectedSiteId,
 				selectedSiteURL,

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -48,7 +48,6 @@ const getErrorMessageForSiteIdAndInternalMessageId = (
 			flags: {
 				forward_to_human_support: true,
 				hide_disclaimer_content: false,
-				show_ai_avatar: true,
 				is_error_message: true,
 			},
 		},

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -1,11 +1,7 @@
 import { useUpdateZendeskUserFields, type ZendeskConversation } from '@automattic/zendesk-client';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Smooch from 'smooch';
-import {
-	getErrorTryAgainLaterMessage,
-	getOdieTransferMessages,
-	getZendeskChatStartedMetaMessage,
-} from '../constants';
+import { getErrorTryAgainLaterMessage, getOdieTransferMessages } from '../constants';
 import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
@@ -181,7 +177,6 @@ export const useCreateZendeskConversation = () => {
 				messages: [
 					...prevChat.messages,
 					...getOdieTransferMessages( currentSupportInteraction?.bot_slug ),
-					getZendeskChatStartedMetaMessage(),
 				],
 				provider: 'zendesk',
 				status: 'loaded',

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -5,7 +5,7 @@ import { useIsMutating } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { getMessageUniqueIdentifier } from '../components/message/utils/get-message-unique-identifier';
-import { getOdieTransferMessages, getZendeskChatStartedMetaMessage } from '../constants';
+import { getOdieTransferedMessage, getZendeskChatStartedMetaMessage } from '../constants';
 import { emptyChat } from '../context';
 import { useGetZendeskConversation, useManageSupportInteraction, useOdieChat } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
@@ -142,7 +142,10 @@ export const useGetCombinedChat = (
 								conversationId: conversation.id,
 								messages: [
 									...( odieChat ? filteredOdieMessages : [] ),
-									...getOdieTransferMessages( currentSupportInteraction?.bot_slug ),
+									...getOdieTransferedMessage( {
+										conversationId: conversation.id,
+										conversationMessages: conversation.messages as Message[],
+									} ),
 									getZendeskChatStartedMetaMessage(),
 									...( deduplicateZDMessages( [
 										// During connection recovery, the user queued messages can be deleted. This ensure they remain. And `deduplicateZDMessages` takes of duplication.
@@ -176,13 +179,16 @@ export const useGetCombinedChat = (
 		}
 	}, [
 		isOdieChatLoading,
+		isLoadingCurrentSupportInteraction,
 		chatStatus,
+		mainChatState.messages.length,
 		refreshingAfterReconnect,
 		isUploadingUnsentMessages,
 		isChatLoaded,
 		conversationId,
 		odieId,
 		currentSupportInteraction,
+		odieChat,
 		canConnectToZendesk,
 		getZendeskConversation,
 		startNewInteraction,

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -5,7 +5,7 @@ import { useIsMutating } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { getMessageUniqueIdentifier } from '../components/message/utils/get-message-unique-identifier';
-import { getOdieTransferedMessage, getZendeskChatStartedMetaMessage } from '../constants';
+import { getOdieTransferedMessage } from '../constants';
 import { emptyChat } from '../context';
 import { useGetZendeskConversation, useManageSupportInteraction, useOdieChat } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
@@ -146,7 +146,6 @@ export const useGetCombinedChat = (
 										conversationId: conversation.id,
 										conversationMessages: conversation.messages as Message[],
 									} ),
-									getZendeskChatStartedMetaMessage(),
 									...( deduplicateZDMessages( [
 										// During connection recovery, the user queued messages can be deleted. This ensure they remain. And `deduplicateZDMessages` takes of duplication.
 										...( isSameConversation

--- a/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
+++ b/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
@@ -2,22 +2,25 @@ import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { zendeskMessageConverter } from '@automattic/zendesk-client';
 import { useSelect } from '@wordpress/data';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../context';
 import { deduplicateZDMessages } from './use-get-combined-chat';
+import type { Message } from '../types';
 import type { ZendeskMessage } from '@automattic/zendesk-client';
 
 /**
  * Listens for messages from Zendesk and converts them to Odie messages.
  */
 export const useZendeskMessageListener = () => {
-	const { setChat, chat } = useOdieAssistantContext();
+	const { setChat, chat, addMessage } = useOdieAssistantContext();
+	const hasAddedStartedLabelForConversation = useRef< string | null >( null );
 
-	const { isChatLoaded } = useSelect( ( select ) => {
+	const { isChatLoaded, typingStatus } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
 			isChatLoaded: helpCenterSelect.getIsChatLoaded(),
+			typingStatus: helpCenterSelect.getSupportTypingStatus( chat.conversationId ?? '' ),
 		};
 	}, [] );
 
@@ -45,6 +48,42 @@ export const useZendeskMessageListener = () => {
 		},
 		[ chat.conversationId, setChat ]
 	);
+
+	useEffect( () => {
+		if ( ! typingStatus || ! chat.conversationId ) {
+			return;
+		}
+
+		if ( hasAddedStartedLabelForConversation.current === chat.conversationId ) {
+			return;
+		}
+
+		const internalMessageId = `chat-with-support-started-${ chat.conversationId }`;
+		const alreadyAdded = chat.messages.some(
+			( message ) => message.internal_message_id === internalMessageId
+		);
+		if ( alreadyAdded ) {
+			hasAddedStartedLabelForConversation.current = chat.conversationId;
+			return;
+		}
+
+		const marker: Message = {
+			content: '',
+			role: 'bot' as const,
+			type: 'meta' as const,
+			internal_message_id: internalMessageId,
+			context: {
+				flags: {
+					show_chat_with_support_started_label: true,
+					hide_disclaimer_content: true,
+					show_ai_avatar: false,
+				},
+				site_id: null,
+			},
+		};
+		addMessage( marker );
+		hasAddedStartedLabelForConversation.current = chat.conversationId;
+	}, [ typingStatus, addMessage, chat.conversationId, chat.messages ] );
 
 	useEffect( () => {
 		if ( ! isChatLoaded ) {

--- a/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
+++ b/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
@@ -74,9 +74,8 @@ export const useZendeskMessageListener = () => {
 			internal_message_id: internalMessageId,
 			context: {
 				flags: {
-					show_chat_with_support_started_label: true,
+					show_happiness_engineer_joined_label: true,
 					hide_disclaimer_content: true,
-					show_ai_avatar: false,
 				},
 				site_id: null,
 			},

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -14,7 +14,6 @@ export type OdieAssistantContextInterface = {
 	clearChat: () => void;
 	currentUser: CurrentUser;
 	experimentVariationName: string | undefined | null;
-	hasUserEverEscalatedToHumanSupport: boolean;
 	isMinimized?: boolean;
 	isUserEligibleForPaidSupport: boolean;
 	odieBroadcastClientId: string;
@@ -114,6 +113,8 @@ export type Context = {
 		failed_zendesk_connection?: boolean;
 		forward_to_human_support?: boolean;
 		hide_disclaimer_content?: boolean;
+		show_waiting_for_human?: boolean;
+		show_chat_with_support_started_label?: boolean;
 		show_ai_avatar?: boolean;
 		is_error_message?: boolean;
 	};

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -114,8 +114,7 @@ export type Context = {
 		forward_to_human_support?: boolean;
 		hide_disclaimer_content?: boolean;
 		show_waiting_for_human?: boolean;
-		show_chat_with_support_started_label?: boolean;
-		show_ai_avatar?: boolean;
+		show_happiness_engineer_joined_label?: boolean;
 		is_error_message?: boolean;
 	};
 };

--- a/packages/odie-client/src/utils/index.ts
+++ b/packages/odie-client/src/utils/index.ts
@@ -16,7 +16,7 @@ export {
 	isZendeskIntroMessage,
 	isAttachment,
 	hasFeedbackForm,
-	isChatWithSupportStartedLabelMessage,
+	isHappinessEngineerJoinedLabelMessage,
 } from './message-utils';
 import type { Chat, Message } from '../types';
 

--- a/packages/odie-client/src/utils/index.ts
+++ b/packages/odie-client/src/utils/index.ts
@@ -8,7 +8,16 @@ export {
 	getConversationIdFromInteraction,
 	getOdieIdFromInteraction,
 } from './support-interaction-utils';
-export { isCSATMessage, hasCSATMessage, hasSubmittedCSATRating } from './csat';
+export {
+	isCSATMessage,
+	hasCSATMessage,
+	hasSubmittedCSATRating,
+	isWaitingForHumanLabelMessage,
+	isZendeskIntroMessage,
+	isAttachment,
+	hasFeedbackForm,
+	isChatWithSupportStartedLabelMessage,
+} from './message-utils';
 import type { Chat, Message } from '../types';
 
 export const getIsRequestingHumanSupport = ( message: Message ) => {

--- a/packages/odie-client/src/utils/message-utils.ts
+++ b/packages/odie-client/src/utils/message-utils.ts
@@ -12,8 +12,11 @@ export const isAttachment = ( message: Message ) =>
 export const isZendeskIntroMessage = ( message: Message | ZendeskMessage ) =>
 	'source' in message && message.source?.type === 'zd:answerBot';
 
-export const isZendeskChatStartedMessage = ( message: Message ) =>
-	message?.internal_message_id === 'zendesk-chat-started';
+export const isWaitingForHumanLabelMessage = ( message: Message ) =>
+	!! message?.context?.flags?.show_waiting_for_human;
+
+export const isChatWithSupportStartedLabelMessage = ( message: Message ) =>
+	!! message?.context?.flags?.show_chat_with_support_started_label;
 
 export const hasCSATMessage = ( chat: Chat ) => {
 	return chat?.messages.some( isCSATMessage );

--- a/packages/odie-client/src/utils/message-utils.ts
+++ b/packages/odie-client/src/utils/message-utils.ts
@@ -15,8 +15,8 @@ export const isZendeskIntroMessage = ( message: Message | ZendeskMessage ) =>
 export const isWaitingForHumanLabelMessage = ( message: Message ) =>
 	!! message?.context?.flags?.show_waiting_for_human;
 
-export const isChatWithSupportStartedLabelMessage = ( message: Message ) =>
-	!! message?.context?.flags?.show_chat_with_support_started_label;
+export const isHappinessEngineerJoinedLabelMessage = ( message: Message ) =>
+	!! message?.context?.flags?.show_happiness_engineer_joined_label;
 
 export const hasCSATMessage = ( chat: Chat ) => {
 	return chat?.messages.some( isCSATMessage );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
