### PR TITLE
e2e tests: skip tests if daily email limit reached

### DIFF
--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -21,6 +21,7 @@ class EnvVariables implements SupportedEnvVariables {
 		GUTENBERG_EDGE: false,
 		GUTENBERG_NIGHTLY: false,
 		HEADLESS: false,
+		MAILOSAUR_LIMIT_REACHED: false,
 		JETPACK_TARGET: 'wpcom-production',
 		PARTNER_DIRECTORY_BASE_URL: 'https://wordpress.com/development-services',
 		RETRY_COUNT: 0,
@@ -94,6 +95,13 @@ class EnvVariables implements SupportedEnvVariables {
 		return value
 			? castAsBoolean( 'GUTENBERG_NIGHTLY', value )
 			: this._defaultEnvVariables.GUTENBERG_NIGHTLY;
+	}
+
+	get MAILOSAUR_LIMIT_REACHED(): boolean {
+		const value = process.env.MAILOSAUR_LIMIT_REACHED;
+		return value
+			? castAsBoolean( 'MAILOSAUR_LIMIT_REACHED', value )
+			: this._defaultEnvVariables.MAILOSAUR_LIMIT_REACHED;
 	}
 
 	get COBLOCKS_EDGE(): boolean {

--- a/packages/calypso-e2e/src/types/env-variables.types.ts
+++ b/packages/calypso-e2e/src/types/env-variables.types.ts
@@ -35,6 +35,7 @@ export interface SupportedEnvVariables {
 	readonly TEST_LOCALES: TestLocales;
 	readonly TEST_ON_ATOMIC: boolean;
 	readonly TIMEOUT: number;
+	readonly MAILOSAUR_LIMIT_REACHED: boolean;
 	readonly VIEWPORT_NAME: ViewportName;
 	readonly WOO_BASE_URL: string;
 	readonly WPCOM_BASE_URL: string;

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -83,7 +83,13 @@ export default defineConfig( {
 	// See https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/deviceDescriptorsSource.json */
 	projects: [
 		{
+			name: 'mailosaur-usage-check',
+			testMatch: /mailosaur-usage\.setup\.ts/,
+			testDir: './setup',
+		},
+		{
 			name: 'chrome',
+			dependencies: [ 'mailosaur-usage-check' ],
 			use: withCustomOptions( {
 				...devices[ 'Desktop Chrome HiDPI' ],
 				userAgent: appendE2EUserAgent( devices[ 'Desktop Chrome HiDPI' ].userAgent ),
@@ -92,6 +98,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'firefox',
+			dependencies: [ 'mailosaur-usage-check' ],
 			use: withCustomOptions( {
 				...devices[ 'Desktop Firefox' ],
 				userAgent: appendE2EUserAgent( devices[ 'Desktop Firefox' ].userAgent ),
@@ -100,6 +107,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'webkit',
+			dependencies: [ 'mailosaur-usage-check' ],
 			use: withCustomOptions( {
 				...devices[ 'Desktop Safari' ],
 				userAgent: appendE2EUserAgent( devices[ 'Desktop Safari' ].userAgent ),
@@ -108,6 +116,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'pixel',
+			dependencies: [ 'mailosaur-usage-check' ],
 			use: withCustomOptions( {
 				...devices[ 'Pixel 7' ],
 				userAgent: appendE2EUserAgent( devices[ 'Pixel 7' ].userAgent ),
@@ -117,6 +126,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'galaxy',
+			dependencies: [ 'mailosaur-usage-check' ],
 			use: withCustomOptions( {
 				...devices[ 'Galaxy S24' ],
 				userAgent: appendE2EUserAgent( devices[ 'Galaxy S24' ].userAgent ),
@@ -126,6 +136,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'iphone',
+			dependencies: [ 'mailosaur-usage-check' ],
 			use: withCustomOptions( {
 				...devices[ 'iPhone 15 Pro' ],
 				userAgent: appendE2EUserAgent( devices[ 'iPhone 15 Pro' ].userAgent ),
@@ -135,6 +146,7 @@ export default defineConfig( {
 		},
 		{
 			name: 'authentication',
+			dependencies: [ 'mailosaur-usage-check' ],
 			retries: 0,
 			testDir: './specs/authentication',
 			use: {

--- a/test/e2e/setup/mailosaur-usage.setup.ts
+++ b/test/e2e/setup/mailosaur-usage.setup.ts
@@ -1,0 +1,34 @@
+import { test as setup } from '@playwright/test';
+import { SecretsManager } from '@automattic/calypso-e2e';
+
+setup( 'check mailosaur daily email limit', async ( { request } ) => {
+	const apiKey = SecretsManager.secrets.mailosaur.apiKey;
+
+	try {
+		const response = await request.get( 'https://mailosaur.com/api/usage/limits', {
+			headers: {
+				Authorization: `Basic ${ Buffer.from( `${ apiKey }:` ).toString( 'base64' ) }`,
+			},
+		} );
+
+		if ( ! response.ok() ) {
+			throw new Error( `Mailosaur API returned ${ response.status() }` );
+		}
+
+		const limits = await response.json();
+		const { current, limit } = limits.email;
+
+		console.log( `Mailosaur email usage: ${ current }/${ limit }` );
+
+		if ( current >= limit ) {
+			console.warn( 'Mailosaur daily email limit reached!' );
+			process.env.MAILOSAUR_LIMIT_REACHED = 'true';
+		} else {
+			process.env.MAILOSAUR_LIMIT_REACHED = 'false';
+		}
+	} catch ( error ) {
+		console.error( 'Failed to check Mailosaur usage limits:', error );
+		// Fail open: don't block tests if we can't check the limit
+		process.env.MAILOSAUR_LIMIT_REACHED = 'false';
+	}
+} );

--- a/test/e2e/setup/mailosaur-usage.setup.ts
+++ b/test/e2e/setup/mailosaur-usage.setup.ts
@@ -1,5 +1,5 @@
-import { test as setup } from '@playwright/test';
 import { SecretsManager } from '@automattic/calypso-e2e';
+import { test as setup } from '@playwright/test';
 
 setup( 'check mailosaur daily email limit', async ( { request } ) => {
 	const apiKey = SecretsManager.secrets.mailosaur.apiKey;

--- a/test/e2e/specs/dashboard/settings__site-visibility.spec.ts
+++ b/test/e2e/specs/dashboard/settings__site-visibility.spec.ts
@@ -1,6 +1,12 @@
+import { envVariables } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Dashboard: Site Visibility Settings', { tag: [ tags.DASHBOARD_PR ] }, () => {
+	test.skip(
+		envVariables.MAILOSAUR_LIMIT_REACHED,
+		'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
+	);
+
 	test( 'As a new simple site user, I can set my site visibility to Private, so that only I can see my site', async ( {
 		pageDashboard,
 		pageDashboardVisibilitySettings,

--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
@@ -1,3 +1,4 @@
+import { envVariables } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe(
@@ -6,6 +7,11 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
+		test.skip(
+			envVariables.MAILOSAUR_LIMIT_REACHED,
+			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
+		);
+
 		test( 'As a user, I can see domain upsell on Home dashboard and proceed to checkout', async ( {
 			helperData,
 			page,

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
@@ -1,6 +1,12 @@
+import { envVariables } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Domain: Upsell (Sidebar)', { tag: [ tags.CALYPSO_RELEASE ] }, () => {
+	test.skip(
+		envVariables.MAILOSAUR_LIMIT_REACHED,
+		'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
+	);
+
 	const planName = 'Premium';
 
 	test( `As a user, I can use the sidebar domain upsell to add a domain and a ${ planName } plan to cart`, async ( {

--- a/test/e2e/specs/domains/domains__add.spec.ts
+++ b/test/e2e/specs/domains/domains__add.spec.ts
@@ -1,4 +1,4 @@
-import { DomainsPage } from '@automattic/calypso-e2e';
+import { DomainsPage, envVariables } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe(
@@ -7,6 +7,11 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
+		test.skip(
+			envVariables.MAILOSAUR_LIMIT_REACHED,
+			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
+		);
+
 		test( 'As a user, I can add a domain to my existing site', async ( {
 			componentDomainSearch,
 			componentSidebar,

--- a/test/e2e/specs/tools/import__sites-medium.spec.ts
+++ b/test/e2e/specs/tools/import__sites-medium.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { envVariables } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 
 const TEST_MEDIUM_EXPORT_FILE_PATH = path.join(
@@ -18,6 +19,11 @@ test.describe(
 		},
 	},
 	() => {
+		test.skip(
+			envVariables.MAILOSAUR_LIMIT_REACHED,
+			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
+		);
+
 		test( 'One: As a New WordPress.com free plan user with a simple site, I can use the "Medium Run Importer" link on the wp-admin Importers List page to import my content from my Medium account', async ( {
 			pageImportContentFromMedium,
 			sitePublic,

--- a/test/e2e/specs/tools/import__sites-squarespace.spec.ts
+++ b/test/e2e/specs/tools/import__sites-squarespace.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { envVariables } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 
 const TEST_SQUARESPACE_EXPORT_FILE_PATH = path.join(
@@ -18,6 +19,11 @@ test.describe(
 		},
 	},
 	() => {
+		test.skip(
+			envVariables.MAILOSAUR_LIMIT_REACHED,
+			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
+		);
+
 		test( 'One: As a New WordPress.com free plan user with a simple site, I can use the "Squarespace Run Importer" link on the wp-admin Importers List page to import my content from my Squarespace site', async ( {
 			pageImportContentFromSquarespace,
 			sitePublic,

--- a/test/e2e/specs/tools/import__sites-substack.spec.ts
+++ b/test/e2e/specs/tools/import__sites-substack.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { envVariables } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 
 const TEST_SUBSTACK_EXPORT_FILE_PATH = path.join( __dirname, 'import-files', 'substackexport.zip' );
@@ -14,6 +15,11 @@ test.describe(
 		},
 	},
 	() => {
+		test.skip(
+			envVariables.MAILOSAUR_LIMIT_REACHED,
+			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
+		);
+
 		const substackSiteURL = 'https://test.substack.com/';
 		const substackSiteName = 'Testing Product';
 

--- a/test/e2e/specs/tools/import__sites-wordpress.spec.ts
+++ b/test/e2e/specs/tools/import__sites-wordpress.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { envVariables } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 
 const TEST_WORDPRESS_EXPORT_FILE_PATH = path.join(
@@ -18,6 +19,11 @@ test.describe(
 		},
 	},
 	() => {
+		test.skip(
+			envVariables.MAILOSAUR_LIMIT_REACHED,
+			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
+		);
+
 		test( 'One: As a New WordPress.com free plan user with a simple site, I can use the "WordPress Run Importer" link on the wp-admin Importers List page to import my content from my WordPress site', async ( {
 			pageImportContentFromWordPress,
 			sitePublic,


### PR DESCRIPTION
Part of QAO-224

## Proposed Changes

Add a Mailosaur API usage check that runs before all test projects. If the daily email limit is reached, tests that require email verification (and would fail) are skipped.


## Testing Instructions

 ### Verify the setup runs and checks the API
  1. Run any e2e test that depends on the check:

```
cd test/e2e
yarn playwright test specs/domains/domains__add.spec.ts
```

  2. Observe the console output includes: Mailosaur email usage: X/Y

  Verify tests skip when limit is reached

  1. Manually set the env variable to simulate limit reached:

  ```
MAILOSAUR_LIMIT_REACHED=true yarn playwright test specs/domains/domains__add.spec.ts
```

  2. Confirm the test is skipped with message: `Skipping: Mailosaur daily email limit reached`

  Verify tests run normally when limit is not reached

  1. Run without the env variable (or with it set to false):

  ```
yarn playwright test specs/domains/domains__add.spec.ts
```

  2. Confirm the test executes normally (not skipped due to Mailosaur limit)
