### PR TITLE
Revert "Domains: Domain move internal product should not consume domain credit"

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -1,9 +1,4 @@
-import {
-	isDomainProduct,
-	isDomainTransfer,
-	isDomainMoveInternal,
-	isPlan,
-} from '@automattic/calypso-products';
+import { isDomainProduct, isDomainTransfer, isPlan } from '@automattic/calypso-products';
 import { DomainSearch } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
@@ -92,9 +87,7 @@ export const useWPCOMDomainSearchCart = ( {
 			return b.item_subtotal_integer - a.item_subtotal_integer;
 		} );
 
-		const firstNonPremiumDomain = domainItems.find(
-			( item ) => ! isDomainMoveInternal( item ) && ! item.extra?.premium
-		);
+		const firstNonPremiumDomain = domainItems.find( ( item ) => ! item.extra?.premium );
 		const freeDomainName = forceFirstNonPremiumDomainToBeFree
 			? firstNonPremiumDomain?.meta
 			: undefined;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#108071