### PR TITLE
MSD: Add ability to stack ActionListItem actions.

### DIFF
--- a/client/dashboard/components/action-list/action-item.stories.tsx
+++ b/client/dashboard/components/action-list/action-item.stories.tsx
@@ -70,3 +70,16 @@ export const WithImage: Story = {
 		),
 	},
 };
+
+export const Stacked: Story = {
+	args: {
+		title: 'Action item title',
+		description: 'Action item description',
+		actions: (
+			<Button variant="secondary" size="compact">
+				Action
+			</Button>
+		),
+		layout: 'stacked',
+	},
+};

--- a/client/dashboard/components/action-list/action-item.tsx
+++ b/client/dashboard/components/action-list/action-item.tsx
@@ -7,7 +7,7 @@ import type { ActionItemProps } from './types';
 import './action-item.scss';
 
 function UnforwardedActionItem(
-	{ title, description, decoration, actions, className }: ActionItemProps,
+	{ title, description, decoration, actions, className, stackActions = false }: ActionItemProps,
 	ref: React.ForwardedRef< HTMLSpanElement >
 ) {
 	return (
@@ -19,14 +19,15 @@ function UnforwardedActionItem(
 			suffix={
 				<ButtonStack
 					className="action-item__actions"
-					justify="flex-end"
-					expanded={ false }
+					justify={ stackActions ? 'flex-start' : 'flex-end' }
+					expanded={ stackActions }
 					as="span"
 				>
 					{ actions }
 				</ButtonStack>
 			}
 			ref={ ref }
+			stackSuffix={ stackActions }
 		/>
 	);
 }

--- a/client/dashboard/components/action-list/action-item.tsx
+++ b/client/dashboard/components/action-list/action-item.tsx
@@ -6,28 +6,34 @@ import type { ActionItemProps } from './types';
 
 import './action-item.scss';
 
+const BUTTON_STACK_CONFIG = {
+	inline: { justify: 'flex-end' as const, expanded: false },
+	stacked: { justify: 'flex-start' as const, expanded: true },
+};
+
 function UnforwardedActionItem(
-	{ title, description, decoration, actions, className, stackActions = false }: ActionItemProps,
+	{ title, description, decoration, actions, className, layout = 'inline' }: ActionItemProps,
 	ref: React.ForwardedRef< HTMLSpanElement >
 ) {
+	const buttonConfig = BUTTON_STACK_CONFIG[ layout ];
 	return (
 		<IconListItem
 			className={ clsx( 'action-item', className ) }
 			title={ title }
 			description={ description }
 			decoration={ decoration }
+			layout={ layout }
 			suffix={
 				<ButtonStack
 					className="action-item__actions"
-					justify={ stackActions ? 'flex-start' : 'flex-end' }
-					expanded={ stackActions }
+					justify={ buttonConfig.justify }
+					expanded={ buttonConfig.expanded }
 					as="span"
 				>
 					{ actions }
 				</ButtonStack>
 			}
 			ref={ ref }
-			stackSuffix={ stackActions }
 		/>
 	);
 }

--- a/client/dashboard/components/action-list/types.ts
+++ b/client/dashboard/components/action-list/types.ts
@@ -1,11 +1,17 @@
 import React from 'react';
 import type { IconListItemProps, IconListProps } from '../icon-list/types';
 
-export interface ActionItemProps extends Omit< IconListItemProps, 'suffix' > {
+export interface ActionItemProps
+	extends Omit< IconListItemProps, 'suffix' | 'stackSuffix' | 'density' > {
 	/**
 	 * Renders a button that invokes the related action.
 	 */
 	actions: React.ReactNode;
+
+	/**
+	 * Whether to stack the actions. Default is false.
+	 */
+	stackActions?: boolean;
 }
 
 export interface ActionListProps extends IconListProps {

--- a/client/dashboard/components/action-list/types.ts
+++ b/client/dashboard/components/action-list/types.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { IconListItemProps, IconListProps } from '../icon-list/types';
+import type { IconListItemProps, IconListProps, ItemLayout } from '../icon-list/types';
 
 export interface ActionItemProps
 	extends Omit< IconListItemProps, 'suffix' | 'stackSuffix' | 'density' > {
@@ -9,9 +9,12 @@ export interface ActionItemProps
 	actions: React.ReactNode;
 
 	/**
-	 * Whether to stack the actions. Default is false.
+	 * Controls the layout of the actions relative to content.
+	 * - 'inline': Actions appear horizontally next to content (default)
+	 * - 'stacked': Actions appear below content in a vertical stack
+	 * @default 'inline'
 	 */
-	stackActions?: boolean;
+	layout?: ItemLayout;
 }
 
 export interface ActionListProps extends IconListProps {

--- a/client/dashboard/components/action-list/types.ts
+++ b/client/dashboard/components/action-list/types.ts
@@ -1,8 +1,7 @@
 import React from 'react';
 import type { IconListItemProps, IconListProps, ItemLayout } from '../icon-list/types';
 
-export interface ActionItemProps
-	extends Omit< IconListItemProps, 'suffix' | 'density' > {
+export interface ActionItemProps extends Omit< IconListItemProps, 'suffix' | 'density' > {
 	/**
 	 * Renders a button that invokes the related action.
 	 */

--- a/client/dashboard/components/action-list/types.ts
+++ b/client/dashboard/components/action-list/types.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import type { IconListItemProps, IconListProps, ItemLayout } from '../icon-list/types';
 
 export interface ActionItemProps
-	extends Omit< IconListItemProps, 'suffix' | 'stackSuffix' | 'density' > {
+	extends Omit< IconListItemProps, 'suffix' | 'density' > {
 	/**
 	 * Renders a button that invokes the related action.
 	 */

--- a/client/dashboard/components/icon-list/icon-list-item.scss
+++ b/client/dashboard/components/icon-list/icon-list-item.scss
@@ -15,5 +15,9 @@
 	.icon-list-item__suffix {
 		flex-shrink: 0;
 	}
+
+	.icon-list-item__content--wrap {
+		flex: 1;
+	}
 }
 

--- a/client/dashboard/components/icon-list/icon-list-item.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.tsx
@@ -5,9 +5,30 @@ import {
 } from '@wordpress/components';
 import clsx from 'clsx';
 import { forwardRef } from 'react';
-import type { IconListItemProps } from './types';
+import type { IconListItemProps, ItemLayout } from './types';
 
 import './icon-list-item.scss';
+
+const LAYOUT_CONFIG: Record<
+	ItemLayout,
+	{
+		Component: typeof HStack | typeof VStack;
+		outerAlignment: string; // For decoration/content alignment
+		innerAlignment: string | undefined; // For suffix alignment within content
+		className?: string;
+	}
+> = {
+	inline: {
+		Component: HStack,
+		innerAlignment: undefined, // Let HStack use default
+		className: undefined,
+	},
+	stacked: {
+		Component: VStack,
+		innerAlignment: 'flex-start',
+		className: 'icon-list-item__content--wrap',
+	},
+};
 
 function UnforwardedIconListItem(
 	{
@@ -17,7 +38,7 @@ function UnforwardedIconListItem(
 		suffix,
 		className,
 		density = 'medium',
-		stackSuffix = false,
+		layout = 'inline',
 	}: IconListItemProps,
 	ref: React.ForwardedRef< HTMLSpanElement >
 ) {
@@ -31,16 +52,20 @@ function UnforwardedIconListItem(
 	const textSpacing = densitySpacingMap[ density ] / 2;
 	const suffixSpacing = densitySpacingMap[ density ];
 	const titleSize = density === 'low' ? '15px' : undefined;
-	const alignment = description || stackSuffix ? 'flex-start' : 'center';
-	const InnerComponent = stackSuffix ? VStack : HStack;
+
+	const layoutConfig = LAYOUT_CONFIG[ layout ];
+	const { Component: LayoutComponent } = layoutConfig;
+
+	// Description forces top alignment regardless of layout
+	const outerAlignment = description ? 'flex-start' : 'center';
 
 	return (
 		<VStack className={ clsx( 'icon-list-item', className ) } ref={ ref } as="span">
-			<HStack spacing={ iconSpacing } alignment={ alignment } as="span">
+			<HStack spacing={ iconSpacing } alignment={ outerAlignment } as="span">
 				{ !! decoration && <span className="icon-list-item__decoration">{ decoration }</span> }
-				<InnerComponent
-					className={ clsx( stackSuffix && 'icon-list-item__content--wrap' ) }
-					alignment={ stackSuffix ? 'flex-start' : undefined }
+				<LayoutComponent
+					className={ layoutConfig.className }
+					alignment={ layoutConfig.innerAlignment }
 					spacing={ suffixSpacing }
 					as="span"
 				>
@@ -51,7 +76,7 @@ function UnforwardedIconListItem(
 						{ description && <Text variant="muted">{ description }</Text> }
 					</VStack>
 					{ suffix }
-				</InnerComponent>
+				</LayoutComponent>
 			</HStack>
 		</VStack>
 	);

--- a/client/dashboard/components/icon-list/icon-list-item.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.tsx
@@ -13,18 +13,20 @@ const LAYOUT_CONFIG: Record<
 	ItemLayout,
 	{
 		Component: typeof HStack | typeof VStack;
-		outerAlignment: string; // For decoration/content alignment
-		innerAlignment: string | undefined; // For suffix alignment within content
+		outerAlignment: string; // For Icon alignment within content
+		innerAlignment: string | undefined;
 		className?: string;
 	}
 > = {
 	inline: {
 		Component: HStack,
-		innerAlignment: undefined, // Let HStack use default
+		outerAlignment: 'center',
+		innerAlignment: undefined,
 		className: undefined,
 	},
 	stacked: {
 		Component: VStack,
+		outerAlignment: 'flex-start',
 		innerAlignment: 'flex-start',
 		className: 'icon-list-item__content--wrap',
 	},
@@ -57,7 +59,7 @@ function UnforwardedIconListItem(
 	const { Component: LayoutComponent } = layoutConfig;
 
 	// Description forces top alignment regardless of layout
-	const outerAlignment = description ? 'flex-start' : 'center';
+	const outerAlignment = description ? 'flex-start' : layoutConfig.outerAlignment;
 
 	return (
 		<VStack className={ clsx( 'icon-list-item', className ) } ref={ ref } as="span">

--- a/client/dashboard/components/icon-list/icon-list-item.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.tsx
@@ -39,7 +39,7 @@ function UnforwardedIconListItem(
 			<HStack spacing={ iconSpacing } alignment={ alignment } as="span">
 				{ !! decoration && <span className="icon-list-item__decoration">{ decoration }</span> }
 				<InnerComponent
-					className={ stackSuffix ? 'icon-list-item__content--wrap' : undefined }
+					className={ clsx( stackSuffix && 'icon-list-item__content--wrap' ) }
 					alignment={ stackSuffix ? 'flex-start' : undefined }
 					spacing={ suffixSpacing }
 					as="span"

--- a/client/dashboard/components/icon-list/icon-list-item.tsx
+++ b/client/dashboard/components/icon-list/icon-list-item.tsx
@@ -10,7 +10,15 @@ import type { IconListItemProps } from './types';
 import './icon-list-item.scss';
 
 function UnforwardedIconListItem(
-	{ title, description, decoration, suffix, className, density = 'medium' }: IconListItemProps,
+	{
+		title,
+		description,
+		decoration,
+		suffix,
+		className,
+		density = 'medium',
+		stackSuffix = false,
+	}: IconListItemProps,
 	ref: React.ForwardedRef< HTMLSpanElement >
 ) {
 	const densitySpacingMap = {
@@ -23,13 +31,19 @@ function UnforwardedIconListItem(
 	const textSpacing = densitySpacingMap[ density ] / 2;
 	const suffixSpacing = densitySpacingMap[ density ];
 	const titleSize = density === 'low' ? '15px' : undefined;
-	const alignment = description ? 'flex-start' : 'center';
+	const alignment = description || stackSuffix ? 'flex-start' : 'center';
+	const InnerComponent = stackSuffix ? VStack : HStack;
 
 	return (
 		<VStack className={ clsx( 'icon-list-item', className ) } ref={ ref } as="span">
 			<HStack spacing={ iconSpacing } alignment={ alignment } as="span">
 				{ !! decoration && <span className="icon-list-item__decoration">{ decoration }</span> }
-				<HStack spacing={ suffixSpacing } as="span">
+				<InnerComponent
+					className={ stackSuffix ? 'icon-list-item__content--wrap' : undefined }
+					alignment={ stackSuffix ? 'flex-start' : undefined }
+					spacing={ suffixSpacing }
+					as="span"
+				>
 					<VStack spacing={ textSpacing } as="span">
 						<Text weight={ 500 } lineHeight="24px" size={ titleSize }>
 							{ title }
@@ -37,7 +51,7 @@ function UnforwardedIconListItem(
 						{ description && <Text variant="muted">{ description }</Text> }
 					</VStack>
 					{ suffix }
-				</HStack>
+				</InnerComponent>
 			</HStack>
 		</VStack>
 	);

--- a/client/dashboard/components/icon-list/types.ts
+++ b/client/dashboard/components/icon-list/types.ts
@@ -1,5 +1,10 @@
 import React from 'react';
 
+/**
+ * Layout configuration for action/suffix positioning
+ */
+export type ItemLayout = 'inline' | 'stacked';
+
 export interface IconListItemProps {
 	/**
 	 * The main label that identifies the item.
@@ -34,9 +39,12 @@ export interface IconListItemProps {
 	density?: 'low' | 'medium' | 'high';
 
 	/**
-	 * Whether to stack the suffix. Default is false.
+	 * Controls the layout of the suffix relative to content.
+	 * - 'inline': Suffix appears horizontally next to content (default)
+	 * - 'stacked': Suffix appears below content in a vertical stack
+	 * @default 'inline'
 	 */
-	stackSuffix?: boolean;
+	layout?: ItemLayout;
 }
 
 export interface IconListProps {

--- a/client/dashboard/components/icon-list/types.ts
+++ b/client/dashboard/components/icon-list/types.ts
@@ -32,6 +32,11 @@ export interface IconListItemProps {
 	 * @default 'medium'
 	 */
 	density?: 'low' | 'medium' | 'high';
+
+	/**
+	 * Whether to stack the suffix. Default is false.
+	 */
+	stackSuffix?: boolean;
 }
 
 export interface IconListProps {


### PR DESCRIPTION
Alternative to #108108.

## Proposed Changes

A more opinionated version of  #108108 where consumers can force the actions to stack. It adds a `layout: inline | stacked;` property that controls whether the actions stack or not.


### Usage

```js

const isMobile = useViewportMatch( 'small' );

<ActionList.ActionItem
  actions={
      <Button
	      isBusy={ isFetchingPurchases }
	      disabled={ mutation.isPending || isFetchingPurchases }
	      onClick={ handleDeleteClick }
	      isDestructive
	      variant="secondary"
	      size="compact"
      >
	      { __( 'Delete account' ) }
      </Button>
  }
  decoration={ <Icon icon={ trash } size={ 24 } /> }
  description={ __( 'Description' ) }
  title={ __( 'Title ) }
  layout={ isMobile ? 'stacked' : 'inline' }
/>

```


| Unstacked  | Stacked |
|--------|--------|
| <img width="1272" height="967" alt="Screenshot 2026-01-15 at 3 53 23 PM" src="https://github.com/user-attachments/assets/1fdca3e0-e33a-4294-a1cb-5b8f5215f1f0" /> | <img width="1265" height="960" alt="Screenshot 2026-01-15 at 3 53 29 PM" src="https://github.com/user-attachments/assets/5d5cdd3b-966b-4d9c-a0db-a9a8ec39e3b6" />  |

## Why are these changes being made?

We need a way to stack the button under the content. We can't simply rely on wrap. There's more context in #108108.

## Testing Instructions

- Run `yarn storybook:start`
- Visit http://localhost:6006/?path=/docs/client-dashboard-actionlist-actionitem--docs
- Try toggle stackActions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
