### PR TITLE
Implement the var1d design

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -22,7 +22,7 @@ type PlanDifferentiatorsExperimentResult = {
 	isShortSet: boolean;
 	/**
 	 * When true, show the differentiator header (3 bullet points).
-	 * Applies to: var1d
+	 * Currently disabled for all variants.
 	 */
 	showDifferentiatorHeader: boolean;
 	/**
@@ -96,7 +96,7 @@ function usePlanDifferentiatorsExperiment( {
 			variant === 'var1' || variant === 'var1d' || variant === 'var3' || variant === 'var5',
 		isLongSet: variant === 'var3' || variant === 'var4',
 		isShortSet: variant === 'var1' || variant === 'var1d' || variant === 'var5',
-		showDifferentiatorHeader: variant === 'var1d',
+		showDifferentiatorHeader: false,
 		useVar5Features: variant === 'var5',
 		useVar4Features: variant === 'var4',
 		useVar3Features: variant === 'var3',

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -46,6 +46,11 @@ type PlanDifferentiatorsExperimentResult = {
 	 */
 	useVar1Features: boolean;
 	/**
+	 * When true, the user is specifically in the var1d variant.
+	 * Used to apply differentiator styling to features below "Everything in X" headers.
+	 */
+	isVar1dVariant: boolean;
+	/**
 	 * When true, the user is in an experiment variant (not control).
 	 */
 	isExperimentVariant: boolean;
@@ -96,6 +101,7 @@ function usePlanDifferentiatorsExperiment( {
 		useVar4Features: variant === 'var4',
 		useVar3Features: variant === 'var3',
 		useVar1Features: variant === 'var1' || variant === 'var1d',
+		isVar1dVariant: variant === 'var1d',
 		isExperimentVariant,
 	};
 }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -387,6 +387,7 @@ const PlansFeaturesMain = ( {
 		useVar3Features,
 		useVar4Features,
 		useVar5Features,
+		isVar1dVariant,
 		isExperimentVariant,
 	} = usePlanDifferentiatorsExperiment( { flowName, intent, isInSignup } );
 
@@ -469,6 +470,7 @@ const PlansFeaturesMain = ( {
 		useShortSetStackedFeatures: useVar1Features,
 		useVar5Features,
 		isExperimentVariant,
+		isVar1dVariant,
 	} );
 
 	// we need only the visible ones for features grid (these should extend into plans-ui data store selectors)
@@ -497,6 +499,7 @@ const PlansFeaturesMain = ( {
 		useShortSetStackedFeatures: useVar1Features,
 		useVar5Features,
 		isExperimentVariant,
+		isVar1dVariant,
 	} );
 
 	// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -950,6 +950,7 @@ const PlansFeaturesMain = ( {
 										enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 										showSimplifiedBillingDescription={ isInSignup }
 										showBillingDescriptionForIncreasedRenewalPrice={ renewalPricingVariation }
+										isVar1dVariant={ isVar1dVariant }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -536,6 +536,9 @@ export const FEATURE_EVERYTHING_IN_PERSONAL_PLUS = 'feature-everything-in-person
 export const FEATURE_EVERYTHING_IN_PREMIUM_PLUS = 'feature-everything-in-premium-plus';
 export const FEATURE_EVERYTHING_IN_BUSINESS_PLUS = 'feature-everything-in-business-plus';
 
+// "Included in plan:" header for Free plan in stacked variants
+export const FEATURE_INCLUDED_IN_PLAN = 'feature-included-in-plan';
+
 // Additional features for plan differentiators experiment
 export const FEATURE_PROFESSIONAL_EMAIL_FREE_YEAR = 'feature-professional-email-free-year';
 export const FEATURE_BLAZE_AD_CREDITS = 'feature-blaze-ad-credits';

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -342,6 +342,7 @@ import {
 	FEATURE_AI_WEBSITE_BUILDER_LIMITED,
 	FEATURE_AI_WRITER_DESIGNER,
 	FEATURE_AI_WRITER_DESIGNER_LIMITED,
+	FEATURE_INCLUDED_IN_PLAN,
 	FEATURE_EVERYTHING_IN_FREE_PLUS,
 	FEATURE_EVERYTHING_IN_PERSONAL_PLUS,
 	FEATURE_EVERYTHING_IN_PREMIUM_PLUS,
@@ -2865,6 +2866,12 @@ const FEATURES_LIST: FeatureList = {
 				: i18n.translate( 'AI Writer & Designer (limited)' ),
 		getDescription: () =>
 			i18n.translate( 'Enhance your content creation with AI-powered writing and design.' ),
+	},
+
+	// "Included in plan:" header for Free plan in stacked variants
+	[ FEATURE_INCLUDED_IN_PLAN ]: {
+		getSlug: () => FEATURE_INCLUDED_IN_PLAN,
+		getTitle: () => i18n.translate( 'Included in plan:' ),
 	},
 
 	// "Everything in X, plus:" features for stacked variants

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -468,6 +468,7 @@ import {
 	FEATURE_AI_WEBSITE_BUILDER_LIMITED,
 	FEATURE_AI_WRITER_DESIGNER,
 	FEATURE_AI_WRITER_DESIGNER_LIMITED,
+	FEATURE_INCLUDED_IN_PLAN,
 	FEATURE_EVERYTHING_IN_FREE_PLUS,
 	FEATURE_EVERYTHING_IN_PERSONAL_PLUS,
 	FEATURE_EVERYTHING_IN_PREMIUM_PLUS,
@@ -630,6 +631,7 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 
 	// Stacked variant: same as above for Free (no previous plan)
 	getLongSetStackedSignupWpcomFeatures: () => [
+		FEATURE_INCLUDED_IN_PLAN,
 		FEATURE_UNLIMITED_ENTITIES,
 		FEATURE_BANDWIDTH,
 		FEATURE_SECURITY_BRUTE_FORCE,
@@ -639,6 +641,7 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 
 	// Short set stacked: Free matches the long stacked base set (no previous plan)
 	getShortSetStackedSignupWpcomFeatures: () => [
+		FEATURE_INCLUDED_IN_PLAN,
 		FEATURE_UNLIMITED_ENTITIES,
 		FEATURE_BANDWIDTH,
 		FEATURE_SECURITY_BRUTE_FORCE,
@@ -647,7 +650,7 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 	],
 
 	// Var5 stacked: copies getShortSetStackedSignupWpcomFeatures for var5 variant
-	getVar5StackedSignupWpcomFeatures: () => [ FEATURE_UNLIMITED_ENTITIES ],
+	getVar5StackedSignupWpcomFeatures: () => [ FEATURE_INCLUDED_IN_PLAN, FEATURE_UNLIMITED_ENTITIES ],
 
 	get2023PlanComparisonFeatureOverride: () => {
 		return [

--- a/packages/plans-grid-next/src/_shared.scss
+++ b/packages/plans-grid-next/src/_shared.scss
@@ -191,7 +191,8 @@ $storage-feature-label-y-padding: 4px;
 	 *****************************/
 
 	&.is-var1d-variant {
-		margin-bottom: 26px;
+		margin-top: 11px;
+		margin-bottom: 14px;
 
 		button[role="combobox"] {
 			height: 26px;

--- a/packages/plans-grid-next/src/_shared.scss
+++ b/packages/plans-grid-next/src/_shared.scss
@@ -193,6 +193,9 @@ $storage-feature-label-y-padding: 4px;
 	&.is-var1d-variant {
 		margin-top: 11px;
 		margin-bottom: 14px;
+		div[class*="input-control"] {
+			border: none;
+		}
 
 		button[role="combobox"] {
 			height: 26px;

--- a/packages/plans-grid-next/src/_shared.scss
+++ b/packages/plans-grid-next/src/_shared.scss
@@ -106,6 +106,15 @@ $storage-feature-label-y-padding: 4px;
 			}
 		}
 	}
+
+	// var1d experiment: storage label styling
+	.is-var1d-variant & {
+		padding: 0 11px;
+		background: var(--studio-gray-0);
+		border-radius: 4px;
+		line-height: 26px;
+		height: 26px;
+	}
 }
 
 .plans-grid-next-plan-storage {
@@ -173,6 +182,32 @@ $storage-feature-label-y-padding: 4px;
 				li {
 					text-align: left;
 				}
+			}
+		}
+	}
+
+	/*****************************
+	 * var1d experiment styling *
+	 *****************************/
+
+	&.is-var1d-variant {
+		margin-bottom: 26px;
+
+		button[role="combobox"] {
+			height: 26px;
+			min-height: 26px;
+			padding: 0 11px;
+			background: var(--studio-gray-0);
+			border-radius: 4px;
+			font-size: $font-body-extra-small;
+
+			.title {
+				font-weight: 400;
+			}
+
+			.plans-grid-next-storage-dropdown__option {
+				padding-top: 2px;
+				min-height: auto;
 			}
 		}
 	}

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -398,6 +398,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		enableTermSavingsPriceDisplay,
 		showSimplifiedBillingDescription,
 		showBillingDescriptionForIncreasedRenewalPrice,
+		isVar1dVariant,
 	} = props;
 
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -459,6 +460,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				showBillingDescriptionForIncreasedRenewalPrice={
 					showBillingDescriptionForIncreasedRenewalPrice
 				}
+				isVar1dVariant={ isVar1dVariant }
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />
 			</PlansGridContextProvider>

--- a/packages/plans-grid-next/src/components/features-grid/mobile-free-domain.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/mobile-free-domain.tsx
@@ -5,6 +5,7 @@ import {
 	isWpcomEnterpriseGridPlan,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
+import { usePlansGridContext } from '../../grid-context';
 import { GridPlan } from '../../types';
 import { PlanFeaturesItem } from '../item';
 
@@ -18,6 +19,12 @@ const MobileFreeDomain = ( {
 	paidDomainName,
 }: MobileFreeDomainProps ) => {
 	const translate = useTranslate();
+	const { isVar1dVariant } = usePlansGridContext();
+
+	// For var1d, don't render the highlighted free domain - it appears in regular feature list
+	if ( isVar1dVariant ) {
+		return null;
+	}
 
 	if ( isMonthlyPlan || isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug ) ) {
 		return null;

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -372,6 +372,22 @@
 			font-weight: 600;
 		}
 
+		// var1d experiment: differentiator feature styling
+		// Features below "Everything in X, plus:" get distinctive underline treatment
+		&.is-differentiator-feature {
+			color: var(--studio-gray-90);
+			font-size: $font-body-extra-small;
+			font-weight: 400;
+			line-height: 16px;
+			text-decoration-line: underline;
+			text-decoration-style: dotted;
+			text-decoration-skip-ink: none;
+			text-decoration-color: #00ba37;
+			text-decoration-thickness: 9%;
+			text-underline-offset: auto;
+			text-underline-position: from-font;
+		}
+
 		@include plans-grid-medium-large {
 			font-size: $font-body-extra-small;
 			line-height: 16px;
@@ -391,6 +407,17 @@
 		& > li {
 			margin-top: 8px;
 		}
+	}
+}
+
+// var1d experiment: 16px vertical margin between differentiator features
+.plan-features-2023-grid__table-item .is-differentiator-feature {
+	.plan-features-2023-grid__item {
+		padding-block-end: 16px;
+	}
+
+	&.is-last-feature .plan-features-2023-grid__item {
+		padding-block-end: 0;
 	}
 }
 

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -423,10 +423,10 @@
 	}
 }
 
-// var1d experiment: 18px vertical margin between differentiator features
+// var1d experiment: 17px vertical margin between differentiator features
 .plan-features-2023-grid__table-item .is-differentiator-feature {
 	.plan-features-2023-grid__item {
-		padding-block-end: 18px;
+		padding-block-end: 17px;
 	}
 
 	&.is-last-feature .plan-features-2023-grid__item {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -375,17 +375,23 @@
 		// var1d experiment: differentiator feature styling
 		// Features below "Everything in X, plus:" get distinctive underline treatment
 		&.is-differentiator-feature {
+			display: flex;
+			align-items: flex-start;
 			color: var(--studio-gray-90);
 			font-size: $font-body-extra-small;
 			font-weight: 400;
 			line-height: 16px;
-			text-decoration-line: underline;
-			text-decoration-style: dotted;
-			text-decoration-skip-ink: none;
-			text-decoration-color: #00ba37;
-			text-decoration-thickness: 9%;
-			text-underline-offset: auto;
-			text-underline-position: from-font;
+
+			// Apply underline styling only to the text, not the icon
+			> span {
+				text-decoration-line: underline;
+				text-decoration-style: dotted;
+				text-decoration-skip-ink: none;
+				text-decoration-color: #00ba37;
+				text-decoration-thickness: 9%;
+				text-underline-offset: auto;
+				text-underline-position: from-font;
+			}
 		}
 
 		@include plans-grid-medium-large {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -382,6 +382,12 @@
 			font-weight: 400;
 			line-height: 16px;
 
+			// Make the tooltip hover area a flex container so text doesn't wrap under icon
+			.plans-2023-tooltip__hover-area-container {
+				display: flex;
+				align-items: flex-start;
+			}
+
 			// Apply underline styling only to the text, not the icon
 			> span {
 				text-decoration-line: underline;

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -428,6 +428,16 @@
 	}
 }
 
+// var1d experiment: 24px bottom margin after last feature
+.plan-features-2023-grid__table-item .is-var1d-last-feature {
+	margin-block-end: 24px;
+}
+
+// Other experiment variants (var1, var3, var4, var5): 37px bottom margin after last feature
+.plan-features-2023-grid__table-item .is-experiment-last-feature {
+	margin-block-end: 37px;
+}
+
 .plan-features-2023-grid__row:last-of-type .plan-features-2023-grid__table-item {
 	border-bottom: solid 1px var(--color-neutral-5);
 

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -410,6 +410,13 @@
 	}
 }
 
+// var1d experiment: 26px margin after header features ("Included in plan:" / "Everything in X, plus:")
+.plan-features-2023-grid__table-item .is-header-feature {
+	.plan-features-2023-grid__item {
+		padding-block-end: 26px;
+	}
+}
+
 // var1d experiment: 16px vertical margin between differentiator features
 .plan-features-2023-grid__table-item .is-differentiator-feature {
 	.plan-features-2023-grid__item {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -417,10 +417,10 @@
 	}
 }
 
-// var1d experiment: 16px vertical margin between differentiator features
+// var1d experiment: 18px vertical margin between differentiator features
 .plan-features-2023-grid__table-item .is-differentiator-feature {
 	.plan-features-2023-grid__item {
-		padding-block-end: 16px;
+		padding-block-end: 18px;
 	}
 
 	&.is-last-feature .plan-features-2023-grid__item {

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -107,6 +107,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 					'is-last-feature': featureIndex + 1 === features.length,
 					'has-min-height': featuresWithMinHeight.includes( featureSlug ),
 					'is-differentiator-feature': currentFeature.isDifferentiatorFeature,
+					'is-header-feature': currentFeature.isHeaderFeature,
 				} );
 				const spanClasses = clsx( 'plan-features-2023-grid__item-info', {
 					'is-annual-plan-feature': currentFeature.availableOnlyForAnnualPlans,

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -22,6 +22,25 @@ const SubdomainSuggestion = styled.div`
 	}
 `;
 
+// var1d experiment: Badge displayed after feature title
+const FeatureBadge = styled.span`
+	display: inline-flex;
+	height: 18px;
+	padding: 0 6px;
+	justify-content: center;
+	align-items: center;
+	gap: 8px;
+	border-radius: 4px;
+	background: #d7ffba;
+	color: #008a20;
+	text-align: center;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 20px;
+	margin-inline-start: 8px;
+	vertical-align: middle;
+`;
+
 const FreePlanCustomDomainFeature: React.FC< {
 	paidDomainName: string;
 	generatedWPComSubdomain?: DataResponse< { domain_name: string } >;
@@ -158,6 +177,9 @@ const PlanFeatures2023GridFeatures: React.FC< {
 												{ currentFeature.getTitle( {
 													domainName: paidDomainName,
 												} ) }
+												{ currentFeature.badgeText && (
+													<FeatureBadge>{ currentFeature.badgeText }</FeatureBadge>
+												) }
 												{ currentFeature?.getSubFeatureObjects?.()?.length ? (
 													<ul className="plan-features-2023-grid__item-sub-feature-list">
 														{ currentFeature.getSubFeatureObjects().map( ( subFeature ) => (

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -108,6 +108,8 @@ const PlanFeatures2023GridFeatures: React.FC< {
 					'has-min-height': featuresWithMinHeight.includes( featureSlug ),
 					'is-differentiator-feature': currentFeature.isDifferentiatorFeature,
 					'is-header-feature': currentFeature.isHeaderFeature,
+					'is-var1d-last-feature': currentFeature.isVar1dLastFeature,
+					'is-experiment-last-feature': currentFeature.isExperimentLastFeature,
 				} );
 				const spanClasses = clsx( 'plan-features-2023-grid__item-info', {
 					'is-annual-plan-feature': currentFeature.availableOnlyForAnnualPlans,

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -106,6 +106,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				const divClasses = clsx( '', getPlanClass( planSlug ), {
 					'is-last-feature': featureIndex + 1 === features.length,
 					'has-min-height': featuresWithMinHeight.includes( featureSlug ),
+					'is-differentiator-feature': currentFeature.isDifferentiatorFeature,
 				} );
 				const spanClasses = clsx( 'plan-features-2023-grid__item-info', {
 					'is-annual-plan-feature': currentFeature.availableOnlyForAnnualPlans,
@@ -114,6 +115,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				} );
 				const itemTitleClasses = clsx( 'plan-features-2023-grid__item-title', {
 					'is-bold': isHighlightedFeature,
+					'is-differentiator-feature': currentFeature.isDifferentiatorFeature,
 				} );
 
 				return (

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -41,6 +41,21 @@ const FeatureBadge = styled.span`
 	vertical-align: middle;
 `;
 
+// var1d experiment: Checkmark bullet icon for differentiator features
+const DifferentiatorCheckIcon = () => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="16"
+		height="20"
+		viewBox="0 0 16 20"
+		fill="none"
+		style={ { flexShrink: 0, marginInlineEnd: '8px', verticalAlign: 'top' } }
+	>
+		<circle opacity="0.13" cx="8" cy="10" r="8" fill="#9CA0B2" />
+		<path d="M5 9.77778L7.14286 12L11 8" stroke="#5B5E6C" strokeWidth="1.2" />
+	</svg>
+);
+
 const FreePlanCustomDomainFeature: React.FC< {
 	paidDomainName: string;
 	generatedWPComSubdomain?: DataResponse< { domain_name: string } >;
@@ -174,6 +189,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 											id={ key }
 										>
 											<>
+												{ currentFeature.isDifferentiatorFeature && <DifferentiatorCheckIcon /> }
 												{ currentFeature.getTitle( {
 													domainName: paidDomainName,
 												} ) }

--- a/packages/plans-grid-next/src/components/plans-2023-tooltip.tsx
+++ b/packages/plans-grid-next/src/components/plans-2023-tooltip.tsx
@@ -4,9 +4,7 @@ import { TranslateResult } from 'i18n-calypso';
 import { Dispatch, PropsWithChildren, SetStateAction, useRef } from 'react';
 import { hasTouch } from '../lib/touch-detect';
 
-const HoverAreaContainer = styled.span`
-	max-width: 220px;
-`;
+const HoverAreaContainer = styled.span``;
 
 const StyledTooltip = styled( Tooltip )`
 	&.tooltip.popover .popover__inner {

--- a/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
@@ -1,5 +1,6 @@
 import { type PlanSlug, isWpcomEnterpriseGridPlan } from '@automattic/calypso-products';
 import { AddOns } from '@automattic/data-stores';
+import clsx from 'clsx';
 import { usePlansGridContext } from '../../../../grid-context';
 import { ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE } from '../constants';
 import StorageDropdown from './storage-dropdown';
@@ -20,7 +21,7 @@ const PlanStorage = ( {
 	options,
 	showUpgradeableStorage,
 }: Props ) => {
-	const { siteId, gridPlansIndex } = usePlansGridContext();
+	const { siteId, gridPlansIndex, isVar1dVariant } = usePlansGridContext();
 	const { availableForPurchase, current, planTitle } = gridPlansIndex[ planSlug ];
 	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId } );
 
@@ -37,8 +38,12 @@ const PlanStorage = ( {
 		availableStorageAddOns.length &&
 		ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE.includes( planSlug );
 
+	const containerClasses = clsx( 'plans-grid-next-plan-storage', {
+		'is-var1d-variant': isVar1dVariant,
+	} );
+
 	return (
-		<div className="plans-grid-next-plan-storage" data-plan-title={ planTitle }>
+		<div className={ containerClasses } data-plan-title={ planTitle }>
 			{ canUpgradeStorageForPlan ? (
 				<StorageDropdown planSlug={ planSlug } onStorageAddOnClick={ onStorageAddOnClick } />
 			) : (

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
@@ -41,14 +41,19 @@ const StorageDropdownOption = ( {
 	const addOnStorageString = useStorageString( addOnStorage || 0 );
 
 	const title = addOnStorage
-		? translate( '%(planStorageString)s + %(addOnStorageString)s', {
+		? translate( '%(planStorageString)s + %(addOnStorageString)s storage', {
 				args: {
 					planStorageString,
 					addOnStorageString,
 				},
+				comment: 'Storage option with add-on. Example: "50GB + 100GB storage"',
 		  } )
-		: planStorageString;
+		: translate( '%(planStorageString)s storage', {
+				args: { planStorageString },
+				comment: 'Storage option. Example: "50GB storage"',
+		  } );
 
+	// Only show price for add-on options, not for the base plan storage
 	const priceString =
 		price && addOnStorage
 			? translate( '%(price)s/month, billed yearly', {
@@ -56,13 +61,13 @@ const StorageDropdownOption = ( {
 					comment:
 						'The cost of a storage add on per month. Example reads as "$50/month, billed yearly"',
 			  } )
-			: translate( 'Included in plan' );
+			: null;
 
 	return priceOnSeparateLine ? (
 		<span className="plans-grid-next-storage-dropdown__option-title">{ title }</span>
 	) : (
 		<DropdownOption className="plans-grid-next-storage-dropdown__option" title={ title }>
-			<div>{ priceString }</div>
+			{ priceString && <div>{ priceString }</div> }
 		</DropdownOption>
 	);
 };
@@ -141,13 +146,17 @@ const StorageDropdown = ( { planSlug, onStorageAddOnClick }: StorageDropdownProp
 	const planStorageString = useStorageString( planStorage );
 	const selectedAddOnStorageString = useStorageString( selectedStorageAddOnStorage );
 	const accessibleOptionName = selectedStorageAddOnStorage
-		? translate( '%(planStorageString)s + %(addOnStorageString)s', {
+		? translate( '%(planStorageString)s + %(addOnStorageString)s storage', {
 				args: {
 					planStorageString,
 					addOnStorageString: selectedAddOnStorageString,
 				},
+				comment: 'Storage amount display with add-on. Example: "50GB + 100GB storage"',
 		  } )
-		: planStorageString;
+		: translate( '%(planStorageString)s storage', {
+				args: { planStorageString },
+				comment: 'Storage amount display. Example: "50GB storage"',
+		  } );
 
 	const selectedOption = {
 		key: selectedStorageOptionForPlan,

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -33,6 +33,7 @@ interface PlansGridContext {
 	reflectStorageSelectionInPlanPrices?: boolean;
 	showSimplifiedBillingDescription?: boolean;
 	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
+	isVar1dVariant?: boolean;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
@@ -60,6 +61,7 @@ const PlansGridContextProvider = ( {
 	reflectStorageSelectionInPlanPrices,
 	showSimplifiedBillingDescription,
 	showBillingDescriptionForIncreasedRenewalPrice,
+	isVar1dVariant,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
@@ -96,6 +98,7 @@ const PlansGridContextProvider = ( {
 				reflectStorageSelectionInPlanPrices,
 				showSimplifiedBillingDescription,
 				showBillingDescriptionForIncreasedRenewalPrice,
+				isVar1dVariant,
 			} }
 		>
 			{ children }

--- a/packages/plans-grid-next/src/hooks/data-store/types.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/types.ts
@@ -55,6 +55,11 @@ export interface UseGridPlansParams {
 	 * When true, the user is in an experiment variant (not control).
 	 */
 	isExperimentVariant?: boolean;
+	/**
+	 * When true, mark features after "Everything in X, plus:" header as differentiator features.
+	 * Used for var1d experiment variant styling.
+	 */
+	isVar1dVariant?: boolean;
 }
 
 export type UseGridPlansType = (

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
@@ -35,6 +35,7 @@ const useGridPlansForComparisonGrid = ( {
 	useShortSetStackedFeatures,
 	useVar5Features,
 	isExperimentVariant,
+	isVar1dVariant,
 }: UseGridPlansParams ): GridPlan[] | null => {
 	const gridPlans = useGridPlans( {
 		allFeaturesList,
@@ -71,6 +72,7 @@ const useGridPlansForComparisonGrid = ( {
 		useShortSetStackedFeatures,
 		useVar5Features,
 		isExperimentVariant,
+		isVar1dVariant,
 	} );
 
 	return useMemo( () => {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
@@ -31,6 +31,7 @@ const useGridPlansForFeaturesGrid = ( {
 	useShortSetStackedFeatures,
 	useVar5Features,
 	isExperimentVariant,
+	isVar1dVariant,
 }: UseGridPlansParams ): GridPlan[] | null => {
 	const gridPlans = useGridPlans( {
 		allFeaturesList,
@@ -70,6 +71,7 @@ const useGridPlansForFeaturesGrid = ( {
 		useShortSetStackedFeatures,
 		useVar5Features,
 		isExperimentVariant,
+		isVar1dVariant,
 	} );
 
 	return useMemo( () => {

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -1,9 +1,17 @@
 import {
 	FEATURE_CUSTOM_DOMAIN,
+	FEATURE_UPLOAD_PLUGINS,
+	FEATURE_SIMPLE_PAYMENTS,
+	FEATURE_WORDADS,
+	FEATURE_AI_WEBSITE_BUILDER,
+	FEATURE_AI_WRITER_DESIGNER,
+	FEATURE_PROFESSIONAL_EMAIL_FREE_YEAR,
+	FEATURE_EARLY_ONBOARDING_CALLS,
 	applyTestFiltersToPlansList,
 	isMonthly,
 } from '@automattic/calypso-products';
 import { useMemo } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
 import getPlanFeaturesObject from '../../lib/get-plan-features-object';
 import useHighlightedFeatures from './use-highlighted-features';
 import type {
@@ -13,6 +21,7 @@ import type {
 	GridPlan,
 } from '../../types';
 import type { FeatureObject, FeatureList } from '@automattic/calypso-products';
+import type { TranslateResult } from 'i18n-calypso';
 
 export type UsePlanFeaturesForGridPlans = ( {
 	gridPlans,
@@ -72,6 +81,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 	isExperimentVariant,
 	isVar1dVariant,
 } ) => {
+	const translate = useTranslate();
 	const highlightedFeatures = useHighlightedFeatures( { intent: intent ?? null, isInSignup } );
 	return useMemo( () => {
 		return gridPlans.reduce(
@@ -294,6 +304,18 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 					// Track whether we've passed a header feature for var1d styling
 					let passedHeaderFeature = false;
 
+					// var1d badge mapping for specific features
+					const var1dBadgeMap: Record< string, TranslateResult > = {
+						[ FEATURE_CUSTOM_DOMAIN ]: translate( 'Free' ),
+						[ FEATURE_UPLOAD_PLUGINS ]: translate( 'New' ),
+						[ FEATURE_SIMPLE_PAYMENTS ]: translate( 'New' ),
+						[ FEATURE_WORDADS ]: translate( 'New' ),
+						[ FEATURE_AI_WEBSITE_BUILDER ]: translate( 'AI' ),
+						[ FEATURE_AI_WRITER_DESIGNER ]: translate( 'AI' ),
+						[ FEATURE_PROFESSIONAL_EMAIL_FREE_YEAR ]: translate( 'New' ),
+						[ FEATURE_EARLY_ONBOARDING_CALLS ]: translate( 'Free' ),
+					};
+
 					wpcomFeatures.forEach( ( feature ) => {
 						// topFeature and highlightedFeatures are already added to the list above
 						const isHighlightedFeature =
@@ -325,6 +347,9 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 							passedHeaderFeature = true;
 						}
 
+						// Get badge text for var1d variant
+						const badgeText = isVar1dVariant ? var1dBadgeMap[ featureSlug ] : undefined;
+
 						wpcomFeaturesTransformed.push( {
 							...feature,
 							availableOnlyForAnnualPlans,
@@ -332,6 +357,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 							...( isHeaderFeature && { isHighlighted: true } ),
 							...( isHeaderFeature && isVar1dVariant && { isHeaderFeature: true } ),
 							...( shouldMarkAsDifferentiator && { isDifferentiatorFeature: true } ),
+							...( badgeText && { badgeText } ),
 						} );
 					} );
 
@@ -379,6 +405,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 		useVar5Features,
 		isExperimentVariant,
 		isVar1dVariant,
+		translate,
 	] );
 };
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -334,6 +334,16 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 							...( shouldMarkAsDifferentiator && { isDifferentiatorFeature: true } ),
 						} );
 					} );
+
+					// Mark the last feature with variant-specific styling for bottom margin
+					if ( wpcomFeaturesTransformed.length > 0 ) {
+						const lastIndex = wpcomFeaturesTransformed.length - 1;
+						if ( isVar1dVariant ) {
+							wpcomFeaturesTransformed[ lastIndex ].isVar1dLastFeature = true;
+						} else if ( isExperimentVariant ) {
+							wpcomFeaturesTransformed[ lastIndex ].isExperimentLastFeature = true;
+						}
+					}
 				}
 
 				const storageFeature = planConstantObj.getStorageFeature?.(

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -291,14 +291,8 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 				}
 
 				if ( annualPlansOnlyFeatures.length > 0 ) {
-					// For var1d: check if plan has "Everything in X, plus:" header
-					// Free plan doesn't have this header, so all its features should be differentiators
-					const hasEverythingInHeader = wpcomFeatures.some( ( feature ) =>
-						feature.getSlug().startsWith( 'feature-everything-in' )
-					);
-
-					// Track whether we've passed the "Everything in X, plus:" header for var1d styling
-					let passedEverythingInHeader = false;
+					// Track whether we've passed a header feature for var1d styling
+					let passedHeaderFeature = false;
 
 					wpcomFeatures.forEach( ( feature ) => {
 						// topFeature and highlightedFeatures are already added to the list above
@@ -315,29 +309,27 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 							feature.getSlug()
 						);
 
-						// Highlight "Everything in X, plus:" features for stacked variants
-						const isEverythingInPlusFeature = feature
-							.getSlug()
-							.startsWith( 'feature-everything-in' );
+						const featureSlug = feature.getSlug();
 
-						// For var1d: mark features as differentiators if:
-						// - Plan has no "Everything in X" header (like Free): all features are differentiators
-						// - Plan has the header: features after the header are differentiators
+						// Header features: "Everything in X, plus:" and "Included in plan:"
+						const isEverythingInPlusFeature = featureSlug.startsWith( 'feature-everything-in' );
+						const isIncludedInPlanFeature = featureSlug === 'feature-included-in-plan';
+						const isHeaderFeature = isEverythingInPlusFeature || isIncludedInPlanFeature;
+
+						// For var1d: mark features after header as differentiators
 						const shouldMarkAsDifferentiator =
-							isVar1dVariant &&
-							! isEverythingInPlusFeature &&
-							( ! hasEverythingInHeader || passedEverythingInHeader );
+							isVar1dVariant && ! isHeaderFeature && passedHeaderFeature;
 
-						// After we see the "Everything in X" header, subsequent features are differentiators
-						if ( isEverythingInPlusFeature ) {
-							passedEverythingInHeader = true;
+						// After we see a header feature, subsequent features are differentiators
+						if ( isHeaderFeature ) {
+							passedHeaderFeature = true;
 						}
 
 						wpcomFeaturesTransformed.push( {
 							...feature,
 							availableOnlyForAnnualPlans,
 							availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
-							...( isEverythingInPlusFeature && { isHighlighted: true } ),
+							...( isHeaderFeature && { isHighlighted: true } ),
 							...( shouldMarkAsDifferentiator && { isDifferentiatorFeature: true } ),
 						} );
 					} );

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -330,6 +330,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 							availableOnlyForAnnualPlans,
 							availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
 							...( isHeaderFeature && { isHighlighted: true } ),
+							...( isHeaderFeature && isVar1dVariant && { isHeaderFeature: true } ),
 							...( shouldMarkAsDifferentiator && { isDifferentiatorFeature: true } ),
 						} );
 					} );

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -29,6 +29,7 @@ export type UsePlanFeaturesForGridPlans = ( {
 	useShortSetStackedFeatures,
 	useVar5Features,
 	isExperimentVariant,
+	isVar1dVariant,
 }: {
 	gridPlans: Omit< GridPlan, 'features' >[];
 	allFeaturesList: FeatureList;
@@ -43,6 +44,11 @@ export type UsePlanFeaturesForGridPlans = ( {
 	useShortSetStackedFeatures?: boolean;
 	useVar5Features?: boolean;
 	isExperimentVariant?: boolean;
+	/**
+	 * When true, mark features after "Everything in X, plus:" header as differentiator features.
+	 * Used for var1d experiment variant styling.
+	 */
+	isVar1dVariant?: boolean;
 } ) => { [ planSlug: string ]: PlanFeaturesForGridPlan };
 
 /**
@@ -64,6 +70,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 	useShortSetStackedFeatures,
 	useVar5Features,
 	isExperimentVariant,
+	isVar1dVariant,
 } ) => {
 	const highlightedFeatures = useHighlightedFeatures( { intent: intent ?? null, isInSignup } );
 	return useMemo( () => {
@@ -284,6 +291,15 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 				}
 
 				if ( annualPlansOnlyFeatures.length > 0 ) {
+					// For var1d: check if plan has "Everything in X, plus:" header
+					// Free plan doesn't have this header, so all its features should be differentiators
+					const hasEverythingInHeader = wpcomFeatures.some( ( feature ) =>
+						feature.getSlug().startsWith( 'feature-everything-in' )
+					);
+
+					// Track whether we've passed the "Everything in X, plus:" header for var1d styling
+					let passedEverythingInHeader = false;
+
 					wpcomFeatures.forEach( ( feature ) => {
 						// topFeature and highlightedFeatures are already added to the list above
 						const isHighlightedFeature =
@@ -304,11 +320,25 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 							.getSlug()
 							.startsWith( 'feature-everything-in' );
 
+						// For var1d: mark features as differentiators if:
+						// - Plan has no "Everything in X" header (like Free): all features are differentiators
+						// - Plan has the header: features after the header are differentiators
+						const shouldMarkAsDifferentiator =
+							isVar1dVariant &&
+							! isEverythingInPlusFeature &&
+							( ! hasEverythingInHeader || passedEverythingInHeader );
+
+						// After we see the "Everything in X" header, subsequent features are differentiators
+						if ( isEverythingInPlusFeature ) {
+							passedEverythingInHeader = true;
+						}
+
 						wpcomFeaturesTransformed.push( {
 							...feature,
 							availableOnlyForAnnualPlans,
 							availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
 							...( isEverythingInPlusFeature && { isHighlighted: true } ),
+							...( shouldMarkAsDifferentiator && { isDifferentiatorFeature: true } ),
 						} );
 					} );
 				}
@@ -345,6 +375,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 		useShortSetStackedFeatures,
 		useVar5Features,
 		isExperimentVariant,
+		isVar1dVariant,
 	] );
 };
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-restructured-plan-features-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-restructured-plan-features-for-comparison-grid.ts
@@ -28,6 +28,7 @@ export type UseRestructuredPlanFeaturesForComparisonGrid = ( {
 	useShortSetStackedFeatures,
 	useVar5Features,
 	isExperimentVariant,
+	isVar1dVariant,
 }: {
 	gridPlans: Omit< GridPlan, 'features' >[];
 	allFeaturesList: FeatureList;
@@ -41,6 +42,7 @@ export type UseRestructuredPlanFeaturesForComparisonGrid = ( {
 	useShortSetStackedFeatures?: boolean;
 	useVar5Features?: boolean;
 	isExperimentVariant?: boolean;
+	isVar1dVariant?: boolean;
 } ) => { [ planSlug: string ]: PlanFeaturesForGridPlan };
 
 const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesForComparisonGrid =
@@ -57,6 +59,7 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 		useShortSetStackedFeatures,
 		useVar5Features,
 		isExperimentVariant,
+		isVar1dVariant,
 	} ) => {
 		const planFeaturesForGridPlans = usePlanFeaturesForGridPlans( {
 			gridPlans,
@@ -70,6 +73,7 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 			useShortSetStackedFeatures,
 			useVar5Features,
 			isExperimentVariant,
+			isVar1dVariant,
 		} );
 
 		return useMemo( () => {

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -29,6 +29,14 @@ export type TransformedFeatureObject = FeatureObject & {
 	 * Used for var1d styling with 26px margin after the header.
 	 */
 	isHeaderFeature?: boolean;
+	/**
+	 * When true, this is the last feature in var1d variant (24px bottom margin).
+	 */
+	isVar1dLastFeature?: boolean;
+	/**
+	 * When true, this is the last feature in a non-var1d experiment variant (37px bottom margin).
+	 */
+	isExperimentLastFeature?: boolean;
 };
 
 export interface PlanFeaturesForGridPlan {

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -18,6 +18,12 @@ export type TransformedFeatureObject = FeatureObject & {
 	availableForCurrentPlan: boolean;
 	availableOnlyForAnnualPlans: boolean;
 	isHighlighted?: boolean;
+	/**
+	 * When true, the feature should receive differentiator styling (var1d experiment).
+	 * Applied to features below the "Everything in X, plus:" header.
+	 * A CSS class will be added based on this flag to allow future customizations (badges, etc.).
+	 */
+	isDifferentiatorFeature?: boolean;
 };
 
 export interface PlanFeaturesForGridPlan {

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -37,6 +37,11 @@ export type TransformedFeatureObject = FeatureObject & {
 	 * When true, this is the last feature in a non-var1d experiment variant (37px bottom margin).
 	 */
 	isExperimentLastFeature?: boolean;
+	/**
+	 * Badge text to display after the feature title (var1d experiment).
+	 * Examples: 'Free', 'New', 'AI'
+	 */
+	badgeText?: TranslateResult;
 };
 
 export interface PlanFeaturesForGridPlan {

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -284,6 +284,11 @@ export type GridContextProps = {
 	 * If, and how to present increased renewal pricing (null, 'crossed_price', 'no_crossed_price')
 	 */
 	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
+
+	/**
+	 * When true, apply var1d experiment styling to storage and other components.
+	 */
+	isVar1dVariant?: boolean;
 };
 
 export type ComparisonGridExternalProps = Omit<

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -24,6 +24,11 @@ export type TransformedFeatureObject = FeatureObject & {
 	 * A CSS class will be added based on this flag to allow future customizations (badges, etc.).
 	 */
 	isDifferentiatorFeature?: boolean;
+	/**
+	 * When true, the feature is a header feature ("Included in plan:" or "Everything in X, plus:").
+	 * Used for var1d styling with 26px margin after the header.
+	 */
+	isHeaderFeature?: boolean;
 };
 
 export interface PlanFeaturesForGridPlan {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15715

## Proposed Changes

* Implement variant1d with some corrections to the other variants as well

## Why are these changes being made?

* Part of the new Pricing Grid experiment

## Testing Instructions

* Assign yourself to the var1d of calypso_plans_differentiators_20260117

<img width="1249" height="733" alt="Screenshot 2026-01-20 at 15 34 26" src="https://github.com/user-attachments/assets/b8eb1673-6f8f-4738-981b-33e48b5ddf41" />
<img width="1402" height="742" alt="Screenshot 2026-01-20 at 14 53 21" src="https://github.com/user-attachments/assets/876b2e34-89ba-402f-83bc-d4b822201010" />

Note: the badges and word wrappings are off when the screen width is 1280, we are aware of it and working on a solution. This is clearly visible on the second screenshot.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
