### PR TITLE
Feature gating for Professional Email

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/titan-banner/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/titan-banner/index.jsx
@@ -1,19 +1,31 @@
+import { WPCOM_FEATURES_TITAN_MAIL_1YEAR_TRIAL } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
 import { TASK_UPSELL_TITAN } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const TitanBanner = () => {
 	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const emailComparisonPath = getEmailManagementPath( siteSlug, siteSlug );
+	const hasOneYearTrial = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_TITAN_MAIL_1YEAR_TRIAL )
+	);
+	const trialMonths = hasOneYearTrial ? 12 : 3;
 
 	return (
 		<Task
-			title={ translate( 'Get 3 months free Professional Email' ) }
+			title={ translate( 'Get %(months)d months free Professional Email', {
+				args: {
+					months: trialMonths,
+				},
+				comment: '%(months)d is the number of free trial months',
+			} ) }
 			description={ translate(
 				'Build your brand with a custom @%(domain)s email address. Professional Email helps promote your site with every email you send.',
 				{

--- a/client/my-sites/customer-home/cards/tasks/titan-banner/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/titan-banner/index.jsx
@@ -19,16 +19,20 @@ const TitanBanner = () => {
 		siteId ? getSiteAvailableProduct( state, siteId, productSlug ) : null
 	);
 	const trialMonths = siteProduct?.introductory_offer?.interval_unit === 'year' ? 12 : 3;
-	return (
-		<>
-			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
-			<Task
-				title={ translate( 'Get %(months)d months free Professional Email', {
+	const bannerTitle =
+		siteProduct?.introductory_offer?.interval_unit === 'year'
+			? translate( 'Get %(months)d months free Professional Email', {
 					args: {
 						months: trialMonths,
 					},
 					comment: '%(months)d is the number of free trial months',
-				} ) }
+			  } )
+			: translate( 'Get 3 months free Professional Email' );
+	return (
+		<>
+			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
+			<Task
+				title={ bannerTitle }
 				description={ translate(
 					'Build your brand with a custom @%(domain)s email address. Professional Email helps promote your site with every email you send.',
 					{

--- a/client/my-sites/customer-home/cards/tasks/titan-banner/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/titan-banner/index.jsx
@@ -1,11 +1,12 @@
-import { WPCOM_FEATURES_TITAN_MAIL_1YEAR_TRIAL } from '@automattic/calypso-products';
+import { TITAN_MAIL_YEARLY_SLUG } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import emailIllustration from 'calypso/assets/images/email-providers/email-illustration.svg';
+import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import { TASK_UPSELL_TITAN } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const TitanBanner = () => {
@@ -13,35 +14,38 @@ const TitanBanner = () => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const emailComparisonPath = getEmailManagementPath( siteSlug, siteSlug );
-	const hasOneYearTrial = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_TITAN_MAIL_1YEAR_TRIAL )
+	const productSlug = TITAN_MAIL_YEARLY_SLUG;
+	const siteProduct = useSelector( ( state ) =>
+		siteId ? getSiteAvailableProduct( state, siteId, productSlug ) : null
 	);
-	const trialMonths = hasOneYearTrial ? 12 : 3;
-
+	const trialMonths = siteProduct?.introductory_offer?.interval_unit === 'year' ? 12 : 3;
 	return (
-		<Task
-			title={ translate( 'Get %(months)d months free Professional Email', {
-				args: {
-					months: trialMonths,
-				},
-				comment: '%(months)d is the number of free trial months',
-			} ) }
-			description={ translate(
-				'Build your brand with a custom @%(domain)s email address. Professional Email helps promote your site with every email you send.',
-				{
+		<>
+			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
+			<Task
+				title={ translate( 'Get %(months)d months free Professional Email', {
 					args: {
-						domain: siteSlug,
+						months: trialMonths,
 					},
-				}
-			) }
-			actionText={ translate( 'Add email for free' ) }
-			actionUrl={ emailComparisonPath }
-			completeOnStart={ false }
-			enableSkipOptions
-			illustration={ emailIllustration }
-			taskId={ TASK_UPSELL_TITAN }
-			timing={ 3 }
-		/>
+					comment: '%(months)d is the number of free trial months',
+				} ) }
+				description={ translate(
+					'Build your brand with a custom @%(domain)s email address. Professional Email helps promote your site with every email you send.',
+					{
+						args: {
+							domain: siteSlug,
+						},
+					}
+				) }
+				actionText={ translate( 'Add email for free' ) }
+				actionUrl={ emailComparisonPath }
+				completeOnStart={ false }
+				enableSkipOptions
+				illustration={ emailIllustration }
+				taskId={ TASK_UPSELL_TITAN }
+				timing={ 3 }
+			/>
+		</>
 	);
 };
 

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -72,6 +72,15 @@ const UpgradeNavItem = ( { currentRoute, domain, selectedSiteId, selectedSiteSlu
 	if ( hasGSuiteWithUs( domain ) || hasTitanMailWithUs( domain ) ) {
 		return null;
 	}
+	const badgeTitle =
+		siteProduct?.introductory_offer?.interval_unit === 'year'
+			? translate( 'Try %(months)d months free', {
+					args: {
+						months: trialMonths,
+					},
+					comment: '%(months)d is the number of free trial months',
+			  } )
+			: translate( 'Try 3 months free' );
 
 	return (
 		<VerticalNavItem
@@ -80,14 +89,7 @@ const UpgradeNavItem = ( { currentRoute, domain, selectedSiteId, selectedSiteSlu
 		>
 			{ translate( 'Upgrade to Professional Email' ) }
 			{ isDomainEligibleForTitanIntroductoryOffer( domain ) && (
-				<Badge type="info-green">
-					{ translate( 'Try %(months)d months free', {
-						args: {
-							months: trialMonths,
-						},
-						comment: '%(months)d is the number of free trial months',
-					} ) }
-				</Badge>
+				<Badge type="info-green">{ badgeTitle }</Badge>
 			) }
 		</VerticalNavItem>
 	);

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { TITAN_MAIL_YEARLY_SLUG } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Badge } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
@@ -6,6 +7,7 @@ import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import titleCase from 'to-title-case';
 import DocumentHead from 'calypso/components/data/document-head';
+import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import VerticalNav from 'calypso/components/vertical-nav';
@@ -54,11 +56,18 @@ import {
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
 
 import './style.scss';
 
-const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
+const UpgradeNavItem = ( { currentRoute, domain, selectedSiteId, selectedSiteSlug } ) => {
 	const translate = useTranslate();
+
+	const productSlug = TITAN_MAIL_YEARLY_SLUG;
+	const siteProduct = useSelector( ( state ) =>
+		selectedSiteId ? getSiteAvailableProduct( state, selectedSiteId, productSlug ) : null
+	);
+	const trialMonths = siteProduct?.introductory_offer?.interval_unit === 'year' ? 12 : 3;
 
 	if ( hasGSuiteWithUs( domain ) || hasTitanMailWithUs( domain ) ) {
 		return null;
@@ -71,7 +80,14 @@ const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 		>
 			{ translate( 'Upgrade to Professional Email' ) }
 			{ isDomainEligibleForTitanIntroductoryOffer( domain ) && (
-				<Badge type="info-green">{ translate( 'Try 3 months free' ) }</Badge>
+				<Badge type="info-green">
+					{ translate( 'Try %(months)d months free', {
+						args: {
+							months: trialMonths,
+						},
+						comment: '%(months)d is the number of free trial months',
+					} ) }
+				</Badge>
 			) }
 		</VerticalNavItem>
 	);
@@ -80,6 +96,7 @@ const UpgradeNavItem = ( { currentRoute, domain, selectedSiteSlug } ) => {
 UpgradeNavItem.propTypes = {
 	currentRoute: PropTypes.string,
 	domain: PropTypes.object.isRequired,
+	selectedSiteId: PropTypes.number,
 	selectedSiteSlug: PropTypes.string.isRequired,
 };
 
@@ -344,6 +361,7 @@ function EmailPlan( {
 
 	return (
 		<>
+			{ selectedSite && <QuerySiteProducts siteId={ selectedSite.ID } /> }
 			{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 			<DocumentHead title={ titleCase( getHeaderText() ) } />
 			{ ! hideMailPoetUpsell && <MailPoetUpsell /> }
@@ -379,6 +397,7 @@ function EmailPlan( {
 						<UpgradeNavItem
 							currentRoute={ currentRoute }
 							domain={ domain }
+							selectedSiteId={ selectedSite?.ID }
 							selectedSiteSlug={ selectedSite.slug }
 						/>
 						{ renderManageAllMailboxesNavItem() }

--- a/client/my-sites/email/email-providers-comparison/price/price-information.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/price-information.tsx
@@ -22,7 +22,12 @@ const getFirstRenewalPrice = ( product: ProductListItem, currencyCode: string ):
 	}
 
 	if ( isTitanMail( product ) ) {
-		return formatCurrency( ( ( product.cost ?? 0 ) * 9 ) / 12, currencyCode, { stripZeros: true } );
+		// We could calculate the first renewal price based on the introductory offer,
+		// but for Tital the options are either 3 month free with prorated renewal or 12 month free with full renewal.
+		const renewalMonths = product.introductory_offer?.interval_unit === 'year' ? 12 : 9;
+		return formatCurrency( ( ( product.cost ?? 0 ) * renewalMonths ) / 12, currencyCode, {
+			stripZeros: true,
+		} );
 	}
 
 	return null;

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -56,12 +56,15 @@ const ProfessionalEmailPrice = ( {
 		isDomainInCart ||
 		isDomainEligibleForTitanFreeTrial( { domain, product: siteProduct ?? product } );
 	const offerMonths = getTitanFreeTrialMonths( siteProduct ?? product );
-	const freeTrialLabel = translate( '%(months)d months free', {
-		args: {
-			months: offerMonths,
-		},
-		comment: '%(months)d is the number of free trial months',
-	} );
+	const freeTrialLabel =
+		offerMonths === 12
+			? translate( '%(months)d months free', {
+					args: {
+						months: offerMonths,
+					},
+					comment: '%(months)d is the number of free trial months',
+			  } )
+			: translate( '3 months free' );
 
 	const priceWithInterval = (
 		<PriceWithInterval

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -13,6 +13,7 @@ import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
 import './style.scss';
 
@@ -20,6 +21,24 @@ const getTitanProductSlug = ( intervalLength: IntervalLength ): string => {
 	return intervalLength === IntervalLength.MONTHLY
 		? TITAN_MAIL_MONTHLY_SLUG
 		: TITAN_MAIL_YEARLY_SLUG;
+};
+
+const getTitanFreeTrialMonths = ( product: ProductListItem | null ): number | null => {
+	const offer = product?.introductory_offer;
+
+	if ( ! offer?.interval_count || ! offer?.interval_unit ) {
+		return null;
+	}
+
+	if ( offer.interval_unit === 'year' ) {
+		return offer.interval_count * 12;
+	}
+
+	if ( offer.interval_unit === 'month' ) {
+		return offer.interval_count;
+	}
+
+	return null;
 };
 
 type ProfessionalEmailPriceProps = {
@@ -50,6 +69,13 @@ const ProfessionalEmailPrice = ( {
 	const isEligibleForFreeTrial =
 		isDomainInCart ||
 		isDomainEligibleForTitanFreeTrial( { domain, product: siteProduct ?? product } );
+	const offerMonths = getTitanFreeTrialMonths( siteProduct ?? product );
+	const freeTrialLabel = translate( '%(months)d months free', {
+		args: {
+			months: offerMonths ?? 3,
+		},
+		comment: '%(months)d is the number of free trial months',
+	} );
 
 	const priceWithInterval = (
 		<PriceWithInterval
@@ -64,7 +90,7 @@ const ProfessionalEmailPrice = ( {
 		<>
 			{ isEligibleForFreeTrial && (
 				<div className="professional-email-price__trial-badge badge badge--info-green">
-					{ translate( '3 months free' ) }
+					{ freeTrialLabel }
 				</div>
 			) }
 

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -10,6 +10,8 @@ import PriceWithInterval from 'calypso/my-sites/email/email-providers-comparison
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 import './style.scss';
@@ -35,20 +37,26 @@ const ProfessionalEmailPrice = ( {
 
 	const productSlug = getTitanProductSlug( intervalLength );
 	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = domain?.blogId ?? selectedSite?.ID;
+	const siteProduct = useSelector( ( state ) =>
+		getSiteAvailableProduct( state, siteId, productSlug )
+	);
 
 	if ( ! domain && ! isDomainInCart ) {
 		return null;
 	}
 
 	const isEligibleForFreeTrial =
-		isDomainInCart || isDomainEligibleForTitanFreeTrial( { domain, product } );
+		isDomainInCart ||
+		isDomainEligibleForTitanFreeTrial( { domain, product: siteProduct ?? product } );
 
 	const priceWithInterval = (
 		<PriceWithInterval
 			currencyCode={ currencyCode ?? '' }
 			intervalLength={ intervalLength }
 			isEligibleForIntroductoryOffer={ isEligibleForFreeTrial }
-			product={ product }
+			product={ siteProduct ?? product }
 		/>
 	);
 
@@ -65,7 +73,7 @@ const ProfessionalEmailPrice = ( {
 					<PriceInformation
 						domain={ domain }
 						isDomainInCart={ isDomainInCart }
-						product={ product }
+						product={ siteProduct ?? product }
 					/>
 				}
 				price={ priceWithInterval }

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -23,7 +23,7 @@ const getTitanProductSlug = ( intervalLength: IntervalLength ): string => {
 		: TITAN_MAIL_YEARLY_SLUG;
 };
 
-const getTitanFreeTrialMonths = ( product: ProductListItem | null ): number | null => {
+const getTitanFreeTrialMonths = ( product: ProductListItem | null ): number => {
 	return product?.introductory_offer?.interval_unit === 'year' ? 12 : 3;
 };
 

--- a/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
+++ b/client/my-sites/email/email-providers-comparison/price/professional-email.tsx
@@ -24,21 +24,7 @@ const getTitanProductSlug = ( intervalLength: IntervalLength ): string => {
 };
 
 const getTitanFreeTrialMonths = ( product: ProductListItem | null ): number | null => {
-	const offer = product?.introductory_offer;
-
-	if ( ! offer?.interval_count || ! offer?.interval_unit ) {
-		return null;
-	}
-
-	if ( offer.interval_unit === 'year' ) {
-		return offer.interval_count * 12;
-	}
-
-	if ( offer.interval_unit === 'month' ) {
-		return offer.interval_count;
-	}
-
-	return null;
+	return product?.introductory_offer?.interval_unit === 'year' ? 12 : 3;
 };
 
 type ProfessionalEmailPriceProps = {
@@ -72,7 +58,7 @@ const ProfessionalEmailPrice = ( {
 	const offerMonths = getTitanFreeTrialMonths( siteProduct ?? product );
 	const freeTrialLabel = translate( '%(months)d months free', {
 		args: {
-			months: offerMonths ?? 3,
+			months: offerMonths,
 		},
 		comment: '%(months)d is the number of free trial months',
 	} );

--- a/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/style.scss
+++ b/client/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card/style.scss
@@ -120,6 +120,10 @@ $width-left-panel-card: 55%;
 	@include break-medium {
 		padding-top: 36px;
 
+		&.card {
+			padding-top: 36px;
+		}
+
 		&.action-panel {
 			padding-bottom: 36px;
 		}

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -12,6 +12,7 @@ import { stringify } from 'qs';
 import { useEffect, useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
@@ -266,6 +267,7 @@ const EmailProvidersStackedComparison = ( {
 		>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			<QueryProductsList />
+			{ selectedSite && <QuerySiteProducts siteId={ selectedSite.ID } /> }
 
 			{ ! isDomainInCart && selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -307,6 +307,7 @@ export const WPCOM_FEATURES_SCAN = 'scan';
 export const WPCOM_FEATURES_SCHEDULED_UPDATES = 'scheduled-updates';
 export const WPCOM_FEATURES_SEO_PREVIEW_TOOLS = 'seo-preview-tools';
 export const WPCOM_FEATURES_SUBSCRIPTION_GIFTING = 'subscription-gifting';
+export const WPCOM_FEATURES_TITAN_MAIL_1YEAR_TRIAL = 'titan_mail_1year_trial';
 export const WPCOM_FEATURES_LOCKED_MODE = 'locked-mode';
 export const WPCOM_FEATURES_LEGACY_CONTACT = 'legacy-contact';
 export const WPCOM_FEATURES_UPLOAD_AUDIO_FILES = 'upload-audio-files';

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -307,7 +307,6 @@ export const WPCOM_FEATURES_SCAN = 'scan';
 export const WPCOM_FEATURES_SCHEDULED_UPDATES = 'scheduled-updates';
 export const WPCOM_FEATURES_SEO_PREVIEW_TOOLS = 'seo-preview-tools';
 export const WPCOM_FEATURES_SUBSCRIPTION_GIFTING = 'subscription-gifting';
-export const WPCOM_FEATURES_TITAN_MAIL_1YEAR_TRIAL = 'titan_mail_1year_trial';
 export const WPCOM_FEATURES_LOCKED_MODE = 'locked-mode';
 export const WPCOM_FEATURES_LEGACY_CONTACT = 'legacy-contact';
 export const WPCOM_FEATURES_UPLOAD_AUDIO_FILES = 'upload-audio-files';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15683

## Proposed Changes

* Update the Calypso UI to correctly display the Professional Mail trial offer duration and cost.

<img width="919" height="371" alt="Screenshot 2026-01-19 at 14 11 21" src="https://github.com/user-attachments/assets/1b8a9c56-de71-4001-b7e3-a4ed6b11d527" />
<img width="1063" height="369" alt="Screenshot 2026-01-19 at 14 14 30" src="https://github.com/user-attachments/assets/f392f00f-fb79-405e-8f4a-8720052cf221" />
<img width="1063" height="387" alt="Screenshot 2026-01-19 at 14 13 57" src="https://github.com/user-attachments/assets/4efb1052-1076-49a6-8e62-8450140ee686" />
<img width="1089" height="288" alt="Screenshot 2026-01-19 at 14 18 28" src="https://github.com/user-attachments/assets/71de769e-746e-42d2-8aaf-8824cfac0a55" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the pricing experiment we're adding a 12-month trial in addition to the standard 3-month trial.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox public-api.wordpress.com and use `add_blog_sticker( 'gating-business-q1', null, null, your_site_id );` to a Business site to setup the new pricing.
* Edit `wp-content/lib/home/views.php` and add `TASK_UPSELL_TITAN,` to `const HIGH_PRIORITY_PROMOS`.
* Check the Mail Banner on http://calypso.localhost:3000/home/{site_url}.
* Go to http://calypso.localhost:3000/email/{site_url} add a domain to the cart and check that the email provider selection dialog shows the correct prices for Professional Mail.
* Purchase a .blog domain, then go to Domains->{your domain}->Email and check the options there.
* Add Email Forwarding, then visit http://calypso.localhost:3000/email/{site_url} again and check the plan duration in "Upgrade to Professional Mail" message 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
