### PR TITLE
A4A: Standardized Button component for external link and update KB link to use Help center.

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -1,8 +1,8 @@
 import { getDataCenterOptions } from '@automattic/api-core';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button, Gridicon } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { CheckboxControl, Icon, Modal, Spinner } from '@wordpress/components';
+import { CheckboxControl, Icon, Modal, Spinner, Button } from '@wordpress/components';
 import { check, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -11,6 +11,7 @@ import useCreateWPCOMDevSiteMutation, {
 	APIError,
 } from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-dev-site';
 import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { getPHPVersions } from 'calypso/data/php-versions';
@@ -51,6 +52,8 @@ export default function SiteConfigurationsModal( {
 
 	const toggleAllowClientsToUseSiteHelpCenter = () =>
 		setAllowClientsToUseSiteHelpCenter( ! allowClientsToUseSiteHelpCenter );
+
+	const { showSupportGuide } = useHelpCenter();
 
 	const phpVersionsElements = phpVersions.map( ( version ) => {
 		if ( version.disabled ) {
@@ -219,11 +222,12 @@ export default function SiteConfigurationsModal( {
 				<FormField
 					label={ translate( 'PHP version' ) }
 					description={ translate(
-						'The PHP version can be changed after your site is created via {{a}}Web Server Settings{{/a}}.',
+						'The PHP version can be changed after your site is created via {{a}}Web Server Settings ↗{{/a}}.',
 						{
 							components: {
 								a: (
-									<a
+									<Button
+										variant="link"
 										target="_blank"
 										href="https://developer.wordpress.com/docs/developer-tools/web-server-settings/"
 										rel="noreferrer"
@@ -253,11 +257,12 @@ export default function SiteConfigurationsModal( {
 						{ isDevSite ? (
 							<label className="dev-sites-label">
 								{ translate(
-									'Clients can’t access the {{HcLink}}WordPress.com Help Center{{/HcLink}} or {{HfLink}}hosting features{{/HfLink}} on development sites. Once the site is launched, enable access in Site Settings.',
+									'Clients can’t access the {{HcLink}}WordPress.com Help Center ↗{{/HcLink}} or {{HfLink}}hosting features ↗{{/HfLink}} on development sites. Once the site is launched, enable access in Site Settings.',
 									{
 										components: {
 											HcLink: (
-												<a
+												<Button
+													variant="link"
 													target="_blank"
 													href={ localizeUrl(
 														'https://wordpress.com/support/help-support-options/#how-to-contact-us'
@@ -266,7 +271,8 @@ export default function SiteConfigurationsModal( {
 												/>
 											),
 											HfLink: (
-												<a
+												<Button
+													variant="link"
 													target="_blank"
 													href={ localizeUrl(
 														'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
@@ -277,15 +283,16 @@ export default function SiteConfigurationsModal( {
 										},
 									}
 								) }{ ' ' }
-								{ translate( '{{a}}Learn more.{{/a}}', {
+								{ translate( '{{a}}Learn more{{/a}}', {
 									components: {
 										a: (
-											<a
-												target="_blank"
-												href={ localizeUrl(
-													'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
-												) }
-												rel="noopener noreferrer"
+											<Button
+												variant="link"
+												onClick={ () =>
+													showSupportGuide(
+														'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting'
+													)
+												}
 											/>
 										),
 									},
@@ -333,7 +340,7 @@ export default function SiteConfigurationsModal( {
 				</FormField>
 				<div className="configure-your-site-modal-form__footer">
 					<Button
-						primary
+						variant="primary"
 						type="submit"
 						busy={ isSubmitting }
 						disabled={ ! siteName.isSiteNameReadyForUse }

--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -342,7 +342,7 @@ export default function SiteConfigurationsModal( {
 					<Button
 						variant="primary"
 						type="submit"
-						busy={ isSubmitting }
+						isBusy={ isSubmitting }
 						disabled={ ! siteName.isSiteNameReadyForUse }
 					>
 						{ translate( 'Create site' ) }

--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -309,12 +309,12 @@ export default function SiteConfigurationsModal( {
 								/>
 								<label htmlFor="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox">
 									{ translate(
-										'Allow clients to use the {{HcLink}}WordPress.com Help Center{{/HcLink}} and {{HfLink}}hosting features.{{/HfLink}}',
+										'Allow clients to use the {{HcLink}}WordPress.com Help Center ↗{{/HcLink}} and {{HfLink}}hosting features ↗{{/HfLink}}.',
 										{
 											components: {
 												HcLink: (
-													<a
-														target="_blank"
+													<Button
+														variant="link"
 														href={ localizeUrl(
 															'https://wordpress.com/support/help-support-options/#how-to-contact-us'
 														) }
@@ -322,8 +322,8 @@ export default function SiteConfigurationsModal( {
 													/>
 												),
 												HfLink: (
-													<a
-														target="_blank"
+													<Button
+														variant="link"
 														href={ localizeUrl(
 															'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
 														) }

--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -319,6 +319,7 @@ export default function SiteConfigurationsModal( {
 															'https://wordpress.com/support/help-support-options/#how-to-contact-us'
 														) }
 														rel="noreferrer"
+														target="_blank"
 													/>
 												),
 												HfLink: (
@@ -328,6 +329,7 @@ export default function SiteConfigurationsModal( {
 															'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
 														) }
 														rel="noreferrer"
+														target="_blank"
 													/>
 												),
 											},

--- a/client/a8c-for-agencies/data/guided-tours/tours/use-marketplace-walkthrough-tour.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/tours/use-marketplace-walkthrough-tour.tsx
@@ -1,8 +1,11 @@
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
 
 export default function useMarketplaceWalkthroughTour() {
 	const translate = useTranslate();
+	const { showSupportGuide } = useHelpCenter();
 
 	return [
 		{
@@ -17,14 +20,17 @@ export default function useMarketplaceWalkthroughTour() {
 			title: translate( 'Earn money when you refer our hosting and products to clients' ),
 			description: preventWidows(
 				translate(
-					'Assemble a cart, send a request for payment to your clients, and earn commissions. {{a}}Learn more ↗{{/a}}',
+					'Assemble a cart, send a request for payment to your clients, and earn commissions. {{a}}Learn more{{/a}}',
 					{
 						components: {
 							a: (
-								<a
-									href="https://agencieshelp.automattic.com/knowledge-base/referring-products-to-clients"
-									target="_blank"
-									rel="noopener noreferrer"
+								<Button
+									variant="link"
+									onClick={ () =>
+										showSupportGuide(
+											'https://agencieshelp.automattic.com/knowledge-base/referring-products-to-clients'
+										)
+									}
 								/>
 							),
 						},

--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -1,6 +1,8 @@
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -11,6 +13,7 @@ type Props = {
 export default function NoticeSummary( { type }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const title = useMemo( () => {
 		switch ( type ) {
@@ -24,18 +27,6 @@ export default function NoticeSummary( { type }: Props ) {
 		}
 	}, [ translate, type ] );
 
-	const handleClientTermsClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_client_terms_click' ) );
-	}, [ dispatch ] );
-
-	const handleSubscriptionInfoLinkClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_subscription_info_link_click' ) );
-	}, [ dispatch ] );
-
-	const handleCancellationInfoLinkClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_cancellation_info_link_click' ) );
-	}, [ dispatch ] );
-
 	const items = useMemo( () => {
 		switch ( type ) {
 			case 'client-purchase':
@@ -46,9 +37,14 @@ export default function NoticeSummary( { type }: Props ) {
 						{
 							components: {
 								a: (
-									<a
+									<Button
+										variant="link"
 										href={ localizeUrl( 'https://wordpress.com/tos' ) }
-										onClick={ handleClientTermsClick }
+										onClick={ () => {
+											dispatch(
+												recordTracksEvent( 'calypso_a4a_client_checkout_client_terms_click' )
+											);
+										} }
 										target="_blank"
 										rel="noreferrer noopener"
 									/>
@@ -61,27 +57,37 @@ export default function NoticeSummary( { type }: Props ) {
 						{
 							components: {
 								subscriptionInfoLink: (
-									<a
-										href={
-											type === 'client-purchase'
-												? 'https://agencieshelp.automattic.com/knowledge-base/client-billing/#how-subscriptions-work'
-												: 'https://agencieshelp.automattic.com/knowledge-base/billing-and-payments'
-										}
-										onClick={ handleSubscriptionInfoLinkClick }
-										target="_blank"
-										rel="noreferrer noopener"
+									<Button
+										variant="link"
+										onClick={ () => {
+											showSupportGuide(
+												type === 'client-purchase'
+													? 'https://agencieshelp.automattic.com/knowledge-base/client-billing/#how-subscriptions-work'
+													: 'https://agencieshelp.automattic.com/knowledge-base/billing-and-payments'
+											);
+											dispatch(
+												recordTracksEvent(
+													'calypso_a4a_client_checkout_subscription_info_link_click'
+												)
+											);
+										} }
 									/>
 								),
 								cancellationInfoLink: (
-									<a
-										href={
-											type === 'client-purchase'
-												? 'https://agencieshelp.automattic.com/knowledge-base/client-billing/#how-to-cancel'
-												: 'https://agencieshelp.automattic.com/knowledge-base/purchases/#canceling-purchases'
-										}
-										onClick={ handleCancellationInfoLinkClick }
-										target="_blank"
-										rel="noreferrer noopener"
+									<Button
+										variant="link"
+										onClick={ () => {
+											showSupportGuide(
+												type === 'client-purchase'
+													? 'https://agencieshelp.automattic.com/knowledge-base/client-billing/#how-to-cancel'
+													: 'https://agencieshelp.automattic.com/knowledge-base/purchases/#canceling-purchases'
+											);
+											dispatch(
+												recordTracksEvent(
+													'calypso_a4a_client_checkout_cancellation_info_link_click'
+												)
+											);
+										} }
 									/>
 								),
 							},
@@ -115,13 +121,7 @@ export default function NoticeSummary( { type }: Props ) {
 			default:
 				return [];
 		}
-	}, [
-		handleCancellationInfoLinkClick,
-		handleClientTermsClick,
-		handleSubscriptionInfoLinkClick,
-		translate,
-		type,
-	] );
+	}, [ dispatch, showSupportGuide, translate, type ] );
 
 	return (
 		<div className="checkout__summary-notice">

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
-import { Button, SearchableDropdown } from '@automattic/components';
-import { TextareaControl, TextControl, ToggleControl } from '@wordpress/components';
+import { SearchableDropdown } from '@automattic/components';
+import { TextareaControl, TextControl, ToggleControl, Button } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -16,6 +16,7 @@ import {
 	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 	A4A_FEEDBACK_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import BudgetSelector from 'calypso/a8c-for-agencies/sections/partner-directory/components/budget-selector';
 import { AgencyDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -43,6 +44,7 @@ type Props = {
 const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const { validate, validationError, updateValidationError } = useDetailsFormValidation();
 
@@ -126,9 +128,12 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			description={
 				<>
 					Add details to your agency's public profile for clients to see.{ ' ' }
-					<a href={ `/partner-directory/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }` }>
+					<Button
+						variant="link"
+						href={ `/partner-directory/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }` }
+					>
 						Want to update your expertise instead?
-					</a>
+					</Button>
 				</>
 			}
 		>
@@ -206,7 +211,8 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 						{
 							components: {
 								a: (
-									<a
+									<Button
+										variant="link"
 										href="https://commonmark.org/help/"
 										target="_blank"
 										rel="noreferrer noopener"
@@ -250,10 +256,13 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 					description={ translate( 'Need help? {{a}}View our logo guidelines.{{/a}}', {
 						components: {
 							a: (
-								<a
-									href="https://agencieshelp.automattic.com/knowledge-base/adding-a-logo-to-the-partner-directory-agency-profile/"
-									target="_blank"
-									rel="noreferrer noopener"
+								<Button
+									variant="link"
+									onClick={ () => {
+										showSupportGuide(
+											'https://agencieshelp.automattic.com/knowledge-base/adding-a-logo-to-the-partner-directory-agency-profile/'
+										);
+									} }
 								/>
 							),
 						},
@@ -380,7 +389,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			</div>
 
 			<div className="partner-directory-agency-cta__footer">
-				<Button primary onClick={ submitForm } disabled={ isSubmitting }>
+				<Button variant="primary" onClick={ submitForm } disabled={ isSubmitting }>
 					{ translate( 'Save public profile' ) }
 				</Button>
 			</div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -14,6 +14,7 @@ import {
 	A4A_LICENSES_LINK,
 	EXTERNAL_PRESSABLE_AUTH_URL,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import {
 	isPressableHostingProduct,
 	isWPCOMHostingProduct,
@@ -109,6 +110,7 @@ export default function LicensePreview( {
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
@@ -230,16 +232,20 @@ export default function LicensePreview( {
 					>
 						<div className="license-preview__migration-content">
 							{ translate(
-								"Your plan is now with Automattic for Agencies. You won't be billed until {{bold}}%(date)s{{/bold}}.{{br/}}{{a}}Learn about billing for transferred sites{{icon/}}{{/a}}",
+								"Your plan is now with Automattic for Agencies. You won't be billed until {{bold}}%(date)s{{/bold}}.{{br/}}{{a}}Learn about billing for transferred sites{{/a}}",
 								{
 									components: {
 										bold: <strong />,
 										br: <br />,
 										a: (
-											<a
-												href="https://agencieshelp.automattic.com/knowledge-base/moving-existing-wordpress-com-plans-into-the-automattic-for-agencies-billing-system/"
-												target="_blank"
-												rel="noreferrer noopener"
+											<Button
+												borderless
+												compact
+												onClick={ () => {
+													showSupportGuide(
+														'https://agencieshelp.automattic.com/knowledge-base/moving-existing-wordpress-com-plans-into-the-automattic-for-agencies-billing-system/'
+													);
+												} }
 											/>
 										),
 										icon: (

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -232,12 +232,12 @@ export default function LicensePreview( {
 					>
 						<div className="license-preview__migration-content">
 							{ translate(
-								"Your plan is now with Automattic for Agencies. You won't be billed until {{bold}}%(date)s{{/bold}}.{{br/}}{{LearnMoreLink}}Learn about billing for transferred sites{{/LearnMoreLink}}",
+								"Your plan is now with Automattic for Agencies. You won't be billed until {{bold}}%(date)s{{/bold}}.{{br/}}{{LearnMoreButton}}Learn about billing for transferred sites{{/LearnMoreButton}}",
 								{
 									components: {
 										bold: <strong />,
 										br: <br />,
-										LearnMoreLink: (
+										LearnMoreButton: (
 											<Button
 												borderless
 												compact

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -232,12 +232,12 @@ export default function LicensePreview( {
 					>
 						<div className="license-preview__migration-content">
 							{ translate(
-								"Your plan is now with Automattic for Agencies. You won't be billed until {{bold}}%(date)s{{/bold}}.{{br/}}{{a}}Learn about billing for transferred sites{{/a}}",
+								"Your plan is now with Automattic for Agencies. You won't be billed until {{bold}}%(date)s{{/bold}}.{{br/}}{{LearnMoreLink}}Learn about billing for transferred sites{{/LearnMoreLink}}",
 								{
 									components: {
 										bold: <strong />,
 										br: <br />,
-										a: (
+										LearnMoreLink: (
 											<Button
 												borderless
 												compact
@@ -246,13 +246,6 @@ export default function LicensePreview( {
 														'https://agencieshelp.automattic.com/knowledge-base/moving-existing-wordpress-com-plans-into-the-automattic-for-agencies-billing-system/'
 													);
 												} }
-											/>
-										),
-										icon: (
-											<Gridicon
-												icon="external"
-												size={ 16 }
-												className="license-preview__migration-external-icon"
 											/>
 										),
 									},

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/index.tsx
@@ -1,9 +1,11 @@
-import { Button, CompactCard } from '@automattic/components';
+import { CompactCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
 import { Icon, trash } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import useRemoveSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-remove-site';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -28,6 +30,7 @@ export default function SiteErrorPreview( {
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const [ showRemoveSiteDialog, setShowRemoveSiteDialog ] = useState( false );
 	const [ isPendingRefetch, setIsPendingRefetch ] = useState( false );
@@ -106,6 +109,7 @@ export default function SiteErrorPreview( {
 						}
 					>
 						<Button
+							variant="secondary"
 							href={ site.url_with_scheme }
 							target="_blank"
 							rel="noopener noreferrer"
@@ -134,14 +138,29 @@ export default function SiteErrorPreview( {
 								  )
 						}
 					>
-						<Button
-							href={ troubleshootingHref }
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_troubleshoot' ) }
-						>
-							{ translate( 'View guide ↗' ) }
-						</Button>
+						{ isA4APluginInstalled ? (
+							<Button
+								variant="secondary"
+								onClick={ () => {
+									trackEvent( 'calypso_a4a_site_indicator_disconnect_troubleshoot' );
+									showSupportGuide(
+										'https://agencieshelp.automattic.com/knowledge-base/fix-automattic-for-agencies-plugin-issues/'
+									);
+								} }
+							>
+								{ translate( 'View guide' ) }
+							</Button>
+						) : (
+							<Button
+								variant="secondary"
+								href={ troubleshootingHref }
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_troubleshoot' ) }
+							>
+								{ translate( 'View guide ↗' ) }
+							</Button>
+						) }
 					</FormattedHeader>
 				</CompactCard>
 				<CompactCard>
@@ -164,6 +183,7 @@ export default function SiteErrorPreview( {
 						}
 					>
 						<Button
+							variant="secondary"
 							href={ disconnectHref }
 							target="_blank"
 							rel="noopener noreferrer"
@@ -180,7 +200,7 @@ export default function SiteErrorPreview( {
 						headerText={ translate( 'Remove site' ) }
 						subHeaderText={ translate( 'Remove this site from the dashboard.' ) }
 					>
-						<Button onClick={ handleRemoveSite }>
+						<Button variant="secondary" onClick={ handleRemoveSite }>
 							{ translate( 'Remove' ) }
 							<Icon icon={ trash } />
 						</Button>

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
@@ -1,11 +1,10 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import {
-	A4A_OVERVIEW_LINK,
-	A4A_TEAM_LINK,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
+import { A4A_TEAM_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StepSection from 'calypso/a8c-for-agencies/components/step-section';
 import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import { useDispatch } from 'calypso/state';
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -18,9 +17,13 @@ type Props = {
 export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
 
 	const onLearnMoreClick = () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_team_learn_more_joining_agency_click' ) );
+		showSupportGuide(
+			'https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#accepting-an-invitation-a-team-member-s-guide'
+		);
 	};
 
 	const onContactSupportClick = () => {
@@ -101,21 +104,18 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 				<Button
 					className="team-accept-invite__learn-more-button"
 					variant="link"
-					target="_blank"
-					href="https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#accepting-an-invitation-a-team-member-s-guide"
 					onClick={ onLearnMoreClick }
 				>
-					{ translate( 'Team members Knowledge Base article ↗' ) }
+					{ translate( 'Team members Knowledge Base article' ) }
 				</Button>
 				<br />
 				<Button
 					className="team-accept-invite__learn-more-button"
 					variant="link"
-					target="_blank"
-					href={ `${ A4A_OVERVIEW_LINK }#contact-support` }
+					href={ CONTACT_URL_HASH_FRAGMENT }
 					onClick={ onContactSupportClick }
 				>
-					{ translate( 'Contact support ↗' ) }
+					{ translate( 'Contact support' ) }
 				</Button>
 			</StepSection>
 		</>


### PR DESCRIPTION
Update the remaining KB link to utilize the Help center.

Closes https://linear.app/a8c/issue/A4A-1942/fix-a4a-dashboard-links-to-help-center-docs

## Proposed Changes

This pull request refactors several UI components to standardize the use of WordPress's `Button` component for external links and help actions, replacing traditional anchor tags. Additionally, it introduces the `useHelpCenter` hook to open help center guides in context, and makes minor improvements to button props and link text for clarity and consistency. These changes improve accessibility, tracking, and maintainability across the codebase.

**Standardization of Button Usage for Links and Actions:**

- Replaced most anchor (`<a>`) tags with the `Button` component from `@wordpress/components` for external links, contextual help, and action buttons across multiple files, ensuring consistent UI and improved accessibility. [[1]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedL222-R230) [[2]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedL256-R265) [[3]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedL269-R275) [[4]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedL280-R295) [[5]](diffhunk://#diff-c9395920c472906a2380064676247c5788ea4ce4d6166311b67f3504b80b196aL20-R33) [[6]](diffhunk://#diff-32e890cba2ff19280c47089975a957f9c22a192c2418815044fac3fee327781dL129-R136) [[7]](diffhunk://#diff-32e890cba2ff19280c47089975a957f9c22a192c2418815044fac3fee327781dL209-R215) [[8]](diffhunk://#diff-32e890cba2ff19280c47089975a957f9c22a192c2418815044fac3fee327781dL253-R265) [[9]](diffhunk://#diff-4c5f9c3ed8e9fa2f76a8d272ff42adbd1355fd18dbaf74aa52f539c063973f3fL232-R247)

- Updated button props to use `variant="primary"` and `isBusy` instead of legacy props for consistency with the latest component API. [[1]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedL336-R345) [[2]](diffhunk://#diff-32e890cba2ff19280c47089975a957f9c22a192c2418815044fac3fee327781dL383-R392)

**Help Center Integration:**

- Introduced and utilized the `useHelpCenter` hook to open help center guides in context, replacing direct external links with button actions that call `showSupportGuide`. This is applied in site configuration, marketplace tours, checkout notices, partner directory, and license preview components. [[1]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedR14) [[2]](diffhunk://#diff-c9395920c472906a2380064676247c5788ea4ce4d6166311b67f3504b80b196aR1-R8) [[3]](diffhunk://#diff-6b8540f0762ccf0003e2c01e7173a13e77fd2bf7da7446fa38ecc6b982c1755cR2-R5) [[4]](diffhunk://#diff-32e890cba2ff19280c47089975a957f9c22a192c2418815044fac3fee327781dR19) [[5]](diffhunk://#diff-4c5f9c3ed8e9fa2f76a8d272ff42adbd1355fd18dbaf74aa52f539c063973f3fR16) [[6]](diffhunk://#diff-c6d005b79e3e712a2218509c938b93655dde1b2559dcbda3a4a0080717266a0dL1-R8)

**Analytics and Tracking Improvements:**

- Moved analytics event tracking for help and terms links from callback handlers on anchor tags to inline `onClick` handlers on `Button` components, ensuring events are tracked whenever a user interacts with these links. [[1]](diffhunk://#diff-6b8540f0762ccf0003e2c01e7173a13e77fd2bf7da7446fa38ecc6b982c1755cL49-R47) [[2]](diffhunk://#diff-6b8540f0762ccf0003e2c01e7173a13e77fd2bf7da7446fa38ecc6b982c1755cL64-R90)

**Minor UI and Text Improvements:**

- Updated link text to include a "↗" symbol where appropriate, clarifying that links open external resources. [[1]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedL222-R230) [[2]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedL256-R265)
- Minor text and prop updates for clarity, such as changing "Learn more." to "Learn more" and updating button labels.

**Import and Dependency Cleanup:**

- Adjusted imports to source `Button` from `@wordpress/components` instead of `@automattic/components` and removed unused imports where necessary. [[1]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedL3-R5) [[2]](diffhunk://#diff-32e890cba2ff19280c47089975a957f9c22a192c2418815044fac3fee327781dL2-R3) [[3]](diffhunk://#diff-c6d005b79e3e712a2218509c938b93655dde1b2559dcbda3a4a0080717266a0dL1-R8)

## Why are these changes being made?

* This enhances UI consistency by adhering to the core standards and using the Help Center for KB links.

## Testing Instructions

* Use the A4A live link and test the following components

| Description | Screenshot |
|--------|--------|
| Create Dev site Modal | <img width="692" height="618" alt="Screenshot 2026-01-24 at 12 11 54 AM" src="https://github.com/user-attachments/assets/9cc23b86-7024-4f2b-9344-3f53a2e4cd2c" /> |
| Marketplace referral walkthrough | <img width="567" height="320" alt="Screenshot 2026-01-24 at 12 22 05 AM" src="https://github.com/user-attachments/assets/1525473e-675c-471d-a2c0-dbd299cb6d9e" /> |
| Checkout notice (Legacy billing) | <img width="568" height="460" alt="Screenshot 2026-01-24 at 12 31 02 AM" src="https://github.com/user-attachments/assets/f4a5ecd2-46d9-468b-86f7-2a0f689ba41b" /> |
| Site Error section | <img width="1448" height="494" alt="Screenshot 2026-01-24 at 12 39 15 AM" src="https://github.com/user-attachments/assets/84ce7500-27d1-462c-8f2e-3b77572eacc2" /> |
| Transfer Badge | <img width="350" height="136" alt="Screenshot 2026-01-24 at 1 03 56 AM" src="https://github.com/user-attachments/assets/180f12bc-8ca1-4e31-82a1-5e5d4b6369c1" /> | 
| No-multi team error message | <img width="1587" height="496" alt="Screenshot 2026-01-24 at 1 00 21 AM" src="https://github.com/user-attachments/assets/a162ca0f-9b50-44b5-bb56-56da42637ef1" /> | 
| Edit Profile section | <img width="946" height="703" alt="Screenshot 2026-01-24 at 1 11 49 AM" src="https://github.com/user-attachments/assets/1f7aa66d-4a9e-44af-9b86-d5ee3fcec737" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
