### PR TITLE
Themes: Hide commercial support link if unknown

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -688,10 +688,14 @@ class ThemeSheet extends Component {
 				{ /* Wrap the content in another <span> to prevent truncation. */ }
 				<span style={ { whiteSpace: 'pre-wrap' } }>
 					{ translate( 'This theme offers additional paid commercial upgrades or support.' ) }
-					&nbsp;
-					<ExternalLink href={ external_support_url } style={ { color: 'inherit' } }>
-						{ translate( 'View support' ) }
-					</ExternalLink>
+					{ external_support_url && (
+						<>
+							&nbsp;
+							<ExternalLink href={ external_support_url } style={ { color: 'inherit' } }>
+								{ translate( 'View support' ) }
+							</ExternalLink>
+						</>
+					) }
 				</span>
 			</Badge>
 		);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTTHEM-152

## Proposed Changes

Only displays the support link if it is included and truthy in the API.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Themes from WordPress.org which are tagged as commercial themes display a support link to learn more about paid support offerings. The link text was being displayed even when a given commercial theme did not supply a support link. Clicking on it just took the user back to the same page.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use the calypso live link below
2. Go to a commercial theme that provides a support link, e.g. /theme/fse-gamer
3. Note a message towards the top of the page saying "This theme offers additional paid commercial upgrades or support. View support↗". Check that the link works
4. Go to a commercial theme that doesn't provide a support link, e.g. /theme/organic-honey
5. Note a message also appears to the top, but it says "This theme offers additional paid commercial upgrades or support." i.e. no support link.

Before | After
-------|------
<img width="758" height="339" alt="Screenshot 2026-01-13 at 14 21 09" src="https://github.com/user-attachments/assets/04202a8f-87d8-4f15-96f5-ba3d8ce31ef7" /> | <img width="758" height="339" alt="Screenshot 2026-01-13 at 14 20 34" src="https://github.com/user-attachments/assets/f4f417e1-9e5a-4a11-83a3-dafadf000338" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
