### PR TITLE
Add dashboard dev verification skill for Claude Code

### DIFF
--- a/.claude/skills/dashboard-dev-verification/SKILL.md
+++ b/.claude/skills/dashboard-dev-verification/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: dashboard-dev-verification
+description: Lint, format, and test changes in client/dashboard/. Use skill to help plan changes to client/dashboard/ code.
+user-invocable: false
+---
+
+
+
+# Dashboard Development Verification
+
+Scripts to verify work in `client/dashboard/`.
+
+Do NOT search for uncommited changes yourself when calling the following scripts, rely on the --changed-only flag instead.
+
+You MUST use these scripts to verify dashboard changes. Do not use `pnpm`.
+
+## Quick Reference
+
+| Check      | Command                                                       | With fix    |
+|------------|---------------------------------------------------------------|-------------|
+| Lint JS/TS | `.claude/skills/dashboard-dev-verification/scripts/lint.sh`   | `... --fix` |
+| Format     | `.claude/skills/dashboard-dev-verification/scripts/format.sh` | `... --fix` |
+| Test       | `.claude/skills/dashboard-dev-verification/scripts/test.sh`   | -           |
+| CSS lint   | `.claude/skills/dashboard-dev-verification/scripts/css.sh`    | `... --fix` |
+| All checks | `.claude/skills/dashboard-dev-verification/scripts/all.sh`    | `... --fix` |
+
+## Common Patterns
+
+**After making changes:**
+```bash
+.claude/skills/dashboard-dev-verification/scripts/lint.sh --changed-only --fix
+.claude/skills/dashboard-dev-verification/scripts/format.sh --changed-only --fix
+```
+
+**Before committing:**
+```bash
+.claude/skills/dashboard-dev-verification/scripts/all.sh --changed-only
+```
+
+**Specific file:**
+```bash
+.claude/skills/dashboard-dev-verification/scripts/lint.sh client/dashboard/sites/overview/index.tsx
+```
+
+## Script Options
+
+All scripts accept:
+- `--changed-only` - Only check files with uncommitted changes
+- `--fix` - Auto-fix issues (lint, format, css only)
+- `[files...]` - Specific files to check
+- MUST be provided one of the options above - verifying all files in `client/dashboard/` is too slow
+
+## Notes
+
+- `test.sh` uses `--findRelatedTests` to run tests affected by changed files

--- a/.claude/skills/dashboard-dev-verification/scripts/all.sh
+++ b/.claude/skills/dashboard-dev-verification/scripts/all.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Run all verification checks for client/dashboard
+# Usage: all.sh [--changed-only] [--fix]
+set -e
+
+DIR="$(dirname "$0")"
+
+echo "=== Lint ===" && "$DIR/lint.sh" "$@"
+echo "=== Format ===" && "$DIR/format.sh" "$@"
+echo "=== Test ===" && "$DIR/test.sh" "$@"
+echo "=== CSS ===" && "$DIR/css.sh" "$@"
+echo "✅ All checks passed"

--- a/.claude/skills/dashboard-dev-verification/scripts/changed-files.sh
+++ b/.claude/skills/dashboard-dev-verification/scripts/changed-files.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Output changed files in client/dashboard (staged + unstaged)
+# Usage: changed-files.sh [js|css|all]
+# Example: changed-files.sh js | xargs yarn lint:js
+
+DASHBOARD_PATH="client/dashboard"
+TYPE="${1:-all}"
+
+files=$({ git diff --name-only HEAD -- "$DASHBOARD_PATH" 2>/dev/null; git diff --cached --name-only -- "$DASHBOARD_PATH" 2>/dev/null; } | sort -u)
+
+case "$TYPE" in
+    js)
+        echo "$files" | grep -E '\.(js|jsx|ts|tsx|mjs|json)$' || true
+        ;;
+    css)
+        echo "$files" | grep -E '\.(css|scss)$' || true
+        ;;
+    all)
+        echo "$files"
+        ;;
+    *)
+        echo "Usage: changed-files.sh [js|css|all]" >&2
+        exit 1
+        ;;
+esac

