### PR TITLE
MSD Follow-up survey with Claude code

### DIFF
--- a/client/dashboard/components/opt-in-follow-up-survey/index.tsx
+++ b/client/dashboard/components/opt-in-follow-up-survey/index.tsx
@@ -1,0 +1,129 @@
+import { userPreferenceQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import { ButtonStack } from '../button-stack';
+import { Notice } from '../notice';
+
+const DISMISSED_AT_KEY = 'dashboard-opt-in-follow-up-survey-dismissed-at';
+const DISMISSED_COUNT_KEY = 'dashboard-opt-in-follow-up-survey-dismissed-count';
+
+const RESHOW_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const MAX_DISMISSES = 2;
+const OPT_IN_DELAY_MS = 14 * 24 * 60 * 60 * 1000; // 14 days after opt-in
+
+const canUseLocalStorage = () =>
+	typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+function getSurveyDismissal(): { dismissedAt: number | null; dismissedCount: number } {
+	if ( ! canUseLocalStorage() ) {
+		return { dismissedAt: null, dismissedCount: 0 };
+	}
+
+	try {
+		const dismissedAt = parseInt( window.localStorage.getItem( DISMISSED_AT_KEY ) || '0' );
+		const dismissedCount = parseInt( window.localStorage.getItem( DISMISSED_COUNT_KEY ) || '0' );
+
+		return { dismissedAt, dismissedCount };
+	} catch {
+		return { dismissedAt: null, dismissedCount: 0 };
+	}
+}
+
+function dismissSurvey() {
+	if ( ! canUseLocalStorage() ) {
+		return;
+	}
+
+	try {
+		const { dismissedCount } = getSurveyDismissal();
+		window.localStorage.setItem( DISMISSED_AT_KEY, String( Date.now() ) );
+		window.localStorage.setItem( DISMISSED_COUNT_KEY, String( dismissedCount + 1 ) );
+	} catch {
+		// ignore
+	}
+}
+
+function checkEligible( optInPreference: { value?: string; updated_at?: string } | null ) {
+	// Must have opted in
+	if ( ! optInPreference || optInPreference.value !== 'opt-in' ) {
+		return false;
+	}
+
+	// Must have an opt-in date and it must be at least 14 days ago
+	const optInDate = optInPreference.updated_at ? new Date( optInPreference.updated_at ) : null;
+	if ( ! optInDate || Date.now() < optInDate.getTime() + OPT_IN_DELAY_MS ) {
+		return false;
+	}
+
+	const { dismissedAt, dismissedCount } = getSurveyDismissal();
+
+	if ( dismissedCount >= MAX_DISMISSES ) {
+		return false;
+	}
+
+	// If previously dismissed, wait 7 days before showing again
+	if ( dismissedAt && Date.now() < dismissedAt + RESHOW_AFTER_MS ) {
+		return false;
+	}
+
+	return true;
+}
+
+export default function OptInFollowUpSurvey() {
+	const { recordTracksEvent } = useAnalytics();
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	const { data: optInPreference } = useSuspenseQuery(
+		userPreferenceQuery( 'hosting-dashboard-opt-in' )
+	);
+
+	const [ isEligible ] = useState( () => checkEligible( optInPreference ) );
+
+	if ( ! isEligible || isDismissed ) {
+		return null;
+	}
+
+	const setDismissedNow = () => {
+		setIsDismissed( true );
+		dismissSurvey();
+	};
+
+	const dismiss = () => {
+		recordTracksEvent( 'calypso_dashboard_opt_in_follow_up_survey_dismiss_click' );
+		setDismissedNow();
+	};
+
+	const confirm = () => {
+		recordTracksEvent( 'calypso_dashboard_opt_in_follow_up_survey_take_click' );
+		setDismissedNow();
+	};
+
+	return (
+		<Notice
+			title={ __( "How's your experience with the Hosting Dashboard after a few weeks?" ) }
+			onClose={ dismiss }
+			actions={
+				<ButtonStack justify="flex-start">
+					<Button
+						variant="primary"
+						size="compact"
+						href="https://automattic.survey.fm/msd-survey-for-opt-in-after-2-weeks"
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ confirm }
+					>
+						{ __( 'Take the survey' ) }
+					</Button>
+					<Button variant="secondary" size="compact" onClick={ dismiss }>
+						{ __( 'Dismiss' ) }
+					</Button>
+				</ButtonStack>
+			}
+		>
+			{ __( 'Share your feedback to help us improve the long-term experience.' ) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -20,6 +20,7 @@ import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
 import { sitesRoute } from '../app/router/sites';
 import { DataViewsEmptyState } from '../components/dataviews';
+import OptInFollowUpSurvey from '../components/opt-in-follow-up-survey';
 import OptInSurvey from '../components/opt-in-survey';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
@@ -470,6 +471,7 @@ export default function Sites() {
 					<>
 						<SitesNotices />
 						{ ! isDashboardBackport() && <OptInSurvey /> }
+						{ ! isDashboardBackport() && <OptInFollowUpSurvey /> }
 					</>
 				}
 			>

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -13,6 +13,7 @@ import { wordpress } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useRef } from 'react';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
+import OptInFollowUpSurvey from '../../components/opt-in-follow-up-survey';
 import OptInSurvey from '../../components/opt-in-survey';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -227,7 +228,14 @@ function SiteOverview( {
 					actions={ renderActions() }
 				/>
 			}
-			notices={ ! isDashboardBackport() && <OptInSurvey /> }
+			notices={
+				! isDashboardBackport() && (
+					<>
+						<OptInSurvey />
+						<OptInFollowUpSurvey />
+					</>
+				)
+			}
 		>
 			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
 				<StorageWarningBanner site={ site } />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
