### PR TITLE
Disable the domains/suggestions-pp while we fix the backend to filter out non-sandboxed TLDs

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -67,7 +67,6 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"domain-search-rewrite": true,
 		"domain-transfer-redesign": true,
-		"domains/suggestions-pp": true,
 		"email-accounts/enabled": true,
 		"global-styles/on-personal-plan": true,
 		"google-drive": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -33,7 +33,6 @@
 		"devdocs": false,
 		"domain-search-rewrite": true,
 		"domain-transfer-redesign": true,
-		"domains/suggestions-pp": true,
 		"global-styles/on-personal-plan": true,
 		"google-my-business": false,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -48,7 +48,6 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"domain-search-rewrite": true,
 		"domain-transfer-redesign": true,
-		"domains/suggestions-pp": true,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,


### PR DESCRIPTION
After I merged https://github.com/Automattic/wp-calypso/pull/108160 the pre-release tests started failing. Turns out that the new combined suggestions engine is not filtering out TLDs that are not enabled on the store sandboxed environment.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMENG-304: Locked (paid) Domain Search Placements 1.1](https://linear.app/a8c/issue/DOMENG-304/locked-paid-domain-search-placements-11)

## Proposed Changes

* Disable the flags till we fix the backend issue

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To unblock Calypso deploys

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* All tests should work

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
