### PR TITLE
Update domain upsell tests to use CALYPSO_RELEASE tag

### DIFF
--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
@@ -3,7 +3,7 @@ import { expect, tags, test } from '../../lib/pw-base';
 test.describe(
 	'Domain: Upsell (Home)',
 	{
-		tag: [ tags.CALYPSO_PR ],
+		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
 		test( 'As a user, I can see domain upsell on Home dashboard and proceed to checkout', async ( {

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
@@ -1,6 +1,6 @@
 import { expect, tags, test } from '../../lib/pw-base';
 
-test.describe( 'Domain: Upsell (Sidebar)', { tag: [ tags.CALYPSO_PR ] }, () => {
+test.describe( 'Domain: Upsell (Sidebar)', { tag: [ tags.CALYPSO_RELEASE ] }, () => {
 	const planName = 'Premium';
 
 	test( `As a user, I can use the sidebar domain upsell to add a domain and a ${ planName } plan to cart`, async ( {


### PR DESCRIPTION


Part of QAO-224

## Proposed Changes

Update domain upsell specs to only run on pre-release event in CI.


