### PR TITLE
Signup Onboarding: Always redirect to /home/%s after checkout

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -289,6 +289,7 @@ export default {
 
 		// Set referral parameter in signup dependency store so we can retrieve it in getSignupDestination().
 		const refParameter = query && query.ref;
+		const localeSlug = context.params.lang;
 		// Set design parameters in signup depencency store so we can retrieve it in getChecklistThemeDestination().
 		const themeParameter = query && query.theme;
 		const themeType = query && query.theme_type;
@@ -314,6 +315,8 @@ export default {
 			...( screenParameter && { screenParameter } ),
 			...( pluginParameter && { pluginParameter } ),
 			...( pluginBillingPeriod && { pluginBillingPeriod } ),
+			...( localeSlug && { localeSlug } ),
+			...( flowName && { flowName } ),
 		};
 		if ( ! isEmpty( additionalDependencies ) ) {
 			context.store.dispatch( updateDependencies( additionalDependencies ) );


### PR DESCRIPTION
Addresses p1769000615803889/1768924501.724759-slack-C08HKNPL2BG.

## Why are these changes being made?

We want to move away from the goals step universally within onboarding. The flows the user can access through `/pricing` were still sending them there, but they should send the user to the home page of their site.

## Testing Instructions

Go through [any flow that has `destination: getSignupDestination`](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/config/flows-pure.js) and verify that the checkout URL sends the user to `/home/%s` instead of `/setup/site-setup`.

The `/start/free` flow should send you directly to `/home/%s` without going through checkout if you don't select a domain.