### PR TITLE
A4A: Implement event tracking for resources in the Resource Center

### DIFF
--- a/client/a8c-for-agencies/data/learn/types.ts
+++ b/client/a8c-for-agencies/data/learn/types.ts
@@ -3,6 +3,7 @@
  */
 
 export interface APIAgencyResource {
+	id: number;
 	name: string;
 	description: string;
 	external_url: string;

--- a/client/a8c-for-agencies/data/learn/use-record-resource-event-mutation.ts
+++ b/client/a8c-for-agencies/data/learn/use-record-resource-event-mutation.ts
@@ -1,0 +1,36 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface RecordResourceEventParams {
+	resourceId: number;
+	agencyId: number;
+}
+
+interface APIResponse {
+	success: boolean;
+}
+
+interface APIError {
+	message: string;
+	code?: string;
+}
+
+function mutationRecordResourceEvent( params: RecordResourceEventParams ): Promise< APIResponse > {
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/agency/resources/record-event',
+		body: {
+			resource_id: params.resourceId,
+			agency_id: params.agencyId,
+		},
+	} );
+}
+
+export default function useRecordResourceEventMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, RecordResourceEventParams, TContext >
+): UseMutationResult< APIResponse, APIError, RecordResourceEventParams, TContext > {
+	return useMutation< APIResponse, APIError, RecordResourceEventParams, TContext >( {
+		...options,
+		mutationFn: mutationRecordResourceEvent,
+	} );
+}

--- a/client/a8c-for-agencies/sections/learn/format-agency-resources.tsx
+++ b/client/a8c-for-agencies/sections/learn/format-agency-resources.tsx
@@ -32,10 +32,7 @@ function getProductLogo( relatedProduct: string ): JSX.Element | null {
  */
 export function formatAgencyResource( resource: APIAgencyResource ): ResourceItem {
 	return {
-		// Generate a unique ID from the resource name and type
-		id: `${ resource.related_product }-${ resource.resource_type }-${ resource.name
-			.toLowerCase()
-			.replace( /\s+/g, '-' ) }`,
+		id: resource.id,
 		name: resource.name,
 		description: resource.description,
 		externalUrl: resource.external_url,

--- a/client/a8c-for-agencies/sections/learn/resource-center/overview-content/browse-all-resources.tsx
+++ b/client/a8c-for-agencies/sections/learn/resource-center/overview-content/browse-all-resources.tsx
@@ -135,6 +135,7 @@ export default function BrowseAllResources( {
 				onChangeView={ setView }
 				paginationInfo={ paginationInfo }
 				defaultLayouts={ { list: {} } }
+				getItemId={ ( item ) => String( item.id ) }
 				search
 			>
 				<HStack justify="start" style={ { paddingBlock: '16px' } }>

--- a/client/a8c-for-agencies/sections/learn/resource-center/overview-content/resource-card.tsx
+++ b/client/a8c-for-agencies/sections/learn/resource-center/overview-content/resource-card.tsx
@@ -7,7 +7,9 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { useDispatch } from 'calypso/state';
+import useRecordResourceEventMutation from 'calypso/a8c-for-agencies/data/learn/use-record-resource-event-mutation';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useResourceCtaLabel } from './hooks/use-resource-cta-label';
 import type { ResourceItem } from './types';
@@ -30,8 +32,10 @@ export default function ResourceCard( {
 	isBorderless = false,
 }: ResourceCardProps ) {
 	const dispatch = useDispatch();
+	const agencyId = useSelector( getActiveAgencyId );
 	const ctaLabel = useResourceCtaLabel( resource.format );
 	const isVideo = resource.format === 'Video';
+	const { mutate: recordResourceEvent } = useRecordResourceEventMutation();
 
 	const handleClick = ( e: React.MouseEvent ) => {
 		if ( isVideo ) {
@@ -39,12 +43,21 @@ export default function ResourceCard( {
 			onOpenVideoModal( resource );
 		}
 
+		// Track event in analytics
 		dispatch(
 			recordTracksEvent( tracksEventName, {
 				resource_id: resource.id,
 				resource_name: resource.name,
 			} )
 		);
+
+		// Record event in the API
+		if ( agencyId ) {
+			recordResourceEvent( {
+				resourceId: resource.id,
+				agencyId,
+			} );
+		}
 	};
 
 	return (

--- a/client/a8c-for-agencies/sections/learn/resource-center/overview-content/types.ts
+++ b/client/a8c-for-agencies/sections/learn/resource-center/overview-content/types.ts
@@ -1,5 +1,5 @@
 export type ResourceItem = {
-	id: string;
+	id: number;
 	name: string;
 	description: string;
 	externalUrl: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://linear.app/a8c/project/launch-mvp-resource-center-9430a7bf5993/overview

## Proposed Changes

* Updated the `ResourceCard` component to call the event recording API whenever users click on resource CTAs.
* Added new mutation hook that sends POST requests to `/agency/resources/record-event` (to record the event in HubSpot)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 199692-ghe-Automattic/wpcom to your sandbox if not merged yet.
* Go to `/learn/resource-center` and click on the CTA on any resource.
* Confirm a POST request was made to `/agency/resources/record-event`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
