### PR TITLE
A4A > Marketplace: Implement term pricing for Referrals

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v1.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v1.tsx
@@ -216,7 +216,9 @@ function CheckoutV1( { isClient, referralBlogId }: Props ) {
 	);
 
 	if ( isAutomatedReferrals && ! onlyFreeItems ) {
-		actionContent = <RequestClientPayment checkoutItems={ checkoutItems } />;
+		actionContent = (
+			<RequestClientPayment checkoutItems={ checkoutItems } termPricing={ termPricing } />
+		);
 	}
 
 	if ( isClient ) {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v1.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v1.tsx
@@ -23,7 +23,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import useFetchClientReferral from '../../client/hooks/use-fetch-client-referral';
-import { MarketplaceTypeContext } from '../context';
+import { MarketplaceTypeContext, TermPricingContext } from '../context';
 import withMarketplaceProviders from '../hoc/with-marketplace-providers';
 import { MARKETPLACE_TYPE_REFERRAL } from '../hoc/with-marketplace-type';
 import useProductsById from '../hooks/use-products-by-id';
@@ -59,6 +59,7 @@ function CheckoutV1( { isClient, referralBlogId }: Props ) {
 	const wrapperRef = useRef< HTMLButtonElement | null >( null );
 
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const { termPricing } = useContext( TermPricingContext );
 	const isAutomatedReferrals = marketplaceType === MARKETPLACE_TYPE_REFERRAL;
 
 	const { selectedCartItems, onRemoveCartItem, onClearCart, setSelectedCartItems } =
@@ -310,6 +311,7 @@ function CheckoutV1( { isClient, referralBlogId }: Props ) {
 							onRemoveItem={ siteId || isClient ? undefined : onRemoveItem }
 							isAutomatedReferrals={ isAutomatedReferrals && ! onlyFreeItems }
 							isClient={ isClient }
+							termPricing={ termPricing }
 						/>
 
 						{ actionContent }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -33,16 +33,17 @@ import {
 import useRequestClientPaymentMutation from '../hooks/use-request-client-payment-mutation';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import NoticeSummary from './notice-summary';
-import type { ShoppingCartItem } from '../types';
+import type { ShoppingCartItem, TermPricingType } from '../types';
 interface Props {
 	checkoutItems: ShoppingCartItem[];
+	termPricing: TermPricingType;
 }
 
 type ValidationState = {
 	email?: string;
 };
 
-function RequestClientPayment( { checkoutItems }: Props ) {
+function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -108,7 +109,10 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 				recordTracksEvent(
 					flowType === 'send'
 						? 'calypso_a4a_marketplace_referral_checkout_request_payment_click'
-						: 'calypso_a4a_marketplace_referral_checkout_request_payment_copy_click'
+						: 'calypso_a4a_marketplace_referral_checkout_request_payment_copy_click',
+					{
+						term_pricing: termPricing,
+					}
 				)
 			);
 			requestPayment(

--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
@@ -8,7 +8,7 @@ import { hasApprovedAgencyStatus } from 'calypso/state/a8c-for-agencies/agency/s
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import { MarketplaceTypeContext } from '../../context';
+import { MarketplaceTypeContext, TermPricingContext } from '../../context';
 
 import './style.scss';
 
@@ -18,6 +18,7 @@ const ReferralToggle = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { marketplaceType, toggleMarketplaceType } = useContext( MarketplaceTypeContext );
+	const { termPricing } = useContext( TermPricingContext );
 	const { guideModal, openGuide } = useReferralsGuide();
 
 	const guideModalSeen = useSelector( ( state ) => getPreference( state, PREFERENCE_NAME ) );
@@ -28,7 +29,8 @@ const ReferralToggle = () => {
 		toggleMarketplaceType();
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_referral_toggle', {
-				purchase_mode: marketplaceType,
+				purchase_mode: marketplaceType === 'referral' ? 'regular' : 'referral',
+				term_pricing: termPricing,
 			} )
 		);
 	};

--- a/client/a8c-for-agencies/sections/marketplace/common/term-pricing-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/term-pricing-toggle/index.tsx
@@ -5,16 +5,27 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext } from 'react';
-import { TermPricingContext } from '../../context';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { MarketplaceTypeContext, TermPricingContext } from '../../context';
 
 export default function TermPricingToggle() {
+	const dispatch = useDispatch();
+
 	const { termPricing, toggleTermPricing } = useContext( TermPricingContext );
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+
+	const isChecked = termPricing === 'yearly';
 
 	const handleToggle = () => {
 		toggleTermPricing();
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_marketplace_term_pricing_toggle', {
+				term_pricing: isChecked ? 'monthly' : 'yearly',
+				purchase_mode: marketplaceType,
+			} )
+		);
 	};
