### PR TITLE
Domains: Domain move internal product should not consume domain credit

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -1,4 +1,9 @@
-import { isDomainProduct, isDomainTransfer, isPlan } from '@automattic/calypso-products';
+import {
+	isDomainProduct,
+	isDomainTransfer,
+	isDomainMoveInternal,
+	isPlan,
+} from '@automattic/calypso-products';
 import { DomainSearch } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
@@ -87,7 +92,9 @@ export const useWPCOMDomainSearchCart = ( {
 			return b.item_subtotal_integer - a.item_subtotal_integer;
 		} );
 
-		const firstNonPremiumDomain = domainItems.find( ( item ) => ! item.extra?.premium );
+		const firstNonPremiumDomain = domainItems.find(
+			( item ) => ! isDomainMoveInternal( item ) && ! item.extra?.premium
+		);
 		const freeDomainName = forceFirstNonPremiumDomainToBeFree
 			? firstNonPremiumDomain?.meta
 			: undefined;


### PR DESCRIPTION
Part of [DOMENG-312](https://linear.app/a8c/issue/DOMENG-312)

## Proposed Changes

This PR updates the domains mini cart code to not consider the domain move internal product in the domain credit calculation.

### Screenshots

| Before | After |
| --- | --- |
| <img width="1920" height="1080" alt="Screenshot 2026-01-12 at 17 01 13" src="https://github.com/user-attachments/assets/8d68df9b-bba3-4055-9d69-02ab41675ccd" /> | <img width="1920" height="1080" alt="Screenshot 2026-01-12 at 16 59 22" src="https://github.com/user-attachments/assets/ca872604-4bb0-493f-a60c-85962b98c6ae" /> |

## Why are these changes being made?

The domain movei internal product is free and shouldn't consume the domain credits provided by a plan.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to `/setup/onboarding`
- Search for a domain that's mapped to another site you own
- Add the domain move internal product to your cart
- Ensure the prices of the other domain suggestions remain $0 (free for the first year)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
