### PR TITLE
help-center: Fix build: disambiguate chunk filenames to prevent parallel write collisions

### DIFF
--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -22,7 +22,7 @@ function getIndividualConfig( options = {} ) {
 			...webpackConfig.output,
 			path: outputPath,
 			filename: '[name].min.js', // dynamic filename
-			chunkFilename: `${ name }.[id].[contenthash:8].min.js`,
+			chunkFilename: `[id].[contenthash:8].min.js`,
 			library: 'helpCenter',
 		},
 		optimization: {

--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -22,6 +22,7 @@ function getIndividualConfig( options = {} ) {
 			...webpackConfig.output,
 			path: outputPath,
 			filename: '[name].min.js', // dynamic filename
+			chunkFilename: `${ name }.[id].[contenthash:8].min.js`,
 			library: 'helpCenter',
 		},
 		optimization: {


### PR DESCRIPTION
## Summary
- Add `chunkFilename` with entry name prefix to prevent multiple webpack configurations from writing to the same chunk file
- Fixes intermittent build failures caused by parallel configs racing to write `949.js` (and potentially other shared chunk IDs)

## See also

pMz3w-nic-p2#comment-131327



## Problem
The help-center webpack config exports an array of 8 configurations that run in parallel. When different entries produce chunks with the same numeric ID (e.g.,`949.min.js`) but different content, they all write to `dist/949.js`. Depending on timing, these writes can interleave, corrupting the output file with syntax errors like `'return' outside of function`.

Build log showed two entries emitting different-sized `949.min.js`:
- `help-center-ciab-admin`: 346 KiB
- `help-center-logged-out`: 350 KiB


## Solution
  Set `chunkFilename: '[id].[contenthash:8].min.js'` so chunks with different content get unique filenames:
  - `949.349932b2.min.js` (ciab-admin)
  - `949.a120de9a.min.js` (logged-out)

  Identical chunks (like `43`, `114`, `915`) naturally dedupe since same content = same hash = same filename.

## Before
```
-rw-r--r--@ 1 dev  staff    39655 Jan 21 13:10 dist/114.min.js
-rw-r--r--@ 1 dev  staff  2163556 Jan 21 13:10 dist/371.min.js
-rw-r--r--@ 1 dev  staff      782 Jan 21 13:10 dist/43.min.js
-rw-r--r--@ 1 dev  staff  2172165 Jan 21 13:10 dist/458.min.js
-rw-r--r--@ 1 dev  staff     3728 Jan 21 13:10 dist/915.min.js
-rw-r--r--@ 1 dev  staff   362081 Jan 21 13:10 dist/949.min.js
-rw-r--r--@ 1 dev  staff     1384 Jan 21 13:10 dist/help-center-ciab-admin-disconnected.min.js
-rw-r--r--@ 1 dev  staff    45285 Jan 21 13:10 dist/help-center-ciab-admin.min.js
-rw-r--r--@ 1 dev  staff  2575296 Jan 21 13:10 dist/help-center-customizer.min.js
-rw-r--r--@ 1 dev  staff    27653 Jan 21 13:10 dist/help-center-gutenberg-disconnected.min.js
-rw-r--r--@ 1 dev  staff  2581599 Jan 21 13:10 dist/help-center-gutenberg.min.js
-rw-r--r--@ 1 dev  staff    31463 Jan 21 13:10 dist/help-center-logged-out.min.js
-rw-r--r--@ 1 dev  staff    27290 Jan 21 13:10 dist/help-center-wp-admin-disconnected.min.js
-rw-r--r--@ 1 dev  staff  2578110 Jan 21 13:10 dist/help-center-wp-admin.min.js
```

## After (two different 949s)
```
-rw-r--r--@ 1 dev  staff    39655 Jan 21 13:12 dist/114.6889c5a4.min.js
-rw-r--r--@ 1 dev  staff  2163556 Jan 21 13:12 dist/371.3fe03165.min.js
-rw-r--r--@ 1 dev  staff      782 Jan 21 13:12 dist/43.66e7376f.min.js
-rw-r--r--@ 1 dev  staff  2172165 Jan 21 13:12 dist/458.752d1658.min.js
-rw-r--r--@ 1 dev  staff     3728 Jan 21 13:12 dist/915.79e5a0a3.min.js
-rw-r--r--@ 1 dev  staff   357368 Jan 21 13:12 dist/949.349932b2.min.js <-------
-rw-r--r--@ 1 dev  staff   362081 Jan 21 13:12 dist/949.a120de9a.min.js <------
-rw-r--r--@ 1 dev  staff     1384 Jan 21 13:12 dist/help-center-ciab-admin-disconnected.min.js
-rw-r--r--@ 1 dev  staff    45370 Jan 21 13:12 dist/help-center-ciab-admin.min.js
-rw-r--r--@ 1 dev  staff  2575351 Jan 21 13:12 dist/help-center-customizer.min.js
-rw-r--r--@ 1 dev  staff    27653 Jan 21 13:12 dist/help-center-gutenberg-disconnected.min.js
-rw-r--r--@ 1 dev  staff  2581654 Jan 21 13:12 dist/help-center-gutenberg.min.js
-rw-r--r--@ 1 dev  staff    31548 Jan 21 13:12 dist/help-center-logged-out.min.js
-rw-r--r--@ 1 dev  staff    27290 Jan 21 13:12 dist/help-center-wp-admin-disconnected.min.js
-rw-r--r--@ 1 dev  staff  2578165 Jan 21 13:12 dist/help-center-wp-admin.min.js
