### PR TITLE
MSD: Fix filter sanitization to account for undefined filter value

### DIFF
--- a/client/dashboard/components/dataviews/sanitize-view.ts
+++ b/client/dashboard/components/dataviews/sanitize-view.ts
@@ -21,11 +21,13 @@ export function sanitizeView( view: View, fields: Field< any >[] ) {
 		if ( ! fieldsSet.has( filter.field ) ) {
 			return false;
 		}
-		if ( filter.operator === 'is' && Array.isArray( filter.value ) ) {
-			return false;
-		}
-		if ( filter.operator === 'isAny' && ! Array.isArray( filter.value ) ) {
-			return false;
+		if ( filter.value !== undefined ) {
+			if ( filter.operator === 'is' && Array.isArray( filter.value ) ) {
+				return false;
+			}
+			if ( filter.operator === 'isAny' && ! Array.isArray( filter.value ) ) {
+				return false;
+			}
 		}
 		return true;
 	} );

--- a/client/dashboard/components/dataviews/test/sanitize-view.test.ts
+++ b/client/dashboard/components/dataviews/test/sanitize-view.test.ts
@@ -10,6 +10,7 @@ describe( 'sanitizeView', () => {
 		{ id: 'name', enableSorting: true },
 		{ id: 'is_deleted', enableSorting: false },
 		{ id: 'visibility', enableSorting: true },
+		{ id: 'plan', enableSorting: true },
 	];
 
 	const validView: View = {
@@ -18,6 +19,7 @@ describe( 'sanitizeView', () => {
 		filters: [
 			{ field: 'is_deleted', operator: 'is', value: true },
 			{ field: 'visibility', operator: 'isAny', value: [ 'public', 'private' ] },
+			{ field: 'plan', operator: 'isAny', value: undefined },
 		],
 	};
 


### PR DESCRIPTION
Fixes p1769403200922879-slack-CRWCHQGUB

## Proposed Changes

This fixes regression from https://github.com/Automattic/wp-calypso/pull/108263. A filter value can be undefined, when the value is not yet selected from the UI.

## Testing Instructions

1. Go to /sites
2. Verify all the filters are working

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?