### PR TITLE
Help Center: Send suggestion buttons directly to AI assistant

### DIFF
--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -36,16 +36,15 @@ export const OdieSendMessageButton = () => {
 	const isInitialLoading = chat.status === 'loading';
 	const isLiveChat = chat.provider?.startsWith( 'zendesk' );
 	const [ searchParams ] = useSearchParams();
-	const initialQuery = searchParams.get( 'query' ) || '';
+	const queryFromParam = searchParams.get( 'query' ) || '';
+	const [ initialQuery, setInitialQuery ] = useState( queryFromParam );
 	const [ inputValue, setInputValue ] = useState( initialQuery );
 	const messageSizeNotice = useMessageSizeErrorNotice( inputValue.trim().length );
 	const connectionNotice = useConnectionStatusNotice( isLiveChat );
 
 	useEffect( () => {
-		if ( initialQuery ) {
-			setInputValue( initialQuery );
-		}
-	}, [ initialQuery ] );
+		setInitialQuery( queryFromParam );
+	}, [ queryFromParam ] );
 
 	// I'm only using adjustHeight from agenttic-ui
 	const { textareaRef } = useInput( {
@@ -140,6 +139,23 @@ export const OdieSendMessageButton = () => {
 	const isDisabled = !! messageSizeNotice || ( isInputEmpty && ! hasAttachments );
 	// When there is a reason to disable the input, we should not convey a processing state.
 	const isProcessing = ( isChatBusy || isAttachingFile || cantTransferToZendesk ) && ! isDisabled;
+
+	useEffect( () => {
+		if ( initialQuery && ! isProcessing && chat.status !== 'loading' ) {
+			setInputValue( initialQuery );
+			setInitialQuery( '' );
+			if ( chat.messages.length === 0 ) {
+				sendMessageHandler();
+			}
+		}
+	}, [
+		initialQuery,
+		sendMessageHandler,
+		isProcessing,
+		isDisabled,
+		chat.messages.length,
+		chat.status,
+	] );
 
 	return (
 		<>


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-404

## What

When a user clicks a suggestion button (like "Ask AI assistant"), this change automatically sends the query to the AI assistant instead of just populating the input field. This creates a smoother user experience by eliminating an extra step.

## How

- Track the initial query from URL parameters separately from the input value
- When the chat is ready and has no messages, automatically trigger the send message handler
- Clear the initial query after sending to prevent duplicate sends

## Testing steps

1. Open Help Center
2. Search something that returns no results
3. Click on "Ask AI assistant"
4. The message should be sent automatically to the AI assistant (not just populated in the input)

## Regression testing (from #107561)

1. Open Help Center
2. Search something that returns no results and click on "Ask AI assistant"
3. Search input should be populated with your query
4. Go back and the search should be populated
5. Try to click "Need help? Get in touch". The chat should be populated.