### PR TITLE
Agent Manager: always open chat from FAB

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -86,7 +86,9 @@ export default function AgentDock( {
 			defaultOpen: isPersistedOpen,
 			onOpenSidebar: () => {
 				setIsOpen( true );
-				navigate( '/' );
+				if ( pathname === '/history' ) {
+					navigate( '/' );
+				}
 			},
 			onCloseSidebar: () => setIsOpen( false ),
 		} );
@@ -159,7 +161,9 @@ export default function AgentDock( {
 
 	const handleExpand = () => {
 		setIsOpen( true );
-		navigate( '/' );
+		if ( pathname === '/history' ) {
+			navigate( '/' );
+		}
 	};
 
 	const handleSelectConversation = ( sessionId: string ) => {

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -84,7 +84,10 @@ export default function AgentDock( {
 			isReady: isStoreReady,
 			defaultDocked: isPersistedDocked,
 			defaultOpen: isPersistedOpen,
-			onOpenSidebar: () => setIsOpen( true ),
+			onOpenSidebar: () => {
+				setIsOpen( true );
+				navigate( '/' );
+			},
 			onCloseSidebar: () => setIsOpen( false ),
 		} );
 

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -154,6 +154,11 @@ export default function AgentDock( {
 		navigate( '/' );
 	};
 
+	const handleExpand = () => {
+		setIsOpen( true );
+		navigate( '/' );
+	};
+
 	const handleSelectConversation = ( sessionId: string ) => {
 		abortCurrentRequest();
 		setSessionId( sessionId );
@@ -219,7 +224,7 @@ export default function AgentDock( {
 			isDocked={ isDocked }
 			isOpen={ isPersistedOpen }
 			onClose={ isDocked ? closeSidebar : () => setIsOpen( false ) }
-			onExpand={ () => setIsOpen( true ) }
+			onExpand={ handleExpand }
 			chatHeaderOptions={ getChatHeaderOptions() }
 			markdownComponents={ markdownComponents }
 			markdownExtensions={ markdownExtensions }
@@ -236,7 +241,7 @@ export default function AgentDock( {
 			onSubmit={ onSubmit }
 			onAbort={ abortCurrentRequest }
 			onClose={ isDocked ? closeSidebar : () => setIsOpen( false ) }
-			onExpand={ () => setIsOpen( true ) }
+			onExpand={ handleExpand }
 			onSelectConversation={ handleSelectConversation }
 			onNewChat={ handleNewChat }
 		/>


### PR DESCRIPTION
When the FAB (floating action button) is pressed we should always open a new chat, ~regardless of what route was last accessed~ if it was last showing the conversation history.

<img width="318" height="236" alt="image" src="https://github.com/user-attachments/assets/3ad6a30a-f778-47f5-8c34-9951b95a41c8" />

Fixes BSKY-1514

## Why are these changes being made?
* Change the route to `/` whenever the FAB is pressed to reset whatever the user was last doing


## Testing Instructions

* `cd apps/agents-manager`
* `yarn dev --sync`
* Open a wp-admin page and open the agent in floating mode. Go to chat history, then close the chat
* Re-open the chat and confirm it opens on a new chat and not chat history
* Start a chat, close the chat window, re-open it and confirm it is still on the chat
* Repeat test, but in docked mode

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
