### PR TITLE
Agent manager: handle suggestions from Big Sky

### DIFF
--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -53,6 +53,10 @@ interface AgentChatProps {
 	markdownComponents?: MarkdownComponents;
 	/** Custom markdown extensions. */
 	markdownExtensions?: MarkdownExtensions;
+	/** Controlled input value for tracking text in the input field. */
+	inputValue?: string;
+	/** Called when the input value changes. */
+	onInputChange?: ( value: string ) => void;
 }
 
 export default function AgentChat( {
@@ -74,6 +78,8 @@ export default function AgentChat( {
 	markdownExtensions = {},
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Kept for API compatibility with ZendeskChat
 	onTypingStatusChange,
+	inputValue,
+	onInputChange,
 }: AgentChatProps ) {
 	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
 	const { floatingPosition } = useSelect( ( select ) => {
@@ -106,13 +112,19 @@ export default function AgentChat( {
 			onExpand={ onExpand }
 			onStop={ onAbort }
 			messageRenderer={ messageRenderer }
+			inputValue={ inputValue }
+			onInputChange={ onInputChange }
 			emptyView={
 				isLoadingConversation ? (
 					<ChatMessageSkeleton count={ 3 } />
 				) : (
 					<EmptyView
 						heading={ __( 'Howdy! How can I help you today?', '__i18n_text_domain__' ) }
-						help={ __( 'Got a different request? Ask away.', '__i18n_text_domain__' ) }
+						help={
+							emptyViewSuggestions.length > 0
+								? __( 'Got a different request? Ask away.', '__i18n_text_domain__' )
+								: undefined
+						}
 						suggestions={ emptyViewSuggestions }
 						icon={ isDocked ? <AI /> : <AI size={ 41 } color="#3858e8" /> }
 					/>

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -76,6 +76,7 @@ export default function AgentDock( {
 	const [ thinkingMessage, setThinkingMessage ] = useState< string | null >( null );
 	const [ isBuildingSite, setIsBuildingSite ] = useState( false );
 	const [ deletedMessageIds, setDeletedMessageIds ] = useState< Set< string > >( new Set() );
+	const [ inputValue, setInputValue ] = useState( '' );
 	const { setIsOpen, setIsDocked } = useDispatch( AGENTS_MANAGER_STORE );
 	const shouldUseAgentsManager = useShouldUseUnifiedAgent();
 	const {
@@ -310,11 +311,21 @@ export default function AgentDock( {
 		thinkingMessage,
 	] );
 
+	// Determine which suggestions to show following Big Sky's logic:
+	// - When there are dynamic suggestions (from block selection, etc.), show those
+	// - Otherwise, show empty view suggestions only when there are no messages AND no input text
+	let displayedEmptyViewSuggestions: Suggestion[] = [];
+	if ( suggestions.length > 0 ) {
+		displayedEmptyViewSuggestions = suggestions;
+	} else if ( visibleMessages.length === 0 && inputValue.length === 0 ) {
+		displayedEmptyViewSuggestions = emptyViewSuggestions;
+	}
+
 	const Chat = (
 		<AgentChat
 			messages={ visibleMessages }
 			suggestions={ suggestions }
-			emptyViewSuggestions={ suggestions.length ? suggestions : emptyViewSuggestions }
+			emptyViewSuggestions={ displayedEmptyViewSuggestions }
 			isProcessing={ isProcessing || ( isThinking && ! isBuildingSite ) }
 			error={ error }
 			onSubmit={ onSubmit }
@@ -328,6 +339,8 @@ export default function AgentDock( {
 			chatHeaderOptions={ getChatHeaderOptions() }
 			markdownComponents={ markdownComponents }
 			markdownExtensions={ markdownExtensions }
+			inputValue={ inputValue }
+			onInputChange={ setInputValue }
 		/>
 	);
 

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -106,7 +106,6 @@ export default function AgentDock( {
 			onCloseSidebar: () => setIsOpen( false ),
 		} );
 
-	const agentChatReturn = useAgentChat( agentConfig );
 	const {
 		addMessage,
 		messages,
@@ -118,15 +117,17 @@ export default function AgentDock( {
 		abortCurrentRequest,
 		clearSuggestions,
 		registerSuggestions,
-	} = agentChatReturn;
+	} = useAgentChat( agentConfig );
 
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
 	const dynamicSuggestions = useSuggestions?.();
 
 	// Register dynamic suggestions whenever they change
 	useEffect( () => {
-		if ( dynamicSuggestions?.suggestions && dynamicSuggestions.suggestions.length > 0 ) {
-			registerSuggestions?.( dynamicSuggestions.suggestions );
+		const suggestions = dynamicSuggestions?.suggestions;
+
+		if ( suggestions && suggestions.length > 0 ) {
+			registerSuggestions?.( suggestions );
 		} else {
 			// Clear suggestions when there are none
 			clearSuggestions?.();

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -9,7 +9,7 @@ import {
 	type Suggestion,
 } from '@automattic/agenttic-ui';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { comment, drawerRight, login, lifesaver } from '@wordpress/icons';
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
@@ -35,6 +35,7 @@ import type {
 	NavigationContinuationHook,
 	AbilitiesSetupHook,
 	GetChatComponent,
+	UseSuggestionsHook,
 	SiteBuildUtils,
 } from '../../utils/load-external-providers';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
@@ -52,6 +53,8 @@ interface AgentDockProps {
 	useNavigationContinuation?: NavigationContinuationHook;
 	/** Hook for setting up abilities that utilize React context. Invoked after custom actions registration. */
 	useAbilitiesSetup?: AbilitiesSetupHook;
+	/** Hook for providing dynamic suggestions based on context (e.g., selected block). */
+	useSuggestions?: UseSuggestionsHook;
 	/** Get a chat component by type for rendering in agent messages. */
 	getChatComponent?: GetChatComponent;
 	siteBuildUtils?: SiteBuildUtils;
@@ -65,6 +68,7 @@ export default function AgentDock( {
 	useNavigationContinuation,
 	useAbilitiesSetup,
 	getChatComponent,
+	useSuggestions,
 	siteBuildUtils,
 }: AgentDockProps ) {
 	const { site, sectionName, isEligibleForChat } = useAgentsManagerContext();
@@ -102,6 +106,7 @@ export default function AgentDock( {
 			onCloseSidebar: () => setIsOpen( false ),
 		} );
 
+	const agentChatReturn = useAgentChat( agentConfig );
 	const {
 		addMessage,
 		messages,
@@ -112,7 +117,21 @@ export default function AgentDock( {
 		onSubmit,
 		abortCurrentRequest,
 		clearSuggestions,
-	} = useAgentChat( agentConfig );
+		registerSuggestions,
+	} = agentChatReturn;
+
+	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
+	const dynamicSuggestions = useSuggestions?.();
+
+	// Register dynamic suggestions whenever they change
+	useEffect( () => {
+		if ( dynamicSuggestions?.suggestions && dynamicSuggestions.suggestions.length > 0 ) {
+			registerSuggestions?.( dynamicSuggestions.suggestions );
+		} else {
+			// Clear suggestions when there are none
+			clearSuggestions?.();
+		}
+	}, [ dynamicSuggestions?.suggestions, registerSuggestions, clearSuggestions ] );
 
 	const { isLoading: isLoadingConversation } = useConversation( {
 		agentId,

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -233,6 +233,7 @@ function AgentSetup( { currentRoute }: UnifiedAIAgentProps ) {
 			markdownExtensions={ loadedProviders.markdownExtensions || {} }
 			useNavigationContinuation={ loadedProviders.useNavigationContinuation }
 			useAbilitiesSetup={ loadedProviders.useAbilitiesSetup }
+			useSuggestions={ loadedProviders.useSuggestions }
 			getChatComponent={ loadedProviders.getChatComponent }
 			siteBuildUtils={ loadedProviders.siteBuildUtils }
 		/>

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -1,10 +1,11 @@
 import { getAgentManager } from '@automattic/agenttic-client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useMemo, useEffect, useState, useRef } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { createCalypsoAuthProvider } from '../../auth/calypso-auth-provider';
 import { ORCHESTRATOR_AGENT_URL, getAgentConfig } from '../../constants';
 import { useAgentsManagerContext } from '../../contexts';
+import { useEmptyViewSuggestions } from '../../hooks/use-empty-view-suggestions';
 import { SESSION_STORAGE_KEY, getSessionId, clearSessionId } from '../../utils/agent-session';
 import { loadExternalProviders, type LoadedProviders } from '../../utils/load-external-providers';
 import AgentDock from '../agent-dock';
@@ -196,39 +197,20 @@ function AgentSetup( { currentRoute }: UnifiedAIAgentProps ) {
 		initializeAgent();
 	}, [ currentRoute, isNewChat, navigate, sessionId, site?.ID ] );
 
-	// Default suggestions - can be overridden by loaded providers
-	const defaultSuggestions = useMemo(
-		() => [
-			{
-				id: 'getting-started',
-				label: 'Getting started with WordPress',
-				prompt: 'How do I get started with WordPress?',
-			},
-			{
-				id: 'create-post',
-				label: 'Create a blog post',
-				prompt: 'How do I create a blog post?',
-			},
-			{
-				id: 'customize-site',
-				label: 'Customize my site',
-				prompt: 'How can I customize my site?',
-			},
-		],
-		[]
-	);
-
 	const loadedProviders = loadedProvidersRef.current;
 
-	// Don't render until the setup is complete
-	if ( ! agentConfig || ! loadedProviders ) {
+	// Load empty view suggestions (handles Big Sky's theme-dependent suggestions)
+	const emptyViewSuggestions = useEmptyViewSuggestions( { loadedProviders } );
+
+	// Don't render until the setup is complete AND suggestions are ready
+	if ( ! agentConfig || ! loadedProviders || emptyViewSuggestions === null ) {
 		return null;
 	}
 
 	return (
 		<AgentDock
 			agentConfig={ agentConfig }
-			emptyViewSuggestions={ loadedProviders.getEmptyViewSuggestions?.() || defaultSuggestions }
+			emptyViewSuggestions={ emptyViewSuggestions }
 			markdownComponents={ loadedProviders.markdownComponents || {} }
 			markdownExtensions={ loadedProviders.markdownExtensions || {} }
 			useNavigationContinuation={ loadedProviders.useNavigationContinuation }

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -228,7 +228,7 @@ function AgentSetup( { currentRoute }: UnifiedAIAgentProps ) {
 	return (
 		<AgentDock
 			agentConfig={ agentConfig }
-			emptyViewSuggestions={ loadedProviders.suggestions || defaultSuggestions }
+			emptyViewSuggestions={ loadedProviders.getEmptyViewSuggestions?.() || defaultSuggestions }
 			markdownComponents={ loadedProviders.markdownComponents || {} }
 			markdownExtensions={ loadedProviders.markdownExtensions || {} }
 			useNavigationContinuation={ loadedProviders.useNavigationContinuation }

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -1,0 +1,97 @@
+import { type Suggestion } from '@automattic/agenttic-ui';
+import { useSelect } from '@wordpress/data';
+import { useEffect, useState, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { LoadedProviders } from '../utils/load-external-providers';
+
+interface UseEmptyViewSuggestionsOptions {
+	loadedProviders: LoadedProviders | null;
+}
+
+/**
+ * Hook to manage empty view suggestions, handling Big Sky's theme-dependent suggestions
+ *
+ * If Big Sky provides getEmptyViewSuggestions, this hook waits for WordPress core store
+ * (specifically theme data) to be ready before calling it. This prevents the suggestions
+ * from "jumping" as the theme data loads.
+ * If Big Sky doesn't provide custom suggestions, returns translated default suggestions.
+ * @param params - Hook parameters
+ * @param params.loadedProviders - External providers loaded from plugins (e.g., Big Sky)
+ * @returns The computed suggestions (either from Big Sky or defaults), or null while loading
+ */
+export function useEmptyViewSuggestions( {
+	loadedProviders,
+}: UseEmptyViewSuggestionsOptions ): Suggestion[] | null {
+	// Default suggestions - used when Big Sky doesn't provide custom ones
+	const defaultSuggestions = useMemo(
+		() => [
+			{
+				id: 'getting-started',
+				label: __( 'Getting started with WordPress', '__i18n_text_domain__' ),
+				prompt: __( 'How do I get started with WordPress?', '__i18n_text_domain__' ),
+			},
+			{
+				id: 'create-post',
+				label: __( 'Create a blog post', '__i18n_text_domain__' ),
+				prompt: __( 'How do I create a blog post?', '__i18n_text_domain__' ),
+			},
+			{
+				id: 'customize-site',
+				label: __( 'Customize my site', '__i18n_text_domain__' ),
+				prompt: __( 'How can I customize my site?', '__i18n_text_domain__' ),
+			},
+		],
+		[]
+	);
+	// Check if Big Sky provides suggestions
+	const hasBigSkySuggestions = !! loadedProviders?.getEmptyViewSuggestions;
+
+	// Wait for WordPress core store to be ready (specifically theme data)
+	// This is needed because Big Sky's getEmptyViewSuggestions filters by theme
+	const isCoreStoreReady = useSelect(
+		( select ) => {
+			if ( ! hasBigSkySuggestions ) {
+				return true; // No need to wait if not using Big Sky suggestions
+			}
+			try {
+				const coreStore = select( 'core' ) as {
+					getCurrentTheme?: () => unknown;
+				};
+				// Check if getCurrentTheme returns a value (meaning store is ready)
+				const theme = coreStore?.getCurrentTheme?.();
+				return !! theme;
+			} catch {
+				return false;
+			}
+		},
+		[ hasBigSkySuggestions ]
+	);
+
+	// Compute empty view suggestions once when store is ready
+	const [ emptyViewSuggestions, setEmptyViewSuggestions ] = useState< Suggestion[] | null >( null );
+
+	useEffect( () => {
+		if ( ! loadedProviders || ! isCoreStoreReady || emptyViewSuggestions !== null ) {
+			return;
+		}
+
+		if ( ! hasBigSkySuggestions ) {
+			// No Big Sky suggestions provider, use defaults immediately
+			setEmptyViewSuggestions( defaultSuggestions );
+		} else {
+			// Big Sky provides suggestions and store is ready - get filtered suggestions
+			const suggestions = loadedProviders.getEmptyViewSuggestions?.();
+			if ( suggestions && suggestions.length > 0 ) {
+				setEmptyViewSuggestions( suggestions );
+			}
+		}
+	}, [
+		loadedProviders,
+		isCoreStoreReady,
+		hasBigSkySuggestions,
+		defaultSuggestions,
+		emptyViewSuggestions,
+	] );
+
+	return emptyViewSuggestions;
+}

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -53,6 +53,14 @@ export type AbilitiesSetupHook = ( actions: {
 	setThinkingMessage: ( message: string | null ) => void;
 } ) => void;
 
+/**
+ * Suggestions hook type - for providing dynamic suggestions based on context
+ * (e.g., selected block in editor). Returns an array of suggestions.
+ */
+export type UseSuggestionsHook = ( maxSuggestions?: number ) => {
+	suggestions: Suggestion[];
+};
+
 export type SiteBuildUtils = {
 	hasSiteBuildMessages: ( messages: UIMessage[] ) => boolean;
 	groupSiteBuildMessages: ( messages: UIMessage[], thinkingMessage: string | null ) => UIMessage[];
@@ -84,6 +92,7 @@ export interface LoadedProviders {
 	markdownExtensions?: MarkdownExtensions;
 	useNavigationContinuation?: NavigationContinuationHook;
 	useAbilitiesSetup?: AbilitiesSetupHook;
+	useSuggestions?: UseSuggestionsHook;
 	getChatComponent?: GetChatComponent;
 	siteBuildUtils?: SiteBuildUtils;
 }
@@ -111,6 +120,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	let mergedNavigationContinuation: NavigationContinuationHook | undefined;
 	let mergedAbilitiesSetup: AbilitiesSetupHook | undefined;
 	let mergedGetChatComponent: GetChatComponent | undefined;
+	let mergedUseSuggestions: UseSuggestionsHook | undefined;
 	let mergedSiteBuildUtils: SiteBuildUtils | undefined;
 
 	for ( const moduleId of agentProviders ) {
@@ -140,6 +150,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			if ( module.useAbilitiesSetup ) {
 				mergedAbilitiesSetup = module.useAbilitiesSetup;
 			}
+			if ( module.useSuggestions ) {
+				mergedUseSuggestions = module.useSuggestions;
+			}
 			if ( module.getChatComponent ) {
 				mergedGetChatComponent = module.getChatComponent;
 			}
@@ -163,6 +176,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		markdownExtensions: mergedMarkdownExtensions,
 		useNavigationContinuation: mergedNavigationContinuation,
 		useAbilitiesSetup: mergedAbilitiesSetup,
+		useSuggestions: mergedUseSuggestions,
 		getChatComponent: mergedGetChatComponent,
 		siteBuildUtils: mergedSiteBuildUtils,
 	};

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -87,7 +87,8 @@ export type GetChatComponent = ( type: ChatComponentType ) => React.ComponentTyp
 export interface LoadedProviders {
 	toolProvider?: ToolProvider;
 	contextProvider?: ContextProvider;
-	suggestions?: Suggestion[];
+	/** Function to get empty view suggestions. Called when component is ready. */
+	getEmptyViewSuggestions?: () => Suggestion[];
 	markdownComponents?: MarkdownComponents;
 	markdownExtensions?: MarkdownExtensions;
 	useNavigationContinuation?: NavigationContinuationHook;
@@ -114,7 +115,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 
 	let mergedToolProvider: ToolProvider | undefined;
 	let mergedContextProvider: ContextProvider | undefined;
-	let mergedSuggestions: Suggestion[] | undefined;
+	let mergedGetEmptyViewSuggestions: ( () => Suggestion[] ) | undefined;
 	let mergedMarkdownComponents: MarkdownComponents | undefined;
 	let mergedMarkdownExtensions: MarkdownExtensions | undefined;
 	let mergedNavigationContinuation: NavigationContinuationHook | undefined;
@@ -135,8 +136,8 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			if ( module.contextProvider ) {
 				mergedContextProvider = module.contextProvider;
 			}
-			if ( module.suggestions ) {
-				mergedSuggestions = module.suggestions;
+			if ( module.getEmptyViewSuggestions ) {
+				mergedGetEmptyViewSuggestions = module.getEmptyViewSuggestions;
 			}
 			if ( module.markdownComponents ) {
 				mergedMarkdownComponents = module.markdownComponents;
@@ -171,7 +172,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	return {
 		toolProvider: mergedToolProvider,
 		contextProvider: mergedContextProvider,
-		suggestions: mergedSuggestions,
+		getEmptyViewSuggestions: mergedGetEmptyViewSuggestions,
 		markdownComponents: mergedMarkdownComponents,
 		markdownExtensions: mergedMarkdownExtensions,
 		useNavigationContinuation: mergedNavigationContinuation,


### PR DESCRIPTION
Implements the Big Sky `useSuggestions` so we get suggestions inline with the chat.

<img width="664" height="500" alt="image" src="https://github.com/user-attachments/assets/b16f43b8-87cf-48ab-9716-1ab135fae519" />

It also switches from `suggestions` for the empty view suggestions, to `getEmptyViewSuggestions` and calls this later on when ready to render so it has access to theme data in the store.

<img width="654" height="818" alt="image" src="https://github.com/user-attachments/assets/6fce4087-ca50-453c-aa59-4224bce97df3" />

Needs to be paired with https://github.com/Automattic/big-sky-plugin/pull/5542. Note that until both have been deployed, the Agents Manager will use default empty view suggestions so it shouldn't be a big issue.

This also fixes a bug in Agents Manager where it doesn't clear the empty view suggestions if you start typing.

## Why are these changes being made?

* We need the suggestions to appear

## Testing Instructions

It can be a little tricky to get the right content to test this. A group with a column inside it seems to do the trick.

* `cd apps/agents-manager`
* `yarn dev --sync`
* Open site editor and chat and confirm you get *five* empty view suggestions, as shown in the screenshot. If you get 3 then its not working properly. The suggestions should appear instantly and without a noticeable jump
* Type a character in the chat box and confirm the empty view suggestions disappear, and the only thing remaining is the introduction text
* Use the document overview to select the group row and confirm the empty view suggestions are removed and you are shown specific suggestions. These will be full width.
<img width="698" height="698" alt="image" src="https://github.com/user-attachments/assets/349ce2c9-9a88-4f9e-90c2-ee6ed874f3c8" />
<img width="656" height="818" alt="image" src="https://github.com/user-attachments/assets/d64a20e0-32be-4ddd-be24-0cbf5aa5541e" />

* Deselect the group row and the suggestions should be replaced with the empty view suggestions
* Start a chat properly. The empty view suggestions will disappear
* Reselect the group row and the suggestions should reappear, but inline with the chat
<img width="656" height="1010" alt="image" src="https://github.com/user-attachments/assets/cb9fcbd8-135c-4f68-84a1-27fee15faf7f" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
