### PR TITLE
MYJP-265 Fixing lightbox price for tiered products

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -1,4 +1,4 @@
-import { JETPACK_SOCIAL_ADVANCED_PRODUCTS } from '@automattic/calypso-products';
+import { JETPACK_SOCIAL_ADVANCED_PRODUCTS, TERM_MONTHLY } from '@automattic/calypso-products';
 import { PlanPrice } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import clsx from 'clsx';
@@ -52,7 +52,14 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 		} );
 
 	const getCurrentTierPrice = () => {
-		const originalCurrentTierPrice = currentTier && currentTier.minimum_price / 100 / 12;
+		const isMonthly = product.term === TERM_MONTHLY;
+		let originalCurrentTierPrice = currentTier && currentTier.minimum_price / 100;
+
+		// If the term is not monthly, we need to convert the price to monthly.
+		if ( ! isMonthly && originalCurrentTierPrice ) {
+			originalCurrentTierPrice = originalCurrentTierPrice / 12;
+		}
+
 		let currentTierPrice = originalCurrentTierPrice;
 		if ( saleCouponDiscount && currentTierPrice ) {
 			currentTierPrice = currentTierPrice * ( 1 - saleCouponDiscount );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Completes MYJP-265

## Proposed Changes

* avoid dividing monthly prices by 12 to fix tiered pricing

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* jetpack.com price modal shows incorrect price for tiered products like stats

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to Jetpack cloud for the PR
* go to pricing and open Stats modal
* change the URL from `jetpack_stats_yearly` to `jetpack_stats_monthly`
* verify that the visible price isn't around 1/12 of the monthly amount
* spin a JN site with prod for comparison

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
