### PR TITLE
MSD: Add Akismet/Jetpack API keys to purchase settings

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/akismet-api-key-card.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/akismet-api-key-card.tsx
@@ -1,0 +1,39 @@
+import { akismetApiKeyQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { ExternalLink } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { key } from '@wordpress/icons';
+import ClipboardInputControl from '../../../components/clipboard-input-control';
+import OverviewCard from '../../../components/overview-card';
+
+export default function AkismetApiKeyCard() {
+	const { data, isError, isLoading } = useQuery( akismetApiKeyQuery() );
+
+	if ( isError ) {
+		return null;
+	}
+
+	const akismetApiKey = data ?? '';
+
+	return (
+		<OverviewCard
+			icon={ key }
+			title={ __( 'API key' ) }
+			heading={
+				<ClipboardInputControl
+					label={ __( 'API key' ) }
+					value={ akismetApiKey }
+					readOnly
+					disabled={ isLoading }
+					hideLabelFromVision
+				/>
+			}
+			description={
+				<ExternalLink href="https://akismet.com/support/getting-started/api-key/">
+					{ __( 'How to activate' ) }
+				</ExternalLink>
+			}
+			isLoading={ isLoading }
+		/>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/akismet-api-key-card.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/akismet-api-key-card.tsx
@@ -7,7 +7,10 @@ import ClipboardInputControl from '../../../components/clipboard-input-control';
 import OverviewCard from '../../../components/overview-card';
 
 export default function AkismetApiKeyCard() {
-	const { data, isError, isLoading } = useQuery( akismetApiKeyQuery() );
+	const { data, isError, isLoading } = useQuery( {
+		...akismetApiKeyQuery(),
+		refetchOnWindowFocus: false,
+	} );
 
 	if ( isError ) {
 		return null;

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -85,6 +85,8 @@ import {
 } from '../../../utils/purchase';
 import BillingFlexUsageCard from '../../billing-flex-usage';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
+import AkismetApiKeyCard from './akismet-api-key-card';
+import JetpackLicenseKeyCard from './jetpack-license-key-card';
 import { PurchaseNotice } from './purchase-notice';
 import type { User, Purchase, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -1210,6 +1212,12 @@ export default function PurchaseSettings() {
 							String( user.ID ) === String( purchase.user_id ) ? user.email : undefined
 						}
 					/>
+					{ purchase.is_jetpack_plan_or_product && (
+						<JetpackLicenseKeyCard purchaseId={ purchase.ID } />
+					) }
+					{ isAkismetProduct( purchase ) && isTemporarySitePurchase( purchase ) && (
+						<AkismetApiKeyCard />
+					) }
 				</Grid>
 				{ site && purchase.subscription_status === 'active' && (
 					<WPComResourceMeters purchase={ purchase } site={ site } />

--- a/client/dashboard/me/billing-purchases/purchase-settings/jetpack-license-key-card.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/jetpack-license-key-card.tsx
@@ -11,7 +11,10 @@ interface JetpackLicenseKeyCardProps {
 }
 
 export default function JetpackLicenseKeyCard( { purchaseId }: JetpackLicenseKeyCardProps ) {
-	const { data, isError, isLoading } = useQuery( jetpackUserLicenseQuery( purchaseId ) );
+	const { data, isError, isLoading } = useQuery( {
+		...jetpackUserLicenseQuery( purchaseId ),
+		refetchOnWindowFocus: false,
+	} );
 
 	if ( isError ) {
 		return null;

--- a/client/dashboard/me/billing-purchases/purchase-settings/jetpack-license-key-card.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/jetpack-license-key-card.tsx
@@ -1,0 +1,43 @@
+import { jetpackUserLicenseQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { ExternalLink } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { key } from '@wordpress/icons';
+import ClipboardInputControl from '../../../components/clipboard-input-control';
+import OverviewCard from '../../../components/overview-card';
+
+interface JetpackLicenseKeyCardProps {
+	purchaseId: number;
+}
+
+export default function JetpackLicenseKeyCard( { purchaseId }: JetpackLicenseKeyCardProps ) {
+	const { data, isError, isLoading } = useQuery( jetpackUserLicenseQuery( purchaseId ) );
+
+	if ( isError ) {
+		return null;
+	}
+
+	const licenseKey = data?.licenseKey ?? '';
+
+	return (
+		<OverviewCard
+			icon={ key }
+			title={ __( 'License key' ) }
+			heading={
+				<ClipboardInputControl
+					label={ __( 'License key' ) }
+					value={ licenseKey }
+					readOnly
+					disabled={ isLoading }
+					hideLabelFromVision
+				/>
+			}
+			description={
+				<ExternalLink href="https://jetpack.com/support/activate-a-jetpack-product-via-license-key/">
+					{ __( 'How to activate' ) }
+				</ExternalLink>
+			}
+			isLoading={ isLoading }
+		/>
+	);
+}

--- a/packages/api-core/src/akismet-api-key/index.ts
+++ b/packages/api-core/src/akismet-api-key/index.ts
@@ -1,0 +1,11 @@
+import { wpcom } from '../wpcom-fetcher';
+
+export type AkismetApiKey = string;
+
+export async function fetchAkismetApiKey(): Promise< AkismetApiKey > {
+	const key: AkismetApiKey = await wpcom.req.get( {
+		path: '/akismet/get-key',
+		apiNamespace: 'wpcom/v2',
+	} );
+	return key;
+}

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -3,6 +3,7 @@ export * from './constants';
 export * from './error';
 
 export * from './agency';
+export * from './akismet-api-key';
 export * from './big-sky-plugin';
 export * from './cancellation-offers';
 export * from './dashboard-site-list';
@@ -31,6 +32,7 @@ export * from './emails';
 export * from './geo';
 export * from './hosting-github';
 export * from './hosting-update-schedules';
+export * from './jetpack-user-license';
 export * from './marketplace-products';
 export * from './marketplace-search';
 export * from './marketing-survey';

--- a/packages/api-core/src/jetpack-user-license/index.ts
+++ b/packages/api-core/src/jetpack-user-license/index.ts
@@ -1,0 +1,30 @@
+import { wpcom } from '../wpcom-fetcher';
+
+export interface JetpackUserLicenseApi {
+	license_key: string;
+	issued_at: string;
+	revoked_at: string | null;
+	subscription_id: number;
+}
+
+export interface JetpackUserLicense {
+	licenseKey: string;
+	issuedAt: string;
+	revokedAt: string | null;
+	subscriptionId: number;
+}
+
+export async function fetchJetpackUserLicense(
+	subscriptionId: number
+): Promise< JetpackUserLicense > {
+	const raw: JetpackUserLicenseApi = await wpcom.req.get( {
+		path: `/jetpack-licensing/user/subscription/${ subscriptionId }`,
+		apiNamespace: 'wpcom/v2',
+	} );
+	return {
+		licenseKey: raw.license_key,
+		issuedAt: raw.issued_at,
+		revokedAt: raw.revoked_at,
+		subscriptionId: raw.subscription_id,
+	};
+}

--- a/packages/api-queries/src/akismet-api-key.ts
+++ b/packages/api-queries/src/akismet-api-key.ts
@@ -5,5 +5,4 @@ export const akismetApiKeyQuery = () =>
 	queryOptions( {
 		queryKey: [ 'akismet-api-key' ],
 		queryFn: () => fetchAkismetApiKey(),
-		refetchOnWindowFocus: false,
 	} );

--- a/packages/api-queries/src/akismet-api-key.ts
+++ b/packages/api-queries/src/akismet-api-key.ts
@@ -1,0 +1,9 @@
+import { fetchAkismetApiKey } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const akismetApiKeyQuery = () =>
+	queryOptions( {
+		queryKey: [ 'akismet-api-key' ],
+		queryFn: () => fetchAkismetApiKey(),
+		refetchOnWindowFocus: false,
+	} );

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -1,5 +1,6 @@
 export * from './query-client';
 
+export * from './akismet-api-key';
 export * from './big-sky-plugin';
 export * from './cancellation-offers';
 export * from './dashboard-site-list';
@@ -27,6 +28,7 @@ export * from './emails';
 export * from './geo';
 export * from './github';
 export * from './hosting-update-schedules';
+export * from './jetpack-user-license';
 export * from './marketplace-search';
 export * from './marketing-survey';
 export * from './me-a8c';

--- a/packages/api-queries/src/jetpack-user-license.ts
+++ b/packages/api-queries/src/jetpack-user-license.ts
@@ -1,0 +1,9 @@
+import { fetchJetpackUserLicense } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+
+export const jetpackUserLicenseQuery = ( subscriptionId: number ) =>
+	queryOptions( {
+		queryKey: [ 'jetpack-user-license', subscriptionId ],
+		queryFn: () => fetchJetpackUserLicense( subscriptionId ),
+		refetchOnWindowFocus: false,
+	} );

--- a/packages/api-queries/src/jetpack-user-license.ts
+++ b/packages/api-queries/src/jetpack-user-license.ts
@@ -5,5 +5,4 @@ export const jetpackUserLicenseQuery = ( subscriptionId: number ) =>
 	queryOptions( {
 		queryKey: [ 'jetpack-user-license', subscriptionId ],
 		queryFn: () => fetchJetpackUserLicense( subscriptionId ),
-		refetchOnWindowFocus: false,
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1550/msd-akismet-purchase-settings-page-does-not-have-an-api-key

## Proposed Changes

This PR adds a card that displays the Akismet and Jetpack API keys to the Multi Site Dashboard (MSD) version of the purchase settings page.

Akismet             |  Jetpack
:-------------------------:|:-------------------------:
<img width="691" height="350" alt="Screenshot 2026-01-23 at 4 21 06 PM" src="https://github.com/user-attachments/assets/d1d7dc06-9fd6-4916-9f81-04e027116414" /> | <img width="686" height="353" alt="Screenshot 2026-01-23 at 4 37 56 PM" src="https://github.com/user-attachments/assets/d223af33-bbeb-42ce-a9ce-a7ea32adaebc" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When the purchase settings page was totally redesigned and rewritten for the MSD, the cards that display the API key for Akismet and Jetpack products was not migrated.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start at https://akismet.com/pricing/
- Buy Akismet Pro.
- Go to https://my.wordpress.com/me/billing/purchases and click through to manage the new purchase.
- Verify that you see the API key displayed.

To test Jetpack, buy Jetpack Security and repeat the above steps.