### PR TITLE
Use the stored preference to automatically load the lazy-loaded Help Center

### DIFF
--- a/client/dashboard/app/help-center/index.ts
+++ b/client/dashboard/app/help-center/index.ts
@@ -1,3 +1,5 @@
+import { userPreferenceQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { dispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState, useRef } from 'react';
 // eslint-disable-next-line no-restricted-imports
@@ -14,6 +16,8 @@ const HELP_CENTER_STORE = 'automattic/help-center';
 export function useHelpCenter() {
 	const loadingPromiseRef = useRef< Promise< unknown > >();
 	const [ isLoading, setIsLoading ] = useState( false );
+	const wasShownFromLastSession = useQuery( userPreferenceQuery( 'help_center_open' ) );
+
 	const isShown = useSelect(
 		( select ) => !! ( select( HELP_CENTER_STORE ) as HelpCenterSelect )?.isHelpCenterShown?.(),
 		[ isLoading ] // We need to re-evaluate this incase a component used the hook before the store was loaded.
@@ -68,7 +72,7 @@ export function useHelpCenter() {
 
 	return {
 		isLoading,
-		isShown,
+		isShown: isShown || wasShownFromLastSession,
 		setShowHelpCenter,
 		setNavigateToRoute,
 		setSubject,

--- a/client/dashboard/app/help-center/index.ts
+++ b/client/dashboard/app/help-center/index.ts
@@ -16,7 +16,7 @@ const HELP_CENTER_STORE = 'automattic/help-center';
 export function useHelpCenter() {
 	const loadingPromiseRef = useRef< Promise< unknown > >();
 	const [ isLoading, setIsLoading ] = useState( false );
-	const wasShownFromLastSession = useQuery( userPreferenceQuery( 'help_center_open' ) );
+	const { data: wasShownFromLastSession } = useQuery( userPreferenceQuery( 'help_center_open' ) );
 
 	const isShown = useSelect(
 		( select ) => !! ( select( HELP_CENTER_STORE ) as HelpCenterSelect )?.isHelpCenterShown?.(),

--- a/client/dashboard/sites/site/test/environment-switcher.test.tsx
+++ b/client/dashboard/sites/site/test/environment-switcher.test.tsx
@@ -64,6 +64,10 @@ jest.mock( '@automattic/api-queries', () => ( {
 		queryKey: [ 'site-by-slug', slug ],
 		queryFn: () => Promise.resolve( { slug, ID: 1 } ),
 	} ) ),
+	userPreferenceQuery: jest.fn( ( preference ) => ( {
+		queryKey: [ 'user-preference', preference ],
+		queryFn: () => Promise.resolve( false ),
+	} ) ),
 } ) );
 
 jest.mock( '@tanstack/react-query', () => ( {

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -18,6 +18,7 @@ export interface ReaderLandingPage extends LandingPagePreference {
 }
 
 export interface UserPreferences {
+	help_center_open?: boolean;
 	'hosting-dashboard-opt-in'?: HostingDashboardOptIn;
 	'hosting-dashboard-opt-in-welcome-modal-dismissed'?: string; // Timestamp when the user dismissed the modal
 	[ key: `hosting-dashboard-dataviews-view-${ string }` ]: View | undefined;

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -4,6 +4,7 @@ import { queryClient } from './query-client';
 import type { UserPreferences } from '@automattic/api-core';
 
 const defaultValues: Required< UserPreferences > = {
+	help_center_open: false,
 	'hosting-dashboard-opt-in': { value: 'unset', updated_at: '' },
 	'hosting-dashboard-opt-in-welcome-modal-dismissed': '',
 	'hosting-dashboard-welcome-notice-dismissed': '',


### PR DESCRIPTION
Fixes DOTMSD-967

## Proposed Changes

Use the persisted use preference to auto-load the lazy-loaded Help Center.

## Why are these changes being made?
To allow the user to continue their chat and general support sessions across page refreshes and redirects.

## Testing Instructions

1. Open the V2 dashboard via the live link or locally (`yarn start-dashboard`).
2. Open the HC.
3. Refresh the page.
4. The HC should pop-back open.