### PR TITLE
MSD: Separate background from EmptyState.

### DIFF
--- a/client/dashboard/components/empty-state/index.stories.tsx
+++ b/client/dashboard/components/empty-state/index.stories.tsx
@@ -36,6 +36,31 @@ export const Default: Story = {
 	},
 };
 
+export const WithContainer: Story = {
+	render: ( args ) => (
+		<EmptyState.Container>
+			<EmptyState { ...args } />
+		</EmptyState.Container>
+	),
+	args: {
+		title: 'No items yet',
+		description: 'Get started by creating your first item.',
+		children: (
+			<EmptyState.ActionList>
+				<EmptyState.ActionItem
+					title="Create item"
+					description="Set up a new item to see it appear here."
+					actions={
+						<Button __next40pxDefaultSize variant="primary">
+							Create item
+						</Button>
+					}
+				/>
+			</EmptyState.ActionList>
+		),
+	},
+};
+
 export const WithMultipleActions: Story = {
 	args: {
 		title: 'Nothing here yet',

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -10,7 +10,9 @@ import './style.scss';
 function EmptyStateContainer( { children }: { children: ReactNode } ) {
 	return (
 		<Card>
-			<CardBody className="dashboard-empty-state">{ children }</CardBody>
+			<CardBody className="dashboard-empty-state">
+				<VStack alignment="center">{ children }</VStack>
+			</CardBody>
 		</Card>
 	);
 }
@@ -25,7 +27,7 @@ function EmptyState( {
 	children?: ReactNode;
 } ) {
 	return (
-		<VStack spacing={ 8 } alignment="center" className="dashboard-empty-state">
+		<VStack spacing={ 8 } alignment="center">
 			<VStack spacing={ 2 } alignment="center">
 				<Text as="h2" align="center" className="dashboard-empty-state__title">
 					{ title }

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -7,6 +7,14 @@ import type { ReactNode } from 'react';
 
 import './style.scss';
 
+function EmptyStateContainer( { children }: { children: ReactNode } ) {
+	return (
+		<Card>
+			<CardBody className="dashboard-empty-state">{ children }</CardBody>
+		</Card>
+	);
+}
+
 function EmptyState( {
 	title,
 	description,
@@ -17,27 +25,24 @@ function EmptyState( {
 	children?: ReactNode;
 } ) {
 	return (
-		<Card>
-			<CardBody>
-				<VStack spacing={ 8 } alignment="center" className="dashboard-empty-state">
-					<VStack spacing={ 2 } alignment="center">
-						<Text as="h2" align="center" className="dashboard-empty-state__title">
-							{ title }
-						</Text>
-						<Text variant="muted" align="center" className="dashboard-empty-state__description">
-							{ description }
-						</Text>
-					</VStack>
-					<VStack spacing={ 6 } className="dashboard-empty-state__content">
-						{ children }
-					</VStack>
-				</VStack>
-			</CardBody>
-		</Card>
+		<VStack spacing={ 8 } alignment="center" className="dashboard-empty-state">
+			<VStack spacing={ 2 } alignment="center">
+				<Text as="h2" align="center" className="dashboard-empty-state__title">
+					{ title }
+				</Text>
+				<Text variant="muted" align="center" className="dashboard-empty-state__description">
+					{ description }
+				</Text>
+			</VStack>
+			<VStack spacing={ 6 } className="dashboard-empty-state__content">
+				{ children }
+			</VStack>
+		</VStack>
 	);
 }
 
 const EmptyStateWithStatics = Object.assign( EmptyState, {
+	Container: EmptyStateContainer,
 	ActionList: EmptyStateActionList,
 	ActionItem: EmptyStateActionItem,
 } );

--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -10,8 +10,10 @@ import './style.scss';
 function EmptyStateContainer( { children }: { children: ReactNode } ) {
 	return (
 		<Card>
-			<CardBody className="dashboard-empty-state">
-				<VStack alignment="center">{ children }</VStack>
+			<CardBody>
+				<VStack alignment="center" className="dashboard-empty-state">
+					{ children }
+				</VStack>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/components/empty-state/style.scss
+++ b/client/dashboard/components/empty-state/style.scss
@@ -11,7 +11,7 @@
 	}
 }
 
-.dashboard-empty-state__title {
+.dashboard-empty-state__title.dashboard-empty-state__title {
 	font-size: $font-size-x-large;
 	font-weight: 500;
 }


### PR DESCRIPTION
Part of DOTMSD-995
Related to: #107909

## Proposed Changes

Move the white background into a composable component called `EmptyState.Container`.

| Name | Screenshot |
|--------|--------|
| Default |  <img width="1362" height="929" alt="Screenshot 2026-01-19 at 10 08 44 AM" src="https://github.com/user-attachments/assets/01e4629d-c8fa-414f-a4de-153f25c04ad0" /> | 
| With Container |  <img width="1363" height="926" alt="Screenshot 2026-01-19 at 10 08 50 AM" src="https://github.com/user-attachments/assets/cd64ffa2-4b26-42ad-a0a1-b1acb5eaad9e" />  | 

## Why are these changes being made?

We should be able to pass the `EmptyState` component as the empty state in a DataView.

**Example**
<img width="500" height="318" alt="Screenshot 2026-01-19 at 10 15 20 AM" src="https://github.com/user-attachments/assets/4aa1e851-f780-432b-bd98-c6c935f07ae2" />


We also need the container for other empty states, like the upsell pages.

**Example**
<img width="500" height="519" alt="Screenshot 2026-01-19 at 9 24 15 AM" src="https://github.com/user-attachments/assets/9b34bc3b-0a38-4926-95f1-2e78403fd10c" />

See: DOTMSD-995

## Considerations

Maybe it doesn't make sense to have `EmptyState.Container` at all and either create a new component entirely or let the consumers provide this. I couldn't think of a use case for it outside of the EmptyState and chose to add it here. I'm open to other suggestions.


## Testing Instructions
- `yarn storybook:start`
- Navigate to http://localhost:6006/?path=/docs/client-dashboard-emptystate--docs.
- Verify the empty state still works!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
