### PR TITLE
Highlight the domain in variations where we have included in...

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -51,6 +51,11 @@ type PlanDifferentiatorsExperimentResult = {
 	 */
 	isVar1dVariant: boolean;
 	/**
+	 * When true, the user is specifically in the var4 variant.
+	 * Used to exclude var4 from certain experiment-specific styling.
+	 */
+	isVar4Variant: boolean;
+	/**
 	 * When true, the user is in an experiment variant (not control).
 	 */
 	isExperimentVariant: boolean;
@@ -102,6 +107,7 @@ function usePlanDifferentiatorsExperiment( {
 		useVar3Features: variant === 'var3',
 		useVar1Features: variant === 'var1' || variant === 'var1d',
 		isVar1dVariant: variant === 'var1d',
+		isVar4Variant: variant === 'var4',
 		isExperimentVariant,
 	};
 }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -391,6 +391,7 @@ const PlansFeaturesMain = ( {
 		useVar4Features,
 		useVar5Features,
 		isVar1dVariant,
+		isVar4Variant,
 		isExperimentVariant,
 	} = usePlanDifferentiatorsExperiment( { flowName, intent, isInSignup } );
 
@@ -970,6 +971,7 @@ const PlansFeaturesMain = ( {
 										showSimplifiedBillingDescription={ isInSignup }
 										showBillingDescriptionForIncreasedRenewalPrice={ renewalPricingVariation }
 										isVar1dVariant={ isVar1dVariant }
+										isVar4Variant={ isVar4Variant }
 										isExperimentVariant={ isExperimentVariant }
 									/>
 								) }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -970,6 +970,7 @@ const PlansFeaturesMain = ( {
 										showSimplifiedBillingDescription={ isInSignup }
 										showBillingDescriptionForIncreasedRenewalPrice={ renewalPricingVariation }
 										isVar1dVariant={ isVar1dVariant }
+										isExperimentVariant={ isExperimentVariant }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -399,6 +399,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		showSimplifiedBillingDescription,
 		showBillingDescriptionForIncreasedRenewalPrice,
 		isVar1dVariant,
+		isExperimentVariant,
 	} = props;
 
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -461,6 +462,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 					showBillingDescriptionForIncreasedRenewalPrice
 				}
 				isVar1dVariant={ isVar1dVariant }
+				isExperimentVariant={ isExperimentVariant }
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />
 			</PlansGridContextProvider>

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -399,6 +399,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		showSimplifiedBillingDescription,
 		showBillingDescriptionForIncreasedRenewalPrice,
 		isVar1dVariant,
+		isVar4Variant,
 		isExperimentVariant,
 	} = props;
 
@@ -462,6 +463,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 					showBillingDescriptionForIncreasedRenewalPrice
 				}
 				isVar1dVariant={ isVar1dVariant }
+				isVar4Variant={ isVar4Variant }
 				isExperimentVariant={ isExperimentVariant }
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />

--- a/packages/plans-grid-next/src/components/features-grid/mobile-free-domain.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/mobile-free-domain.tsx
@@ -4,6 +4,7 @@ import {
 	isWpComFreePlan,
 	isWpcomEnterpriseGridPlan,
 } from '@automattic/calypso-products';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../grid-context';
 import { GridPlan } from '../../types';
