### PR TITLE
A4A > Marketplace: Fix the WPCOM discounted price rounding-off issue

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
@@ -35,22 +35,28 @@ export const calculateDiscountPercentage = (
 export const getWPCOMTieredPrice = (
 	product: APIProductFamilyProduct,
 	quantity: number,
-	termPricing: TermPricingType
+	termPricing: TermPricingType,
+	ownedPlans = 0
 ) => {
 	// Calculate actual cost (base product price * quantity)
 	const basePricePerUnit =
 		termPricing === 'yearly' ? product.yearly_price ?? 0 : product.monthly_price ?? 0;
 	const actualCost = basePricePerUnit * quantity;
+	const tierPrices =
+		termPricing === 'yearly' ? product.tier_yearly_prices : product.tier_monthly_prices;
+	const tierQuantity = quantity + ownedPlans;
 
-	// Find tier for exact quantity, or for 10 units if quantity > 10
+	// Find tier for exact quantity, or get the greatest unit that is less than or equal to tierQuantity
 	const tier =
-		product?.price_tier_list?.find( ( t ) => t.units === quantity ) ||
-		( quantity > 10 ? product?.price_tier_list?.find( ( t ) => t.units === 10 ) : undefined );
+		tierPrices?.find( ( t ) => t.units === tierQuantity ) ||
+		tierPrices
+			?.filter( ( t ) => t.units <= tierQuantity )
+			.sort( ( a, b ) => b.units - a.units )[ 0 ];
 
 	// Get price per unit from tier if found, otherwise from product
 	let pricePerUnit: number;
 	if ( tier ) {
-		pricePerUnit = termPricing === 'yearly' ? tier.yearly_price : tier.monthly_price;
+		pricePerUnit = tier.price;
 	} else {
 		pricePerUnit = basePricePerUnit;
 	}
@@ -200,7 +206,7 @@ export const useGetProductPricingInfo = (
 			let discountPercentage: number;
 
 			if ( isTermPricingEnabled && termPricing ) {
-				const pricingInfo = getWPCOMTieredPrice( product, quantity, termPricing );
+				const pricingInfo = getWPCOMTieredPrice( product, quantity, termPricing, ownedPlans );
 				actualCost = pricingInfo.actualCost;
 				discountedCost = pricingInfo.discountedCost;
 				discountPercentage = pricingInfo.discountPercentage;

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
@@ -16,6 +16,58 @@ import type {
 } from 'calypso/a8c-for-agencies/types/products';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
+/**
+ * Calculates the discount percentage between an original price and a discounted price.
+ * @param originalPrice - The original price before discount
+ * @param discountedPrice - The price after discount
+ * @returns The discount percentage (0-100), or 0 if originalPrice is 0 or negative
+ */
+export const calculateDiscountPercentage = (
+	originalPrice: number,
+	discountedPrice: number
+): number => {
+	if ( originalPrice <= 0 ) {
+		return 0;
+	}
+	return Math.round( ( ( originalPrice - discountedPrice ) / originalPrice ) * 100 );
+};
+
+export const getWPCOMTieredPrice = (
+	product: APIProductFamilyProduct,
+	quantity: number,
+	termPricing: TermPricingType
+) => {
+	// Calculate actual cost (base product price * quantity)
+	const basePricePerUnit =
+		termPricing === 'yearly' ? product.yearly_price ?? 0 : product.monthly_price ?? 0;
+	const actualCost = basePricePerUnit * quantity;
+
+	// Find tier for exact quantity, or for 10 units if quantity > 10
+	const tier =
+		product?.price_tier_list?.find( ( t ) => t.units === quantity ) ||
+		( quantity > 10 ? product?.price_tier_list?.find( ( t ) => t.units === 10 ) : undefined );
+
+	// Get price per unit from tier if found, otherwise from product
+	let pricePerUnit: number;
+	if ( tier ) {
+		pricePerUnit = termPricing === 'yearly' ? tier.yearly_price : tier.monthly_price;
+	} else {
+		pricePerUnit = basePricePerUnit;
+	}
+
+	const discountedCost = pricePerUnit * quantity;
+	// Calculate discount percentage from per-unit prices for consistency
+	// This ensures the percentage matches the tier structure and is consistent across quantities
+	// and currencies, avoiding rounding errors from multiplication
+	const discountPercentage = calculateDiscountPercentage( basePricePerUnit, pricePerUnit );
+
+	return {
+		actualCost,
+		discountedCost,
+		discountPercentage,
+	};
+};
+
 export const checkProductTermAvailability = (
 	product: APIProductFamilyProduct,
 	termPricing?: TermPricingType
@@ -143,15 +195,30 @@ export const useGetProductPricingInfo = (
 		const productBundlePrice = productPrice ? productPrice * quantity : 0;
 
 		if ( product.family_slug === 'wpcom-hosting' ) {
-			const tier = calculateTier( options, quantity + ownedPlans );
-			const discountedCost = productBundlePrice * ( 1 - tier.discount );
+			let actualCost: number;
+			let discountedCost: number;
+			let discountPercentage: number;
+
+			if ( isTermPricingEnabled && termPricing ) {
+				const pricingInfo = getWPCOMTieredPrice( product, quantity, termPricing );
+				actualCost = pricingInfo.actualCost;
+				discountedCost = pricingInfo.discountedCost;
+				discountPercentage = pricingInfo.discountPercentage;
+			} else {
+				// Fallback to discount tier calculation when term pricing is not enabled
+				const tier = calculateTier( options, quantity + ownedPlans );
+				actualCost = productBundlePrice;
+				discountedCost = productBundlePrice * ( 1 - tier.discount );
+				discountPercentage = Math.round( tier.discount * 100 );
+			}
+
 			return {
-				actualCost: productBundlePrice,
+				actualCost,
 				discountedCost,
-				discountPercentage: tier.discount,
-				showActualCost: productBundlePrice > discountedCost,
+				discountPercentage,
+				showActualCost: actualCost > discountedCost,
 				discountedCostFormatted: formatCurrency( discountedCost, currency ?? 'USD' ),
-				actualCostFormatted: formatCurrency( productBundlePrice, currency ?? 'USD' ),
+				actualCostFormatted: formatCurrency( actualCost, currency ?? 'USD' ),
 				isFree: productPrice === 0,
 			};
 		}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
@@ -98,6 +98,7 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 							quantity={ displayQuantity }
 							onChange={ setQuantity }
 							ownedPlans={ ownedPlans }
+							plan={ plan }
 						/>
 					</HostingPlanSection.Banner>
 				) }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -64,7 +64,7 @@ export default function WPCOMPlanSelector( {
 
 	const originalPrice = Number( plan?.amount ?? 0 ) * quantity;
 	const pricingInfo = isTermPricingEnabled
-		? getWPCOMTieredPrice( plan, quantity, termPricing )
+		? getWPCOMTieredPrice( plan, quantity, termPricing, ownedPlans )
 		: {
 				actualCost: originalPrice,
 				discountedCost: originalPrice - originalPrice * discount,

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import A4ANumberInputV2 from 'calypso/a8c-for-agencies/components/a4a-number-input-v2';
+import { getWPCOMTieredPrice } from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-marketplace';
 import useWPCOMPlanDescription from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-wpcom-plan-description';
 import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/lib/wpcom-bulk-values-utils';
 import WPCOMLogo from 'calypso/assets/images/a8c-for-agencies/wpcom-logo.svg';
@@ -61,11 +62,16 @@ export default function WPCOMPlanSelector( {
 		return calculateTier( discountTiers, quantity + ownedPlans ).discount;
 	}, [ discountTiers, ownedPlans, quantity, isReferralMode ] );
 
-	const termPrice = termPricing === 'yearly' ? plan.yearly_price ?? 0 : plan.monthly_price ?? 0;
-	const productPrice = isTermPricingEnabled ? termPrice : Number( plan?.amount ?? 0 );
+	const originalPrice = Number( plan?.amount ?? 0 ) * quantity;
+	const pricingInfo = isTermPricingEnabled
+		? getWPCOMTieredPrice( plan, quantity, termPricing )
+		: {
+				actualCost: originalPrice,
+				discountedCost: originalPrice - originalPrice * discount,
+				discountPercentage: Math.round( discount * 100 ),
+		  };
 
-	const originalPrice = Number( productPrice ) * quantity;
-	const actualPrice = originalPrice - originalPrice * discount;
+	const actualPrice = pricingInfo.discountedCost;
 
 	const { name: planName } = useWPCOMPlanDescription( plan?.slug ?? '' );
 
@@ -140,16 +146,16 @@ export default function WPCOMPlanSelector( {
 					<b className="wpcom-plan-selector__price-actual-value">
 						{ formatCurrency( actualPrice, plan.currency ) }
 					</b>
-					{ !! discount && (
+					{ pricingInfo.discountPercentage > 0 && (
 						<>
 							<b className="wpcom-plan-selector__price-original-value">
-								{ formatCurrency( originalPrice, plan.currency ) }
+								{ formatCurrency( pricingInfo.actualCost, plan.currency ) }
 							</b>
 
 							<span className="wpcom-plan-selector__price-discount">
 								{ translate( 'You save %(discount)s%', {
 									args: {
-										discount: Math.floor( discount * 100 ),
+										discount: pricingInfo.discountPercentage,
 									},
 									comment: '%(discount)s is the discount percentage.',
 								} ) }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-selector/slider.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-selector/slider.tsx
@@ -1,18 +1,61 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import { TermPricingContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
+import { calculateDiscountPercentage } from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-marketplace';
 import wpcomBulkOptions from 'calypso/a8c-for-agencies/sections/marketplace/lib/wpcom-bulk-options';
-import type { APIProductFamily } from 'calypso/a8c-for-agencies/types/products';
+import type { TermPricingType } from 'calypso/a8c-for-agencies/sections/marketplace/types';
+import type {
+	APIProductFamily,
+	APIProductFamilyProduct,
+} from 'calypso/a8c-for-agencies/types/products';
 
 type Props = {
 	ownedPlans: number;
 	quantity: number;
 	onChange: ( quantity: number ) => void;
+	plan?: APIProductFamilyProduct;
 };
 
-export default function WPCOMPlanSlider( { quantity, ownedPlans, onChange }: Props ) {
+const createOptionsFromPriceTierList = (
+	plan: APIProductFamilyProduct,
+	termPricing: TermPricingType
+) => {
+	const priceTierList = plan.price_tier_list || [];
+	const basePrice = termPricing === 'yearly' ? plan.yearly_price ?? 0 : plan.monthly_price ?? 0;
+
+	const options = priceTierList.map( ( tier ) => {
+		const tierPrice = termPricing === 'yearly' ? tier.yearly_price : tier.monthly_price;
+		const discountPercent = calculateDiscountPercentage( basePrice, tierPrice );
+
+		return {
+			value: tier.units,
+			label: `${ tier.units }`,
+			discount: discountPercent / 100,
+			sub: discountPercent > 0 ? `${ discountPercent }%` : '',
+		};
+	} );
+
+	// Ensure first option is always 1
+	if ( options.length === 0 || options[ 0 ]?.value !== 1 ) {
+		options.unshift( {
+			value: 1,
+			label: '1',
+			discount: 0,
+			sub: '',
+		} );
+	}
+
+	return options;
+};
+
+export default function WPCOMPlanSlider( { quantity, ownedPlans, onChange, plan }: Props ) {
 	const translate = useTranslate();
+	const { termPricing } = useContext( TermPricingContext );
+
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
 
 	const { data } = useProductsQuery( true );
 
@@ -23,12 +66,21 @@ export default function WPCOMPlanSlider( { quantity, ownedPlans, onChange }: Pro
 		: undefined;
 
 	const options = useMemo( () => {
-		const options = wpcomBulkOptions( wpcomProducts?.discounts?.tiers );
+		let sliderOptions = [];
+
+		if ( isTermPricingEnabled && termPricing && plan ) {
+			// Use price_tier_list when term pricing is enabled
+			sliderOptions = createOptionsFromPriceTierList( plan, termPricing );
+		} else {
+			// Fallback to discount tiers
+			sliderOptions = wpcomBulkOptions( wpcomProducts?.discounts?.tiers );
+		}
 
 		// Override the last option label to include '+' symbol.
-		options[ options.length - 1 ].label = options[ options.length - 1 ].label + '+';
-		return options;
-	}, [ wpcomProducts?.discounts?.tiers ] );
+		sliderOptions[ sliderOptions.length - 1 ].label =
+			sliderOptions[ sliderOptions.length - 1 ].label + '+';
+		return sliderOptions;
+	}, [ wpcomProducts?.discounts?.tiers, isTermPricingEnabled, termPricing, plan ] );
 
 	const MaxValue = options[ options.length - 1 ].value;
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-selector/slider.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-selector/slider.tsx
@@ -23,12 +23,12 @@ const createOptionsFromPriceTierList = (
 	plan: APIProductFamilyProduct,
 	termPricing: TermPricingType
 ) => {
-	const priceTierList = plan.price_tier_list || [];
+	const priceTierList =
+		termPricing === 'yearly' ? plan.tier_yearly_prices || [] : plan.tier_monthly_prices || [];
 	const basePrice = termPricing === 'yearly' ? plan.yearly_price ?? 0 : plan.monthly_price ?? 0;
 
 	const options = priceTierList.map( ( tier ) => {
-		const tierPrice = termPricing === 'yearly' ? tier.yearly_price : tier.monthly_price;
-		const discountPercent = calculateDiscountPercentage( basePrice, tierPrice );
+		const discountPercent = calculateDiscountPercentage( basePrice, tier.price );
 
 		return {
 			value: tier.units,
@@ -69,7 +69,7 @@ export default function WPCOMPlanSlider( { quantity, ownedPlans, onChange, plan 
 		let sliderOptions = [];
 
 		if ( isTermPricingEnabled && termPricing && plan ) {
-			// Use price_tier_list when term pricing is enabled
+			// Use tiered prices when term pricing is enabled
 			sliderOptions = createOptionsFromPriceTierList( plan, termPricing );
 		} else {
 			// Fallback to discount tiers

--- a/client/a8c-for-agencies/types/products.ts
+++ b/client/a8c-for-agencies/types/products.ts
@@ -4,6 +4,11 @@ export interface APIProductFamilyProductBundlePrice {
 	price_per_unit: number; // price per day in cents
 }
 
+export interface APIProductTierPrice {
+	units: number;
+	price: number;
+}
+
 export interface APIProductFamilyProduct {
 	name: string;
 	slug: string;
@@ -22,11 +27,8 @@ export interface APIProductFamilyProduct {
 	supported_bundles: APIProductFamilyProductBundlePrice[];
 	monthly_price?: number;
 	yearly_price?: number;
-	price_tier_list?: {
-		units: number;
-		monthly_price: number;
-		yearly_price: number;
-	}[];
+	tier_monthly_prices?: APIProductTierPrice[];
+	tier_yearly_prices?: APIProductTierPrice[];
 }
 
 export interface APIProductFamily {

--- a/client/a8c-for-agencies/types/products.ts
+++ b/client/a8c-for-agencies/types/products.ts
@@ -22,6 +22,11 @@ export interface APIProductFamilyProduct {
 	supported_bundles: APIProductFamilyProductBundlePrice[];
 	monthly_price?: number;
 	yearly_price?: number;
+	price_tier_list?: {
+		units: number;
+		monthly_price: number;
+		yearly_price: number;
+	}[];
 }
 
 export interface APIProductFamily {


### PR DESCRIPTION
This PR fixes an issue with the WPCOM discounted price rounding-off. 

## Why are these changes being made?

- To accurately show the price & discount for WPCOM hosting on the A4A Marketplace.

## Testing Instructions

* Patch 200997-ghe-Automattic/wpcom
* Open the A4A live link by signing in as a non-BD agency > Go to Marketplace > Hosting > Standard Agency Hosting > Verify the slider works as expected and the price/discount matches with the https://agencies.automattic.com/marketplace/hosting/wpcom
* Open the A4A live link, signing in as a BD agency by appending the URL with `?flags=-a4a-bd-checkout` to disable the term pricing > Go to Marketplace > Hosting > Standard Agency Hosting > Verify the slider works as expected and the price/discount matches with the https://agencies.automattic.com/marketplace/hosting/wpcom
* Remove the feature flag > Verify the slider works as expected and the price/discount matches with the https://agencies.automattic.com/marketplace/hosting/wpcom. There may be a minor difference in the price and the discount percentage. Please select all the **different tiers (1-10)** with **both monthly and yearly terms** and verify the price matches exactly with the checkout. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?