### PR TITLE
Add dashboard-screenshots-diff Claude Code skill

### DIFF
--- a/.claude/commands/dashboard-screenshot-diff.md
+++ b/.claude/commands/dashboard-screenshot-diff.md
@@ -1,10 +1,16 @@
 # Dashboard Screenshots
 
-Take screenshots of Dashboard pages to compare visual differences between trunk and your current branch.
+Take screenshots of Dashboard pages to compare visual differences between production and your current branch.
 
 ## Instructions
 
-1. Check if auth session exists:
+1. Check the active branch:
+   ```bash
+   git branch --show-current
+   ```
+   This identifies which branch screenshots will be saved under.
+
+2. Check if auth session exists:
    ```bash
    ls .claude/skills/dashboard-screenshots-diff/auth-state.json
    ```
@@ -14,16 +20,24 @@ Take screenshots of Dashboard pages to compare visual differences between trunk 
    ```
    This opens a browser for manual login. After login, click "Resume" in the Playwright inspector.
 
-2. Take screenshots of routes affected by your PR changes:
+3. Take screenshots from **production** (baseline):
+   ```bash
+   DASHBOARD_BASE_URL="https://my.wordpress.com" SCREENSHOT_BRANCH="production" yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
+   ```
+
+4. Take screenshots from **local branch** (current changes):
    ```bash
    yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
    ```
 
    If affected routes include `/sites/$siteSlug/*`, ask the user for their site slug and add `SITE_SLUG="<slug>"` to the command.
 
-3. For headed mode (visible browser), add `--headed` to the command.
+5. For headed mode (visible browser), add `--headed` to the command.
 
-4. Screenshots are saved to: `.claude/skills/dashboard-screenshots-diff/screenshots/{branch-name}/`
+6. Open both screenshot folders for comparison:
+   ```bash
+   open .claude/skills/dashboard-screenshots-diff/screenshots/production .claude/skills/dashboard-screenshots-diff/screenshots/{branch-name}
+   ```
 
 ## Environment Variables
 
@@ -32,19 +46,5 @@ Take screenshots of Dashboard pages to compare visual differences between trunk 
 | `SITE_SLUG` | - | Required only for `/sites/$siteSlug/*` routes |
 | `DOMAIN_NAME` | - | Required only for `/domains/$domainName/*` routes |
 | `SCREENSHOT_ROUTES` | (auto) | Override: comma-separated list of explicit routes |
-
-## Comparing Against Production
-
-To compare production (trunk) vs your branch:
-
-1. Screenshot production:
-   ```bash
-   DASHBOARD_BASE_URL="https://my.wordpress.com" yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
-   ```
-
-2. Screenshot your local branch:
-   ```bash
-   yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
-   ```
-
-3. Compare the screenshots in `screenshots/trunk/` vs `screenshots/{your-branch}/`
+| `DASHBOARD_BASE_URL` | (local) | Base URL for screenshots (use `https://my.wordpress.com` for production) |
+| `SCREENSHOT_BRANCH` | (git branch) | Override the branch name used for screenshot folder |

--- a/.claude/commands/dashboard-screenshot-diff.md
+++ b/.claude/commands/dashboard-screenshot-diff.md
@@ -1,0 +1,50 @@
+# Dashboard Screenshots
+
+Take screenshots of Dashboard pages to compare visual differences between trunk and your current branch.
+
+## Instructions
+
+1. Check if auth session exists:
+   ```bash
+   ls .claude/skills/dashboard-screenshots-diff/auth-state.json
+   ```
+   If missing or expired, run:
+   ```bash
+   yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/save-session.spec.ts --headed
+   ```
+   This opens a browser for manual login. After login, click "Resume" in the Playwright inspector.
+
+2. Take screenshots of routes affected by your PR changes:
+   ```bash
+   yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
+   ```
+
+   If affected routes include `/sites/$siteSlug/*`, ask the user for their site slug and add `SITE_SLUG="<slug>"` to the command.
+
+3. For headed mode (visible browser), add `--headed` to the command.
+
+4. Screenshots are saved to: `.claude/skills/dashboard-screenshots-diff/screenshots/{branch-name}/`
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SITE_SLUG` | - | Required only for `/sites/$siteSlug/*` routes |
+| `DOMAIN_NAME` | - | Required only for `/domains/$domainName/*` routes |
+| `SCREENSHOT_ROUTES` | (auto) | Override: comma-separated list of explicit routes |
+
+## Comparing Against Production
+
+To compare production (trunk) vs your branch:
+
+1. Screenshot production:
+   ```bash
+   DASHBOARD_BASE_URL="https://my.wordpress.com" yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
+   ```
+
+2. Screenshot your local branch:
+   ```bash
+   yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
+   ```
+
+3. Compare the screenshots in `screenshots/trunk/` vs `screenshots/{your-branch}/`

--- a/.claude/commands/dashboard-screenshot-diff.md
+++ b/.claude/commands/dashboard-screenshot-diff.md
@@ -16,27 +16,27 @@ Take screenshots of Dashboard pages to compare visual differences between produc
    ```
    If missing or expired, run:
    ```bash
-   cd .claude/skills/dashboard-screenshots-diff && yarn playwright test save-session.spec.ts --headed
+   yarn workspace wp-e2e-tests playwright test -c .claude/skills/dashboard-screenshots-diff save-session.spec.ts --headed
    ```
    This opens a browser for manual login. After login, click "Resume" in the Playwright inspector.
 
 3. Take screenshots from **production** (baseline):
    ```bash
-   cd .claude/skills/dashboard-screenshots-diff && SCREENSHOT_BRANCH="production" yarn playwright test take-screenshots.spec.ts
+   SCREENSHOT_BRANCH="production" yarn workspace wp-e2e-tests playwright test -c .claude/skills/dashboard-screenshots-diff take-screenshots.spec.ts
    ```
 
 4. Take screenshots from **local branch** (current changes):
    ```bash
-   cd .claude/skills/dashboard-screenshots-diff && yarn playwright test take-screenshots.spec.ts
+   yarn workspace wp-e2e-tests playwright test -c .claude/skills/dashboard-screenshots-diff take-screenshots.spec.ts
    ```
 
    If affected routes include `/sites/$siteSlug/*`, ask the user for their site slug and add `SITE_SLUG="<slug>"` to the command.
 
 5. For headed mode (visible browser), add `--headed` to the command.
 
-6. Open both screenshot folders for comparison:
+6. Open the screenshots folder to compare `*_production.png` vs `*_{branch-name}.png`:
    ```bash
-   open .claude/skills/dashboard-screenshots-diff/screenshots/production .claude/skills/dashboard-screenshots-diff/screenshots/{branch-name}
+   open .claude/skills/dashboard-screenshots-diff/screenshots
    ```
 
 ## Environment Variables

--- a/.claude/commands/dashboard-screenshot-diff.md
+++ b/.claude/commands/dashboard-screenshot-diff.md
@@ -16,18 +16,18 @@ Take screenshots of Dashboard pages to compare visual differences between produc
    ```
    If missing or expired, run:
    ```bash
-   yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/save-session.spec.ts --headed
+   cd .claude/skills/dashboard-screenshots-diff && yarn playwright test save-session.spec.ts --headed
    ```
    This opens a browser for manual login. After login, click "Resume" in the Playwright inspector.
 
 3. Take screenshots from **production** (baseline):
    ```bash
-   DASHBOARD_BASE_URL="https://my.wordpress.com" SCREENSHOT_BRANCH="production" yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
+   cd .claude/skills/dashboard-screenshots-diff && SCREENSHOT_BRANCH="production" yarn playwright test take-screenshots.spec.ts
    ```
 
 4. Take screenshots from **local branch** (current changes):
    ```bash
-   yarn workspace wp-e2e-tests playwright test .claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
+   cd .claude/skills/dashboard-screenshots-diff && yarn playwright test take-screenshots.spec.ts
    ```
 
    If affected routes include `/sites/$siteSlug/*`, ask the user for their site slug and add `SITE_SLUG="<slug>"` to the command.
@@ -46,5 +46,4 @@ Take screenshots of Dashboard pages to compare visual differences between produc
 | `SITE_SLUG` | - | Required only for `/sites/$siteSlug/*` routes |
 | `DOMAIN_NAME` | - | Required only for `/domains/$domainName/*` routes |
 | `SCREENSHOT_ROUTES` | (auto) | Override: comma-separated list of explicit routes |
-| `DASHBOARD_BASE_URL` | (local) | Base URL for screenshots (use `https://my.wordpress.com` for production) |
-| `SCREENSHOT_BRANCH` | (git branch) | Override the branch name used for screenshot folder |
+| `SCREENSHOT_BRANCH` | (git branch) | Override branch name; use `production` to screenshot my.wordpress.com |

--- a/.claude/skills/dashboard-screenshots-diff/.gitignore
+++ b/.claude/skills/dashboard-screenshots-diff/.gitignore
@@ -1,0 +1,9 @@
+# Authentication state (contains cookies)
+auth-state.json
+
+# Screenshots output
+screenshots/
+
+# Playwright output
+test-results/
+playwright-report/

--- a/.claude/skills/dashboard-screenshots-diff/playwright.config.ts
+++ b/.claude/skills/dashboard-screenshots-diff/playwright.config.ts
@@ -11,6 +11,7 @@ export default defineConfig( {
 		trace: 'off',
 		screenshot: 'off',
 		video: 'off',
+		channel: 'chrome', // Use system Chrome, no Chromium install needed
 	},
 	projects: [
 		{

--- a/.claude/skills/dashboard-screenshots-diff/playwright.config.ts
+++ b/.claude/skills/dashboard-screenshots-diff/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig( {
+	testDir: '.',
+	fullyParallel: false,
+	forbidOnly: false,
+	retries: 0,
+	workers: 1,
+	timeout: 300000, // 5 minutes for manual login
+	use: {
+		trace: 'off',
+		screenshot: 'off',
+		video: 'off',
+	},
+	projects: [
+		{
+			name: 'default',
+			use: {
+				...devices[ 'Desktop Chrome HiDPI' ],
+			},
+		},
+	],
+} );

--- a/.claude/skills/dashboard-screenshots-diff/save-session.spec.ts
+++ b/.claude/skills/dashboard-screenshots-diff/save-session.spec.ts
@@ -1,0 +1,28 @@
+import { test } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const AUTH_STATE_PATH = path.join( __dirname, 'auth-state.json' );
+
+test.use( {
+	storageState: undefined,
+	viewport: { width: 1440, height: 900 },
+} );
+
+test( 'Save authentication session', async ( { page, context } ) => {
+	await page.goto( 'https://wordpress.com/log-in' );
+
+	console.log( '\n' + '='.repeat( 60 ) );
+	console.log( 'MANUAL LOGIN REQUIRED' );
+	console.log( '='.repeat( 60 ) );
+	console.log( '\n1. Log in to your WordPress.com account' );
+	console.log( '2. Complete any 2FA if required' );
+	console.log( '3. Wait until you see the dashboard' );
+	console.log( '4. Click "Resume" in the Playwright inspector' );
+	console.log( '\n' + '='.repeat( 60 ) + '\n' );
+
+	await page.pause();
+	await context.storageState( { path: AUTH_STATE_PATH } );
+
+	console.log( '\nSaved to: .claude/skills/dashboard-screenshots-diff/auth-state.json\n' );
+} );

--- a/.claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
+++ b/.claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
@@ -313,13 +313,12 @@ async function getRoutesToScreenshot(): Promise< Route[] > {
 // ============================================================================
 
 test.describe( 'Dashboard Screenshots', () => {
-	const branch = process.env.SCREENSHOT_BRANCH || getCurrentBranch();
-	const outputDir = path.join( SCREENSHOT_DIR, branch );
-	const relOutputDir = `.claude/skills/dashboard-screenshots-diff/screenshots/${ branch }`;
+	const branch = ( process.env.SCREENSHOT_BRANCH || getCurrentBranch() ).replace( /\//g, '-' );
+	const relOutputDir = `.claude/skills/dashboard-screenshots-diff/screenshots`;
 
 	test.beforeAll( () => {
-		fs.mkdirSync( outputDir, { recursive: true } );
-		console.log( `\nScreenshots: ${ relOutputDir }\n` );
+		fs.mkdirSync( SCREENSHOT_DIR, { recursive: true } );
+		console.log( `\nScreenshots: ${ relOutputDir }/*_${ branch }.png\n` );
 	} );
 
 	test( 'Take screenshots', async ( { page } ) => {
@@ -340,7 +339,7 @@ test.describe( 'Dashboard Screenshots', () => {
 			}
 
 			const fullPath = substituteParams( route, params );
-			const filename = `${ pathToFilename( fullPath ) }.png`;
+			const filename = `${ pathToFilename( fullPath ) }_${ branch }.png`;
 			console.log( `Capturing: ${ fullPath }` );
 
 			try {
@@ -355,7 +354,7 @@ test.describe( 'Dashboard Screenshots', () => {
 				} catch {
 					/* ok */
 				}
