### PR TITLE
A4A: Add progress fill and disabled area visualization to slider

### DIFF
--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -1,3 +1,4 @@
+import { useResizeObserver } from '@wordpress/compose';
 import clsx from 'clsx';
 import { useEffect, useRef } from 'react';
 
@@ -31,6 +32,7 @@ export default function A4ASlider( {
 	minimum = 0,
 }: Props ) {
 	const rangeRef = useRef< HTMLInputElement >( null );
+	const [ resizeListener, { width: sliderWidth = 0 } ] = useResizeObserver();
 
 	// Safeguard incase we have minimum value that is out of bounds
 	const normalizeMinimum = Math.min( minimum, options.length - 1 );
@@ -41,13 +43,25 @@ export default function A4ASlider( {
 		onChange?.( options[ Math.max( next, normalizeMinimum ) ] );
 	};
 
-	const sliderWidth = rangeRef.current?.offsetWidth ?? 1;
 	const sliderSectionWidth = sliderWidth / ( options.length - 1 );
 
-	// It is important we have offset otherwise we will encounter some overlapping issues with the thumb and disabled area.
-	// Offset is calculated based on the Thumb size and position of the minimum value.
-	const offset = Math.round( ( THUMB_SIZE * normalizeMinimum ) / ( options.length - 1 ) );
-	const disabledAreaWidth = `${ sliderSectionWidth * normalizeMinimum - offset + 1 }px`;
+	// Disabled area covers owned sites (indices 0 through minimum-1).
+	// With minimum=3, gray covers indices 0,1,2 (labels 1,2,3), extending to position 2.
+	const valueOffset = Math.round( ( THUMB_SIZE * value ) / ( options.length - 1 ) );
+	const lastOwnedIndex = normalizeMinimum - 1;
+	const lastOwnedOffset = Math.round( ( THUMB_SIZE * lastOwnedIndex ) / ( options.length - 1 ) );
+	// Add half the thumb size to align with marker center
+	const disabledEndPosition =
+		normalizeMinimum > 0
+			? sliderSectionWidth * lastOwnedIndex + THUMB_SIZE / 2 - lastOwnedOffset
+			: 0;
+	const disabledAreaWidth = `${ disabledEndPosition }px`;
+
+	// Fill area shows progress from minimum to current value (the newly selected portion).
+	// Starts where disabled area ends for visual continuity.
+	const fillAreaLeft = `${ disabledEndPosition }px`;
+	const fillEndPosition = sliderSectionWidth * value - valueOffset;
+	const fillAreaWidth = `${ Math.max( 0, fillEndPosition - disabledEndPosition + 1 ) }px`;
 
 	useEffect( () => {
 		onChange?.( options[ Math.max( value, normalizeMinimum ) ] );
@@ -63,6 +77,14 @@ export default function A4ASlider( {
 			) }
 
 			<div className="a4a-slider__input">
+				{ resizeListener }
+				<div
+					className="a4a-slider__input-fill-area"
+					style={ {
+						left: fillAreaLeft,
+						width: fillAreaWidth,
+					} }
+				></div>
 				<div
 					className="a4a-slider__input-disabled-area"
 					style={ {

--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -32,10 +32,14 @@ export default function A4ASlider( {
 	minimum = 0,
 }: Props ) {
 	const rangeRef = useRef< HTMLInputElement >( null );
-	const [ resizeListener, { width: sliderWidth = 0 } ] = useResizeObserver();
+	const [ resizeListener, { width } ] = useResizeObserver();
+	const sliderWidth = width ?? 0;
 
 	// Safeguard incase we have minimum value that is out of bounds
 	const normalizeMinimum = Math.min( minimum, options.length - 1 );
+
+	// Ensure displayed value is never below minimum
+	const displayValue = Math.max( value, normalizeMinimum );
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const onSliderChange = ( event: any ) => {
@@ -47,7 +51,7 @@ export default function A4ASlider( {
 
 	// Disabled area covers owned sites (indices 0 through minimum-1).
 	// With minimum=3, gray covers indices 0,1,2 (labels 1,2,3), extending to position 2.
-	const valueOffset = Math.round( ( THUMB_SIZE * value ) / ( options.length - 1 ) );
+	const valueOffset = Math.round( ( THUMB_SIZE * displayValue ) / ( options.length - 1 ) );
 	const lastOwnedIndex = normalizeMinimum - 1;
 	const lastOwnedOffset = Math.round( ( THUMB_SIZE * lastOwnedIndex ) / ( options.length - 1 ) );
 	// Add half the thumb size to align with marker center
@@ -60,7 +64,7 @@ export default function A4ASlider( {
 	// Fill area shows progress from minimum to current value (the newly selected portion).
 	// Starts where disabled area ends for visual continuity.
 	const fillAreaLeft = `${ disabledEndPosition }px`;
-	const fillEndPosition = sliderSectionWidth * value - valueOffset;
+	const fillEndPosition = sliderSectionWidth * displayValue - valueOffset;
 	const fillAreaWidth = `${ Math.max( 0, fillEndPosition - disabledEndPosition + 1 ) }px`;
 
 	useEffect( () => {
@@ -98,7 +102,7 @@ export default function A4ASlider( {
 					min="0"
 					max={ options.length - 1 }
 					onChange={ onSliderChange }
-					value={ value }
+					value={ displayValue }
 				/>
 
 				<div className="a4a-slider__marker-container">

--- a/client/a8c-for-agencies/components/slider/style.scss
+++ b/client/a8c-for-agencies/components/slider/style.scss
@@ -43,7 +43,7 @@
 	}
 
 	@mixin slider-track-style {
-		background: var(--color-primary-40);
+		background: var(--color-primary-5);
 		height: 6px;
 		border-radius: 4px;
 	}
@@ -154,12 +154,31 @@
 	margin: 0;
 }
 
+.a4a-slider__input-fill-area {
+	min-height: 6px;
+	width: 0;
+	background-color: var(--color-primary-40);
+	position: absolute;
+	top: 22px;
+	border-radius: 4px 0 0 4px;
+	z-index: 2;
+	pointer-events: none;
+}
+
 .a4a-slider__input-disabled-area {
 	min-height: 6px;
 	width: 0;
-	background-color: var(--color-primary-0);
+	background: repeating-linear-gradient(
+		-45deg,
+		var(--color-neutral-10),
+		var(--color-neutral-10) 2px,
+		var(--color-neutral-0) 2px,
+		var(--color-neutral-0) 7px
+	);
 	position: absolute;
 	top: 22px;
 	left: -1px;
 	border-radius: 4px 0 0 4px;
+	z-index: 1;
+	pointer-events: none;
 }


### PR DESCRIPTION
## Problem

The A4A marketplace slider is displaying incorrectly - the progress fill appears always full or reversed, making it difficult for users to understand their current selection state.

Fresh state (nothing owned). Appears always filled:
<img width="2512" height="538" alt="image" src="https://github.com/user-attachments/assets/70200095-7b28-4555-8458-167c3e1756d9" />

With owned hosting: Looking reversed (not a standard slider pattern):
<img width="1034" height="208" alt="image" src="https://github.com/user-attachments/assets/dcab3eec-fcab-4ae4-bac7-3cb664a52f0c" />

## Fixes
- Adds a fill area overlay to show the selected range from minimum to current value (dark blue)
- Adds a striped pattern to the disabled area for owned/unavailable options (gray hatched)
- Changes track color to a lighter shade for better visual contrast between sections
- Uses `useResizeObserver` to recalculate dimensions on container resize
- Adds pointer-events: none to overlays for proper click-through behavior

## Visual Changes
The slider now shows three distinct sections:
1. **Gray striped area** - Owned/disabled options that can't be reduced
2. **Dark blue fill** - Currently selected additional items
3. **Light blue track** - Available options

Fresh state (no owned hosting):
<img width="2846" height="1980" alt="image" src="https://github.com/user-attachments/assets/cd6a1446-9caf-4d40-bdee-a5dcdff81937" />

With owned hosting:
<img width="3320" height="1980" alt="image" src="https://github.com/user-attachments/assets/b7c6b052-9d5e-4c6b-9cd7-757b364f36e2" />

<img width="2846" height="1980" alt="image" src="https://github.com/user-attachments/assets/a97e38c3-5001-4495-a442-fc2878bc9166" />

## Test plan
- [ ] Navigate to `/agencies/marketplace/hosting/wpcom`
- [ ] Navigate to `/agencies/marketplace/hosting/pressable`
- [ ] Verify slider shows proper fill when dragging thumb
- [ ] Verify disabled area aligns with markers
- [ ] Resize window and verify fill recalculates correctly
- [ ] Click on track/fill areas and verify clicks pass through to slider