### PR TITLE
Fix redirect after purchasing Titan email from the MSD

### DIFF
--- a/client/dashboard/emails/hooks/use-add-to-cart.ts
+++ b/client/dashboard/emails/hooks/use-add-to-cart.ts
@@ -5,7 +5,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../app/analytics';
 import { emailsRoute, mailboxesReadyRoute } from '../../app/router/emails';
-import { wpcomLink } from '../../utils/link';
+import { dashboardLink, wpcomLink } from '../../utils/link';
 import { MailboxOperations } from '../entities/mailbox-operations';
 import { getCartItems } from '../utils/get-cart-items';
 import { getEmailProductProperties } from '../utils/get-email-product-properties';
@@ -59,7 +59,7 @@ export const useAddToCart = () => {
 			} ).href;
 
 		const checkoutPath = addQueryArgs( wpcomLink( '/checkout/' + site?.slug || '' ), {
-			redirect_to: redirectPath,
+			redirect_to: dashboardLink( redirectPath ),
 			checkoutBackUrl: backUrl,
 		} );
 


### PR DESCRIPTION
Part of DOTEMP-59

## Proposed Changes

- Wrap the `redirect_to` parameter with `dashboardLink()` when redirecting to the mailboxes-ready page after purchasing Titan email from the MSD

## Why are these changes being made?

After purchasing Titan email from the Multi-Site Dashboard (MSD), users were being redirected to a 404 page. This happened because the checkout `redirect_to` parameter was using a relative path (`/emails/mailboxes-ready/...`) without specifying the dashboard origin.

The checkout page lives on `wordpress.com`, so it was redirecting to `https://wordpress.com/emails/mailboxes-ready/...`. However, the `/emails/mailboxes-ready/` route only exists in the MSD (`my.wordpress.com`), not in the main Calypso application.

Wrapping the redirect path with `dashboardLink()` ensures the full MSD URL (`https://my.wordpress.com/emails/mailboxes-ready/...`) is used for the redirect, taking users to the correct destination after checkout.

## Testing Instructions

### Prerequisites
- A WordPress.com site with a custom domain that doesn't have email configured
- Access to the Multi-Site Dashboard (my.wordpress.com)

### Steps
1. Navigate to the MSD: https://my.wordpress.com
2. Select a site that has a custom domain without email configured
3. Go to **Emails** in the site menu
4. Click **Add email** or start the Titan email purchase flow
5. Fill in the mailbox details and proceed to checkout
6. Complete the checkout process
7. **Expected result:** After checkout, you should be redirected to the "mailboxes ready" confirmation page (`/emails/mailboxes-ready/your-domain.com`) in the MSD, not a 404 page

### Before the fix
After checkout, users were redirected to `https://wordpress.com/emails/mailboxes-ready/...` which showed a 404 "This Page Doesn't Exist" error.

### After the fix
After checkout, users are correctly redirected to `https://my.wordpress.com/emails/mailboxes-ready/...` which shows the mailboxes ready confirmation.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?