### PR TITLE
Fix Help center modal interaction overlaps.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/index.tsx
@@ -3,6 +3,7 @@ import { Button } from '@wordpress/components';
 import { clsx } from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 
 import './style.scss';
 
@@ -32,6 +33,7 @@ export function A4AConfirmationDialog( {
 	isDestructive,
 }: Props ) {
 	const translate = useTranslate();
+	useMinimizeHelpCenterOnMount();
 
 	return (
 		<Dialog

--- a/client/a8c-for-agencies/components/a4a-info-modal/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-info-modal/index.tsx
@@ -1,6 +1,7 @@
 import { Modal } from '@wordpress/components';
 import clsx from 'clsx';
 import React from 'react';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 
 import './style.scss';
 
@@ -12,6 +13,8 @@ type InfoModalProps = {
 };
 
 const InfoModal = ( { onClose, children, title, className }: InfoModalProps ) => {
+	useMinimizeHelpCenterOnMount();
+
 	return (
 		<Modal
 			className={ clsx( 'a4a-info-modal', className ) }

--- a/client/a8c-for-agencies/components/a4a-modal/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-modal/index.tsx
@@ -2,6 +2,7 @@ import { Modal, Button } from '@wordpress/components';
 import { Icon, close } from '@wordpress/icons';
 import { clsx } from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 
 import './style.scss';
 
@@ -23,6 +24,7 @@ export default function A4AModal( {
 	showCloseButton?: boolean;
 } ) {
 	const translate = useTranslate();
+	useMinimizeHelpCenterOnMount();
 
 	return (
 		<Modal

--- a/client/a8c-for-agencies/components/a4a-themed-modal/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-themed-modal/index.tsx
@@ -3,6 +3,7 @@ import { Modal } from '@wordpress/components';
 import { Icon, close } from '@wordpress/icons';
 import clsx from 'clsx';
 import { ReactNode } from 'react';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 
 import './style.scss';
 
@@ -23,6 +24,8 @@ export default function A4AThemedModal( {
 	dismissable,
 	modalVideo,
 }: Props ) {
+	useMinimizeHelpCenterOnMount();
+
 	return (
 		<Modal
 			className={ clsx( 'a4a-themed-modal', className ) }

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/index.tsx
@@ -4,6 +4,7 @@ import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import useImportWPCOMSitesMutation from 'calypso/a8c-for-agencies/data/sites/use-import-wpcom-sites';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 import { useDispatch } from 'calypso/state';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import WPCOMSitesTable from './wpcom-sites-table';
@@ -18,6 +19,7 @@ type Props = {
 export default function ImportFromWPCOMModal( { onImport, onClose }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	useMinimizeHelpCenterOnMount();
 
 	const [ selectedSites, setSelectedSites ] = useState< number[] | [] >( [] );
 

--- a/client/a8c-for-agencies/components/guide-modal/index.tsx
+++ b/client/a8c-for-agencies/components/guide-modal/index.tsx
@@ -4,6 +4,7 @@ import { Icon, close } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 
 import './style.scss';
 
@@ -22,6 +23,7 @@ export type GuideModalProps = {
 const GuideModal = ( { onClose, steps, dismissable }: GuideModalProps ) => {
 	const [ step, setStep ] = useState( 0 );
 	const translate = useTranslate();
+	useMinimizeHelpCenterOnMount();
 
 	if ( ! steps || ! steps.length ) {
 		return null;

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
@@ -11,6 +11,7 @@ import {
 	useMemo,
 	useState,
 } from 'react';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { ONBOARDING_TOUR_HASH } from '../hoc/with-onboarding-tour/hooks/use-onboarding-tour';
@@ -32,6 +33,7 @@ interface OnboardingTourModalProps {
 function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	useMinimizeHelpCenterOnMount();
 
 	const sections: ReactElement< OnboardingTourModalSectionProps >[] = Children.toArray(
 		children

--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -12,6 +12,7 @@ import useCreateWPCOMDevSiteMutation, {
 } from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-dev-site';
 import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { getPHPVersions } from 'calypso/data/php-versions';
@@ -49,6 +50,7 @@ export default function SiteConfigurationsModal( {
 	const { mutate: createWPCOMSite } = useCreateWPCOMSiteMutation();
 	const { mutate: createWPCOMDevSite } = useCreateWPCOMDevSiteMutation();
 	const dispatch = useDispatch();
+	useMinimizeHelpCenterOnMount();
 
 	const toggleAllowClientsToUseSiteHelpCenter = () =>
 		setAllowClientsToUseSiteHelpCenter( ! allowClientsToUseSiteHelpCenter );

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -3,6 +3,7 @@ import { Modal } from '@wordpress/components';
 import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, FormEventHandler, useCallback, useEffect, useState } from 'react';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 import { isClientView } from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -35,6 +36,7 @@ export default function UserContactSupportModalForm( {
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	useMinimizeHelpCenterOnMount();
 
 	const user = useSelector( getCurrentUser );
 	const agency = useSelector( getActiveAgency );

--- a/client/a8c-for-agencies/components/user-feedback-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-feedback-modal-form/index.tsx
@@ -3,6 +3,7 @@ import { Modal } from '@wordpress/components';
 import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import ReviewsRatingsStars from 'calypso/components/reviews-rating-stars/reviews-ratings-stars';
@@ -24,6 +25,7 @@ const DEFAULT_RATING_VALUE = 0;
 export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	useMinimizeHelpCenterOnMount();
 
 	const [ feedback, setFeedback ] = useState( DEFAULT_FEEDBACK_VALUE );
 	const [ rating, setRating ] = useState( DEFAULT_RATING_VALUE );

--- a/client/a8c-for-agencies/hooks/use-minimize-help-center-on-mount.ts
+++ b/client/a8c-for-agencies/hooks/use-minimize-help-center-on-mount.ts
@@ -1,0 +1,34 @@
+import { HelpCenter } from '@automattic/data-stores';
+import {
+	useDispatch as useDataStoreDispatch,
+	useSelect as useDateStoreSelect,
+} from '@wordpress/data';
+import { useEffect, useRef } from 'react';
+import type { HelpCenterSelect } from '@automattic/data-stores';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+/**
+ * Hook to minimize the Help Center when the component mounts.
+ * Useful for modals and dialogs to prevent UI overlap.
+ */
+export default function useMinimizeHelpCenterOnMount() {
+	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return {
+			show: store.isHelpCenterShown(),
+			isMinimized: store.getIsMinimized(),
+		};
+	}, [] );
+
+	const { setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const hasMinimizedRef = useRef( false );
+
+	useEffect( () => {
+		// Only minimize if Help Center is shown and not already minimized
+		if ( show && ! isMinimized && ! hasMinimizedRef.current ) {
+			hasMinimizedRef.current = true;
+			setIsMinimized( true );
+		}
+	}, [ show, isMinimized, setIsMinimized ] );
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/discounts-coming-soon-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/discounts-coming-soon-modal/index.tsx
@@ -1,5 +1,7 @@
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
+
 import './style.scss';
 
 type Props = {
@@ -8,6 +10,7 @@ type Props = {
 
 export default function DiscountsComingSoonModal( { onClose }: Props ) {
 	const translate = useTranslate();
+	useMinimizeHelpCenterOnMount();
 
 	return (
 		<Modal

--- a/client/a8c-for-agencies/sections/reports/example-report-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/example-report-modal/index.tsx
@@ -1,5 +1,6 @@
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 import ExampleReport from '../primary/overview/example-report';
 
 import './style.scss';
@@ -11,6 +12,7 @@ type Props = {
 
 export default function ExampleReportModal( { isVisible, onClose }: Props ) {
 	const translate = useTranslate();
+	useMinimizeHelpCenterOnMount();
 
 	if ( ! isVisible ) {
 		return null;

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
@@ -2,6 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { FunctionComponent, ReactNode, useCallback } from 'react';
+import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 import JetpackLightbox, {
 	JetpackLightboxAside,
 	JetpackLightboxFooter,
@@ -61,6 +62,7 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 } ) => {
 	const isLargeScreen = useBreakpoint( '>782px' );
 	const { title, product: productInfo } = useLicenseLightboxData( product );
+	useMinimizeHelpCenterOnMount();
 
 	const onCTAClick = useCallback( () => {
 		onActivate( product );


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1941/handle-help-center-and-feedback-modal-interactions

## Proposed Changes

This pull request introduces a new React hook, `useMinimizeHelpCenterOnMount`, and integrates it across various modal and dialog components in the codebase. The primary goal is to ensure the Help Center UI is minimized whenever a modal or dialog is opened, preventing unwanted UI overlap and improving user experience.

**Key changes:**

**New Hook Implementation:**
- Added `useMinimizeHelpCenterOnMount` in `client/a8c-for-agencies/hooks/use-minimize-help-center-on-mount.ts`. This hook checks if the Help Center is visible and not already minimized, and minimizes it when the component mounts.

**Integration with Modal and Dialog Components:**
- Integrated `useMinimizeHelpCenterOnMount` into the following components to automatically minimize the Help Center when they are rendered:
  - `A4AConfirmationDialog` [[1]](diffhunk://#diff-96bdf55297764acf51f0ed6209b862c54d77d6dce5f029fe9a91ef2a565b7012R6) [[2]](diffhunk://#diff-96bdf55297764acf51f0ed6209b862c54d77d6dce5f029fe9a91ef2a565b7012R36)
  - `A4AInfoModal` [[1]](diffhunk://#diff-6d8ba63ceb06884a12a60b6ae2357f3c21f9954616158e6058ddc660d34037c1R4) [[2]](diffhunk://#diff-6d8ba63ceb06884a12a60b6ae2357f3c21f9954616158e6058ddc660d34037c1R16-R17)
  - `A4AModal` [[1]](diffhunk://#diff-996d7ef2f6119b9b4ebfdf313e41e739acaf9b6e7c72ef7ea71488a7c95f5872R5) [[2]](diffhunk://#diff-996d7ef2f6119b9b4ebfdf313e41e739acaf9b6e7c72ef7ea71488a7c95f5872R27)
  - `A4AThemedModal` [[1]](diffhunk://#diff-cb8f9b35f437cc06ca32adcaf96969cf9ea180d02228ba85c426da184755aa67R6) [[2]](diffhunk://#diff-cb8f9b35f437cc06ca32adcaf96969cf9ea180d02228ba85c426da184755aa67R27-R28)
  - `ImportFromWPCOMModal` [[1]](diffhunk://#diff-b8b4227c1ce3ba19d69f4e900476e419dfd0a43633e7badd36a141170ffecae3R7) [[2]](diffhunk://#diff-b8b4227c1ce3ba19d69f4e900476e419dfd0a43633e7badd36a141170ffecae3R22)
  - `GuideModal` [[1]](diffhunk://#diff-38e8b35e1fdb4f7bd738414b05a5fac430888a739bd61bf8eb5eb0df1911d791R7) [[2]](diffhunk://#diff-38e8b35e1fdb4f7bd738414b05a5fac430888a739bd61bf8eb5eb0df1911d791R26)
  - `OnboardingTourModal` [[1]](diffhunk://#diff-84e1eb8fc399f6be6ac059605a90a9ee06167ed72fb285b762e0f28122a8b5c1R14) [[2]](diffhunk://#diff-84e1eb8fc399f6be6ac059605a90a9ee06167ed72fb285b762e0f28122a8b5c1R36)
  - `SiteConfigurationsModal` [[1]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedR14) [[2]](diffhunk://#diff-947c1ceb305defd4b22deb826f82d631611b47ab272a05ee19a6182b4be15bedR52)
  - `UserContactSupportModalForm` [[1]](diffhunk://#diff-bc05c87ade26d1846a183db9feeca68fec197a906ebb841540ac3c47109e09f0R6) [[2]](diffhunk://#diff-bc05c87ade26d1846a183db9feeca68fec197a906ebb841540ac3c47109e09f0R39)
  - `UserFeedbackModalForm` [[1]](diffhunk://#diff-cdce810d4f2cbe06a6eca39c76a34ce6a41dc372f63e1a9fcd92116f8987ce06R6) [[2]](diffhunk://#diff-cdce810d4f2cbe06a6eca39c76a34ce6a41dc372f63e1a9fcd92116f8987ce06R28)
  - `DiscountsComingSoonModal` [[1]](diffhunk://#diff-b353d097278177345e1264d812f15da693b7aa11fef2f54821b859178979badbR3-R4) [[2]](diffhunk://#diff-b353d097278177345e1264d812f15da693b7aa11fef2f54821b859178979badbR13)
  - `ExampleReportModal` [[1]](diffhunk://#diff-2ee0d9be4f66fc569f0ce2a119511368aed0bb56cb88e70b657bb7a731169ae5R3) [[2]](diffhunk://#diff-2ee0d9be4f66fc569f0ce2a119511368aed0bb56cb88e70b657bb7a731169ae5R15)
  - `LicenseLightbox` [[1]](diffhunk://#diff-957828377b3d2813c0acb329b085171259c570bd19c9b9e4e0494421abb24909R5) [[2]](diffhunk://#diff-957828377b3d2813c0acb329b085171259c570bd19c9b9e4e0494421abb24909R61)

These updates standardize the behavior of modals and dialogs, ensuring a consistent and non-overlapping UI experience whenever these components are used.

## Why are these changes being made?

* This improves the User experience by ensuring we proactively avoid overlapping modals and the help center.

## Testing Instructions

* Use the A4A live link and navigate all pages with a modal.
* Open the Help center by clicking the Help center button at the sidebar's footer.
* Confirm that the Help center minimizes when we open a modal.


https://github.com/user-attachments/assets/b10d56a7-7e86-4eca-8c6b-2703d2bbc037


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
