### PR TITLE
Add bigsky experiment variation

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -277,7 +277,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									coupon,
 								} )
 							);
-						} else if ( providedDependencies?.postCheckoutBigSky ) {
+						} else if ( providedDependencies?.postCheckoutBigSkyVariation === 'big_sky' ) {
 							return navigate( 'setup-your-site-ai' );
 						} else {
 							// replace the location to delete processing step from history.

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -1,10 +1,5 @@
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
-import {
-	clearStepPersistedState,
-	ONBOARDING_FLOW,
-	SITE_MIGRATION_FLOW,
-	SITE_SETUP_FLOW,
-} from '@automattic/onboarding';
+import { clearStepPersistedState, ONBOARDING_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
@@ -219,17 +214,6 @@ const onboarding: FlowV2< typeof initialize > = {
 							return;
 						case 'blank-site':
 							window.location.replace( `/sites/${ siteSlug }` );
-							return;
-						case 'migrate':
-							window.location.assign(
-								addQueryArgs(
-									`/setup/${ SITE_MIGRATION_FLOW }/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }`,
-									{
-										siteSlug,
-										siteId,
-									}
-								)
-							);
 							return;
 						default:
 							return;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -38,14 +38,12 @@ const PostCheckoutOnboarding: StepType< {
 	const { submit } = navigation;
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { site, siteSlug } = useSiteData();
-
+	const eligibleForExperiment =
+		isEnabled( 'onboarding/post-checkout-ai-step' ) &&
+		site?.plan?.features?.active?.includes( FEATURE_BIG_SKY );
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
 		'calyso_post_onboarding_big_sky_202601_v1',
-		{
-			isEligible:
-				isEnabled( 'onboarding/post-checkout-ai-step' ) &&
-				site?.plan?.features?.active?.includes( FEATURE_BIG_SKY ),
-		}
+		{ isEligible: eligibleForExperiment }
 	);
 
 	const intent = useSelect(
@@ -133,7 +131,9 @@ const PostCheckoutOnboarding: StepType< {
 				siteSlug,
 				hasExternalTheme,
 				hasPluginByGoal,
-				postCheckoutBigSkyVariation: experimentAssignment?.variationName,
+				...( eligibleForExperiment
+					? { postCheckoutBigSkyVariation: experimentAssignment?.variationName ?? 'control' }
+					: {} ),
 			};
 
 			if ( isJetpackOrAtomic ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -6,7 +6,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import Loading from 'calypso/components/loading';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
 import { useMarketplaceThemeProducts } from '../../../../hooks/use-marketplace-theme-products';
 import { useSiteData } from '../../../../hooks/use-site-data';
@@ -129,18 +128,12 @@ const PostCheckoutOnboarding: StepType< {
 			return;
 		}
 
-		if ( experimentAssignment?.variationName ) {
-			recordTracksEvent( 'calypso_post_checkout_big_sky_exposure', {
-				variation: experimentAssignment.variationName,
-			} );
-		}
-
 		setPendingAction( async () => {
 			const providedDependencies = {
 				siteSlug,
 				hasExternalTheme,
 				hasPluginByGoal,
-				postCheckoutBigSky: experimentAssignment?.variationName === 'big_sky',
+				postCheckoutBigSkyVariation: experimentAssignment?.variationName,
 			};
 
 			if ( isJetpackOrAtomic ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -3,9 +3,10 @@ import { FEATURE_BIG_SKY } from '@automattic/calypso-products';
 import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { Step } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import Loading from 'calypso/components/loading';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
 import { useMarketplaceThemeProducts } from '../../../../hooks/use-marketplace-theme-products';
 import { useSiteData } from '../../../../hooks/use-site-data';
@@ -39,11 +40,30 @@ const PostCheckoutOnboarding: StepType< {
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { site, siteSlug } = useSiteData();
 
-	const [ , experimentAssignment ] = useExperiment( 'calyso_post_onboarding_big_sky_202601_v1', {
-		isEligible:
-			isEnabled( 'onboarding/post-checkout-ai-step' ) &&
-			site?.plan?.features?.active?.includes( FEATURE_BIG_SKY ),
-	} );
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
+		'calyso_post_onboarding_big_sky_202601_v1',
+		{
+			isEligible:
+				isEnabled( 'onboarding/post-checkout-ai-step' ) &&
+				site?.plan?.features?.active?.includes( FEATURE_BIG_SKY ),
+		}
+	);
+
+	const hasTrackedExposure = useRef( false );
+
+	// Track experiment exposure event
+	useEffect( () => {
+		if ( isLoadingExperiment || ! experimentAssignment || hasTrackedExposure.current ) {
+			return;
+		}
+
+		if ( experimentAssignment.variationName ) {
+			recordTracksEvent( 'calypso_post_checkout_big_sky_exposure', {
+				variation: experimentAssignment.variationName,
+			} );
+		}
+		hasTrackedExposure.current = true;
+	}, [ isLoadingExperiment, experimentAssignment ] );
 
 	const intent = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -3,7 +3,7 @@ import { FEATURE_BIG_SKY } from '@automattic/calypso-products';
 import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { Step } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import Loading from 'calypso/components/loading';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -48,22 +48,6 @@ const PostCheckoutOnboarding: StepType< {
 				site?.plan?.features?.active?.includes( FEATURE_BIG_SKY ),
 		}
 	);
-
-	const hasTrackedExposure = useRef( false );
-
-	// Track experiment exposure event
-	useEffect( () => {
-		if ( isLoadingExperiment || ! experimentAssignment || hasTrackedExposure.current ) {
-			return;
-		}
-
-		if ( experimentAssignment.variationName ) {
-			recordTracksEvent( 'calypso_post_checkout_big_sky_exposure', {
-				variation: experimentAssignment.variationName,
-			} );
-		}
-		hasTrackedExposure.current = true;
-	}, [ isLoadingExperiment, experimentAssignment ] );
 
 	const intent = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
@@ -139,9 +123,16 @@ const PostCheckoutOnboarding: StepType< {
 			! site ||
 			! siteSlug ||
 			isLoadingMarketplaceThemeProducts ||
-			isLoadingSiteTransferStatusData
+			isLoadingSiteTransferStatusData ||
+			isLoadingExperiment
 		) {
 			return;
+		}
+
+		if ( experimentAssignment?.variationName ) {
+			recordTracksEvent( 'calypso_post_checkout_big_sky_exposure', {
+				variation: experimentAssignment.variationName,
+			} );
 		}
 
 		setPendingAction( async () => {
@@ -175,6 +166,7 @@ const PostCheckoutOnboarding: StepType< {
 		siteSlug,
 		isLoadingMarketplaceThemeProducts,
 		isLoadingSiteTransferStatusData,
+		isLoadingExperiment,
 		isJetpackOrAtomic,
 		siteTransferStatusData,
 		selectedDesign,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
@@ -1,6 +1,6 @@
 import { BigSkyLogo, SummaryButton } from '@automattic/components';
 import { Step } from '@automattic/onboarding';
-import { __experimentalVStack as VStack, Button, Icon } from '@wordpress/components';
+import { __experimentalVStack as VStack, Icon } from '@wordpress/components';
 import { code } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -31,16 +31,6 @@ const SetupYourSiteAIStep: StepType = ( { navigation } ) => {
 		} );
 	};
 
-	const handleMigrate = () => {
-		recordTracksEvent( 'calypso_setup_your_site_ai_migrate_click' );
-
-		navigation.submit( {
-			setupChoice: 'migrate',
-			siteSlug,
-			siteId,
-		} );
-	};
-
 	const stepContent = (
 		<VStack alignment="top" spacing={ 3 }>
 			<SummaryButton
@@ -57,13 +47,6 @@ const SetupYourSiteAIStep: StepType = ( { navigation } ) => {
 				decoration={ <Icon icon={ code } /> }
 				onClick={ handleBlankSite }
 			/>
-			<Button
-				className="setup-your-site-ai__migrate-button"
-				variant="link"
-				onClick={ handleMigrate }
-			>
-				{ translate( 'Or migrate your site' ) }
-			</Button>
 		</VStack>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/style.scss
@@ -11,10 +11,5 @@
 			font-weight: 500;
 		}
 	}
-
-	.setup-your-site-ai__migrate-button {
-		color: var(--color-primary, #0675c4);
-		text-decoration: none;
-	}	
 }
 

--- a/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
@@ -1,5 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { FEATURE_BIG_SKY, isBusinessPlan, isPremiumPlan } from '@automattic/calypso-products';
+import {
+	FEATURE_BIG_SKY,
+	isBusinessPlan,
+	isPremiumPlan,
+	isPersonalPlan,
+} from '@automattic/calypso-products';
 import { Onboard } from '@automattic/data-stores';
 import { AI_SITE_BUILDER_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
@@ -34,7 +39,10 @@ export function useIsBigSkyEligible( flowName?: string ) {
 	);
 
 	const isEligibleGoals = isGoalsBigSkyEligible( goals );
-	const isEligiblePlan = isPremiumPlan( product_slug ) || isBusinessPlan( product_slug );
+	const isEligiblePlan =
+		isPersonalPlan( product_slug ) ||
+		isPremiumPlan( product_slug ) ||
+		isBusinessPlan( product_slug );
 	const siteHasBigSkyFeature = site?.plan?.features?.active?.includes( FEATURE_BIG_SKY ) ?? false;
 
 	if ( flowName === AI_SITE_BUILDER_FLOW ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTCOM-15867

## Proposed Changes

* Pass experiment assignment to event

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Distinguish between bigsky and control group

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* To test the following cases you need to follow the onboarding flow with different plans.
* Test with user that is not assigned to the experiment with ineligible plan like e-commerce
* The event `calypso_signup_actions_submit_step` should trigger for `onboarding` flow with `processing` step and `post_checkout_big_sky_variation` should not be present when this event is posted.
* Assign your user to the control group of the experiment. post_checkout_big_sky_variation should become `control` for personal plan.
* Assign your user to the big-sky group. post_checkout_big_sky_variation will become `big_sky` if purchasing business plan.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
