### PR TITLE
MSD Site Owner Transfer: Display error message and send error to logstash

### DIFF
--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -7,6 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useState } from 'react';
+import { logToLogstash } from 'calypso/lib/logstash';
 import Notice from '../../components/notice';
 import type { Site, SiteOwnerTransferConfirmation } from '@automattic/api-core';
 
@@ -18,7 +19,7 @@ export function InvitationEmailSent( {
 	confirmationHash: string;
 } ) {
 	const [ newOwnerEmail, setNewOwnerEmail ] = useState( '' );
-	const [ hasError, setHasError ] = useState( false );
+	const [ error, setError ] = useState( '' );
 	const mutation = useMutation( siteOwnerTransferConfirmMutation( site.ID ) );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const router = useRouter();
@@ -49,20 +50,30 @@ export function InvitationEmailSent( {
 
 					setNewOwnerEmail( new_owner_email );
 				},
-				onError: () => {
-					setHasError( true );
+				onError: ( error: Error ) => {
+					setError( error.message || __( 'There was an error confirming the site transfer.' ) );
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: error.message,
+						tags: [ 'dashboard', 'site-owner-transfer' ],
+						properties: {
+							blog_id: site.ID,
+						},
+					} );
 				},
 			}
 		);
+		// We only want to call the API whenever the confirmationHash changes.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ confirmationHash ] );
 
-	if ( hasError ) {
+	if ( error ) {
 		return (
 			<Notice variant="error">
+				{ error }
+				&nbsp;
 				{ createInterpolateElement(
-					__(
-						'There was an error confirming the site transfer. Please <link>contact our support team</link> for help.'
-					),
+					__( 'Please <link>contact our support team</link> for help.' ),
 					{
 						link: (
 							// @ts-expect-error children prop is injected by createInterpolateElement

--- a/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
+++ b/client/dashboard/sites/settings-transfer-site/invitation-email-sent.tsx
@@ -51,7 +51,7 @@ export function InvitationEmailSent( {
 					setNewOwnerEmail( new_owner_email );
 				},
 				onError: ( error: Error ) => {
-					setError( error.message || __( 'There was an error confirming the site transfer.' ) );
+					setError( error.message );
 					logToLogstash( {
 						feature: 'calypso_client',
 						message: error.message,
@@ -69,11 +69,11 @@ export function InvitationEmailSent( {
 
 	if ( error ) {
 		return (
-			<Notice variant="error">
-				{ error }
-				&nbsp;
+			<Notice variant="error" title={ error }>
 				{ createInterpolateElement(
-					__( 'Please <link>contact our support team</link> for help.' ),
+					__(
+						'There was an error confirming the site transfer. Please <link>contact our support team</link> for help.'
+					),
 					{
 						link: (
 							// @ts-expect-error children prop is injected by createInterpolateElement


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1768307448981649/1768224094.672329-slack-C03TY6J1A

## Proposed Changes

* Display error message and send error to logstash for better debugging

<img width="1356" height="204" alt="image" src="https://github.com/user-attachments/assets/7c864ddd-26ad-40ad-9666-ec531dcbe29a" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Add log for better debugging

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites/:site/settings/transfer-site?site-transfer-confirm=123
* Ensure you can see the error message - "The hash is incorrect."
* Check your network request
* Ensure the error is sent logstash

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?