### PR TITLE
Update welcome modal link text to 'Take a video walkthrough'

### DIFF
--- a/client/dashboard/sites/welcome-modal/opt-in-welcome-modal.tsx
+++ b/client/dashboard/sites/welcome-modal/opt-in-welcome-modal.tsx
@@ -1,4 +1,5 @@
 import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
@@ -22,6 +23,7 @@ const preferenceName = 'hosting-dashboard-opt-in-welcome-modal-dismissed' as con
 
 export default function OptInWelcomeModal() {
 	const { recordTracksEvent } = useAnalytics();
+	const hasEnTranslation = useHasEnTranslation();
 	const isLargeViewport = useViewportMatch( 'small', '>=' );
 	const { data: isDismissedPersisted } = useSuspenseQuery( userPreferenceQuery( preferenceName ) );
 	const { mutate: updateDismissed, isPending: isDismissing } = useMutation(
@@ -70,7 +72,9 @@ export default function OptInWelcomeModal() {
 							recordTracksEvent( 'calypso_dashboard_opt_in_welcome_modal_tutorial_link_click' );
 						} }
 					>
-						{ __( 'Take a quick walkthrough' ) }
+						{ hasEnTranslation( 'Take a video walkthrough' )
+							? __( 'Take a video walkthrough' )
+							: __( 'Take a quick walkthrough' ) }
 					</ExternalLink>
 					<Spacer marginBottom={ 4 } />
 					<Button variant="primary" style={ { marginTop: 'auto' } } onClick={ handleDismiss }>


### PR DESCRIPTION
Part of DOTCOM-15700

## Proposed Changes

* Update the link text in the opt-in welcome modal from "Take a quick walkthrough" to "Take a video walkthrough"
* Use `hasEnTranslation` to gracefully fall back to the old string for non-English locales until the new translation is ready

## Why are these changes being made?

The link text should say "Take a video walkthrough" since it links to a YouTube video tutorial. This more accurately describes the content users will see when they click the link.

## Testing Instructions

1. Navigate to the Hosting Dashboard at `/sites`
2. If you haven't dismissed the welcome modal, you should see it appear
3. Verify the link text shows "Take a video walkthrough" (for English locale)
4. Click the link and verify it opens the YouTube tutorial

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)