### PR TITLE
Add support for showing "indefinite" defensive mode status

### DIFF
--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -105,6 +105,7 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 
 		const { enabled_by_a11n, enabled_until } = data;
 
+		// enabled_until < 0 indicates defensive mode is enabled indefinitely.
 		const date = enabled_until > 0 ? new Date( enabled_until * 1000 ) : null;
 		const enabledUntil = date?.toLocaleString( undefined, {
 			year: 'numeric',

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -105,8 +105,8 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 
 		const { enabled_by_a11n, enabled_until } = data;
 
-		const date = new Date( enabled_until * 1000 );
-		const enabledUntil = date.toLocaleString( undefined, {
+		const date = enabled_until > 0 ? new Date( enabled_until * 1000 ) : null;
+		const enabledUntil = date?.toLocaleString( undefined, {
 			year: 'numeric',
 			month: 'long',
 			day: 'numeric',
@@ -154,13 +154,15 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 						</Text>
 					) }
 
-					<Text as="p">
-						{ sprintf(
-							// translators: %s: timestamp, e.g. May 27, 2025 11:02 AM
-							__( 'This will be automatically disabled on %s.' ),
-							enabledUntil
-						) }
-					</Text>
+					{ enabledUntil && (
+						<Text as="p">
+							{ sprintf(
+								// translators: %s: timestamp, e.g. May 27, 2025 11:02 AM
+								__( 'This will be automatically disabled on %s.' ),
+								enabledUntil
+							) }
+						</Text>
+					) }
 				</VStack>
 			</Notice>
 		);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to: EDGE-153

When Defensive Mode is enabled indefinitely, it currently shows the message: "This will be automatically disabled on undefined". This PR hides the message about auto-disabling defensive mode when it has been enabled indefinitely.

## Proposed Changes

* Hide the "This will be automatically disabled" text when Defensive Mode is enabled indefinitely.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes the UI shown to users when defensive mod is on indefinitely.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use MC BRC to set a test site's defensive mode on indefinitely.
* View the hosting settings and verify that it correctly shows as "Enabled", but no longer shows the text "This will be automatically disabled on....".
* Use MC BRC to set a test site's defensive mode to 1 hour.
* View the hosting settings and verify that it still shows when it will be disabled automatically.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
