### PR TITLE
MSD Domains: Redirect back to the dashboard on domain operations

### DIFF
--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -17,6 +17,7 @@ import {
 import Notice from 'calypso/components/notice';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import wpcom from 'calypso/lib/wp';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
 import { Maybe, StartStepProps } from './types';
@@ -31,6 +32,7 @@ function TransferDomainStepStart( {
 	domainInboundTransferStatusInfo,
 	domain,
 	isFetchingAvailability,
+	dashboard,
 	selectedSite,
 }: StartStepProps ) {
 	const { __ } = useI18n();
@@ -79,6 +81,7 @@ function TransferDomainStepStart( {
 					const availabilityErrorMessage = getAvailabilityErrorMessage( {
 						availabilityData,
 						domainName: domain,
+						dashboard,
 						selectedSite,
 					} );
 
@@ -93,7 +96,7 @@ function TransferDomainStepStart( {
 				setIsFetching( false );
 			}
 		} )();
-	}, [ domain, inboundTransferStatusInfo, selectedSite, isFetching ] );
+	}, [ domain, inboundTransferStatusInfo, selectedSite, isFetching, dashboard ] );
 
 	const stepContent = (
 		<>
@@ -161,6 +164,7 @@ function TransferDomainStepStart( {
 	);
 }
 
-export default connect( ( state ) => ( { selectedSite: getSelectedSite( state ) } ) )(
-	TransferDomainStepStart
-);
+export default connect( ( state ) => ( {
+	dashboard: getCurrentQueryArguments( state as Record< string, unknown > )?.dashboard,
+	selectedSite: getSelectedSite( state ),
+} ) )( TransferDomainStepStart );

--- a/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
+++ b/client/components/domains/connect-domain-step/transfer-domain-step-start.tsx
@@ -15,12 +15,14 @@ import {
 	getDomainTransferrability,
 } from 'calypso/components/domains/use-my-domain/utilities';
 import Notice from 'calypso/components/notice';
+import { getDashboardFromString } from 'calypso/dashboard/utils/link';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import wpcom from 'calypso/lib/wp';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
 import { Maybe, StartStepProps } from './types';
+import type { AppState } from 'calypso/types';
 
 import './style.scss';
 
@@ -164,7 +166,8 @@ function TransferDomainStepStart( {
 	);
 }
 
-export default connect( ( state ) => ( {
-	dashboard: getCurrentQueryArguments( state as Record< string, unknown > )?.dashboard,
+export default connect( ( state: AppState ) => ( {
+	dashboard:
+		getDashboardFromString( getCurrentQueryArguments( state )?.dashboard?.toString() ) ?? undefined,
 	selectedSite: getSelectedSite( state ),
 } ) )( TransferDomainStepStart );

--- a/client/components/domains/connect-domain-step/types/index.tsx
+++ b/client/components/domains/connect-domain-step/types/index.tsx
@@ -1,5 +1,6 @@
 import { stepSlug, useMyDomainInputMode } from '../constants';
 import type { SiteDetails } from '@automattic/data-stores';
+import type { DashboardType } from 'calypso/dashboard/utils/link';
 
 type ValueOf< T > = T[ keyof T ];
 export type Maybe< T > = T | null | undefined;
@@ -56,6 +57,7 @@ export type StartStepProps = {
 	progressStepList: Record< PossibleSlugs, string >;
 	domainInboundTransferStatusInfo: Partial< InboundTransferStatusInfo >;
 	initialMode: PossibleInitialModes;
+	dashboard?: DashboardType;
 	selectedSite: Maybe< SiteDetails >;
 	setPage: ( page: PossibleSlugs ) => void;
 };

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -25,6 +25,7 @@ import {
 	recordInputFocusInMapDomain,
 	recordGoButtonClickInMapDomain,
 } from 'calypso/state/domains/actions';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -258,10 +259,18 @@ class MapDomainStep extends Component {
 				const availabilityStatus = MAPPED === mappableStatus ? mappableStatus : status;
 
 				const maintenanceEndTime = get( result, 'maintenance_end_time', null );
-				const { message, severity } = getAvailabilityNotice( domain, availabilityStatus, {
-					site,
-					maintenanceEndTime,
-				} );
+				const { message, severity } = getAvailabilityNotice(
+					domain,
+					availabilityStatus,
+					{
+						site,
+						maintenanceEndTime,
+					},
+					false,
+					'_self',
+					'',
+					this.props.dashboard
+				);
 				this.setState( { notice: message, noticeSeverity: severity, isPendingSubmit: false } );
 			}
 		);
@@ -271,6 +280,7 @@ class MapDomainStep extends Component {
 export default connect(
 	( state ) => ( {
 		currentUser: getCurrentUser( state ),
+		dashboard: getCurrentQueryArguments( state )?.dashboard,
 		selectedSite: getSelectedSite( state ),
 		primaryWithPlansOnly: getCurrentUser( state )
 			? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -12,6 +12,7 @@ import DomainProductPrice from 'calypso/components/domains/domain-product-price'
 import DomainRegistrationSuggestion from 'calypso/components/domains/domain-registration-suggestion';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import Notice from 'calypso/components/notice';
+import { getDashboardFromString } from 'calypso/dashboard/utils/link';
 import { getDomainPriceRule } from 'calypso/lib/cart-values/cart-items';
 import { getFixedDomainSearch, checkDomainAvailability } from 'calypso/lib/domains';
 import { domainAvailability } from 'calypso/lib/domains/constants';
@@ -280,7 +281,9 @@ class MapDomainStep extends Component {
 export default connect(
 	( state ) => ( {
 		currentUser: getCurrentUser( state ),
-		dashboard: getCurrentQueryArguments( state )?.dashboard,
+		dashboard:
+			getDashboardFromString( getCurrentQueryArguments( state )?.dashboard?.toString() ) ??
+			undefined,
 		selectedSite: getSelectedSite( state ),
 		primaryWithPlansOnly: getCurrentUser( state )
 			? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -19,6 +19,7 @@ import TransferRestrictionMessage from 'calypso/components/domains/transfer-doma
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import HeaderCake from 'calypso/components/header-cake';
 import Notice from 'calypso/components/notice';
+import { getDashboardFromString } from 'calypso/dashboard/utils/link';
 import {
 	isDomainBundledWithPlan,
 	isNextDomainFree,
@@ -735,7 +736,9 @@ export default connect(
 		currentRoute: getCurrentRoute( state ),
 		currentUser: getCurrentUser( state ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
-		dashboard: getCurrentQueryArguments( state )?.dashboard,
+		dashboard:
+			getDashboardFromString( getCurrentQueryArguments( state )?.dashboard?.toString() ) ??
+			undefined,
 		selectedSite: getSelectedSite( state ),
 		productsList: getProductsList( state ),
 	} ),

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -47,6 +47,7 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -635,10 +636,18 @@ class TransferDomainStep extends Component {
 							}
 
 							const maintenanceEndTime = get( result, 'maintenance_end_time', null );
-							const { message, severity } = getAvailabilityNotice( domain, status, {
-								site,
-								maintenanceEndTime,
-							} );
+							const { message, severity } = getAvailabilityNotice(
+								domain,
+								status,
+								{
+									site,
+									maintenanceEndTime,
+								},
+								false,
+								'_self',
+								'',
+								this.props.dashboard
+							);
 							this.setState( { notice: message, noticeSeverity: severity } );
 						}
 					}
@@ -726,6 +735,7 @@ export default connect(
 		currentRoute: getCurrentRoute( state ),
 		currentUser: getCurrentUser( state ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
+		dashboard: getCurrentQueryArguments( state )?.dashboard,
 		selectedSite: getSelectedSite( state ),
 		productsList: getProductsList( state ),
 	} ),

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -25,6 +25,7 @@ import {
 	getDomainNameValidationErrorMessage,
 } from 'calypso/components/domains/use-my-domain/utilities';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { getDashboardFromString } from 'calypso/dashboard/utils/link';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getWpcomRegistrationStatus } from 'calypso/lib/domains/get-wpcom-registration-status';
 import wpcom from 'calypso/lib/wp';
@@ -502,7 +503,8 @@ UseMyDomain.propTypes = {
 };
 
 export default connect( ( state ) => ( {
-	dashboard: getCurrentQueryArguments( state )?.dashboard,
+	dashboard:
+		getDashboardFromString( getCurrentQueryArguments( state )?.dashboard?.toString() ) ?? undefined,
 	selectedSite: getSelectedSite( state ),
 	updatingPrimaryDomain: isUpdatingPrimaryDomain( state, getSelectedSite( state )?.ID ),
 } ) )( UseMyDomain );

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -29,6 +29,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getWpcomRegistrationStatus } from 'calypso/lib/domains/get-wpcom-registration-status';
 import wpcom from 'calypso/lib/wp';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { isUpdatingPrimaryDomain } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import UseMyDomainInput from './domain-input';
@@ -43,6 +44,7 @@ function UseMyDomain( props ) {
 		isSignupStep = false,
 		onConnect,
 		onTransfer,
+		dashboard,
 		selectedSite,
 		transferDomainUrl,
 		initialMode,
@@ -155,11 +157,12 @@ function UseMyDomain( props ) {
 			errorMessage: getAvailabilityErrorMessage( {
 				availabilityData: wpRegistrationCheckData,
 				domainName: filteredDomainName,
+				dashboard,
 				selectedSite,
 				registerNowAction,
 			} ),
 		};
-	}, [ filterDomainName, domainName, selectedSite, registerNowAction ] );
+	}, [ filterDomainName, domainName, selectedSite, registerNowAction, dashboard ] );
 
 	const getAvailability = useCallback( async () => {
 		const filteredDomainName = filterDomainName( domainName );
@@ -178,6 +181,7 @@ function UseMyDomain( props ) {
 			errorMessage: getAvailabilityErrorMessage( {
 				availabilityData,
 				domainName: filteredDomainName,
+				dashboard,
 				selectedSite,
 				registerNowAction,
 			} ),
@@ -188,6 +192,7 @@ function UseMyDomain( props ) {
 		getWpcomAvailabilityErrors,
 		selectedSite,
 		registerNowAction,
+		dashboard,
 	] );
 
 	const setTransferStepsAndLockStatus = useCallback(
@@ -497,6 +502,7 @@ UseMyDomain.propTypes = {
 };
 
 export default connect( ( state ) => ( {
+	dashboard: getCurrentQueryArguments( state )?.dashboard,
 	selectedSite: getSelectedSite( state ),
 	updatingPrimaryDomain: isUpdatingPrimaryDomain( state, getSelectedSite( state )?.ID ),
 } ) )( UseMyDomain );

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import { getDashboardFromString } from 'calypso/dashboard/utils/link';
 import wpcom from 'calypso/lib/wp';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -165,7 +166,9 @@ export default connect(
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			primaryWithPlansOnly: currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS ),
 			productsList: getProductsList( state ),
-			dashboard: getCurrentQueryArguments( state )?.dashboard,
+			dashboard:
+				getDashboardFromString( getCurrentQueryArguments( state )?.dashboard?.toString() ) ??
+				undefined,
 			selectedSite,
 			siteIsOnPaidPlan: isSiteOnPaidPlan( state, selectedSite?.ID ),
 		};

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -13,6 +13,7 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import {
@@ -37,6 +38,7 @@ function DomainTransferOrConnect( {
 	onTransfer,
 	primaryWithPlansOnly,
 	productsList,
+	dashboard,
 	recordMappingButtonClickInUseYourDomain,
 	recordTransferButtonClickInUseYourDomain,
 	selectedSite,
@@ -71,6 +73,7 @@ function DomainTransferOrConnect( {
 		currencyCode,
 		domain,
 		domainInboundTransferStatusInfo: inboundTransferStatusInfo,
+		dashboard,
 		isSignupStep,
 		onConnect: handleConnect,
 		onSkip,
@@ -162,6 +165,7 @@ export default connect(
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			primaryWithPlansOnly: currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS ),
 			productsList: getProductsList( state ),
+			dashboard: getCurrentQueryArguments( state )?.dashboard,
 			selectedSite,
 			siteIsOnPaidPlan: isSiteOnPaidPlan( state, selectedSite?.ID ),
 		};

--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -7,6 +7,7 @@ import { domainAddNew } from 'calypso/my-sites/domains/paths';
 export function getAvailabilityErrorMessage( {
 	availabilityData,
 	domainName,
+	dashboard,
 	selectedSite,
 	registerNowAction = undefined,
 } ) {
@@ -70,12 +71,20 @@ export function getAvailabilityErrorMessage( {
 	const isSiteDomainOnly =
 		site === other_site_domain ? other_site_domain_only : selectedSite?.options?.is_domain_only;
 
-	const errorData = getAvailabilityNotice( domainName, availabilityStatus, {
-		site,
-		maintenanceEndTime,
-		isSiteDomainOnly,
-		cannot_transfer_due_to_unsupported_premium_tld:
-			availabilityData?.cannot_transfer_due_to_unsupported_premium_tld,
-	} );
+	const errorData = getAvailabilityNotice(
+		domainName,
+		availabilityStatus,
+		{
+			site,
+			maintenanceEndTime,
+			isSiteDomainOnly,
+			cannot_transfer_due_to_unsupported_premium_tld:
+				availabilityData?.cannot_transfer_due_to_unsupported_premium_tld,
+		},
+		undefined,
+		undefined,
+		undefined,
+		dashboard
+	);
 	return errorData?.message || null;
 }

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -48,6 +48,7 @@ export function getOptionInfo( {
 	cart,
 	currencyCode,
 	domain,
+	dashboard,
 	isSignupStep,
 	onConnect,
 	onSkip,
@@ -181,7 +182,15 @@ export function getOptionInfo( {
 			};
 			break;
 		default: {
-			const availabilityNotice = getAvailabilityNotice( domain, availability.status );
+			const availabilityNotice = getAvailabilityNotice(
+				domain,
+				availability.status,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				dashboard
+			);
 			transferContent = {
 				...optionInfo.transferNotSupported,
 				topText: availabilityNotice.message,

--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -7,11 +7,9 @@ import { getCurrentDashboard, redirectToDashboardLink, wpcomLink } from '../util
 export function AddDomainButton( {
 	siteSlug,
 	domainConnectionSetupUrl,
-	redirectTo,
 }: {
 	siteSlug?: string;
 	domainConnectionSetupUrl?: string;
-	redirectTo?: string;
 } ) {
 	const buildQueryArgs = () => {
 		const queryArgs: Record< string, string > = {};
@@ -20,9 +18,6 @@ export function AddDomainButton( {
 		}
 		if ( domainConnectionSetupUrl ) {
 			queryArgs.domainConnectionSetupUrl = domainConnectionSetupUrl;
-		}
-		if ( redirectTo ) {
-			queryArgs.redirect_to = redirectTo;
 		}
 
 		queryArgs.dashboard = getCurrentDashboard();

--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -25,19 +25,14 @@ export function AddDomainButton( {
 			queryArgs.redirect_to = redirectTo;
 		}
 
-		const dashboard = getCurrentDashboard();
-		if ( dashboard ) {
-			queryArgs.dashboard = dashboard;
-		}
+		queryArgs.dashboard = getCurrentDashboard();
 		queryArgs.back_to = redirectToDashboardLink();
 		return queryArgs;
 	};
 
 	const navigateTo = ( urlWithSite: string, urlWithoutSite: string ) => {
 		const queryArgs = buildQueryArgs();
-		window.location.href = siteSlug
-			? addQueryArgs( urlWithSite, queryArgs )
-			: addQueryArgs( urlWithoutSite, queryArgs );
+		window.location.href = addQueryArgs( siteSlug ? urlWithSite : urlWithoutSite, queryArgs );
 		return false;
 	};
 

--- a/client/dashboard/emails/components/no-domains-available-empty-state.tsx
+++ b/client/dashboard/emails/components/no-domains-available-empty-state.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { DataViewsEmptyState } from '../../components/dataviews';
-import { wpcomLink } from '../../utils/link';
+import { getCurrentDashboard, wpcomLink } from '../../utils/link';
 import DomainEmptyIllustration from '../resources/domain-empty-illustration';
 
 const NoDomainsAvailableEmptyState = () => {
@@ -13,7 +14,12 @@ const NoDomainsAvailableEmptyState = () => {
 			) }
 			illustration={ <DomainEmptyIllustration /> }
 			actions={
-				<Button variant="primary" href={ wpcomLink( '/setup/domain' ) }>
+				<Button
+					variant="primary"
+					href={ addQueryArgs( wpcomLink( '/setup/domain' ), {
+						dashboard: getCurrentDashboard(),
+					} ) }
+				>
 					{ __( 'Choose a domain' ) }
 				</Button>
 			}

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -5,7 +5,6 @@ import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useAuth } from '../../app/auth';
-import { useAppContext } from '../../app/context';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import { siteRoute, siteDomainsRoute, siteSettingsRedirectRoute } from '../../app/router/sites';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
@@ -62,9 +61,7 @@ function SiteDomains() {
 		fields
 	);
 
-	const { basePath } = useAppContext();
 	const domainConnectionSetupUrl = getDomainConnectionSetupTemplateUrl();
-	const redirectTo = `${ basePath }/sites/${ site.slug }/domains`;
 
 	return (
 		<PageLayout
@@ -75,7 +72,6 @@ function SiteDomains() {
 						<AddDomainButton
 							siteSlug={ site.slug }
 							domainConnectionSetupUrl={ domainConnectionSetupUrl }
-							redirectTo={ redirectTo }
 						/>
 					}
 				/>

--- a/client/dashboard/sites/overview-domain-transfer-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-transfer-upsell-card/index.tsx
@@ -1,8 +1,9 @@
 import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { Callout } from '../../components/callout';
 import UpsellCTAButton from '../../components/upsell-cta-button';
-import { wpcomLink } from '../../utils/link';
+import { getCurrentDashboard, wpcomLink } from '../../utils/link';
 import illustrationTransferDomainUrl from './upsell-illustration-transfer-domain.svg';
 
 export default function DomainTransferUpsellCard() {
@@ -21,7 +22,9 @@ export default function DomainTransferUpsellCard() {
 			imageVariant="full-bleed"
 			actions={
 				<UpsellCTAButton
-					href={ wpcomLink( '/setup/domain-transfer' ) }
+					href={ addQueryArgs( wpcomLink( '/setup/domain-transfer' ), {
+						dashboard: getCurrentDashboard(),
+					} ) }
 					text={ __( 'Transfer domain' ) }
 					size="compact"
 					upsellId="site-overview-transfer-domain"

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -36,7 +36,7 @@ export function a4aLink( path: string ) {
  * Dashboard type identifier.
  * undefined represents the default (main MSD dashboard).
  */
-export type DashboardType = 'ciab' | undefined;
+export type DashboardType = 'ciab' | 'msd';
 
 /**
  * Returns the dashboard type from URL query params.
@@ -84,12 +84,10 @@ function getDashboardFromReferrer(): DashboardType | null {
 
 /**
  * Detects the current dashboard context.
- * Priority: query param → current path → referrer → default (undefined = main MSD)
+ * Priority: query param → current path → referrer → defaults to MSD
  */
 export function getCurrentDashboard(): DashboardType {
-	return (
-		getDashboardFromQuery() ?? getDashboardFromPath() ?? getDashboardFromReferrer() ?? undefined
-	);
+	return getDashboardFromQuery() ?? getDashboardFromPath() ?? getDashboardFromReferrer() ?? 'msd';
 }
 
 /**

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -39,6 +39,17 @@ export function a4aLink( path: string ) {
 export type DashboardType = 'ciab' | 'msd';
 
 /**
+ * Returns the dashboard type from a string.
+ */
+export function getDashboardFromString( dashboard?: string ): DashboardType | null {
+	if ( dashboard === 'ciab' || dashboard === 'msd' ) {
+		return dashboard;
+	}
+
+	return null;
+}
+
+/**
  * Returns the dashboard type from URL query params.
  * Used when in Stepper to know which dashboard the user came from.
  */

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -77,11 +77,13 @@ const DomainSearchStep: StepType< {
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
 	const siteId = useSiteIdParam();
-	const initialQuery = useQuery().get( 'new' ) ?? '';
-	const tldQuery = useQuery().get( 'tld' );
-	const source = useQuery().get( 'source' );
-	const backTo = useQuery().get( 'back_to' ) ?? '';
-	const sourceSlug = useQuery().get( 'sourceSlug' );
+	const queryParams = useQuery();
+	const initialQuery = queryParams.get( 'new' ) ?? '';
+	const tldQuery = queryParams.get( 'tld' );
+	const source = queryParams.get( 'source' );
+	const backTo = queryParams.get( 'back_to' ) ?? '';
+	const sourceSlug = queryParams.get( 'sourceSlug' );
+	const dashboard = queryParams.get( 'dashboard' );
 	const { __ } = useI18n();
 
 	// eslint-disable-next-line no-nested-ternary
@@ -148,6 +150,10 @@ const DomainSearchStep: StepType< {
 			onQueryChange: setQuery,
 			onQueryClear: clearQuery,
 			onMoveDomainToSiteClick( otherSiteDomain: string, domainName: string ) {
+				if ( dashboard ) {
+					window.location.assign( dashboardLink( `/domains/${ domainName }/transfer/other-site` ) );
+					return;
+				}
 				window.location.assign(
 					domainManagementTransferToOtherSite( otherSiteDomain, domainName )
 				);
@@ -157,17 +163,32 @@ const DomainSearchStep: StepType< {
 					return;
 				}
 
+				if ( dashboard ) {
+					window.location.assign( dashboardLink( `/domains/${ siteSlug }` ) );
+					return;
+				}
+
 				window.location.assign( domainManagementList( siteSlug ) );
 			},
 			onRegisterDomainClick: ( otherSiteDomain: string, domainName: string ) => {
 				window.location.assign( domainAddNew( otherSiteDomain, domainName ) );
 			},
 			onCheckTransferStatusClick: ( domainName: string ) => {
+				if ( dashboard ) {
+					window.location.assign( dashboardLink( `/domains/${ domainName }/transfer` ) );
+					return;
+				}
 				window.location.assign(
 					siteSlug ? domainManagementTransferIn( siteSlug, domainName ) : domainManagementRoot()
 				);
 			},
 			onMapDomainClick: ( domainName: string ) => {
+				if ( dashboard ) {
+					window.location.assign(
+						dashboardLink( `/domains/${ domainName }/domain-connection-setup` )
+					);
+					return;
+				}
 				window.location.assign( domainMapping( siteSlug, domainName ) );
 			},
 			onExternalDomainClick: ( domainName?: string ) => {
@@ -211,7 +232,7 @@ const DomainSearchStep: StepType< {
 				} );
 			},
 		};
-	}, [ submit, setQuery, clearQuery, flow, siteSlug ] );
+	}, [ submit, setQuery, clearQuery, flow, siteSlug, dashboard ] );
 
 	// For /setup flows, we want to show the free domain for a year discount for all flows
 	// except if we're in a site context or in the 100-year plan or domain flow

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -2,6 +2,7 @@ import { doesStringResembleDomain } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import { useDebounce } from 'use-debounce';
 import { useIsDomainCodeValid } from 'calypso/landing/stepper/hooks/use-is-domain-code-valid';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 
 export type DomainValidationOptions = {
@@ -27,6 +28,9 @@ export function useValidationMessage(
 		hasGoodDomain && ( ! hasAnyAuthCode || hasGoodAuthCode ) && ! hasDuplicates;
 
 	const isDebouncing = domainDebounced !== domain || authDebounced !== auth;
+
+	const query = useQuery();
+	const dashboard = query.get( 'dashboard' );
 
 	const {
 		data: validationResult,
@@ -86,7 +90,8 @@ export function useValidationMessage(
 		validationResult,
 		true,
 		'_blank',
-		validationResult?.tld
+		validationResult?.tld,
+		dashboard ?? ''
 	);
 
 	// final success

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -10,8 +10,10 @@ import {
 	MAP_EXISTING_DOMAIN,
 	PREMIUM_DOMAINS,
 } from '@automattic/urls';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
+import { dashboardLink, wpcomLink } from 'calypso/dashboard/utils/link';
 import { domainAvailability } from 'calypso/lib/domains/constants';
 import SetAsPrimaryLink from 'calypso/my-sites/domains/domain-management/settings/set-as-primary/link';
 import {
@@ -29,7 +31,8 @@ function getAvailabilityNotice(
 	errorData,
 	isForTransferOnly = false,
 	linksTarget = '_self',
-	domainTld = ''
+	domainTld = '',
+	dashboard = ''
 ) {
 	const tld = domainTld || ( domain ? getTld( domain ) : null );
 	const { site, maintenanceEndTime, availabilityPreCheck, isSiteDomainOnly } = errorData || {};
@@ -82,17 +85,14 @@ function getAvailabilityNotice(
 			break;
 		case domainAvailability.REGISTERED_OTHER_SITE_SAME_USER:
 			if ( site ) {
+				const transferUrl = dashboard
+					? dashboardLink( `/domains/${ domain }/transfer/other-site` )
+					: domainManagementTransferToOtherSite( site, domain );
 				const messageOptions = {
 					args: { domain, site },
 					components: {
 						strong: <strong />,
-						a: (
-							<a
-								target={ linksTarget }
-								rel="noopener noreferrer"
-								href={ domainManagementTransferToOtherSite( site, domain ) }
-							/>
-						),
+						a: <a target={ linksTarget } rel="noopener noreferrer" href={ transferUrl } />,
 					},
 				};
 				if ( isSiteDomainOnly ) {
@@ -156,6 +156,9 @@ function getAvailabilityNotice(
 			break;
 		case domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE:
 			if ( site ) {
+				const transferUrl = dashboard
+					? dashboardLink( `/domains/${ domain }/domain-transfer-setup` )
+					: domainTransferIn( site, domain );
 				message = translate(
 					'{{strong}}%(domain)s{{/strong}} is already connected to this site, but registered somewhere else. Do you want to move ' +
 						'it from your current domain provider to WordPress.com so you can manage the domain and the site ' +
@@ -164,13 +167,7 @@ function getAvailabilityNotice(
 						args: { domain },
 						components: {
 							strong: <strong />,
-							a: (
-								<a
-									target={ linksTarget }
-									rel="noopener noreferrer"
-									href={ domainTransferIn( site, domain ) }
-								/>
-							),
+							a: <a target={ linksTarget } rel="noopener noreferrer" href={ transferUrl } />,
 						},
 					}
 				);
@@ -237,6 +234,9 @@ function getAvailabilityNotice(
 			);
 			break;
 		case domainAvailability.MAPPED_OTHER_SITE_SAME_USER_REGISTRABLE:
+			const registerUrl = dashboard
+				? addQueryArgs( wpcomLink( '/setup/domain' ), { siteSlug: site, ref: 'dashboard' } )
+				: domainAddNew( site, domain );
 			message = translate(
 				'{{strong}}%(domain)s{{/strong}} is already connected to your site %(site)s.' +
 					' {{a}}Register it to the connected site.{{/a}}',
@@ -244,31 +244,25 @@ function getAvailabilityNotice(
 					args: { domain, site },
 					components: {
 						strong: <strong />,
-						a: (
-							<a
-								target={ linksTarget }
-								rel="noopener noreferrer"
-								href={ domainAddNew( site, domain ) }
-							/>
-						),
+						a: <a target={ linksTarget } rel="noopener noreferrer" href={ registerUrl } />,
 					},
 				}
 			);
 			break;
 		case domainAvailability.TRANSFER_PENDING_SAME_USER:
+			// eslint-disable-next-line no-nested-ternary
+			const transferStatusUrl = dashboard
+				? dashboardLink( `/domains/${ domain }/transfer` )
+				: site
+				? domainManagementTransferIn( site, domain )
+				: '/domains/manage';
 			message = translate(
 				'{{strong}}%(domain)s{{/strong}} is pending transfer. {{a}}Check the transfer status{{/a}} to learn more.',
 				{
 					args: { domain },
 					components: {
 						strong: <strong />,
-						a: (
-							<a
-								target={ linksTarget }
-								rel="noopener noreferrer"
-								href={ site ? domainManagementTransferIn( site, domain ) : '/domains/manage' }
-							/>
-						),
+						a: <a target={ linksTarget } rel="noopener noreferrer" href={ transferStatusUrl } />,
 					},
 				}
 			);
@@ -540,19 +534,16 @@ function getAvailabilityNotice(
 
 		case domainAvailability.AVAILABLE_PREMIUM:
 			if ( site ) {
+				const mapUrl = dashboard
+					? dashboardLink( `/domains/${ domain }/domain-connection-setup` )
+					: domainMapping( site, domain );
 				message = translate(
 					"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchasing this premium domain on WordPress.com, but if you purchase the domain elsewhere, you can {{a}}map it to your site{{/a}}.",
 					{
 						args: { domain },
 						components: {
 							strong: <strong />,
-							a: (
-								<a
-									target={ linksTarget }
-									rel="noopener noreferrer"
-									href={ domainMapping( site, domain ) }
-								/>
-							),
+							a: <a target={ linksTarget } rel="noopener noreferrer" href={ mapUrl } />,
 						},
 					}
 				);

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -75,6 +75,7 @@ const DomainSearchUI = (
 
 	const siteSlug = queryObject.siteSlug;
 	const siteId = queryObject.siteId;
+	const dashboard = queryObject.dashboard;
 	const { __ } = useI18n();
 
 	// eslint-disable-next-line no-nested-ternary
@@ -105,6 +106,10 @@ const DomainSearchUI = (
 				return product;
 			},
 			onMoveDomainToSiteClick( otherSiteDomain: string, domainName: string ) {
+				if ( dashboard ) {
+					window.location.assign( dashboardLink( `/domains/${ domainName }/transfer/other-site` ) );
+					return;
+				}
 				page( domainManagementTransferToOtherSite( otherSiteDomain, domainName ) );
 			},
 			onMakePrimaryAddressClick: () => {
@@ -118,11 +123,21 @@ const DomainSearchUI = (
 				page( domainAddNew( otherSiteDomain, domainName ) );
 			},
 			onCheckTransferStatusClick: ( domainName: string ) => {
+				if ( dashboard ) {
+					window.location.assign( dashboardLink( `/domains/${ domainName }/transfer` ) );
+					return;
+				}
 				page(
 					siteSlug ? domainManagementTransferIn( siteSlug, domainName ) : domainManagementRoot()
 				);
 			},
 			onMapDomainClick: ( domainName: string ) => {
+				if ( dashboard ) {
+					window.location.assign(
+						dashboardLink( `/domains/${ domainName }/domain-connection-setup` )
+					);
+					return;
+				}
 				page( domainMapping( siteSlug, domainName ) );
 			},
 			onExternalDomainClick( initialQuery?: string ) {
@@ -219,6 +234,7 @@ const DomainSearchUI = (
 		isDomainOnlyFlow,
 		baseSubmitStepProps,
 		baseSubmitProvidedDependencies,
+		dashboard,
 	] );
 
 	const allowedTldParam = queryObject.tld;


### PR DESCRIPTION
Closes DOMENG-274.

## Proposed Changes
- Ensure domain-related CTAs and “next steps” keep users in the Dashboard context by propagating a dashboard query param through domain flows.
- Update domain availability notices/errors (e.g., “move it to this site”, “check transfer status”, “map it”) to link to Dashboard routes when dashboard is present, while preserving existing Calypso routes otherwise.
- Add Dashboard context to key entry points (e.g., Dashboard “Add domain name” dropdown, domain transfer upsell, and the email empty-state domain CTA).

## Why are these changes being made?

Some domain operations initiated from the Dashboard were sending users to non-Dashboard Calypso pages. This keeps the user in the Dashboard experience (including CIAB via /ciab) and makes the “back to” behavior consistent.

## Testing Instructions

Follow the steps outlined in the linked issue and verify they no longer occur on this branch.

Additionally...

- From the Dashboard, use “Add domain name”:
  - Choose “Use a domain name I own”, enter a domain, and confirm actions like Map, Transfer, Move to this site, and Check transfer status take you to Dashboard routes (not the old Calypso domain management paths).
- Verify the same behavior from:
  - Site overview “Transfer your domain” upsell card
  - Emails empty state “Choose a domain” CTA
- Regression check: run the same flows without dashboard in the URL and confirm existing Calypso navigation remains unchanged.
