### PR TITLE
A4A > Sites: Improve the 'Needs setup' sites loading UX

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/table.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/table.tsx
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import { DATAVIEWS_TABLE } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
-import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { DataViews } from 'calypso/components/dataviews';
 import SiteSort from '../site-sort';
 import PlanField, { AvailablePlans } from './plan-field';
@@ -35,20 +34,14 @@ export default function NeedSetupTable( {
 				</SiteSort>
 			),
 			getValue: () => '-',
-			render: ( { item }: { item: AvailablePlans } ): ReactNode => {
-				if ( isLoading ) {
-					return <TextPlaceholder />;
-				}
-
-				return (
-					<PlanField
-						{ ...item }
-						provisioning={ provisioning }
-						onCreateSite={ onCreateSite }
-						onMigrateSite={ onMigrateSite }
-					/>
-				);
-			},
+			render: ( { item }: { item: AvailablePlans } ): ReactNode => (
+				<PlanField
+					{ ...item }
+					provisioning={ provisioning }
+					onCreateSite={ onCreateSite }
+					onMigrateSite={ onMigrateSite }
+				/>
+			),
 			enableHiding: false,
 			enableSorting: false,
 		},
@@ -56,7 +49,7 @@ export default function NeedSetupTable( {
 
 	return (
 		<DataViews< AvailablePlans >
-			data={ isLoading ? [] : availablePlans }
+			data={ availablePlans }
 			paginationInfo={ { totalItems: 1, totalPages: 1 } }
 			fields={ fields }
 			view={ {
@@ -69,7 +62,7 @@ export default function NeedSetupTable( {
 			search={ false }
 			defaultLayouts={ { table: {} } }
 			actions={ [] }
-			isLoading={ false }
+			isLoading={ isLoading && ! availablePlans.length }
 			getItemId={ ( item: AvailablePlans ) => item.name }
 		/>
 	);


### PR DESCRIPTION
## Proposed Changes

This PR improves the 'Needs setup' sites loading UX on A4A

Reported here: p1766082226148989-slack-C091P0A65U5

## Testing Instructions

* Open the A4A live link
* Go to Sites > Needs setup > Verify the loading state is shown when the sites are loading. It will show the loading state only if the data has not already been loaded. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?