### PR TITLE
e2e tests: remove assertions from page object

### DIFF
--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -64,7 +64,7 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 		} );
 
 		await test.step( 'Then I can see the invite is pending', async function () {
-			await pagePeople.expectInvitationAndAssert( testUser.email, expect );
+			await pagePeople.waitForInvitation( testUser.email );
 		} );
 
 		await test.step( 'When the invited user checks their email', async function () {
@@ -103,16 +103,15 @@ test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
 
 		await test.step( 'Then I can see the invited user part of the team', async function () {
 			// Use direct navigation to avoid finding the user when there are over 100 team members piled up.
-			await pagePeople.visitTeamMemberUserDetailsAndAssert(
+			await pagePeople.visitTeamMemberUserDetails(
 				helperData.getCalypsoURL(),
 				accountPreRelease.credentials.testSites?.primary?.url as string,
-				signedUpUsername,
-				expect
+				signedUpUsername
 			);
 		} );
 
 		await test.step( 'Then I can remove the team member from the site', async function () {
-			await pagePeople.removeUserFromSiteAndAssert( signedUpUsername, expect );
+			await pagePeople.removeUserFromSite( signedUpUsername );
 		} );
 
 		await test.step( 'And the invited user closes their account', async function () {

--- a/test/e2e/specs/users/invite__revoke.spec.ts
+++ b/test/e2e/specs/users/invite__revoke.spec.ts
@@ -62,7 +62,7 @@ test.describe(
 			} );
 
 			await test.step( 'Then I can see the invite is pending', async function () {
-				await pagePeople.expectInvitationAndAssert( testEmailAddress, expect );
+				await pagePeople.waitForInvitation( testEmailAddress );
 			} );
 
 			await test.step( 'When I select the invited user', async function () {
@@ -70,7 +70,7 @@ test.describe(
 			} );
 
 			await test.step( 'And I revoke the invite', async function () {
-				await pagePeople.revokeInviteAndAssert( expect );
+				await pagePeople.revokeInvite();
 			} );
 
 			await test.step( 'Then the invite link is no longer valid', async function () {


### PR DESCRIPTION
## Proposed Changes

Refactors PeoplePage to use Playwright's built-in waiting methods instead of expect assertions, following the page object model pattern where page objects should handle element waiting but leave assertions to test files.

Follow-up of #108051, cc @p-jackson 

## Testing Instructions

```
# Build calypso-e2e package
yarn workspace wp-e2e-tests build

# Run Playwright Test migrated tests
yarn workspace wp-e2e-tests test:pw

# Run legacy Jest tests
yarn workspace wp-e2e-tests test
```
