### PR TITLE
Fix missing header on notification settings Updates tab

### DIFF
--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -265,7 +265,7 @@ class WPCOMNotifications extends Component {
 
 				<NavigationHeader
 					navigationItems={ [] }
-					label={ this.props.translate( 'Notification Settings' ) }
+					title={ this.props.translate( 'Notification Settings' ) }
 				/>
 
 				<Navigation path={ this.props.path } />


### PR DESCRIPTION
## Proposed Changes

* Change NavigationHeader prop from `label` to `title` in the Updates tab component

## Why are these changes being made?

* The Updates tab (`/me/notifications/updates`) was missing the "Notification Settings" header that appears above the tabs on other notification settings pages like Comments
* This caused visual inconsistency when navigating between tabs

## Testing Instructions

1. Navigate to `/me/notifications/updates`
2. Verify "Notification Settings" header appears above the tabs
3. Navigate to `/me/notifications/comments` and confirm both pages look consistent
4. Check the Notifications and Subscription settings tabs as well to ensure all tabs display consistently

## Screenshots

After 
<img width="3702" height="2124" alt="CleanShot 2026-01-14 at 20 01 31@2x" src="https://github.com/user-attachments/assets/96f1481b-568e-4eff-bbc4-96c6314a1fa6" />


Before
<img width="3696" height="2066" alt="CleanShot 2026-01-14 at 20 02 03@2x" src="https://github.com/user-attachments/assets/4c911ee3-8ff9-45cd-b31b-0424dd2fbab2" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?