### PR TITLE
E2E: Fix for Gutenberg 22.4.0, take two

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -44,16 +44,21 @@ export class EditorSidebarBlockInserterComponent {
 		const sidebarParentSelectorDetachedPromise = this.page
 			.locator( sidebarParentSelector )
 			.waitFor( { state: 'detached' } );
+		const closeBlockInserterButtonLocator = editorParent.locator(
+			selectors.closeBlockInserterButton
+		);
 
 		// Gutenberg 22.4.0 closes the sidebar automatically in some cases, so sometimes the button won't be there to click.
-		// So we wait for either click-then-detached or detached to happen on its own.
 		await Promise.any( [
-			editorParent
-				.locator( selectors.closeBlockInserterButton )
-				.click()
-				.then( () => sidebarParentSelectorDetachedPromise ),
+			closeBlockInserterButtonLocator.waitFor(),
 			sidebarParentSelectorDetachedPromise,
 		] );
+
+		// If the button is there, click it.
+		if ( await closeBlockInserterButtonLocator.isVisible() ) {
+			await closeBlockInserterButtonLocator.click();
+			await sidebarParentSelectorDetachedPromise;
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Instead of "wait for click-and-detach or detach", we need to "wait for button-or-detach, then click the button if the former and wait for detach".

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

PR #108283 left a promise floating around waiting to click the button as soon as it showed up. When the inserter is auto-closed, we need to not do that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
