### PR TITLE
Woo Hosted: fix plan selection flow

### DIFF
--- a/client/dashboard/sites/plans.ts
+++ b/client/dashboard/sites/plans.ts
@@ -66,3 +66,8 @@ export function isSitePlanTrial( site: Pick< Site, 'plan' > ) {
 
 	return trialPlans.includes( site.plan?.product_slug as StorePlanSlug );
 }
+
+export function isSitePlanWooHosted( site: Pick< Site, 'plan' > ) {
+	const wooHostedPlans = Object.values( WooHostedPlans ) as StorePlanSlug[];
+	return wooHostedPlans.includes( site.plan?.product_slug as StorePlanSlug );
+}

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -28,6 +28,7 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { getSiteBadge } from '../../utils/site-badge';
 import { hasHostingFeature, hasJetpackModule } from '../../utils/site-features';
+import { isCommerceGarden } from '../../utils/site-types';
 import { getSiteFormattedUrl } from '../../utils/site-url';
 import { getVisibilityLabels } from '../../utils/site-visibility';
 import { canManageSite } from '../features';
@@ -343,6 +344,9 @@ function SiteLaunchNag( { siteSlug }: { siteSlug: string } ) {
 function PlanRenewNag( { site, source }: { site: Pick< Site, 'slug' | 'plan' >; source: string } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const isTrial = isSitePlanTrial( site );
+	const upgradeLink = isCommerceGarden( site )
+		? wpcomLink( `/setup/woo-hosted-plans/${ site.slug }` )
+		: wpcomLink( `/plans/${ site.slug }` );
 
 	return (
 		<>
@@ -353,7 +357,7 @@ function PlanRenewNag( { site, source }: { site: Pick< Site, 'slug' | 'plan' >; 
 			<ExternalLink
 				href={
 					isTrial
-						? wpcomLink( `/plans/${ site.slug }` )
+						? upgradeLink
 						: wpcomLink( `/checkout/${ site.slug }/${ site.plan?.product_slug }` )
 				}
 				onClick={ () => {

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -28,11 +28,10 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { getSiteBadge } from '../../utils/site-badge';
 import { hasHostingFeature, hasJetpackModule } from '../../utils/site-features';
-import { isCommerceGarden } from '../../utils/site-types';
 import { getSiteFormattedUrl } from '../../utils/site-url';
 import { getVisibilityLabels } from '../../utils/site-visibility';
 import { canManageSite } from '../features';
-import { isSitePlanTrial } from '../plans';
+import { isSitePlanTrial, isSitePlanWooHosted } from '../plans';
 import SitePreview from '../site-preview';
 import { JetpackLogo } from './jetpack-logo';
 import type { SiteBadge, SiteBlockingStatus, SiteVisibility } from '../../types';
@@ -344,7 +343,7 @@ function SiteLaunchNag( { siteSlug }: { siteSlug: string } ) {
 function PlanRenewNag( { site, source }: { site: Pick< Site, 'slug' | 'plan' >; source: string } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const isTrial = isSitePlanTrial( site );
-	const upgradeLink = isCommerceGarden( site )
+	const upgradeLink = isSitePlanWooHosted( site )
 		? wpcomLink( `/setup/woo-hosted-plans/${ site.slug }` )
 		: wpcomLink( `/plans/${ site.slug }` );
 

--- a/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/style.scss
@@ -1,6 +1,5 @@
-.is-section-stepper .woo-hosted-plans {
-	.step-container-v2__top-bar-wordpress-logo-wrapper,
-	.step-container-v2__top-bar-divider {
-		display: none;
-	}
+.is-section-stepper .woo-hosted-plans .wp-brand-font,
+.is-section-stepper .woo-hosted-plans .plan-features-2023-grid__header-title,
+.is-section-stepper .woo-hosted-plans .plan-price {
+	font-family: $default-font;
 }

--- a/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/woo-hosted-plans.ts
+++ b/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/woo-hosted-plans.ts
@@ -86,6 +86,9 @@ const wooHostedPlansFlow: FlowV2< typeof initialize > = {
 
 				// Woo Hosted only supports monthly and yearly plans
 				displayedIntervals: [ 'monthly', 'yearly' ],
+
+				// Hide the logo on the plans page
+				hideLogo: true,
 			},
 		};
 	},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -94,6 +94,7 @@ const PlansStepAdaptor: StepType< {
 		isStepperUpgradeFlow?: boolean;
 		selectedFeature?: string;
 		displayedIntervals?: SupportedIntervalTypes[];
+		hideLogo?: boolean;
 		wrapperProps?: {
 			hideBack?: boolean;
 			goBack?: () => void;
@@ -102,8 +103,14 @@ const PlansStepAdaptor: StepType< {
 		};
 	};
 } > = ( props ) => {
-	const { displayedIntervals, isInSignup, isStepperUpgradeFlow, selectedFeature, wrapperProps } =
-		props;
+	const {
+		displayedIntervals,
+		hideLogo,
+		isInSignup,
+		isStepperUpgradeFlow,
+		selectedFeature,
+		wrapperProps,
+	} = props;
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 
@@ -237,6 +244,7 @@ const PlansStepAdaptor: StepType< {
 			onPlanIntervalUpdate={ onPlanIntervalUpdate }
 			intervalType={ planInterval }
 			displayedIntervals={ displayedIntervals }
+			hideLogo={ hideLogo }
 			wrapperProps={ {
 				hideBack: wrapperProps?.hideBack ?? false,
 				goBack: wrapperProps?.goBack ?? props.navigation.goBack,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -119,6 +119,7 @@ export interface UnifiedPlansStepProps {
 		isExtraWideLayout: boolean;
 	};
 
+	hideLogo?: boolean;
 	shouldHideNavButtons?: boolean;
 	intent?: PlansIntent;
 	onIntentChange?: ( intent: PlansIntent ) => void;
@@ -219,6 +220,7 @@ function UnifiedPlansStep( {
 	step,
 	signupDependencies,
 	displayedIntervals,
+	hideLogo,
 	headerText,
 	useEmailOnboardingSubheader,
 	onPlanIntervalUpdate,
@@ -598,6 +600,7 @@ function UnifiedPlansStep( {
 					className="step-container-v2--plans"
 					topBar={
 						<Step.TopBar
+							hideLogo={ hideLogo }
 							leftElement={
 								goBack ? (
 									<Step.BackButton onClick={ goBack }>{ backLabelText }</Step.BackButton>

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -27,7 +27,7 @@ import { errorNotice, infoNotice } from 'calypso/state/notices/actions';
 import hasGravatarDomainQueryParam from 'calypso/state/selectors/has-gravatar-domain-query-param';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, isCommerceGardenSite } from 'calypso/state/sites/selectors';
 import useActOnceOnStrings from '../hooks/use-act-once-on-strings';
 import useAddProductsFromUrl from '../hooks/use-add-products-from-url';
 import useCheckoutFlowTrackKey from '../hooks/use-checkout-flow-track-key';
@@ -136,9 +136,16 @@ export default function CheckoutMain( {
 }: CheckoutMainProps ) {
 	const translate = useTranslate();
 
+	const isCommerceGarden =
+		useSelector( ( state ) => siteId && isCommerceGardenSite( state, siteId ) ) || false;
 	const isJetpackNotAtomic =
 		useSelector( ( state ) => {
-			return siteId && isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
+			return (
+				siteId &&
+				isJetpackSite( state, siteId ) &&
+				! isAtomicSite( state, siteId ) &&
+				! isCommerceGarden
+			);
 		} ) || sitelessCheckoutType === 'jetpack';
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
 	const isGravatarDomain = useSelector( hasGravatarDomainQueryParam );
@@ -571,19 +578,18 @@ export default function CheckoutMain( {
 	// Woo Hosted sites are technically Jetpack, but are supposed to default to
 	// WPcom colors. We should update this once we have a better way to identify
 	// Garden sites outside of the Hosting Dashboard.
-	const jetpackColors =
-		isJetpackNotAtomic && ! updatedSiteSlug?.endsWith( '.commerce-garden.com' )
-			? {
-					primary: colors[ 'Jetpack Green' ],
-					primaryBorder: colors[ 'Jetpack Green 80' ],
-					primaryOver: colors[ 'Jetpack Green 60' ],
-					success: colors[ 'Jetpack Green' ],
-					discount: colors[ 'Jetpack Green' ],
-					highlight: colors[ 'WordPress Blue 50' ],
-					highlightBorder: colors[ 'WordPress Blue 80' ],
-					highlightOver: colors[ 'WordPress Blue 60' ],
-			  }
-			: {};
+	const jetpackColors = isJetpackNotAtomic
+		? {
+				primary: colors[ 'Jetpack Green' ],
+				primaryBorder: colors[ 'Jetpack Green 80' ],
+				primaryOver: colors[ 'Jetpack Green 60' ],
+				success: colors[ 'Jetpack Green' ],
+				discount: colors[ 'Jetpack Green' ],
+				highlight: colors[ 'WordPress Blue 50' ],
+				highlightBorder: colors[ 'WordPress Blue 80' ],
+				highlightOver: colors[ 'WordPress Blue 60' ],
+		  }
+		: {};
 
 	// A4A Theme
 	const a4aColors =

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -136,15 +136,11 @@ export default function CheckoutMain( {
 }: CheckoutMainProps ) {
 	const translate = useTranslate();
 
-	const isCommerceGarden =
-		useSelector( ( state ) => siteId && isCommerceGardenSite( state, siteId ) ) || false;
 	const isJetpackNotAtomic =
 		useSelector( ( state ) => {
+			const isCommerce = siteId && isCommerceGardenSite( state, siteId );
 			return (
-				siteId &&
-				isJetpackSite( state, siteId ) &&
-				! isAtomicSite( state, siteId ) &&
-				! isCommerceGarden
+				siteId && isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) && ! isCommerce
 			);
 		} ) || sitelessCheckoutType === 'jetpack';
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
@@ -575,9 +571,6 @@ export default function CheckoutMain( {
 	}
 
 	// Jetpack Theme
-	// Woo Hosted sites are technically Jetpack, but are supposed to default to
-	// WPcom colors. We should update this once we have a better way to identify
-	// Garden sites outside of the Hosting Dashboard.
 	const jetpackColors = isJetpackNotAtomic
 		? {
 				primary: colors[ 'Jetpack Green' ],

--- a/client/my-sites/checkout/src/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/src/hooks/use-valid-checkout-back-url.ts
@@ -5,6 +5,7 @@ import { resemblesUrl } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { isJetpackSite, getSiteId } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const getAllowedHosts = ( siteSlug?: string ) => {
 	const basicHosts = [
@@ -29,6 +30,8 @@ const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undef
 	const jetpackSite = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
+	const site = useSelector( getSelectedSite );
+	const isCommerce = site?.is_garden && site.garden_name === 'commerce';
 	return useMemo( () => {
 		if ( ! checkoutBackUrl ) {
 			// For akismet specific checkout, if navigated with direct link
@@ -39,7 +42,7 @@ const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undef
 			}
 			// For Jetpack specific checkout, if navigated with direct link
 			// We should redirect to the jetpack pricing page
-			if ( jetpackSite ) {
+			if ( jetpackSite && ! isCommerce ) {
 				return 'https://cloud.jetpack.com/pricing/' + ( siteSlug || '' );
 			}
 			return undefined;

--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -34,8 +34,6 @@ import {
 	PLAN_FREE,
 	PLAN_HOSTING_TRIAL_MONTHLY,
 	PLAN_PERSONAL,
-	PLAN_WOOEXPRESS_MEDIUM,
-	PLAN_WOOEXPRESS_SMALL,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { renderHook } from '@testing-library/react';
@@ -420,32 +418,6 @@ describe( 'useGenerateActionHook', () => {
 		const action = result.current( { planSlug: PLAN_ECOMMERCE, availableForPurchase: true } );
 
 		expect( action.primary.text ).toBe( 'Upgrade' );
-	} );
-
-	it( 'should handle WooExpress Medium plan upgrade', () => {
-		const { result } = renderHook( () =>
-			useGenerateActionHook( { isInSignup: false, isLaunchPage: false } )
-		);
-
-		const action = result.current( {
-			planSlug: PLAN_WOOEXPRESS_MEDIUM,
-			availableForPurchase: true,
-		} );
-
-		expect( action.primary.text ).toBe( 'Get Performance' );
-	} );
-
-	it( 'should handle WooExpress Small plan upgrade', () => {
-		const { result } = renderHook( () =>
-			useGenerateActionHook( { isInSignup: false, isLaunchPage: false } )
-		);
-
-		const action = result.current( {
-			planSlug: PLAN_WOOEXPRESS_SMALL,
-			availableForPurchase: true,
-		} );
-
-		expect( action.primary.text ).toBe( 'Get Essential' );
 	} );
 
 	it( 'should handle business trial upgrade', () => {

--- a/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
+++ b/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
@@ -2,6 +2,7 @@ import {
 	getPlan,
 	getBillingMonthsForTerm,
 	isFreePlan,
+	isWooHostedFreePlan,
 	URL_FRIENDLY_TERMS_MAPPING,
 	UrlFriendlyTermType,
 } from '@automattic/calypso-products';
@@ -28,7 +29,7 @@ const useFilteredDisplayedIntervals = ( {
 		let filteredIntervals = displayedIntervals;
 
 		// Hide interval terms that are less than the current plan's term in months
-		if ( productSlug && ! isFreePlan( productSlug ) ) {
+		if ( productSlug && ! isFreePlan( productSlug ) && ! isWooHostedFreePlan( productSlug ) ) {
 			const currentPlanIntervalInMonths = getBillingMonthsForTerm(
 				getPlan( productSlug )?.term || ''
 			);

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -15,6 +15,7 @@ import {
 	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 	isWooExpressMediumPlan,
 	isWooExpressSmallPlan,
+	isWooHostedPlan,
 	isBusinessTrial,
 	getPlan,
 } from '@automattic/calypso-products';
@@ -592,12 +593,12 @@ function getLoggedInPlansAction( {
 		);
 	}
 
+	// If the current plan matches on a lower-term, then show an "Upgrade to..." button.
 	if (
 		sitePlanSlug &&
 		getPlanClass( planSlug ) === getPlanClass( sitePlanSlug ) &&
 		! isTrialPlan
 	) {
-		// If the current plan matches on a lower-term, then show an "Upgrade to..." button.
 		if ( planMatches( planSlug, { term: TERM_TRIENNIALLY } ) ) {
 			return createLoggedInPlansAction( translate( 'Upgrade to Triennial' ) );
 		}
@@ -611,14 +612,13 @@ function getLoggedInPlansAction( {
 		}
 	}
 
-	if ( isWooExpressMediumPlan( planSlug ) && ! isWooExpressMediumPlan( sitePlanSlug || '' ) ) {
-		return createLoggedInPlansAction( translate( 'Get Performance', { textOnly: true } ) );
-	}
-	if ( isWooExpressSmallPlan( planSlug ) && ! isWooExpressSmallPlan( sitePlanSlug || '' ) ) {
-		return createLoggedInPlansAction( translate( 'Get Essential', { textOnly: true } ) );
-	}
-
-	if ( isBusinessTrial( sitePlanSlug || '' ) ) {
+	// Some flows prefer to have the CTA read "Get {plan name} plan".
+	if (
+		isBusinessTrial( sitePlanSlug || '' ) ||
+		isWooHostedPlan( sitePlanSlug || '' ) ||
+		isWooExpressMediumPlan( sitePlanSlug || '' ) ||
+		isWooExpressSmallPlan( sitePlanSlug || '' )
+	) {
 		return createLoggedInPlansAction(
 			translate( 'Get %(plan)s', {
 				textOnly: true,

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -12,6 +12,7 @@ import {
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_MIGRATION_TRIAL_MONTHLY,
 	PLAN_HOSTING_TRIAL_MONTHLY,
+	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 	isWooExpressMediumPlan,
 	isWooExpressSmallPlan,
 	isBusinessTrial,
@@ -446,7 +447,8 @@ function getLoggedInPlansAction( {
 } & UseActionHookProps ): GridAction {
 	// Use plan type matching instead of exact slug matching for the 'plans-upgrade' intent.
 	// This allows monthly/yearly versions of the same plan to be considered "current"
-	const isUpgradeFlow = plansIntent && [ 'plans-upgrade' ].includes( plansIntent );
+	const isUpgradeFlow =
+		plansIntent && [ 'plans-upgrade', 'plans-woo-hosted' ].includes( plansIntent );
 	const current =
 		isUpgradeFlow && sitePlanSlug
 			? getPlanClass( sitePlanSlug ) === getPlanClass( planSlug )
@@ -454,7 +456,8 @@ function getLoggedInPlansAction( {
 	const isTrialPlan =
 		sitePlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY ||
 		sitePlanSlug === PLAN_MIGRATION_TRIAL_MONTHLY ||
-		sitePlanSlug === PLAN_HOSTING_TRIAL_MONTHLY;
+		sitePlanSlug === PLAN_HOSTING_TRIAL_MONTHLY ||
+		sitePlanSlug === PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY;
 
 	const createLoggedInPlansAction = (
 		text: TranslateResult,

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -446,8 +446,7 @@ function getLoggedInPlansAction( {
 } & UseActionHookProps ): GridAction {
 	// Use plan type matching instead of exact slug matching for the 'plans-upgrade' intent.
 	// This allows monthly/yearly versions of the same plan to be considered "current"
-	const isUpgradeFlow =
-		plansIntent && [ 'plans-upgrade', 'plans-woo-hosted' ].includes( plansIntent );
+	const isUpgradeFlow = plansIntent && [ 'plans-upgrade' ].includes( plansIntent );
 	const current =
 		isUpgradeFlow && sitePlanSlug
 			? getPlanClass( sitePlanSlug ) === getPlanClass( planSlug )

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -15,8 +15,11 @@ import {
 	getWooExpressFeaturesGroupedForComparisonGrid,
 	getPlanFeaturesGroupedForComparisonGrid,
 	getWooExpressFeaturesGroupedForFeaturesGrid,
+	getWooHostedFeaturesGroupedForFeaturesGrid,
+	getWooHostedFeaturesGroupedForComparisonGrid,
 	getSimplifiedPlanFeaturesGroupedForFeaturesGrid,
 	getWordPressHostingFeaturesGroupedForFeaturesGrid,
+	isWooHostedPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
@@ -738,16 +741,32 @@ const PlansFeaturesMain = ( {
 		);
 	}, [ gridPlansForComparisonGrid ] );
 
+	// Check to see if we have at least one Woo Hosted plan we're comparing.
+	const hasWooHostedFeatures = useMemo( () => {
+		return gridPlansForComparisonGrid?.some(
+			( { planSlug, isVisible } ) => isVisible && isWooHostedPlan( planSlug )
+		);
+	}, [ gridPlansForComparisonGrid ] );
+
 	// Get summer special status
 	const isSummerSpecial = useSummerSpecialStatus( { isInSignup, siteId } );
 
-	// If we have a Woo Express plan, use the Woo Express feature groups, otherwise use the regular feature groups.
-	const featureGroupMapForComparisonGrid = hasWooExpressFeatures
-		? getWooExpressFeaturesGroupedForComparisonGrid()
-		: getPlanFeaturesGroupedForComparisonGrid( { isExperimentVariant } );
+	// Determine feature groups for comparison grid
+	let featureGroupMapForComparisonGrid;
+	if ( hasWooHostedFeatures ) {
+		featureGroupMapForComparisonGrid = getWooHostedFeaturesGroupedForComparisonGrid();
+	} else if ( hasWooExpressFeatures ) {
+		featureGroupMapForComparisonGrid = getWooExpressFeaturesGroupedForComparisonGrid();
+	} else {
+		featureGroupMapForComparisonGrid = getPlanFeaturesGroupedForComparisonGrid( {
+			isExperimentVariant,
+		} );
+	}
 
 	let featureGroupMapForFeaturesGrid;
-	if ( hasWooExpressFeatures ) {
+	if ( hasWooHostedFeatures ) {
+		featureGroupMapForFeaturesGrid = getWooHostedFeaturesGroupedForFeaturesGrid();
+	} else if ( hasWooExpressFeatures ) {
 		featureGroupMapForFeaturesGrid = getWooExpressFeaturesGroupedForFeaturesGrid();
 	} else if ( intent === 'plans-wordpress-hosting' ) {
 		featureGroupMapForFeaturesGrid = getWordPressHostingFeaturesGroupedForFeaturesGrid();

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -14,7 +14,9 @@ function showJetpackPlans( context ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const isWpcom = isSiteWpcom( state, siteId );
-	return ! isWpcom;
+	const site = getSelectedSite( state );
+	const isCommerce = site?.is_garden && site.garden_name === 'commerce';
+	return ! isWpcom && ! isCommerce;
 }
 
 function is100YearPlanUser( context ) {

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -7,6 +7,7 @@ import setJetpackPlansHeader from 'calypso/my-sites/plans/jetpack-plans/plans-he
 import { PLAN } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
 import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
+import { isCommerceGardenSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Plans from './main';
 
@@ -14,8 +15,7 @@ function showJetpackPlans( context ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const isWpcom = isSiteWpcom( state, siteId );
-	const site = getSelectedSite( state );
-	const isCommerce = site?.is_garden && site.garden_name === 'commerce';
+	const isCommerce = isCommerceGardenSite( state, siteId );
 	return ! isWpcom && ! isCommerce;
 }
 

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -43,6 +43,7 @@ export { default as hasJetpackSiteCustomDomain } from './has-jetpack-site-custom
 export { default as hasSiteProduct } from './has-site-product';
 export { default as isAdminInterfaceWPAdmin } from './is-admin-interface-wp-admin';
 export { default as isBackupPluginActive } from './is-backup-plugin-active';
+export { default as isCommerceGardenSite } from './is-commerce-garden-site';
 export { default as isCurrentPlanPaid } from './is-current-plan-paid';
 export { default as isCurrentSitePlan } from './is-current-site-plan';
 export { default as isJetpackCloudCartEnabled } from './is-jetpack-cloud-cart-enabled';

--- a/client/state/sites/selectors/is-commerce-garden-site.ts
+++ b/client/state/sites/selectors/is-commerce-garden-site.ts
@@ -1,0 +1,16 @@
+import getRawSite from 'calypso/state/selectors/get-raw-site';
+import { AppState } from 'calypso/types';
+
+/**
+ * Returns true if the site is a Commerce Garden site, false otherwise.
+ * @param  {Object}   state  Global state tree
+ * @param  {number | null}   siteId Site ID
+ * @returns {boolean}        Whether site is a Commerce Garden site or not
+ */
+export default function isCommerceGardenSite( state: AppState, siteId: number | null ) {
+	if ( ! siteId ) {
+		return false;
+	}
+	const site = getRawSite( state, siteId );
+	return site?.is_garden && site.garden_name === 'commerce';
+}

--- a/packages/calypso-products/src/constants/feature-group.ts
+++ b/packages/calypso-products/src/constants/feature-group.ts
@@ -26,6 +26,10 @@ export const FEATURE_GROUP_MARKETING_EMAIL = 'feature-group-marketing-email';
 export const FEATURE_GROUP_SHIPPING = 'feature-group-shipping';
 /* END: Woo Express Feature Groups */
 
+/* START: Woo Hosted Feature Groups */
+export const FEATURE_GROUP_WOO_HOSTED = 'feature-group-woo-hosted';
+/* END: Woo Hosted Feature Groups */
+
 export const FEATURE_GROUP_STORAGE = 'feature-group-storage';
 export const FEATURE_GROUP_ALL_FEATURES = 'feature-group-all-freatures';
 

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -490,6 +490,15 @@ export const FEATURE_DISCOUNTED_SHIPPING = 'discounted-shipping'; // Discounted 
 export const FEATURE_PRINT_SHIPPING_LABELS = 'print-shipping-labels'; // Print shipping labels
 export const FEATURE_AI_ASSISTED_PRODUCT_DESCRIPTION = 'ai-assisted-product-descriptions'; // AI-assisted product descriptions
 
+// Woo Hosted Features
+export const FEATURE_WOO_HOSTED_PACKAGE = 'woo-hosted-package';
+export const FEATURE_WOO_HOSTED_AI_BUILDER = 'woo-hosted-ai-builder';
+export const FEATURE_WOO_HOSTED_MARKETING_TOOLS = 'woo-hosted-marketing-tools';
+export const FEATURE_WOO_HOSTED_BASIC_MAILPOET = 'woo-hosted-basic-mailpoet';
+export const FEATURE_WOO_HOSTED_PRO_MAILPOET = 'woo-hosted-pro-mailpoet';
+export const FEATURE_WOO_HOSTED_BASIC_ADMIN_USERS = 'woo-hosted-basic-admin-users';
+export const FEATURE_WOO_HOSTED_PRO_ADMIN_USERS = 'woo-hosted-pro-admin-users';
+
 // Sensei Features
 export const FEATURE_SENSEI_SUPPORT = 'sensei-support';
 export const FEATURE_SENSEI_UNLIMITED = 'sensei-unlimited';

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -176,6 +176,14 @@ import {
 	FEATURE_PAYMENT_TRANSACTION_FEES_2,
 	FEATURE_PAYMENT_TRANSACTION_FEES_0,
 	FEATURE_GROUP_WORDADS,
+	FEATURE_WOO_HOSTED_PACKAGE,
+	FEATURE_WOO_HOSTED_AI_BUILDER,
+	FEATURE_WOO_HOSTED_MARKETING_TOOLS,
+	FEATURE_WOO_HOSTED_BASIC_MAILPOET,
+	FEATURE_WOO_HOSTED_PRO_MAILPOET,
+	FEATURE_WOO_HOSTED_BASIC_ADMIN_USERS,
+	FEATURE_WOO_HOSTED_PRO_ADMIN_USERS,
+	FEATURE_GROUP_WOO_HOSTED,
 } from './constants';
 import { FeatureGroupMap } from './types';
 
@@ -417,6 +425,26 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 			) ]: [ FEATURE_DISCOUNTED_SHIPPING, FEATURE_PRINT_SHIPPING_LABELS ],
 		} ),
 	},
+	/* END: WooExpress Feature Groups */
+
+	/* START: Woo Hosted (CIAB) Feature Groups */
+	[ FEATURE_GROUP_WOO_HOSTED ]: {
+		slug: FEATURE_GROUP_WOO_HOSTED,
+		getTitle: () => null,
+		getFeatures: () => [
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_PRIORITY_24_7_SUPPORT,
+			FEATURE_WOO_HOSTED_PACKAGE,
+			FEATURE_WOO_HOSTED_AI_BUILDER,
+			FEATURE_WOO_HOSTED_MARKETING_TOOLS,
+			FEATURE_WOO_HOSTED_BASIC_MAILPOET,
+			FEATURE_WOO_HOSTED_PRO_MAILPOET,
+			FEATURE_WOO_HOSTED_BASIC_ADMIN_USERS,
+			FEATURE_WOO_HOSTED_PRO_ADMIN_USERS,
+		],
+	},
+	/* END: Woo Hosted (CIAB) Feature Groups */
+
 	[ FEATURE_GROUP_DOMAIN ]: {
 		slug: FEATURE_GROUP_DOMAIN,
 		getTitle: () => null,
@@ -690,6 +718,23 @@ export function resolveFeatureGroupsForComparisonGrid( props?: {
 }
 
 export function resolveWooExpressFeatureGroupsForComparisonGrid(): Partial< FeatureGroupMap > {
+	return {
+		[ FEATURE_GROUP_YOUR_STORE ]: featureGroups[ FEATURE_GROUP_YOUR_STORE ],
+		[ FEATURE_GROUP_PRODUCTS ]: featureGroups[ FEATURE_GROUP_PRODUCTS ],
+		[ FEATURE_GROUP_PAYMENTS ]: featureGroups[ FEATURE_GROUP_PAYMENTS ],
+		[ FEATURE_GROUP_MARKETING_EMAIL ]: featureGroups[ FEATURE_GROUP_MARKETING_EMAIL ],
+		[ FEATURE_GROUP_SHIPPING ]: featureGroups[ FEATURE_GROUP_SHIPPING ],
+	};
+}
+
+export function resolveWooHostedFeatureGroupsForFeaturesGrid(): Partial< FeatureGroupMap > {
+	return {
+		[ FEATURE_GROUP_STORAGE ]: featureGroups[ FEATURE_GROUP_STORAGE ],
+		[ FEATURE_GROUP_WOO_HOSTED ]: featureGroups[ FEATURE_GROUP_WOO_HOSTED ],
+	};
+}
+
+export function resolveWooHostedFeatureGroupsForComparisonGrid(): Partial< FeatureGroupMap > {
 	return {
 		[ FEATURE_GROUP_YOUR_STORE ]: featureGroups[ FEATURE_GROUP_YOUR_STORE ],
 		[ FEATURE_GROUP_PRODUCTS ]: featureGroups[ FEATURE_GROUP_PRODUCTS ],

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -359,6 +359,13 @@ import {
 	FEATURE_AI_ASSISTANT,
 	FEATURE_ADVANCED_FORM_FEATURES_JP,
 	FEATURE_GROUP_WORDADS,
+	FEATURE_WOO_HOSTED_PACKAGE,
+	FEATURE_WOO_HOSTED_AI_BUILDER,
+	FEATURE_WOO_HOSTED_MARKETING_TOOLS,
+	FEATURE_WOO_HOSTED_BASIC_MAILPOET,
+	FEATURE_WOO_HOSTED_PRO_MAILPOET,
+	FEATURE_WOO_HOSTED_BASIC_ADMIN_USERS,
+	FEATURE_WOO_HOSTED_PRO_ADMIN_USERS,
 } from './constants';
 import type { FeatureList } from './types';
 
@@ -2868,6 +2875,44 @@ const FEATURES_LIST: FeatureList = {
 		getDescription: () => '',
 	},
 	/* END: Woo Express Features */
+
+	/* START: Woo Hosted (CIAB) Features */
+	[ FEATURE_WOO_HOSTED_PACKAGE ]: {
+		getSlug: () => FEATURE_WOO_HOSTED_PACKAGE,
+		getTitle: () => 'All-in-one solution to build and manage your ecommerce store',
+		getDescription: () => '',
+	},
+	[ FEATURE_WOO_HOSTED_AI_BUILDER ]: {
+		getSlug: () => FEATURE_WOO_HOSTED_AI_BUILDER,
+		getTitle: () => 'Build your store quickly with our AI-powered site-building tool',
+		getDescription: () => '',
+	},
+	[ FEATURE_WOO_HOSTED_MARKETING_TOOLS ]: {
+		getSlug: () => FEATURE_WOO_HOSTED_MARKETING_TOOLS,
+		getTitle: () => 'Build your business with included marketing tools',
+		getDescription: () => '',
+	},
+	[ FEATURE_WOO_HOSTED_BASIC_MAILPOET ]: {
+		getSlug: () => FEATURE_WOO_HOSTED_BASIC_MAILPOET,
+		getTitle: () => 'Send up to 5,000 emails/month',
+		getDescription: () => '',
+	},
+	[ FEATURE_WOO_HOSTED_PRO_MAILPOET ]: {
+		getSlug: () => FEATURE_WOO_HOSTED_PRO_MAILPOET,
+		getTitle: () => 'Send up to 250,000 emails/month',
+		getDescription: () => '',
+	},
+	[ FEATURE_WOO_HOSTED_BASIC_ADMIN_USERS ]: {
+		getSlug: () => FEATURE_WOO_HOSTED_BASIC_ADMIN_USERS,
+		getTitle: () => 'One store admin account',
+		getDescription: () => '',
+	},
+	[ FEATURE_WOO_HOSTED_PRO_ADMIN_USERS ]: {
+		getSlug: () => FEATURE_WOO_HOSTED_PRO_ADMIN_USERS,
+		getTitle: () => 'Unlimited store admin accounts',
+		getDescription: () => '',
+	},
+	/* END: Woo Hosted (CIAB) Features */
 
 	/* START: Sensei Features */
 	[ FEATURE_SENSEI_SUPPORT ]: {

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -57,6 +57,8 @@ import {
 	resolveFeatureGroupsForComparisonGrid,
 	resolveFeatureGroupsForFeaturesGrid,
 	resolveWooExpressFeatureGroupsForComparisonGrid,
+	resolveWooHostedFeatureGroupsForFeaturesGrid,
+	resolveWooHostedFeatureGroupsForComparisonGrid,
 	resolveWordPressHostingFeatureGroupsForFeaturesGrid,
 } from './feature-group-plan-map';
 import { FEATURES_LIST } from './features-list';
@@ -112,6 +114,14 @@ export function getWordPressHostingFeaturesGroupedForFeaturesGrid(): Partial< Fe
 
 export function getWooExpressFeaturesGroupedForComparisonGrid(): Partial< FeatureGroupMap > {
 	return resolveWooExpressFeatureGroupsForComparisonGrid();
+}
+
+export function getWooHostedFeaturesGroupedForFeaturesGrid(): Partial< FeatureGroupMap > {
+	return resolveWooHostedFeatureGroupsForFeaturesGrid();
+}
+
+export function getWooHostedFeaturesGroupedForComparisonGrid(): Partial< FeatureGroupMap > {
+	return resolveWooHostedFeatureGroupsForComparisonGrid();
 }
 
 export function getPlansSlugs(): string[] {

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -15,6 +15,10 @@ import {
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 	PLAN_WOO_HOSTED_FREE,
 	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
+	PLAN_WOO_HOSTED_BASIC,
+	PLAN_WOO_HOSTED_BASIC_MONTHLY,
+	PLAN_WOO_HOSTED_PRO,
+	PLAN_WOO_HOSTED_PRO_MONTHLY,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
 	TERM_CENTENNIALLY,
@@ -181,8 +185,12 @@ export function getPlanClass( planKey: string ): string {
 		return 'is-woo-hosted-trial';
 	}
 
-	if ( isWooHostedPlan( planKey ) ) {
-		return 'is-woo-hosted-plan';
+	if ( isWooHostedBasicPlan( planKey ) ) {
+		return 'is-woo-hosted-basic-plan';
+	}
+
+	if ( isWooHostedProPlan( planKey ) ) {
+		return 'is-woo-hosted-pro-plan';
 	}
 
 	if ( isWpcomEnterpriseGridPlan( planKey ) ) {
@@ -401,6 +409,14 @@ export function isWooExpressPlan( planSlug: string ): boolean {
 
 export function isWooHostedFreePlan( planSlug: string ): boolean {
 	return [ PLAN_WOO_HOSTED_FREE, PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY ].includes( planSlug );
+}
+
+export function isWooHostedBasicPlan( planSlug: string ): boolean {
+	return [ PLAN_WOO_HOSTED_BASIC, PLAN_WOO_HOSTED_BASIC_MONTHLY ].includes( planSlug );
+}
+
+export function isWooHostedProPlan( planSlug: string ): boolean {
+	return [ PLAN_WOO_HOSTED_PRO, PLAN_WOO_HOSTED_PRO_MONTHLY ].includes( planSlug );
 }
 
 export function isWooHostedPlan( planSlug: string ): boolean {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -490,6 +490,13 @@ import {
 	WPCOM_FEATURES_LOGS,
 	WPCOM_FEATURES_MONITORING,
 	WPCOM_FEATURES_PERFORMANCE,
+	FEATURE_WOO_HOSTED_PACKAGE,
+	FEATURE_WOO_HOSTED_AI_BUILDER,
+	FEATURE_WOO_HOSTED_MARKETING_TOOLS,
+	FEATURE_WOO_HOSTED_BASIC_MAILPOET,
+	FEATURE_WOO_HOSTED_PRO_MAILPOET,
+	FEATURE_WOO_HOSTED_BASIC_ADMIN_USERS,
+	FEATURE_WOO_HOSTED_PRO_ADMIN_USERS,
 } from './constants';
 import { isBigSkyOnboarding } from './is-big-sky-onboarding';
 import {
@@ -1596,16 +1603,6 @@ const getPlanWooExpressMediumDetails = (): IncompleteWPcomPlan => ( {
 		),
 } );
 
-const getPlanWooHostedProDetails = (): IncompleteWPcomPlan => ( {
-	...getPlanWooExpressMediumDetails(),
-	getTitle: () => i18n.translate( 'Pro' ),
-	getPlanTagline: () => i18n.translate( 'Accelerate your growth with advanced features.' ),
-	getTagline: () =>
-		i18n.translate(
-			'Learn more about everything included with Woo Pro and take advantage of its powerful marketplace features.'
-		),
-} );
-
 const getPlanWooExpressSmallDetails = (): IncompleteWPcomPlan => ( {
 	...getPlanEcommerceDetails(),
 	get2023PricingGridSignupWpcomFeatures: () => [
@@ -1639,13 +1636,47 @@ const getPlanWooExpressSmallDetails = (): IncompleteWPcomPlan => ( {
 } );
 
 const getPlanWooHostedBasicDetails = (): IncompleteWPcomPlan => ( {
-	...getPlanWooExpressSmallDetails(),
+	...getPlanEcommerceDetails(),
+	get2023PricingGridSignupWpcomFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_PRIORITY_24_7_SUPPORT,
+		FEATURE_WOO_HOSTED_PACKAGE,
+		FEATURE_WOO_HOSTED_AI_BUILDER,
+		FEATURE_WOO_HOSTED_MARKETING_TOOLS,
+		FEATURE_WOO_HOSTED_BASIC_MAILPOET,
+		FEATURE_WOO_HOSTED_BASIC_ADMIN_USERS,
+	],
+	getPlanCompareFeatures: () => getWooExpressPlanCompareFeatures(),
+	get2023PlanComparisonFeatureOverride: () => getWooExpressSmallPlanCompareFeatures(),
+	getStorageFeature: () => FEATURE_50GB_STORAGE,
 	getTitle: () => i18n.translate( 'Basic' ),
 	getPlanTagline: () =>
 		i18n.translate( 'Everything you need to set up your store and start selling your products.' ),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with Woo Basic and take advantage of its powerful marketplace features.'
+		),
+} );
+
+const getPlanWooHostedProDetails = (): IncompleteWPcomPlan => ( {
+	...getPlanEcommerceDetails(),
+	get2023PricingGridSignupWpcomFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_PRIORITY_24_7_SUPPORT,
+		FEATURE_WOO_HOSTED_PACKAGE,
+		FEATURE_WOO_HOSTED_AI_BUILDER,
+		FEATURE_WOO_HOSTED_MARKETING_TOOLS,
+		FEATURE_WOO_HOSTED_PRO_MAILPOET,
+		FEATURE_WOO_HOSTED_PRO_ADMIN_USERS,
+	],
+	getPlanCompareFeatures: () => getWooExpressPlanCompareFeatures(),
+	get2023PlanComparisonFeatureOverride: () => getWooExpressSmallPlanCompareFeatures(),
+	getStorageFeature: () => FEATURE_200GB_STORAGE,
+	getTitle: () => i18n.translate( 'Pro' ),
+	getPlanTagline: () => i18n.translate( 'Accelerate your growth with advanced features.' ),
+	getTagline: () =>
+		i18n.translate(
+			'Learn more about everything included with Woo Pro and take advantage of its powerful marketplace features.'
 		),
 } );
 

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -66,6 +66,7 @@ import {
 	FEATURE_GROUP_WP_HOSTING_COMMERCE,
 	FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	FEATURE_GROUP_WORDADS,
+	FEATURE_GROUP_WOO_HOSTED,
 } from './constants';
 import { PriceTierEntry } from './get-price-tier-for-units';
 import type { TranslateResult } from 'i18n-calypso';
@@ -291,7 +292,8 @@ export type FeatureGroupSlug =
 	| typeof FEATURE_GROUP_WP_HOSTING_SUPPORT
 	| typeof FEATURE_GROUP_PAYMENT_TRANSACTION_FEES
 	| typeof FEATURE_GROUP_WORDADS
-	| typeof FEATURE_GROUP_WP_HOSTING_COMMERCE;
+	| typeof FEATURE_GROUP_WP_HOSTING_COMMERCE
+	| typeof FEATURE_GROUP_WOO_HOSTED;
 
 export interface FeatureFootnotes {
 	[ key: string ]: Feature[];

--- a/packages/plans-grid-next/src/components/plan-button/style.scss
+++ b/packages/plans-grid-next/src/components/plan-button/style.scss
@@ -1,4 +1,4 @@
-@import "@automattic/onboarding/styles/mixins";
+@import '@automattic/onboarding/styles/mixins';
 
 .button.plan-features-2023-grid__actions-button {
 	line-height: 20px;
@@ -8,86 +8,99 @@
 	text-align: center;
 	text-wrap: balance;
 	width: 100%;
-	color: var(--color-text-inverted);
+	color: var( --color-text-inverted );
 
 	&:hover {
-		color: var(--color-text-inverted);
+		color: var( --color-text-inverted );
 	}
 
 	&.is-free-plan,
-	&.is-woo-hosted-plan {
-		background-color: var(--studio-wordpress-blue-50);
+	&.is-woo-hosted-basic-plan,
+	&.is-woo-hosted-pro-plan {
+		background-color: var( --studio-wordpress-blue-50 );
 
 		&:focus {
-			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-wordpress-blue-50);
+			box-shadow:
+				0 0 0 2px var( --studio-white ),
+				0 0 0 4px var( --studio-wordpress-blue-50 );
 		}
 
 		&:hover {
-			background-color: var(--studio-wordpress-blue-60);
+			background-color: var( --studio-wordpress-blue-60 );
 		}
 	}
 
 	&.is-personal-plan {
-		background-color: var(--studio-wordpress-blue-60);
+		background-color: var( --studio-wordpress-blue-60 );
 
 		&:focus {
-			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-wordpress-blue-60);
+			box-shadow:
+				0 0 0 2px var( --studio-white ),
+				0 0 0 4px var( --studio-wordpress-blue-60 );
 		}
 
 		&:hover {
-			background-color: var(--studio-wordpress-blue-70);
+			background-color: var( --studio-wordpress-blue-70 );
 		}
 	}
 
 	&.is-premium-plan {
-		background-color: var(--studio-wordpress-blue-70);
+		background-color: var( --studio-wordpress-blue-70 );
 
 		&:focus {
-			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-wordpress-blue-70);
+			box-shadow:
+				0 0 0 2px var( --studio-white ),
+				0 0 0 4px var( --studio-wordpress-blue-70 );
 		}
 
 		&:hover {
-			background-color: var(--studio-wordpress-blue-80);
+			background-color: var( --studio-wordpress-blue-80 );
 		}
 	}
 
 	&.is-business-plan {
-		background-color: var(--studio-woocommerce-purple-60);
+		background-color: var( --studio-woocommerce-purple-60 );
 
 		&:focus {
-			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-woocommerce-purple-60);
+			box-shadow:
+				0 0 0 2px var( --studio-white ),
+				0 0 0 4px var( --studio-woocommerce-purple-60 );
 		}
 
 		&:hover {
-			background-color: var(--studio-woocommerce-purple-70);
+			background-color: var( --studio-woocommerce-purple-70 );
 		}
 
 		+ .button.is-borderless {
 			background: transparent;
 			font-size: $font-body-small;
-			color: var(--studio-woocommerce-purple-60);
+			color: var( --studio-woocommerce-purple-60 );
 			text-decoration: none;
 
 			&:focus {
-				box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-woocommerce-purple-60);
+				box-shadow:
+					0 0 0 2px var( --studio-white ),
+					0 0 0 4px var( --studio-woocommerce-purple-60 );
 			}
 		}
 	}
 
 	&.is-wooexpress-medium-plan {
-		background-color: var(--color-accent);
-		color: var(--color-text-inverted);
+		background-color: var( --color-accent );
+		color: var( --color-text-inverted );
 		font-weight: 400;
 
 		&:focus {
-			box-shadow: 0 0 0 2px var(--color-surface), 0 0 0 4px var(--color-accent);
+			box-shadow:
+				0 0 0 2px var( --color-surface ),
+				0 0 0 4px var( --color-accent );
 		}
 	}
 
 	&.is-wooexpress-small-plan {
-		background-color: var(--color-surface);
-		color: var(--color-accent);
-		border: 1px solid var(--color-accent);
+		background-color: var( --color-surface );
+		color: var( --color-accent );
+		border: 1px solid var( --color-accent );
 		font-weight: 400;
 	}
 
@@ -95,42 +108,48 @@
 		display: inline-block;
 		width: 85%;
 		text-align: center;
-		background-color: var(--color-surface);
-		color: var(--color-accent);
-		border: 1px solid  var(--color-accent);
+		background-color: var( --color-surface );
+		color: var( --color-accent );
+		border: 1px solid var( --color-accent );
 		font-weight: 400;
 	}
 
 	&.is-ecommerce-plan {
-		background-color: var(--studio-woocommerce-purple-40);
+		background-color: var( --studio-woocommerce-purple-40 );
 
 		&:focus {
-			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-woocommerce-purple-40);
+			box-shadow:
+				0 0 0 2px var( --studio-white ),
+				0 0 0 4px var( --studio-woocommerce-purple-40 );
 		}
 
 		&:hover {
-			background-color: var(--studio-woocommerce-purple-50);
+			background-color: var( --studio-woocommerce-purple-50 );
 		}
 	}
 
 	&.is-wpcom-enterprise-grid-plan {
-		background-color: var(--studio-gray-80);
+		background-color: var( --studio-gray-80 );
 
 		&:focus {
-			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-gray-80);
+			box-shadow:
+				0 0 0 2px var( --studio-white ),
+				0 0 0 4px var( --studio-gray-80 );
 		}
 
 		&:hover {
-			background-color: var(--studio-gray-90);
+			background-color: var( --studio-gray-90 );
 		}
 	}
 
 	&.is-p2-plus-plan {
-		background-color: var(--color-accent);
-		color: var(--color-text-inverted);
+		background-color: var( --color-accent );
+		color: var( --color-text-inverted );
 
 		&:focus {
-			box-shadow: 0 0 0 2px var(--color-surface), 0 0 0 4px var(--color-accent);
+			box-shadow:
+				0 0 0 2px var( --color-surface ),
+				0 0 0 4px var( --color-accent );
 		}
 	}
 
@@ -140,18 +159,18 @@
 	&.is-secondary,
 	&.is-current-plan,
 	&.is-default {
-		background-color: var(--studio-white);
-		color: var(--studio-gray-100);
-		box-shadow: inset 0 0 0 1px var(--studio-gray-10);
+		background-color: var( --studio-white );
+		color: var( --studio-gray-100 );
+		box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
 
 		&.is-storage-upgradeable {
-			background-color: var(--color-accent);
-			color: var(--color-text-inverted);
+			background-color: var( --color-accent );
+			color: var( --color-text-inverted );
 		}
 
 		&:hover {
-			background-color: var(--studio-white);
-			box-shadow: inset 0 0 0 1px var(--studio-gray-80);
+			background-color: var( --studio-white );
+			box-shadow: inset 0 0 0 1px var( --studio-gray-80 );
 		}
 	}
 
@@ -162,8 +181,8 @@
 
 	&.disabled,
 	&[disabled] {
-		background-color: var(--studio-white);
-		color: var(--color-neutral-light);
+		background-color: var( --studio-white );
+		color: var( --color-neutral-light );
 		box-shadow: inset 0 0 0 1px #e0e0e0;
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1523/upgrade-path-doesnt-allow-user-to-select-plans
Fixes https://linear.app/a8c/issue/SHILL-1528/update-plans-page-with-copy-and-styles

## Proposed Changes

This fixes a number of regressions and bugs for the plan selection flow for Woo Hosted sites. 

- Fixes upgrade and plan selection links for Woo Hosted sites to use the full-screen `/setup/woo-hosted-plans` Stepper flow
- Fixes the `/woo-hosted-plans` flow to distinguish between free and paid Woo Hosted sites, and allow upgrading between billing terms for the same plan
- Fixes the `/woo-hosted-plans` flow to be able to upgrade a site with a custom domain already selected
- Fixes fallback and success redirection links from the upgrade flow back to CIAB admin pages

It also updates the features and styling for the `/woo-hosted-plans` page, using untranslated features as placeholders until we have final copy.

<img width="3522" height="2394" alt="CleanShot 2026-01-28 at 16 00 50@2x" src="https://github.com/user-attachments/assets/5e56e0ea-a2d8-4f2a-b737-1d23bb2c6e2c" />

## Testing Instructions

- Visit my.wordpress.com/ciab/sites and create a new CIAB site
- Return to my.wordpress.com/ciab/sites after onboarding and click on the site title
- Click on the plan card
- Verify that you are taken to `/setup/woo-hosted-plans/`
- Verify that the feature list looks correct (the storage, emails, and admin accounts are the only differences)
- Verify that that plan CTAs read `Get {plan name}`
- Select the Basic plan
- Verify that you can purchase the basic plan
- Visit the plan management page and click "Upgrade"
- Verify that you are taken to `/setup/woo-hosted-plans/`
- Verify that the current plan is correctly identified and that you can select the Pro plan
- Select the Pro plan
- Click the back button in Checkout and empty the cart
- Verify that you are taken back to the plans page
- Select the Pro plan
- Verify that you can complete Checkout