### PR TITLE
MSD Follow-up survey with Junie default model

### DIFF
--- a/client/dashboard/components/follow-up-survey/index.tsx
+++ b/client/dashboard/components/follow-up-survey/index.tsx
@@ -7,11 +7,11 @@ import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../button-stack';
 import { Notice } from '../notice';
 
-const DISMISSED_AT_KEY = 'dashboard-opt-in-survey-dismissed-at';
-const DISMISSED_COUNT_KEY = 'dashboard-opt-in-survey-dismissed-count';
+const DISMISSED_AT_KEY = 'dashboard-follow-up-survey-dismissed-at';
+const DISMISSED_COUNT_KEY = 'dashboard-follow-up-survey-dismissed-count';
 
 const RESHOW_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
-const FOLLOW_UP_AFTER_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+const INITIAL_DELAY_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 const MAX_DISMISSES = 2;
 
 const canUseLocalStorage = () =>
@@ -60,8 +60,7 @@ function checkEligible( welcomeNoticeDismissedAt: string | null ) {
 	const welcomeNoticeDismissedTime = new Date( welcomeNoticeDismissedAt ).getTime();
 	const now = Date.now();
 
-	// If more than 14 days have passed, we show the follow-up survey instead.
-	if ( now >= welcomeNoticeDismissedTime + FOLLOW_UP_AFTER_MS ) {
+	if ( now < welcomeNoticeDismissedTime + INITIAL_DELAY_MS ) {
 		return false;
 	}
 
@@ -69,7 +68,7 @@ function checkEligible( welcomeNoticeDismissedAt: string | null ) {
 	return now >= lastDismissedDate.getTime() + RESHOW_AFTER_MS;
 }
 
-export default function OptInSurvey() {
+export default function FollowUpSurvey() {
 	const { recordTracksEvent } = useAnalytics();
 	const [ isDismissed, setIsDismissed ] = useState( false );
 
@@ -89,12 +88,12 @@ export default function OptInSurvey() {
 	};
 
 	const dismiss = () => {
-		recordTracksEvent( 'calypso_dashboard_opt_in_survey_dismiss_click' );
+		recordTracksEvent( 'calypso_dashboard_follow_up_survey_dismiss_click' );
 		setDismissedNow();
 	};
 
 	const confirm = () => {
-		recordTracksEvent( 'calypso_dashboard_opt_in_survey_take_click' );
+		recordTracksEvent( 'calypso_dashboard_follow_up_survey_take_click' );
 		setDismissedNow();
 	};
 
@@ -107,7 +106,7 @@ export default function OptInSurvey() {
 					<Button
 						variant="primary"
 						size="compact"
-						href="https://automattic.survey.fm/msd-survey-for-opt-in"
+						href="https://automattic.survey.fm/msd-survey-for-opt-in-after-2-weeks"
 						target="_blank"
 						rel="noopener noreferrer"
 						onClick={ confirm }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -19,7 +19,8 @@ import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
 import { sitesRoute } from '../app/router/sites';
-import { DataViewsEmptyState } from '../components/dataviews';
+import DataViewsEmptyState from '../components/dataviews';
+import FollowUpSurvey from '../components/follow-up-survey';
 import OptInSurvey from '../components/opt-in-survey';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
@@ -309,7 +310,12 @@ export default function Sites() {
 				notices={
 					<>
 						<SitesNotices />
-						{ ! isDashboardBackport() && <OptInSurvey /> }
+						{ ! isDashboardBackport() && (
+							<>
+								<OptInSurvey />
+								<FollowUpSurvey />
+							</>
+						) }
 					</>
 				}
 			>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
