### PR TITLE
Help Center: Hide sound notifications toggle for logged-out users

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -60,7 +60,7 @@ const EllipsisMenu = () => {
 	const navigate = useNavigate();
 	const { recentConversations } = useGetHistoryChats();
 	const { currentUser } = useHelpCenterContext();
-	const isLoggedIn = !! currentUser?.I;
+	const isLoggedIn = !! currentUser?.ID;
 	const { areSoundNotificationsEnabled } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -59,6 +59,8 @@ const EllipsisMenu = () => {
 	const { __ } = useI18n();
 	const navigate = useNavigate();
 	const { recentConversations } = useGetHistoryChats();
+	const { currentUser } = useHelpCenterContext();
+	const isLoggedIn = !! currentUser?.I;
 	const { areSoundNotificationsEnabled } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
@@ -110,23 +112,27 @@ const EllipsisMenu = () => {
 				>
 					<Menu.ItemLabel>{ __( 'Support history', __i18n_text_domain__ ) }</Menu.ItemLabel>
 				</Menu.Item>
-				<Menu.Separator />
-				<Menu.Item
-					onClick={ toggleSoundNotifications }
-					prefix={
-						areSoundNotificationsEnabled ? (
-							<MutedBellIcon />
-						) : (
-							<Icon icon={ bell } width={ 24 } height={ 24 } />
-						)
-					}
-				>
-					<Menu.ItemLabel>
-						{ areSoundNotificationsEnabled
-							? __( 'Turn off sound notifications', __i18n_text_domain__ )
-							: __( 'Turn on sound notifications', __i18n_text_domain__ ) }
-					</Menu.ItemLabel>
-				</Menu.Item>
+				{ isLoggedIn && (
+					<>
+						<Menu.Separator />
+						<Menu.Item
+							onClick={ toggleSoundNotifications }
+							prefix={
+								areSoundNotificationsEnabled ? (
+									<MutedBellIcon />
+								) : (
+									<Icon icon={ bell } width={ 24 } height={ 24 } />
+								)
+							}
+						>
+							<Menu.ItemLabel>
+								{ areSoundNotificationsEnabled
+									? __( 'Turn off sound notifications', __i18n_text_domain__ )
+									: __( 'Turn on sound notifications', __i18n_text_domain__ ) }
+							</Menu.ItemLabel>
+						</Menu.Item>
+					</>
+				) }
 			</Menu.Popover>
 		</Menu>
 	);


### PR DESCRIPTION
Fixes DOTSUP-403

## Summary
- Hide the sound notifications menu item in the Help Center header for logged-out users
- The toggle is only relevant for authenticated users who can persist preferences

## Test plan
- [ ] Open Help Center as a logged-out user and verify the sound notifications toggle is not visible
- [ ] Open Help Center as a logged-in user and verify the sound notifications toggle is still visible and functional

