### PR TITLE
Fix cloud.jetpack.com/login behaviour (not add it to browsing history)

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -135,13 +135,13 @@ function saveOauthFlags() {
 	window.sessionStorage.setItem( 'flags', oauthFlag );
 }
 
-function authorizePath() {
+function authorizePath( nextPath = null ) {
 	const redirectUri = new URL(
 		isJetpackCloud() || isA8CForAgencies() ? '/connect/oauth/token' : '/api/oauth/token',
 		window.location
 	);
 	redirectUri.search = new URLSearchParams( {
-		next: window.location.pathname + window.location.search,
+		next: nextPath || window.location.pathname + window.location.search,
 	} ).toString();
 
 	const authUri = new URL( 'https://public-api.wordpress.com/oauth2/authorize' );
@@ -182,7 +182,10 @@ const oauthTokenMiddleware = () => {
 
 			// Check we have an OAuth token, otherwise redirect to auth/login page
 			if ( getToken() === false && ! isValidSection ) {
-				window.location = authorizePath();
+				// Use previousPath to preserve the original page for redirect after OAuth
+				// This prevents 404 when user presses back after login
+				const nextPath = context.previousPath || '/';
+				window.location.replace( authorizePath( nextPath ) );
 				return;
 			}
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -135,13 +135,13 @@ function saveOauthFlags() {
 	window.sessionStorage.setItem( 'flags', oauthFlag );
 }
 
-function authorizePath( nextPath = null ) {
+function authorizePath() {
 	const redirectUri = new URL(
 		isJetpackCloud() || isA8CForAgencies() ? '/connect/oauth/token' : '/api/oauth/token',
 		window.location
 	);
 	redirectUri.search = new URLSearchParams( {
-		next: nextPath || window.location.pathname + window.location.search,
+		next: window.location.pathname + window.location.search,
 	} ).toString();
 
 	const authUri = new URL( 'https://public-api.wordpress.com/oauth2/authorize' );
@@ -182,10 +182,8 @@ const oauthTokenMiddleware = () => {
 
 			// Check we have an OAuth token, otherwise redirect to auth/login page
 			if ( getToken() === false && ! isValidSection ) {
-				// Use previousPath to preserve the original page for redirect after OAuth
-				// This prevents 404 when user presses back after login
-				const nextPath = context.previousPath || '/';
-				window.location.replace( authorizePath( nextPath ) );
+				// Use replace to avoid adding the current path to browser history
+				window.location.replace( authorizePath() );
 				return;
 			}
 


### PR DESCRIPTION
Closes MYJP-293

## Proposed Changes

* Use `window.location.replace()` instead of `window.location =` in the OAuth middleware to avoid adding `/login/` to browser history

## Why are these changes being made?

When users on cloud.jetpack.com click "Log in", they navigate to `/login/` which triggers the OAuth middleware. The middleware was using `window.location = authorizePath()` which adds `/login/` to browser history before redirecting to wordpress.com for OAuth.

After completing OAuth and returning to the site, pressing the browser back button takes users to `/login/` — which has no route handler, resulting in a 404 error.

Using `window.location.replace()` replaces the `/login/` history entry instead of adding a new one, so `/login/` is never in the browser history.

## Testing Instructions

1. Navigate to https://cloud.jetpack.com/pricing (or local equivalent)
2. Click "Log in" button in the header
3. Press the browser back button
4. Verify you return to `/pricing`
5. Click "Log in" again
6. Complete OAuth flow
7. Verify you return to `/pricing`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
