### PR TITLE
Add Gutenberg E2E Tests build configuration with matrix support

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -184,7 +184,9 @@ object CalypsoE2ETestsBuildTemplate : Template({
 				if [[ -n "%EXTRA_ENV_VARS%" ]]; then
 					IFS=',' read -ra ENV_PAIRS <<< "%EXTRA_ENV_VARS%"
 					for pair in "${'$'}{ENV_PAIRS[@]}"; do
-						echo "##teamcity[setParameter name='env.${'$'}pair']"
+						KEY="${'$'}{pair%%=*}"
+						VALUE="${'$'}{pair#*=}"
+						echo "##teamcity[setParameter name='env.${'$'}KEY' value='${'$'}VALUE']"
 					done
 				fi
 			""".trimIndent()

--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -29,6 +29,7 @@ object CalypsoE2ETestsBuildTemplate : Template({
 		text("CALYPSO_BASE_URL", "")
 		text("DASHBOARD_BASE_URL", "")
 		text("DOCKER_IMAGE_BUILD_NUMBER", "")
+		text("EXTRA_ENV_VARS", "")
 		param("IGNORE_TEST_GROUP_FOR_E2E_CHANGES", "false")
 	}
 
@@ -172,6 +173,21 @@ object CalypsoE2ETestsBuildTemplate : Template({
 					echo "IGNORE_TEST_GROUP_FOR_E2E_CHANGES is false, keeping TEST_GROUP as is"
 				fi
 				"""
+			dockerImage = "%docker_image_e2e%"
+		}
+
+		bashNodeScript {
+			name = "Set extra environment variables"
+			id = "set_extra_env_vars"
+			scriptContent = """
+				# Parse EXTRA_ENV_VARS param (comma-separated KEY=value pairs) and set as TeamCity env params
+				if [[ -n "%EXTRA_ENV_VARS%" ]]; then
+					IFS=',' read -ra ENV_PAIRS <<< "%EXTRA_ENV_VARS%"
+					for pair in "${'$'}{ENV_PAIRS[@]}"; do
+						echo "##teamcity[setParameter name='env.${'$'}pair']"
+					done
+				fi
+			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -21,6 +21,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.exec
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.matrix
 
 object WPComTests : Project({
 	id("WPComTests")
@@ -69,6 +70,7 @@ object WPComTests : Project({
 
 	buildType(I18NTests);
 	buildType(P2E2ETests)
+	buildType(GutenbergPlaywrightTests)
 })
 
 fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false, edge: Boolean = false, nightly: Boolean = false): E2EBuildType {
@@ -364,7 +366,6 @@ fun jetpackAtomicBuildSmokeE2eBuildType( targetDevice: String, buildUuid: String
 	});
 }
 
-
 private object I18NTests : BuildType({
 	templates(CalypsoE2ETestsBuildTemplate)
 	id("WPComTests_i18n")
@@ -448,6 +449,60 @@ private object P2E2ETests : BuildType({
 			schedulingPolicy = cron {
 				hours = "*/3"
 				dayOfWeek = "*"
+			}
+			branchFilter = "+:trunk"
+			triggerBuild = always()
+			withPendingChangesOnly = false
+		}
+	}
+})
+
+private object GutenbergPlaywrightTests : BuildType({
+	templates(CalypsoE2ETestsBuildTemplate)
+	id("WPComTests_GutenbergPlaywrightTests")
+	uuid = "acacb00f-151b-4fb4-9f45-922a0543dcf6"
+	name = "Gutenberg E2E Tests"
+	description = "Runs Gutenberg E2E tests using Playwright Test with matrix for viewport and site configuration"
+
+	params {
+		param("TEST_GROUP", "@gutenberg")
+		param("CALYPSO_BASE_URL", "https://wordpress.com")
+		param("env.AUTHENTICATE_ACCOUNTS", "gutenbergSimpleSiteEdgeUser,gutenbergSimpleSiteUser,simpleSitePersonalPlanUser,gutenbergAtomicSiteUser,gutenbergAtomicSiteEdgeUser,gutenbergAtomicSiteEdgeNightliesUser")
+	}
+
+	features {
+		matrix {
+			param("PROJECT", listOf(
+				value("desktop", label = "Desktop"),
+				value("mobile", label = "Mobile"),
+			))
+			param("EXTRA_ENV_VARS", listOf(
+				value("", label = "Simple Production"),
+				value("GUTENBERG_EDGE=true", label = "Simple Edge"),
+				value("TEST_ON_ATOMIC=true", label = "Atomic Production"),
+				value("TEST_ON_ATOMIC=true,GUTENBERG_EDGE=true", label = "Atomic Edge"),
+				value("TEST_ON_ATOMIC=true,GUTENBERG_NIGHTLY=true", label = "Atomic Nightly"),
+			))
+		}
+		notifications {
+			notifierSettings = slackNotifier {
+				connection = "PROJECT_EXT_11"
+				sendTo = "#gutenberg-e2e"
+				messageFormat = verboseMessageFormat {
+					addBranch = true
+					addStatusText = true
+				}
+			}
+			branchFilter = "+:<default>"
+			buildFailed = true
+			buildFinishedSuccessfully = true
+		}
+	}
+
+	triggers {
+		schedule {
+			schedulingPolicy = daily {
+				hour = 4
 			}
 			branchFilter = "+:trunk"
 			triggerBuild = always()

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -479,9 +479,9 @@ private object GutenbergPlaywrightTests : BuildType({
 			param("EXTRA_ENV_VARS", listOf(
 				value("", label = "Simple Production"),
 				value("GUTENBERG_EDGE=true", label = "Simple Edge"),
-				value("TEST_ON_ATOMIC=true", label = "Atomic Production"),
-				value("TEST_ON_ATOMIC=true,GUTENBERG_EDGE=true", label = "Atomic Edge"),
-				value("TEST_ON_ATOMIC=true,GUTENBERG_NIGHTLY=true", label = "Atomic Nightly"),
+				value("TEST_ON_ATOMIC=true,PW_WORKERS=1", label = "Atomic Production"),
+				value("TEST_ON_ATOMIC=true,GUTENBERG_EDGE=true,PW_WORKERS=1", label = "Atomic Edge"),
+				value("TEST_ON_ATOMIC=true,GUTENBERG_NIGHTLY=true,PW_WORKERS=1", label = "Atomic Nightly"),
 			))
 		}
 		notifications {

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -31,6 +31,13 @@ const E2E_USER_AGENT_SUFFIX = 'wp-e2e-tests';
 
 const appendE2EUserAgent = ( userAgent: string ) => `${ userAgent } ${ E2E_USER_AGENT_SUFFIX }`;
 
+function getWorkers(): number | string {
+	if ( process.env.PW_WORKERS ) {
+		return parseInt( process.env.PW_WORKERS, 10 );
+	}
+	return process.env.CI ? '50%' : '100%';
+}
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -42,8 +49,7 @@ export default defineConfig( {
 	forbidOnly: !! process.env.CI,
 	/* Retry on CI only */
 	retries: process.env.CI ? 2 : 0,
-	/* Workers should use what is available locally, and half on CI*/
-	workers: process.env.CI ? '50%' : '100%',
+	workers: getWorkers(),
 	/* Global timeout for each test */
 	timeout: 120000, // 2 minutes
 	expect: {


### PR DESCRIPTION
Part of QAO-207

## Proposed Changes

- Adds a new GutenbergPlaywrightTests TeamCity build configuration for running migrated Gutenberg Playwright tests
- Uses a 2D matrix (viewport × site config) to cover all 10 combinations in a single config
- Adds generic EXTRA_ENV_VARS param to the E2E template for passing additional environment variables
- Added set_extra_env_vars step that parses and exports them as environment variables


## Testing instructions

- Verify TeamCity DSL syncs successfully (✅ ran the p2 tests build to validate the WPComTests.kt syntax is valid)
- After merge manually trigger a build and confirm:
    - Matrix spawns 10 jobs (2 viewports × 5 configs)
    - Env vars are set correctly (check build logs for ##teamcity[setParameter] output)
    - Tests run with `@gutenberg` tag filter