### PR TITLE
Agent Manager:  tweak spacing around floating empty state message

### DIFF
--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -857,7 +857,6 @@ body:not(.modal-open) .agents-manager-chat--docked {
 	z-index: 9999;
 
 	.Messages-module_container.Messages-module_emptyState {
-		justify-content: start;
 		padding-bottom: 0;
 		padding-top: 0;
 	}

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -432,6 +432,8 @@ body:not(.modal-open) .agents-manager-chat--docked {
 
 		&.Messages-module_emptyState {
 			justify-content: start;
+			padding-bottom: 0;
+			padding-top: 0;
 		}
 
 		.EmptyView-module_container {
@@ -455,6 +457,14 @@ body:not(.modal-open) .agents-manager-chat--docked {
 				margin: 0;
 			}
 		}
+	}
+
+	.EmptyView-module_container .Suggestions-module_container {
+		padding: 0;
+	}
+
+	.Textarea-module_textarea {
+		line-height: 1.8;
 	}
 
 	.big-sky__chat-actions {

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -432,8 +432,6 @@ body:not(.modal-open) .agents-manager-chat--docked {
 
 		&.Messages-module_emptyState {
 			justify-content: start;
-			padding-bottom: 0;
-			padding-top: 0;
 		}
 
 		.EmptyView-module_container {
@@ -857,6 +855,12 @@ body:not(.modal-open) .agents-manager-chat--docked {
 .agents-manager-chat--undocked .agenttic.Chat-module_container.Chat-module_floating {
 	// Fix the undocked chat overlapping with the nav menu
 	z-index: 9999;
+
+	.Messages-module_container.Messages-module_emptyState {
+		justify-content: start;
+		padding-bottom: 0;
+		padding-top: 0;
+	}
 
 	.big-sky__dock__menu__variation-picker .edit-site-global-styles-variations_item {
 		&.is-active,


### PR DESCRIPTION
Tweaks the spacing around the agents manager empty state so that the bottom doesn't overflow as much. Also improves the vertical alignment of the textarea text.

Before:

<img width="814" height="1102" alt="image" src="https://github.com/user-attachments/assets/4ef2ab26-20ec-45a5-8396-ba92c52fb2cf" />

After:

<img width="818" height="1088" alt="image" src="https://github.com/user-attachments/assets/da29dd67-1ecc-4511-b097-ae2a64734b3a" />

Fixes AI-841

## Why are these changes being made?

* Make things look better

## Testing Instructions

* `cd apps/agents-manager`
* `yarn dev --sync`
* Load a wp-admin and enable floating chat panel. Confirm the alignment tweaks in the above screenshots
* Quick check it doesn't break anything else

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
