### PR TITLE
MSD: debug Sentry CALYPSO-2GR5 issue

### DIFF
--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -23,6 +23,7 @@ const requiresPlanUpgrade = ( site: Site ) => {
 };
 
 const useDomainSuggestion = ( site: Site ) => {
+	// Temporary debugging. See: https://github.com/Automattic/wp-calypso/pull/108256
 	if ( site.slug === undefined ) {
 		captureException( new Error( 'site.slug is undefined in useDomainSuggestion()' ), {
 			extra: { site },

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -29,7 +29,7 @@ const useDomainSuggestion = ( site: Site ) => {
 		} );
 	}
 
-	const search = site.slug?.split( '.' )[ 0 ];
+	const search = site.slug?.split( '.' )[ 0 ] ?? '';
 	const { data: allDomainSuggestions } = useQuery(
 		domainSuggestionsQuery( search, {
 			vendor: 'domain-upsell',

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -1,4 +1,5 @@
 import { domainSuggestionsQuery, siteCurrentPlanQuery } from '@automattic/api-queries';
+import { captureException } from '@automattic/calypso-sentry';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalText as Text } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -22,7 +23,13 @@ const requiresPlanUpgrade = ( site: Site ) => {
 };
 
 const useDomainSuggestion = ( site: Site ) => {
-	const search = site.slug.split( '.' )[ 0 ];
+	if ( site.slug === undefined ) {
+		captureException( new Error( 'site.slug is undefined in useDomainSuggestion()' ), {
+			extra: { site },
+		} );
+	}
+
+	const search = site.slug?.split( '.' )[ 0 ];
 	const { data: allDomainSuggestions } = useQuery(
 		domainSuggestionsQuery( search, {
 			vendor: 'domain-upsell',


### PR DESCRIPTION
Part of DOTMSD-1029

## Proposed Changes

The undefined `site.slug` issue is still happening regularly in Sentry even though we think we have fixed them:

- https://github.com/Automattic/wp-calypso/pull/107848
- https://github.com/Automattic/wp-calypso/pull/107954

This means something deeper is happening. I'm capturing a debugging error to Sentry to investigate. 

## Testing Instructions

Go to MSD's /sites/:slug (overview) on Simple sites, verify it works (no regression).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
