### PR TITLE
Plugins redesign: Address design review feedback

### DIFF
--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -388,8 +388,10 @@ const EducationFooter = () => {
 
 function ReadMoreLink() {
 	const { __ } = useI18n();
+	const isMarketplaceRedesignEnabled = useIsMarketplaceRedesignEnabled();
+	const color = isMarketplaceRedesignEnabled ? 'var(--studio-gray-50)' : 'var(--studio-blue-50)';
 
-	return <CardText color="var(--studio-blue-50)">{ __( 'Learn more' ) }</CardText>;
+	return <CardText color={ color }>{ __( 'Learn more' ) }</CardText>;
 }
 
 export default EducationFooter;

--- a/client/my-sites/plugins/plugins-banners/business-plan-banner/style.scss
+++ b/client/my-sites/plugins/plugins-banners/business-plan-banner/style.scss
@@ -79,6 +79,10 @@
 		}
 	}
 
+	.full-width-section & li {
+		margin-bottom: 0;
+	}
+
 	@media ( min-width: $break-small ) {
 		font-size: $font-body-large;
 	}

--- a/client/my-sites/plugins/plugins-banners/telex-banner/style.scss
+++ b/client/my-sites/plugins/plugins-banners/telex-banner/style.scss
@@ -50,8 +50,17 @@
 	font-size: $font-body-large;
 	line-height: 1.5;
 	margin-bottom: 24px;
-	color: var( --studio-gray-80 );
+	color: var( --studio-gray-90 );
 	max-width: 400px;
+}
+
+@keyframes blink {
+	0%, 100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0;
+	}
 }
 
 .components-button.telex-banner__cta {
@@ -66,10 +75,10 @@
 	&::after {
 		content: "|";
 		margin-left: 5px;
-		opacity: 0.6;
 		vertical-align: text-bottom;
 		font-size: 115%;
 		margin-top: -4px;
+		animation: blink 1s step-end infinite;
 	}
 
 	@media ( min-width: $break-small ) {

--- a/client/my-sites/plugins/plugins-banners/telex-banner/style.scss
+++ b/client/my-sites/plugins/plugins-banners/telex-banner/style.scss
@@ -63,6 +63,14 @@
 	}
 }
 
+@media ( prefers-reduced-motion: reduce ) {
+	@keyframes blink {
+		0%, 100% {
+			opacity: 1;
+		}
+	}
+}
+
 .components-button.telex-banner__cta {
 	width: fit-content;
 	font-size: $font-body;

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -180,7 +180,7 @@ body.is-section-plugins #primary .main.is-logged-out {
 		top: 0;
 		left: 50%;
 		width: 50%;
-		min-width: 848px;
+		min-width: 700px;
 		height: 100%;
 		background-image: url(/calypso/images/plugins/plugins_hero_2.svg);
 		background-position: right bottom;
@@ -192,6 +192,9 @@ body.is-section-plugins #primary .main.is-logged-out {
 			left: 0;
 			min-width: 0;
 			width: 100%;
+		}
+		@media screen and ( max-width: $break-large ) {
+			min-width: 848px;
 		}
 	}
 
@@ -237,4 +240,14 @@ body.is-section-plugins #primary .main.is-logged-out {
 }
 .plugins-discovery-page__business-plan-banner {
 	padding-bottom: 2px;
+}
+
+// Swap hover states for education footer cards (marketplace-redesign)
+// Default is lighter, hover increases contrast
+.full-width-section .plugin-how-to-guides .card-block > div {
+	filter: brightness(102%);
+
+	&:hover {
+		filter: brightness(100%);
+	}
 }

--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -38,6 +38,7 @@
 			.plugins-results-header__subtitle {
 				font-size: $font-body-large;
 				line-height: 1.4;
+				color: var(--studio-gray-80);
 			}
 		}
 		.plugins-browser__category-results & {

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -257,10 +257,17 @@ main.is-logged-out .full-width-section .full-width-section__content .search-box-
 	.components-search-control .components-input-base {
 		border-radius: 4px;
 	}
+	.components-input-base:focus-within .components-input-control__backdrop {
+		border-color: var(--studio-blue-50);
+	}
+	input[type="search"]:focus {
+		outline: none;
+	}
 	.search-box-header__header {
 		font-size: rem(70px);
 		line-height: 1;
 		margin-bottom: 6px;
+		color: var(--studio-gray-100);
 
 		@media (max-width: 660px) {
 			font-size: rem(60px);
@@ -268,6 +275,7 @@ main.is-logged-out .full-width-section .full-width-section__content .search-box-
 	}
 	.search-box-header__subtitle {
 		font-size: rem(18px);
+		color: var(--studio-gray-80);
 	}
 
 	&.fixed-top .search-box-header__search {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -759,6 +759,7 @@ body.is-section-plugins #primary {
 
 	.feature-item-container__content {
 		font-size: $font-body;
+		color: var(--studio-gray-50);
 	}
 }
 


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOTDEV-273/evaluate-the-design-through-a-brand-lens
Implementation review: BwSzqN2tZikisxcHhpuj3W-fi-3452_21257

## Proposed Changes

- Update typography colors for better contrast (header gray-100, subtitles gray-80)
- Fix search input focus styling with single blue-50 border
- Add blinking cursor animation to Telex banner CTA
- Swap hover states on education footer cards (light → dark)
- Update "Learn more" links and feature item descriptions to gray-50
- Remove spacing between business plan banner list items

## Why are these changes being made?

Addresses design review feedback on the marketplace redesign implementation to improve visual consistency and contrast across the page.

## Testing Instructions

1. Visit `/plugins?flags=marketplace-redesign`
2. Verify the header "Plug into possibility" is gray-100
3. Verify subtitles are gray-80
4. Click on search input and verify single blue focus border
5. Scroll to Telex banner and verify the blinking cursor on the CTA button
6. Hover over "Get started with plugins" cards and verify they darken on hover
7. Verify "Learn more" text is gray-50
8. Verify feature descriptions in marketplace footer are gray-50

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?