### PR TITLE
Preferences: Add card-based UI for default landing page setting

### DIFF
--- a/client/dashboard/me/preferences-default-landing/illustrations/all-sites.tsx
+++ b/client/dashboard/me/preferences-default-landing/illustrations/all-sites.tsx
@@ -1,0 +1,30 @@
+/**
+ * SVG illustration for the "All Sites" landing page option.
+ * Depicts a grid of site cards representing a multi-site dashboard view.
+ */
+export default function AllSitesIllustration() {
+	return (
+		<svg viewBox="0 0 200 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<rect width="200" height="100" fill="#f0f0f0" />
+			<rect x="10" y="10" width="29" height="8" rx="2" fill="#1e1e1e" fillOpacity="0.5" />
+			<rect x="10" y="24" width="54.6667" height="44" rx="3" fill="white" />
+			<rect x="10.5" y="24.5" width="53.6667" height="43" rx="2.5" stroke="#ddd" />
+			<rect x="10" y="71" width="23" height="4" rx="1" fill="#1e1e1e" fillOpacity="0.4" />
+			<rect x="10" y="78" width="43" height="3" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="72.667" y="24" width="54.6667" height="44" rx="3" fill="white" />
+			<rect x="73.167" y="24.5" width="53.6667" height="43" rx="2.5" stroke="#ddd" />
+			<rect x="72.667" y="71" width="23" height="4" rx="1" fill="#1e1e1e" fillOpacity="0.4" />
+			<rect x="72.667" y="78" width="43" height="3" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="135.334" y="24" width="54.6667" height="44" rx="3" fill="white" />
+			<rect x="135.834" y="24.5" width="53.6667" height="43" rx="2.5" stroke="#ddd" />
+			<rect x="135.334" y="71" width="23" height="4" rx="1" fill="#1e1e1e" fillOpacity="0.4" />
+			<rect x="135.334" y="78" width="43" height="3" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="10" y="87" width="54.6667" height="44" rx="3" fill="white" />
+			<rect x="10.5" y="87.5" width="53.6667" height="43" rx="2.5" stroke="#ddd" />
+			<rect x="72.667" y="87" width="54.6667" height="44" rx="3" fill="white" />
+			<rect x="73.167" y="87.5" width="53.6667" height="43" rx="2.5" stroke="#ddd" />
+			<rect x="135.334" y="87" width="54.6667" height="44" rx="3" fill="white" />
+			<rect x="135.834" y="87.5" width="53.6667" height="43" rx="2.5" stroke="#ddd" />
+		</svg>
+	);
+}

--- a/client/dashboard/me/preferences-default-landing/illustrations/index.ts
+++ b/client/dashboard/me/preferences-default-landing/illustrations/index.ts
@@ -1,0 +1,3 @@
+export { default as AllSitesIllustration } from './all-sites';
+export { default as PrimarySiteIllustration } from './primary-site';
+export { default as ReaderIllustration } from './reader';

--- a/client/dashboard/me/preferences-default-landing/illustrations/primary-site.tsx
+++ b/client/dashboard/me/preferences-default-landing/illustrations/primary-site.tsx
@@ -1,0 +1,29 @@
+/**
+ * SVG illustration for the "Primary Site" landing page option.
+ * Depicts a single site dashboard with sidebar navigation and content areas.
+ */
+export default function PrimarySiteIllustration() {
+	return (
+		<svg viewBox="0 0 200 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<rect width="200" height="100" fill="#f0f0f0" />
+			<rect width="200" height="8" fill="#1e1e1e" />
+			<rect y="8" width="31" height="92" fill="#1e1e1e" />
+			<rect y="15" width="31" height="6" fill="var(--wp-admin-theme-color, #3858E9)" />
+			<rect x="41" y="30" width="99" height="44" fill="white" />
+			<rect x="41.5" y="30.5" width="98" height="43" stroke="#ddd" />
+			<rect x="41" y="82" width="99" height="44" fill="white" />
+			<rect x="41.5" y="82.5" width="98" height="43" stroke="#ddd" />
+			<rect x="150" y="30" width="40" height="44" rx="3" fill="white" />
+			<rect x="150.5" y="30.5" width="39" height="43" rx="2.5" stroke="#ddd" />
+			<rect x="41" y="18" width="29" height="6" rx="2" fill="#1e1e1e" fillOpacity="0.5" />
+			<rect x="150" y="77" width="23" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.2" />
+			<rect x="150" y="88" width="2.41667" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="154.834" y="88" width="24.1667" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="150" y="93" width="2" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="154" y="93" width="17" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="150" y="98" width="2" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="154" y="98" width="20" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="150" y="80" width="19" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+		</svg>
+	);
+}

--- a/client/dashboard/me/preferences-default-landing/illustrations/reader.tsx
+++ b/client/dashboard/me/preferences-default-landing/illustrations/reader.tsx
@@ -1,0 +1,31 @@
+/**
+ * SVG illustration for the "Reader" landing page option.
+ * Depicts a reading interface with sidebar navigation and post cards.
+ */
+export default function ReaderIllustration() {
+	return (
+		<svg viewBox="0 0 200 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<rect width="200" height="100" fill="#f0f0f0" />
+			<rect x="10" y="10" width="29" height="8" rx="2" fill="#1e1e1e" fillOpacity="0.5" />
+			<rect x="10" y="24" width="40" height="44" rx="3" fill="white" />
+			<rect x="10.5" y="24.5" width="39" height="43" rx="2.5" stroke="#ddd" />
+			<rect x="60" y="10" width="130" height="80" rx="3" fill="white" />
+			<rect x="60.5" y="10.5" width="129" height="79" rx="2.5" stroke="#ddd" />
+			<g clipPath="url(#reader-clip)">
+				<rect x="83" y="18" width="84" height="44" rx="5" fill="#1e1e1e" fillOpacity="0.05" />
+				<rect x="83" y="68" width="84" height="44" rx="5" fill="#1e1e1e" fillOpacity="0.05" />
+			</g>
+			<rect x="10" y="76" width="2.41667" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="14.833" y="76" width="24.1667" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="10" y="82" width="2.41667" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="15" y="82" width="20" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="10" y="88" width="2.41667" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<rect x="15" y="88" width="28" height="2" rx="1" fill="#1e1e1e" fillOpacity="0.1" />
+			<defs>
+				<clipPath id="reader-clip">
+					<rect width="84" height="71" fill="white" transform="translate(83 18)" />
+				</clipPath>
+			</defs>
+		</svg>
+	);
+}

--- a/client/dashboard/me/preferences-default-landing/index.tsx
+++ b/client/dashboard/me/preferences-default-landing/index.tsx
@@ -339,7 +339,7 @@ export default function PreferencesDefaultLanding() {
 		{
 			value: 'reader',
 			title: __( 'Reader' ),
-			description: __( 'View posts from sites you follow.' ),
+			description: __( 'Posts you follow.' ),
 			illustration: <ReaderIllustration />,
 		},
 	];

--- a/client/dashboard/me/preferences-default-landing/index.tsx
+++ b/client/dashboard/me/preferences-default-landing/index.tsx
@@ -1,20 +1,325 @@
 import { userPreferencesMutation, rawUserPreferencesQuery } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { DataForm, Field } from '@wordpress/dataviews';
-import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { NavigationBlocker } from '../../app/navigation-blocker';
-import { ButtonStack } from '../../components/button-stack/';
+import clsx from 'clsx';
 import { Card, CardBody } from '../../components/card';
 import { SectionHeader } from '../../components/section-header';
 
+import './style.scss';
+
 type LandingPage = 'primary-site-dashboard' | 'sites' | 'reader';
 
