### PR TITLE
HC: mark recent unread conversations

### DIFF
--- a/packages/help-center/src/components/help-center-recent-conversations.scss
+++ b/packages/help-center/src/components/help-center-recent-conversations.scss
@@ -15,3 +15,23 @@
 		margin-bottom: 8px;
 	}
 }
+
+// Dot indicator for unread conversations
+.summary-button.has-unread-conversation {
+	.summary-button-strapline {
+		position: relative;
+		padding-left: 12px;
+
+		&::before {
+			content: '';
+			position: absolute;
+			left: 0;
+			top: 50%;
+			transform: translateY(-50%);
+			width: 6px;
+			height: 6px;
+			border-radius: 50%;
+			background-color: #e65054;
+		}
+	}
+}

--- a/packages/help-center/src/components/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/help-center-recent-conversations.tsx
@@ -45,9 +45,13 @@ const HelpCenterRecentConversations: React.FC = () => {
 	).toISOString();
 
 	const chatLink = getChatLinkFromConversation( recentConversation );
+	const isUnread =
+		'participants' in recentConversation &&
+		( recentConversation.participants?.[ 0 ]?.unreadCount ?? 0 ) > 0;
 
 	return (
 		<SummaryButton
+			className={ isUnread ? 'has-unread-conversation' : '' }
 			strapline={ __( 'Recent Conversation', __i18n_text_domain__ ) }
 			title={ lastMessage.text || '' }
 			description={

--- a/packages/help-center/src/components/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/help-center-recent-conversations.tsx
@@ -3,6 +3,7 @@ import { TimeSince } from '@automattic/components';
 import SummaryButton from '@automattic/components/src/summary-button';
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
+import clsx from 'clsx';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
@@ -51,7 +52,9 @@ const HelpCenterRecentConversations: React.FC = () => {
 
 	return (
 		<SummaryButton
-			className={ isUnread ? 'has-unread-conversation' : '' }
+			className={ clsx( {
+				'has-unread-conversation': isUnread,
+			} ) }
 			strapline={ __( 'Recent Conversation', __i18n_text_domain__ ) }
 			title={ lastMessage.text || '' }
 			description={


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

| Before  | After |
| ------------- | ------------- |
| <img width="416" height="711" alt="Screenshot 2026-01-14 at 16 09 56" src="https://github.com/user-attachments/assets/ff83ff22-cc61-456f-a151-21dcc6268f14" />  |  <img width="420" height="710" alt="Screenshot 2026-01-14 at 16 09 36" src="https://github.com/user-attachments/assets/7fbb1f84-430a-4fc6-ac18-a7068d0bce4d" /> |

Part of #DOTCOM-15372

## Proposed Changes

* Add dot indicator for unread recent conversations

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improved UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Send a message from support to your testing user, so that you have unread message
* Open the help center, it should have the unread indicator in recent conversations
* Click on that card and you show navigate to the conversation
* Go back to the help center home, the indicator should not show now

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
