### PR TITLE
A4A: Enable development licenses purchase flow for agencies using BD

### DIFF
--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -10,7 +10,9 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import Notice from '../../components/notice';
+import { a4aLink } from '../../utils/link';
 import { SiteLaunchButton } from '../site-launch-button';
+import AgencyDevelopmentSiteLaunchModal from '../site-launch-button/agency-development-site-launch-modal';
 import TrialUpsellNotice from './trial-upsell-notice';
 import type { AgencyBlog, Site } from '@automattic/api-core';
 
@@ -90,7 +92,13 @@ export function LaunchAgencyDevelopmentSiteForm( { site }: { site: Site } ) {
 					<SiteLaunchButton
 						site={ site }
 						tracksContext="agency_site_settings"
-						isBillingTypeBD={ isBillingTypeBD }
+						{ ...( isBillingTypeBD
+							? {
+									launchUrl: a4aLink(
+										`/marketplace/checkout/${ site.slug }/a4a_wp_bundle_business_yearly`
+									),
+							  }
+							: { LaunchModal: AgencyDevelopmentSiteLaunchModal } ) }
 					/>
 					{ shouldShowReferClientButton && (
 						<Button

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -14,9 +14,29 @@ import { SiteLaunchButton } from '../site-launch-button';
 import TrialUpsellNotice from './trial-upsell-notice';
 import type { AgencyBlog, Site } from '@automattic/api-core';
 
-function getAgencyBillingMessage( agency: AgencyBlog | undefined, isAgencyQueryError: boolean ) {
+function getAgencyBillingMessage(
+	agency: AgencyBlog | undefined,
+	isAgencyQueryError: boolean,
+	isBillingTypeBD: boolean
+) {
 	if ( ! agency ) {
 		return undefined;
+	}
+
+	if ( isBillingTypeBD ) {
+		return createInterpolateElement(
+			__(
+				'During the site launch process, you will be charged for this site, with the ability to purchase on an annual or monthly term. <learnMoreLink>Learn more</learnMoreLink>'
+			),
+			{
+				learnMoreLink: (
+					<ExternalLink
+						href="https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/"
+						children={ null }
+					/>
+				),
+			}
+		);
 	}
 
 	const priceInfoIsDefined =
@@ -56,8 +76,8 @@ function getAgencyBillingMessage( agency: AgencyBlog | undefined, isAgencyQueryE
 
 export function LaunchAgencyDevelopmentSiteForm( { site }: { site: Site } ) {
 	const { data, isError } = useQuery( siteAgencyBlogQuery( site.ID ) );
-
-	const billingMessage = getAgencyBillingMessage( data ?? undefined, isError );
+	const isBillingTypeBD = data?.billing_system === 'billingdragon';
+	const billingMessage = getAgencyBillingMessage( data ?? undefined, isError, isBillingTypeBD );
 	const isReferralStatusActive = data?.referral_status === 'active';
 	const shouldShowBillingMessage = ! isReferralStatusActive && !! billingMessage;
 	const shouldShowReferClientButton = ! isReferralStatusActive;
@@ -67,7 +87,11 @@ export function LaunchAgencyDevelopmentSiteForm( { site }: { site: Site } ) {
 			title={ __( 'Your site hasn’t been launched yet' ) }
 			actions={
 				<>
-					<SiteLaunchButton site={ site } tracksContext="agency_site_settings" />
+					<SiteLaunchButton
+						site={ site }
+						tracksContext="agency_site_settings"
+						isBillingTypeBD={ isBillingTypeBD }
+					/>
 					{ shouldShowReferClientButton && (
 						<Button
 							size="compact"

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -12,17 +12,22 @@ import {
 	isSitePlanBigSkyTrial,
 	isSitePlanPaid,
 } from '../plans';
-import AgencyDevelopmentSiteLaunchModal from './agency-development-site-launch-modal';
 import type { Site } from '@automattic/api-core';
 
 export function SiteLaunchButton( {
 	site,
 	tracksContext,
-	isBillingTypeBD = false,
+	launchUrl,
+	LaunchModal,
 }: {
 	site: Site;
 	tracksContext: string;
-	isBillingTypeBD?: boolean;
+	launchUrl?: string;
+	LaunchModal?: React.ComponentType< {
+		isLaunching: boolean;
+		onClose: () => void;
+		onLaunch: () => void;
+	} >;
 } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: domains = [], isLoading } = useQuery( {
@@ -38,8 +43,7 @@ export function SiteLaunchButton( {
 			},
 		},
 	} );
-	const [ isAgencyDevelopmentSiteLaunchModalOpen, setIsAgencyDevelopmentSiteLaunchModalOpen ] =
-		useState( false );
+	const [ isLaunchModalOpen, setIsLaunchModalOpen ] = useState( false );
 
 	const handleTracksEvent = () => {
 		recordTracksEvent( 'calypso_dashboard_site_launch_button_click', { context: tracksContext } );
@@ -49,7 +53,7 @@ export function SiteLaunchButton( {
 		handleTracksEvent();
 		launchMutation.mutate( undefined, {
 			onSettled: () => {
-				setIsAgencyDevelopmentSiteLaunchModalOpen( false );
+				setIsLaunchModalOpen( false );
 			},
 		} );
 	};
@@ -92,30 +96,21 @@ export function SiteLaunchButton( {
 	}
 
 	if ( site.is_a4a_dev_site ) {
-		// For BD billing, redirect to marketplace checkout instead of launching
-		if ( isBillingTypeBD ) {
-			return (
-				<Button
-					{ ...commonProps }
-					onClick={ () => {
-						handleTracksEvent();
-						window.location.href = `/marketplace/checkout/${ site.slug }/a4a_wp_bundle_business_yearly`;
-					} }
-				/>
-			);
+		if ( launchUrl ) {
+			return <Button { ...commonProps } onClick={ handleTracksEvent } href={ launchUrl } />;
 		}
 
-		// For legacy billing, show modal before launching
+		if ( ! LaunchModal ) {
+			return null;
+		}
+
 		return (
 			<>
-				<Button
-					{ ...commonProps }
-					onClick={ () => setIsAgencyDevelopmentSiteLaunchModalOpen( true ) }
-				/>
-				{ isAgencyDevelopmentSiteLaunchModalOpen && (
-					<AgencyDevelopmentSiteLaunchModal
+				<Button { ...commonProps } onClick={ () => setIsLaunchModalOpen( true ) } />
+				{ isLaunchModalOpen && (
+					<LaunchModal
 						isLaunching={ launchMutation.isPending }
-						onClose={ () => setIsAgencyDevelopmentSiteLaunchModalOpen( false ) }
+						onClose={ () => setIsLaunchModalOpen( false ) }
 						onLaunch={ handleLaunch }
 					/>
 				) }

--- a/client/dashboard/sites/site-launch-button/index.tsx
+++ b/client/dashboard/sites/site-launch-button/index.tsx
@@ -15,7 +15,15 @@ import {
 import AgencyDevelopmentSiteLaunchModal from './agency-development-site-launch-modal';
 import type { Site } from '@automattic/api-core';
 
-export function SiteLaunchButton( { site, tracksContext }: { site: Site; tracksContext: string } ) {
+export function SiteLaunchButton( {
+	site,
+	tracksContext,
+	isBillingTypeBD = false,
+}: {
+	site: Site;
+	tracksContext: string;
+	isBillingTypeBD?: boolean;
+} ) {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: domains = [], isLoading } = useQuery( {
 		...domainsQuery(),
@@ -84,6 +92,20 @@ export function SiteLaunchButton( { site, tracksContext }: { site: Site; tracksC
 	}
 
 	if ( site.is_a4a_dev_site ) {
+		// For BD billing, redirect to marketplace checkout instead of launching
+		if ( isBillingTypeBD ) {
+			return (
+				<Button
+					{ ...commonProps }
+					onClick={ () => {
+						handleTracksEvent();
+						window.location.href = `/marketplace/checkout/${ site.slug }/a4a_wp_bundle_business_yearly`;
+					} }
+				/>
+			);
+		}
+
+		// For legacy billing, show modal before launching
 		return (
 			<>
 				<Button

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -25,6 +25,10 @@ export function wpcomLink( path: string ) {
  * This function returns a link to the A4A (Automattic for Agencies) domain.
  */
 export function a4aLink( path: string ) {
+	if ( config( 'env' ) === 'development' ) {
+		return new URL( path, 'http://agencies.localhost:3000' ).href;
+	}
+
 	return new URL( path, 'https://agencies.automattic.com' ).href;
 }
 

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -22,6 +22,13 @@ export function wpcomLink( path: string ) {
 }
 
 /**
+ * This function returns a link to the A4A (Automattic for Agencies) domain.
+ */
+export function a4aLink( path: string ) {
+	return new URL( path, 'https://agencies.automattic.com' ).href;
+}
+
+/**
  * This function returns the link to the dashboard.
  */
 export function dashboardLink( path: string = '' ) {

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -11,6 +11,7 @@ import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SitePreviewLinks from 'calypso/components/site-preview-links';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch, useSelector } from 'calypso/state';
+import { getUserBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -32,9 +33,35 @@ import { LaunchSiteTrialUpsellNotice } from './launch-site-trial-notice';
 
 import './styles.scss';
 
-const createAgencyBillingMessage = ( agency, agencyLoading = false, agencyError = false ) => {
+const createAgencyBillingMessage = (
+	agency,
+	agencyLoading = false,
+	agencyError = false,
+	isBillingTypeBD = false
+) => {
 	if ( ! agency ) {
 		return undefined;
+	}
+
+	// For BD billing, show simplified message
+	if ( isBillingTypeBD ) {
+		return translate(
+			'During the site launch process, you will be charged for this site, with the ability to purchase on an annual or monthly term. {{a}}Learn more.{{/a}}',
+			{
+				components: {
+					a: (
+						<a
+							className="site-settings__general-settings-launch-site-agency-learn-more"
+							href={ localizeUrl(
+								'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
+							) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
+		);
 	}
 
 	const agencyPriceInfoIsDefined =
@@ -97,6 +124,7 @@ const LaunchSite = () => {
 	);
 	const isUnlaunchedSite = useSelector( ( state ) => getIsUnlaunchedSite( state, siteId ) );
 	const isLaunchInProgress = useSelector( ( state ) => getIsSiteLaunchInProgress( state, siteId ) );
+	const userBillingType = useSelector( getUserBillingType );
 
 	const siteDomains = useSelector( ( state ) => getDomainsBySiteId( state, siteId ) );
 
@@ -106,6 +134,7 @@ const LaunchSite = () => {
 	const btnText = translate( 'Launch site' );
 
 	const isDevelopmentSite = Boolean( site?.is_a4a_dev_site );
+	const isBillingTypeBD = userBillingType === 'billingdragon';
 
 	const dispatchSiteLaunch = () => {
 		dispatch( launchSite( site.ID ) );
@@ -126,7 +155,12 @@ const LaunchSite = () => {
 	const handleLaunchSiteClick = () => {
 		recordTracksEvent( 'calypso_site_settings_launch_site_click' );
 		if ( isDevelopmentSite && ! siteReferralActive ) {
-			openLaunchConfirmationModal();
+			// For BD billing, redirect to marketplace checkout instead of showing modal
+			if ( isBillingTypeBD ) {
+				window.location.href = `/marketplace/checkout/${ site.slug }/a4a_wp_bundle_business_yearly`;
+			} else {
+				openLaunchConfirmationModal();
+			}
 		} else {
 			dispatch(
 				launchSiteOrRedirectToLaunchSignupFlow( siteId, 'general-settings', site.title, 'yes' )
@@ -166,7 +200,12 @@ const LaunchSite = () => {
 		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ siteId }`;
 	};
 
-	const agencyBillingMessage = createAgencyBillingMessage( agency, agencyLoading, agencyError );
+	const agencyBillingMessage = createAgencyBillingMessage(
+		agency,
+		agencyLoading,
+		agencyError,
+		isBillingTypeBD
+	);
 
 	const renderConfirmationModal = () => {
 		return (

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -52,7 +52,6 @@ const createAgencyBillingMessage = (
 				components: {
 					a: (
 						<a
-							className="site-settings__general-settings-launch-site-agency-learn-more"
 							href={ localizeUrl(
 								'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
 							) }
@@ -90,7 +89,6 @@ const createAgencyBillingMessage = (
 				strong: <strong />,
 				a: (
 					<a
-						className="site-settings__general-settings-launch-site-agency-learn-more"
 						href={ localizeUrl(
 							'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
 						) }

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -9,6 +9,7 @@ import useFetchAgencyFromBlog from 'calypso/a8c-for-agencies/data/agencies/use-f
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SitePreviewLinks from 'calypso/components/site-preview-links';
+import { a4aLink } from 'calypso/dashboard/utils/link';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getUserBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -155,9 +156,10 @@ const LaunchSite = () => {
 	const handleLaunchSiteClick = () => {
 		recordTracksEvent( 'calypso_site_settings_launch_site_click' );
 		if ( isDevelopmentSite && ! siteReferralActive ) {
-			// For BD billing, redirect to marketplace checkout instead of showing modal
 			if ( isBillingTypeBD ) {
-				window.location.href = `/marketplace/checkout/${ site.slug }/a4a_wp_bundle_business_yearly`;
+				window.location.href = a4aLink(
+					`/marketplace/checkout/${ site.slug }/a4a_wp_bundle_business_yearly`
+				);
 			} else {
 				openLaunchConfirmationModal();
 			}

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -2,6 +2,7 @@ export interface AgencyBlog {
 	name: string;
 	existing_wpcom_license_count: number;
 	referral_status: 'active' | 'pending' | 'canceled' | 'archived';
+	billing_system?: 'billingdragon' | 'legacy';
 	prices: {
 		actual_price: number;
 		currency: string;


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1611/implement-dev-site-purchase-flow-for-agencies

## Proposed Changes

This PR routes the users through the new flow for launching (or purchasing) development licenses if the agency uses BD billing.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Scenario 1: Agency on Billing Dragon (BD)
- Run this branch locally
- Log in as an agency that is on Billing Dragon.
- Create a development site
- Attempt to launch the site by either:
  - Visiting `/sites/YOURSITE.wpcomstaging.com/settings/site-visibility`, or
  - Using Actions → Launch site from the Sites list.
- Verify that you are redirected to the new checkout flow.
- (Optional) You can complete the purchase to verify the flow works as expected.

Scenario 2: Agency on legacy billing
- Run this branch locally
- Log in as an agency that is not on Billing Dragon (legacy billing).
- Create a development site.
- Attempt to launch the site using the same methods as above.
- Verify that the flow hasn't been changed for these users.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
