### PR TITLE
Update Dashboard PR review workflow

### DIFF
--- a/.github/workflows/dashboard-pr-review.yml
+++ b/.github/workflows/dashboard-pr-review.yml
@@ -2,7 +2,7 @@ name: Dashboard PR Review
 
 on:
   pull_request:
-    types: [ready_for_review, synchronize]
+    types: [opened, ready_for_review, synchronize]
     paths:
       - 'client/dashboard/**'
 
@@ -18,6 +18,7 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/dashboard-pr-review.yml
+++ b/.github/workflows/dashboard-pr-review.yml
@@ -1,6 +1,12 @@
 name: Dashboard PR Review
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+
   pull_request:
     types: [opened, ready_for_review, synchronize]
     paths:

--- a/.github/workflows/dashboard-pr-review.yml
+++ b/.github/workflows/dashboard-pr-review.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: false
-          update_comment: true
+          use_sticky_comment: true
           prompt: |
             Read and follow the instructions in .github/prompts/dashboard-pr-review.md
           claude_args: |


### PR DESCRIPTION
Follow-up to #108060

## Proposed Changes

- Add opened event type to trigger workflow when PRs are first created
- Add if: github.event.pull_request.draft == false condition to skip draft PRs
- Fix invalid input update_comment → use_sticky_comment
- Add workflow_dispatch trigger for manual PR review runs

##  Why are these changes being made?

- The workflow previously only triggered on ready_for_review and synchronize, which meant non-draft PRs opened directly didn't trigger the review
- The draft check ensures we don't waste CI resources running reviews on draft PRs that are still work-in-progress
- The update_comment input doesn't exist in the claude-code-action; the correct input is use_sticky_comment
- Manual trigger allows re-running the review on any PR without pushing empty commits

##  Testing Instructions

- Open a new non-draft PR with changes in client/dashboard/ → workflow should run
- Open a new draft PR with changes in client/dashboard/ → workflow should be skipped
- Push commits to a draft PR → workflow should be skipped
- Push commits to a non-draft PR → workflow should run
- Mark a draft PR as ready for review → workflow should run
- Go to Actions → Dashboard PR Review → Run workflow → enter PR number → workflow should run

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
