### PR TITLE
Help Center: Restore logged-out chat session after reopen

### DIFF
--- a/packages/odie-client/src/hooks/use-logged-out-session.ts
+++ b/packages/odie-client/src/hooks/use-logged-out-session.ts
@@ -7,33 +7,44 @@ const HELP_CENTER_STORE = HelpCenter.register();
 export const useLoggedOutSession = () => {
 	const location = useLocation();
 	const params = new URLSearchParams( location.search );
-	// We use these values to identify the logged out chat, not the ones from the data store, to keep the router in charge of the state.
-	const loggedOutOdieChatId = params.get( 'chatId' );
-	const loggedOutOdieSessionId = params.get( 'sessionId' );
-	const loggedOutOdieBotSlug = params.get( 'botSlug' );
 
-	const currentUser = useSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getCurrentUser(),
-		[]
-	);
+	// Primary: URL params (for active sessions where router is in control)
+	const urlChatId = params.get( 'chatId' );
+	const urlSessionId = params.get( 'sessionId' );
+	const urlBotSlug = params.get( 'botSlug' );
+
+	// Fallback: persisted store (for session restoration after Help Center is reopened)
+	const { currentUser, persistedLoggedOutOdieChat } = useSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return {
+			currentUser: store.getCurrentUser(),
+			persistedLoggedOutOdieChat: store.getLoggedOutOdieChat(),
+		};
+	}, [] );
+
 	const isLoggedIn = !! currentUser?.ID;
+
+	// Use URL params if available, otherwise fall back to persisted session
+	const loggedOutOdieChatId = urlChatId || persistedLoggedOutOdieChat?.odieId?.toString() || null;
+	const loggedOutOdieSessionId = urlSessionId || persistedLoggedOutOdieChat?.sessionId || null;
+	const loggedOutOdieBotSlug = urlBotSlug || persistedLoggedOutOdieChat?.botSlug || null;
 
 	const isLoggedOutSession =
 		! isLoggedIn || ( loggedOutOdieChatId && loggedOutOdieSessionId && loggedOutOdieBotSlug );
 
-	if ( ! isLoggedOutSession ) {
+	if ( isLoggedOutSession ) {
 		return {
-			isLoggedOutSession: false,
-			odieId: undefined,
-			sessionId: undefined,
-			botSlug: undefined,
+			isLoggedOutSession: true,
+			loggedOutOdieChatId: loggedOutOdieChatId,
+			sessionId: loggedOutOdieSessionId,
+			botSlug: loggedOutOdieBotSlug,
 		};
 	}
 
 	return {
-		isLoggedOutSession: true,
-		loggedOutOdieChatId: loggedOutOdieChatId,
-		sessionId: loggedOutOdieSessionId,
-		botSlug: loggedOutOdieBotSlug,
+		isLoggedOutSession: false,
+		odieId: undefined,
+		sessionId: undefined,
+		botSlug: undefined,
 	};
 };

--- a/packages/odie-client/src/hooks/use-logged-out-session.ts
+++ b/packages/odie-client/src/hooks/use-logged-out-session.ts
@@ -24,10 +24,13 @@ export const useLoggedOutSession = () => {
 
 	const isLoggedIn = !! currentUser?.ID;
 
-	// Use URL params if available, otherwise fall back to persisted session
-	const loggedOutOdieChatId = urlChatId || persistedLoggedOutOdieChat?.odieId?.toString() || null;
-	const loggedOutOdieSessionId = urlSessionId || persistedLoggedOutOdieChat?.sessionId || null;
-	const loggedOutOdieBotSlug = urlBotSlug || persistedLoggedOutOdieChat?.botSlug || null;
+	// Use URL params if available, fall back to persisted session only when logged out
+	const loggedOutOdieChatId =
+		urlChatId || ( ! isLoggedIn && persistedLoggedOutOdieChat?.odieId?.toString() ) || null;
+	const loggedOutOdieSessionId =
+		urlSessionId || ( ! isLoggedIn && persistedLoggedOutOdieChat?.sessionId ) || null;
+	const loggedOutOdieBotSlug =
+		urlBotSlug || ( ! isLoggedIn && persistedLoggedOutOdieChat?.botSlug ) || null;
 
 	const isLoggedOutSession =
 		! isLoggedIn || ( loggedOutOdieChatId && loggedOutOdieSessionId && loggedOutOdieBotSlug );


### PR DESCRIPTION
## Summary

Fixes https://linear.app/a8c/issue/DSGCOM-396/a-way-to-get-back-after-closing-the-chat

- Fixes logged-out users losing their chat session when closing and reopening the Help Center
- `useLoggedOutSession` now falls back to the persisted `loggedOutOdieChat` from the data-store when URL params are missing

## Problem

When a logged-out user closes the Help Center and reopens it, their chat session was lost because:
1. The router history is reset to `null` on close (in `setShowHelpCenter`)
2. `useLoggedOutSession` previously read ONLY from URL params, ignoring the persisted store data

The session data (`odieId`, `sessionId`, `botSlug`) was already being persisted to localStorage via `setLoggedOutOdieChat`, but never used for restoration.

## Solution

Modified `useLoggedOutSession` to:
- Use URL params as the primary source (for active sessions where router is in control)
- Fall back to the persisted `getLoggedOutOdieChat()` selector when URL params are missing

## Test plan

- [ ] As a logged-out user, start a chat with Wapuu
- [ ] Send a message and receive a response
- [ ] Close the Help Center
- [ ] Reopen the Help Center
- [ ] Verify the previous chat session is restored with message history