### PR TITLE
CIAB: Add partner branding system for signup page

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -101,6 +101,7 @@ class SignupForm extends Component {
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 		disableTosText: PropTypes.bool,
+		allowedSocialServices: PropTypes.arrayOf( PropTypes.string ),
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -823,6 +824,7 @@ class SignupForm extends Component {
 							redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
 							compact
 							disableTosText
+							allowedSocialServices={ this.props.allowedSocialServices }
 						/>
 					</>
 				) }

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -51,6 +51,8 @@ interface SignupFormSocialFirst {
 	isEmailVariation?: boolean;
 	isMessagingVariation?: boolean;
 	isSliderVariation?: boolean;
+	allowedSocialServices?: string[];
+	customTosElement?: JSX.Element;
 }
 
 const options = {
@@ -94,6 +96,8 @@ const SignupFormSocialFirst = ( {
 	isEmailVariation,
 	isMessagingVariation,
 	isSliderVariation,
+	allowedSocialServices,
+	customTosElement,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState< Screen >( userEmail ? 'email' : 'initial' );
 	const { __ } = useI18n();
@@ -102,6 +106,11 @@ const SignupFormSocialFirst = ( {
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
 
 	const renderTermsOfService = () => {
+		// Custom ToS element takes priority (from partner branding)
+		if ( customTosElement ) {
+			return <p className="signup-form-social-first__tos-link">{ customTosElement }</p>;
+		}
+
 		let tosText;
 
 		if ( isWoo ) {
@@ -213,6 +222,7 @@ const SignupFormSocialFirst = ( {
 					compact
 					isSocialFirst={ isSocialFirst }
 					shouldShowEmailButton={ ! isEmailVariation }
+					allowedSocialServices={ allowedSocialServices }
 				/>
 				{ isSliderVariation && (
 					<p className="signup-form-social-first__login-link">

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -33,6 +33,7 @@ class SocialSignupForm extends Component {
 		redirectToAfterLoginUrl: PropTypes.string,
 		isSocialFirst: PropTypes.bool,
 		shouldShowEmailButton: PropTypes.bool,
+		allowedSocialServices: PropTypes.arrayOf( PropTypes.string ),
 	};
 
 	static defaultProps = {
@@ -87,17 +88,106 @@ class SocialSignupForm extends Component {
 		}
 	};
 
+	getSocialButtons() {
+		const { socialServiceResponse, flowName, setCurrentStep, isSocialFirst, shouldShowEmailButton } =
+			this.props;
+
+		return [
+			{
+				service: 'google',
+				enabled: true,
+				button: (
+					<GoogleSocialButton
+						key="social-signup-button-google"
+						responseHandler={ this.handleSignup }
+						onClick={ this.trackSignupAndRememberRedirect }
+					/>
+				),
+			},
+			{
+				service: 'apple',
+				enabled: true,
+				button: (
+					<AppleLoginButton
+						key="social-signup-button-apple"
+						responseHandler={ this.handleSignup }
+						onClick={ this.trackSignupAndRememberRedirect }
+						socialServiceResponse={ socialServiceResponse }
+						queryString={ isWpccFlow( flowName ) ? window?.location?.search?.slice( 1 ) : '' }
+					/>
+				),
+			},
+			{
+				service: 'github',
+				enabled: true,
+				button: (
+					<GithubSocialButton
+						key="social-signup-button-github"
+						responseHandler={ this.handleSignup }
+						onClick={ this.trackSignupAndRememberRedirect }
+						socialServiceResponse={ socialServiceResponse }
+					/>
+				),
+			},
+			{
+				service: 'paypal',
+				enabled: config.isEnabled( 'sign-in-with-paypal' ),
+				button: (
+					<PayPalSocialButton
+						key="social-signup-button-paypal"
+						responseHandler={ this.handleSignup }
+						onClick={ this.trackSignupAndRememberRedirect }
+						socialServiceResponse={ socialServiceResponse }
+					/>
+				),
+			},
+			{
+				service: 'email',
+				enabled: isSocialFirst && shouldShowEmailButton !== false,
+				button: (
+					<UsernameOrEmailButton
+						key="social-signup-button-email"
+						onClick={ () => setCurrentStep( 'email' ) }
+					/>
+				),
+			},
+		];
+	}
+
+	getFilteredSocialButtons() {
+		const { allowedSocialServices } = this.props;
+		const socialButtons = this.getSocialButtons();
+
+		if ( ! allowedSocialServices ) {
+			return socialButtons;
+		}
+
+		// Map allowedSocialServices to buttons (preserves order from config)
+		// Preserve original enabled state for feature-flagged buttons (e.g., PayPal)
+		const buttons = allowedSocialServices
+			.map( ( service ) => socialButtons.find( ( btn ) => btn.service === service ) )
+			.filter( Boolean );
+
+		// Add email button at the end only if not already included in allowedSocialServices
+		if ( ! allowedSocialServices.includes( 'email' ) ) {
+			const emailButton = socialButtons.find( ( btn ) => btn.service === 'email' );
+			if ( emailButton ) {
+				buttons.push( emailButton );
+			}
+		}
+
+		return buttons;
+	}
+
+	renderSocialButton( { enabled, button } ) {
+		if ( ! enabled ) {
+			return null;
+		}
+		return button;
+	}
+
 	render() {
-		const {
-			compact,
-			translate,
-			socialServiceResponse,
-			disableTosText,
-			isSocialFirst,
-			flowName,
-			setCurrentStep,
-			shouldShowEmailButton,
-		} = this.props;
+		const { compact, translate, disableTosText, isSocialFirst } = this.props;
 		return (
 			<Card
 				className={ clsx( 'auth-form__social', 'is-signup', {
@@ -110,35 +200,7 @@ class SocialSignupForm extends Component {
 
 				<div className="auth-form__social-buttons">
 					<div className="auth-form__social-buttons-container">
-						<GoogleSocialButton
-							responseHandler={ this.handleSignup }
-							onClick={ this.trackSignupAndRememberRedirect }
-						/>
-
-						<AppleLoginButton
-							responseHandler={ this.handleSignup }
-							onClick={ this.trackSignupAndRememberRedirect }
-							socialServiceResponse={ socialServiceResponse }
-							queryString={ isWpccFlow( flowName ) ? window?.location?.search?.slice( 1 ) : '' }
-						/>
-
-						<GithubSocialButton
-							responseHandler={ this.handleSignup }
-							onClick={ this.trackSignupAndRememberRedirect }
-							socialServiceResponse={ socialServiceResponse }
-						/>
-
-						{ config.isEnabled( 'sign-in-with-paypal' ) && (
-							<PayPalSocialButton
-								responseHandler={ this.handleSignup }
-								onClick={ this.trackSignupAndRememberRedirect }
-								socialServiceResponse={ socialServiceResponse }
-							/>
-						) }
-
-						{ isSocialFirst && shouldShowEmailButton && (
-							<UsernameOrEmailButton onClick={ () => setCurrentStep( 'email' ) } />
-						) }
+						{ this.getFilteredSocialButtons().map( this.renderSocialButton ) }
 					</div>
 					{ ! disableTosText && <SocialToS /> }
 				</div>

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -89,8 +89,13 @@ class SocialSignupForm extends Component {
 	};
 
 	getSocialButtons() {
-		const { socialServiceResponse, flowName, setCurrentStep, isSocialFirst, shouldShowEmailButton } =
-			this.props;
+		const {
+			socialServiceResponse,
+			flowName,
+			setCurrentStep,
+			isSocialFirst,
+			shouldShowEmailButton,
+		} = this.props;
 
 		return [
 			{

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import SignupFormSocialFirst from 'calypso/blocks/signup-form/signup-form-social-first';
+import loginReducer from 'calypso/state/login/reducer';
+import routeReducer from 'calypso/state/route/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+
+// Mock the analytics module
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+	getDoNotTrack: jest.fn( () => false ),
+	isPiiUrl: jest.fn( () => false ),
+	getCurrentUser: jest.fn( () => null ),
+} ) );
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = ( key: string ) => {
+		if ( key === 'wpcom_signup_id' ) {
+			return 'test-id';
+		}
+		if ( key === 'wpcom_signup_key' ) {
+			return 'test-key';
+		}
+		return null;
+	};
+	config.isEnabled = ( feature: string ) => {
+		if ( feature === 'sign-in-with-paypal' ) {
+			return true;
+		}
+		return false;
+	};
+	return config;
+} );
+
+const defaultProps = {
+	goToNextStep: jest.fn(),
+	stepName: 'user',
+	flowName: 'onboarding',
+	redirectToAfterLoginUrl: 'https://example.com',
+	logInUrl: '/log-in',
+	socialServiceResponse: {},
+	handleSocialResponse: jest.fn(),
+	queryArgs: {},
+	userEmail: '',
+	notice: false as const,
+	isSocialFirst: true,
+};
+
+const render = ( el: React.ReactElement, options = {} ) =>
+	renderWithProvider( el, { ...options, reducers: { login: loginReducer, route: routeReducer } } );
+
+describe( 'SignupFormSocialFirst', () => {
+	describe( 'customTosElement', () => {
+		test( 'renders custom ToS element when provided', () => {
+			const customTos = (
+				<span data-testid="custom-tos">
+					Custom Terms of Service for <a href="/tos">Partner</a>
+				</span>
+			);
+
+			render( <SignupFormSocialFirst { ...defaultProps } customTosElement={ customTos } /> );
+
+			const customTosElement = screen.getByTestId( 'custom-tos' );
+			expect( customTosElement ).toBeInTheDocument();
+			expect( screen.getByText( /Custom Terms of Service for/i ) ).toBeInTheDocument();
+			expect(
+				customTosElement.closest( '.signup-form-social-first__tos-link' )
+			).toBeInTheDocument();
+		} );
+
+		test( 'renders default ToS when customTosElement is not provided', () => {
+			render( <SignupFormSocialFirst { ...defaultProps } /> );
+
+			expect(
+				screen.getByText( /By continuing with any of the options listed/i )
+			).toBeInTheDocument();
+		} );
+
+		test( 'custom ToS element takes priority over default', () => {
+			const customTos = <span data-testid="custom-tos">Partner specific terms</span>;
+
+			render( <SignupFormSocialFirst { ...defaultProps } customTosElement={ customTos } /> );
+
+			// Custom ToS should be visible
+			expect( screen.getByTestId( 'custom-tos' ) ).toBeInTheDocument();
+			// Default ToS text should not be in the initial screen
+			expect(
+				screen.queryByText( /By continuing with any of the options listed/i )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'allowedSocialServices', () => {
+		test( 'passes allowedSocialServices to SocialSignupForm', () => {
+			const allowedServices = [ 'google', 'paypal' ];
+
+			render(
+				<SignupFormSocialFirst { ...defaultProps } allowedSocialServices={ allowedServices } />
+			);
+
+			// Verify filtered buttons are rendered
+			expect( screen.getByText( /Continue with Google/i ) ).toBeInTheDocument();
+			expect( screen.getByText( /Continue with PayPal/i ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/blocks/signup-form/test/social.jsx
+++ b/client/blocks/signup-form/test/social.jsx
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import SocialSignupForm from 'calypso/blocks/signup-form/social';
+import loginReducer from 'calypso/state/login/reducer';
+import routeReducer from 'calypso/state/route/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = jest.fn( ( key ) => {
+		if ( key === 'wpcom_signup_id' ) {
+			return 'test-id';
+		}
+		if ( key === 'wpcom_signup_key' ) {
+			return 'test-key';
+		}
+		return null;
+	} );
+	config.isEnabled = jest.fn( ( feature ) => {
+		if ( feature === 'sign-in-with-paypal' ) {
+			return true;
+		}
+		return false;
+	} );
+	return config;
+} );
+
+const defaultProps = {
+	handleResponse: jest.fn(),
+	setCurrentStep: jest.fn(),
+};
+
+const render = ( el, options ) =>
+	renderWithProvider( el, { ...options, reducers: { login: loginReducer, route: routeReducer } } );
+
+describe( 'SocialSignupForm', () => {
+	test( 'renders Google social signup button', () => {
+		render( <SocialSignupForm { ...defaultProps } /> );
+
+		expect( screen.getByText( /Continue with Google/i ) ).toBeInTheDocument();
+	} );
+
+	test( 'filters social buttons based on allowedSocialServices', () => {
+		render( <SocialSignupForm { ...defaultProps } allowedSocialServices={ [ 'paypal' ] } /> );
+
+		expect( screen.getByText( /Continue with PayPal/i ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Continue with Google/i ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows only specified social buttons from allowedSocialServices', () => {
+		render(
+			<SocialSignupForm { ...defaultProps } allowedSocialServices={ [ 'paypal', 'google' ] } />
+		);
+
+		expect( screen.getByText( /Continue with PayPal/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /Continue with Google/i ) ).toBeInTheDocument();
+	} );
+
+	test( 'adds email button at the end when isSocialFirst and email is not in allowedSocialServices', () => {
+		render(
+			<SocialSignupForm
+				{ ...defaultProps }
+				isSocialFirst
+				allowedSocialServices={ [ 'paypal', 'google' ] }
+			/>
+		);
+
+		expect( screen.getByText( /Continue with PayPal/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /Continue with Google/i ) ).toBeInTheDocument();
+		// Email button should be added at the end
+		expect( screen.getByText( /Continue with email/i ) ).toBeInTheDocument();
+	} );
+
+	test( 'does not duplicate email button when email is already in allowedSocialServices', () => {
+		render(
+			<SocialSignupForm
+				{ ...defaultProps }
+				isSocialFirst
+				allowedSocialServices={ [ 'paypal', 'email' ] }
+			/>
+		);
+
+		const emailButtons = screen.getAllByText( /Continue with email/i );
+		expect( emailButtons ).toHaveLength( 1 );
+	} );
+
+	test( 'does not show email button when not in isSocialFirst mode', () => {
+		render(
+			<SocialSignupForm
+				{ ...defaultProps }
+				isSocialFirst={ false }
+				allowedSocialServices={ [ 'paypal', 'google' ] }
+			/>
+		);
+
+		expect( screen.getByText( /Continue with PayPal/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /Continue with Google/i ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Continue with email/i ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -137,13 +137,15 @@ const UserStepComponent: StepType = function UserStep( {
 	);
 
 	if ( isStepContainerV2 ) {
-		const headingText = isMessagingVariation
-			? translate( 'Welcome to WordPress.com' )
-			: ciabConfig
-				? translate( 'Create an account for %(partner)s', {
-						args: { partner: ciabConfig.displayName },
-				  } )
-				: translate( 'Create your account' );
+		let headingText = translate( 'Create your account' );
+		if ( isMessagingVariation ) {
+			headingText = translate( 'Welcome to WordPress.com' );
+		} else if ( ciabConfig ) {
+			headingText = translate( 'Create an account for %(partner)s', {
+				args: { partner: ciabConfig.displayName },
+				textOnly: true,
+			} );
+		}
 		const heading = (
 			// The locale suggestions are going to be reworked. Don't worry about it now.
 			<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -14,6 +14,7 @@ import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import { AccountCreateReturn } from 'calypso/lib/signup/api/type';
 import wpcom from 'calypso/lib/wp';
@@ -45,6 +46,7 @@ const UserStepComponent: StepType = function UserStep( {
 	const { handleSocialResponse, notice, accountCreateResponse } = useHandleSocialResponse( flow );
 	const [ wpAccountCreateResponse, setWpAccountCreateResponse ] = useState< AccountCreateReturn >();
 	const { socialServiceResponse } = useSocialService();
+	const { topBarLogo, ciabConfig, signupTosElement } = usePartnerBranding();
 
 	const {
 		isExperimentVariant,
@@ -77,6 +79,7 @@ const UserStepComponent: StepType = function UserStep( {
 		signupUrl,
 		redirectTo,
 		locale,
+		from: ciabConfig?.id ?? queryArgs.get( 'from' ) ?? undefined,
 	} );
 
 	const shouldRenderLocaleSuggestions = ! isLoggedIn; // For logged-in users, we respect the user language settings
@@ -120,6 +123,8 @@ const UserStepComponent: StepType = function UserStep( {
 				isEmailVariation={ isEmailVariation }
 				isMessagingVariation={ isMessagingVariation }
 				isSliderVariation={ isSliderVariation }
+				allowedSocialServices={ ciabConfig?.ssoProviders }
+				customTosElement={ signupTosElement }
 			/>
 			{ accountCreateResponse && 'bearer_token' in accountCreateResponse && (
 				<WpcomLoginForm
@@ -134,7 +139,11 @@ const UserStepComponent: StepType = function UserStep( {
 	if ( isStepContainerV2 ) {
 		const headingText = isMessagingVariation
 			? translate( 'Welcome to WordPress.com' )
-			: translate( 'Create your account' );
+			: ciabConfig
+				? translate( 'Create an account for %(partner)s', {
+						args: { partner: ciabConfig.displayName },
+				  } )
+				: translate( 'Create your account' );
 		const heading = (
 			// The locale suggestions are going to be reworked. Don't worry about it now.
 			<>
@@ -149,6 +158,7 @@ const UserStepComponent: StepType = function UserStep( {
 
 		const topBar = (
 			<Step.TopBar
+				logo={ topBarLogo }
 				leftElement={
 					navigation.goBack ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
 				}

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getCiabConfig, getPartnerAllowedSocialServices, CIAB_PARTNERS } from '../partner-branding';
+
+// Mock the config module
+jest.mock( '@automattic/calypso-config', () => {
+	const config = () => null;
+	config.isEnabled = ( feature: string ) => {
+		if ( feature === 'ciab/custom-branding' ) {
+			return true;
+		}
+		return false;
+	};
+	return config;
+} );
+
+describe( 'partner-branding', () => {
+	describe( 'getCiabConfig', () => {
+		test( 'returns partner config when from param matches a valid partner', () => {
+			const config = getCiabConfig( 'woo' );
+
+			expect( config ).not.toBeNull();
+			expect( config?.id ).toBe( 'woo' );
+			expect( config?.displayName ).toBe( 'Woo' );
+		} );
+
+		test( 'returns null when from param does not match any partner', () => {
+			const config = getCiabConfig( 'unknown-partner' );
+
+			expect( config ).toBeNull();
+		} );
+
+		test( 'returns null when from param is undefined', () => {
+			const config = getCiabConfig( undefined );
+
+			expect( config ).toBeNull();
+		} );
+
+		test( 'handles array of from params by using first value', () => {
+			const config = getCiabConfig( [ 'woo', 'other' ] );
+
+			expect( config ).not.toBeNull();
+			expect( config?.id ).toBe( 'woo' );
+		} );
+	} );
+
+	describe( 'getPartnerAllowedSocialServices', () => {
+		test( 'returns ssoProviders array for valid partner', () => {
+			const services = getPartnerAllowedSocialServices( 'woo' );
+
+			expect( services ).toEqual( CIAB_PARTNERS.woo.ssoProviders );
+		} );
+
+		test( 'returns null for unknown partner', () => {
+			const services = getPartnerAllowedSocialServices( 'unknown' );
+
+			expect( services ).toBeNull();
+		} );
+
+		test( 'returns null when from is undefined', () => {
+			const services = getPartnerAllowedSocialServices( undefined );
+
+			expect( services ).toBeNull();
+		} );
+	} );
+
+	describe( 'CIAB_PARTNERS', () => {
+		test( 'woo partner has required configuration', () => {
+			const wooConfig = CIAB_PARTNERS.woo;
+
+			expect( wooConfig ).toBeDefined();
+			expect( wooConfig.id ).toBe( 'woo' );
+			expect( wooConfig.displayName ).toBe( 'Woo' );
+			expect( wooConfig.featureFlag ).toBe( 'ciab/custom-branding' );
+			expect( wooConfig.logo ).toBeDefined();
+			expect( wooConfig.logo.src ).toBeDefined();
+			expect( wooConfig.ssoProviders ).toBeInstanceOf( Array );
+			expect( wooConfig.ssoProviders.length ).toBeGreaterThan( 0 );
+		} );
+	} );
+} );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -24,6 +24,7 @@ import {
 	isVIPOAuth2Client,
 	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
+import { getPartnerAllowedSocialServices } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import LoginContextProvider, { useLoginContext } from 'calypso/login/login-context';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
@@ -544,7 +545,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, isWoo } = this.props;
+		const { oauth2Client, isWoo, from } = this.props;
 		const isPasswordless = true;
 		let socialService;
 		let socialServiceResponse;
@@ -558,6 +559,9 @@ export class UserStep extends Component {
 				socialServiceResponse = hashObject;
 			}
 		}
+
+		const allowedSocialServices = getPartnerAllowedSocialServices( from );
+
 		return (
 			<>
 				<SignupForm
@@ -583,6 +587,7 @@ export class UserStep extends Component {
 					isSocialFirst={ this.props.isSocialFirst }
 					labelText={ this.props.translate( 'Your email' ) }
 					disableTosText={ ! isGravatarOAuth2Client( oauth2Client ) }
+					allowedSocialServices={ allowedSocialServices }
 				/>
 				{ ! isGravatarOAuth2Client( oauth2Client ) && (
 					<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />


### PR DESCRIPTION
Part of ARC-1431
Depends on https://github.com/Automattic/wp-calypso/pull/108293

## Proposed Changes

* Extends the partner branding system to the signup page. When users visit signup with `?from=woo`, they see a fully branded experience.
* **Custom logo** - Woo logo in top bar (replaces WordPress "W")
* **Custom header** - "Create an account for Woo"
* **Filtered SSO providers** - Shows only PayPal, Google, Apple, and Email (hides GitHub)
* **Custom ToS text** - Partner-specific terms of service message
* **Feature flag controlled** - `ciab/custom-branding` for staged rollout

<img width="1512" height="723" alt="Captura de Tela 2026-01-23 às 16 35 08" src="https://github.com/user-attachments/assets/674d6429-58fe-4abc-8f4d-1f83a2bdfccf" />

<img width="1512" height="711" alt="Captura de Tela 2026-01-29 às 12 56 42" src="https://github.com/user-attachments/assets/48ce068e-d18d-4d94-a9b2-4bfb2675fc63" />

## Why are these changes being made?

* CIAB aims to provide a streamlined commerce experience for non-technical merchants. This extends the login page branding (from PR #108293) to the signup page, ensuring consistent partner branding across the entire authentication flow.

## Testing Instructions

* On an incognito window, open `/setup/onboarding/user?from=woo`.
* You should see the Woo branding with custom logo, heading, filtered SSO providers, and custom ToS text.
* Visit `/start/account/user-social?redirect_to=%2Fsites&from=woo` too and verify the branding.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?