### PR TITLE
Help Center: Add currentUser to data store

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -5,6 +5,7 @@ import { Location } from 'history';
 import { default as wpcomRequestPromise, canAccessWpcomApis } from 'wpcom-proxy-request';
 import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
+import { CurrentUser } from '../user/types';
 import { isE2ETest } from '../utils';
 import { wpcomRequest } from '../wpcom-request-controls';
 import { STORE_KEY } from './constants';
@@ -189,6 +190,18 @@ export const setHelpCenterOptions = ( options: HelpCenterOptions ) => ( {
 	options,
 } );
 
+/**
+ * Set the current user in the help center store.
+ * This value is needed because the store makes decisions based on the logged in status.
+ * @param user - The current user to set.
+ * @returns The action object.
+ */
+export const setCurrentUser = ( user: CurrentUser | undefined ) =>
+	( {
+		type: 'HELP_CENTER_SET_CURRENT_USER',
+		user,
+	} ) as const;
+
 export const setShowHelpCenter = function* (
 	show: boolean,
 	options: HelpCenterShowOptions = {
@@ -333,6 +346,7 @@ export type HelpCenterAction =
 			| typeof setOdieBotNameSlug
 			| typeof setHasPremiumSupport
 			| typeof setHelpCenterOptions
+			| typeof setCurrentUser
 	  >
 	| GeneratorReturnType< typeof setShowHelpCenter >
 	| GeneratorReturnType< typeof setHelpCenterRouterHistory >

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@wordpress/data';
 import { Location } from 'history';
 import { SiteDetails } from '../site';
+import { CurrentUser } from '../user/types';
 import type { HelpCenterAction } from './actions';
 import type { HelpCenterOptions } from './types';
 import type { Reducer } from 'redux';
@@ -208,6 +209,13 @@ const helpCenterOptions: Reducer< HelpCenterOptions, HelpCenterAction > = (
 	return state;
 };
 
+const currentUser: Reducer< CurrentUser | undefined, HelpCenterAction > = ( state, action ) => {
+	if ( action.type === 'HELP_CENTER_SET_CURRENT_USER' ) {
+		return action.user;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	showHelpCenter,
 	showMessagingLauncher,
@@ -231,6 +239,7 @@ const reducer = combineReducers( {
 	hasPremiumSupport,
 	contextTerm,
 	helpCenterOptions,
+	currentUser,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -24,3 +24,4 @@ export const getHelpCenterOptions = ( state: State ) => state.helpCenterOptions;
 export const getContextTerm = ( state: State ) => state.contextTerm;
 export const getSupportTypingStatus = ( state: State, conversationId: string ) =>
 	state.typingConversationStatus?.[ conversationId ];
+export const getCurrentUser = ( state: State ) => state.currentUser;

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -4,7 +4,7 @@
  */
 import { initializeAnalytics } from '@automattic/calypso-analytics';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { createPortal, useEffect, useState } from '@wordpress/element';
 /**
  * Internal Dependencies
@@ -36,6 +36,7 @@ const HelpCenter: React.FC< Container > = ( {
 		return helpCenterSelect.isHelpCenterShown();
 	}, [] );
 	const { currentUser } = useHelpCenterContext();
+	const { setCurrentUser } = useDispatch( HELP_CENTER_STORE );
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( !! currentUser?.ID );
 	const { data: supportInteractionsOpen, isLoading: isLoadingOpenInteractions } =
 		useGetSupportInteractions( 'zendesk' );
@@ -47,8 +48,9 @@ const HelpCenter: React.FC< Container > = ( {
 	useEffect( () => {
 		if ( currentUser ) {
 			initializeAnalytics( currentUser, null );
+			setCurrentUser( currentUser );
 		}
-	}, [ currentUser ] );
+	}, [ currentUser, setCurrentUser ] );
 
 	// Create portal container on mount, cleanup on unmount
 	useEffect( () => {


### PR DESCRIPTION
Part of dotcom-15657

## Proposed Changes

* Add `currentUser` state to the help-center data store
* Add `setCurrentUser` action with JSDoc documentation
* Add `getCurrentUser` selector
* Sync the `currentUser` from the Help Center context to the store via an effect

## Why are these changes being made?

The help-center data store needs access to the current user information to make decisions based on the logged-in status. By adding `currentUser` to the store, other parts of the application can access this information through selectors without needing direct access to the Help Center context.

## Testing Instructions

1. Open the Help Center
2. Verify the store contains the current user by checking in React DevTools or via:
   ```js
   wp.data.select('automattic/help-center').getCurrentUser()
   ```
3. Verify the user object contains the expected properties (ID, email, display_name, etc.)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?