### PR TITLE
A4A: Update copies for Migration request form.

### DIFF
--- a/client/a8c-for-agencies/hooks/use-help-center.ts
+++ b/client/a8c-for-agencies/hooks/use-help-center.ts
@@ -40,16 +40,16 @@ export default function useHelpCenter() {
 		setNavigateToRoute( '/post?link=' + encodeURIComponent( link ) );
 	};
 
-	const hasSupportFormHash =
-		window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
-		window.location.hash === CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT ||
-		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
-
 	useEffect( () => {
 		// We support URL hash fragments for the contact support form.
 		// When the hash changes, we need to check if it contains a support form hash fragment.
 		// If it does, we need to set the show help center to true and set the navigate to route to the contact form.
 		const handleHashChange = () => {
+			const hasSupportFormHash =
+				window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
+				window.location.hash === CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT ||
+				window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
+
 			if ( hasSupportFormHash && isEnabled( 'a4a-help-center' ) ) {
 				const isMigrationRequest =
 					window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
@@ -66,7 +66,7 @@ export default function useHelpCenter() {
 		handleHashChange();
 
 		return () => window.removeEventListener( 'hashchange', handleHashChange );
-	}, [ hasSupportFormHash, setNavigateToRoute, setShowHelpCenter ] );
+	}, [ setNavigateToRoute, setShowHelpCenter ] );
 
 	return {
 		toggleHelpCenter: handleToggleHelpCenter,

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -51,9 +51,7 @@ export const HelpCenterA4AContactForm = () => {
 		site: '',
 		product: '',
 		message: isMigrationRequest
-			? __( "I'd like to chat more about the migration offer.", __i18n_text_domain__ ) +
-			  '\n\n' +
-			  __( '[your message here]', __i18n_text_domain__ )
+			? __( "I'd like to migrate from [insert your current host here].", __i18n_text_domain__ )
 			: '',
 		no_of_sites: 1,
 		pressable_contact: 'sales',

--- a/packages/help-center/src/components/help-center-a4a-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-a4a-contact-form.tsx
@@ -7,6 +7,7 @@ import {
 	TextareaControl,
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
+	__experimentalText as Text,
 	Notice,
 	TextControl,
 } from '@wordpress/components';
@@ -120,7 +121,7 @@ export const HelpCenterA4AContactForm = () => {
 			{
 				id: 'product',
 				label: isMigrationRequest
-					? __( 'What hosting product are you considering?', __i18n_text_domain__ )
+					? __( 'Where would you like us to migrate your site?', __i18n_text_domain__ )
 					: __( 'What product would you like help with?', __i18n_text_domain__ ),
 				type: 'text' as const,
 				Edit: 'select',
@@ -139,7 +140,7 @@ export const HelpCenterA4AContactForm = () => {
 								value: 'pressable',
 							},
 							{
-								label: __( "Don't know", __i18n_text_domain__ ),
+								label: __( 'I need help to decide', __i18n_text_domain__ ),
 								value: 'dont-know',
 							},
 					  ]
@@ -192,7 +193,12 @@ export const HelpCenterA4AContactForm = () => {
 			},
 			{
 				id: 'message',
-				label: __( 'How can we help?', __i18n_text_domain__ ),
+				label: isMigrationRequest
+					? __(
+							'Anything we should know about your current site(s) or migration needs?',
+							__i18n_text_domain__
+					  )
+					: __( 'How can we help?', __i18n_text_domain__ ),
 				type: 'text' as const,
 				Edit: ( { field, data, onChange } ) => {
 					const { id, getValue } = field;
@@ -274,7 +280,20 @@ export const HelpCenterA4AContactForm = () => {
 	return (
 		<form onSubmit={ handleSubmit } className="help-center-a4a-contact-form">
 			<VStack spacing={ 4 } justify="flex-start">
-				<Heading level={ 3 }>{ __( 'Contact sales & support', __i18n_text_domain__ ) }</Heading>
+				<Heading level={ 3 }>
+					{ isMigrationRequest
+						? __( 'Request a Free Concierge Migration', __i18n_text_domain__ )
+						: __( 'Contact sales & support', __i18n_text_domain__ ) }
+				</Heading>
+
+				{ isMigrationRequest && (
+					<Text>
+						{ __(
+							'We’ll help move your site to Pressable or WordPress.com for free. Fill out this short form, and our team will get in touch to assist with your migration.',
+							__i18n_text_domain__
+						) }
+					</Text>
+				) }
 
 				<DataForm< FormData >
 					data={ formData }


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-950/clarify-concierge-migration-form-in-the-dashboard

| Before | After |
|--------|--------|
| <img width="436" height="820" alt="Screenshot 2026-01-15 at 8 35 13 PM" src="https://github.com/user-attachments/assets/1ead7ccc-396f-44c8-b3fb-00b63df0eaad" /> | <img width="443" height="838" alt="Screenshot 2026-01-15 at 8 34 23 PM" src="https://github.com/user-attachments/assets/2632735e-eeba-48cb-9e10-34c2098c936b" /> | 

## Proposed Changes

This pull request updates the `HelpCenterA4AContactForm` component to improve the user experience for site migration requests, making the form more context-aware and user-friendly. The changes include dynamic headings, contextual field labels, and additional guidance text for migration scenarios.

**Enhancements for migration requests:**

* The form heading now dynamically displays "Request a Free Concierge Migration" instead of "Contact sales & support" when the user is making a migration request.
* Added a descriptive `Text` component under the heading for migration requests, explaining the free migration service and next steps.

**Field label and option improvements:**

* Updated the label for the product selection field to "Where would you like us to migrate your site?" for migration requests, and clarified the default label for other scenarios.
* Changed the "Don't know" option in the product select dropdown to "I need help to decide" for clearer language.
* The message field label is now contextual: for migration requests, it asks for details about the current site or migration needs.

## Why are these changes being made?

* An agency gave feedback that they were confused while searching for the Concierge process. They found the standard form unclear and abandoned the process. This PR improves the copies to clarify the process.

## Testing Instructions

* Use the A4A live link and navigate to the `/migrations/overview` page.
* Click **Migrate your sites > Concierge service** button at the top right.
* Verify that the migration form has the correct copies. See screenshot above.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
