### PR TITLE
Update feature gating copy and design fixes

### DIFF
--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -791,7 +791,7 @@ const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_SIMPLE_PAYMENTS,
 		getTitle: ( params ) =>
 			params?.isExperimentVariant
-				? i18n.translate( 'Add payment buttons' )
+				? i18n.translate( 'Add payment buttons to your site' )
 				: i18n.translate( 'PayPal Payment Buttons' ),
 		getDescription: () => i18n.translate( 'Sell anything with a simple PayPal button.' ),
 	},
@@ -816,7 +816,10 @@ const FEATURES_LIST: FeatureList = {
 
 	[ FEATURE_UPLOAD_PLUGINS ]: {
 		getSlug: () => FEATURE_UPLOAD_PLUGINS,
-		getTitle: () => i18n.translate( 'Install WordPress plugins' ),
+		getTitle: ( params ) =>
+			params?.isExperimentVariant
+				? i18n.translate( 'Install all WordPress plugins' )
+				: i18n.translate( 'Install WordPress plugins' ),
 		getDescription: () =>
 			i18n.translate(
 				'Plugins extend the functionality of your site and ' +

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -384,7 +384,13 @@
 
 			// Make the tooltip hover area a flex container so text doesn't wrap under icon
 			.plans-2023-tooltip__hover-area-container {
-				display: inline;
+				display: flex;
+				align-items: flex-start;
+			}
+
+			// Text content wrapper to keep badge inline with text
+			.plan-features-2023-grid__item-text-content {
+				flex: 1;
 			}
 
 			// Apply underline styling only to the text, not the icon

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -384,8 +384,7 @@
 
 			// Make the tooltip hover area a flex container so text doesn't wrap under icon
 			.plans-2023-tooltip__hover-area-container {
-				display: flex;
-				align-items: flex-start;
+				display: inline;
 			}
 
 			// Apply underline styling only to the text, not the icon

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -36,7 +36,7 @@ const FeatureBadge = styled.span`
 	text-align: center;
 	font-size: 11px;
 	font-weight: 600;
-	line-height: 18px;
+	line-height: 16px;
 	margin-inline-start: 8px;
 	vertical-align: baseline;
 	text-decoration: none;
@@ -192,12 +192,14 @@ const PlanFeatures2023GridFeatures: React.FC< {
 										>
 											<>
 												{ currentFeature.isDifferentiatorFeature && <DifferentiatorCheckIcon /> }
-												{ currentFeature.getTitle( {
-													domainName: paidDomainName,
-												} ) }
-												{ currentFeature.badgeText && (
-													<FeatureBadge>{ currentFeature.badgeText }</FeatureBadge>
-												) }
+												<span className="plan-features-2023-grid__item-text-content">
+													{ currentFeature.getTitle( {
+														domainName: paidDomainName,
+													} ) }
+													{ currentFeature.badgeText && (
+														<FeatureBadge>{ currentFeature.badgeText }</FeatureBadge>
+													) }
+												</span>
 												{ currentFeature?.getSubFeatureObjects?.()?.length ? (
 													<ul className="plan-features-2023-grid__item-sub-feature-list">
 														{ currentFeature.getSubFeatureObjects().map( ( subFeature ) => (

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -36,9 +36,11 @@ const FeatureBadge = styled.span`
 	text-align: center;
 	font-size: 11px;
 	font-weight: 600;
-	line-height: 20px;
+	line-height: 18px;
 	margin-inline-start: 8px;
-	vertical-align: middle;
+	vertical-align: baseline;
+	text-decoration: none;
+	white-space: nowrap;
 `;
 
 // var1d experiment: Checkmark bullet icon for differentiator features

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
@@ -54,6 +54,7 @@ const useGridPlansForComparisonGrid = ( {
 		useFreeTrialPlanSlugs,
 		isDomainOnlySite,
 		reflectStorageSelectionInPlanPrices,
+		isExperimentVariant,
 	} );
 
 	// Get summer special status

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
@@ -52,6 +52,7 @@ const useGridPlansForFeaturesGrid = ( {
 		highlightLabelOverrides,
 		isDomainOnlySite,
 		reflectStorageSelectionInPlanPrices,
+		isExperimentVariant,
 	} );
 
 	// Get summer special status early

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -306,6 +306,7 @@ const useGridPlans: UseGridPlansType = ( {
 	highlightLabelOverrides,
 	isDomainOnlySite,
 	reflectStorageSelectionInPlanPrices,
+	isExperimentVariant,
 } ) => {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs?.( {
 		intent: intent ?? 'default',
@@ -352,6 +353,7 @@ const useGridPlans: UseGridPlansType = ( {
 		plansAvailabilityForPurchase,
 		highlightLabelOverrides,
 		isDomainOnlySite: isDomainOnlySite || false,
+		isExperimentVariant,
 	} );
 
 	// TODO: pricedAPIPlans to be queried from data-store package

--- a/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
@@ -21,6 +21,7 @@ interface Props {
 	};
 	highlightLabelOverrides?: { [ K in PlanSlug ]?: TranslateResult };
 	isDomainOnlySite: boolean;
+	isExperimentVariant?: boolean;
 }
 
 // TODO clk: move to plans data store
@@ -32,6 +33,7 @@ const useHighlightLabels = ( {
 	plansAvailabilityForPurchase,
 	highlightLabelOverrides,
 	isDomainOnlySite,
+	isExperimentVariant,
 }: Props ) => {
 	const translate = useTranslate();
 	const isVisualSplitIntent =
@@ -75,7 +77,7 @@ const useHighlightLabels = ( {
 			} else if ( 'plans-affiliate' === intent && isBusinessPlan( planSlug ) ) {
 				label = translate( 'Popular' );
 			} else if ( isBusinessPlan( planSlug ) && ! selectedPlan && ! isVisualSplitIntent ) {
-				label = translate( 'Best for devs' );
+				label = isExperimentVariant ? translate( 'Best for growth' ) : translate( 'Best for devs' );
 			} else if ( isPopularPlan( planSlug ) && ! selectedPlan && ! isVisualSplitIntent ) {
 				label = translate( 'Popular' );
 			}


### PR DESCRIPTION
Part of DOTCOM-15734

## Proposed Changes

* The experiment variations needed a bit of random tweaks
* Best for growth rather than best for devs, the badge for var1d changes alignment, some copy gets longer to address orphans in English

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Select variant var1d of calypso_plans_differentiators_20260117

<img width="2786" height="1426" alt="Screenshot 2026-01-21 at 16 43 16" src="https://github.com/user-attachments/assets/61d4f69f-8d06-4671-b4d0-1e1c58be2a10" />

Also

<img width="525" height="173" alt="Screenshot 2026-01-21 at 17 06 59" src="https://github.com/user-attachments/assets/cb950452-2848-445a-9b89-56f863a4a68a" />



Ensure control is unchanged


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
