### PR TITLE
Fix hosting features callout positioning on Staging Site tab

### DIFF
--- a/client/sites/hosting/controller.tsx
+++ b/client/sites/hosting/controller.tsx
@@ -1,7 +1,5 @@
 import { type Site, DotcomFeatures } from '@automattic/api-core';
 import { AnalyticsProvider } from 'calypso/dashboard/app/analytics';
-import { CalloutOverlay } from 'calypso/dashboard/components/callout-overlay';
-import PageLayout from 'calypso/dashboard/components/page-layout';
 import { hasPlanFeature } from 'calypso/dashboard/utils/site-features';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -33,20 +31,14 @@ export function hostingFeatures( context: PageJSContext, next: () => void ) {
 		}
 
 		content = (
-			<>
+			<div className="hosting-features-callout">
 				<PageViewTracker title="Sites > Hosting Features" path={ path } />
-				<PageLayout>
-					<CalloutOverlay
-						callout={
-							shouldShowActivationCallout ? (
-								<HostingActivationCallout path={ path } site={ site } redirectUrl={ redirectUrl } />
-							) : (
-								<HostingUpsellCallout siteSlug={ site.slug } />
-							)
-						}
-					/>
-				</PageLayout>
-			</>
+				{ shouldShowActivationCallout ? (
+					<HostingActivationCallout path={ path } site={ site } redirectUrl={ redirectUrl } />
+				) : (
+					<HostingUpsellCallout siteSlug={ site.slug } />
+				) }
+			</div>
 		);
 	} else {
 		content = <HostingFeatures path={ path } />;


### PR DESCRIPTION
## Proposed Changes

* Changed the hosting features page (`/hosting-features/:site`) to use the same callout structure as other tabs like Performance
* Removed incorrect usage of `CalloutOverlay` component
* Wrapped callout in `<div className="hosting-features-callout">` for proper centering

| Before | After |
| --- | --- |
| <img width="1888" height="1180" alt="SCR-20260120-msdc" src="https://github.com/user-attachments/assets/c8f2399a-3cf2-48f9-8951-4e61ecda1b2c" /> |  <img width="1889" height="1186" alt="SCR-20260120-msad" src="https://github.com/user-attachments/assets/e42c7492-cde0-4427-9bf2-d42010ba224d" /> |

## Why are these changes being made?

The "Activate hosting features" callout on the Staging Site tab was misaligned compared to other tabs. The hosting features page was incorrectly using `CalloutOverlay` which is meant for overlaying content with blur effects, rather than the simpler centered callout pattern used elsewhere.

**Before (incorrect structure):**
```jsx
<PageLayout>
  <CalloutOverlay
    callout={<HostingActivationCallout ... />}
  />
</PageLayout>
```

**After (matches other tabs like Performance):**
```jsx
<div className="hosting-features-callout">
  <PageViewTracker ... />
  <HostingActivationCallout ... />
</div>
```

This matches the pattern in `hostingFeaturesCallout` middleware used by Performance tab (`client/hosting/performance/controller.tsx:21-24`):
```jsx
context.primary = (
  <div className="hosting-features-callout">
    <PageViewTracker ... />
    { callout }
  </div>
);
```

The `hosting-features-callout` CSS class provides centering via flexbox (`client/sites/hosting/style.scss`).

## Testing Instructions

* Navigate to a site that requires hosting feature activation (has Business plan but hasn't activated hosting features)
* Click on the Staging Site tab
* Verify the "Activate hosting features" callout is centered correctly
* Compare with the Performance tab - both should have identical callout positioning

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Using memoizing selectors and Our Approach to Data
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?