### PR TITLE
Big Sky / CIAB: Make the backend build the default

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/ai-site-builder-spec.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/ai-site-builder-spec.ts
@@ -16,8 +16,8 @@ function initialize() {
 	const specId = queryParams.get( 'spec_id' );
 
 	if ( specId ) {
-		// Redirect to main ai-site-builder flow with spec_id
-		window.location.replace( `/setup/ai-site-builder?spec_id=${ specId }` );
+		// Redirect to main ai-site-builder flow preserving query parameters
+		window.location.replace( `/setup/ai-site-builder?${ queryParams.toString() }` );
 		return [];
 	}
 

--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -155,6 +155,7 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 
 							const source = queryParams.get( 'source' );
 							const specId = queryParams.get( 'spec_id' );
+							const triggerBackendBuild = queryParams.get( 'trigger_backend_build' ) !== '0';
 							let sourceParam = '';
 							let specIdParam = '';
 
@@ -231,9 +232,13 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 								specIdParam = `&spec_id=${ encodeURIComponent( specId ) }`;
 							}
 
-							window.location.replace(
-								`${ siteURL }/wp-admin/site-editor.php?canvas=edit&ai-step=spec&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }${ sourceParam }${ specIdParam }`
-							);
+							if ( triggerBackendBuild ) {
+								window.location.replace( `${ siteURL }/wp-admin/` );
+							} else {
+								window.location.replace(
+									`${ siteURL }/wp-admin/site-editor.php?canvas=edit&ai-step=spec&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }${ sourceParam }${ specIdParam }`
+								);
+							}
 						} else if ( providedDependencies.isLaunched ) {
 							const site = await resolveSelect( SITE_STORE ).getSite(
 								providedDependencies.siteSlug

--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -155,7 +155,38 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 
 							const source = queryParams.get( 'source' );
 							const specId = queryParams.get( 'spec_id' );
-							const triggerBackendBuild = queryParams.get( 'trigger_backend_build' ) !== '0';
+
+							/**
+							 * Redirect behavior after site creation:
+							 *
+							 * The `trigger_backend_build` parameter controls where the user is redirected
+							 * after site creation. The default behavior differs based on site type:
+							 *
+							 * NON-GARDEN SITES (no create_garden_site param):
+							 *   - Default: site-editor.php (triggerBackendBuild=false)
+							 *   - With trigger_backend_build=1: /wp-admin/
+							 *   - With trigger_backend_build=0: site-editor.php
+							 *
+							 * GARDEN SITES (create_garden_site=1):
+							 *   - Default: /wp-admin/ (triggerBackendBuild=true)
+							 *   - With trigger_backend_build=1: /wp-admin/
+							 *   - With trigger_backend_build=0: site-editor.php
+							 *
+							 * Full permutation matrix:
+							 * | create_garden_site | trigger_backend_build | Redirect destination                              |
+							 * |--------------------|----------------------|---------------------------------------------------|
+							 * | (not set)          | (not set)            | /wp-admin/site-editor.php?canvas=edit&ai-step=spec |
+							 * | (not set)          | 0                    | /wp-admin/site-editor.php?canvas=edit&ai-step=spec |
+							 * | (not set)          | 1                    | /wp-admin/                                        |
+							 * | 1                  | (not set)            | /wp-admin/                                        |
+							 * | 1                  | 0                    | /wp-admin/site-editor.php?canvas=edit&ai-step=spec |
+							 * | 1                  | 1                    | /wp-admin/                                        |
+							 */
+							const triggerBackendBuildParam = queryParams.get( 'trigger_backend_build' );
+							const triggerBackendBuild = gardenName
+								? triggerBackendBuildParam !== '0' // Garden sites: default to /wp-admin/, opt-out with =0
+								: triggerBackendBuildParam === '1'; // Non-garden: default to site-editor, opt-in with =1
+
 							let sourceParam = '';
 							let specIdParam = '';
 

--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -155,7 +155,6 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 
 							const source = queryParams.get( 'source' );
 							const specId = queryParams.get( 'spec_id' );
-							const triggerBackendBuild = queryParams.get( 'trigger_backend_build' ) === '1';
 							let sourceParam = '';
 							let specIdParam = '';
 
@@ -232,13 +231,9 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 								specIdParam = `&spec_id=${ encodeURIComponent( specId ) }`;
 							}
 
-							if ( triggerBackendBuild ) {
-								window.location.replace( `${ siteURL }/wp-admin/` );
-							} else {
-								window.location.replace(
-									`${ siteURL }/wp-admin/site-editor.php?canvas=edit&ai-step=spec&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }${ sourceParam }${ specIdParam }`
-								);
-							}
+							window.location.replace(
+								`${ siteURL }/wp-admin/site-editor.php?canvas=edit&ai-step=spec&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }${ sourceParam }${ specIdParam }`
+							);
 						} else if ( providedDependencies.isLaunched ) {
 							const site = await resolveSelect( SITE_STORE ).getSite(
 								providedDependencies.siteSlug

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -239,7 +239,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			gardenName,
 			gardenPartnerName,
 			urlQueryParams.get( 'spec_id' ),
-			urlQueryParams.get( 'trigger_backend_build' ) === '1',
 			blueprint
 		);
 

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -12,6 +12,7 @@ import {
 	isTailoredSignupFlow,
 	HUNDRED_YEAR_PLAN_FLOW,
 	isAnyHostingFlow,
+	AI_SITE_BUILDER_FLOW,
 } from '../';
 import cartManagerClient from './create-cart-manager-client';
 import type { DomainSuggestion } from '@automattic/api-core';
@@ -157,7 +158,6 @@ export const createSiteWithCart = async (
 	gardenName?: string | null,
 	gardenPartnerName?: string | null,
 	specId?: string | null,
-	triggerBackendBuild?: boolean | null,
 	blueprint?: string | null
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
@@ -219,9 +219,12 @@ export const createSiteWithCart = async (
 					: {} ),
 				...( siteGoals && { site_goals: siteGoals } ),
 				...( refParam && { ref: refParam } ),
-				...( triggerBackendBuild && {
-					trigger_backend_build: true,
-				} ),
+				// Trigger backend build for ai-site-builder flow with commerce garden and spec_id
+				...( flowName === AI_SITE_BUILDER_FLOW &&
+					gardenName === 'commerce' &&
+					specId && {
+						trigger_backend_build: true,
+					} ),
 			},
 		},
 	} );


### PR DESCRIPTION
This makes the "backend build" the default, without needing to pass the trigger_backend_build flag

## Testing instructions

### Big Sky flow

Nothing should change in the exiting flow
Go to http://calypso.localhost:3000/setup/ai-site-builder/ and see site buing built on the frontend

### CIAB flow

1. go through site spec on automattic/site-spec localhost:3001, select "dont build the site"
2. Copy the "build site" url, **not** the "backend build"URL
3. Replace wordpress.com with calypso.localhost:3000
4. Be redirected to wp-admin
5. Wait a bit see, site built

<img width="885" height="470" alt="Zrzut ekranu 2026-01-16 o 11 00 08" src="https://github.com/user-attachments/assets/771a826e-c742-401c-a626-f5d5cd3e5244" />

