### PR TITLE
A4A: Copy referral link UX refinement.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -92,9 +92,14 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 
 	const handleRequestPayment = useCallback(
 		( flowType: ReferralOrderFlowType ) => {
-			if ( ! hasCompletedForm ) {
+			if ( flowType === 'send' && ! hasCompletedForm ) {
 				return;
 			}
+
+			if ( flowType === 'copy' && ! email ) {
+				return;
+			}
+
 			if ( ! emailValidator.validate( email ) ) {
 				setValidationError( { email: translate( 'Please provide correct email address' ) } );
 				return;
@@ -242,7 +247,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 				<Button
 					primary
 					onClick={ () => handleRequestPayment( 'copy' ) }
-					disabled={ ! hasCompletedForm || isUserUnverified }
+					disabled={ ! email || isUserUnverified }
 					busy={ isPending }
 				>
 					<Icon icon={ customLink } />

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
@@ -67,13 +67,32 @@ export default function NewReferralOrderNotification( {
 						? translate( 'Referral sent to %(referralEmail)s', {
 								args: { referralEmail: referralOrderEmail },
 						  } )
-						: translate( 'Order link copied to your clipboard' ) ) as string
+						: translate( 'The referral link has been copied to your clipboard!' ) ) as string
 				}
 			>
 				<div className="new-referral-order-notification">
-					{ translate(
-						'The referral order link is valid for 14 days, so be sure to share it with your client and have them complete the payment before it expires.'
-					) }
+					<ul>
+						<li>
+							{ translate(
+								'This link is {{b}}valid for 14 days{{/b}}. Please ensure your client makes this purchase before it expires.',
+								{
+									components: {
+										b: <b />,
+									},
+								}
+							) }
+						</li>
+						<li>
+							{ translate(
+								'During checkout, your client will create a WordPress.com account and will be emailed a receipt.'
+							) }
+						</li>
+						<li>
+							{ translate(
+								'After purchase, you can immediately set up the hosting or any products referred.'
+							) }
+						</li>
+					</ul>
 
 					<Button
 						variant="secondary"

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -221,4 +221,8 @@ $data-view-border-color: #f1f1f1;
 	flex-direction: column;
 	gap: 20px;
 	align-items: flex-start;
+
+	ul {
+		margin: 16px;
+	}
 }


### PR DESCRIPTION

Context: pgjTho-1Em-p2#comment-1634

## Proposed Changes

This pull request updates the client payment request and referral notification flows to improve user experience and validation. The main changes include refining validation logic for different payment request actions, updating button states, and enhancing the referral notification with clearer messaging and formatting.

**Validation and UX improvements in payment request flow:**

* Updated the `handleRequestPayment` function in `request-client-payment.tsx` to ensure the form is only required for 'send' actions and that an email is required for 'copy' actions, improving validation logic for different request types.
* Changed the 'copy' button's disabled state to depend on the presence of an email rather than form completion, ensuring the button is only enabled when appropriate.

<img width="546" height="621" alt="Screenshot 2026-01-15 at 8 01 06 PM" src="https://github.com/user-attachments/assets/433bb940-76ee-4e49-8a80-75f4404fc073" />


**Enhancements to referral notification messaging:**

* Updated the notification message in `new-referral-order-notification.tsx` to provide clearer feedback when the referral link is copied, and added a bulleted list with important details about link validity, client checkout, and post-purchase actions.
* Adjusted the styling in `style.scss` to add margin to the new list in the referral notification, improving visual clarity.

<img width="845" height="266" alt="Screenshot 2026-01-15 at 7 58 28 PM" src="https://github.com/user-attachments/assets/96eb5411-5bed-45fb-983c-0291fcfe2a1a" />


## Why are these changes being made?

* Slightly refine the experience around copy referral link flow.

## Testing Instructions

* Use the A4A live link and navigate to the `/marketplace` page.
* Create a referral.
* Verify that you are able to create and copy a link without a message value.
* Verify that the Success referral order notice is updated. See screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?