### PR TITLE
MSD Sites: Disable domains, prepare-for-launch, settings for sites with pending status

### DIFF
--- a/client/dashboard/components/site-icon/index.tsx
+++ b/client/dashboard/components/site-icon/index.tsx
@@ -1,14 +1,14 @@
 import clsx from 'clsx';
 import { useMemo } from 'react';
 import { getSiteDisplayName } from '../../utils/site-name';
-import { getSiteStatus } from '../../utils/site-status';
+import { getSiteBlockingStatus } from '../../utils/site-status';
 import SiteMigrationIcon from './site-migration-icon';
 import type { Site } from '@automattic/api-core';
 
 import './style.scss';
 
 export default function SiteIcon( { site, size }: { site: Site; size?: number } ) {
-	const status = getSiteStatus( site );
+	const status = getSiteBlockingStatus( site );
 	const isMigration = status === 'migration_pending' || status === 'migration_started';
 	const fallbackInitial = getSiteDisplayName( site ).charAt( 0 );
 	return (

--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -22,6 +22,9 @@ export function useActions(): Action< Site >[] {
 	const router = useRouter();
 	const { recordTracksEvent } = useAnalytics();
 
+	// Some actions are not available if the site has migration, deleted, or DIFM status
+	const hasPendingStatus = ( site: Site ) => !! getSiteStatus( site );
+
 	return [
 		{
 			id: 'admin',
@@ -62,7 +65,7 @@ export function useActions(): Action< Site >[] {
 			isEligible: ( item: Site ) =>
 				siteTypeSupportsFeature( item, 'domains' ) &&
 				canManageSite( item ) &&
-				! getSiteStatus( item ),
+				! hasPendingStatus( item ),
 		},
 		{
 			id: 'jetpack-cloud',
@@ -87,7 +90,7 @@ export function useActions(): Action< Site >[] {
 			},
 			isEligible: ( item: Site ) =>
 				canManageSite( item ) &&
-				! getSiteStatus( item ) &&
+				! hasPendingStatus( item ) &&
 				! item.is_wpcom_staging_site &&
 				item.launch_status === 'unlaunched',
 		},
@@ -101,7 +104,7 @@ export function useActions(): Action< Site >[] {
 			isEligible: ( item: Site ) =>
 				siteTypeSupportsFeature( item, 'settings' ) &&
 				canManageSite( item ) &&
-				! getSiteStatus( item ),
+				! hasPendingStatus( item ),
 		},
 		{
 			id: 'restore',

--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -6,6 +6,7 @@ import { lazy, Suspense } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { siteDomainsRoute } from '../../app/router/sites';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
+import { getSiteStatus } from '../../utils/site-status';
 import { siteTypeSupportsFeature } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { canManageSite, canLeaveSite, canRestoreSite } from '../features';
@@ -59,7 +60,9 @@ export function useActions(): Action< Site >[] {
 				router.navigate( { to: siteDomainsRoute.fullPath, params: { siteSlug: site.slug } } );
 			},
 			isEligible: ( item: Site ) =>
-				siteTypeSupportsFeature( item, 'domains' ) && canManageSite( item ),
+				siteTypeSupportsFeature( item, 'domains' ) &&
+				canManageSite( item ) &&
+				! getSiteStatus( item ),
 		},
 		{
 			id: 'jetpack-cloud',
@@ -84,6 +87,7 @@ export function useActions(): Action< Site >[] {
 			},
 			isEligible: ( item: Site ) =>
 				canManageSite( item ) &&
+				! getSiteStatus( item ) &&
 				! item.is_wpcom_staging_site &&
 				item.launch_status === 'unlaunched',
 		},
@@ -95,7 +99,9 @@ export function useActions(): Action< Site >[] {
 				router.navigate( { to: '/sites/$siteSlug/settings', params: { siteSlug: site.slug } } );
 			},
 			isEligible: ( item: Site ) =>
-				siteTypeSupportsFeature( item, 'settings' ) && canManageSite( item ),
+				siteTypeSupportsFeature( item, 'settings' ) &&
+				canManageSite( item ) &&
+				! getSiteStatus( item ),
 		},
 		{
 			id: 'restore',

--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -6,7 +6,7 @@ import { lazy, Suspense } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { siteDomainsRoute } from '../../app/router/sites';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
-import { getSiteStatus } from '../../utils/site-status';
+import { getSiteBlockingStatus } from '../../utils/site-status';
 import { siteTypeSupportsFeature } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { canManageSite, canLeaveSite, canRestoreSite } from '../features';
@@ -23,7 +23,7 @@ export function useActions(): Action< Site >[] {
 	const { recordTracksEvent } = useAnalytics();
 
 	// Some actions are not available if the site has migration, deleted, or DIFM status
-	const hasPendingStatus = ( site: Site ) => !! getSiteStatus( site );
+	const hasBlockingStatus = ( site: Site ) => !! getSiteBlockingStatus( site );
 
 	return [
 		{
@@ -65,7 +65,7 @@ export function useActions(): Action< Site >[] {
 			isEligible: ( item: Site ) =>
 				siteTypeSupportsFeature( item, 'domains' ) &&
 				canManageSite( item ) &&
-				! hasPendingStatus( item ),
+				! hasBlockingStatus( item ),
 		},
 		{
 			id: 'jetpack-cloud',
@@ -90,7 +90,7 @@ export function useActions(): Action< Site >[] {
 			},
 			isEligible: ( item: Site ) =>
 				canManageSite( item ) &&
-				! hasPendingStatus( item ) &&
+				! hasBlockingStatus( item ) &&
 				! item.is_wpcom_staging_site &&
 				item.launch_status === 'unlaunched',
 		},
@@ -104,7 +104,7 @@ export function useActions(): Action< Site >[] {
 			isEligible: ( item: Site ) =>
 				siteTypeSupportsFeature( item, 'settings' ) &&
 				canManageSite( item ) &&
-				! hasPendingStatus( item ),
+				! hasBlockingStatus( item ),
 		},
 		{
 			id: 'restore',

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -9,7 +9,7 @@ import TimeSince from '../../components/time-since';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName, getSitePlanDisplayName__ES } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
-import { getSiteStatus } from '../../utils/site-status';
+import { getSiteBlockingStatus } from '../../utils/site-status';
 import {
 	isSelfHostedJetpackConnected,
 	isSelfHostedJetpackConnected__ES,
@@ -135,7 +135,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 				<Visibility
 					siteSlug={ item.slug }
 					visibility={ field.getValue( { item } ) }
-					status={ getSiteStatus( item ) }
+					status={ getSiteBlockingStatus( item ) }
 					isLaunched={ item.launch_status === 'launched' || item.launch_status === false }
 				/>
 			),

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -35,7 +35,12 @@ import { isSitePlanTrial } from '../plans';
 import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
 import type { SiteVisibility } from '../../types';
-import type { DashboardSiteListSite, Site, SiteBadge, SiteStatus } from '@automattic/api-core';
+import type {
+	DashboardSiteListSite,
+	Site,
+	SiteBadge,
+	SiteBlockingStatus,
+} from '@automattic/api-core';
 import type { ComponentProps } from 'react';
 
 function IneligibleIndicator() {
@@ -474,7 +479,7 @@ export function Visibility( {
 }: {
 	siteSlug: string;
 	visibility: SiteVisibility;
-	status: SiteStatus;
+	status: SiteBlockingStatus;
 	isLaunched?: boolean;
 } ) {
 	const visibilityLabels = getVisibilityLabels();

--- a/client/dashboard/utils/site-badge.ts
+++ b/client/dashboard/utils/site-badge.ts
@@ -1,10 +1,10 @@
 import { isSitePlanTrial } from '../sites/plans';
-import { getSiteStatus } from './site-status';
+import { getSiteBlockingStatus } from './site-status';
 import { isP2 } from './site-types';
 import type { Site, SiteBadge } from '@automattic/api-core';
 
 export function getSiteBadge( site: Site ): SiteBadge {
-	const status = getSiteStatus( site );
+	const status = getSiteBlockingStatus( site );
 	if ( status ) {
 		return status;
 	}

--- a/client/dashboard/utils/site-name.ts
+++ b/client/dashboard/utils/site-name.ts
@@ -1,10 +1,10 @@
 import { __ } from '@wordpress/i18n';
-import { getSiteStatus } from './site-status';
+import { getSiteBlockingStatus } from './site-status';
 import { getSiteDisplayUrl } from './site-url';
 import type { Site } from '@automattic/api-core';
 
 export function getSiteDisplayName( site: Site ) {
-	const status = getSiteStatus( site );
+	const status = getSiteBlockingStatus( site );
 	if ( status === 'migration_pending' || status === 'migration_started' ) {
 		return __( 'Incoming Migration' );
 	}

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -1,10 +1,10 @@
 import type { SiteMigrationStatus } from '../types';
-import type { Site, SiteStatus } from '@automattic/api-core';
+import type { Site, SiteBlockingStatus } from '@automattic/api-core';
 
 const MIGRATION_STATUSES: SiteMigrationStatus[ 'status' ][] = [ 'pending', 'started', 'completed' ];
 const MIGRATION_TYPES: SiteMigrationStatus[ 'type' ][] = [ 'difm', 'diy', 'ssh' ];
 
-export function getSiteStatus( item: Site ): SiteStatus {
+export function getSiteBlockingStatus( item: Site ): SiteBlockingStatus {
 	if ( item.is_deleted ) {
 		return 'deleted';
 	}

--- a/packages/api-core/src/dashboard-site-list/types.ts
+++ b/packages/api-core/src/dashboard-site-list/types.ts
@@ -1,11 +1,11 @@
-export type SiteStatus =
+export type SiteBlockingStatus =
 	| 'deleted'
 	| 'migration_pending'
 	| 'migration_started'
 	| 'difm_lite_in_progress'
 	| null;
 
-export type SiteBadge = 'staging' | 'trial' | 'p2' | SiteStatus;
+export type SiteBadge = 'staging' | 'trial' | 'p2' | SiteBlockingStatus;
 
 export interface DashboardSiteListSite {
 	badge?: SiteBadge;
@@ -44,7 +44,7 @@ export interface DashboardSiteListSite {
 	owner_id?: number;
 	php_version?: string;
 	slug: string; // Slug is always fetched
-	status?: SiteStatus;
+	status?: SiteBlockingStatus;
 	views?: null | number;
 	visitors?: null | number;
 	total_wpcom_subscribers?: number;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1768457680534989-slack-CRWCHQGUB

## Proposed Changes

* Disable domains, prepare-for-launch, settings for sites with pending status

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Trial-expired sites, DIFM sites, and migration sites are not allowed to open domains, prepare-for-launch, and settings page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Click `...` on your trial-expired sites, DIFM sites, and migration sites
* Ensure you won't see the following actions
  * domains
  * prepare-for-launch
  * settings 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?