### PR TITLE
MSD: Always return absolute path for getUpgradeUrl

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -105,11 +105,16 @@ function getUpgradeUrl( purchase: Purchase ): string | undefined {
 		// For the first Iteration of Calypso Akismet checkout we are only suggesting
 		// for immediate upgrades to the next plan. We will change this in the future
 		// with appropriate page.
-		const upgradeProductPath = AkismetUpgradesProductMap[ purchase.product_slug ];
-		if ( upgradeProductPath ) {
-			return upgradeProductPath;
+		const url = AkismetUpgradesProductMap[ purchase.product_slug ];
+		if ( ! url ) {
+			return undefined;
 		}
-		return undefined;
+		const isAbsolute =
+			url.startsWith( 'http://' ) || url.startsWith( 'https://' ) || url.startsWith( '//' );
+		if ( ! isAbsolute ) {
+			return wpcomLink( url );
+		}
+		return url;
 	}
 
 	const upgradeProductSlug = ProductUpgradeMap[ purchase.product_slug ];


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1538/multi-site-dashboard-upgrade-link-for-akismet-purchases-is-broken

## Proposed Changes

This PR modifies `getUpgradeUrl()` inside the purchase settings page of the Multi Site Dashboard so that it always returns an absolute URL (if it returns anything). This allows it to correctly redirect to `wordpress.com` for checkout URLs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start at https://akismet.com/pricing/
- Buy Akismet Pro
- Go to https://my.wordpress.com/me/billing/purchases and click through to manage the new purchase
- Click "Upgrade"
- Verify that you see checkout with an upgrade product in the cart
