### PR TITLE
MSD follow-up survey: new survey shown after 2 weeks

### DIFF
--- a/client/dashboard/components/opt-in-survey/index.tsx
+++ b/client/dashboard/components/opt-in-survey/index.tsx
@@ -1,8 +1,8 @@
 import { userPreferenceQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { ButtonStack } from '../button-stack';
 import { Notice } from '../notice';
@@ -11,6 +11,7 @@ const DISMISSED_AT_KEY = 'dashboard-opt-in-survey-dismissed-at';
 const DISMISSED_COUNT_KEY = 'dashboard-opt-in-survey-dismissed-count';
 
 const RESHOW_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const FOLLOW_UP_AFTER_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 const MAX_DISMISSES = 2;
 
 const canUseLocalStorage = () =>
@@ -74,6 +75,11 @@ export default function OptInSurvey() {
 		return null;
 	}
 
+	const welcomeNoticeDismissedTime = welcomeNoticeDismissedAt
+		? new Date( welcomeNoticeDismissedAt ).getTime()
+		: 0;
+	const isFollowUp = Date.now() >= welcomeNoticeDismissedTime + FOLLOW_UP_AFTER_MS;
+
 	const setDismissedNow = () => {
 		setIsDismissed( true );
 		dismissSurvey();
@@ -89,6 +95,10 @@ export default function OptInSurvey() {
 		setDismissedNow();
 	};
 
+	const surveyUrl = isFollowUp
+		? 'https://automattic.survey.fm/msd-survey-for-opt-in-after-2-weeks'
+		: 'https://automattic.survey.fm/msd-survey-for-opt-in';
+
 	return (
 		<Notice
 			title={ __( 'How’s your experience with the new Hosting Dashboard?' ) }
@@ -98,7 +108,7 @@ export default function OptInSurvey() {
 					<Button
 						variant="primary"
 						size="compact"
-						href="https://automattic.survey.fm/msd-survey-for-opt-in"
+						href={ surveyUrl }
 						target="_blank"
 						rel="noopener noreferrer"
 						onClick={ confirm }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/DOTCOM-15836/add-follow-up-survey-for-msd-users-2-weeks-after-opt-in-to-measure

## Proposed Changes

* Add follow-up survey selection logic based on the welcome notice dismissal timestamp (14 days after opt-in).
* Route users to the follow-up survey link when eligible; otherwise keep the original survey link.
* Keep current dismissal tracking and reshow rules for the survey prompt.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Differentiate onboarding feedback from longer-term usage feedback by prompting a second survey after two weeks.
* Attribute feedback more accurately without increasing survey frequency beyond existing dismissal limits.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Use the Calypso live link
* Make sure you've dismissed the MSD Welcome Notice at least 2 weeks ago.
* If you do not see the survey, clear local storeage with: `localStorage.removeItem('dashboard-opt-in-survey-dismissed-at');`
* You should see the survey button pointing to the new survey now.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
