### PR TITLE
MSD: Introduce paginated site list using v1.3/me/sites endpoint under feature flag

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import {
 	sitesQuery,
+	paginatedSitesQuery,
 	dashboardSiteListQuery,
 	dashboardSiteFiltersQuery,
 } from '@automattic/api-queries';
@@ -9,6 +10,7 @@ import boot from '../app/boot';
 import './translations';
 import type {
 	FetchSitesOptions,
+	FetchPaginatedSitesOptions,
 	FetchDashboardSiteListParams,
 	FetchDashboardSiteFiltersParams,
 } from '@automattic/api-core';
@@ -48,6 +50,8 @@ boot( {
 	queries: {
 		sitesQuery: ( fetchSitesOptions?: FetchSitesOptions ) =>
 			sitesQuery( [ 'commerce-garden' ], fetchSitesOptions ),
+		paginatedSitesQuery: ( fetchSitesOptions?: FetchPaginatedSitesOptions ) =>
+			paginatedSitesQuery( [ 'commerce-garden' ], fetchSitesOptions ),
 		dashboardSiteListQuery: ( fetchDashboardSiteListParams?: FetchDashboardSiteListParams ) =>
 			dashboardSiteListQuery( [ 'commerce-garden' ], fetchDashboardSiteListParams ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import {
 	sitesQuery,
+	paginatedSitesQuery,
 	dashboardSiteListQuery,
 	dashboardSiteFiltersQuery,
 } from '@automattic/api-queries';
@@ -9,6 +10,7 @@ import boot from '../app/boot';
 import Logo from './logo';
 import type {
 	FetchSitesOptions,
+	FetchPaginatedSitesOptions,
 	FetchDashboardSiteListParams,
 	FetchDashboardSiteFiltersParams,
 } from '@automattic/api-core';
@@ -47,6 +49,8 @@ boot( {
 	},
 	queries: {
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
+		paginatedSitesQuery: ( fetchSiteOptions?: FetchPaginatedSitesOptions ) =>
+			paginatedSitesQuery( 'all', fetchSiteOptions ),
 		dashboardSiteListQuery: ( fetchDashboardSiteListParams?: FetchDashboardSiteListParams ) =>
 			dashboardSiteListQuery( 'all', fetchDashboardSiteListParams ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import {
 	sitesQuery,
+	paginatedSitesQuery,
 	dashboardSiteListQuery,
 	dashboardSiteFiltersQuery,
 } from '@automattic/api-queries';
@@ -8,6 +9,7 @@ import {
 import { createContext, useContext } from 'react';
 import type {
 	FetchSitesOptions,
+	FetchPaginatedSitesOptions,
 	FetchDashboardSiteListParams,
 	FetchDashboardSiteFiltersParams,
 } from '@automattic/api-core';
@@ -49,6 +51,9 @@ export type AppConfig = {
 	components: Record< string, () => Promise< { default: React.FC } > >;
 	queries: {
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => ReturnType< typeof sitesQuery >;
+		paginatedSitesQuery: (
+			fetchSiteOptions?: FetchPaginatedSitesOptions
+		) => ReturnType< typeof paginatedSitesQuery >;
 		dashboardSiteListQuery: (
 			params?: FetchDashboardSiteListParams
 		) => ReturnType< typeof dashboardSiteListQuery >;
@@ -80,6 +85,8 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 	components: {},
 	queries: {
 		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
+		paginatedSitesQuery: ( fetchSiteOptions?: FetchPaginatedSitesOptions ) =>
+			paginatedSitesQuery( 'all', fetchSiteOptions ),
 		dashboardSiteListQuery: ( fetchDashboardSiteListParams?: FetchDashboardSiteListParams ) =>
 			dashboardSiteListQuery( 'all', fetchDashboardSiteListParams ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -77,7 +77,10 @@ export const sitesRoute = createRoute( {
 	path: 'sites',
 	loader: async ( { context } ) => {
 		// Preload the default sites list response without blocking.
-		if ( ! isEnabled( 'dashboard/v2/es-site-list' ) ) {
+		if (
+			! isEnabled( 'dashboard/v2/es-site-list' ) &&
+			! isEnabled( 'dashboard/v2/paginated-site-list' )
+		) {
 			queryClient.prefetchQuery( context.config.queries.sitesQuery() );
 		}
 

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -157,6 +157,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 				operators: [ 'is' as Operator ],
 			},
 			render: ( { item } ) => ( item.is_a8c ? __( 'Yes' ) : __( 'No' ) ),
+			enableSorting: false,
 		},
 		{
 			id: 'preview',
@@ -228,6 +229,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 				operators: [ 'is' as Operator ],
 			},
 			enableHiding: false,
+			enableSorting: false,
 		},
 	];
 }

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -11,13 +11,28 @@ export type FetchSiteType = 'atomic' | 'jetpack' | 'wpcom' | 'jetpack-full' | 'c
 export type FetchSiteTypes = 'all' | FetchSiteType[];
 
 export interface FetchSitesOptions {
-	include_a8c_owned: boolean;
 	site_visibility: 'all' | 'visible' | 'hidden' | 'deleted';
+	include_a8c_owned: boolean;
+}
+
+export interface FetchPaginatedSitesOptions extends FetchSitesOptions {
+	search?: string;
+	plan?: string[];
+	visibility?: string[];
+	sort_field?: string;
+	sort_direction?: string;
+	page?: number;
+	per_page?: number;
+}
+
+export interface FetchPaginatedSitesResponse {
+	sites: Site[];
+	total: number;
 }
 
 export async function fetchSites(
 	site_types: FetchSiteTypes,
-	{ include_a8c_owned, site_visibility }: FetchSitesOptions
+	{ site_visibility, include_a8c_owned }: FetchSitesOptions
 ): Promise< Site[] > {
 	const { sites } = await wpcom.req.get(
 		{
@@ -25,14 +40,52 @@ export async function fetchSites(
 			apiVersion: '1.2',
 		},
 		{
-			include_a8c_owned,
-			include_domain_only: false,
-			site_activity: 'active',
-			site_visibility,
 			fields: JOINED_SITE_FIELDS,
 			options: JOINED_SITE_OPTIONS,
+			site_activity: 'active',
+			site_visibility,
+			include_a8c_owned,
+			include_domain_only: false,
 			filters: site_types !== 'all' ? site_types.join( ',' ) : undefined,
 		}
 	);
 	return sites;
+}
+
+export async function fetchPaginatedSites(
+	site_types: FetchSiteTypes,
+	{
+		site_visibility,
+		include_a8c_owned,
+		search,
+		plan,
+		visibility,
+		sort_field,
+		sort_direction,
+		page,
+		per_page,
+	}: FetchPaginatedSitesOptions
+): Promise< FetchPaginatedSitesResponse > {
+	return await wpcom.req.get(
+		{
+			path: '/me/sites',
+			apiVersion: '1.3',
+		},
+		{
+			fields: JOINED_SITE_FIELDS,
+			options: JOINED_SITE_OPTIONS,
+			site_activity: 'active',
+			site_visibility,
+			include_a8c_owned,
+			include_domain_only: false,
+			filters: site_types !== 'all' ? site_types.join( ',' ) : undefined,
+			search,
+			plan,
+			visibility,
+			sort_field,
+			sort_direction,
+			page,
+			per_page,
+		}
+	);
 }

--- a/packages/api-queries/src/sites.ts
+++ b/packages/api-queries/src/sites.ts
@@ -1,6 +1,10 @@
-import { fetchSites, SITE_FIELDS, SITE_OPTIONS } from '@automattic/api-core';
+import { fetchSites, fetchPaginatedSites, SITE_FIELDS, SITE_OPTIONS } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
-import type { FetchSiteTypes, FetchSitesOptions } from '@automattic/api-core';
+import type {
+	FetchSiteTypes,
+	FetchSitesOptions,
+	FetchPaginatedSitesOptions,
+} from '@automattic/api-core';
 
 export const sitesQueryKey = [ 'sites', SITE_FIELDS, SITE_OPTIONS ];
 
@@ -11,6 +15,18 @@ export const sitesQuery = (
 	queryOptions( {
 		queryKey: [ ...sitesQueryKey, siteFilters, fetchSitesOptions ],
 		queryFn: () => fetchSites( siteFilters, fetchSitesOptions ),
+	} );
+
+export const paginatedSitesQuery = (
+	siteFilters: FetchSiteTypes,
+	fetchSitesOptions: FetchPaginatedSitesOptions = {
+		site_visibility: 'visible',
+		include_a8c_owned: false,
+	}
+) =>
+	queryOptions( {
+		queryKey: [ ...sitesQueryKey, 'paginated', siteFilters, fetchSitesOptions ],
+		queryFn: () => fetchPaginatedSites( siteFilters, fetchSitesOptions ),
 	} );
 
 export const allSitesQuery = () => sitesQuery( 'all' );


### PR DESCRIPTION
Context: p1768426082651339-slack-C08JZTRS6NA
Context: pgz0xU-ve-p2

This PR attempts to use the new server-side-paginated site list endpoint, `v1.3/me/sites` (fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qzr%2Qfvgrf%2Qi1%2Q3%2Qraqcbvag.cuc%3Se%3Qp20r5s5s-og), under feature flag.

It is much faster than the previous `v1.2/me/sites` endpoint, because it does the searching, filtering, and sorting without having to build the entire site object for each site. Refer to the linked endpoint to get more details by checking the commented code.

## Testing instructions

1. Go to `<dashboard live link>/sites?flags=dashboard/v2/paginated-site-list`.
2. Verify you can type in the search box and it will search by site name / slug / URL.
3. Verify you can sort by the following supported fields (asc and desc):

     <img width="183" height="295" alt="image" src="https://github.com/user-attachments/assets/33b448b0-4e9e-4f6e-a221-b5223d0d4226" />

4. Verify you can filter by the following supported fields:

    <img width="341" height="189" alt="image" src="https://github.com/user-attachments/assets/cc9c8896-fff8-4310-bd97-fbe2e3b1a906" />

5. Verify the pagination works.
6. Verify the endpoint feels MUCH faster (if you have a lot of sites) compared to production.
7. Verify the site list without the feature flags; check for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?