### PR TITLE
TikTok pixel: Add conversion events

### DIFF
--- a/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
@@ -108,6 +108,26 @@ export async function adTrackSignupComplete( { isNewUserSite } ) {
 		window.fbq( ...params );
 	}
 
+	if ( mayWeTrackByTracker( 'tiktok' ) ) {
+		const params = {
+			contents: [
+				{
+					content_id: syntheticCart.products
+						.map( ( product ) => product.product_slug )
+						.join( ', ' ),
+					content_type: 'product',
+					content_name: syntheticCart.products
+						.map( ( product ) => product.product_name )
+						.join( ', ' ),
+				},
+			],
+			value: syntheticCart.total_cost,
+			currency: syntheticCart.currency,
+		};
+		debug( 'recordSignup: [TikTok]', params );
+		window.ttq.track( 'CompleteRegistration', params );
+	}
+
 	// DCM Floodlight
 
 	if ( mayWeTrackByTracker( 'floodlight' ) ) {

--- a/client/lib/analytics/ad-tracking/record-add-to-cart.js
+++ b/client/lib/analytics/ad-tracking/record-add-to-cart.js
@@ -138,5 +138,22 @@ export async function recordAddToCart( cartItem ) {
 		window.pintrk( ...params );
 	}
 
+	// TikTok
+	if ( mayWeTrackByTracker( 'tiktok' ) ) {
+		const params = {
+			contents: [
+				{
+					content_id: cartItem.product_slug,
+					content_name: cartItem.product_name,
+					content_type: 'product',
+				},
+			],
+			value: cartItem.cost,
+			currency: cartItem.currency,
+		};
+		debug( 'recordAddToCart: [TikTok]', params );
+		window.ttq.track( 'AddToCart', params );
+	}
+
 	debug( 'recordAddToCart: dataLayer:', circularReferenceSafeJSONStringify( window.dataLayer, 2 ) );
 }

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -739,7 +739,7 @@ function recordOrderInTikTok(
 		currency: 'USD',
 	};
 	debug( 'recordOrderInTikTok:', 'track', params );
-	window.ttq.track( 'PlaceAnOrder', params );
+	window.ttq.track( 'Purchase', params );
 }
 
 /**

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -41,6 +41,7 @@ declare global {
 		_qevents: any[];
 		uetq: any[];
 		rdt: any[] & { ( ...args: any[] ): void };
+		ttq: any[] & { ( ...args: any[] ): void };
 	}
 }
 

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -41,7 +41,7 @@ declare global {
 		_qevents: any[];
 		uetq: any[];
 		rdt: any[] & { ( ...args: any[] ): void };
-		ttq: any[] & { ( ...args: any[] ): void };
+		ttq: any;
 	}
 }
 

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -83,6 +83,7 @@ export async function recordOrder(
 	recordOrderInAkismetGTM( cart, orderId, wpcomJetpackCartInfo );
 	recordOrderInJetpackGTM( cart, orderId, wpcomJetpackCartInfo );
 	recordOrderInReddit( orderId, wpcomJetpackCartInfo );
+	recordOrderInTikTok( orderId, wpcomJetpackCartInfo );
 
 	// Fire a single tracking event without any details about what was purchased
 
@@ -717,6 +718,28 @@ function recordOrderInReddit(
 
 	debug( 'recordOrderInReddit:', 'track', params );
 	window.rdt( 'track', 'Purchase', params );
+}
+function recordOrderInTikTok(
+	orderId: number | null | undefined,
+	wpcomJetpackCartInfo: WpcomJetpackCartInfo
+): void {
+	if ( ! mayWeTrackByTracker( 'tiktok' ) ) {
+		return;
+	}
+	if ( ! wpcomJetpackCartInfo.containsWpcomProducts ) {
+		return;
+	}
+	const params = {
+		contents: wpcomJetpackCartInfo.wpcomProducts.map( ( product ) => ( {
+			content_id: product.product_slug,
+			content_name: product.product_name_en,
+			content_type: 'product',
+		} ) ),
+		value: wpcomJetpackCartInfo.wpcomCostUSD,
+		currency: 'USD',
+	};
+	debug( 'recordOrderInTikTok:', 'track', params );
+	window.ttq.track( 'PlaceAnOrder', params );
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes M4R73CH-1619
## Proposed Changes

Track the following TikTok standard events:
- CompleteRegistration
- AddToCart
- Purchase 

The PR does not implement any new events, existing events are reused to also track them in TikTok ads.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To support upcoming TikTok Ads campaigns.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso, open the browser console and enter: `localStorage.set('debug', 'calypso:analytics:adtracking');`
* Make sure the `verbose` console level is enabled.
* Perform the 3 actions above and confirm each of them triggers a TikTok event.

__Note__: As `Purchase` is not triggered using credits, you can test using the sandbox store.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
