### PR TITLE
Dashboard: use siteTypeSupportsFeature for site list actions

### DIFF
--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -6,6 +6,7 @@ import { lazy, Suspense } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { siteDomainsRoute } from '../../app/router/sites';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
+import { siteTypeSupportsFeature } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { canManageSite, canLeaveSite, canRestoreSite } from '../features';
 import type { Site } from '@automattic/api-core';
@@ -57,7 +58,8 @@ export function useActions(): Action< Site >[] {
 
 				router.navigate( { to: siteDomainsRoute.fullPath, params: { siteSlug: site.slug } } );
 			},
-			isEligible: ( item: Site ) => ! isSelfHostedJetpackConnected( item ) && canManageSite( item ),
+			isEligible: ( item: Site ) =>
+				siteTypeSupportsFeature( item, 'domains' ) && canManageSite( item ),
 		},
 		{
 			id: 'jetpack-cloud',
@@ -92,7 +94,8 @@ export function useActions(): Action< Site >[] {
 				const site = sites[ 0 ];
 				router.navigate( { to: '/sites/$siteSlug/settings', params: { siteSlug: site.slug } } );
 			},
-			isEligible: ( item: Site ) => ! isSelfHostedJetpackConnected( item ) && canManageSite( item ),
+			isEligible: ( item: Site ) =>
+				siteTypeSupportsFeature( item, 'settings' ) && canManageSite( item ),
 		},
 		{
 			id: 'restore',


### PR DESCRIPTION
## Proposed Changes

- Use `siteTypeSupportsFeature` to gate Domains and Settings actions in the site list dataviews

## Why are these changes being made?

The site list actions (Domains, Settings) were using `isSelfHostedJetpackConnected()` directly. This change uses `siteTypeSupportsFeature()` for consistency with the site menu and to properly handle different site types:

- **Self-hosted Jetpack**: hides Domains/Settings (all features false)
- **Commerce Garden**: shows Domains/Settings (domains/settings true)
- **Regular WPCOM**: shows Domains/Settings (all features true)

## Testing Instructions

1. Go to the sites list at `/sites`
2. For a **regular WPCOM site**: click the actions menu → should show Domains and Settings
3. For a **self-hosted Jetpack connected site**: click the actions menu → should NOT show Domains or Settings (shows Jetpack Cloud instead)
4. For a **Commerce Garden site** (e.g., `*.commerce-garden.com`): click the actions menu → should show Domains and Settings

Test in both:
- Dashboard: `my.localhost:3000/sites`
- Backport: `calypso.localhost:3000/sites`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?