### PR TITLE
MSD: Add Site List integration test

### DIFF
--- a/client/dashboard/me/preferences-primary-site/test/index.test.tsx
+++ b/client/dashboard/me/preferences-primary-site/test/index.test.tsx
@@ -4,10 +4,9 @@
 
 import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
-import { useAuth } from '../../../app/auth';
 import { render } from '../../../test-utils';
 import PreferencesPrimarySite from '../index';
-import type { Site } from '@automattic/api-core';
+import type { Site, User } from '@automattic/api-core';
 import type { DeepPartial } from 'utility-types';
 
 const mockPrimarySiteId = 123;
@@ -28,10 +27,6 @@ jest.mock( '@wordpress/data', () => ( {
 	dispatch: jest.fn(),
 } ) );
 
-jest.mock( '../../../app/auth', () => ( {
-	useAuth: jest.fn( () => ( { user: { visible_site_count: 2 } } ) ),
-} ) );
-
 jest.mock(
 	'@automattic/api-queries',
 	() => ( {
@@ -49,6 +44,7 @@ jest.mock(
 const mockSitesQuery = jest.fn();
 
 jest.mock( '../../../app/context', () => ( {
+	...jest.requireActual( '../../../app/context' ),
 	useAppContext: jest.fn( () => ( {
 		queries: {
 			sitesQuery: () => mockSitesQuery(),
@@ -93,7 +89,9 @@ function renderPreferencesPrimarySite() {
 		queryFn: () => Promise.resolve( mockSites ),
 	} );
 
-	return render( <PreferencesPrimarySite /> );
+	return render( <PreferencesPrimarySite />, {
+		user: { visible_site_count: 2 } as User,
+	} );
 }
 
 afterEach( () => {
@@ -124,9 +122,9 @@ test( 'hides primary site selector when user has no sites', async () => {
 		queryFn: () => Promise.resolve( [] ),
 	} );
 
-	( useAuth as jest.Mock ).mockReturnValue( { user: { visible_site_count: 0 } } );
-
-	render( <PreferencesPrimarySite /> );
+	render( <PreferencesPrimarySite />, {
+		user: { visible_site_count: 0 } as User,
+	} );
 
 	// Wait for component to render
 	await waitFor( () => {

--- a/client/dashboard/sites/backups/test/index.test.tsx
+++ b/client/dashboard/sites/backups/test/index.test.tsx
@@ -13,12 +13,6 @@ import type { ActivityLogEntry, Site } from '@automattic/api-core';
 const API_BASE = 'https://public-api.wordpress.com';
 const mockSiteId = 123;
 
-jest.mock( '../../../app/auth', () => ( {
-	useAuth: () => ( {
-		user: { id: 'test-user' },
-	} ),
-} ) );
-
 jest.mock( '@wordpress/react-i18n', () => ( {
 	useI18n: jest.fn(),
 } ) );

--- a/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
@@ -15,12 +15,6 @@ const mockNavigate = jest.fn();
 const API_BASE = 'https://public-api.wordpress.com';
 const mockSiteId = 123;
 
-jest.mock( '../../../../app/auth', () => ( {
-	useAuth: () => ( {
-		user: { id: 'test-user' },
-	} ),
-} ) );
-
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		createSuccessNotice: jest.fn(),

--- a/client/dashboard/sites/logs/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs/dataviews/test/index.test.tsx
@@ -14,10 +14,6 @@ import type { DeepPartial } from 'utility-types';
 const API_BASE = 'https://public-api.wordpress.com';
 const mockSiteId = 123;
 
-jest.mock( '../../../../app/auth', () => ( {
-	useAuth: () => ( { user: { id: 'test-user' } } ),
-} ) );
-
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		createSuccessNotice: jest.fn(),

--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -14,10 +14,6 @@ import type { SiteLogsDataViewsProps } from '../dataviews';
 const API_BASE = 'https://public-api.wordpress.com';
 const mockSiteId = 123;
 
-jest.mock( '../../../app/auth', () => ( {
-	useAuth: () => ( { user: { id: 'test-user' } } ),
-} ) );
-
 jest.mock( '../../../components/time-mismatch-notice', () => ( {
 	__esModule: true,
 	default: () => null,

--- a/client/dashboard/sites/overview-backup-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-backup-card/test/index.test.tsx
@@ -27,10 +27,6 @@ const mockSite: Site = {
 	is_wpcom_atomic: true,
 } as Site;
 
-jest.mock( '../../../app/auth', () => ( {
-	useAuth: () => mockSite,
-} ) );
-
 jest.mock( '@wordpress/i18n', () => ( {
 	...jest.requireActual( '@wordpress/i18n' ),
 	__: ( text: string ) => text,

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor, within } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../test-utils';
+import Sites from '../index';
+import type { Site, User } from '@automattic/api-core';
+
+const mockSites = [
+	{
+		ID: 1,
+		name: 'My First Site',
+		slug: 'my-first-site.wordpress.com',
+		URL: 'https://my-first-site.wordpress.com',
+		is_coming_soon: false,
+		is_private: false,
+		subscribers_count: 123,
+		site_migration: {},
+		plan: { product_slug: 'business-bundle', product_name_short: 'Business' },
+	} as Site,
+	{
+		ID: 2,
+		name: 'My Second Site',
+		slug: 'my-second-site.wordpress.com',
+		URL: 'https://my-second-site.wordpress.com',
+		is_coming_soon: true,
+		is_private: false,
+		subscribers_count: 456,
+		site_migration: {},
+		plan: { product_slug: 'free_plan', product_name_short: 'Free' },
+	} as Site,
+];
+
+describe( 'Sites', () => {
+	beforeEach( () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/read/teams' )
+			.query( true )
+			.reply( 200, { teams: [] } );
+
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.1/me/preferences' )
+			.query( true )
+			.reply( 200, { calypso_preferences: {} } );
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/sites' )
+			.query( true )
+			.reply( 200, { sites: mockSites } );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
+	it( 'renders Add new site button', async () => {
+		render( <Sites /> );
+
+		expect( await screen.findByRole( 'button', { name: 'Add new site' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders DataViews', async () => {
+		render( <Sites />, {
+			user: {
+				site_count: 13, // to force the table layout
+			} as User,
+		} );
+
+		await waitFor( () => {
+			const table = screen.getByRole( 'table' );
+			const rows = within( table ).getAllByRole( 'row' );
+			expect( rows ).toHaveLength( 3 );
+		} );
+
+		const table = screen.getByRole( 'table' );
+		const rows = within( table ).getAllByRole( 'row' );
+
+		const header = within( rows[ 0 ] ).getAllByRole( 'columnheader' );
+		expect( header[ 0 ] ).toHaveTextContent( 'Site' );
+		expect( header[ 1 ] ).toHaveTextContent( 'Visibility' );
+		expect( header[ 2 ] ).toHaveTextContent( '7-day visitors' );
+		expect( header[ 3 ] ).toHaveTextContent( 'Subscribers' );
+		expect( header[ 4 ] ).toHaveTextContent( 'Plan' );
+
+		const row1 = within( rows[ 1 ] ).getAllByRole( 'cell' );
+		expect( row1[ 0 ] ).toHaveTextContent( 'My First Site' );
+		expect( row1[ 0 ] ).toHaveTextContent( 'my-first-site.wordpress.com' );
+		expect( row1[ 1 ] ).toHaveTextContent( 'Public' );
+		expect( row1[ 2 ] ).toHaveAccessibleName( '' ); // async-loading
+		expect( row1[ 3 ] ).toHaveTextContent( '123' );
+		expect( row1[ 4 ] ).toHaveTextContent( 'Business' );
+
+		const row2 = within( rows[ 2 ] ).getAllByRole( 'cell' );
+		expect( row2[ 0 ] ).toHaveTextContent( 'My Second Site' );
+		expect( row2[ 0 ] ).toHaveTextContent( 'my-second-site.wordpress.com' );
+		expect( row2[ 1 ] ).toHaveTextContent( 'Coming soon' );
+		expect( row2[ 2 ] ).toHaveAccessibleName( '' ); // async-loading
+		expect( row2[ 3 ] ).toHaveTextContent( '456' );
+		expect( row2[ 4 ] ).toHaveTextContent( 'Free' );
+	} );
+} );

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -69,13 +69,9 @@ describe( 'Sites', () => {
 			} as User,
 		} );
 
-		await waitFor( () => {
-			const table = screen.getByRole( 'table' );
-			const rows = within( table ).getAllByRole( 'row' );
-			expect( rows ).toHaveLength( 3 );
-		} );
+		const table = await screen.findByRole( 'table' );
+		await waitFor( () => expect( within( table ).getAllByRole( 'row' ) ).toHaveLength( 3 ) );
 
-		const table = screen.getByRole( 'table' );
 		const rows = within( table ).getAllByRole( 'row' );
 
 		const header = within( rows[ 0 ] ).getAllByRole( 'columnheader' );
@@ -89,7 +85,7 @@ describe( 'Sites', () => {
 		expect( row1[ 0 ] ).toHaveTextContent( 'My First Site' );
 		expect( row1[ 0 ] ).toHaveTextContent( 'my-first-site.wordpress.com' );
 		expect( row1[ 1 ] ).toHaveTextContent( 'Public' );
-		expect( row1[ 2 ] ).toHaveAccessibleName( '' ); // async-loading
+		expect( row1[ 2 ] ).toHaveAccessibleName( '' ); // empty because it's async-loaded
 		expect( row1[ 3 ] ).toHaveTextContent( '123' );
 		expect( row1[ 4 ] ).toHaveTextContent( 'Business' );
 
@@ -97,7 +93,7 @@ describe( 'Sites', () => {
 		expect( row2[ 0 ] ).toHaveTextContent( 'My Second Site' );
 		expect( row2[ 0 ] ).toHaveTextContent( 'my-second-site.wordpress.com' );
 		expect( row2[ 1 ] ).toHaveTextContent( 'Coming soon' );
-		expect( row2[ 2 ] ).toHaveAccessibleName( '' ); // async-loading
+		expect( row2[ 2 ] ).toHaveAccessibleName( '' ); // empty because it's async-loaded
 		expect( row2[ 3 ] ).toHaveTextContent( '456' );
 		expect( row2[ 4 ] ).toHaveTextContent( 'Free' );
 	} );

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -9,10 +9,8 @@ import type { User } from '@automattic/api-core';
 
 const defaultUser = {
 	ID: 1,
-	display_name: 'Test User',
 	username: 'testuser',
 	email: 'test@example.com',
-	primary_blog: 123,
 	language: 'en',
 } as User;
 

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -3,6 +3,18 @@ import { RouterProvider, createRouter, createRootRoute } from '@tanstack/react-r
 import { render as testingLibraryRender } from '@testing-library/react';
 import { Suspense } from 'react';
 import { type AnalyticsClient, AnalyticsProvider } from './app/analytics';
+import { AuthContext } from './app/auth';
+import { AppProvider, APP_CONTEXT_DEFAULT_CONFIG } from './app/context';
+import type { User } from '@automattic/api-core';
+
+const defaultUser = {
+	ID: 1,
+	display_name: 'Test User',
+	username: 'testuser',
+	email: 'test@example.com',
+	primary_blog: 123,
+	language: 'en',
+} as User;
 
 function createTestRouter( ui: React.ReactElement ) {
 	const Component = () => ui;
@@ -25,7 +37,12 @@ type RenderResult = ReturnType< typeof testingLibraryRender > &
 		queryClient: QueryClient;
 	};
 
-export function render( ui: React.ReactElement ): RenderResult {
+interface RenderOptions {
+	user?: User;
+}
+
+export function render( ui: React.ReactElement, options: RenderOptions = {} ): RenderResult {
+	const { user = defaultUser } = options;
 	const queryClient = new QueryClient( {
 		defaultOptions: {
 			queries: { retry: false },
@@ -38,9 +55,13 @@ export function render( ui: React.ReactElement ): RenderResult {
 
 	const testingLibraryResult = testingLibraryRender(
 		<QueryClientProvider client={ queryClient }>
-			<AnalyticsProvider client={ { recordTracksEvent, recordPageView } }>
-				<RouterProvider router={ router } context={ { config: { basePath: '/' } } } />
-			</AnalyticsProvider>
+			<AppProvider config={ APP_CONTEXT_DEFAULT_CONFIG }>
+				<AnalyticsProvider client={ { recordTracksEvent, recordPageView } }>
+					<AuthContext.Provider value={ { user, logout: jest.fn() } }>
+						<RouterProvider router={ router } context={ { config: { basePath: '/' } } } />
+					</AuthContext.Provider>
+				</AnalyticsProvider>
+			</AppProvider>
 		</QueryClientProvider>
 	);
 


### PR DESCRIPTION
Part of DOTMSD-1069

## Proposed Changes

Adds integration test for MSD Site List, which serves as a good example for other screens in the dashboard.

The main feature is that it uses mocking at the very boundary of the data fetching, which is the public-api backend itself. This means the test (almost) does NOT depend on the internal implementation of the component, which would have been the case if we used higher-level mocking like mocking queries / hooks.

## Testing Instructions

1. Verify this PR passes CI.
2. Read the test and verify it is nice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
