### PR TITLE
Agent Manager: Display Zendesk chat history in conversation list

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -1,5 +1,6 @@
 import {
 	getAgentManager,
+	ServerConversationListItem,
 	useAgentChat,
 	type UseAgentChatConfig,
 } from '@automattic/agenttic-client';
@@ -167,10 +168,14 @@ export default function AgentDock( {
 		}
 	};
 
-	const handleSelectConversation = ( sessionId: string ) => {
-		abortCurrentRequest();
-		setSessionId( sessionId );
-		navigate( '/chat', { state: { sessionId } } );
+	const handleSelectConversation = ( conversation: ServerConversationListItem ) => {
+		if ( conversation.is_zendesk ) {
+			navigate( '/zendesk', { state: { conversationId: conversation.conversation_id } } );
+		} else {
+			abortCurrentRequest();
+			setSessionId( sessionId );
+			navigate( '/chat', { state: { sessionId } } );
+		}
 	};
 
 	const getChatHeaderOptions = (): ChatHeaderOptions => {
@@ -254,7 +259,6 @@ export default function AgentDock( {
 			chatHeaderOptions={ getChatHeaderOptions() }
 			markdownComponents={ markdownComponents }
 			markdownExtensions={ markdownExtensions }
-			emptyViewSuggestions={ emptyViewSuggestions }
 		/>
 	);
 

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -1,6 +1,5 @@
 import {
 	getAgentManager,
-	ServerConversationListItem,
 	useAgentChat,
 	type UseAgentChatConfig,
 } from '@automattic/agenttic-client';
@@ -19,6 +18,7 @@ import useAdminBarIntegration from '../../hooks/use-admin-bar-integration';
 import useAgentLayoutManager from '../../hooks/use-agent-layout-manager';
 import useConversation from '../../hooks/use-conversation';
 import { AGENTS_MANAGER_STORE } from '../../stores';
+import { LocalConversationListItem } from '../../types';
 import { setSessionId } from '../../utils/agent-session';
 import AgentChat from '../agent-chat';
 import AgentHistory from '../agent-history';
@@ -168,7 +168,7 @@ export default function AgentDock( {
 		}
 	};
 
-	const handleSelectConversation = ( conversation: ServerConversationListItem ) => {
+	const handleSelectConversation = ( conversation: LocalConversationListItem ) => {
 		if ( conversation.is_zendesk ) {
 			navigate( '/zendesk', { state: { conversationId: conversation.conversation_id } } );
 		} else {

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -3,9 +3,10 @@ import { AgentsManagerSelect } from '@automattic/data-stores';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { AGENTS_MANAGER_STORE } from '../../stores';
+import { LocalConversationListItem } from '../../types';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import ConversationHistoryView from '../conversation-history-view';
-import type { ServerConversationListItem, UseAgentChatConfig } from '@automattic/agenttic-client';
+import type { UseAgentChatConfig } from '@automattic/agenttic-client';
 
 interface AgentHistoryProps {
 	/** Agent ID for fetching conversation history. */
@@ -27,7 +28,7 @@ interface AgentHistoryProps {
 	/** Called when the chat is expanded (floating mode). */
 	onExpand: () => void;
 	/** Called when a conversation is selected. */
-	onSelectConversation: ( conversation: ServerConversationListItem ) => void;
+	onSelectConversation: ( conversation: LocalConversationListItem ) => void;
 	/** Called when the user starts a new chat. */
 	onNewChat: () => void;
 }

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import ConversationHistoryView from '../conversation-history-view';
-import type { UseAgentChatConfig } from '@automattic/agenttic-client';
+import type { ServerConversationListItem, UseAgentChatConfig } from '@automattic/agenttic-client';
 
 interface AgentHistoryProps {
 	/** Agent ID for fetching conversation history. */
@@ -27,7 +27,7 @@ interface AgentHistoryProps {
 	/** Called when the chat is expanded (floating mode). */
 	onExpand: () => void;
 	/** Called when a conversation is selected. */
-	onSelectConversation: ( sessionId: string ) => void;
+	onSelectConversation: ( conversation: ServerConversationListItem ) => void;
 	/** Called when the user starts a new chat. */
 	onNewChat: () => void;
 }

--- a/packages/agents-manager/src/components/conversation-history-view/index.tsx
+++ b/packages/agents-manager/src/components/conversation-history-view/index.tsx
@@ -3,6 +3,7 @@
  * Displays the list of past conversations with a "new chat" action
  */
 
+import { ServerConversationListItem } from '@automattic/agenttic-client';
 import { Button } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -14,7 +15,7 @@ import './style.scss';
 interface Props {
 	agentId: string;
 	authProvider?: () => Promise< Record< string, string > >;
-	onSelectConversation: ( sessionId: string ) => void;
+	onSelectConversation: ( conversation: ServerConversationListItem ) => void;
 	onNewChat: () => void;
 }
 
@@ -63,7 +64,7 @@ export default function ConversationHistoryView( {
 							<ConversationListItem
 								key={ conversation.session_id }
 								conversation={ conversation }
-								onClick={ ( sessionId ) => onSelectConversationRef.current( sessionId ) }
+								onClick={ ( conversation ) => onSelectConversationRef.current( conversation ) }
 							/>
 						) ) }
 					</div>

--- a/packages/agents-manager/src/components/conversation-history-view/index.tsx
+++ b/packages/agents-manager/src/components/conversation-history-view/index.tsx
@@ -3,11 +3,11 @@
  * Displays the list of past conversations with a "new chat" action
  */
 
-import { ServerConversationListItem } from '@automattic/agenttic-client';
 import { Button } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import useConversationList from '../../hooks/use-conversation-list';
+import { LocalConversationListItem } from '../../types';
 import ConversationListItem from '../conversation-list-item';
 import ConversationListSkeleton from '../conversation-list-skeleton';
 import './style.scss';
@@ -15,7 +15,7 @@ import './style.scss';
 interface Props {
 	agentId: string;
 	authProvider?: () => Promise< Record< string, string > >;
-	onSelectConversation: ( conversation: ServerConversationListItem ) => void;
+	onSelectConversation: ( conversation: LocalConversationListItem ) => void;
 	onNewChat: () => void;
 }
 

--- a/packages/agents-manager/src/components/conversation-list-item/index.tsx
+++ b/packages/agents-manager/src/components/conversation-list-item/index.tsx
@@ -14,11 +14,11 @@ import './style.scss';
 
 interface Props {
 	conversation: ServerConversationListItem;
-	onClick: ( sessionId: string ) => void;
+	onClick: ( conversation: ServerConversationListItem ) => void;
 }
 
 export default function ConversationListItem( { conversation, onClick }: Props ) {
-	const sessionId = conversation.session_id || '';
+	const disabled = ! conversation.session_id && ! conversation.conversation_id;
 	const title = generateConversationTitle( conversation.first_message?.content || '' );
 	const subtitle = generateConversationSubtitle( conversation.first_message?.created_at || '' );
 
@@ -26,8 +26,8 @@ export default function ConversationListItem( { conversation, onClick }: Props )
 		<button
 			className="agents-manager-conversation-list-item"
 			type="button"
-			onClick={ () => onClick( sessionId ) }
-			disabled={ ! sessionId }
+			onClick={ () => onClick( conversation ) }
+			disabled={ disabled }
 			aria-label={ sprintf(
 				/* translators: %1$s: conversation title, %2$s: conversation subtitle */
 				__( 'Load conversation: %1$s, %2$s', '__i18n_text_domain__' ),
@@ -35,7 +35,7 @@ export default function ConversationListItem( { conversation, onClick }: Props )
 				subtitle
 			) }
 		>
-			<ConversationAvatar />
+			<ConversationAvatar isHe={ conversation.is_zendesk } />
 			<div className="agents-manager-conversation-list-item__text">
 				<p className="agents-manager-conversation-list-item__title">{ title }</p>
 				<p className="agents-manager-conversation-list-item__subtitle">{ subtitle }</p>

--- a/packages/agents-manager/src/components/conversation-list-item/index.tsx
+++ b/packages/agents-manager/src/components/conversation-list-item/index.tsx
@@ -9,12 +9,12 @@ import {
 	generateConversationSubtitle,
 } from '../../utils/conversation-history-formatters';
 import ConversationAvatar from '../conversation-avatar';
-import type { ServerConversationListItem } from '@automattic/agenttic-client';
+import type { LocalConversationListItem } from '../../types';
 import './style.scss';
 
 interface Props {
-	conversation: ServerConversationListItem;
-	onClick: ( conversation: ServerConversationListItem ) => void;
+	conversation: LocalConversationListItem;
+	onClick: ( conversation: LocalConversationListItem ) => void;
 }
 
 export default function ConversationListItem( { conversation, onClick }: Props ) {

--- a/packages/agents-manager/src/components/zendesk-chat/index.tsx
+++ b/packages/agents-manager/src/components/zendesk-chat/index.tsx
@@ -1,8 +1,4 @@
-import {
-	type MarkdownComponents,
-	type MarkdownExtensions,
-	type Suggestion,
-} from '@automattic/agenttic-ui';
+import { type MarkdownComponents, type MarkdownExtensions } from '@automattic/agenttic-ui';
 import { useManagedZendeskChat } from '@automattic/zendesk-client';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
@@ -10,12 +6,8 @@ import type { Message } from '@automattic/agenttic-ui/dist/types';
 import './style.scss';
 
 interface ZendeskChatProps {
-	/** Suggestions to show in the chat input. */
-	suggestions?: Suggestion[];
 	/** Chat header menu options. */
 	chatHeaderOptions: ChatHeaderOptions;
-	/** Suggestions displayed when the chat is empty. */
-	emptyViewSuggestions?: Suggestion[];
 	/** Indicates if the chat is docked in the sidebar. */
 	isDocked: boolean;
 	/** Indicates if the chat is expanded (floating mode). */
@@ -31,9 +23,7 @@ interface ZendeskChatProps {
 }
 
 export function ZendeskChat( {
-	suggestions = [],
 	chatHeaderOptions,
-	emptyViewSuggestions = [],
 	isDocked,
 	isOpen,
 	onClose,
@@ -42,13 +32,12 @@ export function ZendeskChat( {
 	markdownExtensions = {},
 }: ZendeskChatProps ) {
 	const { agentticMessages, onSubmit, isLoadingConversation, isProcessing, onTypingStatusChange } =
-		useManagedZendeskChat( true );
+		useManagedZendeskChat();
 
 	return (
 		<AgentChat
 			messages={ agentticMessages as Message[] }
-			suggestions={ suggestions }
-			emptyViewSuggestions={ suggestions.length ? suggestions : emptyViewSuggestions }
+			suggestions={ [] }
 			isProcessing={ isProcessing }
 			error={ null }
 			onSubmit={ onSubmit }

--- a/packages/agents-manager/src/hooks/use-conversation-list.ts
+++ b/packages/agents-manager/src/hooks/use-conversation-list.ts
@@ -3,10 +3,11 @@ import {
 	createOdieBotId,
 	type ServerConversationListItem,
 } from '@automattic/agenttic-client';
+import { useGetZendeskConversations } from '@automattic/zendesk-client';
 import { useQuery } from '@tanstack/react-query';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import { API_BASE_URL } from '../constants';
-
+import { normalizeZendeskConversations } from '../utils/zendesk';
 interface Options {
 	agentId: string;
 	authProvider?: () => Promise< Record< string, string > >;
@@ -20,6 +21,9 @@ interface Result {
 
 export default function useConversationList( { agentId, authProvider }: Options ): Result {
 	const botId = createOdieBotId( agentId );
+
+	const { conversations: zendeskConversations, isLoading: isLoadingZendeskConversations } =
+		useGetZendeskConversations();
 
 	const {
 		data: conversations,
@@ -38,16 +42,7 @@ export default function useConversationList( { agentId, authProvider }: Options 
 				},
 				true
 			);
-
-			// Sort by `first_message.created_at` descending (most recent first)
-			// Note: Dates are in MySQL format "2025-11-06 14:29:49"
-			const sorted = result.sort( ( a, b ) => {
-				const timeA = new Date( a.first_message?.created_at || 0 ).getTime();
-				const timeB = new Date( b.first_message?.created_at || 0 ).getTime();
-				return timeB - timeA;
-			} );
-
-			return sorted;
+			return result;
 		},
 		enabled: !! botId,
 	} );
@@ -59,9 +54,23 @@ export default function useConversationList( { agentId, authProvider }: Options 
 		}
 	}, [ error ] );
 
+	const mergedConversations = useMemo(
+		() =>
+			[ ...( conversations ?? [] ), ...normalizeZendeskConversations( zendeskConversations ) ].sort(
+				( a, b ) => {
+					// Sort by `first_message.created_at` descending (most recent first)
+					// Note: Dates are in ISO format "2025-11-06T14:29:49.000Z"
+					const timeA = new Date( a.first_message?.created_at || 0 ).getTime();
+					const timeB = new Date( b.first_message?.created_at || 0 ).getTime();
+					return timeB - timeA;
+				}
+			),
+		[ conversations, zendeskConversations ]
+	);
+
 	return {
-		conversations: conversations || [],
-		isLoading,
+		conversations: mergedConversations,
+		isLoading: isLoadingZendeskConversations || isLoading,
 		isError,
 	};
 }

--- a/packages/agents-manager/src/hooks/use-conversation-list.ts
+++ b/packages/agents-manager/src/hooks/use-conversation-list.ts
@@ -7,19 +7,14 @@ import { useGetZendeskConversations } from '@automattic/zendesk-client';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo } from '@wordpress/element';
 import { API_BASE_URL } from '../constants';
+import { LocalConversationListItem } from '../types';
 import { normalizeZendeskConversations } from '../utils/zendesk';
 interface Options {
 	agentId: string;
 	authProvider?: () => Promise< Record< string, string > >;
 }
 
-interface Result {
-	conversations: ServerConversationListItem[];
-	isLoading: boolean;
-	isError: boolean;
-}
-
-export default function useConversationList( { agentId, authProvider }: Options ): Result {
+export default function useConversationList( { agentId, authProvider }: Options ) {
 	const botId = createOdieBotId( agentId );
 
 	const { conversations: zendeskConversations, isLoading: isLoadingZendeskConversations } =
@@ -30,7 +25,7 @@ export default function useConversationList( { agentId, authProvider }: Options 
 		isLoading,
 		isError,
 		error,
-	} = useQuery( {
+	} = useQuery< ServerConversationListItem[] >( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps -- we only want to refetch when `botId` changes
 		queryKey: [ 'agents-manager-conversation-list', botId ],
 		queryFn: async () => {
@@ -54,7 +49,7 @@ export default function useConversationList( { agentId, authProvider }: Options 
 		}
 	}, [ error ] );
 
-	const mergedConversations = useMemo(
+	const mergedConversations: LocalConversationListItem[] = useMemo(
 		() =>
 			[ ...( conversations ?? [] ), ...normalizeZendeskConversations( zendeskConversations ) ].sort(
 				( a, b ) => {

--- a/packages/agents-manager/src/types.ts
+++ b/packages/agents-manager/src/types.ts
@@ -1,3 +1,4 @@
+import { ServerConversationListItem } from '@automattic/agenttic-client';
 import type Smooch from 'smooch';
 
 /**
@@ -16,3 +17,8 @@ export type {
 
 export type ZendeskConversation = ReturnType< typeof Smooch.getConversations >[ number ];
 export type ZendeskMessage = ZendeskConversation[ 'messages' ][ number ];
+export type LocalConversationListItem = Omit< ServerConversationListItem, 'chat_id' > & {
+	chat_id?: number;
+	conversation_id?: string;
+	is_zendesk?: true;
+};

--- a/packages/agents-manager/src/types.ts
+++ b/packages/agents-manager/src/types.ts
@@ -1,3 +1,5 @@
+import type Smooch from 'smooch';
+
 /**
  * Common types used across the agents-manager package.
  */
@@ -11,3 +13,6 @@ export type {
 	ContextEntry,
 	Suggestion,
 } from './extension-types';
+
+export type ZendeskConversation = ReturnType< typeof Smooch.getConversations >[ number ];
+export type ZendeskMessage = ZendeskConversation[ 'messages' ][ number ];

--- a/packages/agents-manager/src/utils/zendesk.ts
+++ b/packages/agents-manager/src/utils/zendesk.ts
@@ -1,0 +1,34 @@
+import { ServerConversationListItem } from '@automattic/agenttic-client';
+import { ZendeskConversation, ZendeskMessage } from '../types';
+
+function normalizeZDMessage(
+	message: ZendeskMessage | undefined
+): ServerConversationListItem[ 'first_message' ] {
+	if ( ! message ) {
+		return undefined;
+	}
+
+	return {
+		content: message.text,
+		role: message.role === 'user' ? 'user' : 'bot',
+		created_at: new Date( message.received * 1000 ).toISOString(),
+	};
+}
+
+export function normalizeZendeskConversations(
+	conversations: ZendeskConversation[]
+): ServerConversationListItem[] {
+	return conversations.map( ( conversation ) => {
+		const createdAt = conversation.messages[ 0 ]
+			? new Date( conversation.messages[ 0 ].received * 1000 ).toISOString()
+			: new Date( conversation.lastUpdatedAt * 1000 ).toISOString();
+
+		return {
+			conversation_id: conversation.id,
+			created_at: createdAt,
+			first_message: normalizeZDMessage( conversation.messages[ 0 ] ),
+			last_message: normalizeZDMessage( conversation.messages[ conversation.messages.length - 1 ] ),
+			is_zendesk: true,
+		};
+	} );
+}

--- a/packages/agents-manager/src/utils/zendesk.ts
+++ b/packages/agents-manager/src/utils/zendesk.ts
@@ -1,5 +1,5 @@
 import { ServerConversationListItem } from '@automattic/agenttic-client';
-import { ZendeskConversation, ZendeskMessage } from '../types';
+import { LocalConversationListItem, ZendeskConversation, ZendeskMessage } from '../types';
 
 function normalizeZDMessage(
 	message: ZendeskMessage | undefined
@@ -17,7 +17,7 @@ function normalizeZDMessage(
 
 export function normalizeZendeskConversations(
 	conversations: ZendeskConversation[]
-): ServerConversationListItem[] {
+): LocalConversationListItem[] {
 	return conversations.map( ( conversation ) => {
 		const createdAt = conversation.messages[ 0 ]
 			? new Date( conversation.messages[ 0 ].received * 1000 ).toISOString()

--- a/packages/zendesk-client/src/index.ts
+++ b/packages/zendesk-client/src/index.ts
@@ -25,3 +25,4 @@ export {
 export type * from './types';
 export { zendeskMessageConverter } from './zendesk-message-converter';
 export { useManagedZendeskChat } from './use-managed-zendesk-chat';
+export { useGetZendeskConversations } from './use-managed-zendesk-chat';

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -137,7 +137,7 @@ const playNotificationSound = () => {
  */
 export const useManagedZendeskChat = () => {
 	const { state } = useLocation();
-	const conversationId = state.conversationId as string | undefined;
+	const conversationId = state?.conversationId;
 	const [ conversation, setConversation ] = useState< ZendeskConversation | undefined >();
 	const [ typingStatus, setTypingStatus ] = useState< Record< string, boolean > >( {} );
 	const [ connectionStatus, setConnectionStatus ] = useState<

--- a/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
+++ b/packages/zendesk-client/src/use-managed-zendesk-chat.tsx
@@ -51,10 +51,14 @@ function getSmoochContainer(): HTMLDivElement | null {
 	return smoochContainer;
 }
 
-function useSmooch( jwt?: string, externalId?: string ) {
+function useSmooch() {
 	const queryClient = useQueryClient();
+	const { data: authData, isFetching: isAuthenticatingZendeskMessaging } =
+		useAuthenticateZendeskMessaging( true, 'zendesk', false );
+	const jwt = authData?.jwt;
+	const externalId = authData?.externalId;
 
-	return useQuery( {
+	const smoochQuery = useQuery( {
 		queryKey: [ 'smooch', jwt, externalId ],
 		queryFn: () => {
 			const isTestMode = isTestModeEnvironment();
@@ -95,6 +99,8 @@ function useSmooch( jwt?: string, externalId?: string ) {
 			persist: false,
 		},
 	} );
+
+	return { ...smoochQuery, isLoading: isAuthenticatingZendeskMessaging || smoochQuery.isFetching };
 }
 
 const playNotificationSound = () => {
@@ -121,7 +127,6 @@ const playNotificationSound = () => {
 };
 /**
  * Returns a complete API for managing a Zendesk chat.
- * @param enabled - Whether the chat is enabled.
  * @returns An object with the following properties:
  * - typingStatus: The status of the typing.
  * - clientId: The ID of the client.
@@ -130,20 +135,16 @@ const playNotificationSound = () => {
  * - agentticMessages: The messages in the conversation in Agenttic-compatible format.
  * - sendMessage: A function to send a message to the conversation.
  */
-export const useManagedZendeskChat = ( enabled: boolean ) => {
-	const location = useLocation();
-	const conversationId = new URLSearchParams( location.search ).get( 'conversationId' );
+export const useManagedZendeskChat = () => {
+	const { state } = useLocation();
+	const conversationId = state.conversationId as string | undefined;
 	const [ conversation, setConversation ] = useState< ZendeskConversation | undefined >();
 	const [ typingStatus, setTypingStatus ] = useState< Record< string, boolean > >( {} );
 	const [ connectionStatus, setConnectionStatus ] = useState<
 		'connected' | 'disconnected' | 'reconnecting' | undefined
 	>( undefined );
 
-	const { data: authData } = useAuthenticateZendeskMessaging( enabled, 'zendesk', false );
-	const { data: Smooch, isLoading: isSettingUpSmooch } = useSmooch(
-		authData?.jwt,
-		authData?.externalId
-	);
+	const { data: Smooch, isLoading: isSettingUpSmooch } = useSmooch();
 
 	const getUnreadListener = useCallback(
 		( message: ZendeskMessage, data: { conversation: { id: string } } ) => {
@@ -190,7 +191,6 @@ export const useManagedZendeskChat = ( enabled: boolean ) => {
 
 	const navigate = useNavigate();
 
-	// Initialize Smooch which communicates with Zendesk
 	useEffect( () => {
 		if ( ! Smooch || conversation ) {
 			return;
@@ -206,21 +206,11 @@ export const useManagedZendeskChat = ( enabled: boolean ) => {
 				},
 			} ).then( ( conversation ) => {
 				setConversation( conversation );
-				const params = new URLSearchParams( location.search );
-				params.set( 'conversationId', conversation.id );
-				navigate( `${ location.pathname }?${ params.toString() }`, { replace: true } );
+				navigate( '/zendesk', { state: { conversationId: conversation.id }, replace: true } );
 				Smooch.loadConversation( conversation.id );
 			} );
 		}
-	}, [
-		Smooch,
-		conversationId,
-		location.pathname,
-		location.search,
-		navigate,
-		conversation,
-		Smooch?.render,
-	] );
+	}, [ Smooch, conversationId, navigate, conversation, Smooch?.render ] );
 
 	const currentTypingStatus = typingStatus[ conversation?.id ?? '' ];
 
@@ -290,7 +280,7 @@ export const useManagedZendeskChat = ( enabled: boolean ) => {
 		conversation,
 		connectionStatus,
 		agentticMessages,
-		isLoadingConversation: isSettingUpSmooch,
+		isLoadingConversation: isSettingUpSmooch || ! conversation,
 		onTypingStatusChange: ( typingStatus: boolean ) => {
 			if ( typingStatus ) {
 				Smooch?.startTyping( conversation?.id );
@@ -314,4 +304,7 @@ export const useManagedZendeskChat = ( enabled: boolean ) => {
 	};
 };
 
-export default useManagedZendeskChat;
+export const useGetZendeskConversations = () => {
+	const { data: Smooch, isLoading: isSettingUpSmooch } = useSmooch();
+	return { conversations: Smooch?.getConversations() ?? [], isLoading: isSettingUpSmooch };
+};


### PR DESCRIPTION
Fix BSKY-1570 and BSKY-1569

## Summary
- Integrate Zendesk chat history into the Agents Manager conversation list
- Add `useGetZendeskConversations` hook to fetch Zendesk conversations from Smooch
- Merge and sort Zendesk conversations alongside regular agent conversations
- Refactor `useSmooch` to handle authentication internally for better encapsulation
- Use router state instead of URL query params for conversationId navigation

## Test plan
- [ ] Run this locally to get ZD staging. 
- [ ] Verify Zendesk conversations appear in the conversation history list
- [ ] Confirm conversations are sorted by most recent first (mixed agent + Zendesk)
- [ ] Click on a Zendesk conversation and verify it navigates to `/zendesk` route
- [ ] Click on a regular agent conversation and verify it navigates to `/chat` route
- [ ] Verify conversation avatars show correctly (different for Zendesk vs agent)