### PR TITLE
Refactor Help Center persistence to batch updates

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -13,7 +13,7 @@ import type {
 } from './types';
 
 export function setHelpCenterRouterHistory(
-	history: { entries: Location[]; index: number } | undefined
+	history: { entries: Location[]; index: number } | null
 ) {
 	return {
 		type: 'HELP_CENTER_SET_HELP_CENTER_ROUTER_HISTORY',
@@ -176,7 +176,7 @@ export const setShowHelpCenter = function* (
 	if ( ! show ) {
 		yield setNavigateToRoute( undefined );
 		// Reset the local navigation history when closing the help center.
-		yield setHelpCenterRouterHistory( undefined );
+		yield setHelpCenterRouterHistory( null );
 		return {
 			type: 'HELP_CENTER_SET_SHOW',
 			show: false,

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -59,9 +59,9 @@ const showMessagingLauncher: Reducer< boolean | undefined, HelpCenterAction > = 
 };
 
 const helpCenterRouterHistory: Reducer<
-	{ entries: Location[]; index: number } | undefined,
+	{ entries: Location[]; index: number } | null,
 	HelpCenterAction
-> = ( state, action ) => {
+> = ( state = null, action ) => {
 	switch ( action.type ) {
 		case 'HELP_CENTER_SET_HELP_CENTER_ROUTER_HISTORY':
 			return action.history;

--- a/packages/data-stores/src/help-center/resolvers.ts
+++ b/packages/data-stores/src/help-center/resolvers.ts
@@ -23,7 +23,13 @@ export function* getHelpCenterPreferences() {
 				path: '/me/preferences',
 				apiNamespace: 'wpcom/v2',
 			} );
-			yield setHelpCenterPreferences( preferences[ 'calypso_preferences' ] );
+			// project the preferences to the expected shape
+			const projectedPreferences = {
+				help_center_open: preferences.calypso_preferences.help_center_open,
+				help_center_minimized: preferences.calypso_preferences.help_center_minimized,
+				help_center_router_history: preferences.calypso_preferences.help_center_router_history,
+			};
+			yield setHelpCenterPreferences( projectedPreferences );
 		} else {
 			const preferences: Preferences[ 'calypso_preferences' ] = yield apiFetch( {
 				global: true,


### PR DESCRIPTION
## Summary

- Refactors `persistHelpCenterField` to `persistHelpCenterFields` to accept the entire preferences object instead of individual key-value pairs
- Updates `subscribeToPersist` to batch preference changes and persist them in a single call instead of multiple separate calls for each field
- Projects only relevant Help Center preferences in the resolver to avoid storing unrelated data

## Test plan

- [ ] Open Help Center and verify state persists across page reloads
- [ ] Minimize Help Center and verify minimized state persists
- [ ] Navigate within Help Center and verify router history persists
- [ ] Test as logged-out user to verify localStorage persistence works