-				await page.screenshot( { path: path.join( outputDir, filename ), fullPage: true } );
+				await page.screenshot( { path: path.join( SCREENSHOT_DIR, filename ), fullPage: true } );
 				captured.push( fullPath );
 				console.log( `  -> ${ filename }` );
 			} catch ( e ) {

--- a/.claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
+++ b/.claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
@@ -310,7 +310,7 @@ async function getRoutesToScreenshot(): Promise< Route[] > {
 // ============================================================================
 
 test.describe( 'Dashboard Screenshots', () => {
-	const branch = IS_PRODUCTION ? 'trunk' : getCurrentBranch();
+	const branch = process.env.SCREENSHOT_BRANCH || getCurrentBranch();
 	const outputDir = path.join( SCREENSHOT_DIR, branch );
 	const relOutputDir = `.claude/skills/dashboard-screenshots-diff/screenshots/${ branch }`;
 

--- a/.claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
+++ b/.claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
@@ -1,0 +1,366 @@
+import { test } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+const SCREENSHOT_DIR = path.join( __dirname, 'screenshots' );
+const AUTH_STATE_PATH = path.join( __dirname, 'auth-state.json' );
+const BASE_URL = process.env.DASHBOARD_BASE_URL || 'http://my.localhost:3000';
+const IS_PRODUCTION = BASE_URL.includes( 'wordpress.com' );
+
+test.use( {
+	baseURL: BASE_URL,
+	viewport: { width: 1440, height: 900 },
+	storageState: fs.existsSync( AUTH_STATE_PATH ) ? AUTH_STATE_PATH : undefined,
+} );
+
+// ============================================================================
+// Route Types and Extraction
+// ============================================================================
+
+interface Route {
+	path: string;
+	category: 'sites' | 'domains' | 'emails' | 'plugins' | 'me';
+	hasParams: boolean;
+	params: string[];
+}
+
+interface RouteDefinition {
+	name: string;
+	path: string;
+	parentName: string | null;
+}
+
+const ROUTER_FILES: Record< Route[ 'category' ], string > = {
+	sites: 'client/dashboard/app/router/sites.tsx',
+	domains: 'client/dashboard/app/router/domains.ts',
+	emails: 'client/dashboard/app/router/emails.tsx',
+	plugins: 'client/dashboard/app/router/plugins.tsx',
+	me: 'client/dashboard/app/router/me.tsx',
+};
+
+function extractRouteDefinitions( content: string ): RouteDefinition[] {
+	const routes: RouteDefinition[] = [];
+	const lines = content.split( '\n' );
+	let currentRouteName: string | null = null;
+	let currentPath: string | null = null;
+	let currentParent: string | null = null;
+	let braceDepth = 0;
+	let inCreateRoute = false;
+
+	for ( const line of lines ) {
+		const routeStart = line.match( /export\s+const\s+(\w+)\s*=\s*createRoute\s*\(/ );
+		if ( routeStart ) {
+			if ( currentRouteName && currentPath !== null ) {
+				routes.push( {
+					name: currentRouteName,
+					path: currentPath,
+					parentName: currentParent === 'rootRoute' ? null : currentParent,
+				} );
+			}
+			currentRouteName = routeStart[ 1 ];
+			currentPath = null;
+			currentParent = null;
+			inCreateRoute = true;
+			braceDepth = 0;
+		}
+
+		if ( inCreateRoute ) {
+			braceDepth += ( line.match( /\{/g ) || [] ).length;
+			braceDepth -= ( line.match( /\}/g ) || [] ).length;
+			const pathMatch = line.match( /path:\s*['"`]([^'"`]+)['"`]/ );
+			if ( pathMatch ) currentPath = pathMatch[ 1 ];
+			const parentMatch = line.match( /getParentRoute:\s*\(\)\s*=>\s*(\w+)/ );
+			if ( parentMatch ) currentParent = parentMatch[ 1 ];
+			if ( braceDepth <= 0 && ( line.includes( ')' ) || line.includes( '.lazy' ) ) ) {
+				inCreateRoute = false;
+			}
+		}
+	}
+
+	if ( currentRouteName && currentPath !== null ) {
+		routes.push( {
+			name: currentRouteName,
+			path: currentPath,
+			parentName: currentParent === 'rootRoute' ? null : currentParent,
+		} );
+	}
+	return routes;
+}
+
+function buildFullPaths( definitions: RouteDefinition[] ): Map< string, string > {
+	const routeMap = new Map< string, RouteDefinition >();
+	for ( const def of definitions ) routeMap.set( def.name, def );
+	const fullPaths = new Map< string, string >();
+
+	function resolveFullPath( routeName: string, visited: Set< string > = new Set() ): string {
+		if ( fullPaths.has( routeName ) ) return fullPaths.get( routeName )!;
+		if ( visited.has( routeName ) ) return '';
+		visited.add( routeName );
+		const route = routeMap.get( routeName );
+		if ( ! route ) return '';
+
+		let fullPath: string;
+		if ( route.parentName && routeMap.has( route.parentName ) ) {
+			const parentPath = resolveFullPath( route.parentName, visited );
+			if ( route.path === '/' ) fullPath = parentPath || '/';
+			else if ( route.path.startsWith( '/' ) ) fullPath = `${ parentPath }${ route.path }`;
+			else fullPath = `${ parentPath }/${ route.path }`.replace( /\/+/g, '/' );
+		} else {
+			fullPath = route.path.startsWith( '/' ) ? route.path : `/${ route.path }`;
+		}
+		fullPaths.set( routeName, fullPath );
+		return fullPath;
+	}
+
+	for ( const def of definitions ) resolveFullPath( def.name );
+	return fullPaths;
+}
+
+async function extractRoutes( repoRoot: string ): Promise< Route[] > {
+	const routes: Route[] = [];
+	for ( const [ category, relativePath ] of Object.entries( ROUTER_FILES ) ) {
+		const filePath = path.join( repoRoot, relativePath );
+		if ( ! fs.existsSync( filePath ) ) continue;
+		const content = fs.readFileSync( filePath, 'utf-8' );
+		const definitions = extractRouteDefinitions( content );
+		const fullPaths = buildFullPaths( definitions );
+
+		for ( const [ , fullPath ] of fullPaths ) {
+			if ( fullPath === '/' || fullPath === '' ) continue;
+			const paramMatches = fullPath.match( /\$\w+/g ) || [];
+			routes.push( {
+				path: fullPath,
+				category: category as Route[ 'category' ],
+				hasParams: paramMatches.length > 0,
+				params: paramMatches.map( ( p ) => p.slice( 1 ) ),
+			} );
+		}
+	}
+	routes.sort( ( a, b ) => a.path.localeCompare( b.path ) );
+	const seen = new Set< string >();
+	return routes.filter( ( r ) => ! seen.has( r.path ) && seen.add( r.path ) );
+}
+
+function substituteParams( route: Route, params: Record< string, string > ): string {
+	let routePath = route.path;
+	for ( const param of route.params ) {
+		if ( params[ param ] ) routePath = routePath.replace( `$${ param }`, params[ param ] );
+	}
+	return routePath;
+}
+
+function getChangedDashboardFiles( repoRoot: string, baseBranch: string = 'trunk' ): string[] {
+	const files = new Set< string >();
+	try {
+		execSync( `git diff --name-only ${ baseBranch }...HEAD -- 'client/dashboard/**'`, {
+			cwd: repoRoot,
+			encoding: 'utf-8',
+		} )
+			.trim()
+			.split( '\n' )
+			.filter( Boolean )
+			.forEach( ( f ) => files.add( f ) );
+	} catch {
+		/* ignore */
+	}
+	try {
+		execSync( `git diff --name-only ${ baseBranch } -- 'client/dashboard/**'`, {
+			cwd: repoRoot,
+			encoding: 'utf-8',
+		} )
+			.trim()
+			.split( '\n' )
+			.filter( Boolean )
+			.forEach( ( f ) => files.add( f ) );
+	} catch {
+		/* ignore */
+	}
+	return Array.from( files );
+}
+
+function filePathToRoutePaths( filePath: string ): string[] {
+	const rel = filePath.replace( /^client\/dashboard\//, '' );
+	if ( rel.startsWith( 'app-dotcom/' ) || rel.startsWith( 'app-ciab/' ) ) return [ '/sites' ];
+	if ( /^(app|components|utils|hooks|types)\//.test( rel ) ) return [];
+
+	const parts = rel.split( '/' );
+	const routeParts: string[] = [];
+	for ( const part of parts ) {
+		if ( part.includes( '.' ) ) {
+			const name = part.replace( /\.(tsx?|jsx?|css|scss)$/, '' );
+			if ( ! [ 'index', 'style', 'styles' ].includes( name ) && ! name.startsWith( 'test' ) )
+				routeParts.push( name );
+			break;
+		}
+		routeParts.push( part );
+	}
+	if ( ! routeParts.length ) return [];
+
+	const routes: string[] = [];
+	if ( routeParts[ 0 ] === 'sites' ) {
+		routes.push( '/sites', '/sites/$siteSlug' );
+		if ( routeParts.length > 1 )
+			routes.push( `/sites/$siteSlug/${ routeParts.slice( 1 ).join( '/' ) }` );
+	} else if ( routeParts[ 0 ] === 'domains' ) {
+		routes.push( '/domains' );
+		if ( routeParts.length > 1 )
+			routes.push(
+				`/domains/$domainName/${ routeParts.slice( 1 ).join( '/' ) }`,
+				'/domains/$domainName'
+			);
+	} else {
+		routes.push( '/' + routeParts.join( '/' ) );
+		for ( let i = routeParts.length - 1; i > 0; i-- )
+			routes.push( '/' + routeParts.slice( 0, i ).join( '/' ) );
+	}
+	return routes;
+}
+
+async function getAffectedRoutes(
+	repoRoot: string,
+	allRoutes: Route[],
+	baseBranch: string = 'trunk'
+): Promise< Route[] > {
+	const changedFiles = getChangedDashboardFiles( repoRoot, baseBranch );
+	if ( ! changedFiles.length ) return [];
+	const potentialPaths = new Set< string >();
+	changedFiles.forEach( ( f ) =>
+		filePathToRoutePaths( f ).forEach( ( p ) => potentialPaths.add( p ) )
+	);
+	return allRoutes.filter( ( r ) => potentialPaths.has( r.path ) );
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function findRepoRoot( startDir: string ): string | null {
+	let dir = startDir;
+	while ( dir !== '/' ) {
+		const pkgPath = path.join( dir, 'package.json' );
+		if ( fs.existsSync( pkgPath ) ) {
+			try {
+				if ( JSON.parse( fs.readFileSync( pkgPath, 'utf-8' ) ).name === 'wp-calypso' ) return dir;
+			} catch {
+				/* ignore */
+			}
+		}
+		dir = path.dirname( dir );
+	}
+	return null;
+}
+
+function getCurrentBranch(): string {
+	try {
+		const head = fs.readFileSync(
+			path.join( findRepoRoot( __dirname ) || __dirname, '.git', 'HEAD' ),
+			'utf-8'
+		);
+		const match = head.match( /ref: refs\/heads\/(.+)/ );
+		return match ? match[ 1 ].trim() : 'unknown';
+	} catch {
+		return 'unknown';
+	}
+}
+
+function pathToFilename( routePath: string ): string {
+	return (
+		routePath
+			.replace( /^\//, '' )
+			.replace( /\//g, '-' )
+			.replace( /[^a-zA-Z0-9-_.]/g, '' ) || 'index'
+	);
+}
+
+async function getRoutesToScreenshot(): Promise< Route[] > {
+	const repoRoot = process.env.REPO_ROOT || findRepoRoot( __dirname );
+	if ( ! repoRoot ) throw new Error( 'Could not find wp-calypso repo root.' );
+
+	if ( process.env.SCREENSHOT_ROUTES ) {
+		return process.env.SCREENSHOT_ROUTES.split( ',' )
+			.map( ( p ) => p.trim() )
+			.map( ( p ) => ( {
+				path: p,
+				category: 'sites' as const,
+				hasParams: p.includes( '$' ),
+				params: ( p.match( /\$(\w+)/g ) || [] ).map( ( m ) => m.slice( 1 ) ),
+			} ) );
+	}
+
+	const allRoutes = await extractRoutes( repoRoot );
+	const baseBranch = process.env.BASE_BRANCH || 'trunk';
+	const changedFiles = getChangedDashboardFiles( repoRoot, baseBranch );
+
+	if ( ! changedFiles.length ) {
+		console.log( `\nNo dashboard files changed compared to ${ baseBranch }` );
+		return [];
+	}
+
+	console.log( `\nChanged files (vs ${ baseBranch }):` );
+	changedFiles.forEach( ( f ) => console.log( `  - ${ f }` ) );
+
+	const affected = await getAffectedRoutes( repoRoot, allRoutes, baseBranch );
+	console.log( `\nMapped to ${ affected.length } routes\n` );
+	return affected;
+}
+
+// ============================================================================
+// Test
+// ============================================================================
+
+test.describe( 'Dashboard Screenshots', () => {
+	const branch = IS_PRODUCTION ? 'trunk' : getCurrentBranch();
+	const outputDir = path.join( SCREENSHOT_DIR, branch );
+	const relOutputDir = `.claude/skills/dashboard-screenshots-diff/screenshots/${ branch }`;
+
+	test.beforeAll( () => {
+		fs.mkdirSync( outputDir, { recursive: true } );
+		console.log( `\nScreenshots: ${ relOutputDir }\n` );
+	} );
+
+	test( 'Take screenshots', async ( { page } ) => {
+		const routes = await getRoutesToScreenshot();
+		const params = {
+			siteSlug: process.env.SITE_SLUG || '',
+			domainName: process.env.DOMAIN_NAME || '',
+		};
+
+		const skipped: string[] = [],
+			captured: string[] = [];
+
+		for ( const route of routes ) {
+			const missing = route.params.filter( ( p ) => ! params[ p as keyof typeof params ] );
+			if ( missing.length ) {
+				skipped.push( `${ route.path } (missing: ${ missing.join( ', ' ) })` );
+				continue;
+			}
+
+			const fullPath = substituteParams( route, params );
+			const filename = `${ pathToFilename( fullPath ) }.png`;
+			console.log( `Capturing: ${ fullPath }` );
+
+			try {
+				await page.goto( fullPath, { waitUntil: 'domcontentloaded' } );
+				await page.waitForLoadState( 'load' );
+				await page.waitForTimeout( 1000 );
+				try {
+					await page.waitForSelector( '[class*="loading"], [class*="spinner"]', {
+						state: 'hidden',
+						timeout: 5000,
+					} );
+				} catch {
+					/* ok */
+				}
+				await page.screenshot( { path: path.join( outputDir, filename ), fullPage: true } );
+				captured.push( fullPath );
+				console.log( `  -> ${ filename }` );
+			} catch ( e ) {
+				skipped.push( `${ fullPath } (error)` );
+			}
+		}
+
+		console.log( `\nCaptured: ${ captured.length }, Skipped: ${ skipped.length }` );
+		console.log( `Output: ${ relOutputDir }\n` );
+	} );
+} );

--- a/.claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
+++ b/.claude/skills/dashboard-screenshots-diff/take-screenshots.spec.ts
@@ -5,7 +5,10 @@ import { execSync } from 'child_process';
 
 const SCREENSHOT_DIR = path.join( __dirname, 'screenshots' );
 const AUTH_STATE_PATH = path.join( __dirname, 'auth-state.json' );
-const BASE_URL = process.env.DASHBOARD_BASE_URL || 'http://my.localhost:3000';
+const BASE_URL =
+	process.env.SCREENSHOT_BRANCH === 'production'
+		? 'https://my.wordpress.com'
+		: 'http://my.localhost:3000';
 const IS_PRODUCTION = BASE_URL.includes( 'wordpress.com' );
 
 test.use( {


### PR DESCRIPTION
## Proposed Changes

- Add a Claude Code skill to take screenshots of Dashboard pages for visual comparison
- Automatically detects routes affected by PR changes via git diff
- Cookie-based authentication (login once, reuse session)
- Extracts routes from `client/dashboard/app/router/*.tsx`

## Why are these changes being made?

When reviewing Dashboard PRs, it's helpful to compare visual changes between trunk and the feature branch. This skill automates the screenshot capture process by:

1. Detecting which routes are affected by the PR changes
2. Taking full-page screenshots of those routes
3. Organizing screenshots by branch for easy comparison

## Testing Instructions

1. Install dependencies:
   ```bash
   cd .claude/skills/dashboard-screenshots-diff && npm install && npx playwright install chromium
   ```

2. Save auth session (one-time):
   ```bash
   npm run save-session
   ```

3. Start the dashboard dev server, then take screenshots:
   ```bash
   SITE_SLUG=yoursite.wordpress.com npm run screenshots
   ```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.ai/code)