### PR TITLE
MSD: Add password confirmation field to security password form

### DIFF
--- a/client/dashboard/me/security-password/index.tsx
+++ b/client/dashboard/me/security-password/index.tsx
@@ -7,7 +7,7 @@ import { useDispatch } from '@wordpress/data';
 import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import useDebouncedState from '../../app/hooks/use-debounced-state';
@@ -22,6 +22,7 @@ import './style.scss';
 
 type SecurityPasswordFormData = {
 	password: string;
+	confirmPassword: string;
 };
 
 const fields: Field< SecurityPasswordFormData >[] = [
@@ -30,6 +31,7 @@ const fields: Field< SecurityPasswordFormData >[] = [
 		label: __( 'New password' ),
 		type: 'password' as const,
 		isValid: {
+			required: true,
 			custom: async ( data: SecurityPasswordFormData ) => {
 				const validation = await validatePassword( data.password );
 				if ( ! validation.passed ) {
@@ -40,11 +42,19 @@ const fields: Field< SecurityPasswordFormData >[] = [
 			},
 		},
 	},
+	{
+		id: 'confirmPassword',
+		label: __( 'Confirm new password' ),
+		type: 'password' as const,
+		isValid: {
+			required: true,
+		},
+	},
 ];
 
 const form: Form = {
 	layout: { type: 'regular' as const, labelPosition: 'top' as const },
-	fields: [ 'password' ],
+	fields: [ 'password', 'confirmPassword' ],
 };
 
 export default function SecurityPassword() {
@@ -57,9 +67,54 @@ export default function SecurityPassword() {
 	const [ formData, setFormData, debouncedFormData ] =
 		useDebouncedState< SecurityPasswordFormData >( {
 			password: '',
+			confirmPassword: '',
 		} );
 
-	const { validity, isValid } = useFormValidity( debouncedFormData, fields, form );
+	const { validity: baseValidity, isValid: baseIsValid } = useFormValidity(
+		debouncedFormData,
+		fields,
+		form
+	);
+
+	// Extract values for clearer useMemo dependencies
+	const { password, confirmPassword } = debouncedFormData;
+
+	// Always check password match since DataForm doesn't re-validate confirmPassword when password changes
+	// Also remove confirmPassword validity when valid to hide the "Valid" indicator
+	const { validity, isValid } = useMemo( () => {
+		const passwordHasValue = password.length > 0;
+		const confirmPasswordHasValue = confirmPassword.length > 0;
+		const passwordsMatch = password === confirmPassword;
+
+		// Show mismatch error when confirm has value but doesn't match
+		if ( confirmPasswordHasValue && ! passwordsMatch ) {
+			return {
+				validity: {
+					...baseValidity,
+					confirmPassword: {
+						custom: {
+							type: 'invalid' as const,
+							message: __( 'Passwords do not match.' ),
+						},
+					},
+				},
+				isValid: false,
+			};
+		}
+
+		// When both fields have values and match, hide the "Valid" indicator
+		// by removing confirmPassword from validity
+		if ( passwordHasValue && confirmPasswordHasValue && passwordsMatch ) {
+			const { confirmPassword: _, ...restValidity } = baseValidity ?? {};
+			return {
+				validity: Object.keys( restValidity ).length > 0 ? restValidity : undefined,
+				isValid: baseIsValid,
+			};
+		}
+
+		return { validity: baseValidity, isValid: baseIsValid };
+	}, [ baseValidity, baseIsValid, password, confirmPassword ] );
+
 	const isLoading = mutation.isPending || isReloading;
 
 	const handleSubmit = ( e: React.FormEvent ) => {
@@ -87,9 +142,11 @@ export default function SecurityPassword() {
 
 	const handleGeneratePassword = () => {
 		recordTracksEvent( 'calypso_dashboard_security_password_generate_password_click' );
+		const newPassword = generatePassword();
 		setFormData( ( data ) => ( {
 			...data,
-			password: generatePassword(),
+			password: newPassword,
+			confirmPassword: newPassword,
 		} ) );
 	};
 


### PR DESCRIPTION
Part of DOTMSD-805

## Proposed Changes

- Add a "Confirm new password" field to the password change form
- Both password fields are now marked as required
- Show "Passwords do not match" error when fields differ
- Generate password button now populates both fields with the same value
- Custom validity handling ensures validation re-runs when either field changes

| Before | After |
| --- | --- |
| <img width="739" height="361" alt="SCR-20260121-mgpu" src="https://github.com/user-attachments/assets/9d2ed6c7-5c54-47d7-9314-895726bbe95e" /> | <img width="757" height="440" alt="SCR-20260121-mgip" src="https://github.com/user-attachments/assets/a2a4a071-1db6-42a7-a8b4-510f12bbfd93" /> |


## Why are these changes being made?

To prevent typos when users set a new password. Without a confirmation field, users could accidentally save a mistyped password and lose access to their account.

## Testing Instructions

1. Navigate to `/me/security/password` in the dashboard
2. Enter a password in "New password" field
3. Enter a different password in "Confirm new password" - verify error "Passwords do not match" appears
4. Enter matching password - verify error clears and Save button becomes enabled
5. Click "Generate strong password" - verify both fields populate with the same value
6. Change "New password" after entering matching passwords - verify error reappears on confirm field
7. Submit with matching passwords - verify success

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.ai/claude-code)