### PR TITLE
Help Center Logged out: Use the new logged out bot

### DIFF
--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -28,7 +28,7 @@ const HELP_CENTER_STORE = HelpCenter.register();
 function getBotSlug(
 	supportInteraction: SupportInteraction | undefined,
 	newInteractionsBotSlug: string,
-	loggedOutOdieBotSlug = 'wpcom-chat-loggedout',
+	loggedOutOdieBotSlug = 'wpcom-workflow-chat_loggedout',
 	isLoggedOutSession: boolean
 ): string {
 	if ( supportInteraction ) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-15886/use-the-new-logged-out-bot
Fixes https://linear.app/a8c/issue/DSGCOM-397/fix-escalation-message

### Before

<img width="755" height="292" alt="Screenshot 2026-01-28 at 16 17 46" src="https://github.com/user-attachments/assets/fcf638c4-beb8-462f-b8d7-ea55176bd85a" />

### After

<img width="450" height="597" alt="image" src="https://github.com/user-attachments/assets/0efd626c-ddb0-4bc1-b353-c61ab6f6351f" />
