### PR TITLE
Dashboard: Improve plugins screen scrolling behavior

### DIFF
--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -1,8 +1,13 @@
-// For pages without sub menus, the first header is the sticky header
-// For pages with sub menus, the second header is the sticky header
-.dashboard-root__layout:not(:has(main > .dashboard-header-bar)) > .dashboard-header-bar,
-.dashboard-root__layout > main > .dashboard-header-bar {
+// Primary header - always sticky at top
+.dashboard-root__layout > .dashboard-header-bar {
 	position: sticky;
 	top: 0;
-	z-index: 3; // DataViews header seems to have z-index: 1; CalloutOverlay has z-index: 2
+	z-index: 4; // Above secondary header
+}
+
+// Secondary header - sticky below primary (65px = header height)
+.dashboard-root__layout > main > .dashboard-header-bar {
+	position: sticky;
+	top: 65px;
+	z-index: 3;
 }

--- a/client/dashboard/components/header-bar/style.scss
+++ b/client/dashboard/components/header-bar/style.scss
@@ -8,6 +8,9 @@ $component-icon-padding: 6px;
 
 .dashboard-header-bar {
 	box-sizing: border-box;
+	// Consistent height prevents gaps when stacking sticky headers
+	// padding (12px * 2) + content (40px) + border (1px) = 65px
+	min-height: calc(#{$grid-unit-15} * 2 + 40px + #{$border-width});
 	padding-block: $grid-unit-15;
 	padding-inline: calc(#{$grid-unit-20} - #{$component-icon-padding}); // Adjust for 6px padding on icons.
 	border-bottom: $border-width solid var( --dashboard-header__border-color );

--- a/client/dashboard/plugins/manage/components/plugin-sites.scss
+++ b/client/dashboard/plugins/manage/components/plugin-sites.scss
@@ -1,4 +1,4 @@
-@import './variables.scss';
+@import '@wordpress/base-styles/variables';
 
 .plugin-icon-placeholder {
 	width: 32px;
@@ -14,11 +14,22 @@ img.plugin-icon {
 	height: 32px;
 }
 
+.plugin-sites-card {
+	position: sticky;
+	// Position below both sticky headers (65px each) + page padding
+	top: calc(65px * 2 + #{$grid-unit-40});
+	// Max height to fit within viewport below both headers
+	max-height: calc(100vh - 65px * 2 - #{$grid-unit-40} * 2);
+	display: flex;
+	flex-direction: column;
+}
+
 .plugin-sites-card-body {
-	max-height: $card-height;
 	padding-inline-start: 0;
 	padding-inline-end: 0;
 	overflow-y: auto;
+	flex: 1;
+	min-height: 0; // Allow flex child to shrink below content size
 }
 
 .plugin-sites-card-header {

--- a/client/dashboard/plugins/manage/components/plugin-sites.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-sites.tsx
@@ -41,7 +41,7 @@ export const PluginSites = ( { selectedPluginSlug }: { selectedPluginSlug: strin
 	}, [ isLoadingPlugin, plugin, selectedPluginSlug ] );
 
 	return (
-		<Card>
+		<Card className="plugin-sites-card">
 			<CardBody className="plugin-sites-card-body">
 				<SectionHeader
 					className="plugin-sites-card-header"

--- a/client/dashboard/plugins/manage/components/plugin-switcher.scss
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.scss
@@ -1,5 +1,3 @@
-@import './variables.scss';
-
 .plugin-icon-wrapper {
 	border-radius: 4px;
 	overflow: clip;
@@ -26,9 +24,7 @@
 }
 
 .plugin-switcher-card-body {
-	max-height: $card-height;
 	padding: 8px 0 0;
-	overflow-y: auto;
 }
 
 .plugin-switcher-search {

--- a/client/dashboard/plugins/manage/components/plugin-switcher.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.tsx
@@ -1,5 +1,4 @@
 import { __experimentalVStack as VStack, Icon } from '@wordpress/components';
-import { throttle } from '@wordpress/compose';
 import { Field, View } from '@wordpress/dataviews';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { plugins as pluginIcon } from '@wordpress/icons';
@@ -32,47 +31,40 @@ export const PluginSwitcher = ( {
 	onChangeView: Dispatch< SetStateAction< View > >;
 	paginationInfo: { totalItems: number; totalPages: number };
 } ) => {
-	const scrollRef = useRef< HTMLDivElement >( null );
+	const sentinelRef = useRef< HTMLDivElement >( null );
 	const [ itemsPerPage ] = useState( view.perPage );
 
-	// Load next page when scrolling near bottom
+	// Load more items when sentinel becomes visible
 	const handleLoadMore = useCallback( () => {
-		if ( ! paginationInfo ) {
+		if ( ! paginationInfo || paginationInfo.totalPages <= 1 ) {
 			return;
 		}
 
-		if ( paginationInfo.totalPages > 1 ) {
-			onChangeView( ( currentView ) => ( {
-				...currentView,
-				// @ts-expect-error: perPage can't be undefined
-				perPage: currentView.perPage + itemsPerPage, // Accumulate items
-			} ) );
-		}
+		onChangeView( ( currentView ) => ( {
+			...currentView,
+			// @ts-expect-error: perPage can't be undefined
+			perPage: currentView.perPage + itemsPerPage,
+		} ) );
 	}, [ paginationInfo, onChangeView, itemsPerPage ] );
 
-	// Set up scroll listener
+	// Use Intersection Observer to detect when sentinel is visible
 	useEffect( () => {
-		const menuElement = scrollRef.current;
-
-		if ( ! menuElement || ! paginationInfo ) {
+		const sentinel = sentinelRef.current;
+		if ( ! sentinel || ! paginationInfo ) {
 			return;
 		}
 
-		const handleScroll = throttle( () => {
-			const scrollTop = menuElement.scrollTop;
-			const scrollHeight = menuElement.scrollHeight;
-			const clientHeight = menuElement.clientHeight;
-			// Load more when within 100px of bottom
-			if ( scrollTop + clientHeight >= scrollHeight - 100 ) {
-				handleLoadMore();
-			}
-		}, 100 );
+		const observer = new IntersectionObserver(
+			( entries ) => {
+				if ( entries[ 0 ].isIntersecting ) {
+					handleLoadMore();
+				}
+			},
+			{ rootMargin: '100px' } // Load more when within 100px of viewport
+		);
 
-		// Initial check in case content is shorter than container
-		handleScroll();
-
-		menuElement.addEventListener( 'scroll', handleScroll );
-		return () => menuElement.removeEventListener( 'scroll', handleScroll );
+		observer.observe( sentinel );
+		return () => observer.disconnect();
 	}, [ handleLoadMore, paginationInfo ] );
 
 	const itemClassName = useCallback(
@@ -146,7 +138,7 @@ export const PluginSwitcher = ( {
 
 	return (
 		<Card>
-			<CardBody className="plugin-switcher-card-body" ref={ scrollRef }>
+			<CardBody className="plugin-switcher-card-body">
 				<SwitcherContent
 					itemAlignment="start"
 					itemClassName={ itemClassName }
@@ -175,6 +167,8 @@ export const PluginSwitcher = ( {
 					}
 					filterField={ updatesField }
 				/>
+				{ /* Sentinel for infinite scroll - loads more when this becomes visible */ }
+				{ paginationInfo.totalPages > 1 && <div ref={ sentinelRef } aria-hidden="true" /> }
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/plugins/manage/components/variables.scss
+++ b/client/dashboard/plugins/manage/components/variables.scss
@@ -1,4 +1,0 @@
-// take into account header and nav plus border (64+1), page layout padding (32),
-// page title/description (80), gap between title/description and the cards (32),
-// and select button border (1)
-$card-height: calc(100vh - 2 * ( 64px + 1px ) - 2 * 32px - 80px - 32px - 1px);


### PR DESCRIPTION
Remove viewport-constrained scrolling from the plugins manage screen. The page now scrolls naturally, with the right column (plugin details) being sticky below the header bar with internal scrolling.


https://github.com/user-attachments/assets/321ee1d2-73a5-441e-bd5f-12c49e1e0c69