-
-	const isChecked = termPricing === 'yearly';
 
 	return (
 		<HStack className="a4a-marketplace__term-pricing-toggle" justify="flex-start" spacing={ 0 }>

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -7,10 +7,12 @@ import {
 	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
 import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
 import Checkout from './checkout';
 import { MARKETPLACE_TYPE_SESSION_STORAGE_KEY } from './hoc/with-marketplace-type';
+import { TERM_PRICING_PREFERENCE_KEY, TERM_PRICING_YEARLY } from './hoc/with-term-pricing';
 import HostingOverview from './hosting-overview';
 import { getValidHostingSection } from './lib/hosting';
 import { getValidBrand } from './lib/product-brand';
@@ -18,7 +20,7 @@ import { PLAN_CATEGORY_ENTERPRISE, PLAN_CATEGORY_PREMIUM } from './pressable-ove
 import DownloadProducts from './primary/download-products';
 import ProductsOverview from './products-overview';
 import ReferHosting from './refer-hosting';
-import type { MarketplaceType } from './types';
+import type { MarketplaceType, TermPricingType } from './types';
 
 type Props = {
 	title: string;
@@ -31,6 +33,11 @@ function MarketplacePageViewTracker( { title, path, properties }: Props ) {
 		MARKETPLACE_TYPE_SESSION_STORAGE_KEY
 	) as MarketplaceType;
 
+	const [ termPricingValue ] = useAsyncPreference< TermPricingType >( {
+		defaultValue: TERM_PRICING_YEARLY,
+		preferenceName: TERM_PRICING_PREFERENCE_KEY,
+	} );
+
 	return (
 		<PageViewTracker
 			title={ title }
@@ -38,6 +45,7 @@ function MarketplacePageViewTracker( { title, path, properties }: Props ) {
 			properties={ {
 				...properties,
 				purchase_mode: marketplaceType,
+				term_pricing: termPricingValue,
 			} }
 		/>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
-import { useContext, useMemo } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import useWPCOMOwnedSites from 'calypso/a8c-for-agencies/hooks/use-wpcom-owned-sites';
 import wpcomBulkOptions from 'calypso/a8c-for-agencies/sections/marketplace/lib/wpcom-bulk-options';
@@ -16,8 +16,81 @@ import type {
 } from 'calypso/a8c-for-agencies/types/products';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
-export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currency?: string ) => {
+export const checkProductTermAvailability = (
+	product: APIProductFamilyProduct,
+	termPricing?: TermPricingType
+) => {
+	const monthlyProductId = product?.monthly_product_id;
+	const yearlyProductId = product?.yearly_product_id;
+	const isMonthlyTerm = termPricing === 'monthly';
+	const isYearlyTerm = termPricing === 'yearly';
+	const isMissingMonthlyId = isMonthlyTerm && ! monthlyProductId;
+	const isMissingYearlyId = isYearlyTerm && ! yearlyProductId;
+	return { isMissingMonthlyId, isMissingYearlyId };
+};
+
+export const useProductTermAvailabilityTooltip = ( termPricing: TermPricingType ) => {
 	const translate = useTranslate();
+
+	const termAvailabilityTooltip = useCallback(
+		( product: APIProductFamilyProduct ) => {
+			const { isMissingMonthlyId, isMissingYearlyId } = checkProductTermAvailability(
+				product,
+				termPricing
+			);
+
+			if ( isMissingMonthlyId ) {
+				return translate(
+					'This product is not available for monthly billing. We will bill you yearly instead.'
+				);
+			}
+
+			if ( isMissingYearlyId ) {
+				return translate(
+					'This product is not available for yearly billing. We will bill you monthly instead.'
+				);
+			}
+
+			return undefined;
+		},
+		[ termPricing, translate ]
+	);
+
+	return termAvailabilityTooltip;
+};
+
+export const useTermPricingText = ( termPricing?: TermPricingType, short = true ) => {
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
+	const translate = useTranslate();
+	const yearlyText = short ? translate( '/yr' ) : translate( '/year' );
+	const monthlyText = short ? translate( '/mo' ) : translate( '/month' );
+	return isTermPricingEnabled && termPricing === 'yearly' ? yearlyText : monthlyText;
+};
+
+export const useGetProductPricingInfo = (
+	termPricing?: TermPricingType,
+	currency?: string
+): {
+	getProductPricingInfo: (
+		userProducts: Record< string, ProductListItem >,
+		product: SelectedLicenseProp | APIProductFamilyProduct,
+		quantity: number
+	) => {
+		actualCost: number;
+		discountedCost: number;
+		discountPercentage: number;
+		discountedCostFormatted: string;
+		actualCostFormatted: string;
+		showActualCost: boolean;
+		isFree: boolean;
+	};
+	termPricingPriceInfo: ( product: APIProductFamilyProduct ) => {
+		priceInterval: string;
+		termPrice: number | undefined;
+	};
+} => {
+	const translate = useTranslate();
+
 	const { data } = useProductsQuery( true );
 	const wpcomProducts = data?.find(
 		( product ) => product.slug === 'wpcom-hosting'
@@ -37,6 +110,26 @@ export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currenc
 		return count;
 	}, [ count, marketplaceType ] );
 
+	const termPricingPriceInfo = ( product: APIProductFamilyProduct ) => {
+		const { isMissingMonthlyId, isMissingYearlyId } = checkProductTermAvailability(
+			product,
+			termPricing
+		);
+		let priceInterval =
+			termPricing === 'yearly' ? translate( 'per year' ) : translate( 'per month' );
+		let termPrice = termPricing === 'yearly' ? product.yearly_price : product.monthly_price;
+		if ( isMissingMonthlyId ) {
+			// We manually calculate the monthly price based on the yearly price
+			termPrice = ( product.yearly_price || 0 ) / 12;
+			priceInterval = translate( 'per month, billed yearly' );
+		} else if ( isMissingYearlyId ) {
+			// We manually calculate the yearly price based on the monthly price
+			termPrice = ( product.monthly_price || 0 ) * 12;
+			priceInterval = translate( 'per year, billed monthly' );
+		}
+		return { priceInterval, termPrice };
+	};
+
 	const getProductPricingInfo = (
 		userProducts: Record< string, ProductListItem >,
 		product: SelectedLicenseProp | APIProductFamilyProduct,
@@ -44,11 +137,8 @@ export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currenc
 	) => {
 		const isTermPricingEnabled =
 			isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
-		const termPrice = termPricing === 'yearly' ? product.yearly_price : product.monthly_price;
+		const { termPrice } = termPricingPriceInfo( product );
 		const productPrice = isTermPricingEnabled ? termPrice : Number( product.amount );
-
-		const termPricingText =
-			isTermPricingEnabled && termPricing === 'yearly' ? translate( '/yr' ) : translate( '/mo' );
 
 		const productBundlePrice = productPrice ? productPrice * quantity : 0;
 
@@ -60,7 +150,6 @@ export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currenc
 				discountedCost,
 				discountPercentage: tier.discount,
 				showActualCost: productBundlePrice > discountedCost,
-				termPricingText,
 				discountedCostFormatted: formatCurrency( discountedCost, currency ?? 'USD' ),
 				actualCostFormatted: formatCurrency( productBundlePrice, currency ?? 'USD' ),
 				isFree: productPrice === 0,
@@ -84,7 +173,6 @@ export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currenc
 				discountedCostFormatted: formatCurrency( discountedCost, currency ?? 'USD' ),
 				actualCostFormatted: formatCurrency( actualCost, currency ?? 'USD' ),
 				showActualCost: actualCost > discountedCost,
-				termPricingText,
 				isFree: productPrice === 0,
 			};
 		}
@@ -99,7 +187,6 @@ export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currenc
 				discountedCostFormatted: formatCurrency( actualCost, currency ?? 'USD' ),
 				actualCostFormatted: formatCurrency( actualCost, currency ?? 'USD' ),
 				showActualCost: false,
-				termPricingText,
 				isFree: actualCost === 0,
 			};
 		}
@@ -163,11 +250,11 @@ export const useGetProductPricingInfo = ( termPricing?: TermPricingType, currenc
 			discountedCostFormatted: formatCurrency( discountInfo.discountedCost, currency ?? 'USD' ),
 			actualCostFormatted: formatCurrency( discountInfo.actualCost, currency ?? 'USD' ),
 			showActualCost: discountInfo.actualCost > discountInfo.discountedCost,
-			termPricingText,
 			isFree: discountInfo.actualCost === 0,
 		};
 	};
-	return { getProductPricingInfo };
+
+	return { getProductPricingInfo, termPricingPriceInfo };
 };
 
 export const useTotalInvoiceValue = ( termPricing?: TermPricingType, currency?: string ) => {
@@ -205,22 +292,25 @@ export const useTotalInvoiceValue = ( termPricing?: TermPricingType, currency?: 
 		const isTermPricingEnabled =
 			isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 
-		const totalDiscountedCostFormatted =
-			isTermPricingEnabled && termPricing === 'yearly'
+		const totalCostFormattedText = ( cost: number ) => {
+			return isTermPricingEnabled && termPricing === 'yearly'
 				? translate( '%(total)s/yr', {
-						args: {
-							total: formatCurrency( totalInvoiceValue.discountedCost, currency ?? 'USD' ),
-						},
+						args: { total: formatCurrency( cost, currency ?? 'USD' ) },
 				  } )
 				: translate( '%(total)s/mo', {
-						args: {
-							total: formatCurrency( totalInvoiceValue.discountedCost, currency ?? 'USD' ),
-						},
+						args: { total: formatCurrency( cost, currency ?? 'USD' ) },
 				  } );
+		};
 
 		return {
 			...totalInvoiceValue,
-			totalDiscountedCostFormatted,
+			totalDiscountedCostFormatted: formatCurrency(
+				totalInvoiceValue.discountedCost,
+				currency ?? 'USD'
+			),
+			totalActualCostFormatted: formatCurrency( totalInvoiceValue.actualCost, currency ?? 'USD' ),
+			totalDiscountedCostFormattedText: totalCostFormattedText( totalInvoiceValue.discountedCost ),
+			totalActualCostFormattedText: totalCostFormattedText( totalInvoiceValue.actualCost ),
 		};
 	};
 

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
@@ -191,12 +191,16 @@ export const useGetProductPricingInfo = (
 			};
 		}
 
