### PR TITLE
MSD: Fix the default landing page

### DIFF
--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -1,4 +1,11 @@
-import { createRootRouteWithContext } from '@tanstack/react-router';
+import {
+	queryClient,
+	rawUserPreferencesQuery,
+	userSettingsQuery,
+	siteByIdQuery,
+} from '@automattic/api-queries';
+import { createRootRouteWithContext, redirect } from '@tanstack/react-router';
+import { wpcomLink } from '../../utils/link';
 import Root from '../root';
 import NotFoundRoot from '../root/error';
 import type { AppConfig } from '../context';
@@ -10,4 +17,40 @@ export type RootRouterContext = {
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
 	notFoundComponent: NotFoundRoot,
+	beforeLoad: async ( { location } ) => {
+		if ( location.pathname !== '/' ) {
+			return;
+		}
+
+		const userPreference = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
+		if ( userPreference[ 'sites-landing-page' ]?.useSitesAsLandingPage ) {
+			return;
+		}
+
+		if ( userPreference[ 'reader-landing-page' ]?.useReaderAsLandingPage ) {
+			throw redirect( { href: wpcomLink( '/reader' ), replace: true } );
+		}
+
+		const userSettings = await queryClient.ensureQueryData( userSettingsQuery() );
+		if ( userSettings.primary_site_ID ) {
+			let primarySite;
+			try {
+				primarySite = await queryClient.ensureQueryData(
+					siteByIdQuery( userSettings.primary_site_ID )
+				);
+			} catch ( e ) {
+				// Do nothing if the primary site is not available.
+				return;
+			}
+
+			if (
+				primarySite.options?.wpcom_admin_interface === 'wp-admin' &&
+				primarySite.options?.admin_url
+			) {
+				throw redirect( { href: primarySite.options?.admin_url, replace: true } );
+			}
+
+			throw redirect( { href: wpcomLink( `/home/${ primarySite.slug }` ), replace: true } );
+		}
+	},
 } );

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -22,7 +22,11 @@ export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 			return;
 		}
 
-		const userPreference = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
+		const [ userPreference, userSettings ] = await Promise.all( [
+			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+			queryClient.ensureQueryData( userSettingsQuery() ),
+		] );
+
 		if ( userPreference[ 'sites-landing-page' ]?.useSitesAsLandingPage ) {
 			return;
 		}
@@ -31,7 +35,6 @@ export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 			throw redirect( { href: wpcomLink( '/reader' ), replace: true } );
 		}
 
-		const userSettings = await queryClient.ensureQueryData( userSettingsQuery() );
 		if ( userSettings.primary_site_ID ) {
 			let primarySite;
 			try {

--- a/client/sites/v2/router.tsx
+++ b/client/sites/v2/router.tsx
@@ -13,7 +13,7 @@ import type { RootRouterContext } from 'calypso/dashboard/app/router/root';
  */
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
-	beforeLoad: async () => {},
+	beforeLoad: async () => {}, // Empty beforeLoad is required to maintain type compatibility with MSD
 } );
 
 export const dashboardSitesCompatibilityRoute = createRoute( {

--- a/client/sites/v2/router.tsx
+++ b/client/sites/v2/router.tsx
@@ -13,7 +13,9 @@ import type { RootRouterContext } from 'calypso/dashboard/app/router/root';
  */
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
-	beforeLoad: async () => {}, // Empty beforeLoad is required to maintain type compatibility with MSD
+	// Empty beforeLoad is required to maintain type compatibility with MSD
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	beforeLoad: async ( { location } ) => {},
 } );
 
 export const dashboardSitesCompatibilityRoute = createRoute( {

--- a/client/sites/v2/router.tsx
+++ b/client/sites/v2/router.tsx
@@ -11,7 +11,10 @@ import type { RootRouterContext } from 'calypso/dashboard/app/router/root';
 /**
  * Define general routes
  */
-export const rootRoute = createRootRouteWithContext< RootRouterContext >()( { component: Root } );
+export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
+	component: Root,
+	beforeLoad: async () => {},
+} );
 
 export const dashboardSitesCompatibilityRoute = createRoute( {
 	getParentRoute: () => rootRoute,

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -56,6 +56,7 @@ export const SITE_OPTIONS = [
 	'software_version',
 	'updated_at',
 	'woocommerce_is_active',
+	'wpcom_admin_interface',
 	'wpcom_production_blog_id',
 ];
 

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -35,6 +35,7 @@ export interface SiteOptions {
 	unmapped_url?: string;
 	wordads?: boolean;
 	woocommerce_is_active?: boolean;
+	wpcom_admin_interface?: string;
 	wpcom_production_blog_id?: number;
 	wpcom_staging_blog_ids?: number[];
 	import_engine?: string | null;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1768829160869159-slack-C08JZTRS6NA

## Proposed Changes

* Fix the default landing page on MSD

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The setting doesn't work on MSD

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me/preferences
* Update `Default landing page` and `Primary site`
* Ensure it works as below when you visit `/` directly
  * `Open your primary site’s dashboard` - Open either WP Admin or My Home on your primary site 
  * `See a list of all your sites` - Nothing changed. It opens as before
  * `View posts from sites you follow` - It opens the Reader

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?