### PR TITLE
Add RUM performance tracking to Dashboard

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -74,6 +74,7 @@ module.exports = {
 							'!@automattic/urls',
 							'!@automattic/js-utils',
 							'!@automattic/viewport',
+							'!@automattic/browser-data-collector',
 							// Please do not add exceptions which pull in Calypso code/concepts.
 							// See docs/package-imports.md for policy.
 						],

--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -59,7 +59,7 @@ export function getNormalizedPath( router: AnyRouter ) {
  * hoping to attach site info if it happens to be available. So I think checking
  * both caches represents a "best effort" attempt.
  */
-function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): Site | undefined {
+export function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): Site | undefined {
 	const site = queryClient.getQueryData< Site >( siteBySlugQuery( siteSlug ).queryKey );
 	if ( site ) {
 		return site;

--- a/client/dashboard/app/performance-tracking.ts
+++ b/client/dashboard/app/performance-tracking.ts
@@ -2,6 +2,7 @@ import { queryClient } from '@automattic/api-queries';
 import { start, stop } from '@automattic/browser-data-collector';
 import config from '@automattic/calypso-config';
 import { useLayoutEffect } from 'react';
+import { isDashboardBackport } from '../utils/is-dashboard-backport';
 import { getSiteFromCache } from './analytics/super-props';
 import { AUTH_QUERY_KEY } from './auth';
 import type { User } from '@automattic/api-core';
@@ -34,7 +35,7 @@ function buildCollector( siteSlug?: string ): Collector {
  * Call this in a route's beforeLoad handler.
  */
 export function startPerformanceTracking( id: string, { fullPageLoad = false } = {} ) {
-	if ( ! config.isEnabled( 'rum-tracking/logstash' ) ) {
+	if ( ! config.isEnabled( 'rum-tracking/logstash' ) || isDashboardBackport() ) {
 		return;
 	}
 	start( id, { fullPageLoad } );
@@ -46,7 +47,7 @@ export function startPerformanceTracking( id: string, { fullPageLoad = false } =
  */
 export function usePerformanceTrackerStop( id: string, siteSlug?: string ) {
 	useLayoutEffect( () => {
-		if ( ! config.isEnabled( 'rum-tracking/logstash' ) ) {
+		if ( ! config.isEnabled( 'rum-tracking/logstash' ) || isDashboardBackport() ) {
 			return;
 		}
 		requestAnimationFrame( () => {

--- a/client/dashboard/app/performance-tracking.ts
+++ b/client/dashboard/app/performance-tracking.ts
@@ -1,0 +1,71 @@
+import { queryClient } from '@automattic/api-queries';
+import { start, stop } from '@automattic/browser-data-collector';
+import config from '@automattic/calypso-config';
+import { useLayoutEffect } from 'react';
+import { getSiteFromCache } from './analytics/super-props';
+import { AUTH_QUERY_KEY } from './auth';
+import type { User } from '@automattic/api-core';
+import type { Collector } from '@automattic/browser-data-collector';
+
+function buildCollector( siteSlug?: string ): Collector {
+	const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
+	const site = siteSlug ? getSiteFromCache( queryClient, siteSlug ) : undefined;
+
+	return ( report ) => {
+		report.data.set( 'client', config( 'client_slug' ) );
+
+		if ( user ) {
+			report.data.set( 'sitesCount', user.site_count );
+			report.data.set( 'userLocale', user.language );
+		}
+
+		if ( site ) {
+			report.data.set( 'siteId', site.ID );
+			report.data.set( 'siteIsJetpack', site.jetpack );
+			report.data.set( 'siteIsAtomic', site.is_wpcom_atomic );
+		}
+
+		return report;
+	};
+}
+
+/**
+ * Start performance tracking for a page.
+ * Call this in a route's beforeLoad handler.
+ */
+export function startPerformanceTracking( id: string, { fullPageLoad = false } = {} ) {
+	if ( ! config.isEnabled( 'rum-tracking/logstash' ) ) {
+		return;
+	}
+	start( id, { fullPageLoad } );
+}
+
+/**
+ * Hook to stop performance tracking.
+ * Use in functional components where the page is considered "loaded".
+ */
+export function usePerformanceTrackerStop( id: string, siteSlug?: string ) {
+	useLayoutEffect( () => {
+		if ( ! config.isEnabled( 'rum-tracking/logstash' ) ) {
+			return;
+		}
+		requestAnimationFrame( () => {
+			stop( id, { collectors: [ buildCollector( siteSlug ) ] } );
+		} );
+	}, [ id, siteSlug ] );
+}
+
+/**
+ * Component to stop performance tracking.
+ * Place this where the page is considered "loaded".
+ */
+export function PerformanceTrackerStop( {
+	id,
+	siteSlug,
+}: {
+	id: string;
+	siteSlug?: string;
+} ): null {
+	usePerformanceTrackerStop( id, siteSlug );
+	return null;
+}

--- a/client/dashboard/app/performance-tracking.ts
+++ b/client/dashboard/app/performance-tracking.ts
@@ -1,5 +1,5 @@
 import { queryClient } from '@automattic/api-queries';
-import { start, stop } from '@automattic/browser-data-collector';
+import { cancel, start, stop } from '@automattic/browser-data-collector';
 import config from '@automattic/calypso-config';
 import { useLayoutEffect } from 'react';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
@@ -33,11 +33,21 @@ function buildCollector( siteSlug?: string ): Collector {
 /**
  * Start performance tracking for a page.
  * Call this in a route's beforeLoad handler.
+ *
+ * We cancel any existing in-flight recording before starting. Exposing `cancel()` from
+ * browser-data-collector is not ideal, but it's needed to work around a TanStack Router bug where
+ * `cause` in `beforeLoad` gets cached, causing `'enter'` to be reported instead of `'preload'` on
+ * hover. This leads to spurious `start()` calls (that we need to cancel) that block subsequent
+ * real navigations.
+ *
+ * The `cancel()` call can be removed when the upstream issue is fixed.
+ * @see https://github.com/TanStack/router/issues/3179
  */
 export function startPerformanceTracking( id: string, { fullPageLoad = false } = {} ) {
 	if ( ! config.isEnabled( 'rum-tracking/logstash' ) || isDashboardBackport() ) {
 		return;
 	}
+	cancel( id );
 	start( id, { fullPageLoad } );
 }
 

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -38,6 +38,7 @@ import {
 	checkDomainContactVerificationPermissions,
 } from '../../utils/domain-permissions';
 import { queryParamToArray } from '../../utils/url';
+import { startPerformanceTracking } from '../performance-tracking';
 import { rootRoute } from './root';
 
 const domainsRoute = createRoute( {
@@ -56,6 +57,11 @@ const domainsRoute = createRoute( {
 export const domainsIndexRoute = createRoute( {
 	getParentRoute: () => domainsRoute,
 	path: '/',
+	beforeLoad: ( { cause, context: { fullPageLoad } } ) => {
+		if ( cause === 'enter' ) {
+			startPerformanceTracking( 'dashboard-domain-list', { fullPageLoad } );
+		}
+	},
 	loader: async ( { context } ) => {
 		await Promise.all( [
 			queryClient.ensureQueryData( domainsQuery() ),

--- a/client/dashboard/app/router/first-load-tracker.ts
+++ b/client/dashboard/app/router/first-load-tracker.ts
@@ -1,0 +1,14 @@
+/**
+ * Used for detecting whether a navigation is a fresh page load (see `./root.tsx`)
+ * @returns true if this function hasn't been called before.
+ */
+export const consumeFirstLoad = ( () => {
+	let isFirstLoad = true;
+	return () => {
+		if ( isFirstLoad ) {
+			isFirstLoad = false;
+			return true;
+		}
+		return false;
+	};
+} )();

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -14,23 +14,28 @@ export type RootRouterContext = {
 	config: AppConfig;
 };
 
+let isFirstLoad = true;
+
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
 	notFoundComponent: NotFoundRoot,
 	beforeLoad: async ( { cause } ) => {
+		const fullPageLoad = isFirstLoad;
+		isFirstLoad = false;
+
 		if ( cause === 'preload' ) {
-			return;
+			return { fullPageLoad };
 		}
 
 		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 		if ( user && user.ID <= OLDEST_ELIGIBLE_USER ) {
-			return;
+			return { fullPageLoad };
 		}
 
 		const userPreference = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 		const optIn = userPreference[ 'hosting-dashboard-opt-in' ];
 		if ( optIn?.value === 'opt-in' || optIn?.value === 'forced-opt-in' ) {
-			return;
+			return { fullPageLoad };
 		}
 
 		throw redirect( { href: wpcomLink( '/' ), replace: true } );

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -5,6 +5,7 @@ import { wpcomLink } from '../../utils/link';
 import { AUTH_QUERY_KEY } from '../auth';
 import Root from '../root';
 import NotFoundRoot from '../root/error';
+import { consumeFirstLoad } from './first-load-tracker';
 import type { AppConfig } from '../context';
 import type { User } from '@automattic/api-core';
 
@@ -14,37 +15,23 @@ export type RootRouterContext = {
 	config: AppConfig;
 };
 
-let isFirstLoad = true;
-
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
 	notFoundComponent: NotFoundRoot,
 	beforeLoad: async ( { cause } ) => {
 		if ( cause === 'preload' ) {
-			if ( isFirstLoad ) {
-				isFirstLoad = false;
-				return { fullPageLoad: true };
-			}
-			return { fullPageLoad: false };
+			return { fullPageLoad: consumeFirstLoad() };
 		}
 
 		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 		if ( user && user.ID <= OLDEST_ELIGIBLE_USER ) {
-			if ( isFirstLoad ) {
-				isFirstLoad = false;
-				return { fullPageLoad: true };
-			}
-			return { fullPageLoad: false };
+			return { fullPageLoad: consumeFirstLoad() };
 		}
 
 		const userPreference = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 		const optIn = userPreference[ 'hosting-dashboard-opt-in' ];
 		if ( optIn?.value === 'opt-in' || optIn?.value === 'forced-opt-in' ) {
-			if ( isFirstLoad ) {
-				isFirstLoad = false;
-				return { fullPageLoad: true };
-			}
-			return { fullPageLoad: false };
+			return { fullPageLoad: consumeFirstLoad() };
 		}
 
 		throw redirect( { href: wpcomLink( '/' ), replace: true } );

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -20,22 +20,31 @@ export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
 	notFoundComponent: NotFoundRoot,
 	beforeLoad: async ( { cause } ) => {
-		const fullPageLoad = isFirstLoad;
-		isFirstLoad = false;
-
 		if ( cause === 'preload' ) {
-			return { fullPageLoad };
+			if ( isFirstLoad ) {
+				isFirstLoad = false;
+				return { fullPageLoad: true };
+			}
+			return { fullPageLoad: false };
 		}
 
 		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 		if ( user && user.ID <= OLDEST_ELIGIBLE_USER ) {
-			return { fullPageLoad };
+			if ( isFirstLoad ) {
+				isFirstLoad = false;
+				return { fullPageLoad: true };
+			}
+			return { fullPageLoad: false };
 		}
 
 		const userPreference = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 		const optIn = userPreference[ 'hosting-dashboard-opt-in' ];
 		if ( optIn?.value === 'opt-in' || optIn?.value === 'forced-opt-in' ) {
-			return { fullPageLoad };
+			if ( isFirstLoad ) {
+				isFirstLoad = false;
+				return { fullPageLoad: true };
+			}
+			return { fullPageLoad: false };
 		}
 
 		throw redirect( { href: wpcomLink( '/' ), replace: true } );

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -20,18 +20,18 @@ export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	notFoundComponent: NotFoundRoot,
 	beforeLoad: async ( { cause } ): Promise< { fullPageLoad: boolean } > => {
 		if ( cause === 'preload' ) {
-			return { fullPageLoad: consumeFirstLoad() };
+			return { fullPageLoad: false };
 		}
 
 		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 		if ( user && user.ID <= OLDEST_ELIGIBLE_USER ) {
-			return { fullPageLoad: consumeFirstLoad() };
+			return { fullPageLoad: cause === 'enter' && consumeFirstLoad() };
 		}
 
 		const userPreference = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 		const optIn = userPreference[ 'hosting-dashboard-opt-in' ];
 		if ( optIn?.value === 'opt-in' || optIn?.value === 'forced-opt-in' ) {
-			return { fullPageLoad: consumeFirstLoad() };
+			return { fullPageLoad: cause === 'enter' && consumeFirstLoad() };
 		}
 
 		throw redirect( { href: wpcomLink( '/' ), replace: true } );

--- a/client/dashboard/app/router/root.tsx
+++ b/client/dashboard/app/router/root.tsx
@@ -18,7 +18,7 @@ export type RootRouterContext = {
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
 	notFoundComponent: NotFoundRoot,
-	beforeLoad: async ( { cause } ) => {
+	beforeLoad: async ( { cause } ): Promise< { fullPageLoad: boolean } > => {
 		if ( cause === 'preload' ) {
 			return { fullPageLoad: consumeFirstLoad() };
 		}

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -116,13 +116,9 @@ export const siteRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'sites/$siteSlug',
-	beforeLoad: async ( { cause, params: { siteSlug }, location, matches, context } ) => {
+	beforeLoad: async ( { cause, params: { siteSlug }, location, matches } ) => {
 		if ( cause === 'preload' ) {
 			return;
-		}
-
-		if ( cause === 'enter' ) {
-			startPerformanceTracking( 'dashboard-site-overview', { fullPageLoad: context.fullPageLoad } );
 		}
 
 		let site;
@@ -194,6 +190,11 @@ export const siteRoute = createRoute( {
 export const siteOverviewRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: '/',
+	beforeLoad: ( { cause, context: { fullPageLoad } } ) => {
+		if ( cause === 'enter' ) {
+			startPerformanceTracking( 'dashboard-site-overview', { fullPageLoad } );
+		}
+	},
 	loader: async ( { params: { siteSlug }, preload } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( preload ) {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -63,6 +63,7 @@ import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { AUTH_QUERY_KEY } from '../auth';
+import { startPerformanceTracking } from '../performance-tracking';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
 import type { DifmWebsiteContentResponse, Site, User } from '@automattic/api-core';
@@ -78,6 +79,11 @@ export const sitesRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'sites',
+	beforeLoad: ( { cause, context: { fullPageLoad } } ) => {
+		if ( cause === 'enter' ) {
+			startPerformanceTracking( 'dashboard-site-list', { fullPageLoad } );
+		}
+	},
 	loader: async ( { context } ) => {
 		const tasks: Promise< unknown >[] = [];
 
@@ -110,9 +116,13 @@ export const siteRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'sites/$siteSlug',
-	beforeLoad: async ( { cause, params: { siteSlug }, location, matches } ) => {
+	beforeLoad: async ( { cause, params: { siteSlug }, location, matches, context } ) => {
 		if ( cause === 'preload' ) {
 			return;
+		}
+
+		if ( cause === 'enter' ) {
+			startPerformanceTracking( 'dashboard-site-overview', { fullPageLoad: context.fullPageLoad } );
 		}
 
 		let site;

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
+import { PerformanceTrackerStop } from '../app/performance-tracking';
 import { domainsIndexRoute } from '../app/router/domains';
 import { DataViews, DataViewsCard } from '../components/dataviews';
 import { OptInWelcome } from '../components/opt-in-welcome';
@@ -102,6 +103,7 @@ function Domains() {
 					</DataViewsCard>
 				) }
 			</PageLayout>
+			<PerformanceTrackerStop id="domains" />
 		</Suspense>
 	);
 }

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -103,7 +103,7 @@ function Domains() {
 					</DataViewsCard>
 				) }
 			</PageLayout>
-			<PerformanceTrackerStop id="domains" />
+			<PerformanceTrackerStop id="dashboard-domain-list" />
 		</Suspense>
 	);
 }

--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
+import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
 import { SiteLink } from '../site-fields';
@@ -35,6 +36,7 @@ export function SitesDataViews( {
 
 	return (
 		<>
+			{ ! isLoading && <PerformanceTrackerStop id="dashboard-site-list" /> }
 			<DataViewsCard>
 				<DataViews< Site >
 					getItemId={ ( item ) => item.ID.toString() }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -18,7 +18,6 @@ import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
-import { PerformanceTrackerStop } from '../app/performance-tracking';
 import { sitesRoute } from '../app/router/sites';
 import { DataViewsEmptyState } from '../components/dataviews';
 import OptInSurvey from '../components/opt-in-survey';
@@ -365,7 +364,6 @@ export default function Sites() {
 				treatmentExperience={ null }
 				loadingExperience={ null }
 			/>
-			<PerformanceTrackerStop id="dashboard-site-list" />
 		</>
 	);
 }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -365,7 +365,7 @@ export default function Sites() {
 				treatmentExperience={ null }
 				loadingExperience={ null }
 			/>
-			<PerformanceTrackerStop id="sites" />
+			<PerformanceTrackerStop id="dashboard-site-list" />
 		</>
 	);
 }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -18,6 +18,7 @@ import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
+import { PerformanceTrackerStop } from '../app/performance-tracking';
 import { sitesRoute } from '../app/router/sites';
 import { DataViewsEmptyState } from '../components/dataviews';
 import OptInSurvey from '../components/opt-in-survey';
@@ -364,6 +365,7 @@ export default function Sites() {
 				treatmentExperience={ null }
 				loadingExperience={ null }
 			/>
+			<PerformanceTrackerStop id="sites" />
 		</>
 	);
 }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -269,7 +269,7 @@ function SiteOverview( {
 					/>
 				) }
 			</GuidedTourContextProvider>
-			<PerformanceTrackerStop id="site-overview" siteSlug={ siteSlug } />
+			<PerformanceTrackerStop id="dashboard-site-overview" siteSlug={ siteSlug } />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useRef } from 'react';
+import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
 import OptInSurvey from '../../components/opt-in-survey';
 import { PageHeader } from '../../components/page-header';
@@ -268,6 +269,7 @@ function SiteOverview( {
 					/>
 				) }
 			</GuidedTourContextProvider>
+			<PerformanceTrackerStop id="site-overview" siteSlug={ siteSlug } />
 		</PageLayout>
 	);
 }

--- a/client/sites/v2/router.tsx
+++ b/client/sites/v2/router.tsx
@@ -14,7 +14,9 @@ import type { RootRouterContext } from 'calypso/dashboard/app/router/root';
  */
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
-	beforeLoad: () => ( { fullPageLoad: consumeFirstLoad() } ),
+	beforeLoad: async ( { cause } ): Promise< { fullPageLoad: boolean } > => ( {
+		fullPageLoad: cause === 'enter' && consumeFirstLoad(),
+	} ),
 } );
 
 export const dashboardSitesCompatibilityRoute = createRoute( {

--- a/client/sites/v2/router.tsx
+++ b/client/sites/v2/router.tsx
@@ -16,9 +16,11 @@ let isFirstLoad = true;
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
 	beforeLoad: () => {
-		const fullPageLoad = isFirstLoad;
-		isFirstLoad = false;
-		return { fullPageLoad };
+		if ( isFirstLoad ) {
+			isFirstLoad = false;
+			return { fullPageLoad: true };
+		}
+		return { fullPageLoad: false };
 	},
 } );
 

--- a/client/sites/v2/router.tsx
+++ b/client/sites/v2/router.tsx
@@ -1,6 +1,7 @@
 import { siteBySlugQuery, queryClient } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { Outlet, createRootRouteWithContext, createRoute } from '@tanstack/react-router';
+import { consumeFirstLoad } from 'calypso/dashboard/app/router/first-load-tracker';
 import { canManageSite } from 'calypso/dashboard/sites/features';
 import { getSiteDisplayName } from 'calypso/dashboard/utils/site-name';
 import { hasSiteTrialEnded } from 'calypso/dashboard/utils/site-trial';
@@ -8,20 +9,12 @@ import Root from './components/root';
 import type { Site } from '@automattic/api-core';
 import type { RootRouterContext } from 'calypso/dashboard/app/router/root';
 
-let isFirstLoad = true;
-
 /**
  * Define general routes
  */
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
-	beforeLoad: () => {
-		if ( isFirstLoad ) {
-			isFirstLoad = false;
-			return { fullPageLoad: true };
-		}
-		return { fullPageLoad: false };
-	},
+	beforeLoad: () => ( { fullPageLoad: consumeFirstLoad() } ),
 } );
 
 export const dashboardSitesCompatibilityRoute = createRoute( {

--- a/client/sites/v2/router.tsx
+++ b/client/sites/v2/router.tsx
@@ -8,14 +8,18 @@ import Root from './components/root';
 import type { Site } from '@automattic/api-core';
 import type { RootRouterContext } from 'calypso/dashboard/app/router/root';
 
+let isFirstLoad = true;
+
 /**
  * Define general routes
  */
 export const rootRoute = createRootRouteWithContext< RootRouterContext >()( {
 	component: Root,
-	// Empty beforeLoad is required to maintain type compatibility with MSD
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	beforeLoad: async ( { cause } ) => {},
+	beforeLoad: () => {
+		const fullPageLoad = isFirstLoad;
+		isFirstLoad = false;
+		return { fullPageLoad };
+	},
 } );
 
 export const dashboardSitesCompatibilityRoute = createRoute( {

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -15,6 +15,7 @@
 		"always_use_logout_url": true,
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
+		"rum-tracking/logstash": true,
 		"dashboard/v2": false,
 		"dashboard/v2/paginated-site-list": true,
 		"dev/auth-helper": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -14,6 +14,7 @@
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": false,
 		"cookie-banner": false,
+		"rum-tracking/logstash": true,
 		"dashboard/v2": false,
 		"dashboard/v2/paginated-site-list": true,
 		"dev/auth-helper": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -14,6 +14,7 @@
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": false,
 		"cookie-banner": true,
+		"rum-tracking/logstash": true,
 		"dashboard/v2": false,
 		"dashboard/v2/paginated-site-list": true,
 		"domain-transfer-redesign": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -14,6 +14,7 @@
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": false,
 		"cookie-banner": false,
+		"rum-tracking/logstash": true,
 		"dashboard/v2": false,
 		"dashboard/v2/paginated-site-list": true,
 		"dev/store-sandbox-helper": true,

--- a/packages/browser-data-collector/src/index.ts
+++ b/packages/browser-data-collector/src/index.ts
@@ -30,6 +30,15 @@ export const start = async (
 };
 
 /**
+ * Cancels an in-flight report without sending it.
+ * @see startPerformanceTracking in client/dashboard for why this is needed.
+ * @param id id of the report to cancel
+ */
+export const cancel = ( id: string ) => {
+	inFlightReporters.delete( id );
+};
+
+/**
  * Stops a report and sends it to the transporter.
  * @param id id of the report to send, comes from `start()`
  * @param obj options


### PR DESCRIPTION
Part of DOTMSD-845

## Proposed Changes

Records RUM events for dashboard pages. So far it only records site list, domain list, and site overview pages. I'll follow up with recording events for all the main MSD pages once we've got the pattern established.

- Uses explicit start/stop pattern for RUM performance tracking similar to Calypso
  - I like that the stop event is tied to the rendering of particular React elements, can be sure it is user-centric.
- `startPerformanceTracking()` called in route `beforeLoad`
- `PerformanceTrackerStop` component placed where page is "loaded"

## Why are these changes being made?

Add Real User Monitoring to Dashboard using `@automattic/browser-data-collector` to track page load performance, similar to legacy Calypso.

**Links to dashboard:**
- The calypso perf dashboard 3a339-pb
- A more raw view of the perf logs 3a33f-pb
- Just development logs 3a340-pb

**Reference implementations:**
- [Legacy Calypso performance-tracking lib](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/performance-tracking/lib.js)
- [Stepper performance tracking](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/utils/performance-tracking.tsx)
- [browser-data-collector package](https://github.com/Automattic/wp-calypso/tree/trunk/packages/browser-data-collector)

## Testing Instructions

1. Run the Dashboard locally (`yarn dashboard:dev`)
2. Navigate to `/sites` - should see a POST to `https://public-api.wordpress.com/rest/v1.1/logstash` in Network tab
3. Navigate to a site overview (`/sites/example.wordpress.com`) - should see another logstash POST
4. Navigate to `/domains` - should see another logstash POST
5. Verify each payload contains:
   - `id` matching the page (e.g., "sites", "site-overview", "domains")
   - `duration` with timing data
   - `client` set to "dashboard"
   - User metadata (`sitesCount`, `userLocale`)
   - Site metadata when on site-specific pages (`siteId`, `siteIsJetpack`, `siteIsAtomic`)
   - Verify the `fullPageLoad` is set as expected

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?