### PR TITLE
CenteredColumnLayout: Provide initial topbar height during SSR to prevent layout shift

### DIFF
--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -305,7 +305,8 @@
 		margin: 0;
 
 		.app-promo__qr-code-canvas {
-			flex: 0 0 100px;
+			width: 100px;
+			height: 100px;
 			order: 1;
 		}
 

--- a/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
@@ -47,9 +47,11 @@
 	);
 
 	&.center-aligned {
-		justify-content: center;
-		padding-bottom: calc(
-			var( --step-container-v2-content-block-padding ) + var( --step-container-v2-top-bar-height )
-		);
+		@include break-small {
+			justify-content: center;
+			padding-bottom: calc(
+				var( --step-container-v2-content-block-padding ) + var( --step-container-v2-top-bar-height )
+			);
+		}
 	}
 }

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/StepContainerV2.tsx
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/StepContainerV2.tsx
@@ -3,11 +3,17 @@ import { useMemo, useState } from 'react';
 import { ContentProp, StepContainerV2Context } from './context';
 import './style.scss';
 
-export const StepContainerV2 = ( { children }: { children: ContentProp } ) => {
+export const StepContainerV2 = ( {
+	children,
+	initialTopBarHeight,
+}: {
+	children: ContentProp;
+	initialTopBarHeight?: string;
+} ) => {
 	const isSmallViewport = useViewportMatch( 'small', '>=' );
 	const isLargeViewport = useViewportMatch( 'large', '>=' );
 
-	const [ topBarHeight, setTopBarHeight ] = useState( 0 );
+	const [ topBarHeight, setTopBarHeight ] = useState( initialTopBarHeight ?? '0px' );
 	const [ stickyBottomBarHeight, setStickyBottomBarHeight ] = useState( 0 );
 
 	const stepContainerContextValue = useMemo(
@@ -37,7 +43,7 @@ export const StepContainerV2 = ( { children }: { children: ContentProp } ) => {
 				className="step-container-v2"
 				style={
 					{
-						'--step-container-v2-top-bar-height': `${ topBarHeight }px`,
+						'--step-container-v2-top-bar-height': topBarHeight,
 						'--step-container-v2-sticky-bottom-bar-height': `${ stickyBottomBarHeight }px`,
 					} as React.CSSProperties
 				}

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/context.ts
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/context.ts
@@ -3,8 +3,8 @@ import { createContext, ReactNode } from 'react';
 export interface StepContainerV2InternalContextType {
 	isSmallViewport: boolean;
 	isLargeViewport: boolean;
-	topBarHeight: number;
-	setTopBarHeight: ( height: number ) => void;
+	topBarHeight: string;
+	setTopBarHeight: ( height: string ) => void;
 	stickyBottomBarHeight: number;
 	setStickyBottomBarHeight: ( height: number ) => void;
 }
@@ -18,7 +18,7 @@ export type ContentProp< T = ReactNode > =
 export const StepContainerV2Context = createContext< StepContainerV2InternalContextType >( {
 	isSmallViewport: false,
 	isLargeViewport: false,
-	topBarHeight: 0,
+	topBarHeight: '0px',
 	setTopBarHeight: () => {},
 	stickyBottomBarHeight: 0,
 	setStickyBottomBarHeight: () => {},

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
@@ -5,6 +5,9 @@
 	--step-container-v2-content-block-padding: 2rem;
 	--step-container-v2-content-inline-padding: 1rem;
 
+	--step-container-v2-top-bar-padding: 1rem;
+	--step-container-v2-top-bar-content-height: 24px;
+
 	@include break-small {
 		--step-container-v2-content-inline-padding: 3rem;
 	}

--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
@@ -1,6 +1,6 @@
 import { WordPressLogo, WordPressWordmark } from '@automattic/components';
 import clsx from 'clsx';
-import { ReactNode } from 'react';
+import { isValidElement, type ReactElement, type ReactNode } from 'react';
 
 import './style.scss';
 
@@ -67,4 +67,8 @@ export const TopBar = ( {
 			) }
 		</div>
 	);
+};
+
+export const isTopBar = ( element?: ReactNode ): element is ReactElement< TopBarProps > => {
+	return isValidElement( element ) && element.type === TopBar;
 };

--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBarRenderer.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBarRenderer.tsx
@@ -1,5 +1,16 @@
 import { useContext, useLayoutEffect, useRef } from 'react';
-import { StepContainerV2Context, ContentProp } from '../StepContainerV2/context';
+import {
+	StepContainerV2Context,
+	type ContentProp,
+	type StepContainerV2InternalContextType,
+} from '../StepContainerV2/context';
+
+export const renderTopBar = (
+	topBar: ContentProp,
+	context: Pick< StepContainerV2InternalContextType, 'isSmallViewport' | 'isLargeViewport' >
+) => {
+	return typeof topBar === 'function' ? topBar( context ) : topBar;
+};
 
 export const TopBarRenderer = ( { topBar }: { topBar?: ContentProp } ) => {
 	const context = useContext( StepContainerV2Context );
@@ -10,12 +21,12 @@ export const TopBarRenderer = ( { topBar }: { topBar?: ContentProp } ) => {
 	useLayoutEffect( () => {
 		const resizeObserver = new ResizeObserver( ( [ entry ] ) => {
 			if ( entry ) {
-				setTopBarHeight( entry.contentRect.height );
+				setTopBarHeight( `${ entry.contentRect.height }px` );
 			}
 		} );
 
 		if ( topBarRef.current ) {
-			setTopBarHeight( topBarRef.current.clientHeight );
+			setTopBarHeight( `${ topBarRef.current.clientHeight }px` );
 			resizeObserver.observe( topBarRef.current );
 		}
 
@@ -24,11 +35,9 @@ export const TopBarRenderer = ( { topBar }: { topBar?: ContentProp } ) => {
 		};
 	}, [ setTopBarHeight ] );
 
-	const topBarContent = typeof topBar === 'function' ? topBar( context ) : topBar;
-
 	return (
 		<div ref={ topBarRef } className="step-container-v2__top-bar-wrapper">
-			{ topBarContent }
+			{ renderTopBar( topBar, context ) }
 		</div>
 	);
 };

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -6,7 +6,7 @@
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
-	padding: 1rem;
+	padding: var( --step-container-v2-top-bar-padding );
 
 	@include break-small {
 		padding-inline: 1.5rem;
@@ -20,7 +20,7 @@
 .step-container-v2__top-bar-left-element,
 .step-container-v2__top-bar-right-element,
 .step-container-v2__top-bar-wordpress-logo {
-	height: 24px;
+	height: var( --step-container-v2-top-bar-content-height );
 }
 
 .step-container-v2__top-bar-left-element,
@@ -81,7 +81,7 @@
 
 	a,
 	button {
-		&.components-button:not(.is-destructive).is-link {
+		&.components-button:not( .is-destructive ).is-link {
 			--wp-components-color-accent: var( --color-neutral-100 );
 		}
 	}

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
@@ -4,7 +4,8 @@ import { ContentWrapper } from '../../components/ContentWrapper/ContentWrapper';
 import { StepContainerV2 } from '../../components/StepContainerV2/StepContainerV2';
 import { ContentProp } from '../../components/StepContainerV2/context';
 import { StickyBottomBarRenderer } from '../../components/StickyBottomBar/StickyBottomBarRenderer';
-import { TopBarRenderer } from '../../components/TopBar/TopBarRenderer';
+import { isTopBar } from '../../components/TopBar/TopBar';
+import { renderTopBar, TopBarRenderer } from '../../components/TopBar/TopBarRenderer';
 
 interface CenteredColumnLayoutProps {
 	topBar?: ContentProp;
@@ -26,14 +27,27 @@ export const CenteredColumnLayout = ( {
 	verticalAlign,
 }: CenteredColumnLayoutProps ) => {
 	return (
-		<StepContainerV2>
+		<StepContainerV2
+			initialTopBarHeight={
+				// Calculate the top bar height on the server side to avoid layout shifts.
+				typeof window === 'undefined' &&
+				isTopBar(
+					renderTopBar( topBar, {
+						isLargeViewport: false,
+						isSmallViewport: false,
+					} )
+				)
+					? 'calc( var( --step-container-v2-top-bar-content-height ) + 2 * var( --step-container-v2-top-bar-padding ) )'
+					: '0px'
+			}
+		>
 			{ ( context ) => {
 				const content = typeof children === 'function' ? children( context ) : children;
 
 				return (
 					<>
 						<TopBarRenderer topBar={ topBar } />
-						<ContentWrapper centerAligned={ context.isSmallViewport && verticalAlign === 'center' }>
+						<ContentWrapper centerAligned={ verticalAlign === 'center' }>
 							{ heading && <ContentRow columns={ 6 }>{ heading }</ContentRow> }
 							<ContentRow columns={ columnWidth } className={ className }>
 								{ content }


### PR DESCRIPTION
Closes DOTOBRD-388.

## Proposed Changes

Fixes a layout shift that was happening because we were failing to do height calculations on the back-end, since they depended on the viewport. This "hardcodes" the top bar height to prevent a shift.

"Hardcodes" in quotes because we're defining a default height that's calculated in the front-end again, plus we're only adding the default value if we confirm the user is actually rendering the default top bar from StepContainerV2.

This PR actually fixes two shifts:
- TopBar calculation as mentioned above.
- Content centering on small screens: moved from JS to pure CSS so that when the original page comes from the server there's no shift after hydration.

## Testing Instructions

Enter the Calypso Live link from this PR in an incognito window:
- `/log-in`
- `/log-in/link`

Verify that, contrary to production, the contents do not shift from the top to the middle of the screen after hydration.