### PR TITLE
MSD: Use forced-opt-in to determine whether the user has opt-in and do redirection

### DIFF
--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -96,4 +96,4 @@ export const setSelectedSiteIdByOrigin = () => {};
 // eslint-disable-next-line no-unused-vars
 export const redirectIfDuplicatedView = ( wpAdminPath ) => () => {};
 // eslint-disable-next-line no-unused-vars
-export const redirectIfMultiSiteDashboardForcedOptIn = ( path ) => () => {};
+export const maybeRedirectToMultiSiteDashboard = ( path ) => () => {};

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -95,4 +95,5 @@ export const notFound = () => null;
 export const setSelectedSiteIdByOrigin = () => {};
 // eslint-disable-next-line no-unused-vars
 export const redirectIfDuplicatedView = ( wpAdminPath ) => () => {};
-export const redirectIfMultiSiteDashboardForcedOptIn = () => () => {};
+// eslint-disable-next-line no-unused-vars
+export const redirectIfMultiSiteDashboardForcedOptIn = ( path ) => () => {};

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -95,3 +95,4 @@ export const notFound = () => null;
 export const setSelectedSiteIdByOrigin = () => {};
 // eslint-disable-next-line no-unused-vars
 export const redirectIfDuplicatedView = ( wpAdminPath ) => () => {};
+export const redirectIfMultiSiteDashboardForcedOptIn = () => () => {};

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -16,6 +16,7 @@ import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import EmptyContent from 'calypso/components/empty-content';
 import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { logToLogstash } from 'calypso/lib/logstash';
@@ -29,6 +30,7 @@ import {
 	isContextSourceMyJetpack,
 } from 'calypso/my-sites/checkout/utils';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
+import { hasDashboardForcedOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
 import {
 	getImmediateLoginEmail,
 	getImmediateLoginLocale,
@@ -484,5 +486,19 @@ export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next
 		window.location = wpAdminUrl;
 		return;
 	}
+	next();
+};
+
+/**
+ * Middleware to redirect a user to the multi-site dashboard if the value of
+ * `hosting-dashboard-opt-in` is configured to `forced-opt-in`.
+ */
+export const redirectIfMultiSiteDashboardForcedOptIn = ( path ) => ( context, next ) => {
+	const state = context.store.getState();
+	if ( hasDashboardForcedOptIn( state ) ) {
+		const redirectUrl = typeof path === 'function' ? path( context.params ) : path;
+		return navigate( dashboardLink( redirectUrl ?? context.path ) );
+	}
+
 	next();
 };

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -493,7 +493,7 @@ export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next
  * Middleware to redirect a user to the multi-site dashboard if the value of
  * `hosting-dashboard-opt-in` is configured to `forced-opt-in`.
  */
