### PR TITLE
MSD: Add wrap support for ActionListItem and IconListItem

### DIFF
--- a/client/dashboard/components/action-list/action-item.tsx
+++ b/client/dashboard/components/action-list/action-item.tsx
@@ -7,7 +7,7 @@ import type { ActionItemProps } from './types';
 import './action-item.scss';
 
 function UnforwardedActionItem(
-	{ title, description, decoration, actions, className }: ActionItemProps,
+	{ title, description, decoration, actions, className, wrap }: ActionItemProps,
 	ref: React.ForwardedRef< HTMLSpanElement >
 ) {
 	return (
@@ -27,6 +27,7 @@ function UnforwardedActionItem(
 				</ButtonStack>
 			}
 			ref={ ref }
+			wrap={ wrap }
 		/>
 	);
 }

--- a/client/dashboard/components/icon-list/icon-list-item.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.tsx
@@ -10,7 +10,15 @@ import type { IconListItemProps } from './types';
 import './icon-list-item.scss';
 
 function UnforwardedIconListItem(
-	{ title, description, decoration, suffix, className, density = 'medium' }: IconListItemProps,
+	{
+		title,
+		description,
+		decoration,
+		suffix,
+		className,
+		density = 'medium',
+		wrap = false,
+	}: IconListItemProps,
 	ref: React.ForwardedRef< HTMLSpanElement >
 ) {
 	const densitySpacingMap = {
@@ -29,7 +37,7 @@ function UnforwardedIconListItem(
 		<VStack className={ clsx( 'icon-list-item', className ) } ref={ ref } as="span">
 			<HStack spacing={ iconSpacing } alignment={ alignment } as="span">
 				{ !! decoration && <span className="icon-list-item__decoration">{ decoration }</span> }
-				<HStack spacing={ suffixSpacing } as="span">
+				<HStack spacing={ suffixSpacing } as="span" wrap={ wrap }>
 					<VStack spacing={ textSpacing } as="span">
 						<Text weight={ 500 } lineHeight="24px" size={ titleSize }>
 							{ title }

--- a/client/dashboard/components/icon-list/types.ts
+++ b/client/dashboard/components/icon-list/types.ts
@@ -33,7 +33,7 @@ export interface IconListItemProps {
 	 */
 	density?: 'low' | 'medium' | 'high';
 	/**
-	 * Controls whether the item content should wrap when it exceeds the container width.
+	 * Controls whether the suffix element should wrap.
 	 */
 	/**
 	 * Controls whether the item content should wrap when it exceeds the container width.

--- a/client/dashboard/components/icon-list/types.ts
+++ b/client/dashboard/components/icon-list/types.ts
@@ -35,6 +35,10 @@ export interface IconListItemProps {
 	/**
 	 * Controls whether the item content should wrap when it exceeds the container width.
 	 */
+	/**
+	 * Controls whether the item content should wrap when it exceeds the container width.
+	 * @default false
+	 */
 	wrap?: boolean;
 }
 

--- a/client/dashboard/components/icon-list/types.ts
+++ b/client/dashboard/components/icon-list/types.ts
@@ -34,9 +34,6 @@ export interface IconListItemProps {
 	density?: 'low' | 'medium' | 'high';
 	/**
 	 * Controls whether the suffix element should wrap.
-	 */
-	/**
-	 * Controls whether the item content should wrap when it exceeds the container width.
 	 * @default false
 	 */
 	wrap?: boolean;

--- a/client/dashboard/components/icon-list/types.ts
+++ b/client/dashboard/components/icon-list/types.ts
@@ -32,6 +32,10 @@ export interface IconListItemProps {
 	 * @default 'medium'
 	 */
 	density?: 'low' | 'medium' | 'high';
+	/**
+	 * Controls whether the item content should wrap when it exceeds the container width.
+	 */
+	wrap?: boolean;
 }
 
 export interface IconListProps {


### PR DESCRIPTION
Part of DOTMSD-1008

More context: p9Jlb4-glF-p2#comment-15535

## Proposed Changes

Allow us to set wrap on the IconListItem so we can control it's mobile behavior in parent components.
We don't have a way to control when the `suffix` wraps. We therefore get some really strained layouts on small devices.

| Before | After |
|--------|--------|
| <img width="378" height="163" alt="Screenshot 2026-01-14 at 11 21 57 AM" src="https://github.com/user-attachments/assets/5290bb0d-f4dc-4090-b0a8-1660e160435e" /> | <img width="376" height="169" alt="Screenshot 2026-01-14 at 11 24 10 AM" src="https://github.com/user-attachments/assets/43f3a8d2-53ec-4372-a1c4-17ca1b159b66" /> | 

_The change above is not made in this PR, it will be made in a follow-up_.


## Why not wrap by default?

Since we render this as a list, and we don't control widths of the left or right container, we can get actions wrapping earlier than others. That means we can have a state where some buttons are under the content and some on still right aligned. 


## Testing Instructions
1. Add wrap to `ActionList.ActionItem` in client/dashboard/me/profile-deletion/index.jsx`
2. Change you browser size.
3.  Notice the button wraps.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
