### PR TITLE
Odie: Hide feedback buttons for logged-out users

### DIFF
--- a/packages/odie-client/src/components/message/bot-message-actions.tsx
+++ b/packages/odie-client/src/components/message/bot-message-actions.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@wordpress/components';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
+import { ComponentProps } from 'react';
 import { ODIE_THUMBS_DOWN_RATING_VALUE, ODIE_THUMBS_UP_RATING_VALUE } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { useSendOdieFeedback } from '../../data';
@@ -56,61 +57,42 @@ const BotMessageActions = ( { message }: { message: Message } ) => {
 	}, [ message.content, message.message_id, trackEvent ] );
 
 	const messageActions = useMemo( () => {
-		return isLoggedIn
-			? [
-					// Only show thumbs up if not already disliked
-					...( notLiked
-						? []
-						: [
-								{
-									id: 'thumbs-up',
-									icon: <ThumbsUpIcon />,
-									label: __( 'Yes, this was helpful', __i18n_text_domain__ ),
-									onClick: () => handleIsHelpful( true ),
-									disabled: rated,
-									pressed: rated && liked,
-									tooltip: __( 'Yes, this was helpful', __i18n_text_domain__ ),
-								},
-						  ] ),
-					// Only show thumbs down if not already liked
-					...( liked
-						? []
-						: [
-								{
-									id: 'thumbs-down',
-									icon: <ThumbsDownIcon />,
-									label: __( 'No, this was not helpful', __i18n_text_domain__ ),
-									onClick: () => handleIsHelpful( false ),
-									disabled: rated,
-									pressed: rated && notLiked,
-									tooltip: __( 'No, this was not helpful', __i18n_text_domain__ ),
-								},
-						  ] ),
-					{
-						id: 'copy',
-						icon: isCopied ? <Icon icon={ check } size={ 24 } /> : <CopyIcon />,
-						label: isCopied
-							? __( 'Copied', __i18n_text_domain__ )
-							: __( 'Copy', __i18n_text_domain__ ),
-						onClick: handleCopyToClipboard,
-						tooltip: isCopied
-							? __( 'Copied to clipboard', __i18n_text_domain__ )
-							: __( 'Copy message to clipboard', __i18n_text_domain__ ),
-					},
-			  ]
-			: [
-					{
-						id: 'copy',
-						icon: isCopied ? <Icon icon={ check } size={ 24 } /> : <CopyIcon />,
-						label: isCopied
-							? __( 'Copied', __i18n_text_domain__ )
-							: __( 'Copy', __i18n_text_domain__ ),
-						onClick: handleCopyToClipboard,
-						tooltip: isCopied
-							? __( 'Copied to clipboard', __i18n_text_domain__ )
-							: __( 'Copy message to clipboard', __i18n_text_domain__ ),
-					},
-			  ];
+		const actions: ComponentProps< typeof MessageActions >[ 'message' ][ 'actions' ] = [
+			{
+				id: 'copy',
+				icon: isCopied ? <Icon icon={ check } size={ 24 } /> : <CopyIcon />,
+				label: isCopied ? __( 'Copied', __i18n_text_domain__ ) : __( 'Copy', __i18n_text_domain__ ),
+				onClick: handleCopyToClipboard,
+				tooltip: isCopied
+					? __( 'Copied to clipboard', __i18n_text_domain__ )
+					: __( 'Copy message to clipboard', __i18n_text_domain__ ),
+			},
+		];
+		if ( isLoggedIn ) {
+			if ( ! liked ) {
+				actions.unshift( {
+					id: 'thumbs-down',
+					icon: <ThumbsDownIcon />,
+					label: __( 'No, this was not helpful', __i18n_text_domain__ ),
+					onClick: () => handleIsHelpful( false ),
+					disabled: rated,
+					pressed: rated && notLiked,
+					tooltip: __( 'No, this was not helpful', __i18n_text_domain__ ),
+				} );
+			}
+			if ( ! notLiked ) {
+				actions.unshift( {
+					id: 'thumbs-up',
+					icon: <ThumbsUpIcon />,
+					label: __( 'Yes, this was helpful', __i18n_text_domain__ ),
+					onClick: () => handleIsHelpful( true ),
+					disabled: rated,
+					pressed: rated && liked,
+					tooltip: __( 'Yes, this was helpful', __i18n_text_domain__ ),
+				} );
+			}
+		}
+		return actions;
 	}, [ isLoggedIn, notLiked, liked, rated, isCopied, handleCopyToClipboard, handleIsHelpful ] );
 
 	return (

--- a/packages/odie-client/src/components/message/bot-message-actions.tsx
+++ b/packages/odie-client/src/components/message/bot-message-actions.tsx
@@ -1,6 +1,6 @@
 import { MessageActions, CopyIcon, ThumbsDownIcon, ThumbsUpIcon } from '@automattic/agenttic-ui';
 import { Icon } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
 import { ODIE_THUMBS_DOWN_RATING_VALUE, ODIE_THUMBS_UP_RATING_VALUE } from '../../constants';
@@ -9,7 +9,8 @@ import { useSendOdieFeedback } from '../../data';
 import type { Message } from '../../types';
 
 const BotMessageActions = ( { message }: { message: Message } ) => {
-	const { setMessageLikedStatus, trackEvent } = useOdieAssistantContext();
+	const { setMessageLikedStatus, trackEvent, currentUser } = useOdieAssistantContext();
+	const isLoggedIn = !! currentUser?.ID;
 	const { mutateAsync: sendOdieMessageFeedback } = useSendOdieFeedback();
 	const [ isCopied, setIsCopied ] = useState( false );
 
@@ -17,22 +18,25 @@ const BotMessageActions = ( { message }: { message: Message } ) => {
 	const notLiked = message.rating_value?.toString() === '0' || message.liked === false;
 	const rated = liked || notLiked;
 
-	const handleIsHelpful = ( isHelpful: boolean ) => {
-		sendOdieMessageFeedback( {
-			messageId: Number( message.message_id ),
-			ratingValue: isHelpful ? ODIE_THUMBS_UP_RATING_VALUE : ODIE_THUMBS_DOWN_RATING_VALUE,
-		} );
+	const handleIsHelpful = useCallback(
+		( isHelpful: boolean ) => {
+			sendOdieMessageFeedback( {
+				messageId: Number( message.message_id ),
+				ratingValue: isHelpful ? ODIE_THUMBS_UP_RATING_VALUE : ODIE_THUMBS_DOWN_RATING_VALUE,
+			} );
 
-		setMessageLikedStatus( message, isHelpful );
+			setMessageLikedStatus( message, isHelpful );
 
-		trackEvent( 'chat_message_action_feedback', {
-			action: 'feedback',
-			is_helpful: isHelpful,
-			message_id: message.message_id,
-		} );
-	};
+			trackEvent( 'chat_message_action_feedback', {
+				action: 'feedback',
+				is_helpful: isHelpful,
+				message_id: message.message_id,
+			} );
+		},
+		[ message, sendOdieMessageFeedback, setMessageLikedStatus, trackEvent ]
+	);
 
-	const handleCopyToClipboard = async () => {
+	const handleCopyToClipboard = useCallback( async () => {
 		try {
 			const messageText = typeof message.content === 'string' ? message.content : '';
 			await navigator.clipboard.writeText( messageText );
@@ -49,47 +53,65 @@ const BotMessageActions = ( { message }: { message: Message } ) => {
 		} catch ( error ) {
 			// Fallback for older browsers or when clipboard API is not available
 		}
-	};
+	}, [ message.content, message.message_id, trackEvent ] );
 
-	const messageActions = [
-		// Only show thumbs up if not already disliked
-		...( notLiked
-			? []
+	const messageActions = useMemo( () => {
+		return isLoggedIn
+			? [
+					// Only show thumbs up if not already disliked
+					...( notLiked
+						? []
+						: [
+								{
+									id: 'thumbs-up',
+									icon: <ThumbsUpIcon />,
+									label: __( 'Yes, this was helpful', __i18n_text_domain__ ),
+									onClick: () => handleIsHelpful( true ),
+									disabled: rated,
+									pressed: rated && liked,
+									tooltip: __( 'Yes, this was helpful', __i18n_text_domain__ ),
+								},
+						  ] ),
+					// Only show thumbs down if not already liked
+					...( liked
+						? []
+						: [
+								{
+									id: 'thumbs-down',
+									icon: <ThumbsDownIcon />,
+									label: __( 'No, this was not helpful', __i18n_text_domain__ ),
+									onClick: () => handleIsHelpful( false ),
+									disabled: rated,
+									pressed: rated && notLiked,
+									tooltip: __( 'No, this was not helpful', __i18n_text_domain__ ),
+								},
+						  ] ),
+					{
+						id: 'copy',
+						icon: isCopied ? <Icon icon={ check } size={ 24 } /> : <CopyIcon />,
+						label: isCopied
+							? __( 'Copied', __i18n_text_domain__ )
+							: __( 'Copy', __i18n_text_domain__ ),
+						onClick: handleCopyToClipboard,
+						tooltip: isCopied
+							? __( 'Copied to clipboard', __i18n_text_domain__ )
+							: __( 'Copy message to clipboard', __i18n_text_domain__ ),
+					},
+			  ]
 			: [
 					{
-						id: 'thumbs-up',
-						icon: <ThumbsUpIcon />,
-						label: __( 'Yes, this was helpful', __i18n_text_domain__ ),
-						onClick: () => handleIsHelpful( true ),
-						disabled: rated,
-						pressed: rated && liked,
-						tooltip: __( 'Yes, this was helpful', __i18n_text_domain__ ),
+						id: 'copy',
+						icon: isCopied ? <Icon icon={ check } size={ 24 } /> : <CopyIcon />,
+						label: isCopied
+							? __( 'Copied', __i18n_text_domain__ )
+							: __( 'Copy', __i18n_text_domain__ ),
+						onClick: handleCopyToClipboard,
+						tooltip: isCopied
+							? __( 'Copied to clipboard', __i18n_text_domain__ )
+							: __( 'Copy message to clipboard', __i18n_text_domain__ ),
 					},
-			  ] ),
-		// Only show thumbs down if not already liked
-		...( liked
-			? []
-			: [
-					{
-						id: 'thumbs-down',
-						icon: <ThumbsDownIcon />,
-						label: __( 'No, this was not helpful', __i18n_text_domain__ ),
-						onClick: () => handleIsHelpful( false ),
-						disabled: rated,
-						pressed: rated && notLiked,
-						tooltip: __( 'No, this was not helpful', __i18n_text_domain__ ),
-					},
-			  ] ),
-		{
-			id: 'copy',
-			icon: isCopied ? <Icon icon={ check } size={ 24 } /> : <CopyIcon />,
-			label: isCopied ? __( 'Copied', __i18n_text_domain__ ) : __( 'Copy', __i18n_text_domain__ ),
-			onClick: handleCopyToClipboard,
-			tooltip: isCopied
-				? __( 'Copied to clipboard', __i18n_text_domain__ )
-				: __( 'Copy message to clipboard', __i18n_text_domain__ ),
-		},
-	];
+			  ];
+	}, [ isLoggedIn, notLiked, liked, rated, isCopied, handleCopyToClipboard, handleIsHelpful ] );
 
 	return (
 		<MessageActions


### PR DESCRIPTION
## Summary
- Hides thumbs up/down feedback actions when user is logged out (only copy action remains)
- Wraps `handleIsHelpful` and `handleCopyToClipboard` in `useCallback` to fix React hook dependency warnings

## Test plan
- [ ] As a logged-in user, verify thumbs up/down and copy actions appear on bot messages
- [ ] As a logged-out user, verify only the copy action appears (no feedback buttons)
- [ ] Verify feedback submission still works correctly when logged in