### PR TITLE
A4A: Add resource name to recordResourceEvent mutation

### DIFF
--- a/client/a8c-for-agencies/data/learn/use-record-resource-event-mutation.ts
+++ b/client/a8c-for-agencies/data/learn/use-record-resource-event-mutation.ts
@@ -3,6 +3,7 @@ import wpcom from 'calypso/lib/wp';
 
 interface RecordResourceEventParams {
 	resourceId: number;
+	resourceName: string;
 	agencyId: number;
 }
 
@@ -21,6 +22,7 @@ function mutationRecordResourceEvent( params: RecordResourceEventParams ): Promi
 		path: '/agency/resources/record-event',
 		body: {
 			resource_id: params.resourceId,
+			resource_name: params.resourceName,
 			agency_id: params.agencyId,
 		},
 	} );

--- a/client/a8c-for-agencies/sections/learn/resource-center/overview-content/resource-card.tsx
+++ b/client/a8c-for-agencies/sections/learn/resource-center/overview-content/resource-card.tsx
@@ -55,6 +55,7 @@ export default function ResourceCard( {
 		if ( agencyId ) {
 			recordResourceEvent( {
 				resourceId: resource.id,
+				resourceName: resource.name,
 				agencyId,
 			} );
 		}


### PR DESCRIPTION
Related to https://linear.app/a8c/project/launch-mvp-resource-center-9430a7bf5993/overview

## Proposed Changes

* Added `resourceName` parameter to `RecordResourceEventParams` interface
* Updated API request body to include `resource_name` field
* Updated `ResourceCard` component to pass resource name when recording events

## Why are these changes being made?

The resource name needs to be tracked along with the resource ID when recording resource events in the API. 

## Testing Instructions

* Navigate to the Resource Center section
* Click on a resource card to trigger the event
* Verify that the API request includes the `resource_name` field in the request body
* Check that the resource name matches the displayed resource name

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?