### PR TITLE
Change form responses view helper

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -28,7 +28,7 @@ export class FeedbackInboxPage {
 
 	/**
 	 * View a response row that has the provided text.
-	 * Doesn't verify the row is-selected, it just makes sure the response
+	 * Doesn't verify the row is selected, it just makes sure the response
 	 * is visible (inspector on desktop, modal on mobile)
 	 *
 	 * @param {string} text The text to match in the row. Using the name field is a good choice.
@@ -38,8 +38,7 @@ export class FeedbackInboxPage {
 			.locator( '.dataviews-view-table__row' )
 			.filter( { hasText: text } )
 			.first();
-		await responseRowLocator.waitFor();
-		await responseRowLocator.isVisible();
+		await responseRowLocator.waitFor( { state: 'visible' } );
 		await responseRowLocator.getByRole( 'button', { name: 'Actions' } ).click();
 		// The menu item is on a popover portal, so outside of the response row locator
 		const viewMenuItem = this.page.getByRole( 'menuitem', { name: 'View' } ).first();

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -27,34 +27,27 @@ export class FeedbackInboxPage {
 	}
 
 	/**
-	 * Click on a response row that has the provided text.
+	 * View a response row that has the provided text.
+	 * Doesn't verify the row is-selected, it just makes sure the response
+	 * is visible (inspector on desktop, modal on mobile)
 	 *
 	 * @param {string} text The text to match in the row. Using the name field is a good choice.
 	 */
-	async clickResponseRowByText( text: string ): Promise< void > {
+	async viewResponseRowByText( text: string ): Promise< void > {
 		const responseRowLocator = this.page
 			.locator( '.dataviews-view-table__row' )
 			.filter( { hasText: text } )
 			.first();
 		await responseRowLocator.waitFor();
 		await responseRowLocator.isVisible();
+		await responseRowLocator.getByRole( 'button', { name: 'Actions' } ).click();
+		// The menu item is on a popover portal, so outside of the response row locator
+		const viewMenuItem = this.page.getByRole( 'menuitem', { name: 'View' } ).first();
+		await viewMenuItem.click();
+
 		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
-			// Check if the row is already selected to avoid de-selecting it
-			const isAlreadySelected = await responseRowLocator.evaluate( ( el ) =>
-				el.classList.contains( 'is-selected' )
-			);
-			if ( ! isAlreadySelected ) {
-				await responseRowLocator.click( { position: { x: 1, y: 1 } } );
-			}
-			await this.page
-				.locator( '.dataviews-view-table__row.is-selected' )
-				.filter( { hasText: text } )
-				.waitFor();
+			await this.page.locator( '.jp-forms__inbox-response' ).waitFor( { state: 'visible' } );
 		} else {
-			await responseRowLocator.getByRole( 'button', { name: 'Actions' } ).click();
-			// The menu item is on a popover portal, so outside of the response row locator
-			const viewMenuItem = this.page.getByRole( 'menuitem', { name: 'View' } ).first();
-			await viewMenuItem.click();
 			await this.page
 				.getByRole( 'dialog' )
 				.filter( { has: this.page.getByRole( 'heading', { name: 'Response' } ) } )

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -226,7 +226,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 
 		it( 'If in Spam, mark as not spam', async function () {
 			if ( isInSpam ) {
-				await feedbackInboxPage.clickResponseRowByText( formData1.name );
+				await feedbackInboxPage.viewResponseRowByText( formData1.name );
 				await feedbackInboxPage.clickNotSpamAction();
 			}
 		} );
@@ -240,7 +240,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 		} );
 
 		it( 'Validate first response data', async () => {
-			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.viewResponseRowByText( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.email );
 			await feedbackInboxPage.validateTextInSubmission( formData1.phone );
@@ -283,30 +283,23 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			}
 		} );
 
-		it( 'Click second response row', async () => {
-			await feedbackInboxPage.clickResponseRowByText( formData2.name );
-		} );
-
 		it( 'If in Spam, mark as not spam', async function () {
 			if ( isInSpam ) {
+				await feedbackInboxPage.viewResponseRowByText( formData2.name );
 				await feedbackInboxPage.clickNotSpamAction();
 			}
 		} );
 
