### PR TITLE
Domain Search: Hide free subdomain if user searches for an FQDN

### DIFF
--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -32,14 +32,16 @@ export const useSuggestionsList = () => {
 		enabled: true,
 	} );
 
+	const isFqdnQuery = !! getTld( query );
+
 	const { isLoading: isLoadingFreeSuggestion } = useQuery( {
 		...queries.freeSuggestion( query ),
-		enabled: config.skippable,
+		enabled: config.skippable && ! isFqdnQuery,
 	} );
 
 	const { isLoading: isLoadingQueryAvailability, data: fqdnAvailability } = useQuery( {
 		...queries.domainAvailability( query ),
-		enabled: !! getTld( query ),
+		enabled: isFqdnQuery,
 	} );
 
 	const premiumSuggestions = useMemo(

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -6,13 +6,12 @@ import { SearchNotice } from '../components/search-notice';
 import { SearchResults } from '../components/search-results';
 import { SkipSuggestion } from '../components/skip-suggestion';
 import { UnavailableSearchResult } from '../components/unavailable-search-result';
-import { getTld } from '../helpers/get-tld';
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
 import { useDomainSearch } from './context';
 
 export const ResultsPage = () => {
-	const { slots, config, query } = useDomainSearch();
+	const { slots, config } = useDomainSearch();
 
 	const {
 		isLoading: isLoadingSuggestions,
@@ -21,7 +20,6 @@ export const ResultsPage = () => {
 	} = useSuggestionsList();
 	const numberOfInitialVisibleSuggestions =
 		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
-	const isFqdnQuery = !! getTld( query );
 
 	useRequestTracking();
 
@@ -33,7 +31,7 @@ export const ResultsPage = () => {
 			</VStack>
 			{ slots?.BeforeResults && <slots.BeforeResults /> }
 			<VStack spacing={ 4 }>
-				{ config.skippable && ! isFqdnQuery && (
+				{ config.skippable && (
 					<>{ isLoadingSuggestions ? <SkipSuggestion.Placeholder /> : <SkipSuggestion /> }</>
 				) }
 				{ ! isLoadingSuggestions && <UnavailableSearchResult /> }

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -6,12 +6,13 @@ import { SearchNotice } from '../components/search-notice';
 import { SearchResults } from '../components/search-results';
 import { SkipSuggestion } from '../components/skip-suggestion';
 import { UnavailableSearchResult } from '../components/unavailable-search-result';
+import { getTld } from '../helpers/get-tld';
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
 import { useDomainSearch } from './context';
 
 export const ResultsPage = () => {
-	const { slots, config } = useDomainSearch();
+	const { slots, config, query } = useDomainSearch();
 
 	const {
 		isLoading: isLoadingSuggestions,
@@ -20,6 +21,7 @@ export const ResultsPage = () => {
 	} = useSuggestionsList();
 	const numberOfInitialVisibleSuggestions =
 		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
+	const isFqdnQuery = !! getTld( query );
 
 	useRequestTracking();
 
@@ -31,7 +33,7 @@ export const ResultsPage = () => {
 			</VStack>
 			{ slots?.BeforeResults && <slots.BeforeResults /> }
 			<VStack spacing={ 4 }>
-				{ config.skippable && (
+				{ config.skippable && ! isFqdnQuery && (
 					<>{ isLoadingSuggestions ? <SkipSuggestion.Placeholder /> : <SkipSuggestion /> }</>
 				) }
 				{ ! isLoadingSuggestions && <UnavailableSearchResult /> }

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -682,6 +682,33 @@ describe( 'ResultsPage', () => {
 				await screen.findByLabelText( 'Skip purchase and continue with site.wordpress.com' )
 			).toBeInTheDocument();
 		} );
+
+		it( 'does not render the skip suggestion when searching for a FQDN', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'test.com' },
+				suggestions: [ buildSuggestion( { domain_name: 'test.com' } ) ],
+			} );
+
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'test.com' },
+				availability: buildAvailability( {
+					domain_name: 'test.com',
+					status: DomainAvailabilityStatus.AVAILABLE,
+				} ),
+			} );
+
+			render(
+				<TestDomainSearch config={ { skippable: true } } query="test.com">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByTitle( 'test.com' ) ).toBeInTheDocument();
+			expect( screen.queryByLabelText( 'Loading free domain suggestion' ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', { name: /Skip purchase and continue/i } )
+			).not.toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'tracking', () => {

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -697,6 +697,11 @@ describe( 'ResultsPage', () => {
 				} ),
 			} );
 
+			const freeSuggestionQuery = mockGetFreeSuggestionQuery( {
+				params: { query: 'test.com' },
+				freeSuggestion: buildFreeSuggestion( { domain_name: 'testcom.wordpress.com' } ),
+			} );
+
 			render(
 				<TestDomainSearch config={ { skippable: true } } query="test.com">
 					<ResultsPage />
@@ -704,9 +709,11 @@ describe( 'ResultsPage', () => {
 			);
 
 			expect( await screen.findByTitle( 'test.com' ) ).toBeInTheDocument();
+			// Ensure the free suggestion query does not get triggered
+			expect( freeSuggestionQuery.isDone() ).toBe( false );
 			expect( screen.queryByLabelText( 'Loading free domain suggestion' ) ).not.toBeInTheDocument();
 			expect(
-				screen.queryByRole( 'button', { name: /Skip purchase and continue/i } )
+				screen.queryByLabelText( 'Skip purchase and continue with testcom.wordpress.com' )
 			).not.toBeInTheDocument();
 		} );
 	} );


### PR DESCRIPTION
Part of [DOMENG-347](https://linear.app/a8c/issue/DOMENG-347)

Second attempt at merging #108091.

## Proposed Changes

This PR hides the free WPCOM subdomain suggestion if the user searches for an FQDN.

### Screenshots

| Before | After |
| --- | --- |
|  <img width="1174" height="1099" alt="Screenshot 2026-01-13 at 12 36 48" src="https://github.com/user-attachments/assets/95ef80bb-143b-425e-a589-54892189897d" /> | <img width="1174" height="1099" alt="Screenshot 2026-01-13 at 12 35 49" src="https://github.com/user-attachments/assets/4b15c95f-068b-4815-9656-19d1b25bca29" /> |

## Why are these changes being made?

When a user searches for an FQDN, that's a strong indicator that they are looking to purchase a domain. Removing the free subdomain option 

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to onboarding (`/setup/onboarding`)
- Search for an FQDN and ensure the free subdomain suggestion is not shown
- Search for a regular string and ensure the subdomain suggestion is shown


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
