### PR TITLE
MSD: Fix crash when reading site.capabilities on non-admin sites

### DIFF
--- a/client/dashboard/plugins/manage/hooks/use-sites-by-id.ts
+++ b/client/dashboard/plugins/manage/hooks/use-sites-by-id.ts
@@ -13,7 +13,7 @@ export const useSitesById = () => {
 	}
 
 	const sitesById = sites
-		.filter( ( site ) => site.capabilities.update_plugins )
+		.filter( ( site ) => site.capabilities?.update_plugins )
 		.reduce( ( acc, site ) => {
 			acc.set( site.ID, site );
 			return acc;

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -95,7 +95,7 @@ export const usePlugin = ( pluginSlug: string ) => {
 
 	const [ sitesWithThisPlugin, sitesWithoutThisPlugin ]: [ SiteWithPluginData[], Site[] ] = sites
 		? sites
-				.filter( ( site ) => site.capabilities.update_plugins )
+				.filter( ( site ) => site.capabilities?.update_plugins )
 				.reduce(
 					( acc, site ) => {
 						if ( siteIdsWithThisPlugin.includes( site.ID ) ) {

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -86,7 +86,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 			) }
 			{ supports.sites &&
 				supports.sites.settings &&
-				site.capabilities.manage_options &&
+				site.capabilities?.manage_options &&
 				! isSelfHostedJetpackConnected( site ) && (
 					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
 						{ __( 'Settings' ) }

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -50,7 +50,7 @@ export interface Site {
 		ico: string;
 	};
 	plan?: SitePlan;
-	capabilities: SiteCapabilities;
+	capabilities?: SiteCapabilities;
 	subscribers_count: number;
 	options?: SiteOptions; // Can be undefined for deleted sites.
 	is_a4a_dev_site: boolean;


### PR DESCRIPTION
Fixes DOTMSD-1028

## Proposed Changes

`site.capabilities` is not present for sites where our role is not admin. @arthur791004 also discovered this fact [here](https://github.com/Automattic/wp-calypso/pull/107344/changes#r2567423061). This PR updates all remaining unguarded references to `site.capabilities` to prevent crashes.

Unfortunately, I have not been able to  actually reproduce the specific crash as shown in the Sentry issue; it seems it is the result of some edge case of TanStack query cache state where the user's capability was updated by another admin. 🤔 

## Testing Instructions

Smoke test MSD; verify it works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