-		it( 'Navigate to Inbox tab', async function () {
+		it( 'Navigate to Inbox tab if needed', async function () {
+			// if it's not in spam, we should already be in the inbox tab as per
+			// find and click on the search test above.
 			if ( isInSpam ) {
-				// Clear search first to show all responses
-				await feedbackInboxPage.clearSearch( true );
 				await feedbackInboxPage.clickFolderTab( 'Inbox' );
-				// Wait for folder change to complete
-				await page.waitForTimeout( 1000 );
-				// Search again for the second response in Inbox
-				await feedbackInboxPage.searchResponses( formData2.name );
-				await feedbackInboxPage.clickResponseRowByText( formData2.name );
 			}
 		} );
 
 		it( 'Validate second response data', async () => {
+			await feedbackInboxPage.viewResponseRowByText( formData2.name );
 			await feedbackInboxPage.validateTextInSubmission( formData2.name );
 			await feedbackInboxPage.validateTextInSubmission( formData2.email );
 			await feedbackInboxPage.validateTextInSubmission( formData2.phone );
@@ -327,7 +320,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 		} );
 
 		it( 'Click on first response', async function () {
-			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.viewResponseRowByText( formData1.name );
 		} );
 
 		it( 'Verify first response data is visible', async function () {
@@ -376,8 +369,9 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await feedbackInboxPage.verifyActionExistsInMenu( formData1.name, 'Trash' );
 		} );
 
+		// This step ensures the response is visible to act upon actions on its view
 		it( 'Ensure first response is selected', async function () {
-			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.viewResponseRowByText( formData1.name );
 		} );
 
 		it( 'Mark first response as unread', async function () {
@@ -386,13 +380,11 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 
 		it( 'Mark first response as read', async function () {
 			// Re-select the response after the action
-			// await feedbackInboxPage.clickResponseRowByText( formData1.name );
 			await feedbackInboxPage.clickMarkAsReadAction();
 		} );
 
 		it( 'Mark first response as spam', async function () {
 			// Re-select the response after the action
-			// await feedbackInboxPage.clickResponseRowByText( formData1.name );
 			await feedbackInboxPage.clickMarkAsSpamAction();
 		} );
 
@@ -402,7 +394,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 
 		it( 'Verify first response is in Spam', async function () {
 			await feedbackInboxPage.searchResponses( formData1.email );
-			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.viewResponseRowByText( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 		} );
 
@@ -416,7 +408,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 
 		it( 'Verify first response is back in Inbox', async function () {
 			await feedbackInboxPage.searchResponses( formData1.email, true );
-			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.viewResponseRowByText( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 		} );
 
@@ -430,7 +422,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 
 		it( 'Verify first response is in Trash', async function () {
 			await feedbackInboxPage.searchResponses( formData1.email, true );
-			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.viewResponseRowByText( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 		} );
 
@@ -444,7 +436,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 
 		it( 'Verify first response is restored in Inbox', async function () {
 			await feedbackInboxPage.searchResponses( formData1.email, true );
-			await feedbackInboxPage.clickResponseRowByText( formData1.name );
+			await feedbackInboxPage.viewResponseRowByText( formData1.name );
 			await feedbackInboxPage.validateTextInSubmission( formData1.name );
 		} );
 	} );

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -292,7 +292,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 
 		it( 'Navigate to Inbox tab if needed', async function () {
 			// if it's not in spam, we should already be in the inbox tab as per
-			// find and click on the search test above.
+			// find and click on the search step above.
 			if ( isInSpam ) {
 				await feedbackInboxPage.clickFolderTab( 'Inbox' );
 			}
@@ -369,8 +369,8 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			await feedbackInboxPage.verifyActionExistsInMenu( formData1.name, 'Trash' );
 		} );
 
-		// This step ensures the response is visible to act upon actions on its view
-		it( 'Ensure first response is selected', async function () {
+		// This step ensures the response is opened so actions can be performed on its view
+		it( 'Ensure first response is opened', async function () {
 			await feedbackInboxPage.viewResponseRowByText( formData1.name );
 		} );
 


### PR DESCRIPTION
Part of FORMS-563

## Proposed Changes
Change clickResponseRowByText for viewResponseRowByText, both the inner mechanics but also to reflect what the helper function does: it will make sure the response is being viewed instead of (secondary effect) being selected

Also: realigning first and second response process as the _faux_ A/B test didn't bring any light on it. So, better use the same for both.

## Why are these changes being made?
Because the underlying lib changed how the rows are selected and we needed to update according to the intended tests

## Testing Instructions

Run:
```
yarn workspace wp-e2e-tests build && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts && \
CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" TEST_ON_ATOMIC="true" yarn workspace wp-e2e-tests test test/e2e/specs/published-content/forms__submissions.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
