### PR TITLE
Fix race condition in happy blocks

### DIFF
--- a/apps/happy-blocks/block-library/search-card/view-odie.js
+++ b/apps/happy-blocks/block-library/search-card/view-odie.js
@@ -40,10 +40,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 			input.value = query;
 			submitButton.click();
-
-			setTimeout( () => {
-				input.value = '';
-			}, 100 );
+			input.value = '';
 		} );
 	} );
 
@@ -54,8 +51,11 @@ document.addEventListener( 'DOMContentLoaded', function () {
 				e.preventDefault();
 				e.stopPropagation();
 
+				// Use the submitted value, not the input.value since it's already cleared.
+				const searchQuery = new FormData( form ).get( 'odie-query' );
+
 				recordTracksEvent( 'calypso_happyblocks_support_ask_odie', {
-					query: input.value,
+					query: searchQuery,
 					location: window.location.href,
 				} );
 				const isLoggedOut = ! helpCenterData?.currentUser?.ID;
@@ -67,8 +67,10 @@ document.addEventListener( 'DOMContentLoaded', function () {
 						input.removeAttribute( 'disabled' );
 						if ( window.wp?.data?.dispatch ) {
 							const helpCenterDispatch = window.wp.data.dispatch( 'automattic/help-center' );
+
 							helpCenterDispatch.setNavigateToRoute(
-								'/odie?query=' + encodeURIComponent( input.value )
+								'/odie?query=' + encodeURIComponent( searchQuery ),
+								true
 							);
 							helpCenterDispatch.setShowHelpCenter( true );
 						}
@@ -77,7 +79,8 @@ document.addEventListener( 'DOMContentLoaded', function () {
 					// Logged in variant is already loaded.
 					const helpCenterDispatch = window.wp.data.dispatch( 'automattic/help-center' );
 					helpCenterDispatch.setNavigateToRoute(
-						'/odie?query=' + encodeURIComponent( input.value )
+						'/odie?query=' + encodeURIComponent( searchQuery ),
+						true
 					);
 					helpCenterDispatch.setShowHelpCenter( true );
 				}


### PR DESCRIPTION
### Changes

The Happy Blocks to Help Center integration had a race condition. When you click a suggested prompt in [the support site](https://wordpress.com/support?dotcom_support_enable_odie_answers=true), we load the Help Center asynchronously, and when it loads, we pick up the value from the field. 

But we also cleared the field after 100 ms. This means by the time the HC loads, the prompt will have already been empty.

### Testing
1. `cd apps/happy-blocks` and run `yarn dev --sync`.
2. open the support site with the flag: https://wordpress.com/support?dotcom_support_enable_odie_answers=true 
3. Click a suggestion under the search field.
4. It should populate the input.