### PR TITLE
A4A: Split WooPayments Status column into separate columns

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
@@ -12,6 +12,7 @@ import { getSiteData } from '../lib/site-data';
 import {
 	SiteColumn,
 	WooPaymentsStatusColumn,
+	CommissionEligibilityColumn,
 	TransactionsColumn,
 	CommissionsPaidColumn,
 	TimeframeCommissionsColumn,
@@ -72,8 +73,11 @@ export default function SitesWithWooPaymentsMobileView( {
 								) }
 							</div>
 						</ListItemCardContent>
-						<ListItemCardContent title={ translate( 'Review status' ) }>
-							<WooPaymentsStatusColumn
+						<ListItemCardContent title={ translate( 'WooPayments status' ) }>
+							<WooPaymentsStatusColumn state={ item.state } siteId={ item.blogId } />
+						</ListItemCardContent>
+						<ListItemCardContent title={ translate( 'Commission eligibility' ) }>
+							<CommissionEligibilityColumn
 								state={ item.state }
 								siteId={ item.blogId }
 								woopaymentsData={ woopaymentsData }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -20,6 +20,7 @@ import {
 	CommissionsPaidColumn,
 	TimeframeCommissionsColumn,
 	WooPaymentsStatusColumn,
+	CommissionEligibilityColumn,
 } from './site-columns';
 import type { SitesWithWooPaymentsState } from '../types';
 
@@ -53,6 +54,7 @@ export default function SitesWithWooPayments() {
 			'commissionsPaid',
 			'timeframeCommissions',
 			'woopaymentsStatus',
+			'commissionEligibility',
 		],
 	} );
 
@@ -115,7 +117,17 @@ export default function SitesWithWooPayments() {
 				label: translate( 'WooPayments Status' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item } ) => (
-					<WooPaymentsStatusColumn
+					<WooPaymentsStatusColumn state={ item.state } siteId={ item.blogId } />
+				),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'commissionEligibility',
+				label: translate( 'Commission Eligibility' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item } ) => (
+					<CommissionEligibilityColumn
 						state={ item.state }
 						siteId={ item.blogId }
 						woopaymentsData={ woopaymentsData }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-2055/split-woopayments-status-column-into-separate-columns

## Proposed Changes

<img width="410" height="138" alt="Screenshot 2026-01-20 at 22 27 21" src="https://github.com/user-attachments/assets/fd40fc54-67b7-4299-bd4e-006b148b49a9" />


- Split the combined "WooPayments Status" column into two separate columns:
  - **WooPayments Status**: Shows only the connection state (Active, Disconnected, or "Continue setup" button)
  - **Commission Eligibility**: Shows eligibility status (Eligible or Not eligible with info popover)
- Created new `CommissionEligibilityColumn` component to handle commission eligibility display
- Simplified `WooPaymentsStatusColumn` to focus only on WooPayments connection state
- Updated both desktop table view and mobile view to display both columns separately

## Why are these changes being made?

The previous implementation aggregated both WooPayments connection status and commission eligibility status into a single column, which could be confusing for users. Splitting these into separate columns provides clearer visibility into each distinct status, making it easier for agencies to understand:
1. Whether WooPayments is properly connected on a site
2. Whether that site is eligible for commissions (separate concern)

## Testing Instructions

1. Open the live link
2. Navigate to the A4A WooPayments dashboard
3. Verify the table now shows two separate columns: "WooPayments Status" and "Commission Eligibility"
4. Test with sites in different states:
   - Site with WooPayments not set up: Should show "Continue setup" button in WooPayments Status, and "-" in Commission Eligibility
   - Site with active WooPayments and commission eligible: Should show "Active" and "Eligible" badges
   - Site with active WooPayments but not commission eligible: Should show "Active" and "Not eligible" (with info icon)
   - Site with disconnected WooPayments: Should show "Disconnected" and "-"
5. Click the info icon on "Not eligible" to verify the popover shows the correct reason
6. Test mobile view to ensure both statuses are displayed separately

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?