### PR TITLE
Pass down the feature gating data during site creation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -26,6 +26,7 @@ import useAddEcommerceTrialMutation from 'calypso/data/ecommerce/use-add-ecommer
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useExperiment } from 'calypso/lib/explat';
 import {
 	retrieveSignupDestination,
 	getSignupCompleteFlowName,
@@ -39,7 +40,10 @@ import { useSimplifiedOnboarding } from '../../../../hooks/use-simplified-onboar
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
+import type { PricingDifferentiationExperimentAssignment } from '@automattic/onboarding';
 import './styles.scss';
+
+const PRICING_DIFFERENTIATION_EXPERIMENT_NAME = 'calypso_pricing_differentiation_202601_v1';
 
 const DEFAULT_SITE_MIGRATION_THEME = 'pub/zoologist';
 const DEFAULT_ENTREPRENEUR_FLOW = 'pub/twentytwentytwo';
@@ -188,6 +192,25 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 	const shouldGoToCheckout = Boolean( planCartItem );
 	const [ , isSimplifiedOnboarding ] = useSimplifiedOnboarding();
 
+	// Get the pricing differentiation experiment assignment to pass to site creation.
+	// The experiment is only eligible for onboarding flow, so we check that here.
+	const isEligibleForPricingExperiment = isOnboardingFlow( flow );
+	const [ , pricingExperimentAssignment ] = useExperiment(
+		PRICING_DIFFERENTIATION_EXPERIMENT_NAME,
+		{
+			isEligible: isEligibleForPricingExperiment,
+		}
+	);
+
+	// Build the pricing experiment assignment object to pass to the backend
+	const pricingDifferentiationExperimentAssignment: PricingDifferentiationExperimentAssignment | null =
+		pricingExperimentAssignment?.variationName
+			? {
+					experimentName: PRICING_DIFFERENTIATION_EXPERIMENT_NAME,
+					variationName: pricingExperimentAssignment.variationName,
+			  }
+			: null;
+
 	async function createSite() {
 		if ( isManageSiteFlow ) {
 			const slug = getSignupCompleteSlug();
@@ -239,7 +262,8 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			gardenName,
 			gardenPartnerName,
 			urlQueryParams.get( 'spec_id' ),
-			blueprint
+			blueprint,
+			pricingDifferentiationExperimentAssignment
 		);
 
 		// Poll for garden provisioning status if this is a garden site

--- a/client/landing/stepper/hooks/use-create-site-hook.ts
+++ b/client/landing/stepper/hooks/use-create-site-hook.ts
@@ -11,6 +11,7 @@ import { getFlowFromURL } from '../utils/get-flow-from-url';
 import type { DomainSuggestion } from '@automattic/api-core';
 import type { NewSiteSuccessResponse, Site } from '@automattic/data-stores';
 import type { SiteGoal } from '@automattic/data-stores/src/onboard';
+import type { PricingDifferentiationExperimentAssignment } from '@automattic/onboarding';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 type Params = {
@@ -31,6 +32,7 @@ type Params = {
 	siteGoals?: SiteGoal[];
 	planCartItems?: MinimalRequestCartProduct[] | null;
 	blueprint?: string | null;
+	pricingExperimentAssignment?: PricingDifferentiationExperimentAssignment | null;
 };
 
 async function fillCart(
@@ -80,6 +82,7 @@ export const createSite = async ( {
 	siteIntent,
 	planCartItems,
 	blueprint = null,
+	pricingExperimentAssignment = null,
 }: Params ) => {
 	const newSiteParams = getNewSiteParams( {
 		flowToCheck: flowName,
@@ -108,7 +111,16 @@ export const createSite = async ( {
 			lang_id: getLanguage( locale as string )?.value,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
-			options: newSiteParams.options,
+			options: {
+				...newSiteParams.options,
+				// Pass pricing differentiation experiment assignment so the backend can create blog stickers
+				...( pricingExperimentAssignment && {
+					pricing_experiment_assignment: {
+						experiment_name: pricingExperimentAssignment.experimentName,
+						variation_name: pricingExperimentAssignment.variationName,
+					},
+				} ),
+			},
 		},
 	} );
 

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -74,6 +74,14 @@ export interface CreateSiteParams {
 		is_videopress_initial_purchase?: boolean;
 		wpcom_admin_interface?: string;
 		wpcom_hide_action_bar?: boolean;
+		/**
+		 * Pricing differentiation experiment assignment for the backend to create blog stickers.
+		 * This is specifically for the calypso_pricing_differentiation_202601_v1 experiment.
+		 */
+		pricing_experiment_assignment?: {
+			experiment_name: string;
+			variation_name: string | null;
+		};
 	};
 }
 

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -20,6 +20,16 @@ import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const debug = debugFactory( 'calypso:signup:step-actions' );
 
+/**
+ * Pricing differentiation experiment assignment data to pass to the site creation endpoint.
+ * The backend can use this to create blog stickers after site creation.
+ * This is specifically for the calypso_pricing_differentiation_202601_v1 experiment.
+ */
+export interface PricingDifferentiationExperimentAssignment {
+	experimentName: string;
+	variationName: string | null;
+}
+
 interface GetNewSiteParams {
 	flowToCheck: string;
 	isPurchasingDomainItem: boolean;
@@ -56,6 +66,10 @@ type NewSiteParams = {
 		site_accent_color?: string;
 		site_intent?: string;
 		blueprint?: string;
+		pricing_experiment_assignment?: {
+			experiment_name: string;
+			variation_name: string | null;
+		};
 	};
 	validate: boolean;
 };
@@ -158,7 +172,8 @@ export const createSiteWithCart = async (
 	gardenName?: string | null,
 	gardenPartnerName?: string | null,
 	specId?: string | null,
-	blueprint?: string | null
+	blueprint?: string | null,
+	pricingExperimentAssignment?: PricingDifferentiationExperimentAssignment | null
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
@@ -192,7 +207,6 @@ export const createSiteWithCart = async (
 
 	// This is the parameter that will contain the internal referral, e.g. a landing page.
 	const refParam = new URLSearchParams( document.location.search ).get( 'ref' );
-
 	const siteCreationResponse: NewSiteSuccessResponse = await wpcomRequest( {
 		path: '/sites/new',
 		apiVersion: '1.1',
@@ -225,6 +239,13 @@ export const createSiteWithCart = async (
 					specId && {
 						trigger_backend_build: true,
 					} ),
+				// Pass pricing differentiation experiment assignment so the backend can create blog stickers
+				...( pricingExperimentAssignment && {
+					pricing_experiment_assignment: {
+						experiment_name: pricingExperimentAssignment.experimentName,
+						variation_name: pricingExperimentAssignment.variationName,
+					},
+				} ),
 			},
 		},
 	} );

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -10,6 +10,7 @@ export {
 	replaceProductsInCart,
 	setThemeOnSite,
 } from './cart';
+export type { PricingDifferentiationExperimentAssignment } from './cart';
 export { setupSiteAfterCreation, base64ImageToBlob } from './setup-tailored-site-after-creation';
 export { uploadAndSetSiteLogo } from './upload-and-set-site-logo';
 export { default as Progress } from './progress';


### PR DESCRIPTION
Part of DOTCOM-15679

## Proposed Changes

* Pass down the participation in this experiment to site options. It needs to be verified by the backend but this verification is unnecessary if the site is not part of the experiment, also the verification will cause an assignment.

## Why are these changes being made?

* So free sites can get assignments

## Testing Instructions

* Create a site with onboarding, logged in, logged

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
