### PR TITLE
Chore: Upgrade @wordpress/dataviews to 11.2.0

### DIFF
--- a/apps/design-system-docs/package.json
+++ b/apps/design-system-docs/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/base-styles": "^5.23.0",
 		"@wordpress/browserslist-config": "^6.23.0",
 		"@wordpress/components": "^30.9.0",
-		"@wordpress/dataviews": "^10.3.0",
+		"@wordpress/dataviews": "^11.2.0",
 		"docusaurus-plugin-sass": "^0.2.6",
 		"prism-react-renderer": "^2.4.1",
 		"react": "^18.3.1",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -34,7 +34,7 @@
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/data": "^10.23.0",
-		"@wordpress/dataviews": "^10.3.0",
+		"@wordpress/dataviews": "^11.2.0",
 		"@wordpress/element": "^6.23.0",
 		"@wordpress/i18n": "^5.23.0",
 		"@wordpress/icons": "^10.23.0",

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -199,13 +199,13 @@ export function usePersistentView( {
 	return { view, updateView, resetView: isViewModified ? resetView : undefined };
 }
 
-function removeTransientPropertiesFromView( view: View ): Omit< View, 'page' | 'search' > {
+function removeTransientPropertiesFromView( view: View ): View {
 	const viewToPersist = { ...view };
 
 	delete viewToPersist.page;
 	delete viewToPersist.search;
 
-	return viewToPersist;
+	return viewToPersist as View;
 }
 
 function removeTransientFiltersFromView( view: View, transientFilterFields: string[] ): View {

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -161,7 +161,7 @@ export const defaultView: View = {
 	titleField: 'site',
 	fields: [ 'lastUpdate', 'nextUpdate', 'schedule', 'plugins', 'active' ],
 	sort: { field: 'site', direction: 'asc' },
-	groupByField: 'scheduleId',
+	groupBy: { field: 'scheduleId' },
 	mediaField: 'icon.ico',
 	showMedia: true,
 };

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -161,7 +161,7 @@ export const defaultView: View = {
 	titleField: 'site',
 	fields: [ 'lastUpdate', 'nextUpdate', 'schedule', 'plugins', 'active' ],
 	sort: { field: 'site', direction: 'asc' },
-	groupBy: { field: 'scheduleId' },
+	groupBy: { field: 'scheduleId', direction: 'asc' },
 	mediaField: 'icon.ico',
 	showMedia: true,
 };

--- a/client/dashboard/sites/performance/performance-insight-table.tsx
+++ b/client/dashboard/sites/performance/performance-insight-table.tsx
@@ -108,7 +108,7 @@ const PerformanceInsightTable = ( {
 	const view = {
 		fields: fields.map( ( field ) => field.id ),
 		type: 'table' as const,
-		groupByField: details.isEntityGrouped ? 'entity' : undefined,
+		groupBy: details.isEntityGrouped ? { field: 'entity' } : undefined,
 		layout: {
 			enableMoving: false,
 		},

--- a/client/dashboard/sites/performance/performance-insight-table.tsx
+++ b/client/dashboard/sites/performance/performance-insight-table.tsx
@@ -108,7 +108,7 @@ const PerformanceInsightTable = ( {
 	const view = {
 		fields: fields.map( ( field ) => field.id ),
 		type: 'table' as const,
-		groupBy: details.isEntityGrouped ? { field: 'entity' } : undefined,
+		groupBy: details.isEntityGrouped ? { field: 'entity', direction: 'asc' as const } : undefined,
 		layout: {
 			enableMoving: false,
 		},

--- a/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
@@ -27,7 +27,7 @@ import { AutoRenewDiolog } from './components/auto-renew-dialog';
 import { useDomainsDataViewsContext } from './use-context';
 
 export function useActions(
-	viewType: 'table' | 'list' | 'grid' | 'pickerGrid' | 'pickerTable',
+	viewType: 'table' | 'list' | 'grid' | 'pickerGrid' | 'pickerTable' | 'activity',
 	onClose?: () => void
 ) {
 	const translate = useTranslate();

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -527,6 +527,7 @@ export default function SubscriberDataViews( {
 				showTitle: true,
 				showMedia: true,
 				fields: [],
+				layout: undefined,
 			} ) );
 		} else {
 			// Otherwise, we want to show the table view.

--- a/client/package.json
+++ b/client/package.json
@@ -107,7 +107,7 @@
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/compose": "^7.23.0",
 		"@wordpress/data": "^10.23.0",
-		"@wordpress/dataviews": "^10.3.0",
+		"@wordpress/dataviews": "^11.2.0",
 		"@wordpress/date": "^5.23.0",
 		"@wordpress/dom": "^4.23.0",
 		"@wordpress/edit-post": "^8.23.0",

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -131,7 +131,7 @@ export const isActionEligible = (
 export function useActions( {
 	viewType,
 }: {
-	viewType: 'list' | 'table' | 'grid' | 'pickerGrid' | 'pickerTable';
+	viewType: 'list' | 'table' | 'grid' | 'pickerGrid' | 'pickerTable' | 'activity';
 } ): Action< SiteExcerptData >[] {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();

--- a/client/sites/components/sites-dataviews/site-icon.tsx
+++ b/client/sites/components/sites-dataviews/site-icon.tsx
@@ -21,7 +21,7 @@ export default function SiteIcon( {
 		site: SiteExcerptData,
 		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher'
 	) => void;
-	viewType: 'list' | 'table' | 'grid' | 'breadcrumb' | 'pickerGrid' | 'pickerTable';
+	viewType: 'list' | 'table' | 'grid' | 'breadcrumb' | 'pickerGrid' | 'pickerTable' | 'activity';
 	disableClick?: boolean;
 } ) {
 	const { adminUrl } = useSiteAdminInterfaceData( site.ID );

--- a/package.json
+++ b/package.json
@@ -365,7 +365,7 @@
 		"@wordpress/customize-widgets": "5.23.0",
 		"@wordpress/data-controls": "4.23.0",
 		"@wordpress/data": "^10.23.0",
-		"@wordpress/dataviews": "^10.3.0",
+		"@wordpress/dataviews": "^11.2.0",
 		"@wordpress/date": "5.23.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.24.0",
 		"@wordpress/deprecated": "4.23.0",

--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -36,7 +36,7 @@
 	},
 	"dependencies": {
 		"@automattic/shopping-cart": "workspace:^",
-		"@wordpress/dataviews": "^10.3.0",
+		"@wordpress/dataviews": "^11.2.0",
 		"@wordpress/i18n": "^5.23.0",
 		"he": "^1.2.0",
 		"tslib": "^2.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,7 +409,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
-    "@wordpress/dataviews": "npm:^10.3.0"
+    "@wordpress/dataviews": "npm:^11.2.0"
     "@wordpress/i18n": "npm:^5.23.0"
     he: "npm:^1.2.0"
     react: "npm:^18.3.1"
@@ -1287,7 +1287,7 @@ __metadata:
     "@wordpress/base-styles": "npm:^5.23.0"
     "@wordpress/browserslist-config": "npm:^6.23.0"
     "@wordpress/components": "npm:^30.9.0"
-    "@wordpress/dataviews": "npm:^10.3.0"
+    "@wordpress/dataviews": "npm:^11.2.0"
     docusaurus-plugin-sass: "npm:^0.2.6"
     prism-react-renderer: "npm:^2.4.1"
     react: "npm:^18.3.1"
@@ -1838,7 +1838,7 @@ __metadata:
     "@automattic/wp-babel-makepot": "workspace:^"
     "@wordpress/components": "npm:^30.9.0"
     "@wordpress/data": "npm:^10.23.0"
-    "@wordpress/dataviews": "npm:^10.3.0"
+    "@wordpress/dataviews": "npm:^11.2.0"
     "@wordpress/element": "npm:^6.23.0"
     "@wordpress/i18n": "npm:^5.23.0"
     "@wordpress/icons": "npm:^10.23.0"
@@ -4303,6 +4303,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.28.4":
+  version: 7.28.6
+  resolution: "@babel/runtime@npm:7.28.6"
+  checksum: 358cf2429992ac1c466df1a21c1601d595c46930a13c1d4662fde908d44ee78ec3c183aaff513ecb01ef8c55c3624afe0309eeeb34715672dbfadb7feedb2c0d
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.25.7, @babel/template@npm:^7.27.1, @babel/template@npm:^7.3.3":
   version: 7.27.1
   resolution: "@babel/template@npm:7.27.1"
@@ -4336,6 +4343,47 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.27.1"
   checksum: ed736f14db2fdf0d36c539c8e06b6bb5e8f9649a12b5c0e1c516fed827f27ef35085abe08bf4d1302a4e20c9a254e762eed453bce659786d4a6e01ba26a91377
+  languageName: node
+  linkType: hard
+
+"@base-ui/react@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@base-ui/react@npm:1.1.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+    "@base-ui/utils": "npm:0.2.4"
+    "@floating-ui/react-dom": "npm:^2.1.6"
+    "@floating-ui/utils": "npm:^0.2.10"
+    reselect: "npm:^5.1.1"
+    tabbable: "npm:^6.4.0"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@types/react": ^17 || ^18 || ^19
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 7a84af8ba7e5ace677443e5b98e488039d5b254e24042a2b618cf02e6e4f81ef21c18c64fe9ce7752ae103db2a96a6cd0a102a936f558066ebd8637ac89f6ec4
+  languageName: node
+  linkType: hard
+
+"@base-ui/utils@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@base-ui/utils@npm:0.2.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+    "@floating-ui/utils": "npm:^0.2.10"
+    reselect: "npm:^5.1.1"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@types/react": ^17 || ^18 || ^19
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 98305af23d44fb42a2c331a95a0d90be1008a183dfaf767b3804f0962cee7d339d71d29732b2cb102b32f2b9c0ca5b756d5ca47d9c654673e72e4dbf4dba7f07
   languageName: node
   linkType: hard
 
@@ -6072,6 +6120,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.7.3":
+  version: 1.7.3
+  resolution: "@floating-ui/core@npm:1.7.3"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.10"
+  checksum: edfc23800122d81df0df0fb780b7328ae6c5f00efbb55bd48ea340f4af8c5b3b121ceb4bb81220966ab0f87b443204d37105abdd93d94846468be3243984144c
+  languageName: node
+  linkType: hard
+
 "@floating-ui/dom@npm:^1.0.0, @floating-ui/dom@npm:^1.6.1":
   version: 1.6.3
   resolution: "@floating-ui/dom@npm:1.6.3"
@@ -6079,6 +6136,16 @@ __metadata:
     "@floating-ui/core": "npm:^1.0.0"
     "@floating-ui/utils": "npm:^0.2.0"
   checksum: d6cac10877918ce5a8d1a24b21738d2eb130a0191043d7c0dd43bccac507844d3b4dc5d4107d3891d82f6007945ca8fb4207a1252506e91c37e211f0f73cf77e
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.7.4":
+  version: 1.7.4
+  resolution: "@floating-ui/dom@npm:1.7.4"
+  dependencies:
+    "@floating-ui/core": "npm:^1.7.3"
+    "@floating-ui/utils": "npm:^0.2.10"
+  checksum: da6166c25f9b0729caa9f498685a73a0e28251613b35d27db8de8014bc9d045158a23c092b405321a3d67c2064909b6e2a7e6c1c9cc0f62967dca5779f5aef30
   languageName: node
   linkType: hard
 
@@ -6094,10 +6161,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/react-dom@npm:^2.1.6":
+  version: 2.1.6
+  resolution: "@floating-ui/react-dom@npm:2.1.6"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.7.4"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 6654834a8e73ecbdbc6cad2ad8f7abc698ac7c1800ded4d61113525c591c03d2e3b59d3cf9205859221465ea38c87af4f9e6e204703c5b7a7e85332d1eef2e18
+  languageName: node
+  linkType: hard
+
 "@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
   version: 0.2.1
   resolution: "@floating-ui/utils@npm:0.2.1"
   checksum: ee77756712cf5b000c6bacf11992ffb364f3ea2d0d51cc45197a7e646a17aeb86ea4b192c0b42f3fbb29487aee918a565e84f710b8c3645827767f406a6b4cc9
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.10":
+  version: 0.2.10
+  resolution: "@floating-ui/utils@npm:0.2.10"
+  checksum: e9bc2a1730ede1ee25843937e911ab6e846a733a4488623cd353f94721b05ec2c9ec6437613a2ac9379a94c2fd40c797a2ba6fa1df2716f5ce4aa6ddb1cf9ea4
   languageName: node
   linkType: hard
 
@@ -12414,24 +12500,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dataviews@npm:^10.3.0":
-  version: 10.3.0
-  resolution: "@wordpress/dataviews@npm:10.3.0"
+"@wordpress/dataviews@npm:^11.2.0":
+  version: 11.2.0
+  resolution: "@wordpress/dataviews@npm:11.2.0"
   dependencies:
     "@ariakit/react": "npm:^0.4.15"
-    "@wordpress/base-styles": "npm:^6.11.0"
-    "@wordpress/components": "npm:^30.8.0"
-    "@wordpress/compose": "npm:^7.35.0"
-    "@wordpress/data": "npm:^10.35.0"
-    "@wordpress/date": "npm:^5.35.0"
-    "@wordpress/element": "npm:^6.35.0"
-    "@wordpress/i18n": "npm:^6.8.0"
-    "@wordpress/icons": "npm:^11.2.0"
-    "@wordpress/keycodes": "npm:^4.35.0"
-    "@wordpress/primitives": "npm:^4.35.0"
-    "@wordpress/private-apis": "npm:^1.35.0"
-    "@wordpress/url": "npm:^4.35.0"
-    "@wordpress/warning": "npm:^3.35.0"
+    "@wordpress/base-styles": "npm:^6.14.0"
+    "@wordpress/components": "npm:^32.0.0"
+    "@wordpress/compose": "npm:^7.38.0"
+    "@wordpress/data": "npm:^10.38.0"
+    "@wordpress/date": "npm:^5.38.0"
+    "@wordpress/deprecated": "npm:^4.38.0"
+    "@wordpress/dom": "npm:^4.38.0"
+    "@wordpress/element": "npm:^6.38.0"
+    "@wordpress/i18n": "npm:^6.11.0"
+    "@wordpress/icons": "npm:^11.5.0"
+    "@wordpress/keycodes": "npm:^4.38.0"
+    "@wordpress/primitives": "npm:^4.38.0"
+    "@wordpress/private-apis": "npm:^1.38.0"
+    "@wordpress/theme": "npm:^0.5.0"
+    "@wordpress/ui": "npm:^0.5.0"
+    "@wordpress/url": "npm:^4.38.0"
+    "@wordpress/warning": "npm:^3.38.0"
     clsx: "npm:^2.1.1"
     colord: "npm:^2.7.0"
     date-fns: "npm:^4.1.0"
@@ -12441,7 +12531,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: aeb420b6204a1bc5327864adb9e83095b968cf2ae59af4b5b124acac10de8e544998aa1b26d9847b699674294abb3212be6928f8351904ba964da5f6e9577402
+  checksum: 4682efbb51fee4d1de38f941435165381daa92392c2d237205e773e8e19da41abac0665ba5e10d90677f8345986b59302091338363acb9b0ba7103591527821b
   languageName: node
   linkType: hard
 
@@ -13215,12 +13305,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/theme@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@wordpress/theme@npm:0.5.0"
+  dependencies:
+    "@wordpress/element": "npm:^6.38.0"
+    "@wordpress/private-apis": "npm:^1.38.0"
+    colorjs.io: "npm:^0.6.0"
+    memize: "npm:^2.1.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    stylelint: ^16.8.2
+  peerDependenciesMeta:
+    stylelint:
+      optional: true
+  checksum: 78551c679b1377ab586dd0dda57c3b40cf47ae196dadb5b2281ae17ec18fb57566e085b04b255b09ee3d2b310b07dc2feaee7f9dce152b2a8d0fec7e21473801
+  languageName: node
+  linkType: hard
+
 "@wordpress/token-list@npm:3.23.0":
   version: 3.23.0
   resolution: "@wordpress/token-list@npm:3.23.0"
   dependencies:
     "@babel/runtime": "npm:7.25.7"
   checksum: e2a8f53b871f9fa0774dab021c7fec1e35040d15d744bd49c61b67867d8863046c93200a3387355d519c0016ffb4d5d989c7c70688062302ae8857c09a6ea5ac
+  languageName: node
+  linkType: hard
+
+"@wordpress/ui@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@wordpress/ui@npm:0.5.0"
+  dependencies:
+    "@base-ui/react": "npm:^1.0.0"
+    "@wordpress/a11y": "npm:^4.38.0"
+    "@wordpress/element": "npm:^6.38.0"
+    "@wordpress/i18n": "npm:^6.11.0"
+    "@wordpress/icons": "npm:^11.5.0"
+    "@wordpress/primitives": "npm:^4.38.0"
+    clsx: "npm:^2.1.1"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: fbb20da17d2af5b0d7a07e7b1a11c6efd6e980a90a7f7fd1ada510bf30d277714ebb0af6412c544a9f7f1e9c96d98f0fefcba0c37afe92935fe70ffaa2c33014
   languageName: node
   linkType: hard
 
@@ -15432,7 +15559,7 @@ __metadata:
     "@wordpress/components": "npm:^30.9.0"
     "@wordpress/compose": "npm:^7.23.0"
     "@wordpress/data": "npm:^10.23.0"
-    "@wordpress/dataviews": "npm:^10.3.0"
+    "@wordpress/dataviews": "npm:^11.2.0"
     "@wordpress/date": "npm:^5.23.0"
     "@wordpress/dom": "npm:^4.23.0"
     "@wordpress/edit-post": "npm:^8.23.0"
@@ -16382,6 +16509,13 @@ __metadata:
   version: 0.5.2
   resolution: "colorjs.io@npm:0.5.2"
   checksum: 2e6ea43629e325e721b92429239de3a6f42fb6d88ba6e4c2aeff0288c196d876f2f7ee82aea95bd40072d5cdc8cb87f042f4d94c134dcabf0e34a717e4caacb9
+  languageName: node
+  linkType: hard
+
+"colorjs.io@npm:^0.6.0":
+  version: 0.6.1
+  resolution: "colorjs.io@npm:0.6.1"
+  checksum: 972aff12d88e86726898ff110aa15ea57a0348a3b958aeb93f4d6ae2d0ca91e487864e4d0d98b53943cc3ac3f747fb01b5ba3b6d922848d5c6888cb56e470b84
   languageName: node
   linkType: hard
 
@@ -33320,6 +33454,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reselect@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "reselect@npm:5.1.1"
+  checksum: 219c30da122980f61853db3aebd173524a2accd4b3baec770e3d51941426c87648a125ca08d8c57daa6b8b086f2fdd2703cb035dd6231db98cdbe1176a71f489
+  languageName: node
+  linkType: hard
+
 "resize-observer-polyfill@npm:^1.5.1":
   version: 1.5.1
   resolution: "resize-observer-polyfill@npm:1.5.1"
@@ -35938,6 +36079,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tabbable@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "tabbable@npm:6.4.0"
+  checksum: d931427f4a96b801fd8801ba296a702119e06f70ad262fed8abc5271225c9f1ca51b89fdec4fb2f22e1d35acb3d2881db0a17cedc758272e9ecb540d00299d76
+  languageName: node
+  linkType: hard
+
 "table@npm:^5.2.3":
   version: 5.4.6
   resolution: "table@npm:5.4.6"
@@ -37633,6 +37781,15 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 1b8663515c0be34fa653feb724fdcce3984037c78dd4a18f68b2c8be55cc1a1084c578d5b75f158d41b5ddffc2bf5600766d1af3c19c8e329bb20af2ec6f52f4
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "use-sync-external-store@npm:1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 35e1179f872a53227bdf8a827f7911da4c37c0f4091c29b76b1e32473d1670ebe7bcd880b808b7549ba9a5605c233350f800ffab963ee4a4ee346ee983b6019b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4296,14 +4296,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.28.4":
+"@babel/runtime@npm:7.28.4, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.25.9, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
   version: 7.28.4
   resolution: "@babel/runtime@npm:7.28.4"
   checksum: 792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.25.9, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.28.4":
   version: 7.28.6
   resolution: "@babel/runtime@npm:7.28.6"
   checksum: 358cf2429992ac1c466df1a21c1601d595c46930a13c1d4662fde908d44ee78ec3c183aaff513ecb01ef8c55c3624afe0309eeeb34715672dbfadb7feedb2c0d
@@ -6111,6 +6111,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "@floating-ui/core@npm:1.6.0"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.1"
+  checksum: 667a68036f7dd5ed19442c7792a6002ca02d1799221c4396691bbe0b6008b48f6ccad581225e81fa266bb91232f6c66838a5f825f554217e1ec886178b93381b
+  languageName: node
+  linkType: hard
+
 "@floating-ui/core@npm:^1.7.3":
   version: 1.7.3
   resolution: "@floating-ui/core@npm:1.7.3"
@@ -6120,7 +6129,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.0.0, @floating-ui/dom@npm:^1.6.1, @floating-ui/dom@npm:^1.7.4":
+"@floating-ui/dom@npm:^1.0.0, @floating-ui/dom@npm:^1.6.1":
+  version: 1.6.3
+  resolution: "@floating-ui/dom@npm:1.6.3"
+  dependencies:
+    "@floating-ui/core": "npm:^1.0.0"
+    "@floating-ui/utils": "npm:^0.2.0"
+  checksum: d6cac10877918ce5a8d1a24b21738d2eb130a0191043d7c0dd43bccac507844d3b4dc5d4107d3891d82f6007945ca8fb4207a1252506e91c37e211f0f73cf77e
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.7.4":
   version: 1.7.4
   resolution: "@floating-ui/dom@npm:1.7.4"
   dependencies:
@@ -6151,6 +6170,13 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 6654834a8e73ecbdbc6cad2ad8f7abc698ac7c1800ded4d61113525c591c03d2e3b59d3cf9205859221465ea38c87af4f9e6e204703c5b7a7e85332d1eef2e18
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@floating-ui/utils@npm:0.2.1"
+  checksum: ee77756712cf5b000c6bacf11992ffb364f3ea2d0d51cc45197a7e646a17aeb86ea4b192c0b42f3fbb29487aee918a565e84f710b8c3645827767f406a6b4cc9
   languageName: node
   linkType: hard
 
@@ -37749,7 +37775,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.2.0, use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.5.0, use-sync-external-store@npm:^1.6.0":
+"use-sync-external-store@npm:^1.2.0, use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "use-sync-external-store@npm:1.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 1b8663515c0be34fa653feb724fdcce3984037c78dd4a18f68b2c8be55cc1a1084c578d5b75f158d41b5ddffc2bf5600766d1af3c19c8e329bb20af2ec6f52f4
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.6.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4296,14 +4296,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.28.4, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.25.9, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:7.28.4":
   version: 7.28.4
   resolution: "@babel/runtime@npm:7.28.4"
   checksum: 792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.28.4":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.25.9, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
   version: 7.28.6
   resolution: "@babel/runtime@npm:7.28.6"
   checksum: 358cf2429992ac1c466df1a21c1601d595c46930a13c1d4662fde908d44ee78ec3c183aaff513ecb01ef8c55c3624afe0309eeeb34715672dbfadb7feedb2c0d
@@ -6111,15 +6111,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.0.0":
-  version: 1.6.0
-  resolution: "@floating-ui/core@npm:1.6.0"
-  dependencies:
-    "@floating-ui/utils": "npm:^0.2.1"
-  checksum: 667a68036f7dd5ed19442c7792a6002ca02d1799221c4396691bbe0b6008b48f6ccad581225e81fa266bb91232f6c66838a5f825f554217e1ec886178b93381b
-  languageName: node
-  linkType: hard
-
 "@floating-ui/core@npm:^1.7.3":
   version: 1.7.3
   resolution: "@floating-ui/core@npm:1.7.3"
@@ -6129,17 +6120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.0.0, @floating-ui/dom@npm:^1.6.1":
-  version: 1.6.3
-  resolution: "@floating-ui/dom@npm:1.6.3"
-  dependencies:
-    "@floating-ui/core": "npm:^1.0.0"
-    "@floating-ui/utils": "npm:^0.2.0"
-  checksum: d6cac10877918ce5a8d1a24b21738d2eb130a0191043d7c0dd43bccac507844d3b4dc5d4107d3891d82f6007945ca8fb4207a1252506e91c37e211f0f73cf77e
-  languageName: node
-  linkType: hard
-
-"@floating-ui/dom@npm:^1.7.4":
+"@floating-ui/dom@npm:^1.0.0, @floating-ui/dom@npm:^1.6.1, @floating-ui/dom@npm:^1.7.4":
   version: 1.7.4
   resolution: "@floating-ui/dom@npm:1.7.4"
   dependencies:
@@ -6170,13 +6151,6 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 6654834a8e73ecbdbc6cad2ad8f7abc698ac7c1800ded4d61113525c591c03d2e3b59d3cf9205859221465ea38c87af4f9e6e204703c5b7a7e85332d1eef2e18
-  languageName: node
-  linkType: hard
-
-"@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@floating-ui/utils@npm:0.2.1"
-  checksum: ee77756712cf5b000c6bacf11992ffb364f3ea2d0d51cc45197a7e646a17aeb86ea4b192c0b42f3fbb29487aee918a565e84f710b8c3645827767f406a6b4cc9
   languageName: node
   linkType: hard
 
@@ -37775,16 +37749,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.2.0, use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "use-sync-external-store@npm:1.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 1b8663515c0be34fa653feb724fdcce3984037c78dd4a18f68b2c8be55cc1a1084c578d5b75f158d41b5ddffc2bf5600766d1af3c19c8e329bb20af2ec6f52f4
-  languageName: node
-  linkType: hard
-
-"use-sync-external-store@npm:^1.6.0":
+"use-sync-external-store@npm:^1.2.0, use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.5.0, use-sync-external-store@npm:^1.6.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:


### PR DESCRIPTION
## Proposed Changes

* Upgrade `@wordpress/dataviews` from ^10.3.0 to ^11.2.0 in all 5 package.json files
* Address breaking change from v11.0.0: rename `groupByField` to `groupBy.field` in affected files

## Why are these changes being made?

* Upgrade to latest version of @wordpress/dataviews to get bug fixes, enhancements, and stay current with the WordPress ecosystem

### Breaking Changes Addressed

Per the [changelog](https://github.com/WordPress/gutenberg/blob/trunk/packages/dataviews/CHANGELOG.md):

**v11.0.0:**
- `groupByField` renamed to `groupBy.field` to allow control over both the field and direction of grouping
- `FieldType` type renamed to `FieldTypeName` (not used in codebase)

**v11.2.0:**
- `isNotAll` operator deprecated (not used in codebase)

## Testing Instructions

* Verify Dashboard scheduled updates page renders correctly with grouped data
* Verify Dashboard performance insights table renders correctly with grouped data
* Verify no TypeScript or console errors

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)