### PR TITLE
Reduce CI retries from 2 to 1 in Playwright configuration

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -56,7 +56,7 @@ export default defineConfig( {
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !! process.env.CI,
 	/* Retry on CI only */
-	retries: process.env.CI ? 2 : 0,
+	retries: process.env.CI ? 1 : 0,
 	workers: getWorkers(),
 	/* Global timeout for each test */
 	timeout: 120000, // 2 minutes


### PR DESCRIPTION

Part of QAO-224

## Proposed Changes

Reduce the number of retries in CI from 2 to 1.
If a test needs 2 retries to pass we should fix that or it's not worth keeping. Having 2 retries adds unnecessary runtime and consumes other resources as the email quota.



