### PR TITLE
My Home: Detect restore-in-progress state on Restore a Backup card

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic/index.tsx
+++ b/client/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic/index.tsx
@@ -1,18 +1,36 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import disconnectedIllustration from 'calypso/assets/images/customer-home/disconnected-dark.svg';
+import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import ExternalLinkWithTracking from 'calypso/components/external-link-with-tracking';
+import { EVERY_TEN_SECONDS, useInterval } from 'calypso/lib/interval';
 import {
 	TASK_REACTIVATE_ATOMIC_TRANSFER,
 	TASK_REACTIVATE_EXPIRED_PLAN,
 	TASK_REACTIVATE_RESTORE_BACKUP,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors/index';
+import { useDispatch, useSelector } from 'calypso/state';
+import { requestRewindState } from 'calypso/state/rewind/state/actions';
+import getRewindState from 'calypso/state/selectors/get-rewind-state';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors/index';
 
 export const ReviveAutoRevertedAtomic = ( { card }: { card: string } ) => {
+	const dispatch = useDispatch();
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( getSelectedSiteId );
+	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) );
+	const restoreStatus = rewindState?.rewind?.status ?? null;
+
+	// Poll for rewind state to detect restores started from other tabs.
+	// Once a restore is detected, the data layer takes over with 3-second polling.
+	// Stop polling once the restore is finished.
+	const shouldPoll =
+		card === TASK_REACTIVATE_RESTORE_BACKUP && siteId && restoreStatus !== 'finished';
+	useInterval(
+		() => dispatch( requestRewindState( siteId as number ) ),
+		shouldPoll ? EVERY_TEN_SECONDS : false
+	);
 
 	if ( ! siteSlug || ! isRevivalTask( card ) ) {
 		return null;
@@ -69,7 +87,11 @@ export const ReviveAutoRevertedAtomic = ( { card }: { card: string } ) => {
 
 			case TASK_REACTIVATE_RESTORE_BACKUP:
 				return {
-					title: translate( 'Restore a Backup' ),
+					title: restoreStatus
+						? translate( 'Restore a Backup (status: %(status)s)', {
+								args: { status: restoreStatus },
+						  } )
+						: translate( 'Restore a Backup' ),
 					description: translate(
 						'When your plan previously expired, your site reverted. {{supportLink}}Follow these steps to restore a backup{{/supportLink}}, restoring your site to how it looked before the plan expired.{{lineBreak/}}No further action is needed if you do not need to restore from a backup.',
 						{
@@ -86,7 +108,12 @@ export const ReviveAutoRevertedAtomic = ( { card }: { card: string } ) => {
 	} )();
 
 	return (
-		<Task isUrgent { ...taskProps } taskId={ card } illustration={ disconnectedIllustration } />
+		<>
+			{ card === TASK_REACTIVATE_RESTORE_BACKUP && siteId && (
+				<QueryRewindState siteId={ siteId } />
+			) }
+			<Task isUrgent { ...taskProps } taskId={ card } illustration={ disconnectedIllustration } />
+		</>
 	);
 };
 


### PR DESCRIPTION
Fixes DOTCON-168

## Summary

> ⚠️ **DO NOT MERGE** - This PR is for verification only. The status string displayed in the UI is temporary and will be replaced with proper UI design in a follow-up PR.

Adds restore state detection to the "Restore a Backup" card in My Home (`ReviveAutoRevertedAtomic` component):

- Fetches rewind state via `QueryRewindState` to detect restore status (`queued`, `running`, `finished`, `fail`)
- Polls every 10 seconds to detect restores started from other tabs
- Once a restore is in progress, the data layer's 3-second polling takes over
- Stops polling when restore is finished
- **Temporary:** Displays the raw status string in the card title for verification (e.g., "Restore a Backup (status: running)")


## Test instructions

(Largely inspired by https://github.com/Automattic/wp-calypso/pull/69501)

Preparation

* Create a new Free site.
* Mock Stage 1 by adding woa-revert-from-auto-cleanup blog sticker: wp blog-stickers add --sticker=woa-revert-from-auto-cleanup --who=<who> --blog_id=<id>.
* Visit My Home. You'll find a "Renew the Plan" banner.
* Purchase a Business plan for the site.
* Visit My Home. You'll find an "Activate Hosting Features" banner.
* Activate Hosting features.
* Visit My Home. Finally you'll find the "Restore a Backup" banner. 🎉 
* Open the "Restore a backup" CTA in a new tab to test the behaviour in real time.
* Have My Home in one tab, and Backup in another.

Test

* Open the Networks dev tools in the My Home tab and confirm that the `rewind` endpoint is requested every 10 seconds.
* Start restoring a backup.
* Within 10 seconds, the My Home banner should update the title with a "(status: running)".
* Keep the backup monitored.
* Once the backup is finished, the banner should update to "(status: finished)" within 1 second.
* Open the Networks dev tools in the My Home tab and confirm that the `rewind` endpoint is not requested anymore.

## Pre-merge checklist

- [ ] Has the general commit guidelines been followed? (See: [Commit Guidelines](https://github.com/Automattic/wp-calypso/blob/HEAD/docs/CONTRIBUTING.md#lifecycle-of-a-pull-request))
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (suspended/expired) sites?
- [ ] Have you tested the feature in Atomic suspended and expired sites?
- [ ] Have you tested the feature in Jetpack sites?