### PR TITLE
Add oauth_version field to connected applications schema

### DIFF
--- a/client/state/connected-applications/schema.js
+++ b/client/state/connected-applications/schema.js
@@ -39,6 +39,7 @@ export default {
 				],
 			},
 			title: { type: 'string' },
+			oauth_version: { type: 'string' },
 		},
 		required: [ 'ID' ],
 		additionalProperties: false,

--- a/client/state/connected-applications/test/actions.js
+++ b/client/state/connected-applications/test/actions.js
@@ -48,6 +48,7 @@ describe( 'actions', () => {
 						site_name: 'WordPress',
 					},
 					title: 'WordPress',
+					oauth_version: '2.0',
 				},
 			];
 			const action = receiveConnectedApplications( apps );

--- a/client/state/connected-applications/test/reducer.js
+++ b/client/state/connected-applications/test/reducer.js
@@ -29,6 +29,7 @@ describe( 'reducer', () => {
 			site_name: 'WordPress',
 		},
 		title: 'WordPress',
+		oauth_version: '2.0',
 	};
 	const app2 = {
 		...app1,

--- a/client/state/data-layer/wpcom/me/connected-applications/schema.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/schema.js
@@ -42,6 +42,7 @@ export default {
 						],
 					},
 					title: { type: 'string' },
+					oauth_version: { type: 'string' },
 				},
 				required: [ 'ID' ],
 				additionalProperties: false,

--- a/client/state/data-layer/wpcom/me/connected-applications/test/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/test/index.js
@@ -26,6 +26,7 @@ const apps = [
 			site_name: 'WordPress',
 		},
 		title: 'WordPress',
+		oauth_version: '2.0',
 	},
 ];
 

--- a/client/state/selectors/test/get-connected-applications.js
+++ b/client/state/selectors/test/get-connected-applications.js
@@ -26,6 +26,7 @@ describe( 'getConnectedApplications()', () => {
 					site_name: 'WordPress',
 				},
 				title: 'WordPress',
+				oauth_version: '2.0',
 			},
 		];
 		const state = {

--- a/packages/api-core/src/me-connected-applications/types.ts
+++ b/packages/api-core/src/me-connected-applications/types.ts
@@ -17,6 +17,7 @@ export interface ConnectedApplication {
 		  }
 		| boolean;
 	title: string;
+	oauth_version: string;
 }
 
 export interface ConnectedApplicationSuccess {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/AI-818/investigate-if-oauth-21-clients-should-be-listed-under-connected-apps

## Proposed Changes

* Added `oauth_version` as an optional string field to the connected applications schema and TypeScript types, and updated test mock data to include it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with 199657-ghe-Automattic/wpcom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?