### PR TITLE
Rename Help Center experiment to increase_exposure

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -26,7 +26,7 @@ function HelpCenterContent() {
 	const [ helpCenterPage, setHelpCenterPage ] = useState( null );
 	const { setShowHelpCenter, setNavigateToRoute } = useDispatch( 'automattic/help-center' );
 	const { isInTreatment: isMenuPanelExperimentEnabled, isLoading: isLoadingExperimentAssignment } =
-		useMenuPanelExperiment( 'calypso_help_center_menu_popover_v2', 'menu_popover' );
+		useMenuPanelExperiment( 'calypso_help_center_menu_popover_increase_exposure', 'menu_popover' );
 	const isShown = useSelect( ( s ) => s( 'automattic/help-center' ).isHelpCenterShown(), [] );
 
 	const canvasMode = useCanvasMode();

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -35,7 +35,7 @@ function AdminHelpCenterContent() {
 	const masterbarNotificationsButton = document.getElementById( 'wp-admin-bar-notes' );
 	const supportLinks = document.querySelectorAll( '[data-target="wpcom-help-center"]' );
 	const { isInTreatment: isMenuPanelExperimentEnabled, isLoading: isLoadingExperimentAssignment } =
-		useMenuPanelExperiment( 'calypso_help_center_menu_popover_v2', 'menu_popover' );
+		useMenuPanelExperiment( 'calypso_help_center_menu_popover_increase_exposure', 'menu_popover' );
 
 	const closeHelpCenterWhenNotificationsPanelIsOpened = useCallback( () => {
 		const helpCenterContainerIsVisible = document.querySelector( '.help-center__container' );

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -56,7 +56,7 @@ function Help() {
 	const isUnifiedAgentEnabled = useShouldUseUnifiedAgent();
 
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'calypso_help_center_menu_popover_v2'
+		'calypso_help_center_menu_popover_increase_exposure'
 	);
 	const isMenuPanelExperimentEnabled =
 		! isLoadingExperimentAssignment && experimentAssignment?.variationName === 'menu_popover';

--- a/client/layout/masterbar/masterbar-help-center/index.jsx
+++ b/client/layout/masterbar/masterbar-help-center/index.jsx
@@ -36,7 +36,7 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 		[]
 	);
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'calypso_help_center_menu_popover_v2'
+		'calypso_help_center_menu_popover_increase_exposure'
 	);
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 

--- a/client/reader/components/header/help-center/index.tsx
+++ b/client/reader/components/header/help-center/index.tsx
@@ -27,7 +27,7 @@ export function HelpCenter( { user }: Props ) {
 	const [ helpCenterPage, setHelpCenterPage ] = useState( '' );
 
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'calypso_help_center_menu_popover_v2'
+		'calypso_help_center_menu_popover_increase_exposure'
 	);
 	const isMenuPanelExperimentEnabled =
 		! isLoadingExperimentAssignment && experimentAssignment?.variationName === 'menu_popover';


### PR DESCRIPTION
Part of DOTCOM-15670

## Proposed Changes

* Rename the Help Center menu popover experiment from `calypso_help_center_menu_popover_v2` to `calypso_help_center_menu_popover_increase_exposure`

## Why are these changes being made?

* Updates the experiment name to better reflect its purpose of increasing exposure to the help center menu popover.

## Testing Instructions

* Verify the experiment name change works correctly across all help center entry points:
  - Calypso masterbar
  - Reader header
  - Dashboard secondary menu
  - Gutenberg editor
  - WP Admin