### PR TITLE
Fix typo in PreReleaseE2ETests build parameters

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1170,7 +1170,7 @@ object PreReleaseE2ETests : BuildType({
 		param("env.HEADLESS", "true")
 		param("env.LOCALE", "en")
 		param("env.CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
-		param("end.DASHBOARD_BASE_URL", "https://my.wordpress.com")
+		param("env.DASHBOARD_BASE_URL", "https://my.wordpress.com")
 		param("env.ALLURE_RESULTS_PATH", "allure-results")
 	}
 


### PR DESCRIPTION

## Proposed Changes

Fixes a typo in TeamCity build configuration - "end" should be "env": `end.DASHBOARD_BASE_URL` -> `env.DASHBOARD_BASE_URL`

## Testing Instructions

Team City e2e builds pass
