### PR TITLE
Revert "Restrict to first inserter button on locator"

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -166,7 +166,7 @@ export class AllFormFieldsFlow implements BlockFlow {
 				await context.editorPage.selectParentBlock( 'Form' );
 			}
 
-			await editorCanvas.getByRole( 'button', { name: 'Add block' } ).first().click();
+			await editorCanvas.getByRole( 'button', { name: 'Add block' } ).click();
 		};
 		await context.editorPage.addBlockInline(
 			blockName,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#108348