### PR TITLE
A4A: Add empty state message to resource center search

### DIFF
--- a/client/a8c-for-agencies/sections/learn/resource-center/overview-content/browse-all-resources.tsx
+++ b/client/a8c-for-agencies/sections/learn/resource-center/overview-content/browse-all-resources.tsx
@@ -2,6 +2,8 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalSpacer as Spacer,
 	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useState, useMemo } from '@wordpress/element';
@@ -144,17 +146,30 @@ export default function BrowseAllResources( {
 				</HStack>
 				<DataViews.FiltersToggled className="resource-center-filters" />
 			</DataViews>
-			<div className="resource-center-cards resource-center-browse-all-resources">
-				{ filteredData.map( ( item ) => (
-					<ResourceCard
-						key={ item.id }
-						resource={ item }
-						onOpenVideoModal={ onOpenVideoModal }
-						showLogo
-						tracksEventName="calypso_a4a_resource_center_browse_cta_click"
-					/>
-				) ) }
-			</div>
+			{ filteredData.length > 0 ? (
+				<div className="resource-center-cards resource-center-browse-all-resources">
+					{ filteredData.map( ( item ) => (
+						<ResourceCard
+							key={ item.id }
+							resource={ item }
+							onOpenVideoModal={ onOpenVideoModal }
+							showLogo
+							tracksEventName="calypso_a4a_resource_center_browse_cta_click"
+						/>
+					) ) }
+				</div>
+			) : (
+				<Spacer marginTop={ 2 } marginBottom={ 4 }>
+					<VStack className="resource-center-empty-results" spacing={ 2 }>
+						<Text weight={ 500 }>{ __( "We couldn't find any resources related to that." ) }</Text>
+						<Text>
+							{ __(
+								'Try adjusting your search or exploring other resources to help your agency grow.'
+							) }
+						</Text>
+					</VStack>
+				</Spacer>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
Related to https://linear.app/a8c/project/launch-mvp-resource-center-9430a7bf5993/overview

## Proposed Changes

<img width="516" height="183" alt="Screenshot 2026-01-15 at 13 32 55" src="https://github.com/user-attachments/assets/e3abc11d-4873-41c7-99e6-4e2cd1b0baf3" />

Display a message when no resources are found after searching or filtering in the resource center.

## Testing Instructions

1. Navigate to the A4A resource center
2. Use the search to search for something that doesn't exist
3. Verify the empty state message is displayed

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?