### PR TITLE
Jetpack Cloud: Add filter to remove deleted sites from the sites list

### DIFF
--- a/client/jetpack-cloud/components/sidebar/site-selector.tsx
+++ b/client/jetpack-cloud/components/sidebar/site-selector.tsx
@@ -1,10 +1,11 @@
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import BaseSiteSelector from 'calypso/components/site-selector';
 import { useDispatch, useSelector } from 'calypso/state';
 import { hasJetpackPartnerAccess } from 'calypso/state/partner-portal/partner/selectors';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import useOutsideClickCallback from './use-outside-click-callback';
+import type { SiteDetails } from '@automattic/data-stores';
 
 /* NOTE: Code for this component was borrowed from calypso/my-sites/picker,
  * with some slight modifications because we can safely assume we're using
@@ -44,6 +45,11 @@ const SiteSelector = () => {
 	const siteSelectorRef = useHideSiteSelectorOnFocusOut();
 	const canAccessJetpackManage = useSelector( hasJetpackPartnerAccess );
 
+	// Filter out garden sites and deleted sites from the site selector
+	const filterSites = useCallback( ( site: SiteDetails ) => {
+		return ! site?.is_garden && ! site?.is_deleted;
+	}, [] );
+
 	return (
 		<BaseSiteSelector
 			forwardRef={ siteSelectorRef }
@@ -62,6 +68,7 @@ const SiteSelector = () => {
 			keepCurrentSection={ ! canAccessJetpackManage }
 			allSitesPath="/dashboard"
 			siteBasePath="/landing"
+			filter={ filterSites }
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of ARC-1399

## Proposed Changes

* Hide garden sites and deleted sites in Jetpack Cloud

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Garden sites and deleted sites have no available functionality in Jetpack Cloud and will break the application.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a garden site ( ask Team Avalon if you don't know how to )
* Delete the site
* Go to cloud.jetpack.com 
* On the sidebar, change site to the deleted site , the app will break
* Apply this patch, run locally
* Go to jetpack.cloud.localhost:3000
* On the sidebar, there should be no deleted or garden sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
