### PR TITLE
MSD Domains: Update 'While you wait' card on Domain Connection Verification page

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
@@ -405,5 +405,25 @@ describe( 'DomainConnectionVerification', () => {
 
 			expect( screen.queryByText( 'While you wait' ) ).not.toBeInTheDocument();
 		} );
+
+		test( '"What happens next" card is expanded by default when domain is verifying', () => {
+			const domainMappingStatus = createMockDomainMappingStatus( {
+				has_wpcom_ip_addresses: false,
+				resolves_to_wpcom: false,
+			} );
+
+			render(
+				<DomainConnectionVerification
+					{ ...defaultProps }
+					domainMappingStatus={ domainMappingStatus }
+				/>
+			);
+
+			// Find the "What happens next" card header by its text
+			const [ whatHappensNextHeader ] = screen.getAllByRole( 'button', { name: 'Toggle content' } );
+
+			expect( whatHappensNextHeader ).toHaveAttribute( 'aria-expanded', 'true' );
+			expect( screen.getByText( 'Automatic verification' ) ).toBeVisible();
+		} );
 	} );
 } );

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
@@ -419,10 +419,11 @@ describe( 'DomainConnectionVerification', () => {
 				/>
 			);
 
-			// Find the "What happens next" card header by its text
-			const [ whatHappensNextHeader ] = screen.getAllByRole( 'button', { name: 'Toggle content' } );
+			// Verify the "What happens next" section is visible and expanded
+			const whatHappensNextSection = screen.getByText( 'What happens next' );
+			expect( whatHappensNextSection ).toBeVisible();
 
-			expect( whatHappensNextHeader ).toHaveAttribute( 'aria-expanded', 'true' );
+			// Verify content is visible (indicates expansion)
 			expect( screen.getByText( 'Automatic verification' ) ).toBeVisible();
 		} );
 	} );

--- a/client/dashboard/domains/domain-connection-setup/verification-in-progress-next-steps.tsx
+++ b/client/dashboard/domains/domain-connection-setup/verification-in-progress-next-steps.tsx
@@ -42,6 +42,7 @@ export default function VerificationInProgressNextSteps() {
 		<CollapsibleCard
 			header={ <SectionHeader level={ 3 } title={ __( 'What happens next' ) } /> }
 			className="verification-in-progress-next-steps"
+			initialExpanded
 		>
 			{ data.map( ( item ) => (
 				<IconList.Item


### PR DESCRIPTION
Closes DOMENG-277

## Proposed Changes

* Set "What happens next" card to be expanded by default when the Domain Connection Verification page loads
* Verified "Customize your site" card already uses the correct Multi-Site Dashboard Site Overview route (no changes needed)
* Added test to verify the "What happens next" card is expanded by default

## Why are these changes being made?

The Domain Connection Verification page needs improvements to the "While you wait" section:
1. The "What happens next" accordion should be expanded by default so users can immediately see what to expect
2. The "Customize your site" card should link to the Multi-Site Dashboard Site Overview (already implemented correctly)

This improves the user experience by making important information visible without requiring user interaction.

## Testing Instructions

1. Navigate to the Domain Connection Verification page when a domain is in the verifying state
2. Verify that the "What happens next" card is expanded by default, showing the three steps (Automatic verification, Global propagation, We'll notify you when it's ready)
3. Verify that the card can still be collapsed/expanded manually
4. Click on "Customize your site" and verify it navigates to the Multi-Site Dashboard Site Overview page for the current site
5. Run the test suite: `yarn test-client client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx`

## Acceptance Criteria

- ✅ Clicking "Customize your site" from the Domain Connection Verification page opens the Multi-Site Dashboard's Site Overview for the relevant site
- ✅ On initial page load, "What happens next" content is visible (card is expanded)
- ✅ No regressions to the rest of the Domain Connection Verification flow