### PR TITLE
Adjust the design of the differentiator header according to latest Figma

### DIFF
--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -127,25 +127,81 @@ const PlanBenefitHeader = () => {
 	);
 };
 
+// Inline SVG components
+const ShieldPlusIcon = () => (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M9.12404 5.23988C8.0952 5.51646 7.07304 5.81729 6.05841 6.14212C5.96659 6.17047 5.88463 6.22414 5.82194 6.29698C5.75926 6.36981 5.71839 6.45886 5.70404 6.55387C5.10441 10.938 6.48816 14.1375 8.13854 16.2446C8.96654 17.3021 9.86316 18.0851 10.6102 18.5992C10.9848 18.8558 11.3144 19.0425 11.5743 19.1617C11.7048 19.2214 11.8105 19.2619 11.8915 19.2855C11.9273 19.297 11.9637 19.306 12.0007 19.3125C12.0085 19.3114 12.0434 19.3069 12.1098 19.2866C12.1908 19.2619 12.2965 19.2214 12.427 19.1617C12.6858 19.0425 13.0177 18.8558 13.3912 18.5992C14.3279 17.942 15.161 17.1484 15.8628 16.2446C17.5132 14.1375 18.8969 10.938 18.2973 6.55387C18.2829 6.45886 18.2421 6.36981 18.1794 6.29698C18.1167 6.22414 18.0347 6.17047 17.9429 6.14212C17.2387 5.91712 16.0507 5.55038 14.8773 5.23988C13.678 4.92375 12.5744 4.6875 12.0007 4.6875C11.4269 4.6875 10.3244 4.92375 9.12404 5.23988ZM8.83604 4.15312C10.0094 3.84262 11.2548 3.5625 12.0007 3.5625C12.7454 3.5625 13.9919 3.84262 15.1653 4.15312C16.2119 4.43412 17.2517 4.73983 18.2838 5.07C18.8778 5.259 19.3255 5.77087 19.4122 6.402C20.0568 11.1236 18.5617 14.6224 16.7493 16.9376C15.977 17.9312 15.06 18.8034 14.029 19.5251C13.6706 19.7762 13.2916 19.9968 12.8962 20.1844C12.5924 20.3239 12.2684 20.4375 12.0007 20.4375C11.7329 20.4375 11.4089 20.3239 11.1052 20.1844C10.7096 19.9969 10.3307 19.7764 9.97229 19.5251C8.94172 18.8033 8.02516 17.9311 7.25316 16.9376C5.43854 14.6224 3.94454 11.1236 4.58916 6.402C4.63226 6.09608 4.76112 5.80862 4.96081 5.57289C5.1605 5.33716 5.42286 5.16281 5.71754 5.07C6.74967 4.73984 7.78946 4.43413 8.83604 4.15312Z"
+			fill="#3858E9"
+		/>
+		<path d="M12 8V13.5" stroke="#3858E9" strokeLinecap="round" strokeLinejoin="round" />
+		<path
+			d="M14.7539 10.7461L9.25391 10.7461"
+			stroke="#3858E9"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);
+
+const UnlimitedIcon = () => (
+	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+		<path
+			d="M16 18L16 6M16 6L20 10.125M16 6L12 10.125"
+			stroke="#3858E9"
+			strokeWidth="1.2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<path
+			d="M8 6L8 18M8 18L12 13.875M8 18L4 13.875"
+			stroke="#3858E9"
+			strokeWidth="1.2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);
+
+const IconWrapper = styled.span`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	margin-right: 8px;
+	flex-shrink: 0;
+	color: var( --studio-blue-60 );
+
+	svg {
+		width: 24px;
+		height: 24px;
+		fill: var( --studio-blue-60 );
+		color: var( --studio-blue-60 );
+	}
+`;
+
 const DifferentiatorIconContainer = styled.span`
 	display: inline-flex;
-	align-items: flex-start;
-	margin-right: 24px;
+	align-items: center;
+	margin-right: 12px;
+	padding: 10px 16px;
+	background-color: var( --studio-blue-5 );
+	border-radius: 8px;
 	text-align: left;
+	font-size: 14px;
+	line-height: 24px;
+	font-weight: 400;
+	color: var( --studio-gray-70 );
 
 	&:last-child {
 		margin-right: 0;
 	}
 
-	.gridicon {
-		margin-right: 8px;
-		margin-top: 2px;
-		color: var( --studio-gray-20 );
-	}
-
 	@media ( max-width: 740px ) {
 		margin-right: 0;
 		margin-bottom: 8px;
+		width: 100%;
 
 		&:last-child {
 			margin-bottom: 0;
@@ -159,16 +215,16 @@ const DifferentiatorHeader = () => {
 	return (
 		<HeaderContainer className="plans-features-main__differentiator-header">
 			<DifferentiatorIconContainer>
-				<Gridicon icon="sync" size={ 18 } />
-				{ translate( 'Unlimited traffic & bandwidth' ) }
+				<IconWrapper>
+					<UnlimitedIcon />
+				</IconWrapper>
+				{ translate( 'Unlimited pages, posts, users and visitors' ) }
 			</DifferentiatorIconContainer>
 			<DifferentiatorIconContainer>
-				<Gridicon icon="multiple-users" size={ 18 } />
-				{ translate( 'Unlimited collaborators' ) }
-			</DifferentiatorIconContainer>
-			<DifferentiatorIconContainer>
-				<Gridicon icon="plugins" size={ 18 } />
-				{ translate( 'Install plugins on all paid plans' ) }
+				<IconWrapper>
+					<ShieldPlusIcon />
+				</IconWrapper>
+				{ translate( 'Spam, brutforce, DDoS protection and mitigation' ) }
 			</DifferentiatorIconContainer>
 		</HeaderContainer>
 	);


### PR DESCRIPTION


Part of DOTCOM-15713

## Proposed Changes

* The latest design of this component looks like this:

<img width="808" height="280" alt="Screenshot 2026-01-15 at 18 26 37" src="https://github.com/user-attachments/assets/2524ffea-180e-4f14-9088-d4bd91099fd5" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Assign yourself to `long_set_diff` of the `calypso_plans_differentiators_20251210` experiment
* Go to signup and enjoy the updated design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
