### PR TITLE
A4A: Do not display Missing Payment setting notice when still fetching.

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
@@ -9,14 +9,14 @@ import './style.scss';
 export const MissingPaymentSettingsNotice = ( { isFullWidth }: { isFullWidth?: boolean } ) => {
 	const translate = useTranslate();
 
-	const { data: tipaltiData, isFetching } = useGetTipaltiPayee();
+	const { data: tipaltiData, isFetching, isError } = useGetTipaltiPayee();
 	const isPayable = tipaltiData?.IsPayable;
 
 	const { data: referrals } = useFetchReferrals();
 
 	const hasReferrals = !! referrals?.length;
 
-	if ( isFetching || isPayable || ! hasReferrals ) {
+	if ( isFetching || isError || isPayable || ! hasReferrals ) {
 		return null;
 	}
 

--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
@@ -9,14 +9,14 @@ import './style.scss';
 export const MissingPaymentSettingsNotice = ( { isFullWidth }: { isFullWidth?: boolean } ) => {
 	const translate = useTranslate();
 
-	const { data: tipaltiData } = useGetTipaltiPayee();
+	const { data: tipaltiData, isFetching } = useGetTipaltiPayee();
 	const isPayable = tipaltiData?.IsPayable;
 
 	const { data: referrals } = useFetchReferrals();
 
 	const hasReferrals = !! referrals?.length;
 
-	if ( isPayable || ! hasReferrals ) {
+	if ( isFetching || isPayable || ! hasReferrals ) {
 		return null;
 	}
 

--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
@@ -9,40 +9,40 @@ import './style.scss';
 export const MissingPaymentSettingsNotice = ( { isFullWidth }: { isFullWidth?: boolean } ) => {
 	const translate = useTranslate();
 
-	const { data: tipaltiData, isFetching, isError } = useGetTipaltiPayee();
+	const { data: tipaltiData, isSuccess: isDataReady } = useGetTipaltiPayee();
 	const isPayable = tipaltiData?.IsPayable;
 
 	const { data: referrals } = useFetchReferrals();
 
 	const hasReferrals = !! referrals?.length;
 
-	if ( isFetching || isError || isPayable || ! hasReferrals ) {
-		return null;
+	if ( isDataReady && ! isPayable && hasReferrals ) {
+		return (
+			<LayoutBanner
+				isFullWidth={ isFullWidth }
+				level="warning"
+				title={ translate( 'Add your payment information to get paid' ) }
+				className="missing-payment-settings-notice"
+				allowTemporaryDismissal
+				preferenceName="missing-payment-settings-notice-dismissed"
+				hideCloseButton
+			>
+				<div>
+					{ translate(
+						"You've successfully made a client referral and will be due future commissions. Add your payment details to get paid."
+					) }
+				</div>
+				<Button
+					className="missing-payment-settings-notice__button is-dark"
+					href="/referrals/payment-settings"
+				>
+					{ translate( 'Add your payment information' ) }
+				</Button>
+			</LayoutBanner>
+		);
 	}
 
-	return (
-		<LayoutBanner
-			isFullWidth={ isFullWidth }
-			level="warning"
-			title={ translate( 'Add your payment information to get paid' ) }
-			className="missing-payment-settings-notice"
-			allowTemporaryDismissal
-			preferenceName="missing-payment-settings-notice-dismissed"
-			hideCloseButton
-		>
-			<div>
-				{ translate(
-					"You've successfully made a client referral and will be due future commissions. Add your payment details to get paid."
-				) }
-			</div>
-			<Button
-				className="missing-payment-settings-notice__button is-dark"
-				href="/referrals/payment-settings"
-			>
-				{ translate( 'Add your payment information' ) }
-			</Button>
-		</LayoutBanner>
-	);
+	return null;
 };
 
 export default MissingPaymentSettingsNotice;


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1955/add-payout-information-banner-displaying-even-when-information-is

## Proposed Changes
This pull request refines the rendering logic of the `MissingPaymentSettingsNotice` component to ensure the notice only appears when referral data and payee data are fully loaded, and the payee is not eligible for payment but has referrals.

Improvements to conditional rendering:

* Updated the condition to display the notice only when `isDataReady` is true, the payee is not payable, and there are referrals, preventing premature or unnecessary rendering.
* Moved the `return null` statement to the end of the component to clarify that the banner is only rendered under the new condition.
## Why are these changes being made?
* This ensure we are displaying the notice on the right time and not confuse users.

## Testing Instructions

* This is a bit hard to test, but the easiest thing to do is to spin up this branch locally and modify the following lines:
```

	if ( isDataReady && ! isPayable && hasReferrals ) {
```
to
```
        // Force to always have no payables for testing purpose
         if ( isDataReady && hasReferrals ) {
```
* Navigate to http://agencies.localhost:3000/overview
* Confirm that the notice only displays after fetching is done or there is not error on fetching.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
