### PR TITLE
Multi Site Dashboard: Add status badge to the "Domain connection setup" button

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/summary.tsx
+++ b/client/dashboard/domains/domain-connection-setup/summary.tsx
@@ -22,11 +22,11 @@ export default function DomainConnectionSetupSummary( {
 		isMappingVerificationSuccess( domainMappingStatus.mode ?? null, domainMappingStatus );
 
 	if ( isConnected ) {
-		badges.push( { text: __( 'Connected' ), intent: 'success' as const } );
+		badges.push( { text: __( 'Connected' ), intent: 'success' } );
 	} else if ( domainMappingStatus?.mode === DomainConnectionSetupMode.ADVANCED ) {
-		badges.push( { text: __( 'Verifying DNS' ), intent: 'warning' as const } );
+		badges.push( { text: __( 'Verifying DNS' ), intent: 'warning' } );
 	} else if ( domainMappingStatus?.mode === DomainConnectionSetupMode.SUGGESTED ) {
-		badges.push( { text: __( 'Verifying name servers' ), intent: 'warning' as const } );
+		badges.push( { text: __( 'Verifying name servers' ), intent: 'warning' } );
 	}
 
 	return (

--- a/client/dashboard/domains/domain-connection-setup/summary.tsx
+++ b/client/dashboard/domains/domain-connection-setup/summary.tsx
@@ -1,15 +1,41 @@
+import {
+	DomainConnectionSetupMode,
+	type Domain,
+	type DomainMappingStatus,
+} from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import { domainConnectionSetupRoute } from '../../app/router/domains';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import type { Domain } from '@automattic/api-core';
+import { isMappingVerificationSuccess } from './utils';
+import type { SummaryButtonBadgeProps } from '@automattic/components/src/summary-button/types';
 
-export default function DomainConnectionSetupSummary( { domain }: { domain: Domain } ) {
+export default function DomainConnectionSetupSummary( {
+	domain,
+	domainMappingStatus,
+}: {
+	domain: Domain;
+	domainMappingStatus?: DomainMappingStatus;
+} ) {
+	const badges: SummaryButtonBadgeProps[] = [];
+	const isConnected =
+		domainMappingStatus &&
+		isMappingVerificationSuccess( domainMappingStatus.mode ?? null, domainMappingStatus );
+
+	if ( isConnected ) {
+		badges.push( { text: __( 'Connected' ), intent: 'success' as const } );
+	} else if ( domainMappingStatus?.mode === DomainConnectionSetupMode.ADVANCED ) {
+		badges.push( { text: __( 'Verifying DNS' ), intent: 'warning' as const } );
+	} else if ( domainMappingStatus?.mode === DomainConnectionSetupMode.SUGGESTED ) {
+		badges.push( { text: __( 'Verifying name servers' ), intent: 'warning' as const } );
+	}
+
 	return (
 		<RouterLinkSummaryButton
 			to={ domainConnectionSetupRoute.fullPath }
 			params={ { domainName: domain.domain } }
 			title={ __( 'Domain connection setup' ) }
 			density={ 'medium' as const }
+			badges={ badges }
 		/>
 	);
 }

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -1,5 +1,10 @@
 import { DomainSubtype } from '@automattic/api-core';
-import { domainQuery, purchaseQuery, domainDiagnosticsQuery } from '@automattic/api-queries';
+import {
+	domainQuery,
+	purchaseQuery,
+	domainDiagnosticsQuery,
+	domainMappingStatusQuery,
+} from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Badge } from '@automattic/ui';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
@@ -30,6 +35,11 @@ export default function DomainOverview() {
 	const { data: purchase } = useSuspenseQuery(
 		purchaseQuery( parseInt( domain.subscription_id ?? '0', 10 ) )
 	);
+
+	const { data: domainMappingStatus } = useQuery( {
+		...domainMappingStatusQuery( domain.domain ),
+		enabled: domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION,
+	} );
 
 	const { data: diagnosticsData } = useQuery( {
 		...domainDiagnosticsQuery( domain.domain ),
@@ -126,6 +136,7 @@ export default function DomainOverview() {
 							isDisabled={ isTldInMaintenance( domain ) }
 							domain={ domain }
 							domainDiagnostics={ diagnosticsData }
+							domainMappingStatus={ domainMappingStatus }
 						/>
 					</>
 				) }

--- a/client/dashboard/domains/domain-overview/settings.tsx
+++ b/client/dashboard/domains/domain-overview/settings.tsx
@@ -3,6 +3,7 @@ import {
 	DomainTransferStatus,
 	type Domain,
 	DomainDiagnostics,
+	type DomainMappingStatus,
 } from '@automattic/api-core';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -20,17 +21,23 @@ import NameServersSettingsSummary from '../name-servers/summary';
 export default function DomainOverviewSettings( {
 	domain,
 	domainDiagnostics,
+	domainMappingStatus,
 	isDisabled,
 }: {
 	domain: Domain;
 	domainDiagnostics: DomainDiagnostics | undefined;
+	domainMappingStatus?: DomainMappingStatus;
 	isDisabled?: boolean;
 } ) {
 	const buttonListItems = [];
 
 	if ( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {
 		buttonListItems.push(
-			<DomainConnectionSetupSummary key="connection-setup" domain={ domain } />
+			<DomainConnectionSetupSummary
+				key="connection-setup"
+				domain={ domain }
+				domainMappingStatus={ domainMappingStatus }
+			/>
 		);
 	}
 


### PR DESCRIPTION
Part of [DOMENG-279](https://linear.app/a8c/issue/DOMENG-279)

## Proposed Changes

This PR adds a status badge to the "Domain connection setup" button in the domain overview page in MSD. That button is only shown for domain connections. The badge will have three different states:
- `Connected` when the domain is resolving to our infrastructure
- `Verifying name servers` when the domain is still not resolving to us and the chosen connection mode is "suggested"
- `Verifying DNS` when the domain is still not resolving to us and the chosen connection mode is "advanced"

### Screenshots

| Description | Screenshot |
| --- | --- |
| Before (no badge) | <img width="1256" height="1108" alt="Screenshot 2026-01-23 at 18 36 46" src="https://github.com/user-attachments/assets/f4bf96b4-3b96-472d-af18-4a536192c9e9" /> |
| Domain not connected (suggested) | <img width="1256" height="1108" alt="Screenshot 2026-01-23 at 18 33 15" src="https://github.com/user-attachments/assets/c5a54458-2708-4360-81b8-d14789335eed" /> |
| Domain not connected (advanced) | <img width="1256" height="1108" alt="Screenshot 2026-01-23 at 18 34 18" src="https://github.com/user-attachments/assets/75c77ded-20e3-4c99-bb19-f7cf1a4b434a" /> |
| Domain connected correctly | <img width="1256" height="1108" alt="Screenshot 2026-01-23 at 18 34 44" src="https://github.com/user-attachments/assets/7c0d0315-01a5-42c1-ba86-4350fc5e11de" /> |

## Why are these changes being made?

Showing a status badge in the "Domain connection setup" button helps users understand at a glance if the domain is properly connected or not.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Visit the domain overview page for a domain connection that's resolving to a WPCOM site
- Ensure the badge reads "Connected"
- Visit the domain overview page for a domain connection that's not resolving to a WPCOM site
- Ensure the badge reads either "Verifying name servers" or "Verifying DNS", depending on the connection mode

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
