### PR TITLE
Hosting Dashboard: Prevent setting unconnected domain as primary

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -1,4 +1,4 @@
-import { DomainSubtype } from '@automattic/api-core';
+import { DomainSubtype, DomainStatus } from '@automattic/api-core';
 import { userPurchasesQuery, siteSetPrimaryDomainMutation } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -96,7 +96,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				},
 				isEligible: ( item: DomainSummary ) =>
 					item.subtype.id === DomainSubtype.DOMAIN_CONNECTION &&
-					item.domain_status.id === 'connection_error',
+					item.domain_status.id === DomainStatus.CONNECTION_ERROR,
 			},
 			{
 				id: 'manage-domain',

--- a/client/dashboard/sites/domains/primary-domain-selector.tsx
+++ b/client/dashboard/sites/domains/primary-domain-selector.tsx
@@ -1,4 +1,10 @@
-import { type DomainSummary, type Site, type User, DomainSubtype } from '@automattic/api-core';
+import {
+	type DomainSummary,
+	type Site,
+	type User,
+	DomainSubtype,
+	DomainStatus,
+} from '@automattic/api-core';
 import { siteSetPrimaryDomainMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
@@ -63,7 +69,8 @@ const PrimaryDomainSelector = ( { domains, site, user }: PrimaryDomainSelectorPr
 					domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ||
 					domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS ) &&
 				domain.can_set_as_primary &&
-				! domain.primary_domain;
+				! domain.primary_domain &&
+				domain.domain_status.id !== DomainStatus.CONNECTION_ERROR;
 
 			if ( ! isEligible ) {
 				return false;

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -118,6 +118,7 @@ export function canSetAsPrimary( {
 	return (
 		domain.can_set_as_primary &&
 		! domain.primary_domain &&
+		domain.domain_status.id !== DomainStatus.CONNECTION_ERROR &&
 		! shouldUpgradeToMakeDomainPrimary( {
 			domain,
 			site,


### PR DESCRIPTION
Part of DOMENG-258

## Proposed Changes

- Add `connection_error` status check to `canSetAsPrimary()` utility function
- Add `connection_error` status check to `PrimaryDomainSelector` domain filter
- Update string literal `'connection_error'` to use `DomainStatus.CONNECTION_ERROR` constant for consistency

## Why are these changes being made?

When adding an external domain to a site via the Hosting Dashboard, users could set that domain as the primary even if DNS hadn't been configured (domain has `connection_error` status). The WPCOM `/domains/manage` page requires that a domain be verified with valid DNS before setting as primary.

The dashboard already shows domain connection status (displaying "Setup connection" for unconnected domains), so we use the same mechanism to hide the "Make primary site address" action for domains with `connection_error` status.

## Testing Instructions

1. Add an external domain to a site without configuring DNS
2. Verify the domain shows "Setup connection" link (status = `connection_error`)
3. Verify "Make primary site address" action is NOT shown in the domain actions menu
4. Navigate to the site domains page
5. Verify the unconnected domain is NOT in the primary domain selector dropdown
6. Complete DNS setup for the domain
7. Verify the domain can now be set as primary

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes?
- [x] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?