--- a/.claude/skills/dashboard-dev-verification/scripts/css.sh
+++ b/.claude/skills/dashboard-dev-verification/scripts/css.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Lint CSS/SCSS files in client/dashboard
+# Usage: css.sh [--changed-only] [--fix] [files...]
+set -e
+
+DIR="$(dirname "$0")"
+FIX=""
+CHANGED_ONLY=false
+FILES=()
+
+for arg in "$@"; do
+    case $arg in
+        --fix) FIX="--fix" ;;
+        --changed-only) CHANGED_ONLY=true ;;
+        *) FILES+=("$arg") ;;
+    esac
+done
+
+if [ ${#FILES[@]} -gt 0 ]; then
+    yarn lint:css $FIX "${FILES[@]}"
+elif $CHANGED_ONLY; then
+    files=$("$DIR/changed-files.sh" css | tr '\n' ' ')
+    if [ -n "$files" ]; then
+        npx stylelint $FIX $files
+    else
+        echo "No changed CSS/SCSS files"
+    fi
+else
+	  echo "Must use --changed-only, --fix, or specify files" >&2
+		exit 1
+fi

--- a/.claude/skills/dashboard-dev-verification/scripts/format.sh
+++ b/.claude/skills/dashboard-dev-verification/scripts/format.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Check formatting of JS/TS files in client/dashboard
+# Usage: format.sh [--changed-only] [--fix] [files...]
+set -e
+
+DIR="$(dirname "$0")"
+MODE="--check"
+CHANGED_ONLY=false
+FILES=()
+
+for arg in "$@"; do
+    case $arg in
+        --fix) MODE="--write" ;;
+        --changed-only) CHANGED_ONLY=true ;;
+        *) FILES+=("$arg") ;;
+    esac
+done
+
+if [ ${#FILES[@]} -gt 0 ]; then
+    yarn prettier $MODE "${FILES[@]}"
+elif $CHANGED_ONLY; then
+    files=$("$DIR/changed-files.sh" js | tr '\n' ' ')
+    if [ -n "$files" ]; then
+        yarn prettier $MODE $files
+    else
+        echo "No changed JS/TS files"
+    fi
+else
+    echo "Must use --changed-only, --fix, or specify files" >&2
+    exit 1
+fi

--- a/.claude/skills/dashboard-dev-verification/scripts/lint.sh
+++ b/.claude/skills/dashboard-dev-verification/scripts/lint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Lint JS/TS files in client/dashboard
+# Usage: lint.sh [--changed-only] [--fix] [files...]
+# Examples:
+#   lint.sh --changed-only       # lint changed files
+#   lint.sh --fix                # lint all with autofix
+#   lint.sh path/to/file.ts      # lint specific file
+set -e
+
+DIR="$(dirname "$0")"
+FIX=""
+CHANGED_ONLY=false
+FILES=()
+
+for arg in "$@"; do
+    case $arg in
+        --fix) FIX="--fix" ;;
+        --changed-only) CHANGED_ONLY=true ;;
+        *) FILES+=("$arg") ;;
+    esac
+done
+
+if [ ${#FILES[@]} -gt 0 ]; then
+    yarn lint:js $FIX "${FILES[@]}"
+elif $CHANGED_ONLY; then
+    files=$("$DIR/changed-files.sh" js | tr '\n' ' ')
+    if [ -n "$files" ]; then
+        npx eslint $FIX $files
+    else
+        echo "No changed JS/TS files"
+    fi
+else
+	  echo "Must use --changed-only, --fix, or specify files" >&2
+		exit 1
+fi

--- a/.claude/skills/dashboard-dev-verification/scripts/test.sh
+++ b/.claude/skills/dashboard-dev-verification/scripts/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Run Jest tests for client/dashboard
+# Usage: test.sh [--changed-only] [files...]
+set -e
+
+DIR="$(dirname "$0")"
+CHANGED_ONLY=false
+FILES=()
+
+for arg in "$@"; do
+    case $arg in
+        --changed-only) CHANGED_ONLY=true ;;
+        *) FILES+=("$arg") ;;
+    esac
+done
+
+if [ ${#FILES[@]} -gt 0 ]; then
+    yarn test-client --testPathPattern="client/dashboard" --findRelatedTests ${FILES[@]}
+elif $CHANGED_ONLY; then
+    files=$("$DIR/changed-files.sh" js | tr '\n' ' ')
+    if [ -n "$files" ]; then
+        yarn test-client --testPathPattern="client/dashboard" --findRelatedTests $files
+    else
+        echo "No changed JS/TS files"
+    fi
+else
+    echo "Must use --changed-only, --fix, or specify files" >&2
+    exit 1
+fi

--- a/.rules/dashboard-rules.mdc
+++ b/.rules/dashboard-rules.mdc
@@ -18,6 +18,10 @@ For detailed implementation guidance, refer to:
 - [Typography and Copy](mdc:client/dashboard/docs/typography-and-copy.md) - Capitalization, snackbar messages
 - [Testing](mdc:client/dashboard/docs/testing.md) - Testing strategies
 
+## Verification
+
+Verify your changes to the dashboard code using the dashboard-dev-verification skill.
+
 ## Code Review Guidelines
 
 When reviewing dashboard code, watch for these specific patterns and potential issues:


### PR DESCRIPTION
## Proposed Changes

* Add Claude Code skill for verifying dashboard changes
* Scripts for lint, format, test, and CSS checking
* Reference skill in dashboard-rules.mdc

## Why are these changes being made?

Provides Claude Code with optimized verification tools for `client/dashboard/`. The scripts are designed to use fewer tokens/context than having Claude run verification commands directly—instead of Claude figuring out the right pnpm commands and parsing verbose output, these scripts handle the complexity and return minimal output.

Intentionally excludes type checking because tsc must check the entire project at once (no incremental/file-specific mode), making it too slow for quick verification loops.

This starts with dashboard code as a test. If it works well, the pattern should apply to all Calypso code.

## Testing Instructions

1. Make a change in `client/dashboard/`
2. Run `.claude/skills/dashboard-dev-verification/scripts/all.sh --changed-only`
3. Verify lint/format/test/css checks run on changed files only

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?