### PR TITLE
Revert "Revert "MYJP-265 Fixing lightbox price for tiered products""

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -1,4 +1,4 @@
-import { JETPACK_SOCIAL_ADVANCED_PRODUCTS } from '@automattic/calypso-products';
+import { JETPACK_SOCIAL_ADVANCED_PRODUCTS, TERM_MONTHLY } from '@automattic/calypso-products';
 import { PlanPrice } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import clsx from 'clsx';
@@ -52,7 +52,14 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 		} );
 
 	const getCurrentTierPrice = () => {
-		const originalCurrentTierPrice = currentTier && currentTier.minimum_price / 100 / 12;
+		const isMonthly = product.term === TERM_MONTHLY;
+		let originalCurrentTierPrice = currentTier && currentTier.minimum_price / 100;
+
+		// If the term is not monthly, we need to convert the price to monthly.
+		if ( ! isMonthly && originalCurrentTierPrice ) {
+			originalCurrentTierPrice = originalCurrentTierPrice / 12;
+		}
+
 		let currentTierPrice = originalCurrentTierPrice;
 		if ( saleCouponDiscount && currentTierPrice ) {
 			currentTierPrice = currentTierPrice * ( 1 - saleCouponDiscount );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#108131 - reverting the reverted code so restoring the first merged PR because it wasn't causing the tests to fail.