### PR TITLE
MSD Plugins: Improve fallback icon style

### DIFF
--- a/client/dashboard/plugins/manage/components/plugin-icon.scss
+++ b/client/dashboard/plugins/manage/components/plugin-icon.scss
@@ -7,13 +7,13 @@
 	flex-shrink: 0;
 
 	&.is-fallback {
-		background: #c3c4c7;
-		fill: #fff;
+		border: 1px solid rgba(0, 0, 0, 0.10);
+		background: #F0F0F0;
 
 		svg {
-			fill: var(--wp-components-color-foreground, #1e1e1e);
-			width: 36px;
-			height: 36px;
+			fill: #949494;
+			width: 32px;
+			height: 32px;
 		}
 	}
 }

--- a/client/dashboard/plugins/manage/components/plugin-icon.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-icon.tsx
@@ -6,7 +6,7 @@ import { PluginListRow } from '../types';
 import './plugin-icon.scss';
 
 const ICON_SIZE = 48;
-const FALLBACK_ICON_SIZE = 36;
+const FALLBACK_ICON_SIZE = 32;
 
 export const PluginIcon = ( { item }: { item?: PluginListRow } ) => {
 	const icon = item?.icon ? (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-1042

## Proposed Changes

* Improve the style on the fallback icon for plugins that don't have their own.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The icon size and colors can be distracting when many plugins don't have icons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/plugins/manage`
* Check that the icon style matches the design:

|Before|After|Design|
|---|---|---|
|<img width="1764" height="966" alt="image" src="https://github.com/user-attachments/assets/f25aedc0-45b1-4543-93b8-b30b937ab778" />|<img width="1764" height="966" alt="image" src="https://github.com/user-attachments/assets/15995140-bfe1-4e78-9f28-da1c9c1659b1" />|<img width="1406" height="1406" alt="image" src="https://github.com/user-attachments/assets/fc9d861a-7fb5-4129-a392-467ac49d6320" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
