### PR TITLE
MSD: update notices & modals for forced-opt-in users

### DIFF
--- a/client/dashboard/components/opt-in-survey/index.tsx
+++ b/client/dashboard/components/opt-in-survey/index.tsx
@@ -65,11 +65,20 @@ export default function OptInSurvey() {
 	const { recordTracksEvent } = useAnalytics();
 	const [ isDismissed, setIsDismissed ] = useState( false );
 
+	const { data: dashboardOptIn } = useSuspenseQuery(
+		userPreferenceQuery( 'hosting-dashboard-opt-in' )
+	);
 	const { data: welcomeNoticeDismissedAt } = useSuspenseQuery(
 		userPreferenceQuery( 'hosting-dashboard-welcome-notice-dismissed' )
 	);
 
-	const [ isEligible ] = useState( () => checkEligible( welcomeNoticeDismissedAt ) );
+	const [ isEligible ] = useState( () =>
+		checkEligible(
+			dashboardOptIn?.value === 'forced-opt-in'
+				? dashboardOptIn?.updated_at
+				: welcomeNoticeDismissedAt
+		)
+	);
 
 	if ( ! isEligible || isDismissed ) {
 		return null;
@@ -101,7 +110,11 @@ export default function OptInSurvey() {
 
 	return (
 		<Notice
-			title={ __( 'How’s your experience with the new Hosting Dashboard?' ) }
+			title={
+				dashboardOptIn?.value === 'forced-opt-in'
+					? __( 'How’s your experience with the Hosting Dashboard?' )
+					: __( 'How’s your experience with the new Hosting Dashboard?' )
+			}
 			onClose={ dismiss }
 			actions={
 				<ButtonStack justify="flex-start">

--- a/client/dashboard/components/opt-in-welcome/index.tsx
+++ b/client/dashboard/components/opt-in-welcome/index.tsx
@@ -12,6 +12,9 @@ import ComponentViewTracker from '../component-view-tracker';
 
 export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 	const { optIn } = useAppContext();
+	const { data: dashboardOptIn } = useSuspenseQuery(
+		userPreferenceQuery( 'hosting-dashboard-opt-in' )
+	);
 	const { data: isDismissedPersisted } = useSuspenseQuery(
 		userPreferenceQuery( 'hosting-dashboard-welcome-notice-dismissed' )
 	);
@@ -27,7 +30,7 @@ export function OptInWelcome( { tracksContext }: { tracksContext: string } ) {
 		} );
 	};
 
-	if ( ! optIn ) {
+	if ( ! optIn || dashboardOptIn?.value === 'forced-opt-in' ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/welcome-modal/opt-in-welcome-modal.tsx
+++ b/client/dashboard/sites/welcome-modal/opt-in-welcome-modal.tsx
@@ -25,6 +25,9 @@ export default function OptInWelcomeModal() {
 	const { recordTracksEvent } = useAnalytics();
 	const hasEnTranslation = useHasEnTranslation();
 	const isLargeViewport = useViewportMatch( 'small', '>=' );
+	const { data: dashboardOptIn } = useSuspenseQuery(
+		userPreferenceQuery( 'hosting-dashboard-opt-in' )
+	);
 	const { data: isDismissedPersisted } = useSuspenseQuery( userPreferenceQuery( preferenceName ) );
 	const { mutate: updateDismissed, isPending: isDismissing } = useMutation(
 		userPreferenceMutation( preferenceName )
@@ -36,6 +39,10 @@ export default function OptInWelcomeModal() {
 		recordTracksEvent( 'calypso_dashboard_opt_in_welcome_modal_dismiss_click' );
 		updateDismissed( new Date().toISOString() );
 	};
+
+	if ( dashboardOptIn?.value === 'forced-opt-in' ) {
+		return null;
+	}
 
 	if ( isDismissed ) {
 		return null;


### PR DESCRIPTION
Fixes DOTMSD-1039

## Proposed Changes

For users which is `forced-opt-in` to MSD, we:

1. Hide the following "welcome experiences":

    <img width="1468" height="664" alt="image" src="https://github.com/user-attachments/assets/af42f2a9-5049-4b60-9f0b-ca5c574d7789" />

2. Remove "new" from the survey nudge:

|Before|After|
|-|-|
|<img width="396" height="224" alt="image" src="https://github.com/user-attachments/assets/74919564-c174-4e89-96b9-6b2372403984" />|<img width="412" height="236" alt="image" src="https://github.com/user-attachments/assets/a8a29559-6a5b-4dc3-8784-a0e14fa43109" />|

## Why are these changes being made?

The welcome experience are not applicable to users who are A/B-tested to get the MSD.

## Testing Instructions

1. Clear these preferences from the preference dev tool:

- `hosting-dashboard-opt-in-welcome-modal-dismissed`
- `hosting-dashboard-opt-in-welcome-notice-dismissed`

2. Assign yourself to `forced-opt-in` experience (see: 200431-ghe-Automattic/wpcom)
3. Go to `<dashboard live link>/sites`, verify the modal/notice as mentioned above.
4. To test the survey nudge wording update, you need to check out locally and update `getSurveyDismissal()` to always return true

https://github.com/Automattic/wp-calypso/blob/f04bf3fb9daabda12b5e0934c5e6e196e96b9f36/client/dashboard/components/opt-in-survey/index.tsx#L19

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?