### PR TITLE
Update hosting dashboard preference to use toggle switch

### DIFF
--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -1,165 +1,165 @@
 import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
+	FormToggle,
 	Button,
-	CheckboxControl,
-	__experimentalVStack as VStack,
+	Modal,
 	ExternalLink,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { DataForm } from '@wordpress/dataviews';
-import { useState, createInterpolateElement } from '@wordpress/element';
+import { useId, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useAnalytics } from '../../app/analytics';
+import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import FlashMessage from '../../components/flash-message';
-import { Notice } from '../../components/notice';
-import { SectionHeader } from '../../components/section-header';
 import { wpcomLink } from '../../utils/link';
-import type { Field } from '@wordpress/dataviews';
-
-interface OptInFormData {
-	enabled: boolean;
-}
-
-const form = {
-	layout: {
-		type: 'regular' as const,
-	},
-	fields: [ 'enabled' ],
-};
-
-const fields: Field< OptInFormData >[] = [
-	{
-		id: 'enabled',
-		label: __( 'I want to try the beta version.' ),
-		Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
-			return (
-				<CheckboxControl
-					__nextHasNoMarginBottom
-					checked={ field.getValue( { item: data } ) }
-					label={ hideLabelFromVision ? '' : field.label }
-					onChange={ ( value ) => {
-						onChange( { [ field.id ]: value } );
-					} }
-				/>
-			);
-		},
-	},
-];
 
 export default function PreferencesOptInForm() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
+	const toggleId = useId();
+
 	const { data: optIn } = useSuspenseQuery( userPreferenceQuery( 'hosting-dashboard-opt-in' ) );
 	const { mutate: saveOptInPreference, isPending } = useMutation(
 		userPreferenceMutation( 'hosting-dashboard-opt-in' )
 	);
-	const [ formData, setFormData ] = useState< OptInFormData >( {
-		enabled: optIn.value === 'opt-in',
-	} );
-	const [ isRedirecting, setIsRedirecting ] = useState( false );
 
