### PR TITLE
Products: update product slug definitions to account for Billing Services

### DIFF
--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -1,4 +1,4 @@
-import { DotcomPlans } from '@automattic/api-core';
+import { DotcomPlans, JetpackPlans } from '@automattic/api-core';
 import { siteCurrentPlanQuery, siteByIdQuery, purchaseQuery } from '@automattic/api-queries';
 import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
 import { useQuery } from '@tanstack/react-query';
@@ -218,7 +218,7 @@ function getCardDescription( site: Site, purchase?: Purchase ) {
 		return __( 'Upgrade to access all hosting features.' );
 	}
 
-	if ( site.plan?.product_slug === DotcomPlans.JETPACK_FREE ) {
+	if ( site.plan?.product_slug === JetpackPlans.PLAN_JETPACK_FREE ) {
 		return getJetpackProductsForSite( site ).length > 0
 			? __( 'Manage subscriptions.' )
 			: __( 'Upgrade to access more Jetpack tools.' );

--- a/client/dashboard/sites/plans.ts
+++ b/client/dashboard/sites/plans.ts
@@ -11,7 +11,7 @@ export const isSitePlanNotOneOf = ( site: Site, plans: StorePlanSlug[] ) => {
 		return false;
 	}
 
-	return ! plans.includes( site.plan.product_slug as StorePlanSlug );
+	return ! ( plans as string[] ).includes( site.plan.product_slug );
 };
 
 export const isSitePlanBigSkyTrial = ( site: Site ) => {

--- a/client/dashboard/sites/plans.ts
+++ b/client/dashboard/sites/plans.ts
@@ -1,11 +1,17 @@
-import { DotcomPlans, type DotcomPlanSlug, type Site } from '@automattic/api-core';
+import {
+	DotcomPlans,
+	JetpackPlans,
+	WooHostedPlans,
+	type StorePlanSlug,
+	type Site,
+} from '@automattic/api-core';
 
-export const isSitePlanNotOneOf = ( site: Site, plans: DotcomPlanSlug[] ) => {
+export const isSitePlanNotOneOf = ( site: Site, plans: StorePlanSlug[] ) => {
 	if ( ! site.plan ) {
 		return false;
 	}
 
-	return ! plans.includes( site.plan.product_slug as DotcomPlanSlug );
+	return ! plans.includes( site.plan.product_slug as StorePlanSlug );
 };
 
 export const isSitePlanBigSkyTrial = ( site: Site ) => {
@@ -36,7 +42,11 @@ export const isSitePlanBigSkyTrial = ( site: Site ) => {
 };
 
 export const isSitePlanPaid = ( site: Site ) => {
-	return isSitePlanNotOneOf( site, [ DotcomPlans.JETPACK_FREE, DotcomPlans.FREE_PLAN ] );
+	return isSitePlanNotOneOf( site, [
+		JetpackPlans.PLAN_JETPACK_FREE,
+		DotcomPlans.FREE_PLAN,
+		WooHostedPlans.WOO_HOSTED_FREE_PLAN,
+	] );
 };
 
 export const isSitePlanLaunchable = ( site: Site ) => {
@@ -51,7 +61,8 @@ export function isSitePlanTrial( site: Pick< Site, 'plan' > ) {
 		DotcomPlans.ECOMMERCE_TRIAL_MONTHLY,
 		DotcomPlans.HOSTING_TRIAL_MONTHLY,
 		DotcomPlans.MIGRATION_TRIAL_MONTHLY,
-	] as DotcomPlanSlug[];
+		WooHostedPlans.WOO_HOSTED_FREE_TRIAL_PLAN_MONTHLY,
+	] as StorePlanSlug[];
 
-	return trialPlans.includes( site.plan?.product_slug as DotcomPlanSlug );
+	return trialPlans.includes( site.plan?.product_slug as StorePlanSlug );
 }

--- a/client/dashboard/utils/site-plan.ts
+++ b/client/dashboard/utils/site-plan.ts
@@ -1,4 +1,4 @@
-import { DotcomPlans, JetpackFeatures } from '@automattic/api-core';
+import { JetpackPlans, JetpackFeatures } from '@automattic/api-core';
 import { useRouter } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import {
@@ -90,7 +90,7 @@ export function getSitePlanDisplayName( site: Site ) {
 		return '';
 	}
 
-	if ( plan.product_slug === DotcomPlans.JETPACK_FREE ) {
+	if ( plan.product_slug === JetpackPlans.PLAN_JETPACK_FREE ) {
 		const products = getJetpackProductsForSite( site );
 		if ( products.length === 1 ) {
 			return products[ 0 ].label;

--- a/client/state/sites/selectors/is-current-plan-paid.js
+++ b/client/state/sites/selectors/is-current-plan-paid.js
@@ -1,5 +1,11 @@
 import getSitePlan from './get-site-plan';
 
+const FREE_PLAN_PRODUCT_IDS = [
+	1, // Dotcom Free Plan
+	2002, // Jetpack Free Plan
+	4005, // Woo Hosted Free Plan
+];
+
 /**
  * Returns true if the current site plan is a paid one
  * @param  {Object}   state         Global state tree
@@ -13,5 +19,5 @@ export default function isCurrentPlanPaid( state, siteId ) {
 		return null;
 	}
 
-	return sitePlan.product_id !== 1 && sitePlan.product_id !== 2002;
+	return ! FREE_PLAN_PRODUCT_IDS.includes( sitePlan.product_id );
 }

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -97,6 +97,14 @@ export const WooHostedPlans = {
 	WOO_HOSTED_PRO_PLAN_YEARLY: 'woo_hosted_pro_plan_yearly',
 } as const;
 
+export type DotcomPlanSlug = ( typeof DotcomPlans )[ keyof typeof DotcomPlans ];
+export type JetpackPlanSlug = ( typeof JetpackPlans )[ keyof typeof JetpackPlans ];
+export type AkismetPlanSlug = ( typeof AkismetPlans )[ keyof typeof AkismetPlans ];
+export type WooHostedPlanSlug = ( typeof WooHostedPlans )[ keyof typeof WooHostedPlans ];
+
+// Any valid plan slug sold through Store.
+export type StorePlanSlug = DotcomPlanSlug | JetpackPlanSlug | AkismetPlanSlug | WooHostedPlanSlug;
+
 export const BusinessPlans = [
 	DotcomPlans.BUSINESS_MONTHLY,
 	DotcomPlans.BUSINESS,
@@ -118,8 +126,6 @@ export const TrialPlans = [
 	DotcomPlans.MIGRATION_TRIAL_MONTHLY,
 	WooHostedPlans.WOO_HOSTED_FREE_TRIAL_PLAN_MONTHLY,
 ];
-
-export type DotcomPlanSlug = ( typeof DotcomPlans )[ keyof typeof DotcomPlans ];
 
 export const DotcomFeatures = {
 	ATOMIC: 'atomic',

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -13,7 +13,6 @@ export const DotcomPlans = {
 	ECOMMERCE_TRIAL_MONTHLY: 'ecommerce-trial-bundle-monthly',
 	FREE_PLAN: 'free_plan',
 	HOSTING_TRIAL_MONTHLY: 'wp_bundle_hosting_trial_monthly',
-	JETPACK_FREE: 'jetpack_free',
 	MIGRATION_TRIAL_MONTHLY: 'wp_bundle_migration_trial_monthly',
 	PREMIUM: 'value_bundle',
 	PREMIUM_MONTHLY: 'value_bundle_monthly',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1552/
Fixes https://linear.app/a8c/issue/SHILL-1558/

## Proposed Changes

This updates the definitions and usages of various product slugs to account for the different Billing Services supported by Store. It also defines the Woo Hosted Free plan as an unpaid "plan", similar to WPcom Free and Jetpack Free.

## Why are these changes being made?

Store supports multiple Billing Services (WordPress.com, Jetpack, Akismet, Woo Hosted, and A4A), each with their own products. There are a number of UI customizations based on which Service a user's product belongs to (e.g. custom plans pages, thank you pages, and upgrade links). We should keep these organized in the multi-site dashboard. 

## Testing Instructions

These are mostly type changes, so automated tests and a visual inspection should be fine. 

- Make sure that `DotcomPlans.JETPACK_FREE` and `JetpackPlans.PLAN_JETPACK_FREE` have the same value, and that the former is not used anywhere. 
- Make sure that `DotcomPlanSlug` is only used where we're specifically referencing a WPcom plan.
