### PR TITLE
Responsive tweaks to the feature gating var1d design

### DIFF
--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -785,7 +785,10 @@ const FEATURES_LIST: FeatureList = {
 
 	[ FEATURE_NO_ADS ]: {
 		getSlug: () => WPCOM_FEATURES_NO_ADVERTS,
-		getTitle: () => i18n.translate( 'Remove WordPress.com ads' ),
+		getTitle: ( params ) =>
+			params?.isExperimentVariant
+				? i18n.translate( 'No ads for visitors' )
+				: i18n.translate( 'Remove WordPress.com ads' ),
 		getDescription: () =>
 			i18n.translate(
 				'Allow your visitors to visit and read your website without ' +
@@ -1869,7 +1872,7 @@ const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_SECURITY_BRUTE_FORCE,
 		getTitle: ( params ) =>
 			params?.isExperimentVariant
-				? i18n.translate( 'Spam, brute-force, DDoS protection and mitigation' )
+				? i18n.translate( 'Protection against spam and hacking attacks' )
 				: i18n.translate( 'Brute-force protection' ),
 		getDescription: ( params ) =>
 			params?.isExperimentVariant
@@ -1918,7 +1921,7 @@ const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_STYLE_CUSTOMIZATION,
 		getTitle: ( params ) =>
 			params?.isExperimentVariant
-				? i18n.translate( 'Use custom CSS' )
+				? i18n.translate( 'Customize your site with CSS' )
 				: i18n.translate( 'Customize fonts and colors sitewide' ),
 		getCompareTitle: () =>
 			i18n.translate( 'Take control of every font, color, and detail of your site’s design.' ),
@@ -2003,7 +2006,10 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_CDN ]: {
 		getSlug: () => FEATURE_CDN,
-		getTitle: () => i18n.translate( 'Global CDN with 28+ locations' ),
+		getTitle: ( params ) =>
+			params?.isExperimentVariant
+				? i18n.translate( 'Faster site loading from 28+ global locations' )
+				: i18n.translate( 'Global CDN with 28+ locations' ),
 		getCompareTitle: () =>
 			i18n.translate( 'Rely on ultra-fast site speeds, from any location on earth.' ),
 		getDescription: ( params ) =>

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -785,10 +785,7 @@ const FEATURES_LIST: FeatureList = {
 
 	[ FEATURE_NO_ADS ]: {
 		getSlug: () => WPCOM_FEATURES_NO_ADVERTS,
-		getTitle: ( params ) =>
-			params?.isExperimentVariant
-				? i18n.translate( 'No ads for visitors' )
-				: i18n.translate( 'Remove WordPress.com ads' ),
+		getTitle: () => i18n.translate( 'Remove WordPress.com ads' ),
 		getDescription: () =>
 			i18n.translate(
 				'Allow your visitors to visit and read your website without ' +
@@ -1686,7 +1683,7 @@ const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_AD_FREE_EXPERIENCE,
 		getTitle: ( params ) =>
 			params?.isExperimentVariant
-				? i18n.translate( 'Turn off WordPress.com ads' )
+				? i18n.translate( 'No ads for visitors' )
 				: i18n.translate( 'Ad-free browsing experience for your visitors' ),
 		getDescription: ( params ) =>
 			params?.isExperimentVariant

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -835,7 +835,7 @@ const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_UPLOAD_PLUGINS,
 		getTitle: ( params ) =>
 			params?.isExperimentVariant
-				? i18n.translate( 'Install all WordPress plugins' )
+				? i18n.translate( 'Extend your site with WordPress plugins' )
 				: i18n.translate( 'Install WordPress plugins' ),
 		getDescription: ( params ) =>
 			params?.isExperimentVariant
@@ -2639,10 +2639,7 @@ const FEATURES_LIST: FeatureList = {
 			params?.isExperimentVariant
 				? i18n.translate( 'Free support' )
 				: i18n.translate( 'Support from our expert\u00A0team' ),
-		getDescription: ( params ) =>
-			params?.isExperimentVariant
-				? i18n.translate( 'Get support from our expert, friendly Happiness team.' )
-				: i18n.translate( 'Get support from our expert, friendly Happiness team' ),
+		getDescription: () => i18n.translate( 'Get support from our expert, friendly Happiness team' ),
 	},
 	[ FEATURE_FAST_SUPPORT_FROM_EXPERTS ]: {
 		getSlug: () => FEATURE_FAST_SUPPORT_FROM_EXPERTS,
@@ -2650,10 +2647,8 @@ const FEATURES_LIST: FeatureList = {
 			params?.isExperimentVariant
 				? i18n.translate( 'Free support with faster response times' )
 				: i18n.translate( 'Fast support from our expert\u00A0team' ),
-		getDescription: ( params ) =>
-			params?.isExperimentVariant
-				? i18n.translate( 'Prompt support from our expert, friendly Happiness team.' )
-				: i18n.translate( 'Prompt support from our expert, friendly Happiness team' ),
+		getDescription: () =>
+			i18n.translate( 'Prompt support from our expert, friendly Happiness team' ),
 	},
 	[ FEATURE_FREE_FAST_SUPPORT ]: {
 		getSlug: () => FEATURE_FREE_FAST_SUPPORT,

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -41,6 +41,12 @@ const FeatureBadge = styled.span`
 	vertical-align: baseline;
 	text-decoration: none;
 	white-space: nowrap;
+
+	@media ( max-width: 480px ) {
+		height: 16px;
+		padding: 0 4px;
+		margin-inline-start: 6px;
+	}
 `;
 
 // var1d experiment: Checkmark bullet icon for differentiator features


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15803

## Proposed Changes

* Small tweaks to the badge and a few copy updates

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Assign yourself to var1d of the calypso_pricing_differentiation_202601_v1 experiment
* Go to onboarding signup and use a mobile resolution

the badge should be smaller, with less padding

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
