### PR TITLE
Fix Form dashboard locators on response action and navigation

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -94,7 +94,7 @@ export class FeedbackInboxPage {
 				.or( this.page.getByRole( 'textbox', { name: 'Search responses' } ) )
 				.fill( search );
 			await this.page
-				.getByRole( 'tab', { name: 'Inbox', exact: false, disabled: false } )
+				.getByRole( 'tab', { name: /Inbox\s+[\d,.]*/, exact: false, disabled: false } )
 				.or( this.page.getByRole( 'radio', { name: /^Inbox\s*\([\d,]+\)$/ } ) )
 				.waitFor();
 			return;
@@ -110,7 +110,7 @@ export class FeedbackInboxPage {
 		await this.page.getByRole( 'searchbox', { name: 'Search' } ).fill( search );
 		await responseRequestPromise;
 		await this.page
-			.getByRole( 'tab', { name: 'Inbox', exact: false, disabled: false } )
+			.getByRole( 'tab', { name: /Inbox\s+[\d,.]*/, exact: false, disabled: false } )
 			.or( this.page.getByRole( 'radio', { name: /^Inbox\s*\([\d,]+\)$/ } ) )
 			.waitFor();
 	}
@@ -141,10 +141,12 @@ export class FeedbackInboxPage {
 
 	/**
 	 * Clicks on a folder tab (Inbox, Spam, or Trash).
+	 * State changes are handled client-side in the UI store, so we just need a small
+	 * buffer for the UI to update - no need to wait for API responses.
 	 *
-	 * @param {string} folderName The name of the folder to click (e.g., 'Inbox', 'Spam', 'Trash').
+	 * @param {string | RegExp} folderName The name of the folder to click (e.g., 'Inbox', 'Spam', 'Trash'). Can also be a regular expression.
 	 */
-	async clickFolderTab( folderName: string ): Promise< void > {
+	async clickFolderTab( folderName: string | RegExp ): Promise< void > {
 		const tablist = this.page.getByRole( 'tablist' );
 		await tablist.getByRole( 'tab', { name: folderName } ).click();
 		await this.page.waitForTimeout( 500 ); // Wait for the data to load

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -94,7 +94,7 @@ export class FeedbackInboxPage {
 				.or( this.page.getByRole( 'textbox', { name: 'Search responses' } ) )
 				.fill( search );
 			await this.page
-				.getByRole( 'tab', { name: /Inbox\s+[\d,.]*/, exact: false, disabled: false } )
+				.getByRole( 'tab', { name: 'Inbox', exact: false, disabled: false } )
 				.or( this.page.getByRole( 'radio', { name: /^Inbox\s*\([\d,]+\)$/ } ) )
 				.waitFor();
 			return;
@@ -110,7 +110,7 @@ export class FeedbackInboxPage {
 		await this.page.getByRole( 'searchbox', { name: 'Search' } ).fill( search );
 		await responseRequestPromise;
 		await this.page
-			.getByRole( 'tab', { name: /Inbox\s+[\d,.]*/, exact: false, disabled: false } )
+			.getByRole( 'tab', { name: 'Inbox', exact: false, disabled: false } )
 			.or( this.page.getByRole( 'radio', { name: /^Inbox\s*\([\d,]+\)$/ } ) )
 			.waitFor();
 	}
@@ -144,9 +144,9 @@ export class FeedbackInboxPage {
 	 * State changes are handled client-side in the UI store, so we just need a small
 	 * buffer for the UI to update - no need to wait for API responses.
 	 *
-	 * @param {string | RegExp} folderName The name of the folder to click (e.g., 'Inbox', 'Spam', 'Trash'). Can also be a regular expression.
+	 * @param {string} folderName The name of the folder to click (e.g., 'Inbox', 'Spam', 'Trash').
 	 */
-	async clickFolderTab( folderName: string | RegExp ): Promise< void > {
+	async clickFolderTab( folderName: string ): Promise< void > {
 		const tablist = this.page.getByRole( 'tablist' );
 		await tablist.getByRole( 'tab', { name: folderName } ).click();
 		await this.page.waitForTimeout( 500 ); // Wait for the data to load

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -238,7 +238,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			if ( isInSpam ) {
 				// Clear search first to show all responses
 				await feedbackInboxPage.clearSearch( true );
-				await feedbackInboxPage.clickFolderTab( /Inbox\s*[\d,.]*/ );
+				await feedbackInboxPage.clickFolderTab( 'Inbox' );
 				// Wait for folder change to complete and data to reload
 				await page.waitForTimeout( 2000 );
 				// Search again for the first response in Inbox
@@ -304,7 +304,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			if ( isInSpam ) {
 				// Clear search first to show all responses
 				await feedbackInboxPage.clearSearch( true );
-				await feedbackInboxPage.clickFolderTab( /Inbox\s*[\d,.]*/ );
+				await feedbackInboxPage.clickFolderTab( 'Inbox' );
 				// Wait for folder change to complete
 				await page.waitForTimeout( 1000 );
 				// Search again for the second response in Inbox
@@ -413,7 +413,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			// Use a retry loop since there can be a delay between the action completing
 			// and the item being available in the Spam folder
 			const verifyInSpam = async () => {
-				await feedbackInboxPage.clickFolderTab( /Spam\s*[\d,.]*/ );
+				await feedbackInboxPage.clickFolderTab( 'Spam' );
 				await feedbackInboxPage.searchResponses( formData1.email );
 				// Verify the response appears in search results by checking for a row with the name
 				await page
@@ -483,7 +483,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			// Use a retry loop since there can be a delay between the action completing
 			// and the item being available in the Trash folder
 			const verifyInTrash = async () => {
-				await feedbackInboxPage.clickFolderTab( /Trash\s*[\d,.]*/ );
+				await feedbackInboxPage.clickFolderTab( 'Trash' );
 				await feedbackInboxPage.searchResponses( formData1.email, true );
 				await page
 					.locator( '.dataviews-view-table__row' )
@@ -517,7 +517,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			// Use a retry loop since there can be a delay between the action completing
 			// and the item being available in the Inbox folder
 			const verifyRestoredInInbox = async () => {
-				await feedbackInboxPage.clickFolderTab( /Inbox\s*[\d,.]*/ );
+				await feedbackInboxPage.clickFolderTab( 'Inbox' );
 				await feedbackInboxPage.searchResponses( formData1.email, true );
 				await page
 					.locator( '.dataviews-view-table__row' )

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -202,8 +202,8 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			// So we loop over a search attempt on the email, looking for a folder tab with a result in it!
 			const searchAndClickFolderWithResult = async () => {
 				await feedbackInboxPage.searchResponses( formData1.email );
-				const tabLocator = page
-					.getByRole( 'tab', { name: /(Inbox|Spam) 1/ } )
+				const tabLocator = await page
+					.getByRole( 'tab', { name: /(Inbox|Spam)\s+1/ } )
 					.or( page.getByRole( 'radio', { name: /(Inbox|Spam)\s*\(\s*1\s*\)/ } ) );
 				await tabLocator.click( { timeout: 4000 } );
 				// Check if we're in spam folder
@@ -449,7 +449,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			// Use a retry loop since there can be a delay between the action completing
 			// and the item being available in the Inbox folder
 			const verifyInInbox = async () => {
-				await feedbackInboxPage.clickFolderTab( /Inbox\s+[\d,.]*/ );
+				await feedbackInboxPage.clickFolderTab( 'Inbox' );
 				await feedbackInboxPage.searchResponses( formData1.email, true );
 				await page
 					.locator( '.dataviews-view-table__row' )

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -238,7 +238,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			if ( isInSpam ) {
 				// Clear search first to show all responses
 				await feedbackInboxPage.clearSearch( true );
-				await feedbackInboxPage.clickFolderTab( 'Inbox' );
+				await feedbackInboxPage.clickFolderTab( /Inbox\s*[\d,.]*/ );
 				// Wait for folder change to complete and data to reload
 				await page.waitForTimeout( 2000 );
 				// Search again for the first response in Inbox
@@ -304,7 +304,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			if ( isInSpam ) {
 				// Clear search first to show all responses
 				await feedbackInboxPage.clearSearch( true );
-				await feedbackInboxPage.clickFolderTab( 'Inbox' );
+				await feedbackInboxPage.clickFolderTab( /Inbox\s*[\d,.]*/ );
 				// Wait for folder change to complete
 				await page.waitForTimeout( 1000 );
 				// Search again for the second response in Inbox
@@ -409,12 +409,34 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await feedbackInboxPage.clickMarkAsSpamAction();
 		} );
 
-		it( 'Navigate to Spam folder', async function () {
-			await feedbackInboxPage.clickFolderTab( 'Spam' );
-		} );
-
 		it( 'Verify first response is in Spam', async function () {
-			await feedbackInboxPage.searchResponses( formData1.email );
+			// Use a retry loop since there can be a delay between the action completing
+			// and the item being available in the Spam folder
+			const verifyInSpam = async () => {
+				await feedbackInboxPage.clickFolderTab( /Spam\s*[\d,.]*/ );
+				await feedbackInboxPage.searchResponses( formData1.email );
+				// Verify the response appears in search results by checking for a row with the name
+				await page
+					.locator( '.dataviews-view-table__row' )
+					.filter( { hasText: formData1.name } )
+					.first()
+					.waitFor( { timeout: 3000 } );
+			};
+
+			const MAX_ATTEMPTS = 3;
+			for ( let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ ) {
+				try {
+					await verifyInSpam();
+					break;
+				} catch ( err ) {
+					if ( attempt === MAX_ATTEMPTS ) {
+						throw err;
+					}
+					// Wait before retrying to give backend time to propagate
+					await page.waitForTimeout( 1000 );
+				}
+			}
+
 			await feedbackInboxPage.clickResponseRowByText( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 		} );
@@ -423,12 +445,32 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await feedbackInboxPage.clickNotSpamAction();
 		} );
 
-		it( 'Navigate back to Inbox', async function () {
-			await feedbackInboxPage.clickFolderTab( 'Inbox' );
-		} );
-
 		it( 'Verify first response is back in Inbox', async function () {
-			await feedbackInboxPage.searchResponses( formData1.email, true );
+			// Use a retry loop since there can be a delay between the action completing
+			// and the item being available in the Inbox folder
+			const verifyInInbox = async () => {
+				await feedbackInboxPage.clickFolderTab( /Inbox\s+[\d,.]*/ );
+				await feedbackInboxPage.searchResponses( formData1.email, true );
+				await page
+					.locator( '.dataviews-view-table__row' )
+					.filter( { hasText: formData1.name } )
+					.first()
+					.waitFor( { timeout: 3000 } );
+			};
+
+			const MAX_ATTEMPTS = 3;
+			for ( let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ ) {
+				try {
+					await verifyInInbox();
+					break;
+				} catch ( err ) {
+					if ( attempt === MAX_ATTEMPTS ) {
+						throw err;
+					}
+					await page.waitForTimeout( 1000 );
+				}
+			}
+
 			await feedbackInboxPage.clickResponseRowByText( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 		} );
@@ -437,12 +479,32 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await feedbackInboxPage.clickMoveToTrashAction();
 		} );
 
-		it( 'Navigate to Trash folder', async function () {
-			await feedbackInboxPage.clickFolderTab( 'Trash' );
-		} );
-
 		it( 'Verify first response is in Trash', async function () {
-			await feedbackInboxPage.searchResponses( formData1.email, true );
+			// Use a retry loop since there can be a delay between the action completing
+			// and the item being available in the Trash folder
+			const verifyInTrash = async () => {
+				await feedbackInboxPage.clickFolderTab( /Trash\s*[\d,.]*/ );
+				await feedbackInboxPage.searchResponses( formData1.email, true );
+				await page
+					.locator( '.dataviews-view-table__row' )
+					.filter( { hasText: formData1.name } )
+					.first()
+					.waitFor( { timeout: 3000 } );
+			};
+
+			const MAX_ATTEMPTS = 3;
+			for ( let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ ) {
+				try {
+					await verifyInTrash();
+					break;
+				} catch ( err ) {
+					if ( attempt === MAX_ATTEMPTS ) {
+						throw err;
+					}
+					await page.waitForTimeout( 1000 );
+				}
+			}
+
 			await feedbackInboxPage.clickResponseRowByText( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 		} );
@@ -451,12 +513,32 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await feedbackInboxPage.clickRestoreAction();
 		} );
 
-		it( 'Navigate back to Inbox to confirm', async function () {
-			await feedbackInboxPage.clickFolderTab( 'Inbox' );
-		} );
-
 		it( 'Verify first response is restored in Inbox', async function () {
-			await feedbackInboxPage.searchResponses( formData1.email, true );
+			// Use a retry loop since there can be a delay between the action completing
+			// and the item being available in the Inbox folder
+			const verifyRestoredInInbox = async () => {
+				await feedbackInboxPage.clickFolderTab( /Inbox\s*[\d,.]*/ );
+				await feedbackInboxPage.searchResponses( formData1.email, true );
+				await page
+					.locator( '.dataviews-view-table__row' )
+					.filter( { hasText: formData1.name } )
+					.first()
+					.waitFor( { timeout: 3000 } );
+			};
+
+			const MAX_ATTEMPTS = 3;
+			for ( let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++ ) {
+				try {
+					await verifyRestoredInInbox();
+					break;
+				} catch ( err ) {
+					if ( attempt === MAX_ATTEMPTS ) {
+						throw err;
+					}
+					await page.waitForTimeout( 1000 );
+				}
+			}
+
 			await feedbackInboxPage.clickResponseRowByText( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 		} );


### PR DESCRIPTION

## Proposed Changes
Adapt the locators to use regexes since folder tabs show counts.

## Why are these changes being made?
Because tests were being flagged as flaky and mostly failing due to the locators searching for exact matches of "Inbox", "Spam" and "Trash", disregarding the responses count shown alongside the tab name

## Testing Instructions

Run:

```
yarn workspace wp-e2e-tests build && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="ecomm-plan" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile" ATOMIC_VARIATION="ecomm-plan" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="private" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile" ATOMIC_VARIATION="private" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" TEST_ON_ATOMIC="true" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts
```


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
