### PR TITLE
Forms submission: refactor first response verification test

### DIFF
--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -224,12 +224,9 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			}
 		} );
 
-		it( 'Click first response row', async () => {
-			await feedbackInboxPage.clickResponseRowByText( formData1.name );
-		} );
-
 		it( 'If in Spam, mark as not spam', async function () {
 			if ( isInSpam ) {
+				await feedbackInboxPage.clickResponseRowByText( formData1.name );
 				await feedbackInboxPage.clickNotSpamAction();
 			}
 		} );

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -231,20 +231,16 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			}
 		} );
 
-		it( 'Navigate to Inbox tab', async function () {
+		it( 'Navigate to Inbox tab if needed', async function () {
+			// if it's not in spam, we should already be in the inbox tab as per
+			// find and click on the search test above.
 			if ( isInSpam ) {
-				// Clear search first to show all responses
-				await feedbackInboxPage.clearSearch( true );
 				await feedbackInboxPage.clickFolderTab( 'Inbox' );
-				// Wait for folder change to complete and data to reload
-				await page.waitForTimeout( 2000 );
-				// Search again for the first response in Inbox
-				await feedbackInboxPage.searchResponses( formData1.name );
-				await feedbackInboxPage.clickResponseRowByText( formData1.name );
 			}
 		} );
 
 		it( 'Validate first response data', async () => {
+			await feedbackInboxPage.clickResponseRowByText( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.email );
 			await feedbackInboxPage.validateTextInSubmission( formData1.phone );


### PR DESCRIPTION

## Proposed Changes
This PR changes the sequence we use to locate the first response and move it to inbox (from spam) if needed.
It only does this change on the first response, that seems to be failing more often than not and will allow us to check if the new sequence is both reliable and more effective/performant than the old one (still used on the second response check)

## Why are these changes being made?
Because we can't figure out what's with the random fails we get on that test.

## Testing Instructions
Run:

```
yarn workspace wp-e2e-tests build && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" TEST_ON_ATOMIC="true" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts
```

Throughout the results, besides confirming the tests pass, look for the difference in the sequences between the first and second response verification. First one should (on needed cases, ie, it was flagged as spam) be faster than second, example:

```
    Validate first response
      ✓ Navigate to the Jetpack Forms Inbox (1939 ms)
      ✓ Search for first response email until result shows up (1642 ms)
      ✓ If in Spam, mark as not spam (2960 ms)
      ✓ Navigate to Inbox tab if needed (594 ms) <------------ 
      ✓ Validate first response data (1413 ms)
    Validate second response
      ✓ Search for second response email until result shows up (1339 ms)
      ✓ Click second response row (1743 ms)
      ✓ If in Spam, mark as not spam (1215 ms)
      ✓ Navigate to Inbox tab (3839 ms) <------------ 
      ✓ Validate second response data (522 ms)
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