-interface DefaultLandingPreferencesFormData {
-	defaultLandingPage: LandingPage;
+// Inline SVG illustrations - compact versions
+const AllSitesIllustration = () => (
+	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<rect width="280" height="180" rx="4" fill="#F6F7F7" />
+		<rect y="0" width="280" height="20" fill="#DCDCDE" />
+		<rect x="12" y="28" width="32" height="8" rx="2" fill="#1E1E1E" />
+		<rect x="12" y="42" width="80" height="14" rx="3" fill="#DCDCDE" />
+		<g>
+			<rect
+				x="12"
+				y="64"
+				width="80"
+				height="104"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<rect x="16" y="68" width="72" height="48" rx="2" fill="#C3C4C7" />
+			<rect x="24" y="84" width="56" height="16" rx="2" fill="#A7AAAD" />
+			<rect x="16" y="124" width="50" height="6" rx="1" fill="#1E1E1E" />
+			<rect x="16" y="134" width="40" height="4" rx="1" fill="#A7AAAD" />
+		</g>
+		<g>
+			<rect
+				x="100"
+				y="64"
+				width="80"
+				height="104"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<rect x="104" y="68" width="72" height="48" rx="2" fill="#E9EFF5" />
+			<rect x="112" y="80" width="56" height="10" rx="1" fill="#3858E9" />
+			<rect x="112" y="94" width="40" height="10" rx="1" fill="#A7AAAD" />
+			<rect x="104" y="124" width="45" height="6" rx="1" fill="#1E1E1E" />
+			<rect x="104" y="134" width="55" height="4" rx="1" fill="#A7AAAD" />
+		</g>
+		<g>
+			<rect
+				x="188"
+				y="64"
+				width="80"
+				height="104"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<rect x="192" y="68" width="72" height="48" rx="2" fill="#F0E6FA" />
+			<circle cx="228" cy="92" r="14" fill="#9B59B6" opacity="0.5" />
+			<circle cx="244" cy="82" r="10" fill="#E74C8C" opacity="0.5" />
+			<rect x="192" y="124" width="55" height="6" rx="1" fill="#1E1E1E" />
+			<rect x="192" y="134" width="48" height="4" rx="1" fill="#A7AAAD" />
+		</g>
+	</svg>
+);
+
+const PrimarySiteIllustration = () => (
+	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<rect width="280" height="180" rx="4" fill="#F6F7F7" />
+		<rect y="0" width="280" height="20" fill="#DCDCDE" />
+		<rect x="12" y="28" width="70" height="8" rx="2" fill="#1E1E1E" />
+		<rect x="12" y="40" width="100" height="5" rx="1" fill="#A7AAAD" />
+		<rect x="12" y="52" width="64" height="80" rx="4" fill="#0A4B78" />
+		<rect x="18" y="72" width="52" height="8" rx="1" fill="white" opacity="0.9" />
+		<rect x="18" y="84" width="36" height="4" rx="1" fill="white" opacity="0.6" />
+		<rect x="18" y="108" width="20" height="8" rx="2" fill="#3858E9" />
+		<rect x="42" y="108" width="20" height="8" rx="2" fill="#50575E" />
+		<g>
+			<rect
+				x="84"
+				y="52"
+				width="56"
+				height="36"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<circle cx="96" cy="64" r="5" fill="#00A32A" opacity="0.2" />
+			<path
+				d="M93.5 64L95.5 66L98.5 63"
+				stroke="#00A32A"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<rect x="90" y="74" width="32" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="90" y="80" width="24" height="5" rx="1" fill="#1E1E1E" />
+		</g>
+		<g>
+			<rect
+				x="148"
+				y="52"
+				width="56"
+				height="36"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<rect x="154" y="60" width="14" height="14" rx="2" fill="#E9EFF5" />
+			<rect x="158" y="66" width="6" height="4" rx="1" fill="#3858E9" />
+			<rect x="154" y="80" width="36" height="5" rx="1" fill="#1E1E1E" />
+		</g>
+		<g>
+			<rect
+				x="212"
+				y="52"
+				width="56"
+				height="36"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<circle cx="224" cy="64" r="5" fill="#3858E9" opacity="0.2" />
+			<rect x="221" y="62" width="6" height="4" rx="1" fill="#3858E9" />
+			<rect x="218" y="74" width="32" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="218" y="80" width="24" height="5" rx="1" fill="#1E1E1E" />
+		</g>
+		<g>
+			<rect
+				x="84"
+				y="96"
+				width="56"
+				height="36"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<circle cx="96" cy="108" r="5" fill="#DCDCDE" />
+			<rect x="94" y="106" width="4" height="4" rx="1" fill="#50575E" />
+			<rect x="90" y="118" width="36" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="90" y="124" width="28" height="5" rx="1" fill="#1E1E1E" />
+		</g>
+		<g>
+			<rect
+				x="148"
+				y="96"
+				width="56"
+				height="36"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<circle cx="160" cy="108" r="5" fill="#00A32A" opacity="0.2" />
+			<path
+				d="M157.5 108L159.5 110L162.5 107"
+				stroke="#00A32A"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<rect x="154" y="118" width="40" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="154" y="124" width="32" height="5" rx="1" fill="#1E1E1E" />
+		</g>
+		<g>
+			<rect
+				x="212"
+				y="96"
+				width="56"
+				height="36"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<rect x="218" y="106" width="40" height="4" rx="2" fill="#DCDCDE" />
+			<rect x="218" y="106" width="14" height="4" rx="2" fill="#3858E9" />
+			<rect x="218" y="116" width="28" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="218" y="124" width="20" height="5" rx="1" fill="#1E1E1E" />
+		</g>
+	</svg>
+);
+
+const ReaderIllustration = () => (
+	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<rect width="280" height="180" rx="4" fill="#F6F7F7" />
+		<rect y="0" width="280" height="20" fill="#DCDCDE" />
+		<rect x="0" y="20" width="56" height="160" fill="#FAFAFA" />
+		<rect x="8" y="32" width="40" height="6" rx="1" fill="#3858E9" />
+		<rect x="8" y="44" width="32" height="5" rx="1" fill="#A7AAAD" />
+		<rect x="8" y="54" width="28" height="5" rx="1" fill="#A7AAAD" />
+		<rect x="8" y="64" width="24" height="5" rx="1" fill="#A7AAAD" />
+		<rect x="8" y="74" width="30" height="5" rx="1" fill="#A7AAAD" />
+		<rect x="64" y="28" width="44" height="8" rx="2" fill="#1E1E1E" />
+		<rect x="64" y="40" width="72" height="5" rx="1" fill="#A7AAAD" />
+		<g>
+			<rect
+				x="64"
+				y="52"
+				width="204"
+				height="56"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<circle cx="84" cy="72" r="12" fill="#DCDCDE" />
+			<circle cx="84" cy="70" r="5" fill="#A7AAAD" />
+			<ellipse cx="84" cy="79" rx="7" ry="4" fill="#A7AAAD" />
+			<rect x="104" y="62" width="60" height="6" rx="1" fill="#1E1E1E" />
+			<rect x="104" y="72" width="40" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="104" y="84" width="140" height="6" rx="1" fill="#1E1E1E" />
+			<rect x="104" y="94" width="100" height="4" rx="1" fill="#A7AAAD" />
+		</g>
+		<g>
+			<rect
+				x="64"
+				y="116"
+				width="204"
+				height="56"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<circle cx="84" cy="136" r="12" fill="#E9EFF5" />
+			<circle cx="84" cy="134" r="5" fill="#3858E9" />
+			<ellipse cx="84" cy="143" rx="7" ry="4" fill="#3858E9" opacity="0.5" />
+			<rect x="104" y="126" width="50" height="6" rx="1" fill="#1E1E1E" />
+			<rect x="104" y="136" width="36" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="104" y="148" width="120" height="6" rx="1" fill="#1E1E1E" />
+			<rect x="104" y="158" width="80" height="4" rx="1" fill="#A7AAAD" />
+		</g>
+	</svg>
+);
+
+interface LandingPageOption {
+	value: LandingPage;
+	title: string;
+	description: string;
+	illustration: React.ReactNode;
+}
+
+interface LandingPageOptionCardProps {
+	option: LandingPageOption;
+	isSelected: boolean;
+	isDisabled: boolean;
+	onSelect: ( value: LandingPage ) => void;
+}
+
+function LandingPageOptionCard( {
+	option,
+	isSelected,
+	isDisabled,
+	onSelect,
+}: LandingPageOptionCardProps ) {
+	const handleClick = () => {
+		if ( ! isDisabled ) {
+			onSelect( option.value );
+		}
+	};
+
+	const handleKeyDown = ( event: React.KeyboardEvent ) => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			handleClick();
+		}
+	};
+
+	return (
+		<div
+			className={ clsx( 'landing-page-option-card', {
+				'is-selected': isSelected,
+				'is-disabled': isDisabled,
+			} ) }
+			role="radio"
+			aria-checked={ isSelected }
+			aria-disabled={ isDisabled }
+			tabIndex={ isDisabled ? -1 : 0 }
+			onClick={ handleClick }
+			onKeyDown={ handleKeyDown }
+		>
+			<div className="landing-page-option-card__illustration">
+				{ option.illustration }
+				<input
+					className="landing-page-option-card__radio"
+					type="radio"
+					name="landing-page-option"
+					value={ option.value }
+					checked={ isSelected }
+					disabled={ isDisabled }
+					onChange={ () => onSelect( option.value ) }
+					tabIndex={ -1 }
+					aria-label={ option.title }
+				/>
+			</div>
+			<VStack className="landing-page-option-card__content" spacing={ 0 }>
+				<Text className="landing-page-option-card__title" weight={ 500 }>
+					{ option.title }
+				</Text>
+				<Text className="landing-page-option-card__description" variant="muted">
+					{ option.description }
+				</Text>
+			</VStack>
+		</div>
+	);
 }
 
 export default function PreferencesDefaultLanding() {
@@ -37,44 +342,36 @@ export default function PreferencesDefaultLanding() {
 		userPreferencesMutation()
 	);
 
-	// Initialize form data with default values
-	const [ formData, setFormData ] = useState< DefaultLandingPreferencesFormData >( {
-		defaultLandingPage,
-	} );
-
-	// Define form fields
-	const fields: Field< DefaultLandingPreferencesFormData >[] = [
+	const options: LandingPageOption[] = [
 		{
-			id: 'defaultLandingPage',
-			label: __( 'Page' ),
-			Edit: 'radio',
-			elements: [
-				{ label: __( 'Open your primary site’s dashboard.' ), value: 'primary-site-dashboard' },
-				{ label: __( 'See a list of all your sites.' ), value: 'sites' },
-				{ label: __( 'View posts from sites you follow.' ), value: 'reader' },
-			] satisfies { label: string; value: LandingPage }[],
+			value: 'sites',
+			title: __( 'All Sites' ),
+			description: __( 'See a list of all your sites.' ),
+			illustration: <AllSitesIllustration />,
+		},
+		{
+			value: 'primary-site-dashboard',
+			title: __( 'Primary Site' ),
+			description: __( 'Go to your main site.' ),
+			illustration: <PrimarySiteIllustration />,
+		},
+		{
+			value: 'reader',
+			title: __( 'Reader' ),
+			description: __( 'View posts from sites you follow.' ),
+			illustration: <ReaderIllustration />,
 		},
 	];
 
-	// Check if form has been modified
-	const isDirty = Boolean( defaultLandingPage !== formData.defaultLandingPage );
-
-	// Define form layout
-	const form = {
-		layout: { type: 'regular' as const },
-		fields: [ 'defaultLandingPage' ],
-	};
-
-	const handleSubmit = ( e: React.FormEvent ) => {
-		e.preventDefault();
+	const handleSelect = ( value: LandingPage ) => {
 		const updatedAt = Date.now();
 		saveUserPreferences( {
 			'sites-landing-page': {
-				useSitesAsLandingPage: formData.defaultLandingPage === 'sites',
+				useSitesAsLandingPage: value === 'sites',
 				updatedAt,
 			},
 			'reader-landing-page': {
-				useReaderAsLandingPage: formData.defaultLandingPage === 'reader',
+				useReaderAsLandingPage: value === 'reader',
 				updatedAt,
 			},
 		} )
@@ -93,37 +390,31 @@ export default function PreferencesDefaultLanding() {
 	return (
 		<Card>
 			<CardBody>
-				<form onSubmit={ handleSubmit }>
-					<VStack spacing={ 4 }>
-						<SectionHeader
-							level={ 3 }
-							title={ __( 'Default landing page' ) }
-							description={ __( 'Choose what you see after logging into WordPress.com' ) }
-						/>
+				<VStack spacing={ 4 }>
+					<SectionHeader
+						level={ 3 }
+						title={ __( 'Default landing page' ) }
+						description={ __( 'Choose what you see after logging into WordPress.com' ) }
+					/>
 
-						<NavigationBlocker shouldBlock={ isDirty } />
-						<DataForm< DefaultLandingPreferencesFormData >
-							data={ formData }
-							fields={ fields }
-							form={ form }
-							onChange={ ( edits: Partial< DefaultLandingPreferencesFormData > ) => {
-								setFormData( ( data ) => ( { ...data, ...edits } ) );
-							} }
-						/>
-
-						<ButtonStack>
-							<Button
-								__next40pxDefaultSize
-								variant="primary"
-								type="submit"
-								isBusy={ isSavingUserPreferences }
-								disabled={ isSavingUserPreferences || ! isDirty }
-							>
-								{ __( 'Save' ) }
-							</Button>
-						</ButtonStack>
-					</VStack>
-				</form>
+					<HStack
+						className="landing-page-options"
+						spacing={ 0 }
+						alignment="stretch"
+						role="radiogroup"
+						aria-label={ __( 'Default landing page' ) }
+					>
+						{ options.map( ( option ) => (
+							<LandingPageOptionCard
+								key={ option.value }
+								option={ option }
+								isSelected={ defaultLandingPage === option.value }
+								isDisabled={ isSavingUserPreferences }
+								onSelect={ handleSelect }
+							/>
+						) ) }
+					</HStack>
+				</VStack>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/me/preferences-default-landing/index.tsx
+++ b/client/dashboard/me/preferences-default-landing/index.tsx
@@ -16,236 +16,336 @@ import './style.scss';
 
 type LandingPage = 'primary-site-dashboard' | 'sites' | 'reader';
 
-// Inline SVG illustrations - compact versions
+// Inline SVG illustrations - matching actual UI screenshots
 const AllSitesIllustration = () => (
 	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect width="280" height="180" rx="4" fill="#F6F7F7" />
-		<rect y="0" width="280" height="20" fill="#DCDCDE" />
-		<rect x="12" y="28" width="32" height="8" rx="2" fill="#1E1E1E" />
-		<rect x="12" y="42" width="80" height="14" rx="3" fill="#DCDCDE" />
+		{ /* Background */ }
+		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
+		{ /* Header */ }
+		<rect x="12" y="12" width="32" height="12" rx="2" fill="#1E1E1E" />
+		<rect x="230" y="10" width="40" height="16" rx="4" fill="#1289DB" />
+		{ /* Search bar */ }
+		<rect
+			x="12"
+			y="32"
+			width="80"
+			height="16"
+			rx="4"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		{ /* Site Card 1 - Beach photo style */ }
 		<g>
 			<rect
 				x="12"
-				y="64"
-				width="80"
-				height="104"
+				y="56"
+				width="60"
+				height="76"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<rect x="16" y="68" width="72" height="48" rx="2" fill="#C3C4C7" />
-			<rect x="24" y="84" width="56" height="16" rx="2" fill="#A7AAAD" />
-			<rect x="16" y="124" width="50" height="6" rx="1" fill="#1E1E1E" />
-			<rect x="16" y="134" width="40" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="14" y="58" width="56" height="36" rx="2" fill="#87CEEB" />
+			<rect x="14" y="78" width="56" height="16" fill="#C2B280" />
+			<rect x="16" y="98" width="36" height="5" rx="1" fill="#1E1E1E" />
+			<rect x="16" y="105" width="48" height="3" rx="1" fill="#A7AAAD" />
+			<rect x="16" y="112" width="24" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="16" y="118" width="20" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="16" y="124" width="28" height="3" rx="1" fill="#DCDCDE" />
 		</g>
+		{ /* Site Card 2 - P2 style */ }
 		<g>
 			<rect
-				x="100"
-				y="64"
-				width="80"
-				height="104"
+				x="78"
+				y="56"
+				width="60"
+				height="76"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<rect x="104" y="68" width="72" height="48" rx="2" fill="#E9EFF5" />
-			<rect x="112" y="80" width="56" height="10" rx="1" fill="#3858E9" />
-			<rect x="112" y="94" width="40" height="10" rx="1" fill="#A7AAAD" />
-			<rect x="104" y="124" width="45" height="6" rx="1" fill="#1E1E1E" />
-			<rect x="104" y="134" width="55" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="80" y="58" width="56" height="36" rx="2" fill="#F7F7F7" />
+			<rect x="84" y="62" width="32" height="4" rx="1" fill="#1E1E1E" />
+			<rect x="120" y="62" width="12" height="6" rx="2" fill="#117AC9" />
+			<rect x="84" y="70" width="48" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="84" y="76" width="40" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="82" y="98" width="40" height="5" rx="1" fill="#1E1E1E" />
+			<rect x="82" y="105" width="52" height="3" rx="1" fill="#A7AAAD" />
+			<rect x="82" y="112" width="24" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="82" y="118" width="20" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="82" y="124" width="28" height="3" rx="1" fill="#DCDCDE" />
 		</g>
+		{ /* Site Card 3 - Block Art Museum style */ }
 		<g>
 			<rect
-				x="188"
-				y="64"
-				width="80"
-				height="104"
+				x="144"
+				y="56"
+				width="60"
+				height="76"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<rect x="192" y="68" width="72" height="48" rx="2" fill="#F0E6FA" />
-			<circle cx="228" cy="92" r="14" fill="#9B59B6" opacity="0.5" />
-			<circle cx="244" cy="82" r="10" fill="#E74C8C" opacity="0.5" />
-			<rect x="192" y="124" width="55" height="6" rx="1" fill="#1E1E1E" />
-			<rect x="192" y="134" width="48" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="146" y="58" width="56" height="36" rx="2" fill="#FDF4F7" />
+			<rect x="150" y="64" width="28" height="10" rx="1" fill="#D4576B" />
+			<rect x="150" y="76" width="20" height="6" rx="1" fill="#D4576B" />
+			<circle cx="188" cy="80" r="10" fill="#FFD4E0" />
+			<rect x="148" y="98" width="36" height="5" rx="1" fill="#1E1E1E" />
+			<rect x="148" y="105" width="54" height="3" rx="1" fill="#A7AAAD" />
+			<rect x="148" y="112" width="24" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="148" y="118" width="20" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="148" y="124" width="28" height="3" rx="1" fill="#DCDCDE" />
+		</g>
+		{ /* Site Card 4 - Hello World style */ }
+		<g>
+			<rect
+				x="210"
+				y="56"
+				width="60"
+				height="76"
+				rx="4"
+				fill="white"
+				stroke="#DCDCDE"
+				strokeWidth="1"
+			/>
+			<rect x="212" y="58" width="56" height="36" rx="2" fill="white" />
+			<rect x="216" y="66" width="32" height="6" rx="1" fill="#1289DB" />
+			<rect x="216" y="76" width="44" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="216" y="82" width="36" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="214" y="98" width="44" height="5" rx="1" fill="#1E1E1E" />
+			<rect x="214" y="105" width="52" height="3" rx="1" fill="#A7AAAD" />
+			<rect x="214" y="112" width="24" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="214" y="118" width="20" height="3" rx="1" fill="#DCDCDE" />
+			<rect x="214" y="124" width="28" height="3" rx="1" fill="#DCDCDE" />
 		</g>
 	</svg>
 );
 
 const PrimarySiteIllustration = () => (
 	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect width="280" height="180" rx="4" fill="#F6F7F7" />
-		<rect y="0" width="280" height="20" fill="#DCDCDE" />
-		<rect x="12" y="28" width="70" height="8" rx="2" fill="#1E1E1E" />
-		<rect x="12" y="40" width="100" height="5" rx="1" fill="#A7AAAD" />
-		<rect x="12" y="52" width="64" height="80" rx="4" fill="#0A4B78" />
-		<rect x="18" y="72" width="52" height="8" rx="1" fill="white" opacity="0.9" />
-		<rect x="18" y="84" width="36" height="4" rx="1" fill="white" opacity="0.6" />
-		<rect x="18" y="108" width="20" height="8" rx="2" fill="#3858E9" />
-		<rect x="42" y="108" width="20" height="8" rx="2" fill="#50575E" />
+		{ /* Background */ }
+		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
+		{ /* Header with site name */ }
+		<rect x="12" y="8" width="100" height="14" rx="2" fill="#1E1E1E" />
+		<rect x="12" y="26" width="140" height="4" rx="1" fill="#A7AAAD" />
+		{ /* Site Preview - Dark blue theme */ }
+		<rect x="12" y="38" width="72" height="100" rx="6" fill="#0A4B78" />
+		<rect x="20" y="48" width="56" height="6" rx="1" fill="white" opacity="0.3" />
+		<rect x="20" y="62" width="40" height="8" rx="1" fill="white" opacity="0.9" />
+		<rect x="20" y="74" width="50" height="4" rx="1" fill="white" opacity="0.5" />
+		<rect x="20" y="100" width="22" height="10" rx="3" fill="#3858E9" />
+		<rect x="46" y="100" width="22" height="10" rx="3" fill="#50575E" />
+		<rect x="20" y="122" width="48" height="3" rx="1" fill="white" opacity="0.3" />
+		{ /* Status Card - Visibility (green check) */ }
 		<g>
 			<rect
-				x="84"
-				y="52"
+				x="92"
+				y="38"
 				width="56"
-				height="36"
+				height="44"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<circle cx="96" cy="64" r="5" fill="#00A32A" opacity="0.2" />
+			<circle cx="104" cy="52" r="6" fill="#00BA37" opacity="0.15" />
 			<path
-				d="M93.5 64L95.5 66L98.5 63"
-				stroke="#00A32A"
-				strokeWidth="1.5"
+				d="M101 52L103 54L107 50"
+				stroke="#00BA37"
+				strokeWidth="2"
 				strokeLinecap="round"
 				strokeLinejoin="round"
 			/>
-			<rect x="90" y="74" width="32" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="90" y="80" width="24" height="5" rx="1" fill="#1E1E1E" />
+			<rect x="98" y="64" width="36" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="98" y="72" width="28" height="6" rx="1" fill="#1E1E1E" />
 		</g>
+		{ /* Status Card - Performance */ }
 		<g>
 			<rect
-				x="148"
-				y="52"
+				x="154"
+				y="38"
 				width="56"
-				height="36"
+				height="44"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<rect x="154" y="60" width="14" height="14" rx="2" fill="#E9EFF5" />
-			<rect x="158" y="66" width="6" height="4" rx="1" fill="#3858E9" />
-			<rect x="154" y="80" width="36" height="5" rx="1" fill="#1E1E1E" />
+			<rect x="166" y="48" width="14" height="14" rx="2" fill="#E8F0FE" />
+			<rect x="168" y="56" width="4" height="6" rx="1" fill="#1289DB" />
+			<rect x="174" y="52" width="4" height="10" rx="1" fill="#1289DB" />
+			<rect x="160" y="64" width="40" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="160" y="72" width="32" height="6" rx="1" fill="#1E1E1E" />
 		</g>
+		{ /* Status Card - Plan */ }
 		<g>
 			<rect
-				x="212"
-				y="52"
+				x="216"
+				y="38"
 				width="56"
-				height="36"
+				height="44"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<circle cx="224" cy="64" r="5" fill="#3858E9" opacity="0.2" />
-			<rect x="221" y="62" width="6" height="4" rx="1" fill="#3858E9" />
-			<rect x="218" y="74" width="32" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="218" y="80" width="24" height="5" rx="1" fill="#1E1E1E" />
+			<circle cx="228" cy="52" r="6" fill="#1289DB" opacity="0.15" />
+			<rect x="225" y="50" width="6" height="4" rx="1" fill="#1289DB" />
+			<rect x="222" y="64" width="36" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="222" y="72" width="28" height="6" rx="1" fill="#1E1E1E" />
 		</g>
+		{ /* Status Card - Last Backup */ }
 		<g>
 			<rect
-				x="84"
-				y="96"
+				x="92"
+				y="90"
 				width="56"
-				height="36"
+				height="44"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<circle cx="96" cy="108" r="5" fill="#DCDCDE" />
-			<rect x="94" y="106" width="4" height="4" rx="1" fill="#50575E" />
-			<rect x="90" y="118" width="36" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="90" y="124" width="28" height="5" rx="1" fill="#1E1E1E" />
+			<circle cx="104" cy="104" r="6" fill="#DCDCDE" />
+			<rect x="102" y="102" width="4" height="5" rx="1" fill="#50575E" />
+			<rect x="98" y="116" width="36" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="98" y="124" width="28" height="6" rx="1" fill="#1E1E1E" />
 		</g>
+		{ /* Status Card - Last Scan (green check) */ }
 		<g>
 			<rect
-				x="148"
-				y="96"
+				x="154"
+				y="90"
 				width="56"
-				height="36"
+				height="44"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<circle cx="160" cy="108" r="5" fill="#00A32A" opacity="0.2" />
+			<circle cx="166" cy="104" r="6" fill="#00BA37" opacity="0.15" />
 			<path
-				d="M157.5 108L159.5 110L162.5 107"
-				stroke="#00A32A"
-				strokeWidth="1.5"
+				d="M163 104L165 106L169 102"
+				stroke="#00BA37"
+				strokeWidth="2"
 				strokeLinecap="round"
 				strokeLinejoin="round"
 			/>
-			<rect x="154" y="118" width="40" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="154" y="124" width="32" height="5" rx="1" fill="#1E1E1E" />
+			<rect x="160" y="116" width="40" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="160" y="124" width="32" height="6" rx="1" fill="#1E1E1E" />
 		</g>
+		{ /* Status Card - Storage */ }
 		<g>
 			<rect
-				x="212"
-				y="96"
+				x="216"
+				y="90"
 				width="56"
-				height="36"
+				height="44"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<rect x="218" y="106" width="40" height="4" rx="2" fill="#DCDCDE" />
-			<rect x="218" y="106" width="14" height="4" rx="2" fill="#3858E9" />
-			<rect x="218" y="116" width="28" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="218" y="124" width="20" height="5" rx="1" fill="#1E1E1E" />
+			<rect x="222" y="100" width="44" height="4" rx="2" fill="#DCDCDE" />
+			<rect x="222" y="100" width="16" height="4" rx="2" fill="#00BA37" />
+			<rect x="222" y="110" width="28" height="4" rx="1" fill="#A7AAAD" />
+			<rect x="222" y="118" width="20" height="6" rx="1" fill="#1E1E1E" />
+			<rect x="222" y="128" width="44" height="4" rx="2" fill="#DCDCDE" />
+			<rect x="222" y="128" width="4" height="4" rx="2" fill="#00BA37" />
 		</g>
 	</svg>
 );
 
 const ReaderIllustration = () => (
 	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect width="280" height="180" rx="4" fill="#F6F7F7" />
-		<rect y="0" width="280" height="20" fill="#DCDCDE" />
-		<rect x="0" y="20" width="56" height="160" fill="#FAFAFA" />
-		<rect x="8" y="32" width="40" height="6" rx="1" fill="#3858E9" />
-		<rect x="8" y="44" width="32" height="5" rx="1" fill="#A7AAAD" />
-		<rect x="8" y="54" width="28" height="5" rx="1" fill="#A7AAAD" />
-		<rect x="8" y="64" width="24" height="5" rx="1" fill="#A7AAAD" />
-		<rect x="8" y="74" width="30" height="5" rx="1" fill="#A7AAAD" />
-		<rect x="64" y="28" width="44" height="8" rx="2" fill="#1E1E1E" />
-		<rect x="64" y="40" width="72" height="5" rx="1" fill="#A7AAAD" />
+		{ /* Background */ }
+		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
+		{ /* Sidebar */ }
+		<rect x="0" y="0" width="56" height="180" rx="8" fill="white" />
+		<rect width="48" height="180" fill="white" />
+		{ /* Reader title in sidebar */ }
+		<rect x="8" y="12" width="36" height="10" rx="2" fill="#1E1E1E" />
+		{ /* Sidebar nav items */ }
+		<rect x="8" y="32" width="40" height="8" rx="4" fill="#E8F0FE" />
+		<rect x="12" y="34" width="32" height="4" rx="1" fill="#1289DB" />
+		<rect x="8" y="46" width="28" height="5" rx="1" fill="#A7AAAD" />
+		<rect x="8" y="56" width="32" height="5" rx="1" fill="#A7AAAD" />
+		<rect x="8" y="66" width="24" height="5" rx="1" fill="#A7AAAD" />
+		<rect x="8" y="76" width="36" height="5" rx="1" fill="#A7AAAD" />
+		<rect x="8" y="86" width="20" height="5" rx="1" fill="#A7AAAD" />
+		<rect x="8" y="96" width="26" height="5" rx="1" fill="#A7AAAD" />
+		{ /* Main content area */ }
+		<rect x="64" y="12" width="40" height="8" rx="2" fill="#1E1E1E" />
+		<rect x="64" y="24" width="80" height="4" rx="1" fill="#A7AAAD" />
+		{ /* Write quick post bar */ }
+		<rect
+			x="64"
+			y="36"
+			width="204"
+			height="16"
+			rx="4"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<rect x="72" y="42" width="60" height="4" rx="1" fill="#A7AAAD" />
+		{ /* Post Card 1 - with photo avatar */ }
 		<g>
 			<rect
 				x="64"
-				y="52"
+				y="58"
 				width="204"
-				height="56"
+				height="54"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<circle cx="84" cy="72" r="12" fill="#DCDCDE" />
-			<circle cx="84" cy="70" r="5" fill="#A7AAAD" />
-			<ellipse cx="84" cy="79" rx="7" ry="4" fill="#A7AAAD" />
-			<rect x="104" y="62" width="60" height="6" rx="1" fill="#1E1E1E" />
-			<rect x="104" y="72" width="40" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="104" y="84" width="140" height="6" rx="1" fill="#1E1E1E" />
-			<rect x="104" y="94" width="100" height="4" rx="1" fill="#A7AAAD" />
+			{ /* Avatar - photo style */ }
+			<circle cx="82" cy="76" r="10" fill="#D4A574" />
+			<circle cx="82" cy="73" r="4" fill="#F5E6D3" />
+			<ellipse cx="82" cy="80" rx="5" ry="3" fill="#8B7355" />
+			{ /* Author info */ }
+			<rect x="98" y="68" width="50" height="5" rx="1" fill="#1E1E1E" />
+			<rect x="98" y="76" width="70" height="3" rx="1" fill="#A7AAAD" />
+			{ /* Post title */ }
+			<rect x="98" y="86" width="140" height="6" rx="1" fill="#1E1E1E" />
+			{ /* Excerpt */ }
+			<rect x="98" y="96" width="160" height="4" rx="1" fill="#A7AAAD" />
+			{ /* Action buttons */ }
+			<rect x="230" y="68" width="12" height="8" rx="2" fill="#DCDCDE" />
+			<rect x="246" y="68" width="12" height="8" rx="2" fill="#DCDCDE" />
 		</g>
+		{ /* Post Card 2 - with different avatar */ }
 		<g>
 			<rect
 				x="64"
-				y="116"
+				y="118"
 				width="204"
-				height="56"
+				height="54"
 				rx="4"
 				fill="white"
 				stroke="#DCDCDE"
 				strokeWidth="1"
 			/>
-			<circle cx="84" cy="136" r="12" fill="#E9EFF5" />
-			<circle cx="84" cy="134" r="5" fill="#3858E9" />
-			<ellipse cx="84" cy="143" rx="7" ry="4" fill="#3858E9" opacity="0.5" />
-			<rect x="104" y="126" width="50" height="6" rx="1" fill="#1E1E1E" />
-			<rect x="104" y="136" width="36" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="104" y="148" width="120" height="6" rx="1" fill="#1E1E1E" />
-			<rect x="104" y="158" width="80" height="4" rx="1" fill="#A7AAAD" />
+			{ /* Avatar - blue tint */ }
+			<circle cx="82" cy="136" r="10" fill="#B8D4E8" />
+			<circle cx="82" cy="133" r="4" fill="#E8F4F8" />
+			<ellipse cx="82" cy="140" rx="5" ry="3" fill="#5B8FAD" />
+			{ /* Author info */ }
+			<rect x="98" y="128" width="40" height="5" rx="1" fill="#1E1E1E" />
+			<rect x="98" y="136" width="55" height="3" rx="1" fill="#A7AAAD" />
+			{ /* Post title */ }
+			<rect x="98" y="146" width="120" height="6" rx="1" fill="#1E1E1E" />
+			{ /* Excerpt */ }
+			<rect x="98" y="156" width="150" height="4" rx="1" fill="#A7AAAD" />
+			{ /* Action buttons */ }
+			<rect x="230" y="128" width="12" height="8" rx="2" fill="#DCDCDE" />
+			<rect x="246" y="128" width="12" height="8" rx="2" fill="#DCDCDE" />
 		</g>
 	</svg>
 );

--- a/client/dashboard/me/preferences-default-landing/index.tsx
+++ b/client/dashboard/me/preferences-default-landing/index.tsx
@@ -21,63 +21,93 @@ const AllSitesIllustration = () => (
 	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
 		{ /* Title */ }
-		<rect x="16" y="16" width="40" height="10" rx="2" fill="#1E1E1E" />
-		{ /* Site cards - 2x2 grid */ }
+		<rect x="12" y="12" width="40" height="8" rx="2" fill="#1E1E1E" />
+		{ /* Site cards - 3x2 grid */ }
+		{ /* Row 1 */ }
 		<rect
-			x="16"
-			y="40"
-			width="120"
-			height="60"
-			rx="6"
+			x="12"
+			y="28"
+			width="80"
+			height="68"
+			rx="4"
 			fill="white"
 			stroke="#DCDCDE"
 			strokeWidth="1"
 		/>
-		<rect x="22" y="46" width="108" height="30" rx="3" fill="#DCDCDE" />
-		<rect x="22" y="82" width="60" height="6" rx="1" fill="#1E1E1E" />
-		<rect x="22" y="92" width="80" height="4" rx="1" fill="#C3C4C7" />
+		<rect x="16" y="32" width="72" height="36" rx="2" fill="#DCDCDE" />
+		<rect x="16" y="74" width="40" height="5" rx="1" fill="#1E1E1E" />
+		<rect x="16" y="83" width="56" height="4" rx="1" fill="#C3C4C7" />
 
 		<rect
-			x="144"
-			y="40"
-			width="120"
-			height="60"
-			rx="6"
+			x="100"
+			y="28"
+			width="80"
+			height="68"
+			rx="4"
 			fill="white"
 			stroke="#DCDCDE"
 			strokeWidth="1"
 		/>
-		<rect x="150" y="46" width="108" height="30" rx="3" fill="#DCDCDE" />
-		<rect x="150" y="82" width="50" height="6" rx="1" fill="#1E1E1E" />
-		<rect x="150" y="92" width="70" height="4" rx="1" fill="#C3C4C7" />
+		<rect x="104" y="32" width="72" height="36" rx="2" fill="#DCDCDE" />
+		<rect x="104" y="74" width="36" height="5" rx="1" fill="#1E1E1E" />
+		<rect x="104" y="83" width="50" height="4" rx="1" fill="#C3C4C7" />
 
 		<rect
-			x="16"
-			y="108"
-			width="120"
-			height="60"
-			rx="6"
+			x="188"
+			y="28"
+			width="80"
+			height="68"
+			rx="4"
 			fill="white"
 			stroke="#DCDCDE"
 			strokeWidth="1"
 		/>
-		<rect x="22" y="114" width="108" height="30" rx="3" fill="#DCDCDE" />
-		<rect x="22" y="150" width="70" height="6" rx="1" fill="#1E1E1E" />
-		<rect x="22" y="160" width="90" height="4" rx="1" fill="#C3C4C7" />
+		<rect x="192" y="32" width="72" height="36" rx="2" fill="#DCDCDE" />
+		<rect x="192" y="74" width="44" height="5" rx="1" fill="#1E1E1E" />
+		<rect x="192" y="83" width="60" height="4" rx="1" fill="#C3C4C7" />
+
+		{ /* Row 2 */ }
+		<rect
+			x="12"
+			y="104"
+			width="80"
+			height="68"
+			rx="4"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<rect x="16" y="108" width="72" height="36" rx="2" fill="#DCDCDE" />
+		<rect x="16" y="150" width="48" height="5" rx="1" fill="#1E1E1E" />
+		<rect x="16" y="159" width="64" height="4" rx="1" fill="#C3C4C7" />
 
 		<rect
-			x="144"
-			y="108"
-			width="120"
-			height="60"
-			rx="6"
+			x="100"
+			y="104"
+			width="80"
+			height="68"
+			rx="4"
 			fill="white"
 			stroke="#DCDCDE"
 			strokeWidth="1"
 		/>
-		<rect x="150" y="114" width="108" height="30" rx="3" fill="#DCDCDE" />
-		<rect x="150" y="150" width="55" height="6" rx="1" fill="#1E1E1E" />
-		<rect x="150" y="160" width="75" height="4" rx="1" fill="#C3C4C7" />
+		<rect x="104" y="108" width="72" height="36" rx="2" fill="#DCDCDE" />
+		<rect x="104" y="150" width="32" height="5" rx="1" fill="#1E1E1E" />
+		<rect x="104" y="159" width="48" height="4" rx="1" fill="#C3C4C7" />
+
+		<rect
+			x="188"
+			y="104"
+			width="80"
+			height="68"
+			rx="4"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<rect x="192" y="108" width="72" height="36" rx="2" fill="#DCDCDE" />
+		<rect x="192" y="150" width="52" height="5" rx="1" fill="#1E1E1E" />
+		<rect x="192" y="159" width="68" height="4" rx="1" fill="#C3C4C7" />
 	</svg>
 );
 
@@ -85,65 +115,73 @@ const PrimarySiteIllustration = () => (
 	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
 		{ /* Title */ }
-		<rect x="16" y="16" width="80" height="12" rx="2" fill="#1E1E1E" />
-		<rect x="16" y="32" width="120" height="4" rx="1" fill="#C3C4C7" />
-		{ /* Site preview */ }
-		<rect x="16" y="48" width="80" height="120" rx="6" fill="#1E1E1E" />
-		<rect x="24" y="64" width="64" height="8" rx="1" fill="white" opacity="0.9" />
-		<rect x="24" y="78" width="48" height="4" rx="1" fill="white" opacity="0.5" />
-		<rect x="24" y="100" width="28" height="12" rx="3" fill="white" opacity="0.3" />
+		<rect x="16" y="16" width="80" height="10" rx="2" fill="#1E1E1E" />
+		<rect x="16" y="30" width="120" height="4" rx="1" fill="#C3C4C7" />
+		{ /* Site preview - simple white card */ }
+		<rect
+			x="16"
+			y="44"
+			width="80"
+			height="124"
+			rx="6"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<rect x="28" y="70" width="56" height="8" rx="1" fill="#DCDCDE" />
+		<rect x="28" y="86" width="40" height="4" rx="1" fill="#DCDCDE" />
 		{ /* Status cards - 2x2 grid */ }
 		<rect
 			x="108"
-			y="48"
+			y="44"
 			width="76"
-			height="54"
-			rx="6"
+			height="56"
+			rx="4"
 			fill="white"
 			stroke="#DCDCDE"
 			strokeWidth="1"
 		/>
-		<circle cx="124" cy="68" r="8" fill="#DCDCDE" />
-		<rect x="116" y="86" width="50" height="6" rx="1" fill="#1E1E1E" />
+		<circle cx="124" cy="64" r="8" fill="#DCDCDE" />
+		<rect x="116" y="84" width="50" height="5" rx="1" fill="#1E1E1E" />
 
 		<rect
 			x="192"
-			y="48"
+			y="44"
 			width="76"
-			height="54"
-			rx="6"
+			height="56"
+			rx="4"
 			fill="white"
 			stroke="#DCDCDE"
 			strokeWidth="1"
 		/>
-		<circle cx="208" cy="68" r="8" fill="#DCDCDE" />
-		<rect x="200" y="86" width="50" height="6" rx="1" fill="#1E1E1E" />
+		<circle cx="208" cy="64" r="8" fill="#DCDCDE" />
+		<rect x="200" y="84" width="50" height="5" rx="1" fill="#1E1E1E" />
 
 		<rect
 			x="108"
-			y="110"
+			y="108"
 			width="76"
-			height="54"
-			rx="6"
+			height="56"
+			rx="4"
 			fill="white"
 			stroke="#DCDCDE"
 			strokeWidth="1"
 		/>
-		<circle cx="124" cy="130" r="8" fill="#DCDCDE" />
-		<rect x="116" y="148" width="50" height="6" rx="1" fill="#1E1E1E" />
+		<circle cx="124" cy="128" r="8" fill="#DCDCDE" />
+		<rect x="116" y="148" width="50" height="5" rx="1" fill="#1E1E1E" />
 
 		<rect
 			x="192"
-			y="110"
+			y="108"
 			width="76"
-			height="54"
-			rx="6"
+			height="56"
+			rx="4"
 			fill="white"
 			stroke="#DCDCDE"
 			strokeWidth="1"
 		/>
-		<circle cx="208" cy="130" r="8" fill="#DCDCDE" />
-		<rect x="200" y="148" width="50" height="6" rx="1" fill="#1E1E1E" />
+		<circle cx="208" cy="128" r="8" fill="#DCDCDE" />
+		<rect x="200" y="148" width="50" height="5" rx="1" fill="#1E1E1E" />
 	</svg>
 );
 

--- a/client/dashboard/me/preferences-default-landing/index.tsx
+++ b/client/dashboard/me/preferences-default-landing/index.tsx
@@ -9,228 +9,17 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import clsx from 'clsx';
+import { useState } from 'react';
 import { Card, CardBody } from '../../components/card';
 import { SectionHeader } from '../../components/section-header';
+import { AllSitesIllustration, PrimarySiteIllustration, ReaderIllustration } from './illustrations';
 
 import './style.scss';
 
+/** Valid landing page options for user preferences. */
 type LandingPage = 'primary-site-dashboard' | 'sites' | 'reader';
 
-// Inline SVG illustrations - simple and abstract
-const AllSitesIllustration = () => (
-	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
-		{ /* Title */ }
-		<rect x="12" y="12" width="40" height="8" rx="2" fill="#1E1E1E" />
-		{ /* Site cards - 3x2 grid */ }
-		{ /* Row 1 */ }
-		<rect
-			x="12"
-			y="28"
-			width="80"
-			height="68"
-			rx="4"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<rect x="16" y="32" width="72" height="36" rx="2" fill="#DCDCDE" />
-		<rect x="16" y="74" width="40" height="5" rx="1" fill="#1E1E1E" />
-		<rect x="16" y="83" width="56" height="4" rx="1" fill="#C3C4C7" />
-
-		<rect
-			x="100"
-			y="28"
-			width="80"
-			height="68"
-			rx="4"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<rect x="104" y="32" width="72" height="36" rx="2" fill="#DCDCDE" />
-		<rect x="104" y="74" width="36" height="5" rx="1" fill="#1E1E1E" />
-		<rect x="104" y="83" width="50" height="4" rx="1" fill="#C3C4C7" />
-
-		<rect
-			x="188"
-			y="28"
-			width="80"
-			height="68"
-			rx="4"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<rect x="192" y="32" width="72" height="36" rx="2" fill="#DCDCDE" />
-		<rect x="192" y="74" width="44" height="5" rx="1" fill="#1E1E1E" />
-		<rect x="192" y="83" width="60" height="4" rx="1" fill="#C3C4C7" />
-
-		{ /* Row 2 */ }
-		<rect
-			x="12"
-			y="104"
-			width="80"
-			height="68"
-			rx="4"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<rect x="16" y="108" width="72" height="36" rx="2" fill="#DCDCDE" />
-		<rect x="16" y="150" width="48" height="5" rx="1" fill="#1E1E1E" />
-		<rect x="16" y="159" width="64" height="4" rx="1" fill="#C3C4C7" />
-
-		<rect
-			x="100"
-			y="104"
-			width="80"
-			height="68"
-			rx="4"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<rect x="104" y="108" width="72" height="36" rx="2" fill="#DCDCDE" />
-		<rect x="104" y="150" width="32" height="5" rx="1" fill="#1E1E1E" />
-		<rect x="104" y="159" width="48" height="4" rx="1" fill="#C3C4C7" />
-
-		<rect
-			x="188"
-			y="104"
-			width="80"
-			height="68"
-			rx="4"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<rect x="192" y="108" width="72" height="36" rx="2" fill="#DCDCDE" />
-		<rect x="192" y="150" width="52" height="5" rx="1" fill="#1E1E1E" />
-		<rect x="192" y="159" width="68" height="4" rx="1" fill="#C3C4C7" />
-	</svg>
-);
-
-const PrimarySiteIllustration = () => (
-	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
-		{ /* Title */ }
-		<rect x="16" y="16" width="80" height="10" rx="2" fill="#1E1E1E" />
-		<rect x="16" y="30" width="120" height="4" rx="1" fill="#C3C4C7" />
-		{ /* Site preview - simple white card */ }
-		<rect
-			x="16"
-			y="44"
-			width="80"
-			height="124"
-			rx="6"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<rect x="28" y="70" width="56" height="8" rx="1" fill="#DCDCDE" />
-		<rect x="28" y="86" width="40" height="4" rx="1" fill="#DCDCDE" />
-		{ /* Status cards - 2x2 grid */ }
-		<rect
-			x="108"
-			y="44"
-			width="76"
-			height="56"
-			rx="4"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<circle cx="124" cy="64" r="8" fill="#DCDCDE" />
-		<rect x="116" y="84" width="50" height="5" rx="1" fill="#1E1E1E" />
-
-		<rect
-			x="192"
-			y="44"
-			width="76"
-			height="56"
-			rx="4"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<circle cx="208" cy="64" r="8" fill="#DCDCDE" />
-		<rect x="200" y="84" width="50" height="5" rx="1" fill="#1E1E1E" />
-
-		<rect
-			x="108"
-			y="108"
-			width="76"
-			height="56"
-			rx="4"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<circle cx="124" cy="128" r="8" fill="#DCDCDE" />
-		<rect x="116" y="148" width="50" height="5" rx="1" fill="#1E1E1E" />
-
-		<rect
-			x="192"
-			y="108"
-			width="76"
-			height="56"
-			rx="4"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<circle cx="208" cy="128" r="8" fill="#DCDCDE" />
-		<rect x="200" y="148" width="50" height="5" rx="1" fill="#1E1E1E" />
-	</svg>
-);
-
-const ReaderIllustration = () => (
-	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
-		{ /* Sidebar */ }
-		<rect x="0" y="0" width="56" height="180" fill="white" />
-		<rect x="8" y="16" width="40" height="10" rx="2" fill="#1E1E1E" />
-		<rect x="8" y="36" width="36" height="6" rx="1" fill="#C3C4C7" />
-		<rect x="8" y="48" width="28" height="6" rx="1" fill="#C3C4C7" />
-		<rect x="8" y="60" width="32" height="6" rx="1" fill="#C3C4C7" />
-		<rect x="8" y="72" width="24" height="6" rx="1" fill="#C3C4C7" />
-		{ /* Main content */ }
-		<rect x="68" y="16" width="50" height="10" rx="2" fill="#1E1E1E" />
-		<rect x="68" y="32" width="80" height="4" rx="1" fill="#C3C4C7" />
-		{ /* Post card 1 */ }
-		<rect
-			x="68"
-			y="48"
-			width="200"
-			height="56"
-			rx="6"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<circle cx="88" cy="76" r="12" fill="#DCDCDE" />
-		<rect x="108" y="64" width="60" height="6" rx="1" fill="#1E1E1E" />
-		<rect x="108" y="76" width="140" height="8" rx="1" fill="#1E1E1E" />
-		<rect x="108" y="90" width="120" height="4" rx="1" fill="#C3C4C7" />
-		{ /* Post card 2 */ }
-		<rect
-			x="68"
-			y="112"
-			width="200"
-			height="56"
-			rx="6"
-			fill="white"
-			stroke="#DCDCDE"
-			strokeWidth="1"
-		/>
-		<circle cx="88" cy="140" r="12" fill="#DCDCDE" />
-		<rect x="108" y="128" width="50" height="6" rx="1" fill="#1E1E1E" />
-		<rect x="108" y="140" width="130" height="8" rx="1" fill="#1E1E1E" />
-		<rect x="108" y="154" width="100" height="4" rx="1" fill="#C3C4C7" />
-	</svg>
-);
-
+/** Configuration for a landing page option card. */
 interface LandingPageOption {
 	value: LandingPage;
 	title: string;
@@ -238,6 +27,7 @@ interface LandingPageOption {
 	illustration: React.ReactNode;
 }
 
+/** Props for the LandingPageOptionCard component. */
 interface LandingPageOptionCardProps {
 	option: LandingPageOption;
 	isSelected: boolean;
@@ -245,6 +35,10 @@ interface LandingPageOptionCardProps {
 	onSelect: ( value: LandingPage ) => void;
 }
 
+/**
+ * A selectable card displaying a landing page option with illustration.
+ * Implements accessible radio button pattern with keyboard navigation.
+ */
 function LandingPageOptionCard( {
 	option,
 	isSelected,
@@ -288,7 +82,7 @@ function LandingPageOptionCard( {
 					disabled={ isDisabled }
 					onChange={ () => onSelect( option.value ) }
 					tabIndex={ -1 }
-					aria-label={ option.title }
+					aria-hidden="true"
 				/>
 			</div>
 			<VStack className="landing-page-option-card__content" spacing={ 0 }>
@@ -303,10 +97,15 @@ function LandingPageOptionCard( {
 	);
 }
 
+/**
+ * Preferences section for selecting the default landing page after login.
+ * Displays visual card options for All Sites, Primary Site, or Reader.
+ * Saves immediately on selection with optimistic UI updates.
+ */
 export default function PreferencesDefaultLanding() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const { data: defaultLandingPage } = useSuspenseQuery( {
+	const { data: serverLandingPage } = useSuspenseQuery( {
 		...rawUserPreferencesQuery(),
 		select: ( preferences ): LandingPage => {
 			if ( preferences[ 'sites-landing-page' ]?.useSitesAsLandingPage ) {
@@ -318,6 +117,9 @@ export default function PreferencesDefaultLanding() {
 			return 'primary-site-dashboard';
 		},
 	} );
+
+	// Optimistic state for immediate UI feedback
+	const [ optimisticSelection, setOptimisticSelection ] = useState< LandingPage | null >( null );
 
 	const { mutateAsync: saveUserPreferences, isPending: isSavingUserPreferences } = useMutation(
 		userPreferencesMutation()
@@ -345,6 +147,9 @@ export default function PreferencesDefaultLanding() {
 	];
 
 	const handleSelect = ( value: LandingPage ) => {
+		// Optimistically update the UI immediately
+		setOptimisticSelection( value );
+
 		const updatedAt = Date.now();
 		saveUserPreferences( {
 			'sites-landing-page': {
@@ -357,16 +162,22 @@ export default function PreferencesDefaultLanding() {
 			},
 		} )
 			.then( () => {
+				setOptimisticSelection( null );
 				createSuccessNotice( __( 'Default landing page saved.' ), {
 					type: 'snackbar',
 				} );
 			} )
 			.catch( () => {
+				// Revert optimistic update on error
+				setOptimisticSelection( null );
 				createErrorNotice( __( 'Failed to save default landing page.' ), {
 					type: 'snackbar',
 				} );
 			} );
 	};
+
+	// Use optimistic selection if available, otherwise use server value
+	const currentSelection = optimisticSelection ?? serverLandingPage;
 
 	return (
 		<Card>
@@ -389,7 +200,7 @@ export default function PreferencesDefaultLanding() {
 							<LandingPageOptionCard
 								key={ option.value }
 								option={ option }
-								isSelected={ defaultLandingPage === option.value }
+								isSelected={ currentSelection === option.value }
 								isDisabled={ isSavingUserPreferences }
 								onSelect={ handleSelect }
 							/>

--- a/client/dashboard/me/preferences-default-landing/index.tsx
+++ b/client/dashboard/me/preferences-default-landing/index.tsx
@@ -16,337 +16,180 @@ import './style.scss';
 
 type LandingPage = 'primary-site-dashboard' | 'sites' | 'reader';
 
-// Inline SVG illustrations - matching actual UI screenshots
+// Inline SVG illustrations - simple and abstract
 const AllSitesIllustration = () => (
 	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-		{ /* Background */ }
 		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
-		{ /* Header */ }
-		<rect x="12" y="12" width="32" height="12" rx="2" fill="#1E1E1E" />
-		<rect x="230" y="10" width="40" height="16" rx="4" fill="#1289DB" />
-		{ /* Search bar */ }
+		{ /* Title */ }
+		<rect x="16" y="16" width="40" height="10" rx="2" fill="#1E1E1E" />
+		{ /* Site cards - 2x2 grid */ }
 		<rect
-			x="12"
-			y="32"
-			width="80"
-			height="16"
-			rx="4"
+			x="16"
+			y="40"
+			width="120"
+			height="60"
+			rx="6"
 			fill="white"
 			stroke="#DCDCDE"
 			strokeWidth="1"
 		/>
-		{ /* Site Card 1 - Beach photo style */ }
-		<g>
-			<rect
-				x="12"
-				y="56"
-				width="60"
-				height="76"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			<rect x="14" y="58" width="56" height="36" rx="2" fill="#87CEEB" />
-			<rect x="14" y="78" width="56" height="16" fill="#C2B280" />
-			<rect x="16" y="98" width="36" height="5" rx="1" fill="#1E1E1E" />
-			<rect x="16" y="105" width="48" height="3" rx="1" fill="#A7AAAD" />
-			<rect x="16" y="112" width="24" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="16" y="118" width="20" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="16" y="124" width="28" height="3" rx="1" fill="#DCDCDE" />
-		</g>
-		{ /* Site Card 2 - P2 style */ }
-		<g>
-			<rect
-				x="78"
-				y="56"
-				width="60"
-				height="76"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			<rect x="80" y="58" width="56" height="36" rx="2" fill="#F7F7F7" />
-			<rect x="84" y="62" width="32" height="4" rx="1" fill="#1E1E1E" />
-			<rect x="120" y="62" width="12" height="6" rx="2" fill="#117AC9" />
-			<rect x="84" y="70" width="48" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="84" y="76" width="40" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="82" y="98" width="40" height="5" rx="1" fill="#1E1E1E" />
-			<rect x="82" y="105" width="52" height="3" rx="1" fill="#A7AAAD" />
-			<rect x="82" y="112" width="24" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="82" y="118" width="20" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="82" y="124" width="28" height="3" rx="1" fill="#DCDCDE" />
-		</g>
-		{ /* Site Card 3 - Block Art Museum style */ }
-		<g>
-			<rect
-				x="144"
-				y="56"
-				width="60"
-				height="76"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			<rect x="146" y="58" width="56" height="36" rx="2" fill="#FDF4F7" />
-			<rect x="150" y="64" width="28" height="10" rx="1" fill="#D4576B" />
-			<rect x="150" y="76" width="20" height="6" rx="1" fill="#D4576B" />
-			<circle cx="188" cy="80" r="10" fill="#FFD4E0" />
-			<rect x="148" y="98" width="36" height="5" rx="1" fill="#1E1E1E" />
-			<rect x="148" y="105" width="54" height="3" rx="1" fill="#A7AAAD" />
-			<rect x="148" y="112" width="24" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="148" y="118" width="20" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="148" y="124" width="28" height="3" rx="1" fill="#DCDCDE" />
-		</g>
-		{ /* Site Card 4 - Hello World style */ }
-		<g>
-			<rect
-				x="210"
-				y="56"
-				width="60"
-				height="76"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			<rect x="212" y="58" width="56" height="36" rx="2" fill="white" />
-			<rect x="216" y="66" width="32" height="6" rx="1" fill="#1289DB" />
-			<rect x="216" y="76" width="44" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="216" y="82" width="36" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="214" y="98" width="44" height="5" rx="1" fill="#1E1E1E" />
-			<rect x="214" y="105" width="52" height="3" rx="1" fill="#A7AAAD" />
-			<rect x="214" y="112" width="24" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="214" y="118" width="20" height="3" rx="1" fill="#DCDCDE" />
-			<rect x="214" y="124" width="28" height="3" rx="1" fill="#DCDCDE" />
-		</g>
+		<rect x="22" y="46" width="108" height="30" rx="3" fill="#DCDCDE" />
+		<rect x="22" y="82" width="60" height="6" rx="1" fill="#1E1E1E" />
+		<rect x="22" y="92" width="80" height="4" rx="1" fill="#C3C4C7" />
+
+		<rect
+			x="144"
+			y="40"
+			width="120"
+			height="60"
+			rx="6"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<rect x="150" y="46" width="108" height="30" rx="3" fill="#DCDCDE" />
+		<rect x="150" y="82" width="50" height="6" rx="1" fill="#1E1E1E" />
+		<rect x="150" y="92" width="70" height="4" rx="1" fill="#C3C4C7" />
+
+		<rect
+			x="16"
+			y="108"
+			width="120"
+			height="60"
+			rx="6"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<rect x="22" y="114" width="108" height="30" rx="3" fill="#DCDCDE" />
+		<rect x="22" y="150" width="70" height="6" rx="1" fill="#1E1E1E" />
+		<rect x="22" y="160" width="90" height="4" rx="1" fill="#C3C4C7" />
+
+		<rect
+			x="144"
+			y="108"
+			width="120"
+			height="60"
+			rx="6"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<rect x="150" y="114" width="108" height="30" rx="3" fill="#DCDCDE" />
+		<rect x="150" y="150" width="55" height="6" rx="1" fill="#1E1E1E" />
+		<rect x="150" y="160" width="75" height="4" rx="1" fill="#C3C4C7" />
 	</svg>
 );
 
 const PrimarySiteIllustration = () => (
 	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-		{ /* Background */ }
 		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
-		{ /* Header with site name */ }
-		<rect x="12" y="8" width="100" height="14" rx="2" fill="#1E1E1E" />
-		<rect x="12" y="26" width="140" height="4" rx="1" fill="#A7AAAD" />
-		{ /* Site Preview - Dark blue theme */ }
-		<rect x="12" y="38" width="72" height="100" rx="6" fill="#0A4B78" />
-		<rect x="20" y="48" width="56" height="6" rx="1" fill="white" opacity="0.3" />
-		<rect x="20" y="62" width="40" height="8" rx="1" fill="white" opacity="0.9" />
-		<rect x="20" y="74" width="50" height="4" rx="1" fill="white" opacity="0.5" />
-		<rect x="20" y="100" width="22" height="10" rx="3" fill="#3858E9" />
-		<rect x="46" y="100" width="22" height="10" rx="3" fill="#50575E" />
-		<rect x="20" y="122" width="48" height="3" rx="1" fill="white" opacity="0.3" />
-		{ /* Status Card - Visibility (green check) */ }
-		<g>
-			<rect
-				x="92"
-				y="38"
-				width="56"
-				height="44"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			<circle cx="104" cy="52" r="6" fill="#00BA37" opacity="0.15" />
-			<path
-				d="M101 52L103 54L107 50"
-				stroke="#00BA37"
-				strokeWidth="2"
-				strokeLinecap="round"
-				strokeLinejoin="round"
-			/>
-			<rect x="98" y="64" width="36" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="98" y="72" width="28" height="6" rx="1" fill="#1E1E1E" />
-		</g>
-		{ /* Status Card - Performance */ }
-		<g>
-			<rect
-				x="154"
-				y="38"
-				width="56"
-				height="44"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			<rect x="166" y="48" width="14" height="14" rx="2" fill="#E8F0FE" />
-			<rect x="168" y="56" width="4" height="6" rx="1" fill="#1289DB" />
-			<rect x="174" y="52" width="4" height="10" rx="1" fill="#1289DB" />
-			<rect x="160" y="64" width="40" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="160" y="72" width="32" height="6" rx="1" fill="#1E1E1E" />
-		</g>
-		{ /* Status Card - Plan */ }
-		<g>
-			<rect
-				x="216"
-				y="38"
-				width="56"
-				height="44"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			<circle cx="228" cy="52" r="6" fill="#1289DB" opacity="0.15" />
-			<rect x="225" y="50" width="6" height="4" rx="1" fill="#1289DB" />
-			<rect x="222" y="64" width="36" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="222" y="72" width="28" height="6" rx="1" fill="#1E1E1E" />
-		</g>
-		{ /* Status Card - Last Backup */ }
-		<g>
-			<rect
-				x="92"
-				y="90"
-				width="56"
-				height="44"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			<circle cx="104" cy="104" r="6" fill="#DCDCDE" />
-			<rect x="102" y="102" width="4" height="5" rx="1" fill="#50575E" />
-			<rect x="98" y="116" width="36" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="98" y="124" width="28" height="6" rx="1" fill="#1E1E1E" />
-		</g>
-		{ /* Status Card - Last Scan (green check) */ }
-		<g>
-			<rect
-				x="154"
-				y="90"
-				width="56"
-				height="44"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			<circle cx="166" cy="104" r="6" fill="#00BA37" opacity="0.15" />
-			<path
-				d="M163 104L165 106L169 102"
-				stroke="#00BA37"
-				strokeWidth="2"
-				strokeLinecap="round"
-				strokeLinejoin="round"
-			/>
-			<rect x="160" y="116" width="40" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="160" y="124" width="32" height="6" rx="1" fill="#1E1E1E" />
-		</g>
-		{ /* Status Card - Storage */ }
-		<g>
-			<rect
-				x="216"
-				y="90"
-				width="56"
-				height="44"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			<rect x="222" y="100" width="44" height="4" rx="2" fill="#DCDCDE" />
-			<rect x="222" y="100" width="16" height="4" rx="2" fill="#00BA37" />
-			<rect x="222" y="110" width="28" height="4" rx="1" fill="#A7AAAD" />
-			<rect x="222" y="118" width="20" height="6" rx="1" fill="#1E1E1E" />
-			<rect x="222" y="128" width="44" height="4" rx="2" fill="#DCDCDE" />
-			<rect x="222" y="128" width="4" height="4" rx="2" fill="#00BA37" />
-		</g>
+		{ /* Title */ }
+		<rect x="16" y="16" width="80" height="12" rx="2" fill="#1E1E1E" />
+		<rect x="16" y="32" width="120" height="4" rx="1" fill="#C3C4C7" />
+		{ /* Site preview */ }
+		<rect x="16" y="48" width="80" height="120" rx="6" fill="#1E1E1E" />
+		<rect x="24" y="64" width="64" height="8" rx="1" fill="white" opacity="0.9" />
+		<rect x="24" y="78" width="48" height="4" rx="1" fill="white" opacity="0.5" />
+		<rect x="24" y="100" width="28" height="12" rx="3" fill="white" opacity="0.3" />
+		{ /* Status cards - 2x2 grid */ }
+		<rect
+			x="108"
+			y="48"
+			width="76"
+			height="54"
+			rx="6"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<circle cx="124" cy="68" r="8" fill="#DCDCDE" />
+		<rect x="116" y="86" width="50" height="6" rx="1" fill="#1E1E1E" />
+
+		<rect
+			x="192"
+			y="48"
+			width="76"
+			height="54"
+			rx="6"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<circle cx="208" cy="68" r="8" fill="#DCDCDE" />
+		<rect x="200" y="86" width="50" height="6" rx="1" fill="#1E1E1E" />
+
+		<rect
+			x="108"
+			y="110"
+			width="76"
+			height="54"
+			rx="6"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<circle cx="124" cy="130" r="8" fill="#DCDCDE" />
+		<rect x="116" y="148" width="50" height="6" rx="1" fill="#1E1E1E" />
+
+		<rect
+			x="192"
+			y="110"
+			width="76"
+			height="54"
+			rx="6"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<circle cx="208" cy="130" r="8" fill="#DCDCDE" />
+		<rect x="200" y="148" width="50" height="6" rx="1" fill="#1E1E1E" />
 	</svg>
 );
 
 const ReaderIllustration = () => (
 	<svg viewBox="0 0 280 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-		{ /* Background */ }
 		<rect width="280" height="180" rx="8" fill="#F6F7F7" />
 		{ /* Sidebar */ }
-		<rect x="0" y="0" width="56" height="180" rx="8" fill="white" />
-		<rect width="48" height="180" fill="white" />
-		{ /* Reader title in sidebar */ }
-		<rect x="8" y="12" width="36" height="10" rx="2" fill="#1E1E1E" />
-		{ /* Sidebar nav items */ }
-		<rect x="8" y="32" width="40" height="8" rx="4" fill="#E8F0FE" />
-		<rect x="12" y="34" width="32" height="4" rx="1" fill="#1289DB" />
-		<rect x="8" y="46" width="28" height="5" rx="1" fill="#A7AAAD" />
-		<rect x="8" y="56" width="32" height="5" rx="1" fill="#A7AAAD" />
-		<rect x="8" y="66" width="24" height="5" rx="1" fill="#A7AAAD" />
-		<rect x="8" y="76" width="36" height="5" rx="1" fill="#A7AAAD" />
-		<rect x="8" y="86" width="20" height="5" rx="1" fill="#A7AAAD" />
-		<rect x="8" y="96" width="26" height="5" rx="1" fill="#A7AAAD" />
-		{ /* Main content area */ }
-		<rect x="64" y="12" width="40" height="8" rx="2" fill="#1E1E1E" />
-		<rect x="64" y="24" width="80" height="4" rx="1" fill="#A7AAAD" />
-		{ /* Write quick post bar */ }
+		<rect x="0" y="0" width="56" height="180" fill="white" />
+		<rect x="8" y="16" width="40" height="10" rx="2" fill="#1E1E1E" />
+		<rect x="8" y="36" width="36" height="6" rx="1" fill="#C3C4C7" />
+		<rect x="8" y="48" width="28" height="6" rx="1" fill="#C3C4C7" />
+		<rect x="8" y="60" width="32" height="6" rx="1" fill="#C3C4C7" />
+		<rect x="8" y="72" width="24" height="6" rx="1" fill="#C3C4C7" />
+		{ /* Main content */ }
+		<rect x="68" y="16" width="50" height="10" rx="2" fill="#1E1E1E" />
+		<rect x="68" y="32" width="80" height="4" rx="1" fill="#C3C4C7" />
+		{ /* Post card 1 */ }
 		<rect
-			x="64"
-			y="36"
-			width="204"
-			height="16"
-			rx="4"
+			x="68"
+			y="48"
+			width="200"
+			height="56"
+			rx="6"
 			fill="white"
 			stroke="#DCDCDE"
 			strokeWidth="1"
 		/>
-		<rect x="72" y="42" width="60" height="4" rx="1" fill="#A7AAAD" />
-		{ /* Post Card 1 - with photo avatar */ }
-		<g>
-			<rect
-				x="64"
-				y="58"
-				width="204"
-				height="54"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			{ /* Avatar - photo style */ }
-			<circle cx="82" cy="76" r="10" fill="#D4A574" />
-			<circle cx="82" cy="73" r="4" fill="#F5E6D3" />
-			<ellipse cx="82" cy="80" rx="5" ry="3" fill="#8B7355" />
-			{ /* Author info */ }
-			<rect x="98" y="68" width="50" height="5" rx="1" fill="#1E1E1E" />
-			<rect x="98" y="76" width="70" height="3" rx="1" fill="#A7AAAD" />
-			{ /* Post title */ }
-			<rect x="98" y="86" width="140" height="6" rx="1" fill="#1E1E1E" />
-			{ /* Excerpt */ }
-			<rect x="98" y="96" width="160" height="4" rx="1" fill="#A7AAAD" />
-			{ /* Action buttons */ }
-			<rect x="230" y="68" width="12" height="8" rx="2" fill="#DCDCDE" />
-			<rect x="246" y="68" width="12" height="8" rx="2" fill="#DCDCDE" />
-		</g>
-		{ /* Post Card 2 - with different avatar */ }
-		<g>
-			<rect
-				x="64"
-				y="118"
-				width="204"
-				height="54"
-				rx="4"
-				fill="white"
-				stroke="#DCDCDE"
-				strokeWidth="1"
-			/>
-			{ /* Avatar - blue tint */ }
-			<circle cx="82" cy="136" r="10" fill="#B8D4E8" />
-			<circle cx="82" cy="133" r="4" fill="#E8F4F8" />
-			<ellipse cx="82" cy="140" rx="5" ry="3" fill="#5B8FAD" />
-			{ /* Author info */ }
-			<rect x="98" y="128" width="40" height="5" rx="1" fill="#1E1E1E" />
-			<rect x="98" y="136" width="55" height="3" rx="1" fill="#A7AAAD" />
-			{ /* Post title */ }
-			<rect x="98" y="146" width="120" height="6" rx="1" fill="#1E1E1E" />
-			{ /* Excerpt */ }
-			<rect x="98" y="156" width="150" height="4" rx="1" fill="#A7AAAD" />
-			{ /* Action buttons */ }
-			<rect x="230" y="128" width="12" height="8" rx="2" fill="#DCDCDE" />
-			<rect x="246" y="128" width="12" height="8" rx="2" fill="#DCDCDE" />
-		</g>
+		<circle cx="88" cy="76" r="12" fill="#DCDCDE" />
+		<rect x="108" y="64" width="60" height="6" rx="1" fill="#1E1E1E" />
+		<rect x="108" y="76" width="140" height="8" rx="1" fill="#1E1E1E" />
+		<rect x="108" y="90" width="120" height="4" rx="1" fill="#C3C4C7" />
+		{ /* Post card 2 */ }
+		<rect
+			x="68"
+			y="112"
+			width="200"
+			height="56"
+			rx="6"
+			fill="white"
+			stroke="#DCDCDE"
+			strokeWidth="1"
+		/>
+		<circle cx="88" cy="140" r="12" fill="#DCDCDE" />
+		<rect x="108" y="128" width="50" height="6" rx="1" fill="#1E1E1E" />
+		<rect x="108" y="140" width="130" height="8" rx="1" fill="#1E1E1E" />
+		<rect x="108" y="154" width="100" height="4" rx="1" fill="#C3C4C7" />
 	</svg>
 );
 

--- a/client/dashboard/me/preferences-default-landing/style.scss
+++ b/client/dashboard/me/preferences-default-landing/style.scss
@@ -1,9 +1,8 @@
-@import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/colors";
 
 .landing-page-options {
-	margin-block-start: $grid-unit-20; // 8px
-	gap: $grid-unit-40; // 16px
+	margin-block-start: 8px;
+	gap: 16px;
 }
 
 .landing-page-option-card {
@@ -27,8 +26,8 @@
 
 .landing-page-option-card__illustration {
 	position: relative;
-	margin-block-end: $grid-unit-40; // 16px
-	border-radius: $radius-medium;
+	margin-block-end: 16px;
+	border-radius: 8px;
 	overflow: hidden;
 	box-shadow: 0 0 0 1px transparent;
 	transition: box-shadow 0.1s ease-in-out;
@@ -49,8 +48,8 @@
 }
 
 .landing-page-option-card__title {
-	font-size: $font-size-small; // 13px
-	line-height: $font-line-height-small; // 16px
+	font-size: 14px;
+	line-height: 20px;
 
 	.is-selected & {
 		color: var( --wp-admin-theme-color );
@@ -58,16 +57,16 @@
 }
 
 .landing-page-option-card__description {
-	font-size: $font-size-small;
-	line-height: $font-line-height-small;
+	font-size: 12px;
+	line-height: 16px;
 }
 
 .landing-page-option-card__radio {
 	position: absolute;
-	top: $grid-unit-20; // 8px
-	inset-inline-end: $grid-unit-20; // 8px
-	width: $grid-unit-50; // 20px
-	height: $grid-unit-50; // 20px
+	top: 8px;
+	inset-inline-end: 8px;
+	width: 16px;
+	height: 16px;
 	margin: 0;
 	cursor: pointer;
 	accent-color: var( --wp-admin-theme-color );
@@ -78,7 +77,7 @@
 }
 
 // Responsive: stack vertically on small screens
-@media ( max-width: #{ $break-medium } ) {
+@media ( max-width: 782px ) {
 	.landing-page-options {
 		flex-direction: column;
 	}

--- a/client/dashboard/me/preferences-default-landing/style.scss
+++ b/client/dashboard/me/preferences-default-landing/style.scss
@@ -51,6 +51,10 @@
 .landing-page-option-card__title {
 	font-size: $font-size-small; // 13px
 	line-height: $font-line-height-small; // 16px
+
+	.is-selected & {
+		color: var( --wp-admin-theme-color );
+	}
 }
 
 .landing-page-option-card__description {

--- a/client/dashboard/me/preferences-default-landing/style.scss
+++ b/client/dashboard/me/preferences-default-landing/style.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/colors";
+@import "@wordpress/base-styles/variables";
 
 .landing-page-options {
 	margin-block-start: 8px;
@@ -45,6 +46,10 @@
 	.is-selected & {
 		box-shadow: 0 0 0 2px var( --wp-admin-theme-color );
 	}
+}
+
+.landing-page-option-card__content {
+	padding-inline-start: $grid-unit-05;
 }
 
 .landing-page-option-card__title {

--- a/client/dashboard/me/preferences-default-landing/style.scss
+++ b/client/dashboard/me/preferences-default-landing/style.scss
@@ -1,6 +1,9 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/colors";
+
 .landing-page-options {
-	margin-block-start: 8px;
-	gap: 16px;
+	margin-block-start: $grid-unit-20; // 8px
+	gap: $grid-unit-40; // 16px
 }
 
 .landing-page-option-card {
@@ -24,9 +27,11 @@
 
 .landing-page-option-card__illustration {
 	position: relative;
-	margin-block-end: 8px;
-	border-radius: 8px;
+	margin-block-end: $grid-unit-40; // 16px
+	border-radius: $radius-medium;
 	overflow: hidden;
+	box-shadow: 0 0 0 1px transparent;
+	transition: box-shadow 0.1s ease-in-out;
 
 	svg {
 		display: block;
@@ -34,28 +39,31 @@
 		height: auto;
 	}
 
+	.landing-page-option-card:hover:not( .is-disabled ) & {
+		box-shadow: 0 0 0 1px $gray-300;
+	}
+
 	.is-selected & {
 		box-shadow: 0 0 0 2px var( --wp-admin-theme-color );
 	}
 }
 
-
 .landing-page-option-card__title {
-	font-size: 14px;
-	line-height: 20px;
+	font-size: $font-size-small; // 13px
+	line-height: $font-line-height-small; // 16px
 }
 
 .landing-page-option-card__description {
-	font-size: 12px;
-	line-height: 16px;
+	font-size: $font-size-small;
+	line-height: $font-line-height-small;
 }
 
 .landing-page-option-card__radio {
 	position: absolute;
-	top: 8px;
-	right: 8px;
-	width: 20px;
-	height: 20px;
+	top: $grid-unit-20; // 8px
+	inset-inline-end: $grid-unit-20; // 8px
+	width: $grid-unit-50; // 20px
+	height: $grid-unit-50; // 20px
 	margin: 0;
 	cursor: pointer;
 	accent-color: var( --wp-admin-theme-color );
@@ -66,7 +74,7 @@
 }
 
 // Responsive: stack vertically on small screens
-@media ( max-width: 782px ) {
+@media ( max-width: #{ $break-medium } ) {
 	.landing-page-options {
 		flex-direction: column;
 	}

--- a/client/dashboard/me/preferences-default-landing/style.scss
+++ b/client/dashboard/me/preferences-default-landing/style.scss
@@ -26,7 +26,7 @@
 
 .landing-page-option-card__illustration {
 	position: relative;
-	margin-block-end: 16px;
+	margin-block-end: 8px;
 	border-radius: 8px;
 	overflow: hidden;
 	box-shadow: 0 0 0 1px transparent;
@@ -38,7 +38,7 @@
 		height: auto;
 	}
 
-	.landing-page-option-card:hover:not( .is-disabled ) & {
+	.landing-page-option-card:hover:not( .is-disabled ):not( .is-selected ) & {
 		box-shadow: 0 0 0 1px $gray-300;
 	}
 

--- a/client/dashboard/me/preferences-default-landing/style.scss
+++ b/client/dashboard/me/preferences-default-landing/style.scss
@@ -2,7 +2,7 @@
 
 .landing-page-options {
 	margin-block-start: 8px;
-	gap: 16px;
+	gap: 24px;
 }
 
 .landing-page-option-card {
@@ -29,7 +29,7 @@
 	margin-block-end: 8px;
 	border-radius: 8px;
 	overflow: hidden;
-	box-shadow: 0 0 0 1px transparent;
+	box-shadow: 0 0 0 1px $gray-200;
 	transition: box-shadow 0.1s ease-in-out;
 
 	svg {
@@ -39,7 +39,7 @@
 	}
 
 	.landing-page-option-card:hover:not( .is-disabled ):not( .is-selected ) & {
-		box-shadow: 0 0 0 1px $gray-300;
+		box-shadow: 0 0 0 1px $gray-400;
 	}
 
 	.is-selected & {

--- a/client/dashboard/me/preferences-default-landing/style.scss
+++ b/client/dashboard/me/preferences-default-landing/style.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/colors";
 @import "@wordpress/base-styles/variables";
 
@@ -40,7 +41,7 @@
 	}
 
 	.landing-page-option-card:hover:not( .is-disabled ):not( .is-selected ) & {
-		box-shadow: 0 0 0 1px $gray-400;
+		box-shadow: 0 0 0 1px var( --wp-admin-theme-color );
 	}
 
 	.is-selected & {
@@ -82,7 +83,7 @@
 }
 
 // Responsive: stack vertically on small screens
-@media ( max-width: 782px ) {
+@media ( max-width: $break-medium ) {
 	.landing-page-options {
 		flex-direction: column;
 	}

--- a/client/dashboard/me/preferences-default-landing/style.scss
+++ b/client/dashboard/me/preferences-default-landing/style.scss
@@ -12,8 +12,7 @@
 		outline: none;
 
 		.landing-page-option-card__illustration {
-			outline: 2px solid var( --wp-admin-theme-color );
-			outline-offset: 2px;
+			box-shadow: 0 0 0 2px var( --wp-admin-theme-color );
 		}
 	}
 
@@ -36,8 +35,7 @@
 	}
 
 	.is-selected & {
-		outline: 2px solid var( --wp-admin-theme-color );
-		outline-offset: 2px;
+		box-shadow: 0 0 0 2px var( --wp-admin-theme-color );
 	}
 }
 

--- a/client/dashboard/me/preferences-default-landing/style.scss
+++ b/client/dashboard/me/preferences-default-landing/style.scss
@@ -1,0 +1,75 @@
+.landing-page-options {
+	margin-block-start: 8px;
+	gap: 16px;
+}
+
+.landing-page-option-card {
+	flex: 1 1 0;
+	min-width: 0;
+	cursor: pointer;
+
+	&:focus {
+		outline: none;
+
+		.landing-page-option-card__illustration {
+			outline: 2px solid var( --wp-admin-theme-color );
+			outline-offset: 2px;
+		}
+	}
+
+	&.is-disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+}
+
+.landing-page-option-card__illustration {
+	position: relative;
+	margin-block-end: 8px;
+	border-radius: 8px;
+	overflow: hidden;
+
+	svg {
+		display: block;
+		width: 100%;
+		height: auto;
+	}
+
+	.is-selected & {
+		outline: 2px solid var( --wp-admin-theme-color );
+		outline-offset: 2px;
+	}
+}
+
+
+.landing-page-option-card__title {
+	font-size: 14px;
+	line-height: 20px;
+}
+
+.landing-page-option-card__description {
+	font-size: 12px;
+	line-height: 16px;
+}
+
+.landing-page-option-card__radio {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	width: 20px;
+	height: 20px;
+	margin: 0;
+	cursor: pointer;
+	accent-color: var( --wp-admin-theme-color );
+
+	&:disabled {
+		cursor: not-allowed;
+	}
+}
+
+// Responsive: stack vertically on small screens
+@media ( max-width: 782px ) {
+	.landing-page-options {
+		flex-direction: column;
+	}
+}

--- a/client/dashboard/me/preferences-default-landing/test/index.test.tsx
+++ b/client/dashboard/me/preferences-default-landing/test/index.test.tsx
@@ -67,7 +67,7 @@ afterEach( () => {
 	rawUserPreferencesQuery.mockClear();
 } );
 
-test( 'save button is disabled when form is not dirty', async () => {
+test( 'renders all landing page options as cards', async () => {
 	renderPreferencesDefaultLanding();
 
 	await waitFor(
@@ -77,54 +77,41 @@ test( 'save button is disabled when form is not dirty', async () => {
 		{ timeout: 5000 }
 	);
 
-	const saveButton = screen.getByRole( 'button', { name: 'Save' } );
-	expect( saveButton ).toBeDisabled();
+	// Verify all three options are rendered
+	expect( screen.getByText( 'All Sites' ) ).toBeInTheDocument();
+	expect( screen.getByText( 'Primary Site' ) ).toBeInTheDocument();
+	expect( screen.getByText( 'Reader' ) ).toBeInTheDocument();
+
+	// Verify the radiogroup role is present
+	expect( screen.getByRole( 'radiogroup' ) ).toBeInTheDocument();
+
+	// Verify all radio options are present
+	const radioOptions = screen.getAllByRole( 'radio' );
+	expect( radioOptions ).toHaveLength( 3 );
 } );
 
-test( 'save button becomes enabled when form is modified', async () => {
-	const user = userEvent.setup();
-	renderPreferencesDefaultLanding();
-
-	await waitFor(
-		() => {
-			expect( screen.getByText( 'Default landing page' ) ).toBeInTheDocument();
-		},
-		{ timeout: 5000 }
-	);
-
-	const sitesRadio = screen.getByLabelText( 'See a list of all your sites.' );
-	await user.click( sitesRadio );
-
-	const saveButton = screen.getByRole( 'button', { name: 'Save' } );
-	await waitFor(
-		() => {
-			expect( saveButton ).toBeEnabled();
-		},
-		{ timeout: 5000 }
-	);
-} );
-
-test( 'saves preferences successfully', async () => {
+test( 'clicking an option saves immediately', async () => {
 	const mockCreateSuccessNotice = jest.fn();
 	( useDispatch as jest.Mock ).mockReturnValue( {
 		createSuccessNotice: mockCreateSuccessNotice,
+		createErrorNotice: jest.fn(),
 	} );
 
-	// Override the mock to make mutationFn return a resolved promise
 	const { userPreferencesMutation } = require( '@automattic/api-queries' );
+	const mockMutationFn = jest.fn( () =>
+		Promise.resolve( {
+			'sites-landing-page': {
+				useSitesAsLandingPage: true,
+				updatedAt: Date.now(),
+			},
+			'reader-landing-page': {
+				useReaderAsLandingPage: false,
+				updatedAt: Date.now(),
+			},
+		} )
+	);
 	userPreferencesMutation.mockReturnValue( {
-		mutationFn: jest.fn( () =>
-			Promise.resolve( {
-				'sites-landing-page': {
-					useSitesAsLandingPage: true,
-					updatedAt: Date.now(),
-				},
-				'reader-landing-page': {
-					useReaderAsLandingPage: false,
-					updatedAt: Date.now(),
-				},
-			} )
-		),
+		mutationFn: mockMutationFn,
 	} );
 
 	const user = userEvent.setup();
@@ -137,12 +124,29 @@ test( 'saves preferences successfully', async () => {
 		{ timeout: 5000 }
 	);
 
-	const sitesRadio = screen.getByLabelText( 'See a list of all your sites.' );
-	await user.click( sitesRadio );
+	// Click on the "All Sites" option card
+	const allSitesOption = screen.getByText( 'All Sites' ).closest( '[role="radio"]' );
+	expect( allSitesOption ).toBeInTheDocument();
+	await user.click( allSitesOption! );
 
-	const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+	// Verify mutation was called with correct parameters
+	await waitFor(
+		() => {
+			expect( mockMutationFn ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					'sites-landing-page': expect.objectContaining( {
+						useSitesAsLandingPage: true,
+					} ),
+					'reader-landing-page': expect.objectContaining( {
+						useReaderAsLandingPage: false,
+					} ),
+				} )
+			);
+		},
+		{ timeout: 5000 }
+	);
 
-	await user.click( saveButton );
+	// Verify success notice was shown
 	await waitFor(
 		() => {
 			expect( mockCreateSuccessNotice ).toHaveBeenCalledWith( 'Default landing page saved.', {
@@ -156,11 +160,10 @@ test( 'saves preferences successfully', async () => {
 test( 'handles save error gracefully', async () => {
 	const mockCreateErrorNotice = jest.fn();
 	( useDispatch as jest.Mock ).mockReturnValue( {
+		createSuccessNotice: jest.fn(),
 		createErrorNotice: mockCreateErrorNotice,
 	} );
 
-	// Override the mock to make mutationFn return a rejected promise
-	// This simulates an API error
 	const { userPreferencesMutation } = require( '@automattic/api-queries' );
 	userPreferencesMutation.mockReturnValue( {
 		mutationFn: jest.fn( () => Promise.reject( new Error( 'Server error' ) ) ),
@@ -176,12 +179,11 @@ test( 'handles save error gracefully', async () => {
 		{ timeout: 5000 }
 	);
 
-	const sitesRadio = screen.getByLabelText( 'See a list of all your sites.' );
-	await user.click( sitesRadio );
+	// Click on the "Reader" option card
+	const readerOption = screen.getByText( 'Reader' ).closest( '[role="radio"]' );
+	await user.click( readerOption! );
 
-	const saveButton = screen.getByRole( 'button', { name: 'Save' } );
-	await user.click( saveButton );
-
+	// Verify error notice was shown
 	await waitFor(
 		() => {
 			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
@@ -195,16 +197,13 @@ test( 'handles save error gracefully', async () => {
 	);
 } );
 
-test( 'disables save button while saving', async () => {
+test( 'cards are disabled while saving', async () => {
 	const mockCreateSuccessNotice = jest.fn();
-	const mockCreateErrorNotice = jest.fn();
 	( useDispatch as jest.Mock ).mockReturnValue( {
 		createSuccessNotice: mockCreateSuccessNotice,
-		createErrorNotice: mockCreateErrorNotice,
+		createErrorNotice: jest.fn(),
 	} );
 
-	// Override the mock to make mutationFn return a delayed promise
-	// This simulates an async operation that takes time, making isPending true
 	const { userPreferencesMutation } = require( '@automattic/api-queries' );
 	userPreferencesMutation.mockReturnValue( {
 		mutationFn: jest.fn( () => {
@@ -235,20 +234,58 @@ test( 'disables save button while saving', async () => {
 		{ timeout: 5000 }
 	);
 
-	const sitesRadio = screen.getByLabelText( 'See a list of all your sites.' );
-	await user.click( sitesRadio );
+	const allSitesOption = screen.getByText( 'All Sites' ).closest( '[role="radio"]' );
+	await user.click( allSitesOption! );
 
-	const saveButton = screen.getByRole( 'button', { name: 'Save' } );
-
-	await user.click( saveButton );
-
+	// Verify cards are disabled during save (aria-disabled="true")
 	await waitFor(
 		() => {
-			expect( saveButton ).toBeDisabled();
+			const radioOptions = screen.getAllByRole( 'radio' );
+			radioOptions.forEach( ( option ) => {
+				expect( option ).toHaveAttribute( 'aria-disabled', 'true' );
+			} );
 		},
 		{ timeout: 5000 }
 	);
 
+	// Wait for save to complete
+	await waitFor(
+		() => {
+			expect( mockCreateSuccessNotice ).toHaveBeenCalled();
+		},
+		{ timeout: 5000 }
+	);
+} );
+
+test( 'supports keyboard navigation', async () => {
+	const mockCreateSuccessNotice = jest.fn();
+	( useDispatch as jest.Mock ).mockReturnValue( {
+		createSuccessNotice: mockCreateSuccessNotice,
+		createErrorNotice: jest.fn(),
+	} );
+
+	const { userPreferencesMutation } = require( '@automattic/api-queries' );
+	userPreferencesMutation.mockReturnValue( {
+		mutationFn: jest.fn( () => Promise.resolve( {} ) ),
+	} );
+
+	const user = userEvent.setup();
+	renderPreferencesDefaultLanding();
+
+	await waitFor(
+		() => {
+			expect( screen.getByText( 'Default landing page' ) ).toBeInTheDocument();
+		},
+		{ timeout: 5000 }
+	);
+
+	const allSitesOption = screen.getByText( 'All Sites' ).closest( '[role="radio"]' );
+
+	// Focus the option and press Enter
+	allSitesOption!.focus();
+	await user.keyboard( '{Enter}' );
+
+	// Verify save was triggered
 	await waitFor(
 		() => {
 			expect( mockCreateSuccessNotice ).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Replaces the boring list of radio options for the default landing page with something more visual.

**Before**

<img width="689" height="276" alt="image" src="https://github.com/user-attachments/assets/78994af4-3be2-4906-aecc-46e976adc2d3" />


**After**
<img width="697" height="293" alt="image" src="https://github.com/user-attachments/assets/3b81df70-d6ce-45d5-a12e-e98e22e3e835" />


## Test plan

- [ ] Navigate to /me/preferences in the new dashboard
- [ ] Verify all three options display with illustrations
- [ ] Click each option and verify selection updates
- [ ] Verify hover state shows gray border (except on selected item)
- [ ] Verify selected item has blue border and blue title
- [ ] Test keyboard navigation (Tab, Enter/Space to select)
- [ ] Verify responsive layout stacks vertically on mobile