### PR TITLE
Fix missing i18n for 'Create it yourself' in Add New Site menu

### DIFF
--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -84,7 +84,7 @@ function AddNewSite( { context = 'unknown' }: AddNewSiteProps ) {
 				) }
 				<MenuItem
 					icon={ <WordPressLogo /> }
-					title="Create it yourself"
+					title={ __( 'Create it yourself' ) }
 					description={ __( 'Start with a clean WordPress site and make it yours.' ) }
 					onClick={ wordpressClick }
 					href={ addQueryArgs( wpcomLink( '/start' ), {


### PR DESCRIPTION
## Proposed Changes

* Wrap the hardcoded 'Create it yourself' string with `__()` for proper internationalization

<img width="921" height="397" alt="SCR-20260127-nkoj" src="https://github.com/user-attachments/assets/02e389e4-f6c6-43fc-baf7-c8597a3c1e90" />

## Why are these changes being made?

The "Create it yourself" menu item title in the Add New Site component was not wrapped with the translation function, making it untranslatable. All other strings in this component are properly internationalized.

## Testing Instructions

1. Navigate to the Dashboard sites view
2. Click "Add new site" 
3. Verify the "Create it yourself" option displays correctly
4. (Optional) Switch to a non-English locale and verify the string can be translated

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.ai/claude-code)