### PR TITLE
MSD: Redirect domain-related pages on v1 to MSD if forced-opt-in is enabled

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -496,7 +496,7 @@ export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next
 export const maybeRedirectToMultiSiteDashboard = ( path ) => ( context, next ) => {
 	const state = context.store.getState();
 	if ( hasDashboardForcedOptIn( state ) ) {
-		const redirectUrl = typeof path === 'function' ? path( context.params ) : path;
+		const redirectUrl = typeof path === 'function' ? path( context.params, context.query ) : path;
 		return navigate( dashboardLink( redirectUrl ?? context.path ) );
 	}
 

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -44,13 +44,13 @@ function registerMultiPage( { paths: givenPaths, handlers } ) {
 	givenPaths.forEach( ( path ) => page( path, ...handlers ) );
 }
 
-function registerStandardDomainManagementPages( pathFunction, controller ) {
+function registerStandardDomainManagementPages( pathFunction, controller, handlers = [] ) {
 	registerMultiPage( {
 		paths: [
 			pathFunction( ':site', ':domain' ),
 			pathFunction( ':site', ':domain', paths.domainManagementRoot() ),
 		],
-		handlers: [ ...getCommonHandlers(), controller, makeLayout, clientRender ],
+		handlers: [ ...handlers, ...getCommonHandlers(), controller, makeLayout, clientRender ],
 	} );
 }
 
@@ -124,7 +124,11 @@ export default function () {
 
 	registerStandardDomainManagementPages(
 		paths.domainManagementEditContactInfo,
-		domainManagementController.domainManagementEditContactInfo
+		domainManagementController.domainManagementEditContactInfo,
+		[
+			setupPreferences,
+			maybeRedirectToMultiSiteDashboard( ( params ) => `/domains/${ params.domain }/contact-info` ),
+		]
 	);
 
 	registerStandardDomainManagementPages(
@@ -139,12 +143,20 @@ export default function () {
 
 	registerStandardDomainManagementPages(
 		paths.domainManagementDns,
-		domainManagementController.domainManagementDns
+		domainManagementController.domainManagementDns,
+		[
+			setupPreferences,
+			maybeRedirectToMultiSiteDashboard( ( params ) => `/domains/${ params.domain }/dns` ),
+		]
 	);
 
 	registerStandardDomainManagementPages(
 		paths.domainManagementDnsAddRecord,
-		domainManagementController.domainManagementDnsAddRecord
+		domainManagementController.domainManagementDnsAddRecord,
+		[
+			setupPreferences,
+			maybeRedirectToMultiSiteDashboard( ( params ) => `/domains/${ params.domain }/dns/add` ),
+		]
 	);
 
 	registerStandardDomainManagementPages(
@@ -154,7 +166,11 @@ export default function () {
 
 	registerStandardDomainManagementPages(
 		paths.domainManagementTransfer,
-		domainManagementController.domainManagementTransfer
+		domainManagementController.domainManagementTransfer,
+		[
+			setupPreferences,
+			maybeRedirectToMultiSiteDashboard( ( params ) => `/domains/${ params.domain }/transfer` ),
+		]
 	);
 
 	registerStandardDomainManagementPages(
@@ -164,7 +180,13 @@ export default function () {
 
 	registerStandardDomainManagementPages(
 		paths.domainManagementTransferToAnotherUser,
-		domainManagementController.domainManagementTransferToOtherUser
+		domainManagementController.domainManagementTransferToOtherUser,
+		[
+			setupPreferences,
+			maybeRedirectToMultiSiteDashboard(
+				( params ) => `/domains/${ params.domain }/transfer/other-user`
+			),
+		]
 	);
 
 	registerStandardDomainManagementPages(
@@ -174,7 +196,13 @@ export default function () {
 
 	registerStandardDomainManagementPages(
 		paths.domainManagementTransferToOtherSite,
-		domainManagementController.domainManagementTransferToOtherSite
+		domainManagementController.domainManagementTransferToOtherSite,
+		[
+			setupPreferences,
+			maybeRedirectToMultiSiteDashboard(
+				( params ) => `/domains/${ params.domain }/transfer/other-site`
+			),
+		]
 	);
 
 	// /domains/manage/select-site
@@ -238,7 +266,11 @@ export default function () {
 
 	registerStandardDomainManagementPages(
 		paths.domainManagementEdit,
-		domainManagementController.domainManagementEdit
+		domainManagementController.domainManagementEdit,
+		[
+			setupPreferences,
+			maybeRedirectToMultiSiteDashboard( ( params ) => `/domains/${ params.domain }` ),
+		]
 	);
 
 	registerStandardDomainManagementPages(
@@ -248,7 +280,13 @@ export default function () {
 
 	registerStandardDomainManagementPages(
 		paths.domainManagementTransferIn,
-		domainManagementController.domainManagementTransferIn
+		domainManagementController.domainManagementTransferIn,
+		[
+			setupPreferences,
+			maybeRedirectToMultiSiteDashboard(
+				( params ) => `/domains/${ params.domain }/domain-transfer-setup`
+			),
+		]
 	);
 
 	page(
@@ -386,6 +424,10 @@ export default function () {
 	page(
 		paths.domainUseMyDomain( ':site' ),
 		siteSelection,
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard(
+			( params, queries ) => `/domains/${ queries.initialQuery }/domain-transfer-setup`
+		),
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.jetpackNoDomainsWarning,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -211,6 +211,8 @@ export default function () {
 
 	page(
 		paths.domainManagementList( ':site' ),
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard( ( params ) => `/sites/${ params.site }/domains` ),
 		...getCommonHandlers(),
 		domainManagementController.domainManagementList,
 		makeLayout,
@@ -344,6 +346,10 @@ export default function () {
 
 	page(
 		paths.domainMappingSetup( ':site', ':domain' ),
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard(
+			( params ) => `/domains/${ params.domain }/domain-connection-setup`
+		),
 		siteSelection,
 		navigation,
 		domainsController.jetpackNoDomainsWarning,
@@ -403,6 +409,10 @@ export default function () {
 
 	page(
 		paths.domainManagementRoot() + '/:domain/edit',
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard(
+			( params ) => `/domains/${ params.domain }?back_to=site-domains`
+		),
 		stagingSiteNotSupportedRedirect,
 		domainsController.redirectDomainToSite,
 		makeLayout,
@@ -423,6 +433,8 @@ export default function () {
 	page(
 		paths.domainManagementOverviewRoot() + '/:domain/:site',
 		siteSelection,
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard( ( params ) => `/domains/${ params.domain }` ),
 		navigation,
 		domainManagementController.domainManagementV2,
 		domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
@@ -434,6 +446,10 @@ export default function () {
 	page(
 		paths.domainManagementAllEmailRoot() + '/:domain/:site',
 		siteSelection,
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard(
+			( params ) => `/emails/choose-email-solution/${ params.domain }`
+		),
 		navigation,
 		emailController.emailManagement,
 		domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
@@ -469,6 +485,8 @@ export default function () {
 	page(
 		paths.domainManagementAllRoot() + '/contact-info/edit/:domain/:site',
 		siteSelection,
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard( ( params ) => `/domains/${ params.domain }/contact-info` ),
 		navigation,
 		domainManagementController.domainManagementSubpageParams( EDIT_CONTACT_INFO ),
 		domainManagementController.domainManagementEditContactInfo,
@@ -481,6 +499,8 @@ export default function () {
 	page(
 		paths.domainManagementOverviewRoot() + '/:domain/dns/:site',
 		siteSelection,
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard( ( params ) => `/domains/${ params.domain }/dns` ),
 		navigation,
 		domainManagementController.domainManagementSubpageParams( DNS_RECORDS ),
 		domainManagementController.domainManagementDns,
@@ -493,6 +513,8 @@ export default function () {
 	page(
 		paths.domainManagementOverviewRoot() + '/:domain/dns/add/:site',
 		siteSelection,
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard( ( params ) => `/domains/${ params.domain }/dns/add` ),
 		navigation,
 		domainManagementController.domainManagementSubpageParams( ADD_DNS_RECORD ),
 		domainManagementController.domainManagementDnsAddRecord,
@@ -529,6 +551,10 @@ export default function () {
 	page(
 		paths.domainManagementOverviewRoot() + '/:domain/transfer/other-site/:site',
 		siteSelection,
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard(
+			( params ) => `/domains/${ params.domain }/transfer/other-site`
+		),
 		navigation,
 		domainManagementController.domainManagementSubpageParams( TRANSFER_OTHER_SITE ),
 		domainManagementController.domainManagementTransferToOtherSite,

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -1,6 +1,11 @@
 import page from '@automattic/calypso-router';
 import { translate } from 'i18n-calypso';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	maybeRedirectToMultiSiteDashboard,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import {
 	navigation,
@@ -30,7 +35,15 @@ const emailMailboxesSiteSelectionHeader = ( context, next ) => {
 };
 
 export default function () {
-	page( paths.getEmailManagementPath(), siteSelection, sites, makeLayout, clientRender );
+	page(
+		paths.getEmailManagementPath(),
+		siteSelection,
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard( 'emails' ),
+		sites,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		paths.getMailboxesPath(),
@@ -55,7 +68,14 @@ export default function () {
 			paths.getEmailManagementPath( ':site', ':domain' ),
 			paths.getEmailManagementPath( ':site' ),
 		],
-		handlers: [ ...commonHandlers, controller.emailManagement, makeLayout, clientRender ],
+		handlers: [
+			setupPreferences,
+			maybeRedirectToMultiSiteDashboard( ( params ) => `/email?domainName=${ params.domain }` ),
+			...commonHandlers,
+			controller.emailManagement,
+			makeLayout,
+			clientRender,
+		],
 	} );
 
 	const productType = `:productType(${ GOOGLE_WORKSPACE_PRODUCT_TYPE }|${ GSUITE_PRODUCT_TYPE })`;
@@ -137,6 +157,10 @@ export default function () {
 			paths.getPurchaseNewEmailAccountPath( ':site', ':domain' ),
 		],
 		handlers: [
+			setupPreferences,
+			maybeRedirectToMultiSiteDashboard(
+				( params ) => `/emails/choose-email-solution/${ params.domain }`
+			),
 			...commonHandlers,
 			controller.emailManagementPurchaseNewEmailAccount,
 			makeLayout,

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -39,7 +39,7 @@ export default function () {
 		paths.getEmailManagementPath(),
 		siteSelection,
 		setupPreferences,
-		maybeRedirectToMultiSiteDashboard( 'emails' ),
+		maybeRedirectToMultiSiteDashboard( '/emails' ),
 		sites,
 		makeLayout,
 		clientRender
@@ -70,7 +70,7 @@ export default function () {
 		],
 		handlers: [
 			setupPreferences,
-			maybeRedirectToMultiSiteDashboard( ( params ) => `/email?domainName=${ params.domain }` ),
+			maybeRedirectToMultiSiteDashboard( ( params ) => `/emails?domainName=${ params.domain }` ),
 			...commonHandlers,
 			controller.emailManagement,
 			makeLayout,

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -62,11 +62,18 @@ export default function () {
 		clientRender
 	);
 
+	page(
+		paths.getEmailManagementPath( ':site' ),
+		...commonHandlers,
+		controller.emailManagement,
+		makeLayout,
+		clientRender
+	);
+
 	registerMultiPage( {
 		paths: [
 			paths.getEmailManagementPath( ':site', ':domain', paths.emailManagementAllSitesPrefix ),
 			paths.getEmailManagementPath( ':site', ':domain' ),
-			paths.getEmailManagementPath( ':site' ),
 		],
 		handlers: [
 			setupPreferences,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-1038

## Proposed Changes

* Update the domain-related routes to do the redirection if it has the corresponding page on v2.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We have to do the redirection if the `hosting-dashboard-opt-in` calypso preference is configured to `forced-opt-in`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Add the feature flag `?flags=dashboard/forced-opt-in` to the old URL and ensure the page will be redirected to the new URL

#### Domain list / site-level domain management

| Old URL | New URL |
|--------|---------|
| /domains/manage | /domains |
| /domains/manage/`<site_slug>` | /sites/`<site_slug>`/domains |


#### Domain management pages

| Old URL | New URL |
|--------|---------|
| /domains/manage/`<domain>`/edit/`<site_slug>` | /domains/`<domain>`?back_to=site-domains |
| /domains/manage/`<domain>`/edit-contact-info/`<site_slug>` | /domains/`<domain>`/contact-info |
| /domains/manage/`<domain>`/dns/`<site_slug>` | /domains/`<domain>`/dns |
| /domains/manage/`<domain>`/add-dns-record/`<site_slug>` | /domains/`<domain>`/dns/add |
| /domains/manage/`<domain>`/transfer/`<site_slug>` | /domains/`<domain>`/transfer |
| /domains/manage/`<domain>`/transfer/other-user/`<site_slug>` | /domains/`<domain>`/transfer/other-user |
| /domains/manage/`<domain>`/transfer/other-site/`<site_slug>` | /domains/`<domain>`/transfer/other-site |
| /email/`<domain>`/manage/`<site_slug>` | /emails?domainName=`<domain>` |
| /email/`<domain>`/purchase/`<site_slug>` | /emails/choose-email-solution/`<domain>` |


#### Domain management pages (overview)

| Old URL | New URL |
|--------|---------|
| /domains/manage/all/contact-info/edit/`<domain>/`<site_slug>` | /domains/`<domain>`/contact-info |
| /domains/manage/all/overview/`<domain>/`<site_slug>` | /domains/`<domain>`?back_to=site-domains |
| /domains/manage/all/overview/`<domain>/dns/`<site_slug>` | /domains/`<domain>`/dns |
| /domains/manage/all/overview/`<domain>/dns/add/`<site_slug>` | /domains/`<domain>`/dns/add |
| /domains/manage/all/`<domain>`/transfer/`<site_slug>` | /domains/`<domain>`/transfer |
| /domains/manage/all/`<domain>`/transfer/other-user/`<site_slug>` | /domains/`<domain>`/transfer/other-user |
| /domains/manage/all/`<domain>`/transfer/other-site/`<site_slug>` | /domains/`<domain>`/transfer/other-site |
| /domains/manage/all/email/`<domain>`/`<site_slug>` | /emails/choose-email-solution/`<domain>` |

#### Add domain to site

| Old URL | New URL |
|--------|---------|
| /domains/mapping/`<site_slug>`/setup/`<domain>` | /domains/`<domain>`/domain-connection-setup |
| /domains/manage/`<domain>`/transfer/in/`<blog_id>` | /domains/`<domain>`/domain-transfer-setup |
| /domains/add/use-my-domain/`<site_slug>`?initialQuery=`<domain>`&initialMode=start-pending-transfer | /domains/`<domain>`/domain-transfer-setup |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
