### PR TITLE
Reader: Fix misaligned search icon on sidebar

### DIFF
--- a/client/reader/components/icons/search-icon.jsx
+++ b/client/reader/components/icons/search-icon.jsx
@@ -1,4 +1,4 @@
-export default function ReaderSearchIcon( { viewBox = '0 0 20 20' } ) {
+export default function ReaderSearchIcon( { viewBox = '0 0 24 24' } ) {
 	return (
 		<svg
 			className="sidebar__menu-icon sidebar_svg-search"

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -66,7 +66,7 @@ const DeprecatedReaderSidebarHeader = ( { onSearchClicked } ) => {
 				onClick={ onSearchClicked }
 				aria-label={ translate( 'Search' ) }
 			>
-				<ReaderSearchIcon viewBox="0 0 24 24" />
+				<ReaderSearchIcon />
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes: [READ-256](https://linear.app/a8c/issue/READ-256)

## Proposed Changes

| Before | After |
| -------|------| 
| <img width="257" height="385" alt="image" src="https://github.com/user-attachments/assets/521bede3-8586-4b16-a47d-399f49c7b57f" /> |  <img width="248" height="357" alt="image" src="https://github.com/user-attachments/assets/d6fc8efc-01f0-417d-81f1-fe1d686fc8bc" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To improve UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /reader and verify search icon alignment on sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
