### PR TITLE
Marketplace: Add introductory pricing support for Pressable plans

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -35,20 +35,14 @@ export default function PricingSummary( {
 		discountedCost,
 		totalActualCostFormatted,
 		totalDiscountedCostFormatted,
-		totalActualCostFormattedText,
 		totalDiscountedCostFormattedText,
 	} = getTotalInvoiceValue( userProducts, items );
 
 	const termPricingText = useTermPricingText( termPricing, false );
 
-	// Show actual cost if the agency is referring a client
-	const totalCost = isAutomatedReferrals ? actualCost : discountedCost;
-	const totalCostFormatted = isAutomatedReferrals
-		? totalActualCostFormatted
-		: totalDiscountedCostFormatted;
-	const totalCostFormattedText = isAutomatedReferrals
-		? totalActualCostFormattedText
-		: totalDiscountedCostFormattedText;
+	const totalCost = discountedCost;
+	const totalCostFormatted = totalDiscountedCostFormatted;
+	const totalCostFormattedText = totalDiscountedCostFormattedText;
 
 	// Agency checkout is when the user is not purchasing automated referrals and not a client
 	const isAgencyCheckout = ! isAutomatedReferrals && ! isClient;

--- a/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
@@ -24,7 +24,9 @@ export default function CommissionsInfo( {
 			product.family_slug
 		);
 		const termPrice =
-			termPricing === 'yearly' ? product.yearly_price ?? 0 : product.monthly_price ?? 0;
+			termPricing === 'yearly'
+				? product.yearly_introductory_price ?? product.yearly_price ?? 0
+				: product.monthly_introductory_price ?? product.monthly_price ?? 0;
 		const productAmount = product?.amount ? Number( product.amount.replace( /,/g, '' ) ) : 0;
 		const productPrice = isTermPricingEnabled ? termPrice : productAmount;
 		const totalCommissions = productPrice * commissionPercentage || 0;

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
@@ -249,7 +249,7 @@ export const useGetProductPricingInfo = (
 				const isPressableProduct = product.family_slug === 'pressable-hosting';
 				if ( isPressableProduct ) {
 					// Only show intro pricing for Pressable if user has no active plan OR is in referral mode
-					return pressableOwnership === 'none' || isReferralMode;
+					return pressableOwnership !== 'agency' || isReferralMode;
 				}
 				return true; // Non-Pressable products always apply intro pricing if available
 			};

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
@@ -8,6 +8,7 @@ import wpcomBulkOptions from 'calypso/a8c-for-agencies/sections/marketplace/lib/
 import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/lib/wpcom-bulk-values-utils';
 import { isWooCommerceProduct } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/woocommerce-product-slug-mapping';
 import { MarketplaceTypeContext } from '../context';
+import usePressableOwnershipType from '../hosting-overview/hooks/use-pressable-ownership-type';
 import type { TermPricingType } from '../types';
 import type {
 	APIProductFamily,
@@ -159,6 +160,8 @@ export const useGetProductPricingInfo = (
 	);
 	const { count } = useWPCOMOwnedSites();
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const pressableOwnership = usePressableOwnershipType();
+	const isReferralMode = marketplaceType === 'referral';
 	const ownedPlans = useMemo( () => {
 		// We don't count ownded plans when referring products
 		if ( marketplaceType === 'referral' ) {
@@ -240,7 +243,19 @@ export const useGetProductPricingInfo = (
 					: product.monthly_introductory_price;
 			const regularTermPrice =
 				termPricing === 'yearly' ? product.yearly_price : product.monthly_price;
-			const hasIntroductoryPricing = introductoryPrice !== undefined && introductoryPrice !== null;
+
+			// Determine if intro pricing should be applied for this product
+			const shouldApplyIntroPricing = () => {
+				const isPressableProduct = product.family_slug === 'pressable-hosting';
+				if ( isPressableProduct ) {
+					// Only show intro pricing for Pressable if user has no active plan OR is in referral mode
+					return pressableOwnership === 'none' || isReferralMode;
+				}
+				return true; // Non-Pressable products always apply intro pricing if available
+			};
+
+			const hasIntroductoryPricing =
+				introductoryPrice !== undefined && introductoryPrice !== null && shouldApplyIntroPricing();
 
 			let actualCost: number;
 			let discountedCost: number;

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-marketplace.ts
@@ -232,12 +232,32 @@ export const useGetProductPricingInfo = (
 		if ( isTermPricingEnabled ) {
 			// TODO: When we enable BD for all the agencies, we will only keep this logic for all the products, remove the rest of the logic.
 			const isDailyPricing = product.price_interval === 'day';
-			const actualCost = isDailyPricing ? productBundlePrice / 365 : productBundlePrice;
-			const discountedCost = productPrice || 0;
 
-			const discountPercentage = discountedCost
-				? Math.round( ( ( actualCost - discountedCost ) / actualCost ) * 100 )
-				: 100;
+			// Check for introductory pricing
+			const introductoryPrice =
+				termPricing === 'yearly'
+					? product.yearly_introductory_price
+					: product.monthly_introductory_price;
+			const regularTermPrice =
+				termPricing === 'yearly' ? product.yearly_price : product.monthly_price;
+			const hasIntroductoryPricing = introductoryPrice !== undefined && introductoryPrice !== null;
+
+			let actualCost: number;
+			let discountedCost: number;
+
+			if ( hasIntroductoryPricing && regularTermPrice ) {
+				// Use introductory pricing: introductory price is the discounted cost
+				actualCost = regularTermPrice * quantity;
+				discountedCost = introductoryPrice * quantity;
+			} else {
+				actualCost = isDailyPricing ? productBundlePrice / 365 : productBundlePrice;
+				discountedCost = productPrice || 0;
+			}
+
+			const discountPercentage =
+				actualCost > 0 && actualCost > discountedCost
+					? calculateDiscountPercentage( actualCost, discountedCost )
+					: 0;
 
 			return {
 				actualCost,

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
@@ -81,6 +81,19 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 		);
 	}, [ existingPlanInfo, isReferralMode ] );
 
+	// Determine effective ownership for UI purposes.
+	// 'regular' means the agency has a Pressable account (e.g. from a referral) but no active
+	// A4A subscription — treat as 'none' so intro pricing UI is shown.
+	const effectiveOwnership = ( () => {
+		if ( isReferralMode || agencyPressablePlan ) {
+			return 'agency';
+		}
+		if ( pressableOwnership === 'regular' ) {
+			return 'none';
+		}
+		return pressableOwnership;
+	} )();
+
 	return (
 		<div className="premier-agency-hosting">
 			{ agencyPressablePlan && ! isReferralMode && (
@@ -89,13 +102,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 			<PressablePlanSection
 				onSelect={ onAddToCart }
 				isReferralMode={ isReferralMode }
-				pressableOwnership={
-					isReferralMode ||
-					agencyPressablePlan ||
-					( pressableOwnership === 'regular' && ! agencyPressablePlan ) // Agency has an existing Pressable account, but no active subscription.
-						? 'agency'
-						: pressableOwnership
-				}
+				pressableOwnership={ effectiveOwnership }
 				existingPlan={ agencyPressablePlan }
 				existingPlanInfo={ existingPlanInfo }
 				isFetching={ isExistingPlanFetched }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
@@ -133,7 +133,7 @@ export default function RegularPlanCardContent( {
 						showActualCost &&
 						( pressableOwnership === 'none' || isReferralMode ) && (
 							<span className="pressable-plan-card-content__promo-footnote">
-								{ translate( '*Limited time only. {{a}}See details{{/a}}', {
+								{ translate( '*Limited time only. {{a}}See details{{/a}} ↗', {
 									components: {
 										a: (
 											<a

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
@@ -30,9 +30,14 @@ export default function RegularPlanCardContent( {
 
 	const userProducts = useSelector( getProductsList );
 
-	const { discountedCostFormatted, actualCostFormatted, showActualCost } = plan
+	const { discountedCostFormatted, actualCostFormatted, showActualCost, discountPercentage } = plan
 		? getProductPricingInfo( userProducts, plan, 1 )
-		: { discountedCostFormatted: '', actualCostFormatted: '', showActualCost: false };
+		: {
+				discountedCostFormatted: '',
+				actualCostFormatted: '',
+				showActualCost: false,
+				discountPercentage: 0,
+		  };
 
 	const ctaLabel = useMemo( () => {
 		if ( isReferralMode ) {
@@ -90,9 +95,20 @@ export default function RegularPlanCardContent( {
 							{ isTermPricingEnabled &&
 								showActualCost &&
 								( pressableOwnership === 'none' || isReferralMode ) && (
-									<span className="pressable-plan-card-content__price-original">
-										{ actualCostFormatted }
-									</span>
+									<>
+										<span className="pressable-plan-card-content__price-original">
+											{ actualCostFormatted }
+										</span>
+										<span className="pressable-plan-card-content__price-discount">
+											{ translate( 'Save %(discountPercentage)s%%*', {
+												args: {
+													discountPercentage,
+												},
+												comment:
+													'%(discountPercentage)s is the discount percentage. The asterisk indicates limited time offer.',
+											} ) }
+										</span>
+									</>
 								) }
 						</div>
 
@@ -112,13 +128,32 @@ export default function RegularPlanCardContent( {
 					{ translate( 'Manage in Pressable ↗' ) }
 				</Button>
 			) : (
-				<Button
-					className="pressable-plan-card-content__cta-button"
-					variant="primary"
-					onClick={ () => onSelect( plan ) }
-				>
-					{ ctaLabel }
-				</Button>
+				<div className="pressable-plan-card-content__cta-section">
+					{ isTermPricingEnabled &&
+						showActualCost &&
+						( pressableOwnership === 'none' || isReferralMode ) && (
+							<span className="pressable-plan-card-content__promo-footnote">
+								{ translate( '*Limited time only. {{a}}See details{{/a}}', {
+									components: {
+										a: (
+											<a
+												href="https://pressable.com/legal/hosting-promotion-terms/"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								} ) }
+							</span>
+						) }
+					<Button
+						className="pressable-plan-card-content__cta-button"
+						variant="primary"
+						onClick={ () => onSelect( plan ) }
+					>
+						{ ctaLabel }
+					</Button>
+				</div>
 			) }
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
@@ -30,9 +30,9 @@ export default function RegularPlanCardContent( {
 
 	const userProducts = useSelector( getProductsList );
 
-	const { discountedCostFormatted } = plan
+	const { discountedCostFormatted, actualCostFormatted, showActualCost } = plan
 		? getProductPricingInfo( userProducts, plan, 1 )
-		: { discountedCostFormatted: '' };
+		: { discountedCostFormatted: '', actualCostFormatted: '', showActualCost: false };
 
 	const ctaLabel = useMemo( () => {
 		if ( isReferralMode ) {
@@ -83,9 +83,16 @@ export default function RegularPlanCardContent( {
 					</div>
 				) : (
 					<div className="pressable-plan-card-content__price">
-						<b className="pressable-plan-card-content__price-actual-value">
-							{ discountedCostFormatted }
-						</b>
+						<div className="pressable-plan-card-content__price-row">
+							<b className="pressable-plan-card-content__price-actual-value">
+								{ discountedCostFormatted }
+							</b>
+							{ isTermPricingEnabled && showActualCost && (
+								<span className="pressable-plan-card-content__price-original">
+									{ actualCostFormatted }
+								</span>
+							) }
+						</div>
 
 						<div className="pressable-plan-card-content__price-interval">{ priceInterval() }</div>
 					</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
@@ -87,11 +87,13 @@ export default function RegularPlanCardContent( {
 							<b className="pressable-plan-card-content__price-actual-value">
 								{ discountedCostFormatted }
 							</b>
-							{ isTermPricingEnabled && showActualCost && (
-								<span className="pressable-plan-card-content__price-original">
-									{ actualCostFormatted }
-								</span>
-							) }
+							{ isTermPricingEnabled &&
+								showActualCost &&
+								( pressableOwnership === 'none' || isReferralMode ) && (
+									<span className="pressable-plan-card-content__price-original">
+										{ actualCostFormatted }
+									</span>
+								) }
 						</div>
 
 						<div className="pressable-plan-card-content__price-interval">{ priceInterval() }</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
@@ -57,7 +57,7 @@
 	color: var(--color-neutral-50);
 
 	a {
-		color: var(--color-link);
+		color: var(--color-text);
 		text-decoration: underline;
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
@@ -37,6 +37,31 @@
 	color: var(--color-neutral-50);
 }
 
+.pressable-plan-card-content__price-discount {
+	@include body-small;
+	color: var(--color-success-50);
+	background-color: var(--color-success-5);
+	padding: 4px 8px;
+	border-radius: 4px;
+	text-wrap: nowrap;
+}
+
+.pressable-plan-card-content__cta-section {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.pressable-plan-card-content__promo-footnote {
+	@include body-small;
+	color: var(--color-neutral-50);
+
+	a {
+		color: var(--color-link);
+		text-decoration: underline;
+	}
+}
+
 // We need to do this specifically to override the white-space.
 .pressable-plan-card-content__cta-button.pressable-plan-card-content__cta-button.pressable-plan-card-content__cta-button {
 	min-width: 0;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
@@ -25,6 +25,18 @@
 	@include body-small;
 }
 
+.pressable-plan-card-content__price-row {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+}
+
+.pressable-plan-card-content__price-original {
+	text-decoration: line-through;
+	@include body-small;
+	color: var(--color-neutral-50);
+}
+
 // We need to do this specifically to override the white-space.
 .pressable-plan-card-content__cta-button.pressable-plan-card-content__cta-button.pressable-plan-card-content__cta-button {
 	min-width: 0;

--- a/client/a8c-for-agencies/types/products.ts
+++ b/client/a8c-for-agencies/types/products.ts
@@ -27,6 +27,8 @@ export interface APIProductFamilyProduct {
 	supported_bundles: APIProductFamilyProductBundlePrice[];
 	monthly_price?: number;
 	yearly_price?: number;
+	monthly_introductory_price?: number;
+	yearly_introductory_price?: number;
 	tier_monthly_prices?: APIProductTierPrice[];
 	tier_yearly_prices?: APIProductTierPrice[];
 }

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -1,4 +1,7 @@
-import { isMultiYearDomainProduct } from '@automattic/calypso-products';
+import {
+	isA4ASitelessCheckoutProduct,
+	isMultiYearDomainProduct,
+} from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -65,6 +68,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	const isIntroductoryOffer = introCount > 0;
 	const translate = useTranslate();
 	const isMultiYearDomain = isMultiYearDomainProduct( product );
+	const isA4ACheckout = isA4ASitelessCheckoutProduct( product );
 
 	const translatedIntroOfferDetails = () => {
 		const args = {
@@ -197,7 +201,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 
 				<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
 				<IntroPricing>
-					{ ! isMultiYearDomain && (
+					{ ! isMultiYearDomain && ! isA4ACheckout && (
 						<IntroPricingText>
 							{ isIntroductoryOffer && translatedIntroOfferDetails() }
 						</IntroPricingText>

--- a/packages/calypso-products/src/is-a4a-siteless-checkout-product.ts
+++ b/packages/calypso-products/src/is-a4a-siteless-checkout-product.ts
@@ -1,0 +1,9 @@
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * @param product Product to check.
+ * @returns boolean indicating whether the product is an A4A siteless checkout product.
+ */
+export function isA4ASitelessCheckoutProduct( product: ResponseCartProduct ): boolean {
+	return Boolean( product?.extra?.isA4ASitelessCheckout );
+}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -133,6 +133,7 @@ export { isJetpackSecuritySlug } from './is-jetpack-security-slug';
 export { isJetpackSecurityT1Slug } from './is-jetpack-security-t1-slug';
 export { isTieredVolumeSpaceAddon } from './is-tiered-volume-space-addon';
 export { isMultiYearDomainProduct } from './is-multi-year-domain-product';
+export { isA4ASitelessCheckoutProduct } from './is-a4a-siteless-checkout-product';
 export { isThemePurchase } from './is-theme-purchase';
 export { isTitanMail } from './is-titan-mail';
 export { isTitanMailMonthly } from './is-titan-mail-monthly';


### PR DESCRIPTION
Related to https://linear.app/a8c/project/pressable-plan-incentive-portal-pricing-changes-2ca1461b59ed/overview

Built on top of https://github.com/Automattic/wp-calypso/pull/108280, so should be merged after that one.

### Marketplace

#### Monthly term

<img width="987" height="364" alt="image" src="https://github.com/user-attachments/assets/431669be-c2b5-449f-a85c-afa548329bd9" />

#### Yearly term

<img width="978" height="362" alt="image" src="https://github.com/user-attachments/assets/6491d996-1ccd-40ac-bf5e-909211ae90cd" />

### Marketplace

#### Regular purchase

<img width="503" height="228" alt="image" src="https://github.com/user-attachments/assets/9468fe41-0be1-47c8-9e47-4ea2cc403f6a" />

#### Referral purchase

<img width="546" height="369" alt="image" src="https://github.com/user-attachments/assets/a51fc9c1-1cf3-4686-b537-dcd40284c1b8" />

### Checkout

<img width="1339" height="863" alt="image" src="https://github.com/user-attachments/assets/42fb4837-46fe-4bba-912a-bea99a64319e" />

## Proposed Changes

* Add support for displaying introductory/promotional pricing in the Pressable marketplace section
* Show the introductory price as the main price with the original price struck through beside it
* Add `monthly_introductory_price` and `yearly_introductory_price` fields to the product type definition
* Update pricing logic in `useGetProductPricingInfo` to use introductory prices when available
* Only display promotional pricing for users without an active Pressable plan, or when in referral mode

## Why are these changes being made?

* To display promotional pricing for Pressable plans when introductory pricing is available from the API
* This helps agencies see the discounted introductory price alongside the regular price, making the promotion more visible and transparent

## Testing Instructions

* Enable feature flags `a4a-bd-term-pricing` and `a4a-bd-checkout`
* Navigate to the A4A Marketplace > Hosting > Premier Agency Hosting section
* You need to temporarily comment out these lines on your sandbox to allow introductory prices during checkout: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Snqzva%2Qcyhtvaf%2Sjcpbz%2Qovyyvat%2Scebqhpgf%2Sn4n%2Qcebqhpgf.cuc%3Se%3Q29qr86s6%23759%2Q762-og
* For Pressable plans that have `monthly_introductory_price` or `yearly_introductory_price` in the API response:
  * Verify the introductory price is displayed as the main price
  * Verify the original price is displayed with strikethrough beside it
* For plans without introductory pricing, verify the regular price is displayed without strikethrough
* Verify promotional pricing is NOT shown for users who already have an active Pressable plan (agency ownership)
* Verify promotional pricing IS shown in referral mode regardless of ownership

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?