### PR TITLE
Plans: Fix orphaned Jetpack icons in plans comparison table

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -75,10 +75,14 @@ const featureGroupRowTitleCellMaxWidth = 450;
 const rowCellMaxWidth = 290;
 
 const JetpackIconContainer = styled.div`
-	padding-inline-start: 6px;
+	padding-inline-start: 3px;
 	display: inline-block;
 	vertical-align: middle;
 	line-height: 1;
+`;
+
+const TitlePreventOrphans = styled.span`
+	white-space: nowrap;
 `;
 
 const Title = styled.div< { isHiddenInMobile?: boolean } >`
@@ -813,27 +817,47 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 									activeTooltipId={ activeTooltipId }
 									id={ tooltipId }
 								>
-									{ feature.getTitle() }
-									{ footnote && (
-										<FeatureFootnote>
-											<sup>{ footnote }</sup>
-										</FeatureFootnote>
+									{ typeof title === 'string' ? (
+										<>
+											{ title.split( ' ' ).slice( 0, -1 ).join( ' ' ) }
+											{ title.includes( ' ' ) ? ' ' : null }
+											<TitlePreventOrphans>
+												{ title.split( ' ' ).slice( -1 ) }
+												{ footnote && (
+													<FeatureFootnote>
+														<sup>{ footnote }</sup>
+													</FeatureFootnote>
+												) }
+												{ allJetpackFeatures.has( feature.getSlug() ) ? (
+													<>
+														{ '\u00A0' }
+														<JetpackIconContainer>
+															<Plans2023Tooltip
+																text={ translate(
+																	'Security, performance, and growth tools—powered by Jetpack.'
+																) }
+																setActiveTooltipId={ setActiveTooltipId }
+																activeTooltipId={ activeTooltipId }
+																id={ `jp-${ tooltipId }` }
+															>
+																<JetpackLogo size={ 16 } />
+															</Plans2023Tooltip>
+														</JetpackIconContainer>
+													</>
+												) : null }
+											</TitlePreventOrphans>
+										</>
+									) : (
+										<>
+											{ feature.getTitle() }
+											{ footnote && (
+												<FeatureFootnote>
+													<sup>{ footnote }</sup>
+												</FeatureFootnote>
+											) }
+										</>
 									) }
 								</Plans2023Tooltip>
-								{ allJetpackFeatures.has( feature.getSlug() ) ? (
-									<JetpackIconContainer>
-										<Plans2023Tooltip
-											text={ translate(
-												'Security, performance, and growth tools—powered by Jetpack.'
-											) }
-											setActiveTooltipId={ setActiveTooltipId }
-											activeTooltipId={ activeTooltipId }
-											id={ `jp-${ tooltipId }` }
-										>
-											<JetpackLogo size={ 16 } />
-										</Plans2023Tooltip>
-									</JetpackIconContainer>
-								) : null }
 							</>
 						) }
 					</>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15844

## Proposed Changes

* Fix the handling of Jetpack icons to prevent them from being orphaned.

|Before|After|
|----|----|
|<img width="483" height="604" alt="Screenshot 2026-01-27 at 17 04 14" src="https://github.com/user-attachments/assets/f116d3b6-eee1-46c5-a838-9a566ef21703" />|<img width="483" height="604" alt="Screenshot 2026-01-27 at 17 06 32" src="https://github.com/user-attachments/assets/ccdf1e23-ca22-4b79-bbe2-fe43e886f477" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should be avoiding typographic orphans.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the plans comparison table at /plans/{your site} and check that the Jetpack icons after `Real-time backups and one-click restores` and `Unlimited automatic shares in social media` are not appearing on a new line.
* Check for regression issues, particularly that the tooltips are working correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
