### PR TITLE
MSD: Add performance tracking to backported site list with default view

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -53,6 +53,7 @@ import {
 	canViewSiteVisibilitySettings,
 	canViewWordPressSettings,
 } from '../../sites/features';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSiteMigrationInProgress, getSiteMigrationState } from '../../utils/site-status';
@@ -78,7 +79,13 @@ export const sitesRoute = createRoute( {
 	loader: async ( { context } ) => {
 		// Preload the default sites list response without blocking.
 		if ( ! isEnabled( 'dashboard/v2/paginated-site-list' ) ) {
-			queryClient.prefetchQuery( context.config.queries.sitesQuery() );
+			queryClient.prefetchQuery(
+				context.config.queries.sitesQuery( {
+					source: isDashboardBackport() ? 'dashboard-site-list-default' : undefined,
+					site_visibility: 'visible',
+					include_a8c_owned: false,
+				} )
+			);
 		}
 
 		await Promise.all( [

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -46,6 +46,7 @@ import type {
 import type { View, Filter } from '@wordpress/dataviews';
 
 type SiteListQueryOptions = {
+	isDefaultView?: boolean;
 	isRestoringAccount: boolean;
 	isAutomattician: boolean;
 };
@@ -75,7 +76,7 @@ const getFetchSitesOptions = (
 
 const getFetchPaginatedSitesOptions = (
 	view: View,
-	{ isRestoringAccount, isAutomattician }: SiteListQueryOptions,
+	{ isDefaultView, isRestoringAccount, isAutomattician }: SiteListQueryOptions,
 	siteFilters: DashboardFilters = {}
 ): FetchPaginatedSitesOptions => {
 	const filters = view.filters ?? [];
@@ -86,6 +87,8 @@ const getFetchPaginatedSitesOptions = (
 		! filters.some( ( item: Filter ) => item.field === 'is_a8c' && item.value === false );
 
 	const options: FetchPaginatedSitesOptions = {
+		source: isDashboardBackport() && isDefaultView ? 'dashboard-site-list-default' : undefined,
+
 		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
 		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
@@ -202,7 +205,11 @@ export default function Sites() {
 
 	const { sites, isLoadingSites, isPlaceholderData, hasNoData, totalItems } = useSiteListQuery(
 		view,
-		{ isRestoringAccount, isAutomattician }
+		{
+			isDefaultView: ! resetView && ! view.search && view.page === 1,
+			isRestoringAccount,
+			isAutomattician,
+		}
 	);
 
 	const fields = useFields( { isAutomattician, viewType: view.type } );

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -11,6 +11,7 @@ export type FetchSiteType = 'atomic' | 'jetpack' | 'wpcom' | 'jetpack-full' | 'c
 export type FetchSiteTypes = 'all' | FetchSiteType[];
 
 export interface FetchSitesOptions {
+	source?: string;
 	site_visibility: 'all' | 'visible' | 'hidden' | 'deleted';
 	include_a8c_owned: boolean;
 }
@@ -32,7 +33,7 @@ export interface FetchPaginatedSitesResponse {
 
 export async function fetchSites(
 	site_types: FetchSiteTypes,
-	{ site_visibility, include_a8c_owned }: FetchSitesOptions
+	{ source, site_visibility, include_a8c_owned }: FetchSitesOptions
 ): Promise< Site[] > {
 	const { sites } = await wpcom.req.get(
 		{
@@ -42,6 +43,7 @@ export async function fetchSites(
 		{
 			fields: JOINED_SITE_FIELDS,
 			options: JOINED_SITE_OPTIONS,
+			source,
 			site_activity: 'active',
 			site_visibility,
 			include_a8c_owned,
@@ -55,6 +57,7 @@ export async function fetchSites(
 export async function fetchPaginatedSites(
 	site_types: FetchSiteTypes,
 	{
+		source,
 		site_visibility,
 		include_a8c_owned,
 		search,
@@ -74,6 +77,7 @@ export async function fetchPaginatedSites(
 		{
 			fields: JOINED_SITE_FIELDS,
 			options: JOINED_SITE_OPTIONS,
+			source,
 			site_activity: 'active',
 			site_visibility,
 			include_a8c_owned,

--- a/packages/api-queries/src/sites.ts
+++ b/packages/api-queries/src/sites.ts
@@ -11,11 +11,13 @@ export const sitesQueryKey = [ 'sites', SITE_FIELDS, SITE_OPTIONS ];
 export const sitesQuery = (
 	siteFilters: FetchSiteTypes,
 	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
-) =>
-	queryOptions( {
-		queryKey: [ ...sitesQueryKey, siteFilters, fetchSitesOptions ],
+) => {
+	const { source, ...fetchSitesOptionsKey } = fetchSitesOptions;
+	return queryOptions( {
+		queryKey: [ ...sitesQueryKey, siteFilters, fetchSitesOptionsKey ],
 		queryFn: () => fetchSites( siteFilters, fetchSitesOptions ),
 	} );
+};
 
 export const paginatedSitesQuery = (
 	siteFilters: FetchSiteTypes,
@@ -23,10 +25,12 @@ export const paginatedSitesQuery = (
 		site_visibility: 'visible',
 		include_a8c_owned: false,
 	}
-) =>
-	queryOptions( {
-		queryKey: [ ...sitesQueryKey, 'paginated', siteFilters, fetchSitesOptions ],
+) => {
+	const { source, ...fetchSitesOptionsKey } = fetchSitesOptions;
+	return queryOptions( {
+		queryKey: [ ...sitesQueryKey, 'paginated', siteFilters, fetchSitesOptionsKey ],
 		queryFn: () => fetchPaginatedSites( siteFilters, fetchSitesOptions ),
 	} );
+};
 
 export const allSitesQuery = () => sitesQuery( 'all' );


### PR DESCRIPTION
Related to p7DVsv-oFQ-p2

## Proposed Changes

We want to track how much performance gain by switching to the new site list endpoint (`v1.3/me/sites`). This is done by passing a new `source=dashboard-site-list-default` when we open the site list with the default view (i.e., no search term, page=1, default page size = 12). We do this in the backported site list (`wordpress.com/sites`).

## Testing Instructions

1. Sandbox public-api with 201434-ghe-Automattic/wpcom
2. With the browser network tools open, visit `<calypso live link>/sites`:
    - Observe there's request to `v1.2/me/sites` with a new `source=dashboard-site-list-default` query param present.
    - Try to go to next page or add filter or search etc.
    - Observe there's NO request to `v1.2/me/sites` with a new `source=dashboard-site-list-default` query param present. 
2. With the browser network tools open, visit `<calypso live link>/sites?flags=dashboard/v2/paginated-site-list`:
    - Observe there's request to `v1.3/me/sites` with a new `source=dashboard-site-list-default` query param present.
    - Try to go to next page or add filter or search etc.
    - Observe there's NO request to `v1.3/me/sites` with a new `source=dashboard-site-list-default` query param present. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?