### PR TITLE
MSD Site Settings: Gate features by the site types

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -20,16 +20,7 @@ boot( {
 	mainRoute: '/sites',
 	Logo: null,
 	supports: {
-		sites: {
-			settings: {
-				general: {
-					redirect: false,
-				},
-				server: false,
-				security: false,
-				experimental: false,
-			},
-		},
+		sites: true,
 		domains: true,
 		emails: true,
 		themes: false,

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -20,16 +20,7 @@ boot( {
 	mainRoute: '/sites',
 	Logo,
 	supports: {
-		sites: {
-			settings: {
-				general: {
-					redirect: true,
-				},
-				server: true,
-				security: true,
-				experimental: true,
-			},
-		},
+		sites: true,
 		domains: true,
 		emails: true,
 		themes: true,

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -12,21 +12,6 @@ import type {
 	FetchDashboardSiteFiltersParams,
 } from '@automattic/api-core';
 
-export type SiteSettingsGeneralSupports = {
-	redirect: boolean;
-};
-
-export type SiteSettingsSupports = {
-	general: SiteSettingsGeneralSupports;
-	server: boolean;
-	security: boolean;
-	experimental: boolean;
-};
-
-export type SiteFeatureSupports = {
-	settings: SiteSettingsSupports | false;
-};
-
 export type MeBillingSupports = {
 	monetizeSubscriptions: boolean;
 };
@@ -49,7 +34,7 @@ export type AppConfig = {
 	Logo: React.FC | null;
 	LoadingLogo?: React.FC;
 	supports: {
-		sites: SiteFeatureSupports | false;
+		sites: boolean;
 		plugins: boolean;
 		domains: boolean;
 		emails: boolean;

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -587,6 +587,7 @@ export const siteSettingsIndexRoute = createRoute( {
 );
 
 export const siteSettingsSiteVisibilityRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneral' },
 	head: () => ( {
 		meta: [
 			{
@@ -626,6 +627,7 @@ export const siteSettingsSiteVisibilityRoute = createRoute( {
 );
 
 export const siteSettingsRedirectRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneralRedirect' },
 	head: () => ( {
 		meta: [
 			{
@@ -651,6 +653,7 @@ export const siteSettingsRedirectRoute = createRoute( {
 );
 
 export const siteSettingsSubscriptionGiftingRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneral' },
 	head: () => ( {
 		meta: [
 			{
@@ -683,6 +686,7 @@ export const siteSettingsSubscriptionGiftingRoute = createRoute( {
 );
 
 export const siteSettingsWordPressRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
 	head: () => ( {
 		meta: [
 			{
@@ -707,6 +711,7 @@ export const siteSettingsWordPressRoute = createRoute( {
 );
 
 export const siteSettingsPHPRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
 	head: () => ( {
 		meta: [
 			{
@@ -731,6 +736,7 @@ export const siteSettingsPHPRoute = createRoute( {
 );
 
 export const siteSettingsDatabaseRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
 	head: () => ( {
 		meta: [
 			{
@@ -749,6 +755,7 @@ export const siteSettingsDatabaseRoute = createRoute( {
 );
 
 export const siteSettingsAgencyRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneral' },
 	head: () => ( {
 		meta: [
 			{
@@ -786,6 +793,7 @@ export const siteSettingsAgencyRoute = createRoute( {
 );
 
 export const siteSettingsHundredYearPlanRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsGeneral' },
 	head: () => ( {
 		meta: [
 			{
@@ -818,6 +826,7 @@ export const siteSettingsHundredYearPlanRoute = createRoute( {
 );
 
 export const siteSettingsPrimaryDataCenterRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
 	head: () => ( {
 		meta: [
 			{
@@ -857,6 +866,7 @@ export const siteSettingsPrimaryDataCenterRoute = createRoute( {
 );
 
 export const siteSettingsStaticFile404Route = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
 	head: () => ( {
 		meta: [
 			{
@@ -881,6 +891,7 @@ export const siteSettingsStaticFile404Route = createRoute( {
 );
 
 export const siteSettingsCachingRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
 	head: () => ( {
 		meta: [
 			{
@@ -905,6 +916,7 @@ export const siteSettingsCachingRoute = createRoute( {
 );
 
 export const siteSettingsDefensiveModeRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsSecurity' },
 	head: () => ( {
 		meta: [
 			{
@@ -929,6 +941,7 @@ export const siteSettingsDefensiveModeRoute = createRoute( {
 );
 
 export const siteSettingsSftpSshRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
 	head: () => ( {
 		meta: [
 			{
@@ -987,6 +1000,7 @@ export const siteSettingsTransferSiteRoute = createRoute( {
 );
 
 export const siteSettingsWebApplicationFirewallRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsSecurity' },
 	head: () => ( {
 		meta: [
 			{
@@ -1014,6 +1028,7 @@ export const siteSettingsWebApplicationFirewallRoute = createRoute( {
 );
 
 export const siteSettingsWpcomLoginRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsSecurity' },
 	head: () => ( {
 		meta: [
 			{
@@ -1041,6 +1056,7 @@ export const siteSettingsWpcomLoginRoute = createRoute( {
 );
 
 export const siteSettingsExperimentalRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsExperimental' },
 	head: () => ( {
 		meta: [
 			{
@@ -1061,6 +1077,7 @@ export const siteSettingsExperimentalRoute = createRoute( {
 	)
 );
 export const siteSettingsRepositoriesRoute = createRoute( {
+	staticData: { requiresSiteTypeSupport: 'settingsServer' },
 	head: () => ( {
 		meta: [
 			{
@@ -1333,59 +1350,43 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 		siteDomainsRoute,
 	];
 
-	if ( config.supports.sites.settings ) {
-		const settingsRoutes: AnyRoute[] = [ siteSettingsIndexRoute, siteSettingsTransferSiteRoute ];
+	const settingsRoutes: AnyRoute[] = [
+		siteSettingsIndexRoute,
+		siteSettingsTransferSiteRoute,
 
-		if ( config.supports.sites.settings.general ) {
-			const settingsGeneralRoutes: AnyRoute[] = [
-				siteSettingsSiteVisibilityRoute,
-				siteSettingsSubscriptionGiftingRoute,
-				siteSettingsAgencyRoute,
-				siteSettingsHundredYearPlanRoute,
-			];
+		// General
+		siteSettingsSiteVisibilityRoute,
+		siteSettingsSubscriptionGiftingRoute,
+		siteSettingsAgencyRoute,
+		siteSettingsHundredYearPlanRoute,
+		siteSettingsRedirectRoute,
 
-			if ( config.supports.sites.settings.general.redirect ) {
-				settingsGeneralRoutes.push( siteSettingsRedirectRoute );
-			}
+		// Server
+		siteSettingsWordPressRoute,
+		siteSettingsPHPRoute,
+		siteSettingsSftpSshRoute,
+		siteSettingsRepositoriesRoute.addChildren( [
+			siteSettingsRepositoriesIndexRoute,
+			siteSettingsRepositoriesConnectRoute,
+			siteSettingsRepositoriesManageRoute,
+		] ),
+		siteSettingsDatabaseRoute,
+		siteSettingsPrimaryDataCenterRoute,
+		siteSettingsStaticFile404Route,
+		siteSettingsCachingRoute,
 
-			settingsRoutes.push( ...settingsGeneralRoutes );
-		}
+		// Security
+		siteSettingsWebApplicationFirewallRoute,
+		siteSettingsWpcomLoginRoute,
+		siteSettingsDefensiveModeRoute,
+	];
 
-		if ( config.supports.sites.settings.server ) {
-			settingsRoutes.push(
-				...[
-					siteSettingsWordPressRoute,
-					siteSettingsPHPRoute,
-					siteSettingsSftpSshRoute,
-					siteSettingsRepositoriesRoute.addChildren( [
-						siteSettingsRepositoriesIndexRoute,
-						siteSettingsRepositoriesConnectRoute,
-						siteSettingsRepositoriesManageRoute,
-					] ),
-					siteSettingsDatabaseRoute,
-					siteSettingsPrimaryDataCenterRoute,
-					siteSettingsStaticFile404Route,
-					siteSettingsCachingRoute,
-				]
-			);
-		}
-
-		if ( config.supports.sites.settings.security ) {
-			settingsRoutes.push(
-				...[
-					siteSettingsWebApplicationFirewallRoute,
-					siteSettingsWpcomLoginRoute,
-					siteSettingsDefensiveModeRoute,
-				]
-			);
-		}
-
-		if ( config.supports.sites.settings.experimental && isEnabled( 'wordpress-ai-assistant' ) ) {
-			settingsRoutes.push( siteSettingsExperimentalRoute );
-		}
-
-		siteRoutes.push( siteSettingsRoute.addChildren( settingsRoutes ) );
+	// Experimental
+	if ( isEnabled( 'wordpress-ai-assistant' ) ) {
+		settingsRoutes.push( siteSettingsExperimentalRoute );
 	}
+
+	siteRoutes.push( siteSettingsRoute.addChildren( settingsRoutes ) );
 
 	return [
 		sitesRoute.lazy( () =>

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -3,11 +3,11 @@ import config from '@automattic/calypso-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useAppContext } from '../../app/context';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
 import { SummaryButtonList } from '../../components/summary-button-list';
+import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import AgencySettingsSummary from '../settings-agency/summary';
 import AISiteAssistantSettingsSummary from '../settings-ai-assistant/summary';
 import CachingSettingsSummary from '../settings-caching/summary';
@@ -33,10 +33,9 @@ import type { SiteSettings } from '@automattic/api-core';
 export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: settings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
-	const { supports } = useAppContext();
-	const supportsSettings = supports.sites && supports.sites.settings;
+	const siteTypeSupports = getSiteTypeFeatureSupports( site );
 
-	if ( ! supportsSettings ) {
+	if ( ! siteTypeSupports.settings ) {
 		return null;
 	}
 
@@ -50,12 +49,12 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				/>
 			}
 		>
-			{ supportsSettings.general && (
+			{ siteTypeSupports.settingsGeneral && (
 				<VStack spacing={ 3 }>
 					<SectionHeader title={ __( 'General' ) } level={ 3 } />
 					<SummaryButtonList>
 						<SiteVisibilitySettingsSummary site={ site } />
-						{ supportsSettings.general.redirect ? (
+						{ siteTypeSupports.settingsGeneralRedirect ? (
 							<SiteRedirectSettingsSummary site={ site } />
 						) : null }
 						<SubscriptionGiftingSettingsSummary site={ site } settings={ settings } />
@@ -65,7 +64,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 					</SummaryButtonList>
 				</VStack>
 			) }
-			{ supportsSettings.server && (
+			{ siteTypeSupports.settingsServer && (
 				<VStack spacing={ 3 }>
 					<SectionHeader title={ __( 'Server' ) } level={ 3 } />
 					<SummaryButtonList>
@@ -80,7 +79,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 					</SummaryButtonList>
 				</VStack>
 			) }
-			{ supportsSettings.security && (
+			{ siteTypeSupports.settingsSecurity && (
 				<VStack spacing={ 3 }>
 					<SectionHeader title={ __( 'Security' ) } level={ 3 } />
 					<SummaryButtonList>
@@ -90,7 +89,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 					</SummaryButtonList>
 				</VStack>
 			) }
-			{ supportsSettings.experimental && config.isEnabled( 'wordpress-ai-assistant' ) && (
+			{ siteTypeSupports.settingsExperimental && config.isEnabled( 'wordpress-ai-assistant' ) && (
 				<VStack spacing={ 3 }>
 					<SectionHeader title={ __( 'Experimental (Staging)' ) } level={ 3 } />
 					<SummaryButtonList>

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -35,10 +35,6 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: settings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );
 	const siteTypeSupports = getSiteTypeFeatureSupports( site );
 
-	if ( ! siteTypeSupports.settings ) {
-		return null;
-	}
-
 	return (
 		<PageLayout
 			size="small"

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,6 +1,5 @@
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { __ } from '@wordpress/i18n';
-import { useAppContext } from '../../app/context';
 import MenuDivider from '../../components/menu-divider';
 import ResponsiveMenu from '../../components/responsive-menu';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
@@ -9,7 +8,6 @@ import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { Site } from '@automattic/api-core';
 
 const SiteMenu = ( { site }: { site: Site } ) => {
-	const { supports } = useAppContext();
 	const siteSlug = site.slug;
 
 	const siteTypeSupports = getSiteTypeFeatureSupports( site );
@@ -84,8 +82,7 @@ const SiteMenu = ( { site }: { site: Site } ) => {
 					{ __( 'Domains' ) }
 				</ResponsiveMenu.Item>
 			) }
-			{ supports.sites &&
-				supports.sites.settings &&
+			{ siteTypeSupports.settings &&
 				site.capabilities?.manage_options &&
 				! isSelfHostedJetpackConnected( site ) && (
 					<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>

--- a/client/dashboard/utils/site-type-feature-support.ts
+++ b/client/dashboard/utils/site-type-feature-support.ts
@@ -1,22 +1,28 @@
 import { isCommerceGarden, isSelfHostedJetpackConnected } from './site-types';
 import type { Site } from '@automattic/api-core';
 
+export type SiteTypeFeatureSupports = {
+	deployments: boolean;
+	performance: boolean;
+	monitoring: boolean;
+	logs: boolean;
+	backups: boolean;
+	scan: boolean;
+	domains: boolean;
+	emails: boolean;
+	settings: boolean;
+	settingsGeneral?: boolean;
+	settingsGeneralRedirect?: boolean;
+	settingsServer?: boolean;
+	settingsSecurity?: boolean;
+	settingsExperimental?: boolean;
+};
+
 /**
  * Features that can be gated based on site type.
  * This determines route availability, not feature availability within routes.
  */
-export type SiteTypeFeature =
-	| 'deployments'
-	| 'performance'
-	| 'monitoring'
-	| 'logs'
-	| 'backups'
-	| 'scan'
-	| 'domains'
-	| 'emails'
-	| 'settings';
-
-export type SiteTypeFeatureSupports = Record< SiteTypeFeature, boolean >;
+export type SiteTypeFeature = keyof SiteTypeFeatureSupports;
 
 /**
  * Returns a complete map of which features are supported for a given site type.
@@ -51,6 +57,11 @@ export function getSiteTypeFeatureSupports( site: Site ): SiteTypeFeatureSupport
 			domains: true,
 			emails: true,
 			settings: true,
+			settingsGeneral: true,
+			settingsGeneralRedirect: true,
+			settingsServer: false,
+			settingsSecurity: false,
+			settingsExperimental: false,
 		};
 	}
 
@@ -64,6 +75,11 @@ export function getSiteTypeFeatureSupports( site: Site ): SiteTypeFeatureSupport
 		domains: true,
 		emails: true,
 		settings: true,
+		settingsGeneral: true,
+		settingsGeneralRedirect: true,
+		settingsServer: true,
+		settingsSecurity: true,
+		settingsExperimental: true,
 	};
 }
 
@@ -71,5 +87,5 @@ export function getSiteTypeFeatureSupports( site: Site ): SiteTypeFeatureSupport
  * Determines if a site type supports a specific feature.
  */
 export function siteTypeSupportsFeature( site: Site, feature: SiteTypeFeature ): boolean {
-	return getSiteTypeFeatureSupports( site )[ feature ];
+	return !! getSiteTypeFeatureSupports( site )[ feature ];
 }

--- a/client/sites/v2/site-settings/layout.tsx
+++ b/client/sites/v2/site-settings/layout.tsx
@@ -59,16 +59,7 @@ function Layout( {
 	const APP_CONFIG = {
 		...APP_CONTEXT_DEFAULT_CONFIG,
 		supports: {
-			sites: {
-				settings: {
-					general: {
-						redirect: true,
-					},
-					server: true,
-					security: true,
-					experimental: true,
-				},
-			},
+			sites: true,
 		},
 	};
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-1012

## Proposed Changes

* Gate features by the site types.
* Here are settings features
  * settings
  * settingsGeneral
  * settingsGeneralRedirect
  * settingsServer
  * settingsSecurity
  * settingsExperimental

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Showing site-level features based on "app type" isn't the correct model. When a garden site is accessed via the dotcom MSD, it can't automatically gain all the features of a dotcom site. There is no guaranteeing that the underlying garden type implementation even supports the feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Pick dotcom sites, navigate to settings, and ensure you can access following settings. It should look the same as production
  * Visibility
  * Subscription Gift
  * Agency (for agency blog)
  * Hundred Year Plan
  * Redirect
  * WordPress
  * PHP
  * Sftp & SSH
  * Repository
  * Database
  * Primary Data Center
  * Static File 404
  * Caching
  * Web Application Firewall
  * Wpcom Login
  * Defensive Mode
* Pick CIAB sites, navigate to settings, and ensure you can access following settings. It should look the same as production
  * Visibility
  * Subscription Gift
  * Agency
  * Hundred Year Plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
