### PR TITLE
Remove URLRenderer indirection in site-fields

### DIFF
--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -125,31 +125,13 @@ export function NameRenderer( {
 }
 
 export function URL( { site, value }: { site: Site; value: string } ) {
-	return (
-		<URLRenderer
-			disabled={ site.is_deleted }
-			href={ getSiteFormattedUrl( site ) }
-			value={ value }
-		/>
-	);
-}
-
-export function URLRenderer( {
-	disabled,
-	href,
-	value,
-}: {
-	disabled: boolean;
-	href: string;
-	value: string;
-} ) {
-	return disabled ? (
+	return site.is_deleted ? (
 		<Text variant="muted">{ value }</Text>
 	) : (
 		<ExternalLink
 			className="dataviews-url-field"
 			style={ titleFieldTextOverflowStyles }
-			href={ href }
+			href={ getSiteFormattedUrl( site ) }
 		>
 			{ value }
 		</ExternalLink>


### PR DESCRIPTION
Part of #108259

## Proposed Changes

* Inline `URLRenderer` into `URL` component, removing unnecessary indirection

## Why are these changes being made?

PR #108259 removed ES site list feature flag. Reviewer suggested removing renderer indirection since generic handling is no longer needed.

`NameRenderer` is kept as it's still used by the legacy sites dashboard:
https://github.com/Automattic/wp-calypso/blob/trunk/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx#L2

## Testing Instructions

* Load `/sites` in dashboard - verify site list renders correctly

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)