### PR TITLE
Prevent the AI feature from jumping on hover

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -737,6 +737,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 
 const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	feature?: FeatureObject | TransformedFeatureObject;
+	featureGroupSlug: string;
 	isHiddenInMobile: boolean;
 	allJetpackFeatures: Set< string >;
 	visibleGridPlans: GridPlan[];
@@ -750,6 +751,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 } > = ( {
 	feature,
+	featureGroupSlug,
 	isHiddenInMobile,
 	allJetpackFeatures,
 	visibleGridPlans,
@@ -768,7 +770,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	} );
 	const featureSlug = feature?.getSlug() ?? '';
 	const footnote = planFeatureFootnotes?.footnotesByFeature?.[ featureSlug ];
-	const tooltipId = `${ feature?.getSlug() }-comparison-grid`;
+	const tooltipId = `${ featureGroupSlug }-${ feature?.getSlug() }-comparison-grid`;
 	const title = feature?.getTitle?.();
 	const headerAriaLabel: string = typeof title === 'string' ? title : '';
 
@@ -961,6 +963,7 @@ const FeatureGroup = ( {
 				<ComparisonGridFeatureGroupRow
 					key={ feature.getSlug() }
 					feature={ feature }
+					featureGroupSlug={ featureGroup.slug }
 					isHiddenInMobile={ isHiddenInMobile }
 					allJetpackFeatures={ allJetpackFeatures }
 					visibleGridPlans={ visibleGridPlans }
@@ -977,6 +980,7 @@ const FeatureGroup = ( {
 			{ featureGroup.slug === FEATURE_GROUP_ESSENTIAL_FEATURES ? (
 				<ComparisonGridFeatureGroupRow
 					key="feature-storage"
+					featureGroupSlug={ featureGroup.slug }
 					isHiddenInMobile={ isHiddenInMobile }
 					allJetpackFeatures={ allJetpackFeatures }
 					visibleGridPlans={ visibleGridPlans }


### PR DESCRIPTION


<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15857

## Proposed Changes

In the experiment variant, FEATURE_AI_WEBSITE_BUILDER appears in two feature groups: FEATURE_GROUP_ESSENTIAL_FEATURES
FEATURE_GROUP_MARKETING_GROWTH_AND_MONETIZATION_TOOLS The tooltip ID was being generated using only the feature slug.

Rather than removing the feature from one of the feature group, make the slug more unique

## Why are these changes being made?

*

## Testing Instructions

* Assign yourself to the test variant var1d from calypso_pricing_differentiation_202601_v1
* In the signup onboarding, plans step, compare plans
* Scroll down to growth tools, and point to the second feature
* Before - jumping. After - no jumping. There's video in the linear issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
