### PR TITLE
MSD Domains: Do not show primary domain badge within general list

### DIFF
--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -39,7 +39,7 @@ const defaultView = {
 function Domains() {
 	const { user } = useAuth();
 	const { queries } = useAppContext();
-	const fields = useFields();
+	const fields = useFields( { showPrimaryDomainBadge: false } );
 	const { data: sites } = useQuery( queries.sitesQuery() );
 	const actions = useActions( { user, sites } );
 	const searchParams = domainsIndexRoute.useSearch();


### PR DESCRIPTION
Closes DOTMSD-944.

## Proposed Changes

We're showing "Primary site address" below every domain in `/v2/domains` while we shouldn't, since we're not in the site context.

This was causing issues for unattached domains (i.e., domain-only sites) and rendering misleading information, as reported in the Linear issue.

## Testing Instructions

Purchase a domain and don't attach it to a site. Enter `/v2/domains` and verify you don't see the "Primary site address" below it, with the "Attach site" link to the right.
