### PR TITLE
Help Center: Add the website source of the article

### DIFF
--- a/packages/support-articles/src/components/help-center-article/index.tsx
+++ b/packages/support-articles/src/components/help-center-article/index.tsx
@@ -64,6 +64,7 @@ export const HelpCenterArticle = ( {
 				post_id: post.ID,
 				blog_id: post.site_ID,
 				search_query: query,
+				article_source: post.source,
 			};
 
 			recordTracksEvent( 'calypso_helpcenter_article_viewed', tracksData );

--- a/packages/support-articles/src/types.ts
+++ b/packages/support-articles/src/types.ts
@@ -5,6 +5,7 @@ export interface PostObject {
 	ID: number;
 	site_ID: number;
 	slug: string;
+	source?: string;
 }
 
 export interface ArticleContentProps {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-15752/help-center-distinguish-blog-articles

Adds a `article_source` event prop to `calypso_helpcenter_article_viewed` to distinguish from which website the post comes from (support, blogs, ecc ).

## Testing steps

1. Visit an article
2. Check the event sent