-		const bundle = product?.supported_bundles?.find( ( bundle ) => bundle.quantity === quantity );
-		const bundleAmount = bundle && bundle.amount ? bundle.amount.replace( ',', '' ) : '';
+		const getAmount = ( amount?: string ) => {
+			if ( ! amount ) {
+				return 0;
+			}
+			return parseFloat( amount.replace( ',', '' ) ) || 0;
+		};
 
-		const productBundleCost = bundle
-			? parseFloat( bundleAmount )
-			: parseFloat( product?.amount.replace( ',', '' ) ) || 0;
+		const bundle = product?.supported_bundles?.find( ( bundle ) => bundle.quantity === quantity );
+
+		const productBundleCost = bundle ? getAmount( bundle.amount ) : getAmount( product.amount );
 		const isDailyPricing = product.price_interval === 'day';
 
 		const discountInfo: {
@@ -231,7 +235,7 @@ export const useGetProductPricingInfo = (
 
 			// If a monthly product is found, calculate the actual cost and discount percentage
 			if ( monthlyProduct ) {
-				const monthlyProductBundleCost = parseFloat( product.amount.replace( ',', '' ) ) * quantity;
+				const monthlyProductBundleCost = getAmount( product.amount ) * quantity;
 				const actualCost = isDailyPricing
 					? monthlyProductBundleCost / 365
 					: monthlyProductBundleCost;

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id.ts
@@ -11,14 +11,43 @@ export default function useProductsById( products: ReferralProduct[] | [], isEna
 	useEffect( () => {
 		if ( data ) {
 			if ( ! products ) {
-				return setReferredProducts( [] );
+				setReferredProducts( [] );
 			}
 			const allProducts = products
 				.map( ( p ) => {
-					return {
-						...data.find( ( product ) => product.product_id === p.product_id ),
-						quantity: 1,
-					};
+					let matchedProduct: ShoppingCartItem | undefined;
+					let matchedProductId: number | undefined;
+					let matchedAlternativeProductId: number | undefined;
+
+					const product = data.find( ( product ) => {
+						if ( product.monthly_product_id === p.product_id ) {
+							matchedProductId = product.monthly_product_id;
+							matchedAlternativeProductId = product.monthly_alternative_product_id;
+							return true;
+						}
+						if ( product.yearly_product_id === p.product_id ) {
+							matchedProductId = product.yearly_product_id;
+							matchedAlternativeProductId = product.yearly_alternative_product_id;
+							return true;
+						}
+						if ( product.product_id === p.product_id ) {
+							matchedProductId = product.product_id;
+							matchedAlternativeProductId = product.alternative_product_id;
+							return true;
+						}
+						return false;
+					} );
+
+					if ( product && matchedProductId !== undefined ) {
+						matchedProduct = {
+							...product,
+							product_id: matchedProductId,
+							alternative_product_id: matchedAlternativeProductId,
+							quantity: 1,
+						};
+					}
+
+					return matchedProduct;
 				} )
 				.filter( ( product ) => product ) as ShoppingCartItem[];
 

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
@@ -30,6 +30,7 @@ export default function useShoppingCart() {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_toggle_cart', {
 				purchase_mode: marketplaceType,
+				term_pricing: termPricing,
 			} )
 		);
 		setShowCart( ( prevState ) => {

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
@@ -1,9 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { getQueryArg } from '@wordpress/url';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { MarketplaceTypeContext } from '../context';
+import { MarketplaceTypeContext, TermPricingContext } from '../context';
 import { CART_URL_HASH_FRAGMENT } from '../shopping-cart';
 import { type ShoppingCartItem } from '../types';
 
@@ -15,6 +16,7 @@ export default function useShoppingCart() {
 
 	const [ selectedCartItems, setSelectedCartItems ] = useState< ShoppingCartItem[] >( [] );
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const { termPricing } = useContext( TermPricingContext );
 
 	const [ showCart, setShowCart ] = useState( window.location.hash === CART_URL_HASH_FRAGMENT );
 
@@ -117,13 +119,34 @@ export default function useShoppingCart() {
 		[ storageKey ]
 	);
 
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
+
+	const updatedSelectedCartItems = useMemo( () => {
+		return selectedCartItems.map( ( item ) => {
+			const termBasedProductId =
+				( termPricing === 'yearly' ? item.yearly_product_id : item.monthly_product_id ) ||
+				item.product_id;
+			const termBasedAlternativeProductId =
+				( termPricing === 'yearly'
+					? item.yearly_alternative_product_id
+					: item.monthly_alternative_product_id ) || item.alternative_product_id;
+			return {
+				...item,
+				product_id: isTermPricingEnabled ? termBasedProductId : item.product_id,
+				alternative_product_id: isTermPricingEnabled
+					? termBasedAlternativeProductId
+					: item.alternative_product_id,
+			};
+		} );
+	}, [ isTermPricingEnabled, selectedCartItems, termPricing ] );
+
 	const onRemoveCartItem = useCallback(
 		( item: ShoppingCartItem ) => {
 			setAndCacheSelectedItems(
-				selectedCartItems.filter( ( selectedCartItem ) => selectedCartItem !== item )
+				updatedSelectedCartItems.filter( ( selectedCartItem ) => selectedCartItem !== item )
 			);
 		},
-		[ selectedCartItems, setAndCacheSelectedItems ]
+		[ updatedSelectedCartItems, setAndCacheSelectedItems ]
 	);
 
 	const onClearCart = useCallback( () => {
@@ -131,7 +154,7 @@ export default function useShoppingCart() {
 	}, [ setAndCacheSelectedItems ] );
 
 	return {
-		selectedCartItems,
+		selectedCartItems: updatedSelectedCartItems,
 		setSelectedCartItems: setAndCacheSelectedItems,
 		onRemoveCartItem,
 		onClearCart,

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { useGetProductPricingInfo } from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value';
+import { useGetProductPricingInfo } from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-marketplace';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useLayoutEffect, useState } from 'react';
+import { useCallback, useContext, useLayoutEffect, useState } from 'react';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -25,6 +25,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ReferralToggle from '../common/referral-toggle';
 import TermPricingToggle from '../common/term-pricing-toggle';
+import { MarketplaceTypeContext, TermPricingContext } from '../context';
 import withMarketplaceProviders from '../hoc/with-marketplace-providers';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
@@ -46,6 +47,9 @@ function HostingOverview( { section }: SectionProps ) {
 	const isNarrowView = useBreakpoint( '<660px' );
 
 	const [ referralToggleRef, setReferralToggleRef ] = useState< HTMLElement | null >();
+
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const { termPricing } = useContext( TermPricingContext );
 
 	const {
 		selectedCartItems,
@@ -70,11 +74,13 @@ function HostingOverview( { section }: SectionProps ) {
 					recordTracksEvent( 'calypso_a4a_marketplace_hosting_add_to_cart', {
 						quantity,
 						item: plan.family_slug,
+						purchase_mode: marketplaceType,
+						term_pricing: termPricing,
 					} )
 				);
 			}
 		},
-		[ dispatch, selectedCartItems, setSelectedCartItems, setShowCart ]
+		[ dispatch, marketplaceType, selectedCartItems, setSelectedCartItems, setShowCart, termPricing ]
 	);
 
 	const handleSectionChange = useCallback(

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
-import { useGetProductPricingInfo } from '../../hooks/use-total-invoice-value';
+import { useGetProductPricingInfo } from '../../hooks/use-marketplace';
 import getPressablePlan from '../lib/get-pressable-plan';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/index.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import withMarketplaceProviders from 'calypso/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-providers';
-import { useGetProductPricingInfo } from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-total-invoice-value';
+import { useGetProductPricingInfo } from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-marketplace';
 import { useSelector } from 'calypso/state';
 import { isProductsListFetching, getProductsList } from 'calypso/state/products-list/selectors';
 import type { TermPricingType } from 'calypso/a8c-for-agencies/sections/marketplace/types';
@@ -34,10 +34,15 @@ function ProductPriceWithDiscount( {
 
 	const isBundle = quantity > 1;
 
-	const { getProductPricingInfo } = useGetProductPricingInfo( termPricing, product.currency );
+	const { getProductPricingInfo, termPricingPriceInfo } = useGetProductPricingInfo(
+		termPricing,
+		product.currency
+	);
 
 	const { discountedCostFormatted, actualCostFormatted, discountPercentage, isFree } =
 		getProductPricingInfo( userProducts, product, quantity );
+
+	const { priceInterval: termPriceInterval } = termPricingPriceInfo( product );
 
 	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 
@@ -55,7 +60,7 @@ function ProductPriceWithDiscount( {
 
 	const priceInterval = () => {
 		if ( isTermPricingEnabled ) {
-			return termPricing === 'yearly' ? translate( 'per year' ) : translate( 'per month' );
+			return termPriceInterval;
 		}
 		if ( isDailyPricing ) {
 			return isBundle ? translate( 'per bundle per day' ) : translate( 'per license per day' );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -12,6 +12,7 @@ import {
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { MarketplaceTypeContext, ShoppingCartContext } from '../../context';
+import { useProductTermAvailabilityTooltip } from '../../hooks/use-marketplace';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
 import { SelectedFilters } from '../../lib/product-filter';
 import { getSupportedBundleSizes } from '../hooks/use-product-bundle-size';
@@ -52,6 +53,8 @@ export default function ProductListing( {
 
 	const { selectedCartItems, setSelectedCartItems } = useContext( ShoppingCartContext );
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
+
+	const termAvailabilityTooltip = useProductTermAvailabilityTooltip( termPricing );
 
 	const quantity = useMemo(
 		() => ( isReferralMode ? 1 : selectedBundleSize ),
@@ -263,6 +266,14 @@ export default function ProductListing( {
 						)
 				);
 
+			const termAvailabilityTooltipMessage = termAvailabilityTooltip( productOption );
+
+			const tooltip =
+				termAvailabilityTooltipMessage ||
+				( productDoNotHaveSupportedBundles
+					? translate( 'This product does not offer volume discounts.' )
+					: undefined );
+
 			return (
 				<ProductCard
 					asReferral={ isReferralMode }
@@ -282,11 +293,7 @@ export default function ProductListing( {
 					suggestedProduct={ suggestedProduct }
 					quantity={ productDoNotHaveSupportedBundles ? 1 : quantity }
 					withCustomCard={ withCustomCard }
-					tooltip={
-						productDoNotHaveSupportedBundles
-							? translate( 'This product does not offer volume discounts.' )
-							: undefined
-					}
+					tooltip={ tooltip }
 					tooltipPosition="bottom"
 				/>
 			);

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -147,6 +147,7 @@ export default function ProductListing( {
 						product: product.slug,
 						quantity,
 						purchase_mode: marketplaceType,
+						term_pricing: termPricing,
 					} )
 				);
 			} else {
@@ -157,11 +158,12 @@ export default function ProductListing( {
 						product: product.slug,
 						quantity,
 						purchase_mode: marketplaceType,
+						term_pricing: termPricing,
 					} )
 				);
 			}
 		},
-		[ dispatch, marketplaceType, quantity, selectedCartItems, setSelectedCartItems ]
+		[ dispatch, marketplaceType, quantity, selectedCartItems, setSelectedCartItems, termPricing ]
 	);
 
 	const onSelectOrReplaceProduct = useCallback(
@@ -183,6 +185,7 @@ export default function ProductListing( {
 						product: replace.slug,
 						quantity,
 						purchase_mode: marketplaceType,
+						term_pricing: termPricing,
 					} )
 				);
 
@@ -191,6 +194,7 @@ export default function ProductListing( {
 						product: product.slug,
 						quantity,
 						purchase_mode: marketplaceType,
+						term_pricing: termPricing,
 					} )
 				);
 			} else {
@@ -204,6 +208,7 @@ export default function ProductListing( {
 			selectedCartItems,
 			setSelectedCartItems,
 			marketplaceType,
+			termPricing,
 		]
 	);
 

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
@@ -7,7 +7,7 @@ import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import CommissionsInfo from '../../commissions-info';
 import { MarketplaceTypeContext, TermPricingContext } from '../../context';
-import { useTotalInvoiceValue } from '../../hooks/use-total-invoice-value';
+import { useTotalInvoiceValue } from '../../hooks/use-marketplace';
 import ShoppingCartMenuItem from './item';
 import type { ShoppingCartItem } from '../../types';
 
@@ -31,7 +31,7 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 		termPricing,
 		items[ 0 ]?.currency ?? 'USD'
 	);
-	const { totalDiscountedCostFormatted } = getTotalInvoiceValue( userProducts, items );
+	const { totalDiscountedCostFormattedText } = getTotalInvoiceValue( userProducts, items );
 
 	return (
 		<Popover
@@ -74,7 +74,7 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 								: translate( 'Total your client will pay:' ) }
 						</span>
 
-						<span>{ totalDiscountedCostFormatted }</span>
+						<span>{ totalDiscountedCostFormattedText }</span>
 					</div>
 
 					{ marketplaceType === 'referral' && (

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -1,9 +1,14 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
-import { useGetProductPricingInfo } from '../../hooks/use-total-invoice-value';
+import {
+	checkProductTermAvailability,
+	useGetProductPricingInfo,
+	useTermPricingText,
+} from '../../hooks/use-marketplace';
 import type { ShoppingCartItem, TermPricingType } from '../../types';
 
 import './style.scss';
@@ -18,9 +23,12 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem, termPricing 
 	const translate = useTranslate();
 	const userProducts = useSelector( getProductsList );
 
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
+
 	const { getProductPricingInfo } = useGetProductPricingInfo( termPricing, item.currency );
-	const { showActualCost, termPricingText, discountedCostFormatted, actualCostFormatted, isFree } =
+	const { showActualCost, discountedCostFormatted, actualCostFormatted, isFree } =
 		getProductPricingInfo( userProducts, item, item.quantity );
+	const termPricingText = useTermPricingText( termPricing );
 	// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
 	//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
 	const productDisplayName =
@@ -31,6 +39,11 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem, termPricing 
 					args: { productName: productDisplayName, quantity: item.quantity },
 			  } )
 			: productDisplayName;
+
+	const { isMissingMonthlyId, isMissingYearlyId } = checkProductTermAvailability(
+		item,
+		termPricing
+	);
 
 	return (
 		<li className="shopping-cart__menu-list-item">
@@ -51,6 +64,13 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem, termPricing 
 								</span>
 							) }
 							<span>{ termPricingText }</span>
+							&nbsp;
+							{ isTermPricingEnabled && isMissingMonthlyId && (
+								<span>({ translate( 'billed yearly' ) })</span>
+							) }
+							{ isTermPricingEnabled && isMissingYearlyId && (
+								<span>({ translate( 'billed monthly' ) })</span>
+							) }
 						</>
 					) }
 				</div>

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/product-details.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/product-details.tsx
@@ -9,7 +9,11 @@ type Props = {
 };
 
 const ProductDetails = ( { purchase, data, isFetching }: Props ) => {
-	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
+	const product = data?.find( ( product ) =>
+		[ product.monthly_product_id, product.yearly_product_id, product.product_id ].includes(
+			purchase.product_id
+		)
+	);
 
 	if ( isFetching ) {
 		return <TextPlaceholder />;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/product-details.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/product-details.tsx
@@ -9,18 +9,20 @@ type Props = {
 };
 
 const ProductDetails = ( { purchase, data, isFetching }: Props ) => {
-	const product = data?.find( ( product ) =>
-		[ product.monthly_product_id, product.yearly_product_id, product.product_id ].includes(
-			purchase.product_id
-		)
-	);
-
 	if ( isFetching ) {
 		return <TextPlaceholder />;
 	}
 
-	// Use product_name from subscription if available, otherwise fall back to product name from data
-	const productName = purchase.subscription?.product_name || product?.name;
+	let productName = purchase.subscription?.product_name;
+
+	if ( ! productName ) {
+		const product = data?.find( ( product ) =>
+			[ product.monthly_product_id, product.yearly_product_id, product.product_id ].includes(
+				purchase.product_id
+			)
+		);
+		productName = product?.name;
+	}
 
 	return productName;
 };

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/referral-products.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/referral-products.tsx
@@ -3,8 +3,11 @@ import type { ReferralPurchase } from '../../types';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 const getProductName = ( purchase: ReferralPurchase, data: APIProductFamilyProduct[] ) => {
-	const product = data.find( ( product ) => product.product_id === purchase.product_id );
-
+	const product = data?.find( ( product ) =>
+		[ product.monthly_product_id, product.yearly_product_id, product.product_id ].includes(
+			purchase.product_id
+		)
+	);
 	// Use product_name from subscription if available, otherwise fall back to product name from data
 	return purchase.subscription?.product_name || product?.name;
 };

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/referral-products.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/referral-products.tsx
@@ -3,13 +3,18 @@ import type { ReferralPurchase } from '../../types';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
 const getProductName = ( purchase: ReferralPurchase, data: APIProductFamilyProduct[] ) => {
-	const product = data?.find( ( product ) =>
-		[ product.monthly_product_id, product.yearly_product_id, product.product_id ].includes(
-			purchase.product_id
-		)
-	);
-	// Use product_name from subscription if available, otherwise fall back to product name from data
-	return purchase.subscription?.product_name || product?.name;
+	let productName = purchase.subscription?.product_name;
+
+	if ( ! productName ) {
+		const product = data?.find( ( product ) =>
+			[ product.monthly_product_id, product.yearly_product_id, product.product_id ].includes(
+				purchase.product_id
+			)
+		);
+		productName = product?.name;
+	}
+
+	return productName;
 };
 
 export default function ReferralProducts( {


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/107867

Resolves https://linear.app/a8c/issue/A4A-2016/implement-term-based-pricing-for-referrals
Resolves https://linear.app/a8c/issue/A4A-1924/janitorial-add-event-tracking

## Proposed Changes

This PR:
- Implements term pricing support for Referrals.
- Adds event tracking to Marketplace changes

## Why are these changes being made?

* To allow agencies to refer products on a monthly/yearly basis.

## Testing Instructions

* Patch 200442-ghe-Automattic/wpcom
* Test all the instructions below for 3 scenarios:

1) Non-BD checkout (test with old agency account)
2) BD checkout (test with new account and disable the feature flag: `?flags=-a4a-bd-checkout` )
3) BD checkout with term pricing.

* Go to Marketplace > Toggle the refer mode > All a mix of products with yearly billing. Please ensure to select a free product, backup storage, WPCOM hosting, Pressable hosting, WooCommerce product, Jetpack product > Send the referral 
* When checking out as a client, verify the products are pre-selected to the term selected when sending a referral > Purchase these products as a client and verify that it works as expected
* Repeat the referral + purchase with monthly billing and verify that it works as expected.

When monthly billing is selected & hovering over a product with only a yearly term.

<img width="495" height="426" alt="Screenshot 2026-01-19 at 9 02 34 PM" src="https://github.com/user-attachments/assets/cea7fdd3-85ac-4ecd-b4fb-e265d496f5bd" />

When the yearly billing is selected, and hovering over a product that has only a monthly term. The price is multiplied by 12 here.

<img width="840" height="628" alt="Screenshot 2026-01-19 at 9 02 11 PM" src="https://github.com/user-attachments/assets/d005d48d-e5ec-47db-ab74-a9dcf44daeae" />

When the yearly billing is selected, and a product is added that has only a monthly term:

<img width="599" height="341" alt="Screenshot 2026-01-19 at 9 03 06 PM" src="https://github.com/user-attachments/assets/5020cf3a-f9f0-4046-b56c-f5d68c48cca0" />

<img width="583" height="404" alt="Screenshot 2026-01-19 at 9 03 17 PM" src="https://github.com/user-attachments/assets/3fb84398-e2ff-43d0-9a37-01e75c54e0d0" />

<img width="525" height="399" alt="Screenshot 2026-01-19 at 9 03 22 PM" src="https://github.com/user-attachments/assets/d7c554d4-44f6-47b3-9311-e7b2e2e9322e" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?