### PR TITLE
A4A: Fix incorrect login redirect for A4A express checkout.

### DIFF
--- a/client/my-sites/checkout/src/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/src/lib/contact-validation.tsx
@@ -45,6 +45,7 @@ const getEmailTakenLoginRedirectMessage = (
 	const { href, pathname } = window.location;
 	const isJetpackCheckout = pathname.includes( '/checkout/jetpack' );
 	const isAkismetCheckout = pathname.includes( '/checkout/akismet' );
+	const isA4AExpressCheckout = pathname.includes( '/checkout/agency/referral' );
 	const isGiftingCheckout = pathname.includes( '/gift/' );
 
 	// Users with a WP.com account should return to the checkout page
@@ -52,7 +53,7 @@ const getEmailTakenLoginRedirectMessage = (
 	// checkout -> login -> checkout.
 	const currentURLQueryParameters = Object.fromEntries( new URL( href ).searchParams.entries() );
 	const redirectTo =
-		isJetpackCheckout || isAkismetCheckout || isGiftingCheckout
+		isJetpackCheckout || isAkismetCheckout || isGiftingCheckout || isA4AExpressCheckout
 			? addQueryArgs( { ...currentURLQueryParameters, flow: 'coming_from_login' }, pathname )
 			: '/checkout/no-site?cart=no-user';
 


### PR DESCRIPTION
Depends on 199041-ghe-Automattic/wpcom
Follow up on https://github.com/Automattic/wp-calypso/pull/107734

## Proposed Changes

This pull request updates the email taken login redirect logic to support an additional checkout flow. Specifically, it ensures users in the Agency Express Referral checkout flow are redirected back to the correct page after logging in.

* Checkout flow handling:
  * Updated the `getEmailTakenLoginRedirectMessage` function in `contact-validation.tsx` to recognize the `/checkout/agency/referral` path as a valid checkout flow and include it in the redirect logic.

## Why are these changes being made?

* The login redirect is causing broken flow for A4A express checkout.

## Testing Instructions

* Apply and point your sandbox to this patch: 199041-ghe-Automattic/wpcom
* Create a referral order from existing BD client email.
* Copy the referral link.
* Use the A4A live link and replace the domain (e.g. https://wordpress.com/checkout/agency/referral > https://<A4ALIVELINK>/checkout/agency/referral
* Submit Country information and continue payment.
* Click the `Please login` link
   <img width="599" height="130" alt="Screenshot 2026-01-13 at 11 27 16 PM" src="https://github.com/user-attachments/assets/b5707478-5020-4303-8733-720dbf0393a4" />
* Continue to login with the email
* Confirm that after you login, you are redirected back to the express checkout link.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?