### PR TITLE
A4A: Update Total commission payout to use new endpoint.

### DIFF
--- a/client/a8c-for-agencies/data/referrals/use-fetch-commission-payout.ts
+++ b/client/a8c-for-agencies/data/referrals/use-fetch-commission-payout.ts
@@ -3,7 +3,7 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
-export interface CommissionsResponse {
+export interface CommissionPayoutResponse {
 	total_amount: number;
 	total_commission: number;
 	client_data: Array< {
@@ -19,15 +19,18 @@ export interface CommissionsResponse {
 	} >;
 }
 
-export const getCommissionsQueryKey = ( agencyId?: number ) => {
-	return [ 'a4a-referrals-commissions', agencyId ];
+export const getCommissionPayoutQueryKey = ( agencyId?: number ) => {
+	return [ 'a4a-referrals-commission-payout', agencyId ];
 };
 
-export default function useFetchCommissions(): UseQueryResult< CommissionsResponse, unknown > {
+export default function useFetchCommissionPayout(): UseQueryResult<
+	CommissionPayoutResponse,
+	unknown
+> {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
-		queryKey: getCommissionsQueryKey( agencyId ),
+		queryKey: getCommissionPayoutQueryKey( agencyId ),
 		queryFn: () =>
 			wpcom.req.get( {
 				apiNamespace: 'wpcom/v2',

--- a/client/a8c-for-agencies/data/referrals/use-fetch-commissions.ts
+++ b/client/a8c-for-agencies/data/referrals/use-fetch-commissions.ts
@@ -1,0 +1,39 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export interface CommissionsResponse {
+	total_amount: number;
+	total_commission: number;
+	client_data: Array< {
+		client_user_id: number;
+		email: string;
+		total_amount: number;
+		total_commission: number;
+		products: Array< {
+			product_name: string;
+			total_amount: number;
+			total_commission: number;
+		} >;
+	} >;
+}
+
+export const getCommissionsQueryKey = ( agencyId?: number ) => {
+	return [ 'a4a-referrals-commissions', agencyId ];
+};
+
+export default function useFetchCommissions(): UseQueryResult< CommissionsResponse, unknown > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: getCommissionsQueryKey( agencyId ),
+		queryFn: () =>
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/referrals/commission-payout`,
+			} ),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -7,6 +7,7 @@ import {
 } from 'calypso/a8c-for-agencies/components/consolidated-stats-card';
 import { AGENCY_EARNINGS_LEARN_MORE_LINK } from 'calypso/a8c-for-agencies/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import useFetchCommissions from 'calypso/a8c-for-agencies/data/referrals/use-fetch-commissions';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import useGetConsolidatedPayoutData from '../hooks/use-get-consolidated-payout-data';
 import PayoutCards from './payout-cards';
@@ -14,40 +15,41 @@ import type { Referral } from '../types';
 
 type ConsolidatedViewsProps = {
 	referrals: Referral[];
-	totalPayouts?: number;
 };
 
-export default function ConsolidatedViews( { referrals, totalPayouts }: ConsolidatedViewsProps ) {
+export default function ConsolidatedViews( { referrals }: ConsolidatedViewsProps ) {
 	const translate = useTranslate();
 	const { data: productsData, isFetching } = useProductsQuery( false, true );
+	const { data: commissionsData, isFetching: isFetchingCommissions } = useFetchCommissions();
 	const { previousQuarterExpectedCommission, pendingOrders, currentQuarterExpectedCommission } =
 		useGetConsolidatedPayoutData( referrals, productsData );
 	const { showSupportGuide } = useHelpCenter();
 
+	const totalPayouts = commissionsData?.total_commission;
+
 	return (
 		<ConsolidatedStatsGroup className="consolidated-view">
-			{ totalPayouts !== undefined && (
-				<ConsolidatedStatsCard
-					value={ formatCurrency( totalPayouts, 'USD' ) }
-					footerText={ translate( 'All time referral payouts' ) }
-					popoverTitle={ translate( 'Total payouts' ) }
-					popoverContent={ translate(
-						'The exact amount your agency has been paid out for referrals.' +
-							'{{br/}}{{br/}}{{a}}Learn more{{/a}}',
-						{
-							components: {
-								a: (
-									<Button
-										variant="link"
-										onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) }
-									/>
-								),
-								br: <br />,
-							},
-						}
-					) }
-				/>
-			) }
+			<ConsolidatedStatsCard
+				value={ formatCurrency( totalPayouts ?? 0, 'USD' ) }
+				footerText={ translate( 'All time referral payouts' ) }
+				popoverTitle={ translate( 'Total payouts' ) }
+				popoverContent={ translate(
+					'The exact amount your agency has been paid out for referrals.' +
+						'{{br/}}{{br/}}{{a}}Learn more{{/a}}',
+					{
+						components: {
+							a: (
+								<Button
+									variant="link"
+									onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) }
+								/>
+							),
+							br: <br />,
+						},
+					}
+				) }
+				isLoading={ isFetchingCommissions }
+			/>
 			<PayoutCards
 				isFetching={ isFetching }
 				previousQuarterExpectedCommission={ previousQuarterExpectedCommission }

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -7,7 +7,6 @@ import {
 } from 'calypso/a8c-for-agencies/components/consolidated-stats-card';
 import { AGENCY_EARNINGS_LEARN_MORE_LINK } from 'calypso/a8c-for-agencies/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import useFetchCommissions from 'calypso/a8c-for-agencies/data/referrals/use-fetch-commissions';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import useGetConsolidatedPayoutData from '../hooks/use-get-consolidated-payout-data';
 import PayoutCards from './payout-cards';
@@ -15,41 +14,41 @@ import type { Referral } from '../types';
 
 type ConsolidatedViewsProps = {
 	referrals: Referral[];
+	totalPayouts?: number;
 };
 
-export default function ConsolidatedViews( { referrals }: ConsolidatedViewsProps ) {
+export default function ConsolidatedViews( { referrals, totalPayouts }: ConsolidatedViewsProps ) {
 	const translate = useTranslate();
 	const { data: productsData, isFetching } = useProductsQuery( false, true );
-	const { data: commissionsData, isFetching: isFetchingCommissions } = useFetchCommissions();
 	const { previousQuarterExpectedCommission, pendingOrders, currentQuarterExpectedCommission } =
 		useGetConsolidatedPayoutData( referrals, productsData );
 	const { showSupportGuide } = useHelpCenter();
 
-	const totalPayouts = commissionsData?.total_commission;
-
 	return (
 		<ConsolidatedStatsGroup className="consolidated-view">
-			<ConsolidatedStatsCard
-				value={ formatCurrency( totalPayouts ?? 0, 'USD' ) }
-				footerText={ translate( 'All time referral payouts' ) }
-				popoverTitle={ translate( 'Total payouts' ) }
-				popoverContent={ translate(
-					'The exact amount your agency has been paid out for referrals.' +
-						'{{br/}}{{br/}}{{a}}Learn more{{/a}}',
-					{
-						components: {
-							a: (
-								<Button
-									variant="link"
-									onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) }
-								/>
-							),
-							br: <br />,
-						},
-					}
-				) }
-				isLoading={ isFetchingCommissions }
-			/>
+			{ totalPayouts !== undefined && (
+				<ConsolidatedStatsCard
+					value={ formatCurrency( totalPayouts, 'USD' ) }
+					footerText={ translate( 'All time referral payouts' ) }
+					popoverTitle={ translate( 'Total payouts' ) }
+					popoverContent={ translate(
+						'The exact amount your agency has been paid out for referrals.' +
+							'{{br/}}{{br/}}{{a}}Learn more{{/a}}',
+						{
+							components: {
+								a: (
+									<Button
+										variant="link"
+										onClick={ () => showSupportGuide( AGENCY_EARNINGS_LEARN_MORE_LINK ) }
+									/>
+								),
+								br: <br />,
+							},
+						}
+					) }
+				/>
+			) }
+
 			<PayoutCards
 				isFetching={ isFetching }
 				previousQuarterExpectedCommission={ previousQuarterExpectedCommission }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -100,12 +100,7 @@ export default function LayoutBodyContent( {
 	if ( referrals?.length ) {
 		return (
 			<>
-				{ ! dataViewsState.selectedItem && (
-					<ConsolidatedViews
-						referrals={ referrals }
-						totalPayouts={ tipaltiData?.PaymentsStatus?.submittedTotal }
-					/>
-				) }
+				{ ! dataViewsState.selectedItem && <ConsolidatedViews referrals={ referrals } /> }
 				<ReferralList
 					referrals={ referrals }
 					dataViewsState={ dataViewsState }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -13,6 +13,7 @@ import {
 import StepSection from 'calypso/a8c-for-agencies/components/step-section';
 import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import useFetchCommissionPayout from 'calypso/a8c-for-agencies/data/referrals/use-fetch-commission-payout';
 import {
 	MARKETPLACE_TYPE_REFERRAL,
 	MARKETPLACE_TYPE_SESSION_STORAGE_KEY,
@@ -47,6 +48,8 @@ export default function LayoutBodyContent( {
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const { data: commissionPayoutData } = useFetchCommissionPayout();
 
 	const onAddBankDetailsClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_add_bank_details_button_click' ) );
@@ -100,7 +103,12 @@ export default function LayoutBodyContent( {
 	if ( referrals?.length ) {
 		return (
 			<>
-				{ ! dataViewsState.selectedItem && <ConsolidatedViews referrals={ referrals } /> }
+				{ ! dataViewsState.selectedItem && (
+					<ConsolidatedViews
+						referrals={ referrals }
+						totalPayouts={ commissionPayoutData?.total_commission }
+					/>
+				) }
 				<ReferralList
 					referrals={ referrals }
 					dataViewsState={ dataViewsState }


### PR DESCRIPTION
Depends on 200856-ghe-Automattic/wpcom
Closes https://linear.app/a8c/issue/A4A-1814/referrals-total-commissions-payout-is-populated-instead-of-referrals


## Proposed Changes
This pull request introduces a new data fetching hook for commission payout information and refactors the referrals overview to use this new source for payout data. The main goal is to improve how commission payout data is retrieved and displayed by switching from the previous payout data source to a more relevant API.

**Data fetching improvements:**

* Added a new hook `useFetchCommissionPayout` in `use-fetch-commission-payout.ts` to fetch commission payout data for the active agency using React Query and a new API endpoint.
* Updated `layout-body-content.tsx` to use the new `useFetchCommissionPayout` hook and retrieve commission payout data, replacing the previous data source. [[1]](diffhunk://#diff-16f8400b81866142f71bedcb697ab0cc91dc10ddf6f1f98abcd8befc3655f6f3R16) [[2]](diffhunk://#diff-16f8400b81866142f71bedcb697ab0cc91dc10ddf6f1f98abcd8befc3655f6f3R52-R53)

**UI data source refactor:**

* Changed the `totalPayouts` prop in `ConsolidatedViews` to use `commissionPayoutData.total_commission` instead of `tipaltiData.PaymentsStatus.submittedTotal`, ensuring the UI reflects the new commission payout data.
* Minor adjustment in `consolidated-view/index.tsx` to support the new payout data flow.

## Why are these changes being made?

* We are showing an incorrect payout value, which includes everything (migrations, WooPayments, and referrals). We only want to calculate payouts for referrals.

## Testing Instructions
* Apply patch 200856-ghe-Automattic/wpcom
* Use the A4A live link and navigate to the `referrals/dashboard` page
* Confirm that the total referral payout is correct and loading data from the new endpoint.
<img width="553" height="151" alt="Screenshot 2026-01-22 at 10 38 17 PM" src="https://github.com/user-attachments/assets/49181123-4926-430a-bb0d-0431870c67b9" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?