### PR TITLE
Add guideline to check PR description before suggesting alternatives

### DIFF
--- a/.github/prompts/dashboard-pr-review.md
+++ b/.github/prompts/dashboard-pr-review.md
@@ -22,6 +22,7 @@ Read `.cursor/rules/dashboard-rules.mdc` before reviewing.
 - Provide fix suggestions.
 - Focus on files changed in this PR.
 - Don't nitpick minor style issues unless they violate project guidelines.
+- Before suggesting alternative implementations, check if the PR description already addresses why that approach wasn't used.
 
 ## Output Format
 


### PR DESCRIPTION
Part of improving AI code review quality.

## Proposed Changes

* Add a guideline to the dashboard PR review prompt instructing reviewers to check if the PR description already addresses why an alternative approach wasn't used before suggesting one.

## Why are these changes being made?

In [#108055](https://github.com/Automattic/wp-calypso/pull/108055#discussion_r2681880951), an AI reviewer suggested an alternative implementation, but the PR author had already explained in the description why that approach wasn't feasible. This guideline helps avoid redundant suggestions.

## Testing Instructions

* Review the updated prompt in `.github/prompts/dashboard-pr-review.md`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.ai/code)