### PR TITLE
A4A: Fix issue with Dev license flow not adding item to cart.

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -236,7 +236,7 @@ function chooseAddHandler( {
 
 	// A4A checkout handles products directly via replaceProductsInCart in the checkout component
 	// so we should not try to add products from localStorage or other sources
-	if ( sitelessCheckoutType === 'a4a' ) {
+	if ( sitelessCheckoutType === 'a4a' && isLoggedOutCart ) {
 		return 'doNotAdd';
 	}
 


### PR DESCRIPTION
Follow up on https://github.com/Automattic/wp-calypso/pull/107734

## Proposed Changes

* This PR fixes a bug with the Dev license flow not adding to the cart. The `DoNotAdd` flow should only be applied to logged-out flows.

## Why are these changes being made?

* This causes a broken flow and need to be fixed.

## Testing Instructions

* Create a dev WPCOM site.
* Launch the site
* Use the A4A live link and replace the checkout URL. e.g. `/marketplace/checkout/zealousninja.wpcomstaging.com/a4a_wp_bundle_business_yearly`
* Confirm you see the cart item getting loaded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
