### PR TITLE
Fix Sentry error when blurring search component

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -208,7 +208,7 @@ class Search extends Component {
 		setTimeout( () => this.searchInput && this.searchInput.focus(), 0 );
 	};
 
-	blur = () => this.searchInput.blur();
+	blur = () => this.searchInput?.blur();
 
 	clear = () => this.setState( { keyword: '' } );
 


### PR DESCRIPTION
Fixes DOTMSD-1060

## Proposed Changes

Fixes a crash in the `<Search>` component because of a possible function call to an `undefined` reference.

## Testing Instructions

I have not been able to reproduce the issue, but the issue has been happening for hundreds of users so we should fix this. We can smoke-test screens using this component; for example, verify this card in `/home/:siteSlug` is still working"

<img width="715" height="458" alt="image" src="https://github.com/user-attachments/assets/1411f5f3-d301-4b23-8226-c5b75ac5185e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
