### PR TITLE
Add TikTok advertising base tracking pixel

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -38,6 +38,7 @@ export const QUORA_SCRIPT_URL = 'https://a.quora.com/qevents.js';
 export const OUTBRAIN_SCRIPT_URL = 'https://amplify.outbrain.com/cp/obtp.js';
 export const PINTEREST_SCRIPT_URL = 'https://s.pinimg.com/ct/core.js';
 export const PARSLEY_SCRIPT_URL = 'https://cdn.parsely.com/keys/wordpress.com/p.js?ver=3.3.2';
+// We're storing the pixel ID separately to reuse it, but it needs to be passed in the URL.
 export const TIKTOK_SCRIPT_URL = 'https://analytics.tiktok.com/i18n/pixel/events.js?sdkid=';
 export const TRACKING_IDS = {
 	bingInit: '4074038',

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -38,6 +38,7 @@ export const QUORA_SCRIPT_URL = 'https://a.quora.com/qevents.js';
 export const OUTBRAIN_SCRIPT_URL = 'https://amplify.outbrain.com/cp/obtp.js';
 export const PINTEREST_SCRIPT_URL = 'https://s.pinimg.com/ct/core.js';
 export const PARSLEY_SCRIPT_URL = 'https://cdn.parsely.com/keys/wordpress.com/p.js?ver=3.3.2';
+export const TIKTOK_SCRIPT_URL = 'https://analytics.tiktok.com/i18n/pixel/events.js?sdkid=';
 export const TRACKING_IDS = {
 	bingInit: '4074038',
 	criteo: '31321',
@@ -75,6 +76,7 @@ export const TRACKING_IDS = {
 	wooGoogleTagManagerId: 'GTM-W64W8Q',
 	parselyTracker: 'wordpress.com',
 	wpcomLinkedinId: '7224796',
+	tiktokPixelId: 'D5JLDS3C77UAODHQ56P0',
 };
 // This name is something we created to store a session id for DCM Floodlight session tracking
 export const DCM_FLOODLIGHT_SESSION_COOKIE_NAME = 'dcmsid';

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -19,6 +19,7 @@ import {
 	GOOGLE_GTM_SCRIPT_URL,
 	WPCOM_CLARITY_URI,
 	REDDIT_TRACKING_SCRIPT_URL,
+	TIKTOK_SCRIPT_URL,
 	WPCOM_REDDIT_PIXEL_ID,
 } from './constants';
 import { circularReferenceSafeJSONStringify } from './debug';
@@ -121,6 +122,10 @@ function getTrackingScriptsToLoad() {
 
 	if ( mayWeTrackByTracker( 'reddit' ) ) {
 		scripts.push( REDDIT_TRACKING_SCRIPT_URL );
+	}
+
+	if ( mayWeTrackByTracker( 'tiktok' ) ) {
+		scripts.push( TIKTOK_SCRIPT_URL + TRACKING_IDS.tiktokPixelId );
 	}
 
 	return scripts;

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -123,7 +123,7 @@ function getTrackingScriptsToLoad() {
 	if ( mayWeTrackByTracker( 'reddit' ) ) {
 		scripts.push( REDDIT_TRACKING_SCRIPT_URL );
 	}
-
+	// The pixel must be loaded with the ID in the URL.
 	if ( mayWeTrackByTracker( 'tiktok' ) ) {
 		scripts.push( TIKTOK_SCRIPT_URL + TRACKING_IDS.tiktokPixelId );
 	}

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -249,7 +249,9 @@ function setupRedditGlobal() {
 
 	window.rdt.callQueue = [];
 }
-
+/**
+ * Sets up the TikTok advertising pixel based on the obfuscated code provided by TikTok.
+ */
 function setupTikTokGlobal() {
 	if ( window.ttq ) {
 		return;

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -7,6 +7,7 @@ import {
 	ADROLL_PAGEVIEW_PIXEL_URL_2,
 	ADROLL_PURCHASE_PIXEL_URL_1,
 	ADROLL_PURCHASE_PIXEL_URL_2,
+	TIKTOK_SCRIPT_URL,
 	TRACKING_IDS,
 } from './constants';
 
@@ -105,6 +106,10 @@ export function setup() {
 		// Reddit
 		if ( mayWeInitTracker( 'reddit' ) ) {
 			setupRedditGlobal();
+		}
+
+		if ( mayWeInitTracker( 'tiktok' ) ) {
+			setupTikTokGlobal();
 		}
 	}
 }
@@ -243,6 +248,47 @@ function setupRedditGlobal() {
 		};
 
 	window.rdt.callQueue = [];
+}
+
+function setupTikTokGlobal() {
+	if ( window.ttq ) {
+		return;
+	}
+	// This is usually set when calling load, but we load the script through a separate mechanism.
+	window.TiktokAnalyticsObject = 'ttq';
+	window.ttq = Object.assign( [], {
+		_i: {
+			[ TRACKING_IDS.tiktokPixelId ]: {
+				_u: TIKTOK_SCRIPT_URL,
+			},
+		},
+		_t: {
+			[ TRACKING_IDS.tiktokPixelId ]: +new Date(),
+		},
+	} );
+	const methods = [
+		'page',
+		'track',
+		'identify',
+		'instances',
+		'debug',
+		'on',
+		'off',
+		'once',
+		'ready',
+		'alias',
+		'group',
+		'enableCookie',
+		'disableCookie',
+		'holdConsent',
+		'revokeConsent',
+		'grantConsent',
+	];
+	methods.forEach( function ( value ) {
+		window.ttq[ value ] = function () {
+			window.ttq.push( [ value ].concat( Array.prototype.slice.call( arguments, 0 ) ) );
+		};
+	} );
 }
 
 function setupGtag() {

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -34,6 +34,7 @@ const allAdTrackers = [
 	'parsely',
 	'clarity',
 	'reddit',
+	'tiktok',
 ] as const;
 
 const sessionAdTrackers = [ 'hotjar', 'logrocket' ];
@@ -63,6 +64,7 @@ export const AdTrackersBuckets: { [ key in AdTracker ]: Bucket | null } = {
 	facebook: Bucket.ADVERTISING,
 	reddit: Bucket.ADVERTISING,
 	linkedin: Bucket.ADVERTISING,
+	tiktok: Bucket.ADVERTISING,
 
 	// Disabled trackers:
 	quantcast: null,
@@ -101,6 +103,7 @@ export const AdTrackersInitGuards: Partial< { [ key in AdTracker ]: () => boolea
 	adroll: () => 'adRoll' in window,
 	clarity: () => 'clarity' in window,
 	reddit: () => 'rdt' in window,
+	tiktok: () => 'ttq' in window,
 };
 
 const isTrackerIntialized = ( tracker: AdTracker ): boolean => {

--- a/client/lib/analytics/utils/get-exceptions.ts
+++ b/client/lib/analytics/utils/get-exceptions.ts
@@ -12,6 +12,7 @@ const getExceptions = (): Partial< Record< AdTracker, boolean > > => {
 
 	return {
 		facebook: region === 'california' && countryCode === 'us',
+		tiktok: region === 'california' && countryCode === 'us',
 	};
 };
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -550,6 +550,7 @@ function setUpCSP( req, res, next ) {
 			'https://connect.facebook.net', // Facebook Pixel
 			'https://snap.licdn.com', // LinkedIn analytics
 			'www.redditstatic.com', // Reddit tracking pixel
+			'https://analytics.tiktok.com', // TikTok tracking pixel
 			'www.googletagmanager.com',
 			'https://accounts.google.com',
 			'https://bat.bing.com', // Bing Ads JS
@@ -665,6 +666,7 @@ function setUpCSP( req, res, next ) {
 			'https://survey.survicate.com', // Survicate API
 			'*.sentry.io',
 			'*.reddit.com',
+			'https://analytics.tiktok.com', // TikTok tracking pixel
 			// Payment provider APIs (for tokenization and payment processing)
 			'*.stripe.com', // Stripe API calls
 			'api.stripe.com', // Stripe API endpoint


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1619

## Proposed Changes

* Add the base TikTok advertising pixel.
* Rewrite the provided obfuscated pixel so we can load it using the privacy toolkit.
* Respect the `California` exception, similar to what we're doing for `Meta`.
* Update CSP to be able to load content from `https://analytics.tiktok.com`.

Note: This PR handles loading the pixel, triggering events will be handled in a follow-up PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To support upcoming TikTok Ads campaigns.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit https://container-musing-morse.calypso.live/setup/onboarding/domains and make sure you clear the `sensitive_pixel_options` cookie if set.
* Visit https://container-musing-morse.calypso.live/setup/onboarding/domains?flags=ad-tracking,cookie-banner, confirm there are no console errors and no script containing `tiktok` is loaded.
* Click on `Customize`, accept Analytics but not Advertising and click `Accept selection`. Confirm there are no console errors and no script containing `tiktok` is loaded.
* Clear the `sensitive_pixel_options` cookie and refresh the page.
* Accept Advertising and confirm there are no console errors and the pixel: `https://analytics.tiktok.com/i18n/pixel/events.js?sdkid=D5JLDS3C77UAODHQ56P0` was loaded successfuly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
