### PR TITLE
MSD: Do not add site slug for Akismet product renewal urls

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -447,6 +447,14 @@ function getCheckoutProductSlugFromPurchase( purchase: Purchase ): string {
 	return checkoutProductSlug;
 }
 
+function getCheckoutSiteSlugForPurchase( purchase: Purchase ): string {
+	if ( isAkismetProduct( purchase ) ) {
+		// Akismet checkout never uses a site slug.
+		return '';
+	}
+	return purchase.site_slug || '';
+}
+
 export function getRenewalUrlFromPurchase(
 	purchase: Purchase,
 	checkoutSiteSlugForUrl?: string
@@ -465,7 +473,8 @@ export function getRenewUrlForPurchases(
 	const checkoutProductSlug = purchases
 		.map( ( purchase ) => getCheckoutProductSlugFromPurchase( purchase ) )
 		.join( ',' );
-	const checkoutSiteSlug = checkoutSiteSlugForUrl || firstPurchase.site_slug || '';
+	const checkoutSiteSlug =
+		checkoutSiteSlugForUrl || getCheckoutSiteSlugForPurchase( firstPurchase );
 	const servicePath = getServicePathForCheckoutFromPurchase( firstPurchase );
 	const purchaseIds = purchases.map( ( purchase ) => purchase.ID ).join( ',' );
 	const backUrl = redirectToDashboardLink();


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1539/multi-site-dashboard-renew-link-for-akismet-purchases-is-broken

## Proposed Changes

In this PR we modify the code in the Multi-Site Dashboard to prevent adding a site slug to the renewal URL if the product being renewed is an Akismet product.

<img width="707" height="275" alt="Screenshot 2026-01-21 at 6 25 31 PM" src="https://github.com/user-attachments/assets/e48f2aac-f685-4765-98b9-a90341259a98" />

Before             |  After
:-------------------------:|:-------------------------:
<img width="1502" height="696" alt="Screenshot 2026-01-21 at 6 26 12 PM" src="https://github.com/user-attachments/assets/bf62b544-23b9-4dfb-a78d-de025deeeb28" /> | <img width="1512" height="465" alt="Screenshot 2026-01-22 at 11 39 14 AM" src="https://github.com/user-attachments/assets/85a6ef22-a24e-4f52-8de9-5a478c6dbf6d" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When generating a renewal URL for Akismet purchases, we don't want the renewal URL to include a site slug because calypso uses the site slug to set the current site (this is not a checkout feature; it's a core part of calypso itself) and Akismet site slugs look something like `siteless.akismet.com:ABCDEF`, which is not a real site. As a result, checkout never loads if its URL ends in one of these slugs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Point public-api.wordpress.com to your sandbox and enable Store Sanbox mode.
- Start at https://akismet.com/pricing/
- Buy Akismet Pro. Complete the checkout process.
- Either wait for the product to pass its refund period or enable the `ALLOW_RENEWING_REFUNDABLE_SUBSCRIPTIONS` flag on your sandbox.
- Go to https://my.wordpress.com/me/billing/purchases and click through to manage the new purchase.
- Click "Renew" (see screenshot).
- Verify that checkout loads correctly.
