### PR TITLE
MSD Domains: Inform users about DNS requirements when setting up email forwarding

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -583,15 +583,15 @@ const contextLinks = {
 		post_id: 6595,
 	},
 	'dns-default-mx-records': {
-		link: 'https://wordpress.com/support/domains/custom-dns/view-or-restore-default-dns-records/#default-mx-records',
+		link: 'https://wordpress.com/support/domains/custom-dns/view-or-restore-default-dns-records/#restore-default-email-records',
 		post_id: 386585,
 	},
 	'dns-default-a-records': {
-		link: 'https://wordpress.com/support/domains/custom-dns/view-or-restore-default-dns-records/#default-a-records',
+		link: 'https://wordpress.com/support/domains/custom-dns/view-or-restore-default-dns-records/#restore-default-a-records',
 		post_id: 386585,
 	},
 	'dns-default-cname-records': {
-		link: 'https://wordpress.com/support/domains/custom-dns/view-or-restore-default-dns-records/#default-cname-record',
+		link: 'https://wordpress.com/support/domains/custom-dns/view-or-restore-default-dns-records/#restore-default-cname-record',
 		post_id: 386585,
 	},
 	'add-a-new-dns-record': {

--- a/client/dashboard/emails/add-forwarder/dns-requirements-notice.tsx
+++ b/client/dashboard/emails/add-forwarder/dns-requirements-notice.tsx
@@ -1,0 +1,64 @@
+import { DomainSubtype, Domain } from '@automattic/api-core';
+import { Link } from '@tanstack/react-router';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { domainDnsRoute, domainNameServersRoute } from '../../app/router/domains';
+import InlineSupportLink from '../../components/inline-support-link';
+import Notice from '../../components/notice';
+
+interface DnsRequirementsNoticeProps {
+	domainName: string;
+	domainData: Domain | undefined;
+}
+
+export const DnsRequirementsNotice = ( { domainName, domainData }: DnsRequirementsNoticeProps ) => {
+	if ( ! domainData || domainData.has_wpcom_nameservers ) {
+		return null;
+	}
+
+	if ( domainData.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {
+		return (
+			<Notice variant="warning" title={ __( 'DNS configuration required' ) }>
+				{ createInterpolateElement(
+					__(
+						'Your domain is using external name servers. To set up email forwarding, you need to configure MX records in your DNS settings. <learnMoreLink />'
+					),
+					{
+						learnMoreLink: (
+							<InlineSupportLink supportContext="dns-default-mx-records">
+								{ __( 'Learn more about MX records' ) }
+							</InlineSupportLink>
+						),
+					}
+				) }
+			</Notice>
+		);
+	}
+
+	return (
+		<Notice variant="warning" title={ __( 'DNS configuration required' ) }>
+			{ createInterpolateElement(
+				__(
+					'Your domain is using external name servers. To set up email forwarding, you need to configure MX records in your DNS settings. <dnsLink>Manage DNS records</dnsLink> or <nameServersLink>switch to WordPress.com name servers</nameServersLink>. <learnMoreLink />'
+				),
+				{
+					dnsLink: (
+						<Link to={ domainDnsRoute.fullPath } params={ { domainName } }>
+							{ __( 'Manage DNS records' ) }
+						</Link>
+					),
+					nameServersLink: (
+						<Link to={ domainNameServersRoute.fullPath } params={ { domainName } }>
+							{ __( 'switch to WordPress.com name servers' ) }
+						</Link>
+					),
+					learnMoreLink: (
+						<InlineSupportLink supportContext="dns-default-mx-records">
+							{ __( 'Learn more about MX records' ) }
+						</InlineSupportLink>
+					),
+				}
+			) }
+		</Notice>
+	);
+};

--- a/client/dashboard/emails/add-forwarder/dns-requirements-notice.tsx
+++ b/client/dashboard/emails/add-forwarder/dns-requirements-notice.tsx
@@ -1,63 +1,62 @@
 import { DomainSubtype, Domain } from '@automattic/api-core';
-import { Link } from '@tanstack/react-router';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { domainDnsRoute, domainNameServersRoute } from '../../app/router/domains';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
+import RouterLinkButton from '../../components/router-link-button';
 
 interface DnsRequirementsNoticeProps {
 	domainName: string;
-	domainData: Domain | undefined;
+	domainData: Domain;
 }
 
 export const DnsRequirementsNotice = ( { domainName, domainData }: DnsRequirementsNoticeProps ) => {
-	if ( ! domainData || domainData.has_wpcom_nameservers ) {
+	if ( ! domainData.has_wpcom_nameservers ) {
 		return null;
 	}
 
 	if ( domainData.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {
 		return (
-			<Notice variant="warning" title={ __( 'DNS configuration required' ) }>
-				{ createInterpolateElement(
-					__(
-						'Your domain is using external name servers. To set up email forwarding, you need to configure MX records in your DNS settings. <learnMoreLink />'
-					),
-					{
-						learnMoreLink: (
-							<InlineSupportLink supportContext="dns-default-mx-records">
-								{ __( 'Learn more about MX records' ) }
-							</InlineSupportLink>
-						),
-					}
+			<Notice
+				variant="warning"
+				title={ __( 'DNS configuration required' ) }
+				actions={
+					<InlineSupportLink supportContext="dns-default-mx-records">
+						{ __( 'Learn more about MX records' ) }
+					</InlineSupportLink>
+				}
+			>
+				{ __(
+					'Your domain is using external name servers. To set up email forwarding, you need to configure MX records in your DNS settings.'
 				) }
 			</Notice>
 		);
 	}
 
 	return (
-		<Notice variant="warning" title={ __( 'DNS configuration required' ) }>
-			{ createInterpolateElement(
-				__(
-					'Your domain is using external name servers. To set up email forwarding, you need to configure MX records in your DNS settings. <dnsLink>Manage DNS records</dnsLink> or <nameServersLink>switch to WordPress.com name servers</nameServersLink>. <learnMoreLink />'
-				),
-				{
-					dnsLink: (
-						<Link to={ domainDnsRoute.fullPath } params={ { domainName } }>
-							{ __( 'Manage DNS records' ) }
-						</Link>
-					),
-					nameServersLink: (
-						<Link to={ domainNameServersRoute.fullPath } params={ { domainName } }>
-							{ __( 'switch to WordPress.com name servers' ) }
-						</Link>
-					),
-					learnMoreLink: (
-						<InlineSupportLink supportContext="dns-default-mx-records">
-							{ __( 'Learn more about MX records' ) }
-						</InlineSupportLink>
-					),
-				}
+		<Notice
+			variant="warning"
+			title={ __( 'DNS configuration required' ) }
+			actions={
+				<>
+					<RouterLinkButton to={ domainDnsRoute.fullPath } params={ { domainName } } variant="link">
+						{ __( 'Manage DNS records' ) }
+					</RouterLinkButton>
+					<RouterLinkButton
+						to={ domainNameServersRoute.fullPath }
+						params={ { domainName } }
+						variant="link"
+					>
+						{ __( 'Switch to WordPress.com name servers' ) }
+					</RouterLinkButton>
+					<InlineSupportLink supportContext="dns-default-mx-records">
+						{ __( 'Learn more about MX records' ) }
+					</InlineSupportLink>
+				</>
+			}
+		>
+			{ __(
+				'Your domain is using external name servers. To set up email forwarding, you need to configure MX records in your DNS settings.'
 			) }
 		</Notice>
 	);

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -256,6 +256,9 @@ function AddEmailForwarder() {
 			}
 			size="small"
 		>
+			{ formData.domain && domainData && (
+				<DnsRequirementsNotice domainName={ formData.domain } domainData={ domainData } />
+			) }
 			{ eligibleDomains.length === 0 ? (
 				<>
 					<Text size={ 16 }>
@@ -276,10 +279,6 @@ function AddEmailForwarder() {
 										setFormData( ( data ) => ( { ...data, ...edits } ) );
 									} }
 								/>
-
-								{ formData.domain && (
-									<DnsRequirementsNotice domainName={ formData.domain } domainData={ domainData } />
-								) }
 
 								<FormTokenField
 									__next40pxDefaultSize
@@ -377,7 +376,7 @@ function AddEmailForwarder() {
 										variant="primary"
 										type="submit"
 										isBusy={ isBusy }
-										disabled={ isBusy || ! allFieldsSet || ! isValid }
+										disabled={ isBusy || ! allFieldsSet || ! isValid || ! domainData }
 									>
 										{ __( 'Save' ) }
 									</Button>

--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -1,5 +1,9 @@
 import { EmailProvider } from '@automattic/api-core';
-import { addEmailForwarderMutation, userMailboxesQuery } from '@automattic/api-queries';
+import {
+	addEmailForwarderMutation,
+	domainQuery,
+	userMailboxesQuery,
+} from '@automattic/api-queries';
 import { CALYPSO_CONTACT } from '@automattic/urls';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
@@ -27,6 +31,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { Text } from '../../components/text';
 import AddNewDomain from '../components/add-new-domain';
+import { DnsRequirementsNotice } from './dns-requirements-notice';
 import { DEFAULT_MAX_DOMAIN_FORWARDS, useDomainMaxForwards } from './hooks/use-domain-max-forwards';
 import { useForwardingAddresses } from './hooks/use-forwarding-addresses';
 import type { Field } from '@wordpress/dataviews';
@@ -87,6 +92,11 @@ function AddEmailForwarder() {
 		forwards,
 		maxForwards,
 	} = useDomainMaxForwards( formData.domain );
+
+	const { data: domainData } = useQuery( {
+		...domainQuery( formData.domain ),
+		enabled: !! formData.domain,
+	} );
 
 	const fields: Field< FormData >[] = useMemo(
 		() => [
@@ -266,6 +276,10 @@ function AddEmailForwarder() {
 										setFormData( ( data ) => ( { ...data, ...edits } ) );
 									} }
 								/>
+
+								{ formData.domain && (
+									<DnsRequirementsNotice domainName={ formData.domain } domainData={ domainData } />
+								) }
 
 								<FormTokenField
 									__next40pxDefaultSize


### PR DESCRIPTION
Part of DOMENG-281

## Proposed Changes

* Add DNS requirements notice component that displays when users select a domain without WordPress.com nameservers
* Query domain data when a domain is selected in the email forwarding form
* Display warning notice informing users they need to configure MX records manually
* Provide helpful links to DNS settings and support documentation

## Screenshots

### DNS records managed by us

<img width="719" height="594" alt="image" src="https://github.com/user-attachments/assets/94c840d1-8ea6-4bf5-84c9-e6eb2c33ddba" />

### DNS records managed externally

<img width="716" height="603" alt="image" src="https://github.com/user-attachments/assets/eaba5380-c39e-4a44-a26a-e32ff58db383" />

## Testing Instructions

1. Navigate to the email forwarding setup page (`/emails/add-forwarder`)
2. Select a domain that doesn't use WordPress.com nameservers
3. Verify that a warning notice appears below the domain selection field
4. Verify the notice includes:
   - A clear message about DNS configuration requirements
   - Links to manage DNS records (for non-connection domains)
   - Link to switch to WordPress.com name servers (for non-connection domains)
   - Support documentation link about MX records
5. For domain connection subtypes, verify the notice shows only the support link (no direct DNS management links)
6. Verify the notice does NOT appear for domains using WordPress.com nameservers
7. Verify the notice does NOT appear when no domain is selected