### PR TITLE
MSD Domains: Update /start/domain and /setup/domain-transfer so it links back to the dashboard at the end of the flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain-transfer/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-transfer/domain-transfer.ts
@@ -1,8 +1,10 @@
 import { DOMAIN_TRANSFER } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import {
 	clearSignupDestinationCookie,
 	setSignupCompleteSlug,
@@ -58,7 +60,7 @@ const domainTransfer: FlowV1 = {
 
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
-			redirectTo: `/setup/${ flowName }/domains`,
+			redirectTo: addQueryArgs( `/setup/${ flowName }/domains`, window.location.search ),
 			pageTitle: 'Bulk Transfer',
 		} );
 
@@ -85,14 +87,24 @@ const domainTransfer: FlowV1 = {
 							? `/setup/${ this.variantSlug }/domains`
 							: '/setup/domain-transfer/domains',
 						window.location.href
+					).href;
+
+					const checkoutBackURLWithQueryArgs = addQueryArgs(
+						checkoutBackURL,
+						window.location.search
 					);
 
+					const destination = addQueryArgs( '/checkout/no-site', {
+						signup: 0,
+						isDomainOnly: 1,
+						redirect_to: new URLSearchParams( window.location.search ).get( 'dashboard' )
+							? dashboardLink( '/domains' )
+							: undefined,
+						checkoutBackUrl: checkoutBackURLWithQueryArgs,
+					} );
+
 					// use replace instead of assign to remove the processing URL from history
-					return window.location.replace(
-						`/checkout/no-site?signup=0&isDomainOnly=1&checkoutBackUrl=${ encodeURIComponent(
-							checkoutBackURL.href
-						) }`
-					);
+					return window.location.replace( destination );
 				}
 				default:
 					return;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -103,10 +103,11 @@ function getLaunchDestination( dependencies ) {
 	return addQueryArgs( { celebrateLaunch: 'true' }, `/home/${ dependencies.siteSlug }` );
 }
 
