### PR TITLE
Update localStorage key for help center preferences

### DIFF
--- a/apps/help-center/help-center-logged-out.js
+++ b/apps/help-center/help-center-logged-out.js
@@ -8,10 +8,11 @@ import loadHelpCenter from './async-help-center';
  */
 function shouldAutoLoadHelpCenter() {
 	try {
-		const preferences = window.localStorage.getItem( 'logged_out_help_center_preferences' );
+		const preferences = window.localStorage.getItem(
+			'logged_out_help_center_preferences_help_center_open'
+		);
 		if ( preferences ) {
-			const preferencesObject = JSON.parse( preferences );
-			return preferencesObject.help_center_open;
+			return JSON.parse( preferences );
 		}
 		return false;
 	} catch ( error ) {


### PR DESCRIPTION
It had an incorrect key.

## Proposed Changes

Fix the local storage key for the Help Center open/closed preference.

## Why are these changes being made?
To fix auto-opening when logged out.

## Testing Instructions

1. cd into apps/help-center and run `yarn dev --sync`.
2. Sandbox widgets.wp.com.
3. Visit https://wordpress.com/support/?dotcom_support_enable_odie_answers=true.
4. Ask a question.
5. Refresh the page.
6. HC should remain open.
