### PR TITLE
A4A: Add VIP agency tier badges.

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx
@@ -1,4 +1,4 @@
-import { JetpackLogo } from '@automattic/components';
+import { JetpackLogo, VIPLogo } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/product-logos/pressable.svg';
@@ -89,6 +89,18 @@ function DownloadLink( {
 				name: translate( 'Pressable Premier Agency Partner' ),
 				href: 'https://automattic.com/wp-content/uploads/2025/08/agency_tier_pressable_premier_partner.zip',
 				icon: <img src={ PressableLogo } alt="Pressable" />,
+			},
+		},
+		vip: {
+			'vip-pro-agency-partner': {
+				name: translate( 'Pro Agency Partner' ),
+				href: 'https://automattic.wordpress.com/wp-content/uploads/2026/01/agency_tier_vip_vip_pro_partner.zip',
+				icon: <VIPLogo width={ 57 } height={ 25 } />,
+			},
+			'premier-partner': {
+				name: translate( 'Premier Agency Partner' ),
+				href: 'https://automattic.wordpress.com/wp-content/uploads/2026/01/agency_tier_vip_premier_partner.zip',
+				icon: <VIPLogo width={ 57 } height={ 25 } />,
 			},
 		},
 	};

--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx
@@ -38,7 +38,10 @@ export default function DownloadBadges( {
 		dispatch( recordTracksEvent( 'calypso_a8c_agency_tier_badges_download_modal_open' ) );
 	};
 
-	if ( ! partnerDirectories.length || ! currentAgencyTier ) {
+	const isVIPAgencyTier =
+		currentAgencyTier === 'vip-pro-agency-partner' || currentAgencyTier === 'premier-partner';
+
+	if ( ( ! isVIPAgencyTier && ! partnerDirectories.length ) || ! currentAgencyTier ) {
 		return null;
 	}
 
@@ -85,6 +88,10 @@ export default function DownloadBadges( {
 									currentAgencyTier={ currentAgencyTier }
 								/>
 							) ) }
+
+							{ isVIPAgencyTier && (
+								<DownloadLink product="vip" currentAgencyTier={ currentAgencyTier } />
+							) }
 						</div>
 					</div>
 				</A4AThemedModal>

--- a/client/a8c-for-agencies/sections/agency-tier/types.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/types.ts
@@ -2,6 +2,7 @@ export type AgencyTier =
 	| 'emerging-partner'
 	| 'agency-partner'
 	| 'pro-agency-partner'
+	| 'vip-pro-agency-partner'
 	| 'premier-partner';
 
 export interface AgencyTierCelebrationModal {

--- a/client/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors.ts
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 import { availableLanguages } from '../../lib/available-languages';
-import { DirectoryApplicationType } from '../../types';
 
 export function reverseMap< T >( obj: Record< string, T > ): Record< string, string > {
 	return Object.fromEntries( Object.entries( obj ).map( ( [ key, value ] ) => [ value, key ] ) );
@@ -64,7 +63,7 @@ export function useFormSelectors() {
 		pressable: 'Pressable',
 	};
 
-	const availableDirectories: Record< DirectoryApplicationType, string > = {
+	const availableDirectories: Record< string, string > = {
 		wordpress: 'WordPress.com',
 		woocommerce: 'WooCommerce.com',
 		jetpack: 'Jetpack.com',

--- a/client/a8c-for-agencies/sections/partner-directory/types.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/types.ts
@@ -1,6 +1,11 @@
 export type AgencyDirectoryApplicationStatus = 'pending' | 'in-progress' | 'completed';
 
-export type DirectoryApplicationType = 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable';
+export type DirectoryApplicationType =
+	| 'wordpress'
+	| 'jetpack'
+	| 'woocommerce'
+	| 'pressable'
+	| 'vip';
 
 export interface AgencyDirectoryApplication {
 	products: string[];


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1991/tiers-allow-download-of-vip-premier-and-vip-pro-partner-badges

## Proposed Changes

This pull request adds support for VIP agency tiers and their badge downloads in the agency tier badge download modal. The main changes involve introducing new VIP agency tiers, updating logic to handle these tiers, and enabling VIP badge downloads.

**VIP Agency Tier Support:**

* Added new agency tier values: `'vip-pro-agency-partner'` and updated type definitions to include VIP tiers (`client/a8c-for-agencies/sections/agency-tier/types.ts`).
* Updated the `DirectoryApplicationType` to include `'vip'` to support VIP-related directory applications (`client/a8c-for-agencies/sections/partner-directory/types.ts`).

**Badge Download Functionality:**

* Added VIP badge download links and icons to the `DownloadLink` component, enabling users in VIP tiers to download their respective badges (`client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx`). [[1]](diffhunk://#diff-448cd032cb99be1c61daa0de6a7700536ab2bd8f7d2927608d8cbac7a44ce9c5L1-R1) [[2]](diffhunk://#diff-448cd032cb99be1c61daa0de6a7700536ab2bd8f7d2927608d8cbac7a44ce9c5R94-R105)
* Updated the badge download modal logic to recognize VIP agency tiers and display the appropriate download options (`client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx`). [[1]](diffhunk://#diff-f9773a8b31de6b355789e11e30bdc3691984be0f6e3acc7cbf35d3bc9203729cL41-R44) [[2]](diffhunk://#diff-f9773a8b31de6b355789e11e30bdc3691984be0f6e3acc7cbf35d3bc9203729cR91-R94)

<img width="380" height="214" alt="Screenshot 2026-01-13 at 5 55 33 PM" src="https://github.com/user-attachments/assets/5adb1726-e4c7-4b3f-a85a-957597a2d781" />
<img width="367" height="209" alt="Screenshot 2026-01-13 at 5 55 55 PM" src="https://github.com/user-attachments/assets/734d38f7-d344-4c03-b7fc-936bfc7239fb" />


## Why are these changes being made?

* This is to allow our VIP agency to download their tier badge.

## Testing Instructions

* First, set your agency's tier to either VIP Pro Partner or Premier Partner in the MC.
* Use the A4A live link and navigate to `/agency-tier`
* Scroll down and click the `Download your badge` button.
   <img width="793" height="301" alt="Screenshot 2026-01-13 at 6 04 49 PM" src="https://github.com/user-attachments/assets/0755343e-80b7-489d-ab7e-6a76e14ef4a3" />

* Confirm you see the VIP download link button.
* Click and confirm you are able to download the file.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
