### PR TITLE
Customer Home: Rename Quick Links card to Piña Colada

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -287,7 +287,7 @@ export const QuickLinks = ( {
 		<FoldableCard
 			className="quick-links customer-home__card"
 			headerTagName="h2"
-			header={ translate( 'Quick links' ) }
+			header={ translate( 'Piña Colada' ) }
 			clickableHeader
 			expanded={ isSiteLaunched ? externalIsExpanded : false }
 			onOpen={ () => debouncedUpdateHomeQuickLinksToggleStatus( 'expanded' ) }


### PR DESCRIPTION
## Summary
- Renamed the Quick Links foldable card to "Piña Colada" in the My Home page

## Test plan
- Run the dev server and open the local dev environment
- Go to freesite651's home (URL should be `/home/freesite651.wordpress.com`)
- Verify you see the "Piña Colada" foldable card below the site preview