### PR TITLE
MSD: Enable paginated site list endpoint on backported v1 Site List

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -55,6 +55,7 @@
 		"current-site/notice": true,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
+		"dashboard/v2/paginated-site-list": true,
 		"design-picker/use-assembler-styles": true,
 		"dev/account-settings-helper": true,
 		"dev/auth-helper": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -29,6 +29,7 @@
 		"current-site/notice": true,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
+		"dashboard/v2/paginated-site-list": true,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"domain-transfer-redesign": true,

--- a/config/production.json
+++ b/config/production.json
@@ -40,6 +40,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/v2": true,
+		"dashboard/v2/paginated-site-list": true,
 		"dashboard/v2/backport/site-overview": true,
 		"domain-transfer-redesign": true,
 		"global-styles/on-personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -39,6 +39,7 @@
 		"current-site/notice": true,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
+		"dashboard/v2/paginated-site-list": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -39,6 +39,7 @@
 		"current-site/notice": true,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
+		"dashboard/v2/paginated-site-list": true,
 		"design-picker/use-assembler-styles": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,


### PR DESCRIPTION
Part of DOTMSD-1052

Follow-up to https://github.com/Automattic/wp-calypso/pull/108326

## Proposed Changes

Roll out the new `/v1.3/me/sites` endpoint for MSD site list in backported `wordpress.com/sites` environments.

## Testing Instructions

Go to `<Calypso live link>/sites`; verify no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
