### PR TITLE
Purchases: Fix manage purchase and card styles conflicts

### DIFF
--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -27,7 +27,7 @@
 	}
 }
 
-.manage-purchase__info {
+.card.manage-purchase__info {
 	font-size: $font-body-small;
 	padding: 0;
 


### PR DESCRIPTION
## Proposed Changes

Fixes broken spacing inside the manage purchase card.

## Why are these changes being made?

There's a spacing bug with how we display the business plan card:

<img width="1057" height="383" alt="Screenshot 2026-01-16 at 15 15 52" src="https://github.com/user-attachments/assets/796eef48-58bb-4b40-aef9-1260c36d5f55" />

It's caused by style precedence issues. I can currently reproduce only on wpcalypso, but this may happen in other issues if the component styles are loaded in the same order.

Found while working on #108171.

## Testing Instructions

* Open `https://wordpress.com/me/purchases/SLUG/PURCHASE_ID` where `SLUG` is the site slug and `PURCHASE_ID` is the ID of a business plan purchase.
* Verify the spacing looks good:

<img width="1054" height="331" alt="Screenshot 2026-01-16 at 15 16 20" src="https://github.com/user-attachments/assets/944c9361-7718-48a7-8431-60ca324d1dd0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
