### PR TITLE
Magic Login: Update heading and subheading when changing locale

### DIFF
--- a/client/login/login-context.tsx
+++ b/client/login/login-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback } from '@wordpress/element';
+import { createContext, useContext, useState, useCallback, useEffect } from '@wordpress/element';
 import { type TranslateResult } from 'i18n-calypso';
 
 export interface LoginContextType {
@@ -40,6 +40,19 @@ const LoginContextProvider = ( {
 	const [ subHeadingTextSecondary, setSubHeadingTextSecondary ] = useState<
 		TranslateResult | undefined | null
 	>( initialSubHeadingSecondary ?? undefined );
+
+	// Sync state when initial values change (e.g., when locale changes)
+	useEffect( () => {
+		setHeadingText( initialHeading ?? undefined );
+	}, [ initialHeading ] );
+
+	useEffect( () => {
+		setSubHeadingText( initialSubHeading ?? undefined );
+	}, [ initialSubHeading ] );
+
+	useEffect( () => {
+		setSubHeadingTextSecondary( initialSubHeadingSecondary ?? undefined );
+	}, [ initialSubHeadingSecondary ] );
 
 	const setHeaders = useCallback(
 		( {

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -146,15 +146,6 @@ class RequestLoginEmailForm extends Component {
 		if ( ! prevProps.showCheckYourEmail && this.props.showCheckYourEmail ) {
 			this.setCheckYourEmailHeaders();
 		}
-
-		// Update headers when locale changes
-		if ( prevProps.locale !== this.props.locale ) {
-			if ( this.props.showCheckYourEmail ) {
-				this.setCheckYourEmailHeaders();
-			} else {
-				this.setRequestLoginHeaders();
-			}
-		}
 	}
 
 	onUsernameOrEmailFieldChange = ( event ) => {

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -146,6 +146,15 @@ class RequestLoginEmailForm extends Component {
 		if ( ! prevProps.showCheckYourEmail && this.props.showCheckYourEmail ) {
 			this.setCheckYourEmailHeaders();
 		}
+
+		// Update headers when locale changes
+		if ( prevProps.locale !== this.props.locale ) {
+			if ( this.props.showCheckYourEmail ) {
+				this.setCheckYourEmailHeaders();
+			} else {
+				this.setRequestLoginHeaders();
+			}
+		}
 	}
 
 	onUsernameOrEmailFieldChange = ( event ) => {

--- a/client/login/test/login-context-provider.test.tsx
+++ b/client/login/test/login-context-provider.test.tsx
@@ -1,3 +1,8 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import LoginContextProvider, { useLoginContext } from '../login-context';
 
@@ -22,5 +27,28 @@ describe( 'LoginContextProvider (SSR)', () => {
 
 		expect( html ).toContain( 'Hello' );
 		expect( html ).toContain( 'World' );
+	} );
+} );
+
+describe( 'LoginContextProvider (locale change)', () => {
+	test( 'updates headings when initial values change (e.g., when locale changes)', () => {
+		const { rerender } = render(
+			<LoginContextProvider initialHeading="Bonjour" initialSubHeading="Le Monde">
+				<TestConsumer />
+			</LoginContextProvider>
+		);
+
+		expect( screen.getByTestId( 'heading' ) ).toHaveTextContent( 'Bonjour' );
+		expect( screen.getByTestId( 'subheading' ) ).toHaveTextContent( 'Le Monde' );
+
+		// Simulate locale change by re-rendering with new translations
+		rerender(
+			<LoginContextProvider initialHeading="Hello" initialSubHeading="World">
+				<TestConsumer />
+			</LoginContextProvider>
+		);
+
+		expect( screen.getByTestId( 'heading' ) ).toHaveTextContent( 'Hello' );
+		expect( screen.getByTestId( 'subheading' ) ).toHaveTextContent( 'World' );
 	} );
 } );


### PR DESCRIPTION
Part of DOTOBRD-389

## Proposed Changes

*   Added `useEffect` hooks in `client/login/login-context.tsx` to synchronize the context state with `initialHeading`, `initialSubHeading`, and `initialSubHeadingSecondary` when these props change.
*   Added a new test case in `client/login/test/login-context-provider.test.tsx` to verify that headings update correctly upon locale changes.
*   Configured `client/login/test/login-context-provider.test.tsx` to use the `jsdom` environment.

## Why are these changes being made?

*   The heading and subheading on the `/log-in/link` page were not updating when the user changed the locale.
*   The `LoginContextProvider` was using `useState` for initial values, which only initializes on mount and ignores subsequent changes to those props, preventing translated headers from being applied on re-renders.

## Testing Instructions

1.  Navigate to the `/log-in/link` page.
2.  Change the site locale (e.g., from English to French) using the language switcher or browser settings.
3.  Verify that the heading and subheading text on the login page update correctly to the new locale.
4.  Change the locale back to the original language and confirm the text updates again.
5.  Run `yarn test client/login/test/login-context-provider.test.tsx` to ensure all tests pass, including the new locale change test case.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

---
<a href="https://cursor.com/background-agent?bcId=bc-017b43d8-8499-49c4-8c73-10b542fba6b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-017b43d8-8499-49c4-8c73-10b542fba6b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

