### PR TITLE
Revert "Domain Search: Hide free subdomain if user searches for an FQDN"

### DIFF
--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -6,13 +6,12 @@ import { SearchNotice } from '../components/search-notice';
 import { SearchResults } from '../components/search-results';
 import { SkipSuggestion } from '../components/skip-suggestion';
 import { UnavailableSearchResult } from '../components/unavailable-search-result';
-import { getTld } from '../helpers/get-tld';
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
 import { useDomainSearch } from './context';
 
 export const ResultsPage = () => {
-	const { slots, config, query } = useDomainSearch();
+	const { slots, config } = useDomainSearch();
 
 	const {
 		isLoading: isLoadingSuggestions,
@@ -21,7 +20,6 @@ export const ResultsPage = () => {
 	} = useSuggestionsList();
 	const numberOfInitialVisibleSuggestions =
 		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
-	const isFqdnQuery = !! getTld( query );
 
 	useRequestTracking();
 
@@ -33,7 +31,7 @@ export const ResultsPage = () => {
 			</VStack>
 			{ slots?.BeforeResults && <slots.BeforeResults /> }
 			<VStack spacing={ 4 }>
-				{ config.skippable && ! isFqdnQuery && (
+				{ config.skippable && (
 					<>{ isLoadingSuggestions ? <SkipSuggestion.Placeholder /> : <SkipSuggestion /> }</>
 				) }
 				{ ! isLoadingSuggestions && <UnavailableSearchResult /> }

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -682,33 +682,6 @@ describe( 'ResultsPage', () => {
 				await screen.findByLabelText( 'Skip purchase and continue with site.wordpress.com' )
 			).toBeInTheDocument();
 		} );
-
-		it( 'does not render the skip suggestion when searching for a FQDN', async () => {
-			mockGetSuggestionsQuery( {
-				params: { query: 'test.com' },
-				suggestions: [ buildSuggestion( { domain_name: 'test.com' } ) ],
-			} );
-
-			mockGetAvailabilityQuery( {
-				params: { domainName: 'test.com' },
-				availability: buildAvailability( {
-					domain_name: 'test.com',
-					status: DomainAvailabilityStatus.AVAILABLE,
-				} ),
-			} );
-
-			render(
-				<TestDomainSearch config={ { skippable: true } } query="test.com">
-					<ResultsPage />
-				</TestDomainSearch>
-			);
-
-			expect( await screen.findByTitle( 'test.com' ) ).toBeInTheDocument();
-			expect( screen.queryByLabelText( 'Loading free domain suggestion' ) ).not.toBeInTheDocument();
-			expect(
-				screen.queryByRole( 'button', { name: /Skip purchase and continue/i } )
-			).not.toBeInTheDocument();
-		} );
 	} );
 
 	describe( 'tracking', () => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#108091 due to failing E2E test