### PR TITLE
Add typing indicators for Zendesk chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
 		"whybundled:server": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons CONCATENATE_MODULES=false yarn run build-server && whybundled client/stats-server.json"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.35",
+		"@automattic/agenttic-ui": "^0.1.37",
 		"@automattic/calypso-babel-config": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -44,6 +44,8 @@ interface AgentChatProps {
 	onClose: () => void;
 	/** Called when the chat is expanded (floating mode). */
 	onExpand: () => void;
+	/** Called when the typing status changes. */
+	onTypingStatusChange: ( typingStatus: boolean ) => void;
 	/** Custom components for rendering markdown. */
 	markdownComponents?: MarkdownComponents;
 	/** Custom markdown extensions. */
@@ -66,6 +68,7 @@ export default function AgentChat( {
 	onExpand,
 	markdownComponents = {},
 	markdownExtensions = {},
+	onTypingStatusChange,
 }: AgentChatProps ) {
 	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
 	const { floatingPosition } = useSelect( ( select ) => {
@@ -97,6 +100,7 @@ export default function AgentChat( {
 			onExpand={ onExpand }
 			onStop={ onAbort }
 			messageRenderer={ messageRenderer }
+			onTypingStatusChange={ onTypingStatusChange }
 			emptyView={
 				isLoadingConversation ? (
 					<ChatMessageSkeleton count={ 3 } />

--- a/packages/agents-manager/src/components/agent-dock/zendesk-chat.tsx
+++ b/packages/agents-manager/src/components/agent-dock/zendesk-chat.tsx
@@ -41,7 +41,7 @@ export function ZendeskChat( {
 	markdownComponents = {},
 	markdownExtensions = {},
 }: ZendeskChatProps ) {
-	const { agentticMessages, onSubmit, isLoadingConversation, isProcessing } =
+	const { agentticMessages, onSubmit, isLoadingConversation, isProcessing, onTypingStatusChange } =
 		useManagedZendeskChat( true );
 
 	return (
@@ -61,6 +61,7 @@ export function ZendeskChat( {
 			chatHeaderOptions={ chatHeaderOptions }
 			markdownComponents={ markdownComponents }
 			markdownExtensions={ markdownExtensions }
+			onTypingStatusChange={ onTypingStatusChange }
 		/>
 	);
 }

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -301,6 +301,13 @@ export const useManagedZendeskChat = ( enabled: boolean ) => {
 		connectionStatus,
 		agentticMessages,
 		isLoadingConversation: isSettingUpSmooch,
+		onTypingStatusChange: ( typingStatus: boolean ) => {
+			if ( typingStatus ) {
+				Smooch?.startTyping( conversation?.id );
+			} else {
+				Smooch?.stopTyping( conversation?.id );
+			}
+		},
 		onSubmit: ( message: string ) => {
 			const messageToSend = {
 				type: 'text',

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,9 +370,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.35":
-  version: 0.1.35
-  resolution: "@automattic/agenttic-ui@npm:0.1.35"
+"@automattic/agenttic-ui@npm:^0.1.35, @automattic/agenttic-ui@npm:^0.1.37":
+  version: 0.1.37
+  resolution: "@automattic/agenttic-ui@npm:0.1.37"
   dependencies:
     "@automattic/charts": "npm:>=0.14.0 <1.0.0"
     "@radix-ui/react-scroll-area": "npm:^1.2.9"
@@ -397,7 +397,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: 17364d5eb87a779809f90e5f2685d0963d5c25565eb849f99fb5f237eaba2b4f7eea786c8bd9657102a9098b46d635636c840fe798c8b9820066cafcda853716
+  checksum: 627e7eee721f49c41137e39bbf83f47cb8b3d743a93ae1cde8984378d2d174b9a8f9277e6ecfbfa3a2a7b35fecbbc0bec186923b1a45d2733d9a78a5f8c065f3
   languageName: node
   linkType: hard
 
@@ -38446,7 +38446,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wp-calypso@workspace:."
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.35"
+    "@automattic/agenttic-ui": "npm:^0.1.37"
     "@automattic/calypso-babel-config": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"


### PR DESCRIPTION
## Summary
- Adds `onTypingStatusChange` callback to wire typing indicators from the chat UI to Smooch API
- When a user starts typing, `Smooch.startTyping()` is called; when they stop, `Smooch.stopTyping()` is called
- Bumps `@automattic/agenttic-ui` to 0.1.37 which includes typing indicator support

## Test plan
- [ ] Open a Zendesk chat session in the agents manager
- [ ] Start typing a message - verify the typing indicator is shown to the support agent
- [ ] Stop typing - verify the typing indicator disappears for the support agent