@@ -19,7 +20,7 @@ const MobileFreeDomain = ( {
 	paidDomainName,
 }: MobileFreeDomainProps ) => {
 	const translate = useTranslate();
-	const { isVar1dVariant } = usePlansGridContext();
+	const { isVar1dVariant, isExperimentVariant } = usePlansGridContext();
 
 	// For var1d, don't render the highlighted free domain - it appears in regular feature list
 	if ( isVar1dVariant ) {
@@ -44,11 +45,19 @@ const MobileFreeDomain = ( {
 		  } )
 		: translate( 'Free domain for one year' );
 
+	// Apply green styling for experiment variants (which use "Everything in X, plus:" features)
+	// but not for var1d or control experience
+	const shouldHighlightDomain = isExperimentVariant && paidDomainName;
+
+	const titleClasses = clsx( 'plan-features-2023-grid__item-title', 'is-bold', {
+		'is-domain-included-highlight': shouldHighlightDomain,
+	} );
+
 	return (
 		<div className="plan-features-2023-grid__highlighted-feature">
 			<PlanFeaturesItem>
 				<span className="plan-features-2023-grid__item-info is-annual-plan-feature is-available">
-					<span className="plan-features-2023-grid__item-title is-bold">{ displayText }</span>
+					<span className={ titleClasses }>{ displayText }</span>
 				</span>
 			</PlanFeaturesItem>
 		</div>

--- a/packages/plans-grid-next/src/components/features-grid/mobile-free-domain.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/mobile-free-domain.tsx
@@ -20,7 +20,7 @@ const MobileFreeDomain = ( {
 	paidDomainName,
 }: MobileFreeDomainProps ) => {
 	const translate = useTranslate();
-	const { isVar1dVariant, isExperimentVariant } = usePlansGridContext();
+	const { isVar1dVariant, isVar4Variant, isExperimentVariant } = usePlansGridContext();
 
 	// For var1d, don't render the highlighted free domain - it appears in regular feature list
 	if ( isVar1dVariant ) {
@@ -46,8 +46,8 @@ const MobileFreeDomain = ( {
 		: translate( 'Free domain for one year' );
 
 	// Apply green styling for experiment variants (which use "Everything in X, plus:" features)
-	// but not for var1d or control experience
-	const shouldHighlightDomain = isExperimentVariant && paidDomainName;
+	// but not for var1d, var4, or control experience
+	const shouldHighlightDomain = isExperimentVariant && ! isVar4Variant && paidDomainName;
 
 	const titleClasses = clsx( 'plan-features-2023-grid__item-title', 'is-bold', {
 		'is-domain-included-highlight': shouldHighlightDomain,

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -372,6 +372,12 @@
 			font-weight: 600;
 		}
 
+		// Experiment variants: domain included text gets green color
+		// Applies to variants with "Everything in X, plus:" features (not var1d or control)
+		&.is-domain-included-highlight {
+			color: var(--studio-green-60);
+		}
+
 		// var1d experiment: differentiator feature styling
 		// Features below "Everything in X, plus:" get distinctive underline treatment
 		&.is-differentiator-feature {

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -114,7 +114,8 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	setActiveTooltipId,
 } ) => {
 	const translate = useTranslate();
-	const { enableFeatureTooltips, isExperimentVariant, isVar1dVariant } = usePlansGridContext();
+	const { enableFeatureTooltips, isExperimentVariant, isVar1dVariant, isVar4Variant } =
+		usePlansGridContext();
 
 	return (
 		<>
@@ -145,13 +146,16 @@ const PlanFeatures2023GridFeatures: React.FC< {
 					'upload-video',
 				];
 
-				// Apply green styling for domain feature in experiment variants (not var1d or control)
+				// Apply green styling for domain feature in experiment variants (not var1d, var4, or control)
 				const isCustomDomainFeatureWithPaidDomain =
 					currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN &&
 					paidDomainName &&
 					! isFreePlan( planSlug );
 				const shouldHighlightDomainFeature =
-					isCustomDomainFeatureWithPaidDomain && isExperimentVariant && ! isVar1dVariant;
+					isCustomDomainFeatureWithPaidDomain &&
+					isExperimentVariant &&
+					! isVar1dVariant &&
+					! isVar4Variant;
 
 				const divClasses = clsx( '', getPlanClass( planSlug ), {
 					'is-last-feature': featureIndex + 1 === features.length,

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -114,7 +114,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	setActiveTooltipId,
 } ) => {
 	const translate = useTranslate();
-	const { enableFeatureTooltips } = usePlansGridContext();
+	const { enableFeatureTooltips, isExperimentVariant, isVar1dVariant } = usePlansGridContext();
 
 	return (
 		<>
@@ -145,6 +145,14 @@ const PlanFeatures2023GridFeatures: React.FC< {
 					'upload-video',
 				];
 
+				// Apply green styling for domain feature in experiment variants (not var1d or control)
+				const isCustomDomainFeatureWithPaidDomain =
+					currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN &&
+					paidDomainName &&
+					! isFreePlan( planSlug );
+				const shouldHighlightDomainFeature =
+					isCustomDomainFeatureWithPaidDomain && isExperimentVariant && ! isVar1dVariant;
+
 				const divClasses = clsx( '', getPlanClass( planSlug ), {
 					'is-last-feature': featureIndex + 1 === features.length,
 					'has-min-height': featuresWithMinHeight.includes( featureSlug ),
@@ -161,6 +169,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 				const itemTitleClasses = clsx( 'plan-features-2023-grid__item-title', {
 					'is-bold': isHighlightedFeature,
 					'is-differentiator-feature': currentFeature.isDifferentiatorFeature,
+					'is-domain-included-highlight': shouldHighlightDomainFeature,
 				} );
 
 				return (

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -34,6 +34,7 @@ interface PlansGridContext {
 	showSimplifiedBillingDescription?: boolean;
 	showBillingDescriptionForIncreasedRenewalPrice?: string | null;
 	isVar1dVariant?: boolean;
+	isVar4Variant?: boolean;
 	isExperimentVariant?: boolean;
 }
 
@@ -63,6 +64,7 @@ const PlansGridContextProvider = ( {
 	showSimplifiedBillingDescription,
 	showBillingDescriptionForIncreasedRenewalPrice,
 	isVar1dVariant,
+	isVar4Variant,
 	isExperimentVariant,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
@@ -101,6 +103,7 @@ const PlansGridContextProvider = ( {
 				showSimplifiedBillingDescription,
 				showBillingDescriptionForIncreasedRenewalPrice,
 				isVar1dVariant,
+				isVar4Variant,
 				isExperimentVariant,
 			} }
 		>

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -291,6 +291,12 @@ export type GridContextProps = {
 	isVar1dVariant?: boolean;
 
 	/**
+	 * When true, indicates the user is in the var4 experiment variant.
+	 * Used to exclude var4 from certain experiment-specific styling.
+	 */
+	isVar4Variant?: boolean;
+
+	/**
 	 * When true, indicates the user is in an experiment variant.
 	 * Used to display experiment-specific feature titles in the comparison grid.
 	 */


### PR DESCRIPTION

Part of DOTCOM-15845

## Proposed Changes

* Make the domain green for highlights

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

calypso_pricing_differentiation_202601_v1 - go over all variations, the variations where only one plan displays the domain should have the domain in green

<img width="298" height="402" alt="Screenshot 2026-01-28 at 17 03 15" src="https://github.com/user-attachments/assets/ae23cc61-fed1-48c6-a652-40c342358058" />
<img width="298" height="402" alt="Screenshot 2026-01-28 at 16 55 12" src="https://github.com/user-attachments/assets/0648007a-20ce-41c0-a641-a2b8da2f0046" />
<img width="298" height="402" alt="Screenshot 2026-01-28 at 16 54 24" src="https://github.com/user-attachments/assets/4ba6a5c9-ebe9-4c9a-86f7-f625a9d8091b" />
<img width="298" height="402" alt="Screenshot 2026-01-28 at 16 52 14" src="https://github.com/user-attachments/assets/0a29903a-5b32-473a-af9e-d525effa5f21" />
<img width="298" height="402" alt="Screenshot 2026-01-28 at 16 51 38" src="https://github.com/user-attachments/assets/261cc958-8fec-46d9-8a7b-8a3418c670e0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
