### PR TITLE
[A4A] Resource Center: Update copy and remove format filter

### DIFF
--- a/client/a8c-for-agencies/sections/learn/resource-center/overview-content/browse-all-resources.tsx
+++ b/client/a8c-for-agencies/sections/learn/resource-center/overview-content/browse-all-resources.tsx
@@ -36,7 +36,6 @@ export default function BrowseAllResources( {
 	const filterOptions = useMemo( () => {
 		const products = new Set< string >();
 		const resourceTypes = new Set< string >();
-		const formats = new Set< string >();
 
 		resources.forEach( ( resource ) => {
 			if ( resource.relatedProduct ) {
@@ -44,9 +43,6 @@ export default function BrowseAllResources( {
 			}
 			if ( resource.resourceType ) {
 				resourceTypes.add( resource.resourceType );
-			}
-			if ( resource.format ) {
-				formats.add( resource.format );
 			}
 		} );
 
@@ -56,10 +52,6 @@ export default function BrowseAllResources( {
 				label: value,
 			} ) ),
 			resourceTypes: Array.from( resourceTypes ).map( ( value ) => ( {
-				value,
-				label: value,
-			} ) ),
-			formats: Array.from( formats ).map( ( value ) => ( {
 				value,
 				label: value,
 			} ) ),
@@ -96,18 +88,6 @@ export default function BrowseAllResources( {
 				type: 'text',
 				getValue: ( { item } ) => item.resourceType,
 				elements: filterOptions.resourceTypes,
-				filterBy: {
-					operators: [ 'is' ],
-				},
-				enableSorting: false,
-				enableHiding: true,
-			},
-			{
-				id: 'format',
-				label: __( 'Format' ),
-				type: 'text',
-				getValue: ( { item } ) => item.format,
-				elements: filterOptions.formats,
 				filterBy: {
 					operators: [ 'is' ],
 				},

--- a/client/a8c-for-agencies/sections/learn/resource-center/overview-content/hooks/use-resource-cta-label.ts
+++ b/client/a8c-for-agencies/sections/learn/resource-center/overview-content/hooks/use-resource-cta-label.ts
@@ -10,10 +10,10 @@ export function useResourceCtaLabel( format: string ): string {
 		case 'Video':
 			return __( 'Watch now' );
 		case 'PDF':
-			return __( 'Download Guide' );
+			return __( 'Download guide' );
 		case 'Slide Deck':
-			return __( 'View Deck' );
+			return __( 'View deck' );
 		default:
-			return __( 'Read more' );
+			return __( 'Learn more' );
 	}
 }

--- a/client/a8c-for-agencies/sections/learn/resource-center/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/learn/resource-center/overview-content/index.tsx
@@ -50,7 +50,7 @@ export default function ResourceCenterOverviewContent( {
 			<Spacer marginBottom={ 8 } style={ { maxWidth: '650px' } }>
 				<Text size={ 15 }>
 					{ __(
-						"Explore our resource center for agencies, where you'll find exclusive materials designed to help you sell and integrate Automattic products effectively. These tools not only enhance your sales strategies but also support you in running your agency smoothly and maximizing conversions."
+						'Explore our resource center for agencies, with exclusive materials designed to help you grow and run your agency more effectively. You will find practical guidance, playbooks, and training, including resources to understand, position, and integrate Automattic products when they are the right fit.'
 					) }
 				</Text>
 			</Spacer>
@@ -66,8 +66,10 @@ export default function ResourceCenterOverviewContent( {
 			/>
 
 			<ResourceSection
-				title={ __( 'The art of the deal' ) }
-				description={ __( 'Learn tips from our world-class sales team to win clients!' ) }
+				title={ __( 'Client conversations that work' ) }
+				description={ __(
+					'Learn practical ways to have better client conversations, build trust, and guide decisions that lead to new business and extended partnerships.'
+				) }
 				resources={ artOfTheDealResources }
 				onOpenVideoModal={ handleOpenVideoModal }
 				maxResources={ 2 }

--- a/client/a8c-for-agencies/sections/learn/resource-center/overview-content/resource-section.tsx
+++ b/client/a8c-for-agencies/sections/learn/resource-center/overview-content/resource-section.tsx
@@ -41,7 +41,11 @@ export default function ResourceSection( {
 				<Heading level={ 2 } weight={ 500 } size={ 20 }>
 					{ title }
 				</Heading>
-				{ description && <Text size={ 15 }>{ description }</Text> }
+				{ description && (
+					<Text size={ 15 } style={ { display: 'block', maxWidth: '650px' } }>
+						{ description }
+					</Text>
+				) }
 			</Spacer>
 
 			<div className={ `resource-center-cards ${ className }` }>


### PR DESCRIPTION
## Proposed Changes

* Update copy/text in the Resource Center overview content
* Remove "format" filter from the browse all resources filters

## Why are these changes being made?

* This PR implements the team feedback requested during the CFT.

## Testing Instructions

1. Open the live link
2. Navigate to the Resource Center in A4A
3. Verify the updated copy appears correctly
4. Open the "Browse all resources" section
5. Verify that only "Product" and "Resource type" filters are available (format filter should be removed)
6. Test filtering functionality with the remaining filters

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
