### PR TITLE
MSD Domains: Always send the user to /setup/domain/use-my-domain when they want to use a domain they already own

### DIFF
--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -39,7 +39,10 @@ export function AddDomainButton( {
 		navigateTo( wpcomLink( '/setup/domain' ), wpcomLink( '/start/domain' ) );
 
 	const onTransferOrConnectClick = () =>
-		navigateTo( wpcomLink( '/setup/domain/use-my-domain' ), wpcomLink( '/setup/domain-transfer' ) );
+		navigateTo(
+			wpcomLink( '/setup/domain/use-my-domain' ),
+			wpcomLink( '/setup/domain/use-my-domain' )
+		);
 
 	return (
 		<Dropdown
@@ -61,7 +64,7 @@ export function AddDomainButton( {
 						{ __( 'Search domain names' ) }
 					</MenuItem>
 					<MenuItem iconPosition="left" icon={ globe } onClick={ onTransferOrConnectClick }>
-						{ siteSlug ? __( 'Use a domain name I own' ) : __( 'Transfer domain name' ) }
+						{ __( 'Use a domain name I own' ) }
 					</MenuItem>
 				</>
 			) }


### PR DESCRIPTION
Closes DOMAINS-2028.

## Proposed Changes

Always redirect to `/setup/domain` when clicking the use existing domain option within the `Add Domain Name` CTA.

## Why are these changes being made?

If the user is not in the site context, the only option that shows up is to transfer a domain (in which we give them a domain-only site.)

That's not necessary and we can adjust the label for consistency since the `/setup/domain/use-my-domain` flow asks if the user wants to register a new site or attach the domain (transfer, connect) to an existing site as soon as they pick one of the domain handling options.

## Testing Instructions

Enter `/sites/%s/domains` and verify the "Add domain name > Use a domain name I own" button links to `/setup/domain/use-my-domain?siteSlug=%s`. Start the transfer or connect flows and verify you end up at checkout with the domain attached to your existing site.

Enter `/domains` and verify the "Add domain name > Use a domain name I own" button links to `/setup/domain/use-my-domain`. Start the transfer or connect flows and verify the prompt to attach the domain to an existing site or create a new one shows up right after picking the option. You should go to checkout after that, using the selected site.