### PR TITLE
Labels: stop recommending the use of labels with [Type] prefix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Help us improve our product!
-labels: ["Needs triage", "[Type] Bug"]
+labels: ["Needs triage", "Bug"]
 type: 'Bug'
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature Request
 description: Suggest an idea for Calypso!
 title: "Feature Request:"
 type: 'Enhancement'
-labels: ["[Type] Feature Request"]
+labels: ["New Feature"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md
+++ b/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md
@@ -2,7 +2,7 @@
 name: Gutenberg Plugin Upgrade
 about: Installing and activating a new version of the Gutenberg Plugin
 title: 'Gutenberg: [v#.#.#] plugin upgrade'
-labels: gutenberg-upgrade, [Type] Task
+labels: [ 'gutenberg-upgrade', 'Task' ]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -2,7 +2,7 @@ name: Task
 description: Create a task
 title: "Task:"
 type: 'Task'
-labels: ["[Type] Task"]
+labels: ["Task"]
 body:
   - type: textarea
     id: details

--- a/.github/ISSUE_TEMPLATE/tooling_request.yml
+++ b/.github/ISSUE_TEMPLATE/tooling_request.yml
@@ -1,7 +1,7 @@
 name: Tooling Request
 description: Bug or feature request related to scripts, tooling, DevX, etc.
 title: 'Tooling:'
-labels: '[Type] Tooling'
+labels: 'Enhancement'
 type: 'Enhancement'
 body:
   - type: markdown

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -92,7 +92,7 @@ If you feel yourself waiting for someone to review a PR, don’t hesitate to per
 
 ### We’re Here To Help
 
-We encourage you to ask for help at any point. We want your first experience with Calypso to be a good one, so don’t be shy. If you’re wondering why something is the way it is, or how a decision was made, you can tag issues with **<span class="label type-question">[Type] Question</span>** or prefix them with “Question:”.
+We encourage you to ask for help at any point. We want your first experience with Calypso to be a good one, so don’t be shy. If you’re wondering why something is the way it is, or how a decision was made, you can tag issues with **<span class="label type-question">Question</span>** or prefix them with “Question:”.
 
 ## License
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -127,7 +127,7 @@
 	rebaseWhen: 'conflicted',
 
 	// --- Metadata settings for git ---
-	labels: [ 'Framework', '[Type] Task', 'dependencies' ],
+	labels: [ 'Framework', 'Task', 'dependencies' ],
 	reviewers: [ 'team:@automattic/calypso-dependency-updates' ],
 	branchPrefix: 'renovate/',
 	gitAuthor: 'Renovate Bot (self-hosted) <bot@renovateapp.com>',


### PR DESCRIPTION
See QAO-204

## Proposed Changes, why are these changes being made?

We're moving away from those labels with the introduction of Linear.

## Testing Instructions

Not much to test, just check for typos.

Of note, I left one instance, which does not have a matching Linear label:
https://github.com/Automattic/wp-calypso/blob/2cb42e8af06f804069ea9861bee57d73143f5355/.github/ISSUE_TEMPLATE/flaky-e2e-spec-report.yml#L4

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