-function getDomainSignupFlowDestination( { domainItem, cartItems, siteId, designType, siteSlug } ) {
+function getDomainSignupFlowDestination( { siteId, designType, siteSlug } ) {
 	const isDashboardFlow = new URLSearchParams( window.location.search ).has( 'dashboard' );
 
-	if ( domainItem && cartItems && cartItems.length > 0 && designType !== 'existing-site' ) {
+	// This designType represents a new site.
+	if ( designType === 'page' ) {
 		if ( isDashboardFlow ) {
 			return dashboardLink( `/sites/${ siteSlug }/domains` );
 		}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -103,10 +103,10 @@ function getLaunchDestination( dependencies ) {
 	return addQueryArgs( { celebrateLaunch: 'true' }, `/home/${ dependencies.siteSlug }` );
 }
 
-function getDomainSignupFlowDestination( { domainItem, cartItem, siteId, designType, siteSlug } ) {
+function getDomainSignupFlowDestination( { domainItem, cartItems, siteId, designType, siteSlug } ) {
 	const isDashboardFlow = new URLSearchParams( window.location.search ).has( 'dashboard' );
 
-	if ( domainItem && cartItem && designType !== 'existing-site' ) {
+	if ( domainItem && cartItems && cartItems.length > 0 && designType !== 'existing-site' ) {
 		if ( isDashboardFlow ) {
 			return dashboardLink( `/sites/${ siteSlug }/domains` );
 		}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -104,23 +104,24 @@ function getLaunchDestination( dependencies ) {
 }
 
 function getDomainSignupFlowDestination( { siteId, designType, siteSlug } ) {
-	const isDashboardFlow = new URLSearchParams( window.location.search ).has( 'dashboard' );
+	const dashboardType = new URLSearchParams( window.location.search ).get( 'dashboard' );
 
 	// This designType represents a new site.
 	if ( designType === 'page' ) {
-		if ( isDashboardFlow ) {
+		if ( dashboardType ) {
 			return dashboardLink( `/sites/${ siteSlug }/domains` );
 		}
 
 		return addQueryArgs( { siteId }, '/start/setup-site' );
 	} else if ( designType === 'existing-site' ) {
-		if ( isDashboardFlow ) {
+		if ( dashboardType ) {
 			return dashboardLink( `/sites/${ siteSlug }/domains` );
 		}
+
 		return `/checkout/thank-you/${ siteSlug }`;
 	}
 
-	if ( isDashboardFlow ) {
+	if ( dashboardType ) {
 		return dashboardLink( '/domains' );
 	}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -7,6 +7,7 @@ import {
 import { DOMAIN_FOR_GRAVATAR_FLOW, isDomainForGravatarFlow } from '@automattic/onboarding';
 import { isURL } from '@wordpress/url';
 import { get, includes, reject } from 'lodash';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { getOnboardingPostCheckoutDestination } from 'calypso/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { addQueryArgs, pathToUrl } from 'calypso/lib/url';
@@ -103,10 +104,23 @@ function getLaunchDestination( dependencies ) {
 }
 
 function getDomainSignupFlowDestination( { domainItem, cartItem, siteId, designType, siteSlug } ) {
+	const isDashboardFlow = new URLSearchParams( window.location.search ).has( 'dashboard' );
+
 	if ( domainItem && cartItem && designType !== 'existing-site' ) {
+		if ( isDashboardFlow ) {
+			return dashboardLink( `/sites/${ siteSlug }/domains` );
+		}
+
 		return addQueryArgs( { siteId }, '/start/setup-site' );
 	} else if ( designType === 'existing-site' ) {
+		if ( isDashboardFlow ) {
+			return dashboardLink( `/sites/${ siteSlug }/domains` );
+		}
 		return `/checkout/thank-you/${ siteSlug }`;
+	}
+
+	if ( isDashboardFlow ) {
+		return dashboardLink( '/domains' );
 	}
 
 	// `getThankYouPageUrl` appends a receipt ID to this slug even if it doesn't contain the

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -650,12 +650,13 @@ class Signup extends Component {
 		// For now, we simply make sure they are considered as dependency data when they are explicitly designated.
 		// It works, but the code could have been cleaner if there is no naming conflict.
 		// We should do a query parameter audit to make sure each query parameter means one and only one thing, and then seek for a future-proof solution.
-		const { siteId, siteSlug, flags } = queryObject;
+		const { siteId, siteSlug, flags, dashboard } = queryObject;
 
 		return {
 			siteId,
 			siteSlug,
 			flags,
+			dashboard,
 			...dependenciesInQuery,
 		};
 	};

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -146,6 +146,7 @@ const DomainSearchUI = (
 						addQueryArgs( '/setup/domain-transfer/intro', {
 							new: initialQuery,
 							search: 'yes',
+							dashboard,
 						} )
 					);
 				}


### PR DESCRIPTION
Closes DOMENG-408.

### Summary
- Ensures domain flows started from the Dashboard (via `?dashboard` in the URL) **return users to Dashboard domains** instead of the default signup/thank-you destinations.
- Preserves relevant query params through login + checkout so the “back” / completion navigation stays in the Dashboard context.

### What changed
- **Domain transfer flow**: carries `window.location.search` through login redirect + `checkoutBackUrl`, and sets `redirect_to` to Dashboard Domains when `dashboard` is present.
- **Signup domain destinations**: when `dashboard` is present, routes completion to:
  - Site domains: `/sites/:siteSlug/domains`
  - All domains: `/domains`
- **Query plumbing**: includes `dashboard` in signup dependencies and forwards it into the domain-transfer intro URL.

### Test plan

- Go through `/setup/domain-transfer?dashboard=msd` and verify the redirect URL at checkout points to `/domains` from MSD.
- Go through `/start/domain?dashboard=msd` (or `/domains > Add Domain Name > Search domain names`) and verify the redirect URL at checkout points back to the MSD (`/sites/%s/domains` if a site was created/picked or `/domains` if it's a domain-only purchase.)

Go thorugh both flows without the `dashboard` query parameter and verify they're still linking to the regular Calypso post-checkout places.