### PR TITLE
Help Center: Introduce logged-out variant for better performance

### DIFF
--- a/apps/help-center/help-center-logged-out.js
+++ b/apps/help-center/help-center-logged-out.js
@@ -1,0 +1,32 @@
+import './config';
+import './help-center.scss';
+import loadHelpCenter from './async-help-center';
+
+/**
+ * Checks if the help center should be automatically to keep session continuity.
+ * @returns {boolean} Whether the help center should be automatically loaded.
+ */
+function shouldAutoLoadHelpCenter() {
+	try {
+		const preferences = window.localStorage.getItem( 'logged_out_help_center_preferences' );
+		if ( preferences ) {
+			const preferencesObject = JSON.parse( preferences );
+			return preferencesObject.help_center_open;
+		}
+		return false;
+	} catch ( error ) {
+		return false;
+	}
+}
+
+window.addEventListener( 'DOMContentLoaded', () => {
+	shouldAutoLoadHelpCenter().then( ( shouldAutoLoad ) => {
+		if ( shouldAutoLoad ) {
+			loadHelpCenter();
+		}
+	} );
+} );
+
+document.dispatchEvent( new Event( 'help-center-ready-to-load' ) );
+
+export { loadHelpCenter };

--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -86,6 +86,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 		getIndividualConfig( { env, argv, name: 'help-center-wp-admin' } ),
 		getIndividualConfig( { env, argv, name: 'help-center-customizer' } ),
 		getIndividualConfig( { env, argv, name: 'help-center-gutenberg-disconnected' } ),
+		getIndividualConfig( { env, argv, name: 'help-center-logged-out' } ),
 		getIndividualConfig( {
 			env,
 			argv,

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -41,6 +41,12 @@ export const OdieSendMessageButton = () => {
 	const messageSizeNotice = useMessageSizeErrorNotice( inputValue.trim().length );
 	const connectionNotice = useConnectionStatusNotice( isLiveChat );
 
+	useEffect( () => {
+		if ( initialQuery ) {
+			setInputValue( initialQuery );
+		}
+	}, [ initialQuery ] );
+
 	// I'm only using adjustHeight from agenttic-ui
 	const { textareaRef } = useInput( {
 		value: inputValue,


### PR DESCRIPTION
## Summary

- Introduces a new Help Center entry point (`help-center-logged-out`) optimized for logged-out contexts
- This variant uses localStorage preferences instead of authenticated user data for session continuity
- Adds support for pre-filling the initial query in the Odie chat input

## Test plan

- [ ] Build the help-center app and verify the new `help-center-logged-out` bundle is generated
- [ ] Test the logged-out Help Center variant loads correctly on pages that use it
- [ ] Verify session continuity works by checking `logged_out_help_center_preferences` in localStorage
- [ ] Confirm the `help-center-ready-to-load` event is dispatched for consumers to hook into