### PR TITLE
Revert "Changed tags page header to avoid confusion"

### DIFF
--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -68,7 +68,7 @@ const TagsPageHeaderSection = () => {
 			<h1>
 				{
 					// translators: The title of the reader trending tags page
-					translate( 'Popular Tags' )
+					translate( 'All the Tags' )
 				}
 			</h1>
 			<p>{ translate( "For every one of your interests, there's a tag on WordPress.com." ) }</p>

--- a/client/reader/tags/main.tsx
+++ b/client/reader/tags/main.tsx
@@ -21,7 +21,7 @@ export default function TagsPage( { trendingTags, alphabeticTags }: Props ) {
 		<ReaderMain className="tags__main">
 			{ isLoggedIn && (
 				<NavigationHeader
-					title={ translate( 'Popular Tags' ) }
+					title={ translate( 'All the Tags' ) }
 					subtitle={ translate(
 						"For every one of your interests, there's a tag on WordPress.com."
 					) }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#108390