### PR TITLE
Dashboard Site List v1: show pulsing dot then scroll when paginating

### DIFF
--- a/client/layout/loader.jsx
+++ b/client/layout/loader.jsx
@@ -1,4 +1,6 @@
+import { queryClient } from '@automattic/api-queries';
 import clsx from 'clsx';
+import { useSyncExternalStore } from 'react';
 import { useSelector } from 'react-redux';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import { isSectionLoading } from 'calypso/state/ui/selectors';
@@ -6,10 +8,37 @@ import './loader.scss';
 
 export default function LayoutLoader() {
 	const isLoading = useSelector( isSectionLoading );
+	const queryCache = queryClient.getQueryCache();
+
+	const isLoadingWithFullPageLoader = useSyncExternalStore(
+		( onStoreChange ) => queryCache.subscribe( onStoreChange ),
+		() => {
+			const fullPageLoaderQueries = queryClient
+				.getQueryCache()
+				.findAll()
+				.filter( ( query ) => query.meta?.fullPageLoader );
+
+			// Only show loader after initial data has loaded (at least one query completed).
+			const hasCompletedFetch = fullPageLoaderQueries.some(
+				( query ) => query.state.status === 'success' && query.state.fetchStatus === 'idle'
+			);
+
+			if ( ! hasCompletedFetch ) {
+				return false;
+			}
+
+			// Only show loader if we don't have cached data yet.
+			return fullPageLoaderQueries.some(
+				( query ) => query.state.fetchStatus === 'fetching' && query.state.status !== 'success'
+			);
+		}
+	);
+
+	const showLoader = isLoading || isLoadingWithFullPageLoader;
 
 	return (
-		<div className={ clsx( 'layout__loader', { 'is-active': isLoading } ) }>
-			{ isLoading && <PulsingDot delay={ 400 } active /> }
+		<div className={ clsx( 'layout__loader', { 'is-active': showLoader } ) }>
+			{ showLoader && <PulsingDot delay={ 400 } active /> }
 		</div>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

This PR improves the behavior of the site list when the `dashboard/v2/paginated-site-list` flag is true. Note that when this flag is true, a backend fetch will happen to fetch the next page, as opposed to instantaneous loading.

**Before**

There is no feedback whatsoever that the page is still loading. It feels a bit janky.


https://github.com/user-attachments/assets/4f190f50-3ba9-4342-a9de-e89786a8440a



After

We show this kind of feedback:

- show a pulsing dot
- scroll to the top after the page load

https://github.com/user-attachments/assets/b2bde400-4cf8-4c3f-8581-7c89d174871e

We also do this when searching or filtering.

Note that the feedback is not shown when a cached data is used (instant feedback).


## Why are these changes being made?

Improve the experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `<Calypso live link>/sites?flags=dashboard/v2/paginated-site-list`
2. Try paginating, searching, filtering... verify the experience is smooth and predictable.
3. Smoke-test v1 site list (without the flag) and v2 site list; verify no regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?