### PR TITLE
Checkout: Only hide logo for Woo Hosted checkout

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -400,6 +400,9 @@ export default function CheckoutMainContent( {
 		getWpComDomainBySiteId( state, selectedSiteData?.ID )
 	);
 
+	const isWooHostedCheckout =
+		selectedSiteData?.is_garden && selectedSiteData?.garden_name === 'commerce';
+
 	// Only show the site preview for WPCOM domains that have a site connected to the site id
 	const shouldShowSitePreview =
 		showSitePreview && selectedSiteData && wpcomDomain && ! isSignupCheckout && ! isDIFMInCart;
@@ -876,7 +879,7 @@ export default function CheckoutMainContent( {
 									</Step.LinkButton>
 								</span>
 							}
-							hideLogo
+							hideLogo={ isWooHostedCheckout }
 						/>
 					);
 

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -8,6 +8,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_coming_soon',
 	'is_vip',
 	'is_garden',
+	'garden_name',
 	'jetpack',
 	'jetpack_connection',
 	'jetpack_modules',

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -137,6 +137,8 @@ export interface SiteDetails {
 	is_wpcom_staging_site?: boolean;
 	is_a4a_client?: boolean;
 	is_a4a_dev_site?: boolean;
+	is_garden?: boolean;
+	garden_name?: string | null;
 	jetpack: boolean;
 	jetpack_connection?: boolean;
 	lang?: string;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-344/checkout-page-wordpresscom-logo-missing

## Proposed Changes

This changes the logic that hides the logo in Signup's Checkout to only hide the branding for Woo Hosted sites. It achieves this by extending the `getSelectedSiteData` selector and query to additionally request and return garden site data.

## Why are these changes being made?

In #107163, I added support for Woo Hosted plans and checkout, with some visual customizations like hiding the branding in Checkout and the Stepper flow. Unfortunately, I dropped the condition to only hide the branding for Woo Hosted flows, hiding it for all flows instead.

## Testing Instructions

- Create a new site with `wordpress.com/start/` and choose a paid plan
- When you visit Checkout, verify that the WP logo is shown.
- For a CIAB site, visit `wordpress.com/setup/woo-hosted-plans?siteSlug={siteslug}` and choose a paid plan
- When you visit Checkout, verify that the logo is hidden.