### PR TITLE
Notifications: Simplify PendingApprovalBadge props and CSS

### DIFF
--- a/apps/notifications/src/app/templates/actions.jsx
+++ b/apps/notifications/src/app/templates/actions.jsx
@@ -1,10 +1,8 @@
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	Icon,
 } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
-import { pending } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { getActions, getReferenceId } from '../../panel/helpers/notes';
@@ -53,13 +51,7 @@ const ActionsPane = ( { isApproved, isLiked, note, goBack } ) => {
 
 	return (
 		<VStack spacing={ 4 } style={ { width: '100%' } }>
-			{ showPendingApprovalBadge && (
-				<PendingApprovalBadge
-					note={ note }
-					translate={ __ }
-					icon={ <Icon icon={ pending } size={ 16 } /> }
-				/>
-			) }
+			{ showPendingApprovalBadge && <PendingApprovalBadge note={ note } /> }
 			<HStack spacing={ 2 }>
 				{ hasAction( 'approve-comment' ) && (
 					<ApproveButton note={ note } isApproved={ isApproved } />

--- a/apps/notifications/src/panel/templates/actions.jsx
+++ b/apps/notifications/src/panel/templates/actions.jsx
@@ -14,7 +14,6 @@ import LikeButton from './button-like';
 import SpamButton from './button-spam';
 import TrashButton from './button-trash';
 import ReplyInput from './comment-reply-input';
-import Gridicon from './gridicons';
 
 const getType = ( note ) => ( null === getReferenceId( note, 'comment' ) ? 'post' : 'comment' );
 
@@ -51,13 +50,7 @@ const ActionsPane = ( { global, isApproved, isLiked, note, translate } ) => {
 
 	return (
 		<div className="wpnc__note-actions">
-			{ showPendingApprovalBadge && (
-				<PendingApprovalBadge
-					note={ note }
-					translate={ translate }
-					icon={ <Gridicon icon="time" size={ 16 } /> }
-				/>
-			) }
+			{ showPendingApprovalBadge && <PendingApprovalBadge note={ note } /> }
 			<div className="wpnc__note-actions__buttons">
 				{ hasAction( 'approve-comment' ) && <ApproveButton { ...{ note, isApproved } } /> }
 				{ hasAction( 'spam-comment' ) && <SpamButton note={ note } /> }

--- a/apps/notifications/src/shared/pending-approval-badge.scss
+++ b/apps/notifications/src/shared/pending-approval-badge.scss
@@ -1,31 +1,24 @@
-// Increase specificity to override reset styles
-.wpnc__main .wpnc__pending-approval-badge,
-.wpnc__pending-approval-badge {
+.wpnc__main .wpnc-pending-approval-badge {
 	display: flex;
 	align-items: center;
-	border-bottom: 1px solid var(--color-neutral-5, #dcdcde);
 	gap: 8px;
 	padding: 12px 9px;
-	margin: -17px 0 16px 14px;
+	margin-bottom: 5px;
 	background-color: color-mix(in srgb, var(--color-warning, #f0b849) 10%, transparent);
-	border-inline-start: 4px solid var(--color-warning, #f0b849);
 	font-size: 13px;
 	color: var(--color-text);
 
-	.gridicon,
 	svg {
 		fill: var(--color-warning, #f0b849);
 		flex-shrink: 0;
 	}
 
-	&__text,
-	.wpnc__pending-approval-badge__text {
+	.wpnc-pending-approval-badge__text {
 		font-weight: 500;
 		color: var(--color-warning-80, #614200);
 	}
 
-	&__link,
-	.wpnc__pending-approval-badge__link {
+	.wpnc-pending-approval-badge__link {
 		margin-inline-start: auto;
 		color: var(--color-warning-80, #614200);
 		text-decoration: none;

--- a/apps/notifications/src/shared/pending-approval-badge.tsx
+++ b/apps/notifications/src/shared/pending-approval-badge.tsx
@@ -1,37 +1,30 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
-
-import { ReactElement } from 'react';
-import type { Note } from '../app/types';
+import { Icon, pending } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import { getCommentsUrl, getReferenceId } from '../panel/helpers/notes';
+import type { Note } from '../app/types';
 
 import './pending-approval-badge.scss';
 
 interface PendingApprovalBadgeProps {
 	note: Note;
-	translate: ( text: string ) => string;
-	icon: ReactElement;
 }
 
-/**
- * PendingApprovalBadge component that works with both modern and legacy systems
- */
-const PendingApprovalBadge = ( { note, translate, icon }: PendingApprovalBadgeProps ) => {
+const PendingApprovalBadge = ( { note }: PendingApprovalBadgeProps ): JSX.Element => {
+	const translate = useTranslate();
 	const commentsUrl = getCommentsUrl( getReferenceId( note, 'site' ) );
-	const pendingText = translate( 'Pending Approval' );
-	const manageText = translate( 'Manage Comments' );
 
 	return (
-		<div className="wpnc__pending-approval-badge">
-			{ icon }
-			<span className="wpnc__pending-approval-badge__text">{ pendingText }</span>
+		<div className="wpnc-pending-approval-badge">
+			<Icon icon={ pending } size={ 20 } />
+			<span className="wpnc-pending-approval-badge__text">{ translate( 'Pending Approval' ) }</span>
 			{ commentsUrl && (
 				<a
-					className="wpnc__pending-approval-badge__link"
+					className="wpnc-pending-approval-badge__link"
 					href={ commentsUrl }
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					{ manageText }
+					{ translate( 'Manage Comments' ) }
 				</a>
 			) }
 		</div>


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/pull/108325

### Testing

- Tested on Calypso.
- Tested on https://widgets.wp.com/notifications/