### PR TITLE
AI Tools: Add summary button to site settings

### DIFF
--- a/client/dashboard/sites/settings-ai-tools/summary.tsx
+++ b/client/dashboard/sites/settings-ai-tools/summary.tsx
@@ -1,0 +1,50 @@
+import { bigSkyPluginQuery } from '@automattic/api-queries';
+import { BigSkyLogo } from '@automattic/components/src/logos/big-sky-logo';
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Site } from '@automattic/api-core';
+import type { Density } from '@automattic/components/src/summary-button/types';
+
+export default function AISiteToolsSettingsSummary( {
+	site,
+	density,
+}: {
+	site: Site;
+	density?: Density;
+} ) {
+	const { data: pluginStatus } = useQuery( bigSkyPluginQuery( site.ID ) );
+	const isEnabled = pluginStatus?.enabled ?? false;
+	const isAvailable = pluginStatus?.available ?? false;
+
+	const getBadge = () => {
+		if ( ! isAvailable ) {
+			return [];
+		}
+
+		if ( isEnabled ) {
+			return [
+				{
+					text: __( 'Enabled' ),
+					intent: 'success' as const,
+				},
+			];
+		}
+
+		return [
+			{
+				text: __( 'Disabled' ),
+			},
+		];
+	};
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/ai-tools` }
+			title={ __( 'AI tools (early access)' ) }
+			density={ density }
+			decoration={ <BigSkyLogo.CentralLogo heartless size={ 24 } fill="#757575" /> }
+			badges={ getBadge() }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings-ai-tools/summary.tsx
+++ b/client/dashboard/sites/settings-ai-tools/summary.tsx
@@ -13,12 +13,12 @@ export default function AISiteToolsSettingsSummary( {
 	site: Site;
 	density?: Density;
 } ) {
-	const { data: pluginStatus } = useQuery( bigSkyPluginQuery( site.ID ) );
+	const { data: pluginStatus, isLoading } = useQuery( bigSkyPluginQuery( site.ID ) );
 	const isEnabled = pluginStatus?.enabled ?? false;
 	const isAvailable = pluginStatus?.available ?? false;
 
 	const getBadge = () => {
-		if ( ! isAvailable ) {
+		if ( isLoading || ! isAvailable ) {
 			return [];
 		}
 

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -1,5 +1,5 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
-import config from '@automattic/calypso-config';
+import { isEnabled } from '@automattic/calypso-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -10,6 +10,7 @@ import { SummaryButtonList } from '../../components/summary-button-list';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import AgencySettingsSummary from '../settings-agency/summary';
 import AISiteAssistantSettingsSummary from '../settings-ai-assistant/summary';
+import AISiteToolsSettingsSummary from '../settings-ai-tools/summary';
 import CachingSettingsSummary from '../settings-caching/summary';
 import DatabaseSettingsSummary from '../settings-database/summary';
 import DefensiveModeSettingsSummary from '../settings-defensive-mode/summary';
@@ -50,6 +51,9 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 					<SectionHeader title={ __( 'General' ) } level={ 3 } />
 					<SummaryButtonList>
 						<SiteVisibilitySettingsSummary site={ site } />
+						{ isEnabled( 'wordpress-ai-tools' ) ? (
+							<AISiteToolsSettingsSummary site={ site } />
+						) : null }
 						{ siteTypeSupports.settingsGeneralRedirect ? (
 							<SiteRedirectSettingsSummary site={ site } />
 						) : null }
@@ -85,7 +89,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 					</SummaryButtonList>
 				</VStack>
 			) }
-			{ siteTypeSupports.settingsExperimental && config.isEnabled( 'wordpress-ai-assistant' ) && (
+			{ siteTypeSupports.settingsExperimental && isEnabled( 'wordpress-ai-assistant' ) && (
 				<VStack spacing={ 3 }>
 					<SectionHeader title={ __( 'Experimental (Staging)' ) } level={ 3 } />
 					<SummaryButtonList>

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -22,7 +22,8 @@
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
-		"wordpress-ai-assistant": true
+		"wordpress-ai-assistant": true,
+		"wordpress-ai-tools": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -20,7 +20,7 @@
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
-		"wordpress-ai-tools": false
+		"wordpress-ai-tools": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -19,7 +19,8 @@
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,
-		"mcp-settings": true
+		"mcp-settings": true,
+		"wordpress-ai-tools": false
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -16,7 +16,8 @@
 		"dashboard/v2": false,
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,
-		"mcp-settings": true
+		"mcp-settings": true,
+		"wordpress-ai-tools": false
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -18,7 +18,8 @@
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
-		"wordpress-ai-assistant": true
+		"wordpress-ai-assistant": true,
+		"wordpress-ai-tools": false
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/development.json
+++ b/config/development.json
@@ -202,6 +202,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"user-management-revamp": true,
 		"wordpress-ai-assistant": true,
+		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -135,6 +135,7 @@
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
 		"wordpress-ai-assistant": false,
+		"wordpress-ai-tools": false,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/production.json
+++ b/config/production.json
@@ -171,6 +171,7 @@
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
 		"wordpress-ai-assistant": false,
+		"wordpress-ai-tools": false,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/stage.json
+++ b/config/stage.json
@@ -168,6 +168,7 @@
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
 		"wordpress-ai-assistant": true,
+		"wordpress-ai-tools": false,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -173,6 +173,7 @@
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
 		"wordpress-ai-assistant": false,
+		"wordpress-ai-tools": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-1057

## Proposed Changes

* Use `wordpress-ai-tools` feature flag to control the new AI tools setting
* Add AI tools summary button to site settings

| Available sites | Unavailable sites
| - | - |
| <img width="676" height="70" alt="image" src="https://github.com/user-attachments/assets/c7127760-cb40-4089-81df-2aa123313c39" /> |<img width="673" height="71" alt="image" src="https://github.com/user-attachments/assets/77c1948e-e8bc-4f14-a849-f44e5850bc78" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A new AI Settings section in site settings

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites/:site/settings on your site
* Ensure you can see the "Disabled/Enabled" badge on your Business or above site
* Ensure you cannot see the badge on your Business below site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
