### PR TITLE
Odie sources: Remove icon and period.

### DIFF
--- a/packages/odie-client/src/components/message/sources.tsx
+++ b/packages/odie-client/src/components/message/sources.tsx
@@ -58,7 +58,7 @@ export const Sources = ( {
 	const renderDisclaimers = () => (
 		<div className="disclaimer">
 			{ createInterpolateElement(
-				__( 'Some responses may be inaccurate. <a>Learn more</a>.', __i18n_text_domain__ ),
+				__( 'Some responses may be inaccurate. <a>Learn more</a>', __i18n_text_domain__ ),
 				{
 					a: (
 						// @ts-expect-error Children must be passed to External link. This is done by createInterpolateElement, but the types don't see that.

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -293,7 +293,12 @@ $blueberry-color: #3858e9;
 			margin-top: 8px;
 
 			.components-external-link {
-				color: var( --studio-gray-20 );
+				color: var( --studio-gray-60 );
+			}
+
+			.components-external-link__icon {
+
+				display: none;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DSGCOM-400/learn-more-link-is-too-subdued