### PR TITLE
Changed tags page header to avoid confusion

### DIFF
--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -68,7 +68,7 @@ const TagsPageHeaderSection = () => {
 			<h1>
 				{
 					// translators: The title of the reader trending tags page
-					translate( 'All the Tags' )
+					translate( 'Popular Tags' )
 				}
 			</h1>
 			<p>{ translate( "For every one of your interests, there's a tag on WordPress.com." ) }</p>

--- a/client/reader/tags/main.tsx
+++ b/client/reader/tags/main.tsx
@@ -21,7 +21,7 @@ export default function TagsPage( { trendingTags, alphabeticTags }: Props ) {
 		<ReaderMain className="tags__main">
 			{ isLoggedIn && (
 				<NavigationHeader
-					title={ translate( 'All the Tags' ) }
+					title={ translate( 'Popular Tags' ) }
 					subtitle={ translate(
 						"For every one of your interests, there's a tag on WordPress.com."
 					) }


### PR DESCRIPTION
## Description

@rootjosh pinged about possible confusion from the current title of the tags page. Ref: pdhack-1Q1-p2#comment-2665

In this PR, I changes the title so it's less confusing.

### Before

<img width="1850" height="746" alt="CleanShot 2026-01-28 at 07 04 49@2x" src="https://github.com/user-attachments/assets/917e1ad9-735f-417c-85a0-2f779e9550fe" />

### After

<img width="1894" height="812" alt="CleanShot 2026-01-28 at 07 05 19@2x" src="https://github.com/user-attachments/assets/b717c3b1-622d-47a7-86da-35b115e3ffff" />

## Testing

- Test logged in: http://calypso.localhost:3000/tags
- And logged out (in an incognito window): http://calypso.localhost:3000/tags

If you're seeing a flash of the old title on the logged out page, run `yarn clean & yarn start`