### PR TITLE
Remove dependency with Help Center for Agents Manager app.

### DIFF
--- a/apps/agents-manager/agents-manager-with-provider.js
+++ b/apps/agents-manager/agents-manager-with-provider.js
@@ -1,4 +1,4 @@
-/* global helpCenterData */
+/* global agentsManagerData */
 import AgentsManager from '@automattic/agents-manager';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -8,9 +8,9 @@ export default function AgentsManagerWithProvider() {
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<AgentsManager
-				sectionName={ helpCenterData.sectionName || 'wp-admin' }
-				currentUser={ helpCenterData.currentUser }
-				site={ helpCenterData.site }
+				sectionName={ agentsManagerData.sectionName || 'wp-admin' }
+				currentUser={ agentsManagerData.currentUser }
+				site={ agentsManagerData.site }
 			/>
 		</QueryClientProvider>
 	);

--- a/apps/agents-manager/agents-manager-with-provider.js
+++ b/apps/agents-manager/agents-manager-with-provider.js
@@ -11,7 +11,6 @@ export default function AgentsManagerWithProvider() {
 				sectionName={ agentsManagerData.sectionName || 'wp-admin' }
 				currentUser={ agentsManagerData.currentUser }
 				site={ agentsManagerData.site }
-				isEligibleForChat={ agentsManagerData.isEligibleForChat ?? false }
 			/>
 		</QueryClientProvider>
 	);

--- a/apps/agents-manager/agents-manager-with-provider.js
+++ b/apps/agents-manager/agents-manager-with-provider.js
@@ -11,6 +11,7 @@ export default function AgentsManagerWithProvider() {
 				sectionName={ agentsManagerData.sectionName || 'wp-admin' }
 				currentUser={ agentsManagerData.currentUser }
 				site={ agentsManagerData.site }
+				isEligibleForChat={ agentsManagerData.isEligibleForChat ?? false }
 			/>
 		</QueryClientProvider>
 	);