-	const isDirty = formData.enabled !== ( optIn.value === 'opt-in' );
+	const isEnabled = optIn.value === 'opt-in';
+	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 
-	const handleSubmit = ( e: React.FormEvent ) => {
-		e.preventDefault();
+	const handleToggle = () => {
+		const newValue = ! isEnabled;
 
-		recordTracksEvent( 'calypso_dashboard_me_preferences_new_hosting_dashboard_submit', {
-			enabled: formData.enabled,
+		recordTracksEvent( 'calypso_dashboard_me_preferences_new_hosting_dashboard_toggle_click', {
+			enabled: newValue,
 		} );
+
+		if ( ! newValue ) {
+			// Show confirmation modal when disabling
+			setShowConfirmModal( true );
+		} else {
+			// Enable directly
+			saveOptInPreference(
+				{
+					value: 'opt-in',
+					updated_at: new Date().toISOString(),
+				},
+				{
+					onSuccess() {
+						createSuccessNotice( __( 'New Hosting Dashboard enabled.' ), { type: 'snackbar' } );
+					},
+					onError() {
+						createErrorNotice( __( 'Failed to enable new Hosting Dashboard.' ), {
+							type: 'snackbar',
+						} );
+					},
+				}
+			);
+		}
+	};
+
+	const handleConfirmOptOut = () => {
+		recordTracksEvent( 'calypso_dashboard_me_preferences_new_hosting_dashboard_opt_out_confirm' );
 
 		saveOptInPreference(
 			{
-				value: formData.enabled ? 'opt-in' : 'opt-out',
+				value: 'opt-out',
 				updated_at: new Date().toISOString(),
 			},
 			{
-				onSuccess( _, data ) {
-					if ( data?.value === 'opt-in' ) {
-						createSuccessNotice( __( 'New Hosting Dashboard enabled.' ), { type: 'snackbar' } );
-					} else {
-						setIsRedirecting( true );
-						window.location.href = wpcomLink( '/me/account?flash=dashboard' );
-					}
+				onSuccess() {
+					createSuccessNotice( __( 'New Hosting Dashboard disabled.' ), { type: 'snackbar' } );
+					window.location.href = wpcomLink( '/me/account' );
 				},
-				onError( _, data ) {
-					createErrorNotice(
-						data?.value === 'opt-in'
-							? __( 'Failed to enable new Hosting Dashboard.' )
-							: __( 'Failed to disable new Hosting Dashboard.' ),
-						{
-							type: 'snackbar',
-						}
-					);
+				onError() {
+					createErrorNotice( __( 'Failed to disable new Hosting Dashboard.' ), {
+						type: 'snackbar',
+					} );
+					setShowConfirmModal( false );
 				},
 			}
 		);
 	};
 
+	const handleCloseModal = () => {
+		setShowConfirmModal( false );
+	};
+
 	return (
-		<Card>
+		<>
 			<FlashMessage id="dashboard" message={ __( 'New Hosting Dashboard enabled.' ) } />
-			<CardBody>
-				<VStack as="form" onSubmit={ handleSubmit } spacing={ 4 } alignment="flex-start">
-					<SectionHeader
-						title={ __( 'Try the new Hosting Dashboard' ) }
-						description={ __(
-							'We’ve recently updated the dashboard with a modern design and smarter tools for managing your hosting.'
-						) }
-						level={ 3 }
-					/>
-					<DataForm< OptInFormData >
-						data={ formData }
-						fields={ fields }
-						form={ form }
-						onChange={ ( edits ) => {
-							if ( edits.hasOwnProperty( 'enabled' ) ) {
-								recordTracksEvent(
-									'calypso_dashboard_me_preferences_new_hosting_dashboard_toggle_click',
-									{
-										enabled: edits.enabled,
-									}
-								);
-							}
-							setFormData( ( current ) => ( { ...current, ...edits } ) );
-						} }
-					/>
-					{ ! formData.enabled && ( optIn.value === 'opt-in' || isRedirecting ) && (
-						<Notice title={ __( 'Prefer the previous version?' ) } variant="info">
-							{ createInterpolateElement(
-								__(
-									'<surveyLink>Please complete this short survey</surveyLink> to help us understand what didn’t work and how we can improve.'
-								),
-								{
-									surveyLink: (
-										<ExternalLink
-											href="https://automattic.survey.fm/msd-survey-for-opt-out"
-											onClick={ () =>
-												recordTracksEvent(
-													'calypso_dashboard_me_preferences_new_hosting_dashboard_survey_click'
-												)
-											}
-											children={ null }
-										/>
-									),
-								}
+			<Card>
+				<CardBody>
+					<VStack spacing={ 2 }>
+						<HStack alignment="top" justify="space-between">
+							<Text as="label" htmlFor={ toggleId } size="15px" weight={ 500 } lineHeight="20px">
+								{ __( 'Try the new Hosting Dashboard' ) }
+							</Text>
+							<FormToggle
+								id={ toggleId }
+								checked={ isEnabled }
+								onChange={ handleToggle }
+								disabled={ isPending }
+							/>
+						</HStack>
+						<Text variant="muted" lineHeight="20px">
+							{ __(
+								"We've recently updated the dashboard with a modern design and smarter tools for managing your hosting."
 							) }
-						</Notice>
-					) }
-					<Button
-						variant="primary"
-						type="submit"
-						__next40pxDefaultSize
-						accessibleWhenDisabled
-						isBusy={ isPending || isRedirecting }
-						disabled={ isPending || isRedirecting || ! isDirty }
-					>
-						{ __( 'Save' ) }
-					</Button>
-				</VStack>
-			</CardBody>
-		</Card>
+						</Text>
+					</VStack>
+				</CardBody>
+			</Card>
+
+			{ showConfirmModal && (
+				<Modal
+					title={ __( 'Disable the new dashboard?' ) }
+					onRequestClose={ handleCloseModal }
+					size="small"
+				>
+					<VStack spacing={ 6 }>
+						<Text>
+							{ __(
+								"We're actively working to make the new dashboard better. If something isn't working for you or you have ideas for improvement, we'd really appreciate hearing about it."
+							) }
+						</Text>
+						<Text>
+							{ __(
+								'Your feedback helps us understand what matters most and build a better experience for everyone.'
+							) }
+						</Text>
+						<ExternalLink
+							href="https://automattic.survey.fm/msd-survey-for-opt-out"
+							onClick={ () =>
+								recordTracksEvent(
+									'calypso_dashboard_me_preferences_new_hosting_dashboard_survey_click'
+								)
+							}
+						>
+							{ __( 'Take a quick survey' ) }
+						</ExternalLink>
+						<ButtonStack justify="flex-end">
+							<Button __next40pxDefaultSize variant="tertiary" onClick={ handleCloseModal }>
+								{ __( 'Keep using new dashboard' ) }
+							</Button>
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								onClick={ handleConfirmOptOut }
+								isBusy={ isPending }
+								disabled={ isPending }
+							>
+								{ __( 'Disable' ) }
+							</Button>
+						</ButtonStack>
+					</VStack>
+				</Modal>
+			) }
+		</>
 	);
 }

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -19,6 +19,8 @@ import { Card, CardBody } from '../../components/card';
 import FlashMessage from '../../components/flash-message';
 import { wpcomLink } from '../../utils/link';
 
+import './style.scss';
+
 export default function PreferencesOptInForm() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
@@ -93,26 +95,26 @@ export default function PreferencesOptInForm() {
 	return (
 		<>
 			<FlashMessage id="dashboard" message={ __( 'New Hosting Dashboard enabled.' ) } />
-			<Card>
+			<Card className="preferences-new-hosting-dashboard">
 				<CardBody>
-					<VStack spacing={ 2 }>
-						<HStack alignment="top" justify="space-between">
+					<HStack alignment="center" justify="space-between" spacing={ 4 }>
+						<VStack spacing={ 1 }>
 							<Text as="label" htmlFor={ toggleId } size="15px" weight={ 500 } lineHeight="20px">
-								{ __( 'Try the new Hosting Dashboard' ) }
+								{ __( 'New Hosting Dashboard' ) }
 							</Text>
-							<FormToggle
-								id={ toggleId }
-								checked={ isEnabled }
-								onChange={ handleToggle }
-								disabled={ isPending }
-							/>
-						</HStack>
-						<Text variant="muted" lineHeight="20px">
-							{ __(
-								"We've recently updated the dashboard with a modern design and smarter tools for managing your hosting."
-							) }
-						</Text>
-					</VStack>
+							<Text variant="muted" lineHeight="20px">
+								{ __(
+									"You're using the redesigned dashboard with a modern interface and smarter tools for managing your hosting. We're actively adding new features and improvements."
+								) }
+							</Text>
+						</VStack>
+						<FormToggle
+							id={ toggleId }
+							checked={ isEnabled }
+							onChange={ handleToggle }
+							disabled={ isPending }
+						/>
+					</HStack>
 				</CardBody>
 			</Card>
 

--- a/client/dashboard/me/preferences-new-hosting-dashboard/style.scss
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/style.scss
@@ -1,0 +1,7 @@
+@import "@wordpress/base-styles/variables";
+
+.preferences-new-hosting-dashboard {
+	.components-form-toggle {
+		margin-inline-end: $grid-unit-10;
+	}
+}

--- a/client/me/account/hosting-dashboard-opt-in-form.scss
+++ b/client/me/account/hosting-dashboard-opt-in-form.scss
@@ -1,0 +1,39 @@
+@import "@automattic/typography/styles/variables";
+
+.hosting-dashboard-opt-in {
+	&__row {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 16px;
+	}
+
+	&__content {
+		flex: 1;
+		min-width: 0;
+	}
+
+	&__label {
+		display: block;
+		font-size: 0.875rem;
+		font-weight: 600;
+		margin-bottom: 5px;
+		cursor: pointer;
+	}
+
+	&__description {
+		font-size: $font-body-small;
+		color: var(--color-text-subtle);
+		margin: 0;
+		font-style: italic;
+	}
+
+	&__survey {
+		margin-top: 24px;
+		margin-bottom: 0;
+	}
+
+	.components-form-toggle {
+		flex-shrink: 0;
+	}
+}

--- a/client/me/account/hosting-dashboard-opt-in-form.scss
+++ b/client/me/account/hosting-dashboard-opt-in-form.scss
@@ -1,36 +1,24 @@
 @import "@automattic/typography/styles/variables";
 
 .hosting-dashboard-opt-in {
-	&__row {
+	&__header {
 		display: flex;
-		align-items: flex-start;
+		align-items: center;
 		justify-content: space-between;
 		gap: 16px;
 	}
 
-	&__content {
-		flex: 1;
-		min-width: 0;
-	}
-
 	&__label {
-		display: block;
 		font-size: 0.875rem;
 		font-weight: 600;
-		margin-bottom: 5px;
 		cursor: pointer;
 	}
 
 	&__description {
 		font-size: $font-body-small;
 		color: var(--color-text-subtle);
-		margin: 0;
+		margin: 8px 0 0;
 		font-style: italic;
-	}
-
-	&__survey {
-		margin-top: 24px;
-		margin-bottom: 0;
 	}
 
 	.components-form-toggle {

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -1,11 +1,9 @@
-import { Card, FormLabel, ExternalLink } from '@automattic/components';
+import { Card, ExternalLink } from '@automattic/components';
+import { FormToggle } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import Banner from 'calypso/components/banner';
-import FormButton from 'calypso/components/forms/form-button';
-import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import SectionHeader from 'calypso/components/section-header';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -15,143 +13,116 @@ import {
 	getPreference,
 	isSavingPreference,
 	isFetchingPreferences,
-	preferencesLastSaveError,
 } from 'calypso/state/preferences/selectors';
 import type { HostingDashboardOptIn } from '@automattic/api-core';
+
+import './hosting-dashboard-opt-in-form.scss';
 
 export default function HostingDashboardOptInForm() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const toggleId = useId();
 
 	const savedPreference = useSelector(
 		( state ) => getPreference( state, 'hosting-dashboard-opt-in' ) as HostingDashboardOptIn | null
 	);
 	const isSaving = useSelector( isSavingPreference );
 	const isFetching = useSelector( isFetchingPreferences );
-	const lastSaveError = useSelector( preferencesLastSaveError );
-	const [ isRedirecting, setIsRedirecting ] = useState( false );
-	const [ enabled, setEnabled ] = useState( savedPreference?.value === 'opt-in' );
+
+	const isEnabled = savedPreference?.value === 'opt-in';
 
 	// We do not want the survey banner to disappear immediately after opting out
 	// is complete. This state is used to keep it around until the component is unmounted.
 	const [ optedOutThisMount, setOptedOutThisMount ] = useState( false );
 
-	const [ wasFetching, setWasFetching ] = useState( isFetching );
-	if ( isFetching !== wasFetching ) {
-		// Preferences have finished fetching
-		setEnabled( savedPreference?.value === 'opt-in' );
-		setWasFetching( isFetching );
-	}
-
-	const isDirty = enabled !== ( savedPreference?.value === 'opt-in' );
-
 	const showOptOutSurvey =
 		( isSaving && savedPreference?.value === 'opt-out' ) ||
 		( ! isSaving && savedPreference?.value === 'opt-out' && optedOutThisMount ) ||
-		( ! isSaving && ! enabled && savedPreference?.value === 'opt-in' );
+		( ! isSaving && ! isEnabled && savedPreference?.value === 'opt-in' );
 
-	const handleSubmit = async ( event: React.FormEvent ) => {
-		event.preventDefault();
+	const handleToggle = async () => {
+		const newValue = ! isEnabled;
 
 		dispatch(
-			recordTracksEvent( 'calypso_account_new_hosting_dashboard_submit', {
-				enabled,
+			recordTracksEvent( 'calypso_account_new_hosting_dashboard_toggle_click', {
+				enabled: newValue,
 			} )
 		);
 
 		const preference = {
-			value: enabled ? 'opt-in' : 'opt-out',
+			value: newValue ? 'opt-in' : 'opt-out',
 			updated_at: new Date().toISOString(),
 		} satisfies HostingDashboardOptIn;
 
-		await dispatch( savePreference( 'hosting-dashboard-opt-in', preference ) );
+		try {
+			await dispatch( savePreference( 'hosting-dashboard-opt-in', preference ) );
 
-		if ( lastSaveError ) {
-			dispatch(
-				errorNotice( translate( 'Failed to save preference.' ), {
-					duration: 5000,
-				} )
-			);
-		} else if ( enabled ) {
-			setIsRedirecting( true );
-			window.location.href = dashboardLink( '/me/preferences?flash=dashboard' );
-		} else {
-			dispatch(
-				successNotice( translate( 'Successfully saved preference.' ), {
-					duration: 5000,
-				} )
-			);
-			if ( ! enabled ) {
+			if ( newValue ) {
+				window.location.href = dashboardLink( '/me/preferences?flash=dashboard' );
+			} else {
+				dispatch(
+					successNotice( translate( 'New Hosting Dashboard disabled.' ), { duration: 5000 } )
+				);
 				setOptedOutThisMount( true );
 			}
+		} catch {
+			dispatch(
+				errorNotice(
+					newValue
+						? translate( 'Failed to enable new Hosting Dashboard.' )
+						: translate( 'Failed to disable new Hosting Dashboard.' ),
+					{ duration: 5000 }
+				)
+			);
 		}
 	};
 
 	return (
-		<>
-			<SectionHeader label={ translate( 'Try the new Hosting Dashboard' ) } />
-			<Card className="account__settings">
-				<form onSubmit={ handleSubmit }>
-					<p className="account__hosting-dashboard-description">
+		<Card className="account__settings hosting-dashboard-opt-in">
+			<div className="hosting-dashboard-opt-in__row">
+				<div className="hosting-dashboard-opt-in__content">
+					<label htmlFor={ toggleId } className="hosting-dashboard-opt-in__label">
+						{ translate( 'Try the new Hosting Dashboard' ) }
+					</label>
+					<p className="hosting-dashboard-opt-in__description">
 						{ translate(
-							'We’ve recently updated the dashboard with a modern design and smarter tools for managing your hosting.'
+							"We've recently updated the dashboard with a modern design and smarter tools for managing your hosting."
 						) }
 					</p>
-					<FormFieldset className="account__settings-admin-home">
-						<FormLabel>
-							<FormCheckbox
-								checked={ enabled }
-								disabled={ isFetching || isSaving }
-								onChange={ ( event ) => {
-									setEnabled( event.target.checked );
-									dispatch(
-										recordTracksEvent( 'calypso_account_new_hosting_dashboard_toggle_click', {
-											enabled: event.target.checked,
-										} )
-									);
-								} }
-							/>
-							<span>{ translate( 'I want to try the beta version.' ) }</span>
-						</FormLabel>
-					</FormFieldset>
-					{ showOptOutSurvey && (
-						<FormFieldset>
-							<Banner
-								title={ translate( 'Prefer the previous version?' ) }
-								showIcon={ false }
-								description={ translate(
-									'{{surveyLink}}Please complete this short survey{{/surveyLink}} to help us understand what didn’t work and how we can improve.',
-									{
-										components: {
-											surveyLink: (
-												<ExternalLink
-													href="https://automattic.survey.fm/msd-survey-for-opt-out"
-													icon
-													onClick={ () =>
-														dispatch(
-															recordTracksEvent(
-																'calypso_account_new_hosting_dashboard_survey_click'
-															)
-														)
-													}
-												/>
-											),
-										},
-									}
-								) }
-							/>
-						</FormFieldset>
-					) }
-					<FormButton
-						isSubmitting={ isSaving }
-						disabled={ isFetching || isSaving || ! isDirty }
-						busy={ isSaving || isRedirecting }
-						type="submit"
-					>
-						{ translate( 'Save' ) }
-					</FormButton>
-				</form>
-			</Card>
-		</>
+				</div>
+				<FormToggle
+					id={ toggleId }
+					checked={ isEnabled }
+					onChange={ handleToggle }
+					disabled={ isFetching || isSaving }
+				/>
+			</div>
+			{ showOptOutSurvey && (
+				<FormFieldset className="hosting-dashboard-opt-in__survey">
+					<Banner
+						title={ translate( 'Prefer the previous version?' ) }
+						showIcon={ false }
+						description={ translate(
+							"{{surveyLink}}Please complete this short survey{{/surveyLink}} to help us understand what didn't work and how we can improve.",
+							{
+								components: {
+									surveyLink: (
+										<ExternalLink
+											href="https://automattic.survey.fm/msd-survey-for-opt-out"
+											icon
+											onClick={ () =>
+												dispatch(
+													recordTracksEvent( 'calypso_account_new_hosting_dashboard_survey_click' )
+												)
+											}
+										/>
+									),
+								},
+							}
+						) }
+					/>
+				</FormFieldset>
+			) }
+		</Card>
 	);
 }

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -1,9 +1,7 @@
-import { Card, ExternalLink } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { FormToggle } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useId, useState } from 'react';
-import Banner from 'calypso/components/banner';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
+import { useId } from 'react';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -31,15 +29,6 @@ export default function HostingDashboardOptInForm() {
 
 	const isEnabled = savedPreference?.value === 'opt-in';
 
-	// We do not want the survey banner to disappear immediately after opting out
-	// is complete. This state is used to keep it around until the component is unmounted.
-	const [ optedOutThisMount, setOptedOutThisMount ] = useState( false );
-
-	const showOptOutSurvey =
-		( isSaving && savedPreference?.value === 'opt-out' ) ||
-		( ! isSaving && savedPreference?.value === 'opt-out' && optedOutThisMount ) ||
-		( ! isSaving && ! isEnabled && savedPreference?.value === 'opt-in' );
-
 	const handleToggle = async () => {
 		const newValue = ! isEnabled;
 
@@ -63,7 +52,6 @@ export default function HostingDashboardOptInForm() {
 				dispatch(
 					successNotice( translate( 'New Hosting Dashboard disabled.' ), { duration: 5000 } )
 				);
-				setOptedOutThisMount( true );
 			}
 		} catch {
 			dispatch(
@@ -79,17 +67,10 @@ export default function HostingDashboardOptInForm() {
 
 	return (
 		<Card className="account__settings hosting-dashboard-opt-in">
-			<div className="hosting-dashboard-opt-in__row">
-				<div className="hosting-dashboard-opt-in__content">
-					<label htmlFor={ toggleId } className="hosting-dashboard-opt-in__label">
-						{ translate( 'Try the new Hosting Dashboard' ) }
-					</label>
-					<p className="hosting-dashboard-opt-in__description">
-						{ translate(
-							"We've recently updated the dashboard with a modern design and smarter tools for managing your hosting."
-						) }
-					</p>
-				</div>
+			<div className="hosting-dashboard-opt-in__header">
+				<label htmlFor={ toggleId } className="hosting-dashboard-opt-in__label">
+					{ translate( 'Try the new Hosting Dashboard' ) }
+				</label>
 				<FormToggle
 					id={ toggleId }
 					checked={ isEnabled }
@@ -97,32 +78,11 @@ export default function HostingDashboardOptInForm() {
 					disabled={ isFetching || isSaving }
 				/>
 			</div>
-			{ showOptOutSurvey && (
-				<FormFieldset className="hosting-dashboard-opt-in__survey">
-					<Banner
-						title={ translate( 'Prefer the previous version?' ) }
-						showIcon={ false }
-						description={ translate(
-							"{{surveyLink}}Please complete this short survey{{/surveyLink}} to help us understand what didn't work and how we can improve.",
-							{
-								components: {
-									surveyLink: (
-										<ExternalLink
-											href="https://automattic.survey.fm/msd-survey-for-opt-out"
-											icon
-											onClick={ () =>
-												dispatch(
-													recordTracksEvent( 'calypso_account_new_hosting_dashboard_survey_click' )
-												)
-											}
-										/>
-									),
-								},
-							}
-						) }
-					/>
-				</FormFieldset>
-			) }
+			<p className="hosting-dashboard-opt-in__description">
+				{ translate(
+					"We've recently updated the dashboard with a modern design and smarter tools for managing your hosting."
+				) }
+			</p>
 		</Card>
 	);
 }

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -92,10 +92,6 @@
 	}
 }
 
-.account__hosting-dashboard-description {
-	font-size: $font-body-small;
-}
-
 main.account {
 	.email-verification-banner {
 		margin-bottom: 16px;


### PR DESCRIPTION
## Summary

Updates the hosting dashboard opt-in preference UI in both classic Calypso and the new dashboard:

- Replace checkbox + save button with an auto-saving toggle switch
- Toggle and title are now on the same line for a cleaner layout
- New dashboard shows a confirmation modal with survey link when disabling
- Classic Calypso has a simple toggle (no survey - that's only in the new dashboard)

## Before

<img width="1241" height="1084" alt="image" src="https://github.com/user-attachments/assets/f5a6611d-260f-4e9c-936a-32a35abee182" />

<img width="1241" height="1084" alt="image" src="https://github.com/user-attachments/assets/5dd91e1a-d4f1-4c8a-baf7-c2cd88bad733" />

<img width="1241" height="1084" alt="image" src="https://github.com/user-attachments/assets/2c3d4b08-8a26-4b75-a46c-7779e9e9e0cb" />

## After

<img width="1241" height="1084" alt="image" src="https://github.com/user-attachments/assets/5181ec20-fd38-4499-b991-2a07714a436c" />

<img width="1241" height="1084" alt="image" src="https://github.com/user-attachments/assets/4b0ef8df-25b8-45a9-9a04-3352c9a21684" />

<img width="1241" height="1084" alt="image" src="https://github.com/user-attachments/assets/c5d478c4-7b80-412f-a199-48e58c9536af" />


## Test plan

- [ ] Classic Calypso: Toggle on redirects to new dashboard
- [ ] Classic Calypso: Toggle off disables without survey
- [ ] New Dashboard: Toggle on enables immediately
- [ ] New Dashboard: Toggle off shows confirmation modal
- [ ] Confirmation modal: "Keep using new dashboard" closes modal
- [ ] Confirmation modal: "Disable" redirects to classic Calypso
- [ ] Survey link in modal tracks click event