### PR TITLE
Add clarity when revoking a license from bundle.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
@@ -35,6 +35,7 @@ const CancelLicenseFeedbackModal = ( {
 	siteUrl,
 	isAtomicSite,
 	isClientLicense,
+	isChildLicense,
 }: {
 	onClose: () => void;
 	productName: string;
@@ -44,6 +45,7 @@ const CancelLicenseFeedbackModal = ( {
 	siteUrl?: string | null;
 	isAtomicSite?: boolean;
 	isClientLicense?: boolean;
+	isChildLicense?: boolean;
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -206,9 +208,22 @@ const CancelLicenseFeedbackModal = ( {
 	return (
 		<A4AModal
 			title={ translate( 'Are you sure you want to revoke this license?' ) }
-			subtile={ translate(
-				'A revoked license cannot be reused, and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
-			) }
+			subtile={
+				<>
+					{ translate(
+						'A revoked license cannot be reused, and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
+					) }
+					{ isChildLicense && (
+						<>
+							<br />
+							<br />
+							{ translate(
+								"When you revoke this license, we will add an unassigned replacement license to the bundle which can be assigned to a new site when you're ready."
+							) }
+						</>
+					) }
+				</>
+			}
 			onClose={ onClose }
 			showCloseButton={ false }
 			extraActions={

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -186,6 +186,7 @@ export default function LicenseDetailsActions( {
 					siteUrl={ siteUrl }
 					onClose={ closeRevokeDialog }
 					isClientLicense={ isClientLicense }
+					isChildLicense={ isChildLicense }
 				/>
 			) }
 		</div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -87,6 +87,7 @@ export default function LicenseActions( {
 					siteUrl={ siteUrl }
 					productId={ productId }
 					isClientLicense={ isClientLicense }
+					isChildLicense={ isChildLicense }
 				/>
 			) }
 		</>


### PR DESCRIPTION

Follow up on https://github.com/Automattic/wp-calypso/pull/102629
Closes https://linear.app/a8c/issue/A4A-670/add-clarity-to-revoking-licenses-in-a-bundle-and-how-to-revoke-a-whole

## Proposed Changes
This pull request updates the license revocation flow to better handle "child licenses" within the agency dashboard. The main enhancement is that when a child license is being revoked, the user is now informed that a replacement license will be automatically added to the bundle, making the process clearer for users managing multiple licenses. Additionally, the relevant components and props have been updated to support this new logic.

<img width="885" height="700" alt="Screenshot 2026-01-23 at 11 59 50 PM" src="https://github.com/user-attachments/assets/24ca5c35-b4a0-4d30-98be-68e4873ee85b" />

## Why are these changes being made?

* This adds clarity on what to expect when revoking a child license.

## Testing Instructions

* Use the A4A live link and navigate to `/purchases`.
* Revoke a license from a bundle.
* Confirm you see additional text about what happens when revoking a child license.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
