### PR TITLE
Fix smooch cleanup

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -21,29 +21,34 @@ import { HELP_CENTER_STORE } from '../stores';
 import { getClientId, getZendeskConversations } from './utils';
 import type { ZendeskMessage } from '@automattic/zendesk-client';
 
-const destroy = () => {
-	try {
-		Smooch.destroy();
-	} catch ( error ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Error destroying Smooch', error );
+// Module-level promise to ensure init() waits for any pending destroy() to complete
+let destroyPromise: Promise< void > | null = null;
+
+const destroySmooch = (): Promise< void > => {
+	const result = Smooch?.destroy?.();
+
+	// Smooch.destroy() returns undefined if Smooch wasn't initialized
+	if ( ! result ) {
+		return Promise.resolve();
 	}
+
+	destroyPromise = result.finally( () => {
+		destroyPromise = null;
+	} );
+
+	return destroyPromise;
 };
 
-const initSmooch = (
-	{
-		jwt,
-		externalId,
-	}: {
-		isLoggedIn: boolean;
-		jwt: string;
-		externalId: string | undefined;
-	},
+const waitForPendingDestroy = (): Promise< void > => destroyPromise ?? Promise.resolve();
+
+const initSmooch = async (
+	jwt: string,
+	externalId: string,
 	queryClient: QueryClient
-) => {
+): Promise< void > => {
 	const isTestMode = isTestModeEnvironment();
 
-	return Smooch.init( {
+	await Smooch.init( {
 		integrationId: isTestMode ? SMOOCH_INTEGRATION_ID_STAGING : SMOOCH_INTEGRATION_ID,
 		delegate: {
 			async onInvalidAuth() {
@@ -116,7 +121,9 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 	const allowChat = canConnectToZendesk && enableAuth && ( isEligibleForChat || hasPremiumSupport );
 
 	const { data: authData } = useAuthenticateZendeskMessaging( allowChat, 'messenger' );
-
+	const authJwt = authData?.jwt;
+	const authExternalId = authData?.externalId;
+	const authIsLoggedIn = authData?.isLoggedIn;
 	const { isMessagingScriptLoaded } = useLoadZendeskMessaging( allowChat, allowChat );
 	const {
 		setIsChatLoaded,
@@ -187,47 +194,67 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 
 	// Initialize Smooch which communicates with Zendesk
 	useEffect( () => {
-		if (
-			! isMessagingScriptLoaded ||
-			! authData?.isLoggedIn ||
-			! authData?.jwt ||
-			! authData?.externalId
-		) {
+		if ( ! isMessagingScriptLoaded || ! authIsLoggedIn || ! authJwt || ! authExternalId ) {
 			return;
 		}
 
 		let retryTimeout: ReturnType< typeof setTimeout > | undefined;
+		let isCancelled = false;
 
-		const initializeSmooch = async () => {
-			initSmooch( authData, queryClient )
-				.then( () => {
-					setIsChatLoaded( true );
-					recordTracksEvent( 'calypso_smooch_messenger_init', {
-						success: true,
-						error: '',
-					} );
-				} )
-				.catch( ( error ) => {
-					setIsChatLoaded( false );
-					retryTimeout = setTimeout( initializeSmooch, 30000 );
-					recordTracksEvent( 'calypso_smooch_messenger_init', {
-						success: false,
-						error: error.message,
-					} );
+		const initialize = async () => {
+			await waitForPendingDestroy();
+
+			if ( isCancelled ) {
+				return;
+			}
+
+			setIsChatLoaded( false );
+
+			try {
+				await initSmooch( authJwt, authExternalId, queryClient );
+
+				if ( isCancelled ) {
+					return;
+				}
+
+				setIsChatLoaded( true );
+				recordTracksEvent( 'calypso_smooch_messenger_init', {
+					success: true,
+					error: '',
 				} );
+			} catch ( error ) {
+				if ( isCancelled ) {
+					return;
+				}
+
+				setIsChatLoaded( false );
+				retryTimeout = setTimeout( initialize, 30000 );
+				recordTracksEvent( 'calypso_smooch_messenger_init', {
+					success: false,
+					error: ( error as Error ).message,
+				} );
+			}
 		};
 
-		initializeSmooch();
+		initialize();
 
 		if ( smoochRef.current ) {
 			Smooch.render( smoochRef.current );
 		}
 
 		return () => {
+			isCancelled = true;
 			clearTimeout( retryTimeout );
-			destroy();
+			destroySmooch();
 		};
-	}, [ isMessagingScriptLoaded, authData, setIsChatLoaded, queryClient ] );
+	}, [
+		isMessagingScriptLoaded,
+		authIsLoggedIn,
+		authJwt,
+		authExternalId,
+		setIsChatLoaded,
+		queryClient,
+	] );
 
 	useEffect( () => {
 		if ( isChatLoaded && getZendeskConversations ) {

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -21,26 +21,6 @@ import { HELP_CENTER_STORE } from '../stores';
 import { getClientId, getZendeskConversations } from './utils';
 import type { ZendeskMessage } from '@automattic/zendesk-client';
 
-// Module-level promise to ensure init() waits for any pending destroy() to complete
-let destroyPromise: Promise< void > | null = null;
-
-const destroySmooch = (): Promise< void > => {
-	const result = Smooch?.destroy?.();
-
-	// Smooch.destroy() returns undefined if Smooch wasn't initialized
-	if ( ! result ) {
-		return Promise.resolve();
-	}
-
-	destroyPromise = result.finally( () => {
-		destroyPromise = null;
-	} );
-
-	return destroyPromise;
-};
-
-const waitForPendingDestroy = (): Promise< void > => destroyPromise ?? Promise.resolve();
-
 const initSmooch = async (
 	jwt: string,
 	externalId: string,
@@ -202,13 +182,12 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 		let isCancelled = false;
 
 		const initialize = async () => {
-			await waitForPendingDestroy();
+			setIsChatLoaded( false );
+			await Smooch?.destroy?.();
 
 			if ( isCancelled ) {
 				return;
 			}
-
-			setIsChatLoaded( false );
 
 			try {
 				await initSmooch( authJwt, authExternalId, queryClient );
@@ -245,7 +224,7 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 		return () => {
 			isCancelled = true;
 			clearTimeout( retryTimeout );
-			destroySmooch();
+			Smooch?.destroy?.();
 		};
 	}, [
 		isMessagingScriptLoaded,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTCOM-15835

## Proposed Changes

* Before initialising smooch ensure destroy is awaited properly and everything is cleaned up.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Race condition can trigger in some scenarios

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Run `yarn && yarn start-dashboard`
* Add console tracking to the init smooch promise to log errors
* Open and close the help center multiple times to trigger the condition
* Before this PR smooch init can fail with: "Web Messenger is already initialized. Call `destroy()` first before calling `init()`"
* We didn't recover properly from this state properly resulting in users unable to reach support.
* Test for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
