### PR TITLE
/Support: Open HC logged out when clicking on contact 

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/includes.php
+++ b/apps/happy-blocks/block-library/support-content-footer/includes.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Title: Footer content for support sites
  * Slug: happy-blocks/support-content-footer
@@ -7,20 +8,25 @@
  * @package happy-blocks
  */
 
-if ( ! function_exists( 'happy_blocks_get_content_footer_asset' ) ) {
+if (! function_exists('happy_blocks_get_content_footer_asset')) {
 	/**
 	 * Find the URL of the asset file from happy-blocks.
 	 *
 	 * @param file $file The file name.
 	 */
-	function happy_blocks_get_content_footer_asset( $file ) {
+	function happy_blocks_get_content_footer_asset($file)
+	{
 		return array(
 			'path'    => "https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-library/support-content-footer/build/$file",
-			'version' => filemtime( __DIR__ . "/build/$file" ),
+			'version' => filemtime(__DIR__ . "/build/$file"),
 		);
 	}
 }
 
-$css = happy_blocks_get_content_footer_asset( is_rtl() ? 'view.rtl.css' : 'view.css' );
+$css = happy_blocks_get_content_footer_asset(is_rtl() ? 'view.rtl.css' : 'view.css');
+wp_enqueue_style('happy-blocks-support-footer-style', $css['path'], array(), $css['version']);
 
-wp_enqueue_style( 'happy-blocks-support-footer-style', $css['path'], array(), $css['version'] );
+if (! is_user_logged_in()) {
+	$js = happy_blocks_get_content_footer_asset('view.js');
+	wp_enqueue_script('happy-blocks-support-footer-view', $js['path'], array(), $js['version'], true);
+}

--- a/apps/happy-blocks/block-library/support-content-footer/view.js
+++ b/apps/happy-blocks/block-library/support-content-footer/view.js
@@ -1,1 +1,27 @@
 import './style.scss';
+
+document.addEventListener( 'DOMContentLoaded', function () {
+	const helpCenterLinks = document.querySelectorAll(
+		'.happy-blocks-new-support-content-footer.contact-page a[data-track-destination="help_center"], .happy-blocks-new-support-content-footer a[data-track-destination="contact_form"]'
+	);
+
+	if ( ! helpCenterLinks.length ) {
+		return;
+	}
+
+	helpCenterLinks.forEach( ( link ) =>
+		link.addEventListener( 'click', function ( e ) {
+			if ( window.helpCenter?.loadHelpCenter ) {
+				e.preventDefault();
+
+				window.helpCenter.loadHelpCenter().then( () => {
+					if ( window.wp?.data?.dispatch ) {
+						const helpCenterDispatch = window.wp.data.dispatch( 'automattic/help-center' );
+						helpCenterDispatch.setNavigateToRoute( '/odie' );
+						helpCenterDispatch.setShowHelpCenter( true );
+					}
+				} );
+			}
+		} )
+	);
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-408/update-contact-cta-to-open-ai-assistant

<img width="1341" height="478" alt="image" src="https://github.com/user-attachments/assets/88128311-e263-4701-9102-e14912830da4" />

On logged out /support, open the Help Center instead of going to /contact

## Testing steps

1. Sanbox widgets and en.support.wordpress.com
2. `yarn dev --sync` from `apps/happy-blocks`
3. Visit wordpress.com/support logged out
4. Go to the bottom and click on "Contact WordPress..."
5. The Help Center should open on AI
6. Try logged in, you should go to /contact