### PR TITLE
Fix text locators on form submission tests

### DIFF
--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -108,16 +108,23 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 		it( 'Submit first form', async function () {
 			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).click();
 
-			await page.getByText( /Thank you for your response\./ ).waitFor( { timeout: 20 * 1000 } );
+			await page
+				// TODO: "Thank you for your response" changed to "Your message has been sent" in the latest version of the plugin.
+				// Eventually we can remove the "Thank you for your response" option and just use "Your message has been sent" (we don't check for emojis).
+				.getByText( /Thank you for your response\.|Your message has been sent/ )
+				.waitFor( { timeout: 20 * 1000 } );
 		} );
 
 		it( 'Verify "← Back" link appears', async function () {
-			// The "← Back" can be either a link or button depending on the implementation
-			await page.getByRole( 'button', { name: /Back/ } ).waitFor();
+			// TODO: "back" link changed from "Go back" to "← Back" in the latest version of the plugin.
+			// Eventually we can remove the "Go back" option and just use "Back" (we don't check for emojis).
+			await page.getByRole( 'button', { name: /Back|Go back/ } ).waitFor();
 		} );
 
 		it( 'Click "← Back" to return to form', async function () {
-			await page.getByRole( 'button', { name: /Back/ } ).click();
+			// TODO: "back" link changed from "Go back" to "← Back" in the latest version of the plugin.
+			// Eventually we can remove the "Go back" option and just use "Back" (we don't check for emojis).
+			await page.getByRole( 'button', { name: /Back|Go back/ } ).click();
 			// Verify the form is visible again and the success message is hidden
 			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).waitFor();
 			// Wait for the success message to be hidden
@@ -153,7 +160,11 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).click();
 
 			// Wait for the success message to become visible (not just exist)
-			await page.getByText( /Thank you for your response\./ ).waitFor( { timeout: 20 * 1000 } );
+			await page
+				// TODO: "Thank you for your response" changed to "Your message has been sent" in the latest version of the plugin.
+				// Eventually we can remove the "Thank you for your response" option and just use "Your message has been sent" (we don't check for emojis).
+				.getByText( /Thank you for your response\.|Your message has been sent/ )
+				.waitFor( { timeout: 20 * 1000 } );
 		} );
 	} );
 

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -108,16 +108,16 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 		it( 'Submit first form', async function () {
 			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).click();
 
-			await page.getByText( 'Thank you for your response. ✨' ).waitFor( { timeout: 20 * 1000 } );
+			await page.getByText( /Thank you for your response\./ ).waitFor( { timeout: 20 * 1000 } );
 		} );
 
-		it( 'Verify "Go back" link appears', async function () {
-			// The "Go back" can be either a link or button depending on the implementation
-			await page.getByText( 'Go back', { exact: true } ).waitFor();
+		it( 'Verify "← Back" link appears', async function () {
+			// The "← Back" can be either a link or button depending on the implementation
+			await page.getByRole( 'button', { name: /Back/ } ).waitFor();
 		} );
 
-		it( 'Click "Go back" to return to form', async function () {
-			await page.getByText( 'Go back', { exact: true } ).click();
+		it( 'Click "← Back" to return to form', async function () {
+			await page.getByRole( 'button', { name: /Back/ } ).click();
 			// Verify the form is visible again and the success message is hidden
 			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).waitFor();
 			// Wait for the success message to be hidden
@@ -153,9 +153,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await publishedFormLocator.getByRole( 'button', { name: 'Send' } ).click();
 
 			// Wait for the success message to become visible (not just exist)
-			await page
-				.getByText( 'Your message has been sent' )
-				.waitFor( { state: 'visible', timeout: 20 * 1000 } );
+			await page.getByText( /Thank you for your response\./ ).waitFor( { timeout: 20 * 1000 } );
 		} );
 	} );
 


### PR DESCRIPTION
Remove emojis from locators and use regexes, some instances will swap emojis for imgs. Also, use the same locator on second form submit

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #108095 

## Proposed Changes

Use regexes on some locators as the emojis can be swaped for img tags on some instances.

## Why are these changes being made?
Because tests were failing yet the render was the expected one.

## Testing Instructions

Run:

```
yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
