### PR TITLE
Cancellation Flow: only show Atomic revert confirmation for plans

### DIFF
--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -707,15 +707,17 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					) }
 					<ProductLink purchase={ purchase } selectedSite={ this.props.site } />
 
-					<AtomicRevertChanges
-						atomicTransfer={ atomicTransfer }
-						purchase={ purchase }
-						onConfirmationChange={ this.onAtomicRevertConfirmationChange }
-						needsAtomicRevertConfirmation={ Boolean(
-							atomicTransfer?.created_at && ! isRefundable( purchase )
-						) }
-						isLoading={ this.state.isLoading }
-					/>
+					{ isPlan( purchase ) && (
+						<AtomicRevertChanges
+							atomicTransfer={ atomicTransfer }
+							purchase={ purchase }
+							onConfirmationChange={ this.onAtomicRevertConfirmationChange }
+							needsAtomicRevertConfirmation={ Boolean(
+								atomicTransfer?.created_at && ! isRefundable( purchase )
+							) }
+							isLoading={ this.state.isLoading }
+						/>
+					) }
 				</CompactCard>
 
 				<CompactCard className="cancel-purchase__footer">


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-353/cancelling-google-workspace-on-wow-site-shows-site-downgrade-notice

## Proposed Changes

This restricts the Atomic Revert confirmation to only be shown in the product cancellation flow if the purchase is a plan.

## Why are these changes being made?

In #107974 the Atomic revert confirmation notice was added to the cancellation flow that's shown for plans without cancellation features (e.g. the legacy Pro plan), however that flow is also shown for any non-plan products (e.g. domains, emails, themes, premium plugins). Since the only gating on the notice is whether or not an Atomic transfer has happened, and not whether or not the purchase in question will revert the transfer, the notice is now being shown for any product that happens to be attached to an Atomic site.

| Before | After |
| ----------- | ----------- |
| <img width="1822" height="1430" alt="CleanShot 2026-01-16 at 16 04 13@2x" src="https://github.com/user-attachments/assets/5ee4d89c-1b88-4c9d-a302-ea52e9d25ec9" /> | <img width="1806" height="1048" alt="CleanShot 2026-01-16 at 16 03 51@2x" src="https://github.com/user-attachments/assets/964fc020-2f43-4ec4-b1d1-7f9336937d70" /> |

## Testing Instructions

- For an Atomic site with an email subscription
- Visit Me > Purchases and click on the email subscription
- From the subscription management page, click "Cancel purchase"
- Verify that the Atomic Revert confirmation is not shown
- Verify that you can still cancel your email subscription
