### PR TITLE
Fix magic login link losing 'from' query parameter

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -503,6 +503,7 @@ export class LoginForm extends Component {
 			oauth2ClientId: this.props.oauth2Client?.id,
 			emailAddress: usernameOrEmail || query?.email_address || this.state.usernameOrEmail,
 			redirectTo: this.props.redirectTo,
+			from: this.props.currentQuery?.from,
 		} );
 	}
 


### PR DESCRIPTION
Part of ARC-1388
Related to https://github.com/Automattic/wp-calypso/pull/108293

## Proposed Changes

* Adds the `from` query parameter to the magic login link URL in `getMagicLoginPageLink()`.

## Why are these changes being made?

* When clicking "Email me a login link" on the login page, the `from` query parameter was not being passed to the magic login page URL. This caused the parameter to be lost when users clicked "Enter a password instead" or navigated to "Create an account" from the magic login page.
* This fix ensures the `from` parameter is preserved throughout the login flow, which is essential for CIAB partner branding to work correctly across all login paths.

## Testing Instructions

1. Navigate to `/log-in?from=woo` (or any other `from` value).
2. Click "Email me a login link".
3. Verify the URL contains `from=woo`.
4. Click "Enter a password instead".
5. Verify the URL still contains `from=woo`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?