--- a/packages/agents-manager/README.md
+++ b/packages/agents-manager/README.md
@@ -64,14 +64,14 @@ function MyComponent() {
 
 ### UnifiedAIAgent Props
 
-| Prop                | Type                        | Description                                                |
-| ------------------- | --------------------------- | ---------------------------------------------------------- |
-| `currentRoute`      | `string` (optional)         | The current route path.                                    |
-| `isEligibleForChat` | `boolean`                   | Indicates if the user is eligible for chat.                |
-| `sectionName`       | `string`                    | The name of the current section (e.g., 'posts', 'pages').  |
-| `site`              | `HelpCenterSite` (optional) | The selected site object (from `@automattic/data-stores`). |
-| `currentUser`       | `CurrentUser` (optional)    | The current user object (from `@automattic/data-stores`).  |
-| `handleClose`       | `() => void` (optional)     | Called when the agent is closed.                           |
+| Prop                | Type                           | Description                                                |
+| ------------------- | ------------------------------ | ---------------------------------------------------------- |
+| `currentRoute`      | `string` (optional)            | The current route path.                                    |
+| `isEligibleForChat` | `boolean`                      | Indicates if the user is eligible for chat.                |
+| `sectionName`       | `string`                       | The name of the current section (e.g., 'posts', 'pages').  |
+| `site`              | `AgentsManagerSite` (optional) | The selected site object (from `@automattic/data-stores`). |
+| `currentUser`       | `CurrentUser` (optional)       | The current user object (from `@automattic/data-stores`).  |
+| `handleClose`       | `() => void` (optional)        | Called when the agent is closed.                           |
 
 ### Exported Types
 

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -72,6 +72,7 @@ export default function AgentChat( {
 	clearSuggestions,
 	markdownComponents = {},
 	markdownExtensions = {},
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Kept for API compatibility with ZendeskChat
 	onTypingStatusChange,
 }: AgentChatProps ) {
 	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
@@ -105,7 +106,6 @@ export default function AgentChat( {
 			onExpand={ onExpand }
 			onStop={ onAbort }
 			messageRenderer={ messageRenderer }
-			onTypingStatusChange={ onTypingStatusChange }
 			emptyView={
 				isLoadingConversation ? (
 					<ChatMessageSkeleton count={ 3 } />

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -33,11 +33,11 @@ import type {
 	AbilitiesSetupHook,
 } from '../../utils/load-external-providers';
 import type { Message as UILibraryMessage } from '@automattic/agenttic-ui/dist/types';
-import type { AgentsManagerSelect, HelpCenterSite } from '@automattic/data-stores';
+import type { AgentsManagerSelect, AgentsManagerSite } from '@automattic/data-stores';
 
 interface AgentDockProps {
 	/** The selected site object. */
-	site?: HelpCenterSite | null;
+	site?: AgentsManagerSite | null;
 	/** The name of the current section (e.g., 'posts', 'pages'). */
 	sectionName: string;
 	/** Indicates if the user is eligible for chat. */

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { comment, drawerRight, login, lifesaver } from '@wordpress/icons';
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
+import { useAgentsManagerContext } from '../../contexts';
 import useAdminBarIntegration from '../../hooks/use-admin-bar-integration';
 import useAgentLayoutManager from '../../hooks/use-agent-layout-manager';
 import useConversation from '../../hooks/use-conversation';
@@ -33,15 +34,9 @@ import type {
 	AbilitiesSetupHook,
 } from '../../utils/load-external-providers';
 import type { Message as UILibraryMessage } from '@automattic/agenttic-ui/dist/types';
-import type { AgentsManagerSelect, AgentsManagerSite } from '@automattic/data-stores';
+import type { AgentsManagerSelect } from '@automattic/data-stores';
 
 interface AgentDockProps {
-	/** The selected site object. */
-	site?: AgentsManagerSite | null;
-	/** The name of the current section (e.g., 'posts', 'pages'). */
-	sectionName: string;
-	/** Indicates if the user is eligible for chat. */
-	isEligibleForChat: boolean;
 	/** Agent configuration for the chat client. */
 	agentConfig: UseAgentChatConfig;
 	/** Suggestions displayed when the chat is empty. */
@@ -58,15 +53,13 @@ interface AgentDockProps {
 
 export default function AgentDock( {
 	agentConfig,
-	site,
-	sectionName,
-	isEligibleForChat,
 	emptyViewSuggestions = [],
 	markdownComponents = {},
 	markdownExtensions = {},
 	useNavigationContinuation,
 	useAbilitiesSetup,
 }: AgentDockProps ) {
+	const { site, sectionName, isEligibleForChat } = useAgentsManagerContext();
 	const [ isThinking, setIsThinking ] = useState( false );
 	const [ deletedMessageIds, setDeletedMessageIds ] = useState< Set< string > >( new Set() );
 	const { setIsOpen, setIsDocked } = useDispatch( AGENTS_MANAGER_STORE );

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -34,8 +34,6 @@ function AgentsManagerInner( {
  *
  * Wraps children with AgentsManagerContextProvider to make user, site,
  * and section data available throughout the component tree.
- *
- * This follows the same pattern as Help Center's ContextualizedHelpCenter.
  */
 export default function AgentsManager( {
 	sectionName,

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -1,15 +1,26 @@
-import {
-	HelpCenterRequiredContextProvider,
-	type HelpCenterRequiredInformation,
-	useHelpCenterContext,
-} from '@automattic/help-center/src/contexts/HelpCenterContext';
-import useChatStatus from '@automattic/help-center/src/hooks/use-chat-status';
 import UnifiedAIAgent from './unified-ai-agent';
+import type { AgentsManagerSite, CurrentUser } from '@automattic/data-stores';
 
-function AgentsManager() {
-	const { currentUser, site, sectionName } = useHelpCenterContext();
-	const { isEligibleForChat } = useChatStatus();
+export interface AgentsManagerProps {
+	sectionName: string;
+	currentUser?: CurrentUser;
+	site?: AgentsManagerSite | null;
+	isEligibleForChat: boolean;
+}
 
+/**
+ * Standalone AgentsManager component.
+ *
+ * Unlike the Help Center integration, this component receives all required
+ * data as props rather than through context. This allows it to work
+ * independently of the Help Center plugin.
+ */
+export default function AgentsManager( {
+	sectionName,
+	currentUser,
+	site,
+	isEligibleForChat,
+}: AgentsManagerProps ) {
 	return (
 		<UnifiedAIAgent
 			isEligibleForChat={ isEligibleForChat }
@@ -17,15 +28,5 @@ function AgentsManager() {
 			site={ site }
 			sectionName={ sectionName }
 		/>
-	);
-}
-
-export default function ContextualizedAgentsManager(
-	props: Pick< HelpCenterRequiredInformation, 'currentUser' | 'sectionName' | 'site' >
-) {
-	return (
-		<HelpCenterRequiredContextProvider value={ props }>
-			<AgentsManager />
-		</HelpCenterRequiredContextProvider>
 	);
 }

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -1,32 +1,52 @@
+import { AgentsManagerContextProvider } from '../contexts';
 import UnifiedAIAgent from './unified-ai-agent';
 import type { AgentsManagerSite, CurrentUser } from '@automattic/data-stores';
 
 export interface AgentsManagerProps {
+	/** The name of the current section (e.g., 'wp-admin', 'gutenberg'). */
 	sectionName: string;
+	/** The current user object. */
 	currentUser?: CurrentUser;
+	/** The selected site object. */
 	site?: AgentsManagerSite | null;
-	isEligibleForChat: boolean;
+	/** The current route path. */
+	currentRoute?: string;
+	/** Called when the agent is closed. */
+	handleClose?: () => void;
 }
 
 /**
- * Standalone AgentsManager component.
+ * Inner component that renders UnifiedAIAgent.
+ * Separated to keep context provider at the top level.
+ */
+function AgentsManagerInner( {
+	currentRoute,
+	handleClose,
+}: {
+	currentRoute?: string;
+	handleClose?: () => void;
+} ) {
+	return <UnifiedAIAgent currentRoute={ currentRoute } handleClose={ handleClose } />;
+}
+
+/**
+ * Main AgentsManager component.
  *
- * Unlike the Help Center integration, this component receives all required
- * data as props rather than through context. This allows it to work
- * independently of the Help Center plugin.
+ * Wraps children with AgentsManagerContextProvider to make user, site,
+ * and section data available throughout the component tree.
+ *
+ * This follows the same pattern as Help Center's ContextualizedHelpCenter.
  */
 export default function AgentsManager( {
 	sectionName,
 	currentUser,
 	site,
-	isEligibleForChat,
+	currentRoute,
+	handleClose,
 }: AgentsManagerProps ) {
 	return (
-		<UnifiedAIAgent
-			isEligibleForChat={ isEligibleForChat }
-			currentUser={ currentUser }
-			site={ site }
-			sectionName={ sectionName }
-		/>
+		<AgentsManagerContextProvider value={ { sectionName, currentUser, site } }>
+			<AgentsManagerInner currentRoute={ currentRoute } handleClose={ handleClose } />
+		</AgentsManagerContextProvider>
 	);
 }

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -1,6 +1,5 @@
 import { AgentUI } from '@automattic/agenttic-ui';
 import { AgentsManagerSelect } from '@automattic/data-stores';
-import { useHelpSearchQuery } from '@automattic/help-center/src/hooks/use-help-search-query';
 import {
 	SearchControl,
 	__experimentalVStack as VStack,
@@ -16,6 +15,19 @@ import { Link } from 'react-router-dom';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import ChatHeader, { Options } from '../chat-header';
 import './style.scss';
+
+/**
+ * Stub for useHelpSearchQuery.
+ * TODO: Implement actual search functionality when adding support for support guides.
+ * This was previously imported from @automattic/help-center but removed to decouple packages.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function useHelpSearchQuery( query: string, locale: string, sectionName: string ) {
+	return {
+		data: [] as Array< { post_id: number; link: string; title: string } >,
+		isFetching: false,
+	};
+}
 
 function SearchResults( { searchInput }: { searchInput: string } ) {
 	const { data: searchData, isFetching: isSearching } = useHelpSearchQuery(

--- a/packages/agents-manager/src/components/test/AgentsManager.test.tsx
+++ b/packages/agents-manager/src/components/test/AgentsManager.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- AgentsManager must be imported after jest.mock */
+import { render, screen } from '@testing-library/react';
+import type { AgentsManagerContextType } from '../../contexts';
+
+// Store context values captured by the mock
+let mockCapturedContext: AgentsManagerContextType | null = null;
+
+// Mock UnifiedAIAgent to avoid complex dependencies and capture context
+jest.mock( '../unified-ai-agent', () => ( {
+	__esModule: true,
+	default: function MockUnifiedAIAgent() {
+		// Import context hook inside mock (allowed with require)
+		const { useAgentsManagerContext } = require( '../../contexts' );
+		mockCapturedContext = useAgentsManagerContext();
+		return (
+			<div data-testid="mock-unified-agent">
+				<span data-testid="context-sectionName">{ mockCapturedContext.sectionName }</span>
+				<span data-testid="context-userId">{ mockCapturedContext.currentUser?.ID ?? 'none' }</span>
+				<span data-testid="context-siteId">{ mockCapturedContext.site?.ID ?? 'none' }</span>
+				<span data-testid="context-siteDomain">{ mockCapturedContext.site?.domain ?? 'none' }</span>
+				<span data-testid="context-isEligibleForChat">
+					{ String( mockCapturedContext.isEligibleForChat ) }
+				</span>
+			</div>
+		);
+	},
+} ) );
+
+// Import AgentsManager after mocking UnifiedAIAgent
+import AgentsManager from '../agents-manager';
+
+describe( 'AgentsManager', () => {
+	beforeEach( () => {
+		mockCapturedContext = null;
+	} );
+
+	it( 'provides sectionName to child components via context', () => {
+		render( <AgentsManager sectionName="gutenberg" /> );
+
+		expect( screen.getByTestId( 'context-sectionName' ).textContent ).toBe( 'gutenberg' );
+	} );
+
+	it( 'provides currentUser to child components via context', () => {
+		const mockUser = {
+			ID: 123,
+			username: 'testuser',
+			display_name: 'Test User',
+			email: 'test@example.com',
+		} as AgentsManagerContextType[ 'currentUser' ];
+
+		render( <AgentsManager sectionName="wp-admin" currentUser={ mockUser } /> );
+
+		expect( screen.getByTestId( 'context-userId' ).textContent ).toBe( '123' );
+	} );
+
+	it( 'provides site to child components via context', () => {
+		const mockSite = {
+			ID: 456,
+			domain: 'example.com',
+		};
+
+		render( <AgentsManager sectionName="wp-admin" site={ mockSite } /> );
+
+		expect( screen.getByTestId( 'context-siteId' ).textContent ).toBe( '456' );
+		expect( screen.getByTestId( 'context-siteDomain' ).textContent ).toBe( 'example.com' );
+	} );
+
+	it( 'uses default values for unspecified context fields', () => {
+		render( <AgentsManager sectionName="wp-admin" /> );
+
+		expect( screen.getByTestId( 'context-sectionName' ).textContent ).toBe( 'wp-admin' );
+		expect( screen.getByTestId( 'context-userId' ).textContent ).toBe( 'none' );
+		expect( screen.getByTestId( 'context-siteId' ).textContent ).toBe( 'none' );
+		expect( screen.getByTestId( 'context-isEligibleForChat' ).textContent ).toBe( 'false' );
+	} );
+
+	it( 'provides all props together to child components', () => {
+		const mockUser = {
+			ID: 789,
+			username: 'fulltest',
+			display_name: 'Full Test User',
+			email: 'full@example.com',
+		} as AgentsManagerContextType[ 'currentUser' ];
+
+		const mockSite = {
+			ID: 999,
+			domain: 'fulltest.com',
+		};
+
+		render(
+			<AgentsManager sectionName="site-editor" currentUser={ mockUser } site={ mockSite } />
+		);
+
+		expect( screen.getByTestId( 'context-sectionName' ).textContent ).toBe( 'site-editor' );
+		expect( screen.getByTestId( 'context-userId' ).textContent ).toBe( '789' );
+		expect( screen.getByTestId( 'context-siteId' ).textContent ).toBe( '999' );
+		expect( screen.getByTestId( 'context-siteDomain' ).textContent ).toBe( 'fulltest.com' );
+	} );
+} );

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -4,25 +4,17 @@ import { useMemo, useEffect, useState, useRef } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { createCalypsoAuthProvider } from '../../auth/calypso-auth-provider';
 import { ORCHESTRATOR_AGENT_URL, getAgentConfig } from '../../constants';
+import { useAgentsManagerContext } from '../../contexts';
 import { SESSION_STORAGE_KEY, getSessionId, clearSessionId } from '../../utils/agent-session';
 import { loadExternalProviders, type LoadedProviders } from '../../utils/load-external-providers';
 import AgentDock from '../agent-dock';
 import { PersistentRouter } from '../persistent-router';
 import type { ContextEntry } from '../../extension-types';
 import type { UseAgentChatConfig, Ability as AgenticAbility } from '@automattic/agenttic-client';
-import type { AgentsManagerSite, CurrentUser } from '@automattic/data-stores';
 
 export interface UnifiedAIAgentProps {
 	/** The current route path. */
 	currentRoute?: string;
-	/** Indicates if the user is eligible for chat. */
-	isEligibleForChat: boolean;
-	/** The name of the current section (e.g., 'posts', 'pages'). */
-	sectionName: string;
-	/** The selected site object. */
-	site?: AgentsManagerSite | null;
-	/** The current user object. */
-	currentUser?: CurrentUser;
 	/** Called when the agent is closed. */
 	handleClose?: () => void;
 }
@@ -73,12 +65,8 @@ export default function UnifiedAIAgent( props: UnifiedAIAgentProps ) {
 }
 
 // Separate component that uses hooks within `PersistentRouter` context
-function AgentSetup( {
-	currentRoute,
-	site = null,
-	sectionName,
-	isEligibleForChat,
-}: UnifiedAIAgentProps ) {
+function AgentSetup( { currentRoute }: UnifiedAIAgentProps ) {
+	const { site } = useAgentsManagerContext();
 	const [ agentConfig, setAgentConfig ] = useState< UseAgentChatConfig | null >( null );
 	const loadedProvidersRef = useRef< LoadedProviders | null >( null );
 	const navigate = useNavigate();
@@ -240,9 +228,6 @@ function AgentSetup( {
 	return (
 		<AgentDock
 			agentConfig={ agentConfig }
-			isEligibleForChat={ isEligibleForChat }
-			site={ site }
-			sectionName={ sectionName }
 			emptyViewSuggestions={ loadedProviders.suggestions || defaultSuggestions }
 			markdownComponents={ loadedProviders.markdownComponents || {} }
 			markdownExtensions={ loadedProviders.markdownExtensions || {} }

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -10,7 +10,7 @@ import AgentDock from '../agent-dock';
 import { PersistentRouter } from '../persistent-router';
 import type { ContextEntry } from '../../extension-types';
 import type { UseAgentChatConfig, Ability as AgenticAbility } from '@automattic/agenttic-client';
-import type { HelpCenterSite, CurrentUser } from '@automattic/data-stores';
+import type { AgentsManagerSite, CurrentUser } from '@automattic/data-stores';
 
 export interface UnifiedAIAgentProps {
 	/** The current route path. */
@@ -20,7 +20,7 @@ export interface UnifiedAIAgentProps {
 	/** The name of the current section (e.g., 'posts', 'pages'). */
 	sectionName: string;
 	/** The selected site object. */
-	site?: HelpCenterSite | null;
+	site?: AgentsManagerSite | null;
 	/** The current user object. */
 	currentUser?: CurrentUser;
 	/** Called when the agent is closed. */

--- a/packages/agents-manager/src/contexts/AgentsManagerContext.tsx
+++ b/packages/agents-manager/src/contexts/AgentsManagerContext.tsx
@@ -1,0 +1,75 @@
+import { createContext, useContext } from '@wordpress/element';
+import type { AgentsManagerSite, CurrentUser } from '@automattic/data-stores';
+
+/**
+ * Context type for AgentsManager data.
+ *
+ * This context provides user, site, and section data to all components
+ * in the AgentsManager tree, avoiding prop drilling.
+ */
+export interface AgentsManagerContextType {
+	/** The current user object. */
+	currentUser?: CurrentUser;
+	/** The selected site object. */
+	site?: AgentsManagerSite | null;
+	/** The name of the current section (e.g., 'wp-admin', 'gutenberg'). */
+	sectionName: string;
+	/**
+	 * Whether the user is eligible for chat support.
+	 *
+	 * TODO: Implement with dedicated endpoint. Currently hardcoded to false.
+	 */
+	isEligibleForChat: boolean;
+}
+
+const defaultContext: AgentsManagerContextType = {
+	currentUser: undefined,
+	site: null,
+	sectionName: 'wp-admin',
+	isEligibleForChat: false,
+};
+
+const AgentsManagerContext = createContext< AgentsManagerContextType >( defaultContext );
+
+/**
+ * Props for AgentsManagerContextProvider.
+ *
+ * Requires `sectionName` to be provided. Other fields are optional
+ * and will use defaults if not provided.
+ */
+export interface AgentsManagerContextProviderProps {
+	children: React.ReactNode;
+	value: Partial< AgentsManagerContextType > & Pick< AgentsManagerContextType, 'sectionName' >;
+}
+
+/**
+ * Provider component that makes AgentsManager data available to all children.
+ *
+ * Usage:
+ * ```tsx
+ * <AgentsManagerContextProvider value={{ sectionName: 'wp-admin', currentUser, site }}>
+ *   <YourComponent />
+ * </AgentsManagerContextProvider>
+ * ```
+ */
+export const AgentsManagerContextProvider: React.FC< AgentsManagerContextProviderProps > = ( {
+	children,
+	value,
+} ) => {
+	return (
+		<AgentsManagerContext.Provider value={ { ...defaultContext, ...value } }>
+			{ children }
+		</AgentsManagerContext.Provider>
+	);
+};
+
+/**
+ * Hook to access AgentsManager context data.
+ *
+ * Must be used within an AgentsManagerContextProvider.
+ *
+ * @returns The current context value with user, site, and section data.
+ */
+export function useAgentsManagerContext(): AgentsManagerContextType {
+	return useContext( AgentsManagerContext );
+}

--- a/packages/agents-manager/src/contexts/index.ts
+++ b/packages/agents-manager/src/contexts/index.ts
@@ -1,0 +1,6 @@
+export {
+	AgentsManagerContextProvider,
+	useAgentsManagerContext,
+	type AgentsManagerContextType,
+	type AgentsManagerContextProviderProps,
+} from './AgentsManagerContext';

--- a/packages/agents-manager/src/contexts/test/AgentsManagerContext.test.tsx
+++ b/packages/agents-manager/src/contexts/test/AgentsManagerContext.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import {
+	AgentsManagerContextProvider,
+	useAgentsManagerContext,
+	type AgentsManagerContextType,
+} from '../AgentsManagerContext';
+
+// Test component that displays context values
+function ContextConsumer() {
+	const context = useAgentsManagerContext();
+	return (
+		<div>
+			<span data-testid="sectionName">{ context.sectionName }</span>
+			<span data-testid="isEligibleForChat">{ String( context.isEligibleForChat ) }</span>
+			<span data-testid="userId">{ context.currentUser?.ID ?? 'none' }</span>
+			<span data-testid="siteId">{ context.site?.ID ?? 'none' }</span>
+		</div>
+	);
+}
+
+describe( 'AgentsManagerContext', () => {
+	describe( 'useAgentsManagerContext', () => {
+		it( 'returns default values when used outside provider', () => {
+			render( <ContextConsumer /> );
+
+			expect( screen.getByTestId( 'sectionName' ).textContent ).toBe( 'wp-admin' );
+			expect( screen.getByTestId( 'isEligibleForChat' ).textContent ).toBe( 'false' );
+			expect( screen.getByTestId( 'userId' ).textContent ).toBe( 'none' );
+			expect( screen.getByTestId( 'siteId' ).textContent ).toBe( 'none' );
+		} );
+	} );
+
+	describe( 'AgentsManagerContextProvider', () => {
+		it( 'provides sectionName to children', () => {
+			render(
+				<AgentsManagerContextProvider value={ { sectionName: 'gutenberg' } }>
+					<ContextConsumer />
+				</AgentsManagerContextProvider>
+			);
+
+			expect( screen.getByTestId( 'sectionName' ).textContent ).toBe( 'gutenberg' );
+		} );
+
+		it( 'provides currentUser to children', () => {
+			const mockUser = {
+				ID: 123,
+				username: 'testuser',
+				display_name: 'Test User',
+				email: 'test@example.com',
+			} as AgentsManagerContextType[ 'currentUser' ];
+
+			render(
+				<AgentsManagerContextProvider value={ { sectionName: 'wp-admin', currentUser: mockUser } }>
+					<ContextConsumer />
+				</AgentsManagerContextProvider>
+			);
+
+			expect( screen.getByTestId( 'userId' ).textContent ).toBe( '123' );
+		} );
+
+		it( 'provides site to children', () => {
+			const mockSite = {
+				ID: 456,
+				domain: 'example.com',
+			};
+
+			render(
+				<AgentsManagerContextProvider value={ { sectionName: 'wp-admin', site: mockSite } }>
+					<ContextConsumer />
+				</AgentsManagerContextProvider>
+			);
+
+			expect( screen.getByTestId( 'siteId' ).textContent ).toBe( '456' );
+		} );
+
+		it( 'uses default values for unspecified fields', () => {
+			render(
+				<AgentsManagerContextProvider value={ { sectionName: 'custom-section' } }>
+					<ContextConsumer />
+				</AgentsManagerContextProvider>
+			);
+
+			expect( screen.getByTestId( 'sectionName' ).textContent ).toBe( 'custom-section' );
+			expect( screen.getByTestId( 'isEligibleForChat' ).textContent ).toBe( 'false' );
+			expect( screen.getByTestId( 'userId' ).textContent ).toBe( 'none' );
+			expect( screen.getByTestId( 'siteId' ).textContent ).toBe( 'none' );
+		} );
+
+		it( 'merges provided values with defaults', () => {
+			const mockUser = { ID: 789 } as AgentsManagerContextType[ 'currentUser' ];
+
+			render(
+				<AgentsManagerContextProvider
+					value={ {
+						sectionName: 'wp-admin',
+						currentUser: mockUser,
+						// site not provided - should use default (null)
+					} }
+				>
+					<ContextConsumer />
+				</AgentsManagerContextProvider>
+			);
+
+			expect( screen.getByTestId( 'userId' ).textContent ).toBe( '789' );
+			expect( screen.getByTestId( 'siteId' ).textContent ).toBe( 'none' );
+		} );
+
+		it( 'always returns isEligibleForChat as false (hardcoded)', () => {
+			render(
+				<AgentsManagerContextProvider value={ { sectionName: 'wp-admin' } }>
+					<ContextConsumer />
+				</AgentsManagerContextProvider>
+			);
+
+			expect( screen.getByTestId( 'isEligibleForChat' ).textContent ).toBe( 'false' );
+		} );
+	} );
+} );

--- a/packages/agents-manager/src/index.ts
+++ b/packages/agents-manager/src/index.ts
@@ -5,6 +5,9 @@ export type { UnifiedAIAgentProps } from './components/unified-ai-agent';
 
 export { AGENTS_MANAGER_STORE } from './stores';
 
+// Context exports
+export { useAgentsManagerContext, type AgentsManagerContextType } from './contexts';
+
 // Utility for checking unified experience from inline script data
 export { getUseUnifiedExperienceFromInlineData } from './utils/load-external-providers';
 

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -1,7 +1,7 @@
 /**
  * External Provider Loading Utility
  *
- * Loads external agent providers registered via the help_center_agent_providers
+ * Loads external agent providers registered via the agents_manager_agent_providers
  * PHP filter. Each provider module should export toolProvider and/or contextProvider.
  */
 

--- a/packages/data-stores/src/agents-manager/types.ts
+++ b/packages/data-stores/src/agents-manager/types.ts
@@ -2,5 +2,17 @@ import * as actions from './actions';
 import * as selectors from './selectors';
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 
+/**
+ * Minimal site data needed by AgentsManager.
+ *
+ * Unlike HelpCenterSite which has many fields, AgentsManager only uses:
+ * - ID: for JWT auth token generation
+ * - domain: for support article content filtering
+ */
+export interface AgentsManagerSite {
+	ID: number | string;
+	domain: string;
+}
+
 export type Dispatch = DispatchFromMap< typeof actions >;
 export type AgentsManagerSelect = SelectFromMap< typeof selectors >;

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -67,6 +67,7 @@ export type {
 } from './help-center/types';
 export type {
 	AgentsManagerSelect,
+	AgentsManagerSite,
 	Dispatch as AgentsManagerDispatch,
 } from './agents-manager/types';
 export type { OnboardSelect, OnboardActions } from './onboard';


### PR DESCRIPTION
Fixes DOTCOM-15807

## Proposed Changes

Remove @automattic/help-center dependencies from the agents-manager package by creating our own context provider, allowing it to operate independently without the Help Center plugin.

**Changes:**
- Create AgentsManagerContext with useAgentsManagerContext() hook (replaces Help Center's context)
- Remove HelpCenterRequiredContextProvider, useChatStatus, and useHelpCenterContext imports
- Add AgentsManagerSite type to data-stores (minimal type with only ID and domain)
- Update entry point to read from agentsManagerData instead of helpCenterData
- Add test coverage for context and component (12 tests total)
- Fix pre-existing build error: remove unsupported onTypingStatusChange prop from AgentUI.Container

## Why are these changes being made?

The agents-manager app currently crashes when the Help Center plugin is disabled because it imports React context and hooks from @automattic/help-center. These imports cause config/API errors when Help Center isn't loaded.

By creating our own AgentsManagerContext and reading data from agentsManagerData (provided by Jetpack), the app becomes self-contained and can work in any environment where Jetpack's agents-manager feature is active.

**Before**: Props → HelpCenterRequiredContextProvider → useHelpCenterContext() → nested components
**After**: Props → AgentsManagerContextProvider → useAgentsManagerContext() → nested components
## Dependencies

The context pattern is preserved (needed for deeply nested components to access data + standalone calypso), but now uses our own implementation instead of Help Center's.

> ⚠️ **IMPORTANT**: This PR requires [Automattic/jetpack#46763](https://github.com/Automattic/jetpack/pull/46763) to be deployed first.
> **If it's not deployed you need to load that in your sandbox**. With `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/agents-manager-user-site-data`.

The Jetpack PR adds the following fields to agentsManagerData:
- sectionName - Current admin section
- currentUser - User ID, username, display name, avatar URL, email
- site - Site ID and domain

## Testing Instructions

### Calypso

1. Enable unified experience via wpcom profile > Automattician Options > "Unified Chat"
2. Run `yarn && yarn start`
3. Navigate to the main Calypso page
4. You must see the unified experience chat with normality
5. ✅ Verify no console errors and chat works normally

**Known issue**: When navigating from `/` to any `/site/x.com` view the correct context is propagated but it's not being used because it's cached. [I've created an issue to fix that](https://linear.app/a8c/issue/AI-848/auth-provider-uses-stale-site-id-when-navigating-within-calypso-spa).

### wp-admin (standalone app)

**Prerequisites:**
1. Deploy Jetpack PR #46763 first (or test with local Jetpack build)
2. Enable unified experience via wpcom profile > Automattician Options > "Unified Chat"
3. In `apps/agents-manager`, run `yarn dev --sync` (requires sandboxing widgets.wp.com)

**Test with Help Center enabled:**
1. Navigate to any wp-admin page on a test site
2. Open browser console and verify `agentsManagerData` contains `sectionName`, `currentUser`, `site`
3. You must see the unified experience chat with normality
4. ✅ Should work without errors

**Test with Help Center disabled (critical):**
1. Disable Help Center plugin on an Atomic/Garden site
2. Navigate to wp-admin
3. You must see the unified experience chat with normality
4. ✅ Should work without errors

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you checked the E2E test CI results?