### PR TITLE
Update SitesDropdown to remove staging sites.

### DIFF
--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -62,7 +62,7 @@ export class SitesDropdown extends PureComponent {
 
 	// Our filter prop handles siteIds, while SiteSelector's filter prop needs objects
 	siteFilter( site ) {
-		return this.props.filter( site.ID );
+		return this.props.filter( site.ID, site );
 	}
 
 	toggleOpen() {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -531,6 +531,7 @@ class Account extends Component {
 				selectedSiteId={ primarySiteId }
 				onSiteSelect={ this.onSiteSelect }
 				disabled={ this.state.submittingForm }
+				filter={ ( siteId, site ) => ! site?.is_wpcom_staging_site }
 			/>
 		);
 	}


### PR DESCRIPTION
Part of DOTMSD-220

Related to #108019

## Proposed Changes

Filter out staging sites from the Primary Site dropdown in `/me/account`.

## Why are these changes being made?

We're removing staging sites from the site lists in the Multi-site dashboard, which will include the primary site selector in the new dashboard profile settings. Since the API changes will also backport the staging site removal for the Hosting dashboard v1 sites list, we should also make the primary site selectors consistent as well and remove it there.

## Testing Instructions

With a staging site:
- Navigate to `me/account`
- Open your Primary site dropdown
- Search for your staging site
- Expect it **not** to be found.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
