### PR TITLE
Dashboard: document package import policy

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -31,8 +31,8 @@ module.exports = {
 							'calypso/assets/*',
 							'!calypso/assets/icons',
 							'!calypso/assets/images',
-							// Please do not add exceptions unless agreed on
-							// with the #architecture group.
+							// Please do not add exceptions which pull in Calypso code/concepts.
+							// See docs/package-imports.md for policy.
 						],
 						message: 'Importing from calypso/ is not allowed in the dashboard folder.',
 					},
@@ -73,8 +73,8 @@ module.exports = {
 							'!@automattic/urls',
 							'!@automattic/js-utils',
 							'!@automattic/viewport',
-							// Please do not add exceptions unless agreed on
-							// with the #architecture group.
+							// Please do not add exceptions which pull in Calypso code/concepts.
+							// See docs/package-imports.md for policy.
 						],
 						message: 'Importing from @automattic/ is not allowed in the dashboard folder.',
 					},

--- a/client/dashboard/README.md
+++ b/client/dashboard/README.md
@@ -28,6 +28,7 @@ This `docs` directory contains comprehensive design documentation for the `/clie
 - [Entry Points](./docs/entry-points.md) - Documentation for the entry points and how to define new ones (a4a, WordPress.com, etc.)
 - [Internationalization](./docs/i18n.md) - Documentation for internationalization and translation practices
 - [Typography and Copy](./docs/typography-and-copy.md) - Documentation for typography guidelines and copy standards
+- [Package Imports](./docs/package-imports.md) - Documentation for package import restrictions and policy
 
 ## Bugs
 

--- a/client/dashboard/docs/package-imports.md
+++ b/client/dashboard/docs/package-imports.md
@@ -5,12 +5,12 @@ The dashboard restricts imports from `calypso/` and `@automattic/` packages. Thi
 ## Why imports are restricted
 
 - Many packages pull in Calypso code/concepts we want to avoid
-- Non-Core UI elements that don't match the design system
-- They may d Calypso context providers or Redux store dependencies
+- Non-core UI elements that don't match the design system
+- They may depend on Calypso context providers or Redux store dependencies
 
 ## Ideal dependencies
 
-The ideal dependencies for this project are:
+The ideal dependencies for this project:
 
 - Have minimal dependencies of their own
 - Use `@automattic/api-core` for API types

--- a/client/dashboard/docs/package-imports.md
+++ b/client/dashboard/docs/package-imports.md
@@ -1,0 +1,22 @@
+# Package Import Restrictions
+
+The dashboard restricts imports from `calypso/` and `@automattic/` packages. This is enforced by ESLint rules in `.eslintrc.js`.
+
+## Why imports are restricted
+
+- Many packages pull in Calypso code/concepts we want to avoid
+- Non-Core UI elements that don't match the design system
+- They may d Calypso context providers or Redux store dependencies
+
+## Ideal dependencies
+
+The ideal dependencies for this project are:
+
+- Have minimal dependencies of their own
+- Use `@automattic/api-core` for API types
+- Do not depend on Calypso "providers" or Redux state
+- Do not provide whole chunks or UI, only utilities or UI primitives
+
+## Adding exceptions
+
+Exceptions are discussed during normal PR review. When adding a new exception, discuss why it's needed and how it has been vetted.


### PR DESCRIPTION
## Summary

- Add `docs/package-imports.md` documenting the dashboard's package import restriction policy
- Replace Slack channel references in `.eslintrc.js` with links to the new doc
- Add link to new doc in README's documentation list

## Test plan

- [ ] Verify eslint rules still work: `yarn eslint client/dashboard/components/stat/index.tsx`
- [ ] Verify doc link in README renders correctly