### PR TITLE
MSD: sanitize persisted view's filters

### DIFF
--- a/client/dashboard/components/dataviews/sanitize-view.ts
+++ b/client/dashboard/components/dataviews/sanitize-view.ts
@@ -7,14 +7,7 @@ export function sanitizeView( view: View, fields: Field< any >[] ) {
 	// If no sanitization is needed then a reference to the same object should be returned.
 	let sanitized = view;
 
-	if ( sanitized.type === 'grid' && sanitized.layout?.previewSize ) {
-		// From PreviewSizePicker imageSizes in GB https://github.com/WordPress/gutenberg/blob/58a5abc7714bdff204d5f6bc350980f73686d54f/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx#L14-L39
-		const smallestSize = 120;
-		if ( isNaN( sanitized.layout.previewSize ) || sanitized.layout.previewSize < smallestSize ) {
-			delete sanitized.layout.previewSize;
-		}
-	}
-
+	// TODO: remove once this upstream patch is released: https://github.com/WordPress/gutenberg/pull/73950
 	if ( sanitized.sort?.field ) {
 		const field = fields.find( ( field ) => field.id === sanitized.sort?.field );
 		if ( ! field || field.enableSorting === false ) {
@@ -24,7 +17,18 @@ export function sanitizeView( view: View, fields: Field< any >[] ) {
 	}
 
 	const fieldsSet = new Set( fields.map( ( field ) => field.id ) );
-	view.filters = view.filters?.filter( ( filter ) => fieldsSet.has( filter.field ) );
+	sanitized.filters = sanitized.filters?.filter( ( filter ) => {
+		if ( ! fieldsSet.has( filter.field ) ) {
+			return false;
+		}
+		if ( filter.operator === 'is' && Array.isArray( filter.value ) ) {
+			return false;
+		}
+		if ( filter.operator === 'isAny' && ! Array.isArray( filter.value ) ) {
+			return false;
+		}
+		return true;
+	} );
 
 	return sanitized;
 }


### PR DESCRIPTION
Alternative approach for DOTMSD-972 (check the issue for comment).

## Proposed Changes

In `sanitizeView()`, we remove invalid filters:

- non-existant `filter.field`
- `field.operator` is `is` but the `field.value` is not scalar
- `field.operator` is `isAny` but the `field.value` is not array

## Why are these changes being made?

Since view is persisted, it could be the case that a user still has obsolete / corrupted value. This will trigger 500 error without any way to reset the view.

## Testing Instructions

Smoke-test filters in site list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
