### PR TITLE
MSD Site Settings: Improve the experience of the Defensive mode setting

### DIFF
--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -75,6 +75,7 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 	} );
 	const mutation = useMutation( siteDefensiveModeSettingsMutation( site.ID ) );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const [ shouldShowDisabledNotice, setShouldShowDisabledNotice ] = useState( true );
 
 	const [ formData, setFormData ] = useState< { ttl: string } >( {
 		ttl: availableTtls[ 0 ].value,
@@ -177,7 +178,11 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 
 		return (
 			<VStack spacing={ 8 }>
-				<Notice>{ __( 'Defensive mode is disabled.' ) }</Notice>
+				{ shouldShowDisabledNotice && (
+					<Notice onClose={ () => setShouldShowDisabledNotice( false ) }>
+						{ __( 'Defensive mode is disabled.' ) }
+					</Notice>
+				) }
 				<Card>
 					<CardBody>
 						<form onSubmit={ handleEnable }>

--- a/client/dashboard/sites/settings-defensive-mode/index.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/index.tsx
@@ -99,7 +99,21 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 		} );
 	};
 
-	const renderEnabled = () => {
+	const handleDisable = () => {
+		handleSubmit( {
+			active: false,
+		} );
+	};
+
+	const handleEnable = ( event: React.FormEvent ) => {
+		event.preventDefault();
+		handleSubmit( {
+			active: true,
+			ttl: Number( formData.ttl ),
+		} );
+	};
+
+	const renderEnabledNotice = () => {
 		if ( ! data ) {
 			return null;
 		}
@@ -115,12 +129,6 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 			minute: '2-digit',
 		} );
 
-		const handleDisable = () => {
-			handleSubmit( {
-				active: false,
-			} );
-		};
-
 		return (
 			<Notice
 				variant="success"
@@ -128,7 +136,7 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 				actions={
 					! enabled_by_a11n && (
 						<Button
-							variant="primary"
+							variant="secondary"
 							size="compact"
 							type="submit"
 							isBusy={ isPending }
@@ -167,51 +175,15 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 		);
 	};
 
-	const renderDisabled = () => {
-		const handleEnable = ( event: React.FormEvent ) => {
-			event.preventDefault();
-			handleSubmit( {
-				active: true,
-				ttl: Number( formData.ttl ),
-			} );
-		};
+	const renderDisabledNotice = () => {
+		if ( ! shouldShowDisabledNotice ) {
+			return null;
+		}
 
 		return (
-			<VStack spacing={ 8 }>
-				{ shouldShowDisabledNotice && (
-					<Notice onClose={ () => setShouldShowDisabledNotice( false ) }>
-						{ __( 'Defensive mode is disabled.' ) }
-					</Notice>
-				) }
-				<Card>
-					<CardBody>
-						<form onSubmit={ handleEnable }>
-							<VStack spacing={ 4 }>
-								<SectionHeader title={ __( 'Enable defensive mode' ) } level={ 3 } />
-								<DataForm< { ttl: string } >
-									data={ formData }
-									fields={ fields }
-									form={ form }
-									onChange={ ( edits: { ttl?: string } ) => {
-										setFormData( ( data ) => ( { ...data, ...edits } ) );
-									} }
-								/>
-								<ButtonStack justify="flex-start">
-									<Button
-										__next40pxDefaultSize
-										variant="primary"
-										type="submit"
-										isBusy={ isPending }
-										disabled={ isPending }
-									>
-										{ __( 'Enable' ) }
-									</Button>
-								</ButtonStack>
-							</VStack>
-						</form>
-					</CardBody>
-				</Card>
-			</VStack>
+			<Notice onClose={ () => setShouldShowDisabledNotice( false ) }>
+				{ __( 'Defensive mode is disabled.' ) }
+			</Notice>
 		);
 	};
 
@@ -238,7 +210,37 @@ export default function DefensiveModeSettings( { siteSlug }: { siteSlug: string 
 				feature={ HostingFeatures.DEFENSIVE_MODE }
 				upsellId="site-settings-defensive-mode"
 			>
-				{ data?.enabled ? renderEnabled() : renderDisabled() }
+				<VStack spacing={ 8 }>
+					{ data?.enabled ? renderEnabledNotice() : renderDisabledNotice() }
+					<Card>
+						<CardBody>
+							<form onSubmit={ handleEnable }>
+								<VStack spacing={ 4 }>
+									<SectionHeader title={ __( 'Enable defensive mode' ) } level={ 3 } />
+									<DataForm< { ttl: string } >
+										data={ formData }
+										fields={ fields }
+										form={ form }
+										onChange={ ( edits: { ttl?: string } ) => {
+											setFormData( ( data ) => ( { ...data, ...edits } ) );
+										} }
+									/>
+									<ButtonStack justify="flex-start">
+										<Button
+											__next40pxDefaultSize
+											variant="primary"
+											type="submit"
+											isBusy={ isPending && ! data?.enabled }
+											disabled={ isPending || !! data?.enabled }
+										>
+											{ __( 'Enable' ) }
+										</Button>
+									</ButtonStack>
+								</VStack>
+							</form>
+						</CardBody>
+					</Card>
+				</VStack>
 			</HostingFeatureGatedWithCallout>
 		</PageLayout>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DES-443

## Proposed Changes

* Allow to dismiss the disabled notice
* Show the form even if the feature is enabled

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the experience of the Defensive mode setting

| Before | After |
| - | - |
|<img width="694" height="475" alt="image" src="https://github.com/user-attachments/assets/287ccaa2-16ac-49aa-ae9b-f19f8ea3a31a" />|<img width="690" height="473" alt="image" src="https://github.com/user-attachments/assets/9f169339-d7f0-4f74-ae05-b2d63729076a" />|
|<img width="711" height="519" alt="image" src="https://github.com/user-attachments/assets/31f94030-c9d5-46bc-9295-6550f3f907db" />|<img width="710" height="562" alt="image" src="https://github.com/user-attachments/assets/98519926-4050-4a7e-bd22-441801d85258" />|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites/:site/settings/defensive-mode on your atomic site
* Enable/Disable the defensive mode
* Ensure it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