-export const redirectIfMultiSiteDashboardForcedOptIn = ( path ) => ( context, next ) => {
+export const maybeRedirectToMultiSiteDashboard = ( path ) => ( context, next ) => {
 	const state = context.store.getState();
 	if ( hasDashboardForcedOptIn( state ) ) {
 		const redirectUrl = typeof path === 'function' ? path( context.params ) : path;

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -98,6 +98,10 @@ export default function PreferencesOptInForm() {
 		);
 	};
 
+	if ( optIn.value === 'forced-opt-in' ) {
+		return null;
+	}
+
 	return (
 		<Card>
 			<FlashMessage id="dashboard" message={ __( 'New Hosting Dashboard enabled.' ) } />

--- a/client/hosting/performance/index.tsx
+++ b/client/hosting/performance/index.tsx
@@ -1,5 +1,10 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { PERFORMANCE } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
@@ -11,6 +16,10 @@ export default function () {
 	page(
 		'/sites/performance/:site',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params: Record< string, string > ) => `/sites/${ params.site }/performance`
+		),
 		navigation,
 		sitePerformance,
 		sitePerformanceCallout,

--- a/client/hosting/performance/index.tsx
+++ b/client/hosting/performance/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
@@ -17,7 +17,7 @@ export default function () {
 		'/sites/performance/:site',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params: Record< string, string > ) => `/sites/${ params.site }/performance`
 		),
 		navigation,

--- a/client/me/account/hosting-dashboard-opt-in-form.tsx
+++ b/client/me/account/hosting-dashboard-opt-in-form.tsx
@@ -87,6 +87,10 @@ export default function HostingDashboardOptInForm() {
 		}
 	};
 
+	if ( savedPreference?.value === 'forced-opt-in' ) {
+		return null;
+	}
+
 	return (
 		<>
 			<SectionHeader label={ translate( 'Try the new Hosting Dashboard' ) } />

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -3,7 +3,7 @@ import {
 	makeLayout,
 	render as clientRender,
 	setSelectedSiteIdByOrigin,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
@@ -15,7 +15,7 @@ export default function () {
 		'/me/account',
 		maybeRedirectToDashboard,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/preferences' ),
+		maybeRedirectToMultiSiteDashboard( '/me/preferences' ),
 		sidebar,
 		setSelectedSiteIdByOrigin,
 		account,

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -1,5 +1,11 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	setSelectedSiteIdByOrigin,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
 import { maybeRedirectToDashboard } from '../controller';
 import { account } from './controller';
@@ -8,6 +14,8 @@ export default function () {
 	page(
 		'/me/account',
 		maybeRedirectToDashboard,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/preferences' ),
 		sidebar,
 		setSelectedSiteIdByOrigin,
 		account,

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -31,8 +31,32 @@ export default function () {
 	page( '/me/trophies', controller.profileRedirect, makeLayout, clientRender );
 	page( '/me/find-friends', controller.profileRedirect, makeLayout, clientRender );
 
-	page( '/me/get-apps', controller.sidebar, controller.apps, makeLayout, clientRender );
+	page(
+		'/me/get-apps',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/apps' ),
+		controller.sidebar,
+		controller.apps,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/me/mcp', controller.sidebar, controller.mcp, makeLayout, clientRender );
-	page( '/me/mcp-setup', controller.sidebar, controller.mcpSetup, makeLayout, clientRender );
+	page(
+		'/me/mcp',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/mcp' ),
+		controller.sidebar,
+		controller.mcp,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/me/mcp-setup',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/mcp/setup' ),
+		controller.sidebar,
+		controller.mcpSetup,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -3,7 +3,7 @@ import {
 	makeLayout,
 	render as clientRender,
 	setSelectedSiteIdByOrigin,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import * as controller from './controller';
@@ -15,7 +15,7 @@ export default function () {
 		'/me',
 		controller.maybeRedirectToDashboard,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/profile' ),
+		maybeRedirectToMultiSiteDashboard( '/me/profile' ),
 		controller.sidebar,
 		setSelectedSiteIdByOrigin,
 		controller.profile,
@@ -34,7 +34,7 @@ export default function () {
 	page(
 		'/me/get-apps',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/apps' ),
+		maybeRedirectToMultiSiteDashboard( '/me/apps' ),
 		controller.sidebar,
 		controller.apps,
 		makeLayout,
@@ -44,7 +44,7 @@ export default function () {
 	page(
 		'/me/mcp',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/mcp' ),
+		maybeRedirectToMultiSiteDashboard( '/me/mcp' ),
 		controller.sidebar,
 		controller.mcp,
 		makeLayout,
@@ -53,7 +53,7 @@ export default function () {
 	page(
 		'/me/mcp-setup',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/mcp/setup' ),
+		maybeRedirectToMultiSiteDashboard( '/me/mcp/setup' ),
 		controller.sidebar,
 		controller.mcpSetup,
 		makeLayout,

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -1,5 +1,11 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	setSelectedSiteIdByOrigin,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import * as controller from './controller';
 
 import './style.scss';
@@ -8,6 +14,8 @@ export default function () {
 	page(
 		'/me',
 		controller.maybeRedirectToDashboard,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/profile' ),
 		controller.sidebar,
 		setSelectedSiteIdByOrigin,
 		controller.profile,

--- a/client/me/mcp/index.js
+++ b/client/me/mcp/index.js
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar, mcp } from 'calypso/me/controller';
@@ -11,7 +11,7 @@ export default function () {
 	page(
 		'/me/mcp',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/mcp' ),
+		maybeRedirectToMultiSiteDashboard( '/me/mcp' ),
 		sidebar,
 		mcp,
 		makeLayout,

--- a/client/me/mcp/index.js
+++ b/client/me/mcp/index.js
@@ -1,7 +1,20 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar, mcp } from 'calypso/me/controller';
 
 export default function () {
-	page( '/me/mcp', sidebar, mcp, makeLayout, clientRender );
+	page(
+		'/me/mcp',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/mcp' ),
+		sidebar,
+		mcp,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/me/notification-settings/index.js
+++ b/client/me/notification-settings/index.js
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
@@ -12,7 +12,7 @@ export default function () {
 	page(
 		'/me/notifications',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/notifications' ),
+		maybeRedirectToMultiSiteDashboard( '/me/notifications' ),
 		sidebar,
 		notifications,
 		makeLayout,
@@ -21,7 +21,7 @@ export default function () {
 	page(
 		'/me/notifications/comments',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/notifications/comments' ),
+		maybeRedirectToMultiSiteDashboard( '/me/notifications/comments' ),
 		sidebar,
 		comments,
 		makeLayout,
@@ -30,7 +30,7 @@ export default function () {
 	page(
 		'/me/notifications/updates',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/notifications/extras' ),
+		maybeRedirectToMultiSiteDashboard( '/me/notifications/extras' ),
 		sidebar,
 		updates,
 		makeLayout,
@@ -39,7 +39,7 @@ export default function () {
 	page(
 		'/me/notifications/subscriptions',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/notifications/emails' ),
+		maybeRedirectToMultiSiteDashboard( '/me/notifications/emails' ),
 		sidebar,
 		subscriptions,
 		makeLayout,

--- a/client/me/notification-settings/index.js
+++ b/client/me/notification-settings/index.js
@@ -1,11 +1,48 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
 import { notifications, comments, updates, subscriptions } from './controller';
 
 export default function () {
-	page( '/me/notifications', sidebar, notifications, makeLayout, clientRender );
-	page( '/me/notifications/comments', sidebar, comments, makeLayout, clientRender );
-	page( '/me/notifications/updates', sidebar, updates, makeLayout, clientRender );
-	page( '/me/notifications/subscriptions', sidebar, subscriptions, makeLayout, clientRender );
+	page(
+		'/me/notifications',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/notifications' ),
+		sidebar,
+		notifications,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/me/notifications/comments',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/notifications/comments' ),
+		sidebar,
+		comments,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/me/notifications/updates',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/notifications/extras' ),
+		sidebar,
+		updates,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/me/notifications/subscriptions',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/notifications/emails' ),
+		sidebar,
+		subscriptions,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/me/privacy/index.js
+++ b/client/me/privacy/index.js
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
@@ -12,7 +12,7 @@ export default function () {
 	page(
 		'/me/privacy',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/privacy' ),
+		maybeRedirectToMultiSiteDashboard( '/me/privacy' ),
 		sidebar,
 		privacy,
 		makeLayout,

--- a/client/me/privacy/index.js
+++ b/client/me/privacy/index.js
@@ -1,8 +1,21 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
 import { privacy } from './controller';
 
 export default function () {
-	page( '/me/privacy', sidebar, privacy, makeLayout, clientRender );
+	page(
+		'/me/privacy',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/privacy' ),
+		sidebar,
+		privacy,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -1,5 +1,10 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
 import * as membershipsController from 'calypso/me/memberships/controller';
 import * as billingController from 'calypso/me/purchases/billing-history/controller';
@@ -11,6 +16,8 @@ import * as paths from './paths';
 export default ( router ) => {
 	router(
 		paths.paymentMethods,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/payment-methods' ),
 		sidebar,
 		paymentMethodsController.paymentMethods,
 		makeLayout,
@@ -19,23 +26,43 @@ export default ( router ) => {
 
 	router(
 		paths.addNewPaymentMethod,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/payment-methods/add' ),
 		sidebar,
 		controller.addNewPaymentMethod,
 		makeLayout,
 		clientRender
 	);
 
-	router( paths.addCreditCard, sidebar, controller.addNewPaymentMethod, makeLayout, clientRender );
+	router(
+		paths.addCreditCard,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/payment-methods/add' ),
+		sidebar,
+		controller.addNewPaymentMethod,
+		makeLayout,
+		clientRender
+	);
 
 	// redirect legacy urls
 	router( '/payment-methods/add-credit-card', () => {
 		page.redirect( paths.addCreditCard );
 	} );
 
-	router( paths.vatDetails, sidebar, controller.vatDetails, makeLayout, clientRender );
+	router(
+		paths.vatDetails,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/payment-methods/tax-details' ),
+		sidebar,
+		controller.vatDetails,
+		makeLayout,
+		clientRender
+	);
 
 	router(
 		paths.billingHistory,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/history' ),
 		sidebar,
 		billingController.billingHistory,
 		makeLayout,
@@ -44,6 +71,8 @@ export default ( router ) => {
 
 	router(
 		paths.purchasesRoot + '/other/:subscriptionId',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/history' ),
 		sidebar,
 		membershipsController.subscription,
 		makeLayout,
@@ -52,6 +81,8 @@ export default ( router ) => {
 
 	router(
 		paths.purchasesRoot + '/crm-downloads/:subscription',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/history' ),
 		sidebar,
 		controller.crmDownloads,
 		makeLayout,
@@ -60,6 +91,8 @@ export default ( router ) => {
 
 	router(
 		paths.purchasesRoot + '/subscription-removed',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/history' ),
 		sidebar,
 		membershipsController.cancelledSubscriptionReturnFromRedirect,
 		makeLayout,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -72,7 +72,9 @@ export default ( router ) => {
 	router(
 		paths.purchasesRoot + '/other/:subscriptionId',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/history' ),
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params ) => `/me/billing/monetize-subscriptions/${ params.subscriptionId }`
+		),
 		sidebar,
 		membershipsController.subscription,
 		makeLayout,
@@ -82,7 +84,9 @@ export default ( router ) => {
 	router(
 		paths.purchasesRoot + '/crm-downloads/:subscription',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/history' ),
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params ) => `/me/billing/monetize-subscriptions/${ params.subscription }`
+		),
 		sidebar,
 		controller.crmDownloads,
 		makeLayout,
@@ -92,7 +96,7 @@ export default ( router ) => {
 	router(
 		paths.purchasesRoot + '/subscription-removed',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/history' ),
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/monetize-subscriptions' ),
 		sidebar,
 		membershipsController.cancelledSubscriptionReturnFromRedirect,
 		makeLayout,
@@ -115,13 +119,25 @@ export default ( router ) => {
 
 	router(
 		paths.billingHistoryReceipt( ':receiptId' ),
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params ) => `/me/billing/history/${ params.receiptId }`
+		),
 		sidebar,
 		billingController.transaction,
 		makeLayout,
 		clientRender
 	);
 
-	router( paths.purchasesRoot, sidebar, controller.list, makeLayout, clientRender );
+	router(
+		paths.purchasesRoot,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/purchases' ),
+		sidebar,
+		controller.list,
+		makeLayout,
+		clientRender
+	);
 
 	/**
 	 * The siteSelection middleware has been removed from this route.
@@ -129,6 +145,10 @@ export default ( router ) => {
 	 */
 	router(
 		paths.managePurchase( ':site', ':purchaseId' ),
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params ) => `/me/billing/purchases/${ params.purchaseId }`
+		),
 		sidebar,
 		controller.managePurchase,
 		makeLayout,
@@ -137,6 +157,8 @@ export default ( router ) => {
 
 	router(
 		paths.managePurchaseByOwnership( ':ownershipId' ),
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/purchases' ),
 		sidebar,
 		controller.managePurchaseByOwnership,
 		makeLayout,
@@ -149,6 +171,10 @@ export default ( router ) => {
 	 */
 	router(
 		paths.cancelPurchase( ':site', ':purchaseId' ),
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params ) => `/me/billing/purchases/${ params.purchaseId }/cancel`
+		),
 		sidebar,
 		controller.cancelPurchase,
 		makeLayout,
@@ -165,6 +191,10 @@ export default ( router ) => {
 
 	router(
 		paths.confirmCancelDomain( ':site', ':purchaseId' ),
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params ) => `/me/billing/purchases/${ params.purchaseId }/cancel`
+		),
 		sidebar,
 		siteSelection,
 		controller.confirmCancelDomain,
@@ -178,6 +208,10 @@ export default ( router ) => {
 	 */
 	router(
 		paths.addPaymentMethod( ':site', ':purchaseId' ),
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params ) => `/me/billing/purchases/${ params.purchaseId }/payment-method/change`
+		),
 		sidebar,
 		controller.changePaymentMethod,
 		makeLayout,
@@ -190,6 +224,10 @@ export default ( router ) => {
 	 */
 	router(
 		paths.changePaymentMethod( ':site', ':purchaseId', ':cardId' ),
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params ) => `me/billing/purchases/${ params.purchaseId }/payment-method/change`
+		),
 		sidebar,
 		controller.changePaymentMethod,
 		makeLayout,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -95,8 +95,6 @@ export default ( router ) => {
 
 	router(
 		paths.purchasesRoot + '/subscription-removed',
-		setupPreferences,
-		maybeRedirectToMultiSiteDashboard( '/me/billing/monetize-subscriptions' ),
 		sidebar,
 		membershipsController.cancelledSubscriptionReturnFromRedirect,
 		makeLayout,
@@ -155,8 +153,6 @@ export default ( router ) => {
 
 	router(
 		paths.managePurchaseByOwnership( ':ownershipId' ),
-		setupPreferences,
-		maybeRedirectToMultiSiteDashboard( '/me/billing/purchases' ),
 		sidebar,
 		controller.managePurchaseByOwnership,
 		makeLayout,

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
@@ -17,7 +17,7 @@ export default ( router ) => {
 	router(
 		paths.paymentMethods,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/payment-methods' ),
+		maybeRedirectToMultiSiteDashboard( '/me/billing/payment-methods' ),
 		sidebar,
 		paymentMethodsController.paymentMethods,
 		makeLayout,
@@ -27,7 +27,7 @@ export default ( router ) => {
 	router(
 		paths.addNewPaymentMethod,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/payment-methods/add' ),
+		maybeRedirectToMultiSiteDashboard( '/me/billing/payment-methods/add' ),
 		sidebar,
 		controller.addNewPaymentMethod,
 		makeLayout,
@@ -37,7 +37,7 @@ export default ( router ) => {
 	router(
 		paths.addCreditCard,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/payment-methods/add' ),
+		maybeRedirectToMultiSiteDashboard( '/me/billing/payment-methods/add' ),
 		sidebar,
 		controller.addNewPaymentMethod,
 		makeLayout,
@@ -52,7 +52,7 @@ export default ( router ) => {
 	router(
 		paths.vatDetails,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/payment-methods/tax-details' ),
+		maybeRedirectToMultiSiteDashboard( '/me/billing/payment-methods/tax-details' ),
 		sidebar,
 		controller.vatDetails,
 		makeLayout,
@@ -62,7 +62,7 @@ export default ( router ) => {
 	router(
 		paths.billingHistory,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/history' ),
+		maybeRedirectToMultiSiteDashboard( '/me/billing/history' ),
 		sidebar,
 		billingController.billingHistory,
 		makeLayout,
@@ -72,7 +72,7 @@ export default ( router ) => {
 	router(
 		paths.purchasesRoot + '/other/:subscriptionId',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params ) => `/me/billing/monetize-subscriptions/${ params.subscriptionId }`
 		),
 		sidebar,
@@ -84,7 +84,7 @@ export default ( router ) => {
 	router(
 		paths.purchasesRoot + '/crm-downloads/:subscription',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params ) => `/me/billing/monetize-subscriptions/${ params.subscription }`
 		),
 		sidebar,
@@ -96,7 +96,7 @@ export default ( router ) => {
 	router(
 		paths.purchasesRoot + '/subscription-removed',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/monetize-subscriptions' ),
+		maybeRedirectToMultiSiteDashboard( '/me/billing/monetize-subscriptions' ),
 		sidebar,
 		membershipsController.cancelledSubscriptionReturnFromRedirect,
 		makeLayout,
@@ -120,9 +120,7 @@ export default ( router ) => {
 	router(
 		paths.billingHistoryReceipt( ':receiptId' ),
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
-			( params ) => `/me/billing/history/${ params.receiptId }`
-		),
+		maybeRedirectToMultiSiteDashboard( ( params ) => `/me/billing/history/${ params.receiptId }` ),
 		sidebar,
 		billingController.transaction,
 		makeLayout,
@@ -132,7 +130,7 @@ export default ( router ) => {
 	router(
 		paths.purchasesRoot,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/purchases' ),
+		maybeRedirectToMultiSiteDashboard( '/me/billing/purchases' ),
 		sidebar,
 		controller.list,
 		makeLayout,
@@ -146,7 +144,7 @@ export default ( router ) => {
 	router(
 		paths.managePurchase( ':site', ':purchaseId' ),
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params ) => `/me/billing/purchases/${ params.purchaseId }`
 		),
 		sidebar,
@@ -158,7 +156,7 @@ export default ( router ) => {
 	router(
 		paths.managePurchaseByOwnership( ':ownershipId' ),
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/billing/purchases' ),
+		maybeRedirectToMultiSiteDashboard( '/me/billing/purchases' ),
 		sidebar,
 		controller.managePurchaseByOwnership,
 		makeLayout,
@@ -172,7 +170,7 @@ export default ( router ) => {
 	router(
 		paths.cancelPurchase( ':site', ':purchaseId' ),
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params ) => `/me/billing/purchases/${ params.purchaseId }/cancel`
 		),
 		sidebar,
@@ -192,7 +190,7 @@ export default ( router ) => {
 	router(
 		paths.confirmCancelDomain( ':site', ':purchaseId' ),
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params ) => `/me/billing/purchases/${ params.purchaseId }/cancel`
 		),
 		sidebar,
@@ -209,7 +207,7 @@ export default ( router ) => {
 	router(
 		paths.addPaymentMethod( ':site', ':purchaseId' ),
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params ) => `/me/billing/purchases/${ params.purchaseId }/payment-method/change`
 		),
 		sidebar,
@@ -225,7 +223,7 @@ export default ( router ) => {
 	router(
 		paths.changePaymentMethod( ':site', ':purchaseId', ':cardId' ),
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params ) => `me/billing/purchases/${ params.purchaseId }/payment-method/change`
 		),
 		sidebar,

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
@@ -23,7 +23,7 @@ export default function () {
 	page(
 		'/me/security',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/security' ),
+		maybeRedirectToMultiSiteDashboard( '/me/security' ),
 		sidebar,
 		mainPageFunction,
 		makeLayout,
@@ -33,7 +33,7 @@ export default function () {
 	page(
 		'/me/security/account-email',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/profile' ),
+		maybeRedirectToMultiSiteDashboard( '/me/security/profile' ),
 		sidebar,
 		securityAccountEmail,
 		makeLayout,
@@ -43,7 +43,7 @@ export default function () {
 	page(
 		'/me/security/password',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/password' ),
+		maybeRedirectToMultiSiteDashboard( '/me/security/password' ),
 		sidebar,
 		password,
 		makeLayout,
@@ -53,7 +53,7 @@ export default function () {
 	page(
 		'/me/security/social-login',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/social-logins' ),
+		maybeRedirectToMultiSiteDashboard( '/me/security/social-logins' ),
 		sidebar,
 		socialLogin,
 		makeLayout,
@@ -63,7 +63,7 @@ export default function () {
 	page(
 		'/me/security/two-step',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/two-step-auth' ),
+		maybeRedirectToMultiSiteDashboard( '/me/security/two-step-auth' ),
 		sidebar,
 		twoStep,
 		makeLayout,
@@ -73,7 +73,7 @@ export default function () {
 	page(
 		'/me/security/connected-applications',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/connected-apps' ),
+		maybeRedirectToMultiSiteDashboard( '/me/security/connected-apps' ),
 		sidebar,
 		connectedApplications,
 		makeLayout,
@@ -83,7 +83,7 @@ export default function () {
 	page(
 		'/me/security/account-recovery',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/account-recovery' ),
+		maybeRedirectToMultiSiteDashboard( '/me/security/account-recovery' ),
 		sidebar,
 		accountRecovery,
 		makeLayout,
@@ -93,7 +93,7 @@ export default function () {
 	page(
 		'/me/security/ssh-key',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/ssh-key' ),
+		maybeRedirectToMultiSiteDashboard( '/me/security/ssh-key' ),
 		sidebar,
 		sshKey,
 		makeLayout,

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -1,6 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
 import {
 	accountRecovery,
@@ -15,25 +20,83 @@ import {
 
 export default function () {
 	const mainPageFunction = isEnabled( 'security/security-checkup' ) ? securityCheckup : password;
-	page( '/me/security', sidebar, mainPageFunction, makeLayout, clientRender );
+	page(
+		'/me/security',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/security' ),
+		sidebar,
+		mainPageFunction,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/me/security/account-email', sidebar, securityAccountEmail, makeLayout, clientRender );
+	page(
+		'/me/security/account-email',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/profile' ),
+		sidebar,
+		securityAccountEmail,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/me/security/password', sidebar, password, makeLayout, clientRender );
+	page(
+		'/me/security/password',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/password' ),
+		sidebar,
+		password,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/me/security/social-login', sidebar, socialLogin, makeLayout, clientRender );
+	page(
+		'/me/security/social-login',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/social-logins' ),
+		sidebar,
+		socialLogin,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/me/security/two-step', sidebar, twoStep, makeLayout, clientRender );
+	page(
+		'/me/security/two-step',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/two-step-auth' ),
+		sidebar,
+		twoStep,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/me/security/connected-applications',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/connected-apps' ),
 		sidebar,
 		connectedApplications,
 		makeLayout,
 		clientRender
 	);
 
-	page( '/me/security/account-recovery', sidebar, accountRecovery, makeLayout, clientRender );
+	page(
+		'/me/security/account-recovery',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/account-recovery' ),
+		sidebar,
+		accountRecovery,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/me/security/ssh-key', sidebar, sshKey, makeLayout, clientRender );
+	page(
+		'/me/security/ssh-key',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/security/ssh-key' ),
+		sidebar,
+		sshKey,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/me/site-blocks/index.js
+++ b/client/me/site-blocks/index.js
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
@@ -12,7 +12,7 @@ export default function () {
 	page(
 		'/me/site-blocks',
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/me/blocked-sites' ),
+		maybeRedirectToMultiSiteDashboard( '/me/blocked-sites' ),
 		sidebar,
 		siteBlockList,
 		makeLayout,

--- a/client/me/site-blocks/index.js
+++ b/client/me/site-blocks/index.js
@@ -1,8 +1,21 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
 import { siteBlockList } from './controller';
 
 export default function () {
-	page( '/me/site-blocks', sidebar, siteBlockList, makeLayout, clientRender );
+	page(
+		'/me/site-blocks',
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/me/blocked-sites' ),
+		sidebar,
+		siteBlockList,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -1,5 +1,10 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import {
 	navigation,
@@ -194,6 +199,8 @@ export default function () {
 
 	page(
 		paths.domainManagementRoot(),
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/domains' ),
 		domainsController.maybeRedirectToDashboard,
 		noSite,
 		...getCommonHandlers( { noSitePath: false, noSiteSelection: true } ),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { recordSiftScienceUser } from 'calypso/lib/siftscience';
@@ -200,7 +200,7 @@ export default function () {
 	page(
 		paths.domainManagementRoot(),
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/domains' ),
+		maybeRedirectToMultiSiteDashboard( '/domains' ),
 		domainsController.maybeRedirectToDashboard,
 		noSite,
 		...getCommonHandlers( { noSitePath: false, noSiteSelection: true } ),

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -192,6 +192,18 @@ export default function ( router ) {
 			`/${ langParam }/plugins/scheduled-updates/:action(edit)/:id`,
 		],
 		redirectLoggedOut,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( ( params ) => {
+			if ( params.action === 'create' ) {
+				return `/plugins/scheduled-updates/new`;
+			}
+
+			if ( params.action === 'edit' && params.id ) {
+				return `/plugins/scheduled-updates/edit/${ params.id }`;
+			}
+
+			return '/plugins/scheduled-updates';
+		} ),
 		navigation,
 		renderPluginsSidebar,
 		scheduledUpdatesMultisite,

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -6,6 +6,7 @@ import {
 	redirectWithoutLocaleParamIfLoggedIn,
 	render as clientRender,
 	redirectIfCurrentUserCannot,
+	redirectIfMultiSiteDashboardForcedOptIn,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { noSite, navigation, siteSelection, sites } from 'calypso/my-sites/controller';
@@ -126,6 +127,8 @@ export default function ( router ) {
 		`/${ langParam }/plugins/manage/sites`,
 		redirectLoggedOut,
 		redirectWithoutLocaleParamIfLoggedIn,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( '/plugins' ),
 		scrollTopIfNoHash,
 		navigation,
 		redirectTrialSites,
@@ -140,6 +143,8 @@ export default function ( router ) {
 		`/${ langParam }/plugins/manage/sites/:slug`,
 		redirectLoggedOut,
 		redirectWithoutLocaleParamIfLoggedIn,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn( ( params ) => `/plugins/manage/${ params.slug }` ),
 		scrollTopIfNoHash,
 		navigation,
 		redirectTrialSites,

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -6,7 +6,7 @@ import {
 	redirectWithoutLocaleParamIfLoggedIn,
 	render as clientRender,
 	redirectIfCurrentUserCannot,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { noSite, navigation, siteSelection, sites } from 'calypso/my-sites/controller';
@@ -128,7 +128,7 @@ export default function ( router ) {
 		redirectLoggedOut,
 		redirectWithoutLocaleParamIfLoggedIn,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( '/plugins' ),
+		maybeRedirectToMultiSiteDashboard( '/plugins' ),
 		scrollTopIfNoHash,
 		navigation,
 		redirectTrialSites,
@@ -144,7 +144,7 @@ export default function ( router ) {
 		redirectLoggedOut,
 		redirectWithoutLocaleParamIfLoggedIn,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( ( params ) => `/plugins/manage/${ params.slug }` ),
+		maybeRedirectToMultiSiteDashboard( ( params ) => `/plugins/manage/${ params.slug }` ),
 		scrollTopIfNoHash,
 		navigation,
 		redirectTrialSites,
@@ -193,7 +193,7 @@ export default function ( router ) {
 		],
 		redirectLoggedOut,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn( ( params ) => {
+		maybeRedirectToMultiSiteDashboard( ( params ) => {
 			if ( params.action === 'create' ) {
 				return `/plugins/scheduled-updates/new`;
 			}

--- a/client/sites/deployments/index.tsx
+++ b/client/sites/deployments/index.tsx
@@ -1,5 +1,10 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { DEPLOYMENTS } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
@@ -17,6 +22,10 @@ export default function () {
 	page(
 		'/github-deployments/:site',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params: Record< string, string > ) => `/sites/deployments/${ params.site }`
+		),
 		navigation,
 		deploymentsList,
 		deploymentCallout,
@@ -28,6 +37,10 @@ export default function () {
 	page(
 		'/github-deployments/:site/create',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params: Record< string, string > ) => `/sites/${ params.site }/settings/repositories`
+		),
 		navigation,
 		deploymentCreation,
 		deploymentCallout,
@@ -39,6 +52,11 @@ export default function () {
 	page(
 		'/github-deployments/:site/manage/:deploymentId',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params: Record< string, string > ) =>
+				`/sites/${ params.site }/settings/repositories/manage/${ params.deploymentId }`
+		),
 		navigation,
 		deploymentManagement,
 		deploymentCallout,
@@ -50,6 +68,10 @@ export default function () {
 	page(
 		'/github-deployments/:site/logs/:deploymentId',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params: Record< string, string > ) => `/sites/deployments/${ params.site }`
+		),
 		navigation,
 		deploymentRunLogs,
 		deploymentCallout,

--- a/client/sites/deployments/index.tsx
+++ b/client/sites/deployments/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
@@ -23,7 +23,7 @@ export default function () {
 		'/github-deployments/:site',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params: Record< string, string > ) => `/sites/${ params.site }/deployments`
 		),
 		navigation,
@@ -38,7 +38,7 @@ export default function () {
 		'/github-deployments/:site/create',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params: Record< string, string > ) => `/sites/${ params.site }/settings/repositories`
 		),
 		navigation,
@@ -53,7 +53,7 @@ export default function () {
 		'/github-deployments/:site/manage/:deploymentId',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params: Record< string, string > ) =>
 				`/sites/${ params.site }/settings/repositories/manage/${ params.deploymentId }`
 		),
@@ -69,7 +69,7 @@ export default function () {
 		'/github-deployments/:site/logs/:deploymentId',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params: Record< string, string > ) => `/sites/${ params.site }/deployments`
 		),
 		navigation,

--- a/client/sites/deployments/index.tsx
+++ b/client/sites/deployments/index.tsx
@@ -24,7 +24,7 @@ export default function () {
 		siteSelection,
 		setupPreferences,
 		redirectIfMultiSiteDashboardForcedOptIn(
-			( params: Record< string, string > ) => `/sites/deployments/${ params.site }`
+			( params: Record< string, string > ) => `/sites/${ params.site }/deployments`
 		),
 		navigation,
 		deploymentsList,
@@ -70,7 +70,7 @@ export default function () {
 		siteSelection,
 		setupPreferences,
 		redirectIfMultiSiteDashboardForcedOptIn(
-			( params: Record< string, string > ) => `/sites/deployments/${ params.site }`
+			( params: Record< string, string > ) => `/sites/${ params.site }/deployments`
 		),
 		navigation,
 		deploymentRunLogs,

--- a/client/sites/index.tsx
+++ b/client/sites/index.tsx
@@ -1,5 +1,11 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender, setSelectedSiteIdByOrigin } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	setSelectedSiteIdByOrigin,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { siteSelection, navigation } from 'calypso/my-sites/controller';
 import { maybeRedirectToDashboard, siteDashboard } from 'calypso/sites/controller';
 import { OVERVIEW, SETTINGS_SITE } from './components/site-preview-pane/constants';
@@ -18,6 +24,8 @@ export default function () {
 	page(
 		'/sites/:site/settings/:feature?',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(),
 		navigation,
 		dashboardBackportSiteSettings,
 		siteDashboard( SETTINGS_SITE ),
@@ -28,6 +36,8 @@ export default function () {
 	page(
 		'/sites/:site',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(),
 		navigation,
 		dashboardBackportSiteOverview,
 		siteDashboard( OVERVIEW ),
@@ -50,6 +60,8 @@ export default function () {
 		'/sites',
 		maybeRemoveCheckoutSuccessNotice,
 		maybeRedirectToDashboard,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(),
 		sanitizeQueryParameters,
 		navigation,
 		setSelectedSiteIdByOrigin,

--- a/client/sites/index.tsx
+++ b/client/sites/index.tsx
@@ -3,7 +3,7 @@ import {
 	makeLayout,
 	render as clientRender,
 	setSelectedSiteIdByOrigin,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { siteSelection, navigation } from 'calypso/my-sites/controller';
@@ -25,7 +25,7 @@ export default function () {
 		'/sites/:site/settings/:feature?',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(),
+		maybeRedirectToMultiSiteDashboard(),
 		navigation,
 		dashboardBackportSiteSettings,
 		siteDashboard( SETTINGS_SITE ),
@@ -37,7 +37,7 @@ export default function () {
 		'/sites/:site',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(),
+		maybeRedirectToMultiSiteDashboard(),
 		navigation,
 		dashboardBackportSiteOverview,
 		siteDashboard( OVERVIEW ),
@@ -61,7 +61,7 @@ export default function () {
 		maybeRemoveCheckoutSuccessNotice,
 		maybeRedirectToDashboard,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(),
+		maybeRedirectToMultiSiteDashboard(),
 		sanitizeQueryParameters,
 		navigation,
 		setSelectedSiteIdByOrigin,

--- a/client/sites/logs/index.tsx
+++ b/client/sites/logs/index.tsx
@@ -2,7 +2,7 @@ import page, { type Callback, type Context } from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
@@ -22,7 +22,7 @@ export default function () {
 		'/site-logs/:site/php',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params: Record< string, string > ) => `/sites/${ params.site }/logs/php`
 		),
 		navigation,
@@ -36,7 +36,7 @@ export default function () {
 		'/site-logs/:site/web',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params: Record< string, string > ) => `/sites/${ params.site }/logs/server`
 		),
 		navigation,

--- a/client/sites/logs/index.tsx
+++ b/client/sites/logs/index.tsx
@@ -1,5 +1,10 @@
 import page, { type Callback, type Context } from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { LOGS_PHP, LOGS_WEB } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
@@ -16,6 +21,10 @@ export default function () {
 	page(
 		'/site-logs/:site/php',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params: Record< string, string > ) => `/sites/${ params.site }/logs/php`
+		),
 		navigation,
 		phpErrorLogs,
 		siteLogsCallout,
@@ -26,6 +35,10 @@ export default function () {
 	page(
 		'/site-logs/:site/web',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params: Record< string, string > ) => `/sites/${ params.site }/logs/server`
+		),
 		navigation,
 		webServerLogs,
 		siteLogsCallout,

--- a/client/sites/monitoring/index.tsx
+++ b/client/sites/monitoring/index.tsx
@@ -1,5 +1,10 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfMultiSiteDashboardForcedOptIn,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { MONITORING } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
@@ -11,6 +16,10 @@ export default function () {
 	page(
 		'/site-monitoring/:site',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params: Record< string, string > ) => `/sites/${ params.site }/monitoring`
+		),
 		navigation,
 		siteMonitoring,
 		siteMonitoringCallout,

--- a/client/sites/monitoring/index.tsx
+++ b/client/sites/monitoring/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
@@ -17,7 +17,7 @@ export default function () {
 		'/site-monitoring/:site',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params: Record< string, string > ) => `/sites/${ params.site }/monitoring`
 		),
 		navigation,

--- a/client/sites/overview/controller.tsx
+++ b/client/sites/overview/controller.tsx
@@ -4,7 +4,6 @@ import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { isMigrationInProgress } from 'calypso/data/site-migration';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
-import { isDashboardEnabled } from 'calypso/state/dashboard/selectors/is-dashboard-enabled';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -42,10 +41,6 @@ function overview( context: PageJSContext, next: () => void ) {
 export function redirectToSiteOverview( context: PageJSContext ) {
 	const { dispatch, getState } = context.store;
 	const path = `/sites/${ context.params.site }`;
-
-	if ( ! isDashboardEnabled( getState() ) ) {
-		return page.redirect( path );
-	}
 
 	dispatch( waitForPrefs() ).finally( () => {
 		if ( hasDashboardOptIn( getState() ) ) {

--- a/client/sites/staging-site/index.tsx
+++ b/client/sites/staging-site/index.tsx
@@ -3,7 +3,9 @@ import {
 	makeLayout,
 	render as clientRender,
 	redirectIfCurrentUserCannot,
+	redirectIfMultiSiteDashboardForcedOptIn,
 } from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { handleHostingPanelRedirect } from 'calypso/hosting/server-settings/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { STAGING_SITE } from 'calypso/sites/components/site-preview-pane/constants';
@@ -16,6 +18,10 @@ export default function () {
 	page(
 		'/staging-site/:site',
 		siteSelection,
+		setupPreferences,
+		redirectIfMultiSiteDashboardForcedOptIn(
+			( params: Record< string, string > ) => `/sites/${ params.site }`
+		),
 		navigation,
 		redirectToHostingFeaturesIfNotAtomic,
 		redirectIfCurrentUserCannot( 'manage_options' ),

--- a/client/sites/staging-site/index.tsx
+++ b/client/sites/staging-site/index.tsx
@@ -3,7 +3,7 @@ import {
 	makeLayout,
 	render as clientRender,
 	redirectIfCurrentUserCannot,
-	redirectIfMultiSiteDashboardForcedOptIn,
+	maybeRedirectToMultiSiteDashboard,
 } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { handleHostingPanelRedirect } from 'calypso/hosting/server-settings/controller';
@@ -19,7 +19,7 @@ export default function () {
 		'/staging-site/:site',
 		siteSelection,
 		setupPreferences,
-		redirectIfMultiSiteDashboardForcedOptIn(
+		maybeRedirectToMultiSiteDashboard(
 			( params: Record< string, string > ) => `/sites/${ params.site }`
 		),
 		navigation,

--- a/client/state/dashboard/selectors/has-dashboard-opt-in.ts
+++ b/client/state/dashboard/selectors/has-dashboard-opt-in.ts
@@ -14,3 +14,11 @@ export const hasDashboardOptIn = ( state: AppState ): boolean => {
 
 	return preference?.value === 'opt-in';
 };
+
+export const hasDashboardForcedOptIn = ( state: AppState ): boolean => {
+	const preference = getPreference( state, 'hosting-dashboard-opt-in' ) as
+		| HostingDashboardOptIn
+		| undefined;
+
+	return preference?.value === 'forced-opt-in';
+};

--- a/client/state/dashboard/selectors/has-dashboard-opt-in.ts
+++ b/client/state/dashboard/selectors/has-dashboard-opt-in.ts
@@ -4,12 +4,13 @@ import type { HostingDashboardOptIn } from '@automattic/api-core';
 import type { AppState } from 'calypso/types';
 
 export const hasDashboardOptIn = ( state: AppState ): boolean => {
-	if ( ! isDashboardEnabled( state ) ) {
-		return false;
-	}
-
 	const preference = getPreference( state, 'hosting-dashboard-opt-in' ) as
 		| HostingDashboardOptIn
 		| undefined;
+
+	if ( ! isDashboardEnabled( state ) ) {
+		return preference?.value === 'forced-opt-in';
+	}
+
 	return preference?.value === 'opt-in';
 };

--- a/client/state/dashboard/selectors/has-dashboard-opt-in.ts
+++ b/client/state/dashboard/selectors/has-dashboard-opt-in.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { isDashboardEnabled } from './is-dashboard-enabled';
 import type { HostingDashboardOptIn } from '@automattic/api-core';
@@ -9,7 +10,7 @@ export const hasDashboardOptIn = ( state: AppState ): boolean => {
 		| undefined;
 
 	if ( ! isDashboardEnabled( state ) ) {
-		return preference?.value === 'forced-opt-in';
+		return preference?.value === 'forced-opt-in' || isEnabled( 'dashboard/forced-opt-in' );
 	}
 
 	return preference?.value === 'opt-in';
@@ -20,5 +21,5 @@ export const hasDashboardForcedOptIn = ( state: AppState ): boolean => {
 		| HostingDashboardOptIn
 		| undefined;
 
-	return preference?.value === 'forced-opt-in';
+	return preference?.value === 'forced-opt-in' || isEnabled( 'dashboard/forced-opt-in' );
 };

--- a/client/state/dashboard/selectors/is-dashboard-enabled.ts
+++ b/client/state/dashboard/selectors/is-dashboard-enabled.ts
@@ -14,5 +14,5 @@ export const isDashboardEnabled = ( state: AppState ): boolean => {
 		return false;
 	}
 
-	return true;
+	return false;
 };

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -1,7 +1,7 @@
 import type { View } from '@wordpress/dataviews';
 
 export interface HostingDashboardOptIn {
-	value: 'unset' | 'opt-in' | 'opt-out';
+	value: 'unset' | 'opt-in' | 'opt-out' | 'forced-opt-in';
 	updated_at: string; // ISO date string
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-1037
Part of DOTMSD-1038

## Proposed Changes

* Use `forced-opt-in` to determine whether the user has opt-in as well
* If the user has `forced-opt-in`, then redirect to the corresponding page on MSD directly.
* Introduce `redirectIfMultiSiteDashboardForcedOptIn` middleware to handle the redirection
* Will handle paths below in the follow-up PR
  * domain-related paths 
  * billing-related paths
    * /crm-downloads/:subscription
    * /subscription-removed
    * /me/purchases-by-owner/:ownershipId

| V1 | V2 |
| - | - |
| /sites | /sites |
| /sites/:site | /sites/:site |
| /github-deployments | /sites/:site/deployments |
| /site-monitoring | /sites/:site/monitoring |
| /sites-performance | /sites/:site/performance |
| /site-logs | /sites/:site/logs/* |
| /staging-site | /sites/:site |
| /domains/manage | /domains |
| /plugins/manage/sites | /plugins/manage |
| /plugins/manage/sites/:slug | /plugins/manage/:slug |
| /plugins/scheduled-updates | /plugins/scheduled-updates |
| /plugins/scheduled-updates/create | /plugins/scheduled-updates/new |
| /plugins/scheduled-updates/edit/:id | /plugins/scheduled-updates/edit/:id |
| /me/* | /me/* |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The MSD is enabled if the user's `hosting-dashboard-opt-in` calypso preference is either `opt-in` or `forced-opt-in`, and we have to do the redirection if the value is `forced-opt-in`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There are two ways to test `forced-opt-in` behavior
  * Follow instructions on 200431-ghe-Automattic/wpcom to create new user under the `forced-opt-in` experiment
  * Enable the feature flag `dashboard/forced-opt-in` by adding `?flags=dashboard/forced-opt-in` to the URL
* Go to any paths mentioned above on Calypso
* Add `?flags=dashboard/forced-opt-in` if you're account doesn't have `forced-opt-in` feature
* Ensure the page will be redirected to the corresponding page on MSD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?