### PR TITLE
Plans: Fix business plan description interpolation

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1851,7 +1851,8 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		i18n.translate( 'Expand your blog with plugins and powerful tools to help you scale.' ),
 	getDescription: () =>
 		i18n.translate(
-			'{{strong}}Best for developers and business owners:{{/strong}} Use powerful developer and business tools, without the overhead.'
+			'{{strong}}Best for developers and business owners:{{/strong}} Use powerful developer and business tools, without the overhead.',
+			plansDescriptionHeadingComponent
 		),
 	getShortDescription: () =>
 		i18n.translate( 'Use powerful developer and business tools, without the overhead.' ),


### PR DESCRIPTION
## Proposed Changes

Fixes bad interpolation of business plan description.

## Why are these changes being made?

There's a bug with how we display the business plan description in purchases:

<img width="1054" height="334" alt="Screenshot 2026-01-16 at 14 46 42" src="https://github.com/user-attachments/assets/e94bf3d5-956a-431e-b008-2e12766c5fb2" />


Introduced in #107836

## Testing Instructions

* Open `https://wordpress.com/me/purchases/SLUG/PURCHASE_ID` where `SLUG` is the site slug and `PURCHASE_ID` is the ID of a business plan purchase.
* Verify the `{{strong}}` in the description is now properly represented:

<img width="1056" height="335" alt="Screenshot 2026-01-16 at 15 09 09" src="https://github.com/user-attachments/assets/eefdbd96-353f-4b64-8496-042022f63983" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
