### PR TITLE
CIAB: Add unified Accept Invite page

### DIFF
--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -73,6 +73,27 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 };
 
 /**
+ * Get CIAB partner config from garden info
+ * Maps garden partner/name combinations to CIAB branding configs
+ */
+export function getCiabConfigFromGarden(
+	gardenPartner?: string,
+	gardenName?: string
+): CiabPartnerConfig | null {
+	if ( ! gardenPartner || ! gardenName ) {
+		return null;
+	}
+
+	// Map garden partners to branding configs
+	if ( gardenPartner === 'woo' && gardenName === 'commerce' ) {
+		return CIAB_PARTNERS.woo ?? null;
+	}
+
+	// Future: add mappings for other partners like "paypal"
+	return null;
+}
+
+/**
  * Get CIAB partner config from URL 'from' param
  * Returns the full partner config or null if not a CIAB partner
  */

--- a/client/my-sites/invites-unified/controller.tsx
+++ b/client/my-sites/invites-unified/controller.tsx
@@ -1,0 +1,83 @@
+import { type Context } from '@automattic/calypso-router';
+import { getQueryArg } from '@wordpress/url';
+import wpcom from 'calypso/lib/wp';
+import UnifiedInviteAccept from './index';
+import type { InviteBlogDetails } from './types';
+
+/**
+ * Determine if unified invite flow should be used
+ * Currently enabled for CIAB sites or when ?unified=1 is present
+ */
+function shouldUseUnifiedFlow( blogDetails?: InviteBlogDetails ): boolean {
+	// Check for force flags in URL
+	const forceUnified = getQueryArg( window.location.href, 'unified' ) === '1';
+	const forceLegacy = getQueryArg( window.location.href, 'legacy' ) === '1';
+
+	if ( forceLegacy ) {
+		return false;
+	}
+
+	if ( forceUnified ) {
+		return true;
+	}
+
+	// Enable for CIAB (Commerce Garden) sites
+	return Boolean(
+		blogDetails?.is_garden_site &&
+			blogDetails?.garden?.partner === 'woo' &&
+			blogDetails?.garden?.name === 'commerce'
+	);
+}
+
+/**
+ * Middleware that checks if unified invite flow should be used
+ * If unified should be used, renders the unified UI and sets a flag to skip legacy controller
+ * Otherwise, calls next() to let the legacy acceptInvite controller run
+ */
+export async function maybeUseUnifiedInvite( context: Context, next: () => void ) {
+	const { site_id: siteId, invitation_key: inviteKey } = context.params;
+
+	// Check for legacy flag first - skip unified entirely
+	const forceLegacy = getQueryArg( window.location.href, 'legacy' ) === '1';
+	if ( forceLegacy ) {
+		return next();
+	}
+
+	try {
+		// Fetch invite data to determine site type
+		const response = await wpcom.req.get( `/sites/${ siteId }/invites/${ inviteKey }` );
+		context.inviteData = response;
+
+		if ( shouldUseUnifiedFlow( response?.blog_details ) ) {
+			renderUnifiedInvite( context );
+			context.useUnifiedInvite = true;
+		}
+
+		return next();
+	} catch {
+		// On error, fallback to legacy flow (it handles errors gracefully)
+		return next();
+	}
+}
+
+/**
+ * Render the unified invite accept component
+ */
+function renderUnifiedInvite( context: Context ) {
+	const {
+		site_id: siteId,
+		invitation_key: inviteKey,
+		activation_key: activationKey,
+		auth_key: authKey,
+	} = context.params;
+
+	context.primary = (
+		<UnifiedInviteAccept
+			siteId={ siteId }
+			inviteKey={ inviteKey }
+			activationKey={ activationKey }
+			authKey={ authKey }
+			inviteData={ context.inviteData }
+		/>
+	);
+}

--- a/client/my-sites/invites-unified/index.tsx
+++ b/client/my-sites/invites-unified/index.tsx
@@ -1,0 +1,50 @@
+import page from '@automattic/calypso-router';
+import { useSelector } from 'react-redux';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import AcceptInviteScreen from './screens/accept-invite-screen';
+import type { Invite } from './types';
+
+/**
+ * Build the legacy invite path for fallback redirects
+ */
+function buildLegacyPath(
+	siteId: string,
+	inviteKey: string,
+	...optionalKeys: ( string | undefined )[]
+): string {
+	const basePath = `/accept-invite/${ siteId }/${ inviteKey }`;
+	const fullPath = optionalKeys
+		.filter( Boolean )
+		.reduce( ( path, key ) => `${ path }/${ key }`, basePath );
+	return `${ fullPath }?legacy=1`;
+}
+
+interface UnifiedInviteAcceptProps {
+	siteId: string;
+	inviteKey: string;
+	activationKey?: string;
+	authKey?: string;
+	inviteData: Record< string, unknown >;
+}
+
+export function UnifiedInviteAccept( {
+	siteId,
+	inviteKey,
+	activationKey,
+	authKey,
+	inviteData,
+}: UnifiedInviteAcceptProps ) {
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
+	// Redirect to legacy flow if not logged in (signup flow will be added later)
+	if ( ! isLoggedIn ) {
+		page.redirect( buildLegacyPath( siteId, inviteKey, activationKey, authKey ) );
+		return null;
+	}
+
+	const invite = { ...inviteData, inviteKey, activationKey } as Invite;
+
+	return <AcceptInviteScreen invite={ invite } />;
+}
+
+export default UnifiedInviteAccept;

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -11,7 +11,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
-import { CIAB_PARTNERS, type CiabPartnerConfig } from 'calypso/lib/partner-branding';
+import { getCiabConfigFromGarden, type CiabPartnerConfig } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
 import { useDispatch } from 'calypso/state';
@@ -48,24 +48,14 @@ function toLegacyInvite( invite: Invite ) {
 }
 
 /**
- * Map garden partner to CIAB branding config
- * - "wpcom" partner uses "woo" branding
+ * Get CIAB branding config from blog details
  */
 function getBrandingFromBlogDetails( blogDetails?: InviteBlogDetails ): CiabPartnerConfig | null {
 	if ( ! blogDetails?.is_garden_site || ! blogDetails?.garden ) {
 		return null;
 	}
 
-	const { garden } = blogDetails;
-
-	// Map garden partners to branding configs
-	// "wpcom" partner uses "woo" branding
-	if ( garden.partner === 'woo' && garden.name === 'commerce' ) {
-		return CIAB_PARTNERS.woo ?? null;
-	}
-
-	// Future: add mappings for other partners like "paypal"
-	return null;
+	return getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name );
 }
 
 interface AcceptInviteScreenProps {

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -1,0 +1,323 @@
+import page from '@automattic/calypso-router';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Step } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
+import { ConsentText } from 'calypso/components/connect-screen/consent-text';
+import { UserCard, type UserCardUser } from 'calypso/components/connect-screen/user-card';
+import DocumentHead from 'calypso/components/data/document-head';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { navigate } from 'calypso/lib/navigate';
+import { CIAB_PARTNERS, type CiabPartnerConfig } from 'calypso/lib/partner-branding';
+import { login } from 'calypso/lib/paths';
+import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
+import { useDispatch } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
+import { acceptInvite } from 'calypso/state/invites/actions';
+import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
+import { hideMasterbar } from 'calypso/state/ui/actions';
+import EmailMismatchScreen from './email-mismatch-screen';
+import type { Invite, InviteBlogDetails } from '../types';
+
+import './style.scss';
+
+/**
+ * Transform invite data to the format expected by acceptInvite action and getRedirectAfterAccept
+ */
+function toLegacyInvite( invite: Invite ) {
+	const blogDetails = invite.blog_details;
+	return {
+		inviteKey: invite.inviteKey,
+		activationKey: invite.activationKey,
+		site: {
+			URL: blogDetails?.URL || '',
+			title: blogDetails?.title || '',
+			is_wpforteams_site: false,
+			ID: invite.invite?.blog_id || '',
+			domain: blogDetails?.domain || '',
+			admin_url: blogDetails?.admin_url || '',
+			is_vip: blogDetails?.is_vip || false,
+		},
+		role: invite.invite?.meta?.role || '',
+		sentTo: invite.invite?.meta?.sent_to || '',
+	};
+}
+
+/**
+ * Map garden partner to CIAB branding config
+ * - "wpcom" partner uses "woo" branding
+ */
+function getBrandingFromBlogDetails( blogDetails?: InviteBlogDetails ): CiabPartnerConfig | null {
+	if ( ! blogDetails?.is_garden_site || ! blogDetails?.garden ) {
+		return null;
+	}
+
+	const { garden } = blogDetails;
+
+	// Map garden partners to branding configs
+	// "wpcom" partner uses "woo" branding
+	if ( garden.partner === 'woo' && garden.name === 'commerce' ) {
+		return CIAB_PARTNERS.woo ?? null;
+	}
+
+	// Future: add mappings for other partners like "paypal"
+	return null;
+}
+
+interface AcceptInviteScreenProps {
+	invite: Invite;
+}
+
+/**
+ * Get the button labels for accepting an invite based on role
+ */
+function getAcceptButtonLabels(
+	role: string,
+	translate: ReturnType< typeof useTranslate >
+): { accepting: React.ReactNode; accept: React.ReactNode } {
+	switch ( role ) {
+		case 'follower':
+			return {
+				accepting: translate( 'Following…', { context: 'button' } ),
+				accept: translate( 'Follow', { context: 'button' } ),
+			};
+		default:
+			return {
+				accepting: translate( 'Joining…', { context: 'button' } ),
+				accept: translate( 'Join', { context: 'button' } ),
+			};
+	}
+}
+
+/**
+ * Get the description text for a role invitation
+ */
+function getRoleDescription(
+	role: string,
+	siteDomain: string,
+	translate: ReturnType< typeof useTranslate >
+) {
+	switch ( role ) {
+		case 'administrator':
+			return translate(
+				'As an administrator on %(siteDomain)s, you will be able to manage all aspects of the store.',
+				{ args: { siteDomain } }
+			);
+		case 'editor':
+			return translate(
+				'As an editor on %(siteDomain)s, you will be able to publish and manage posts and products.',
+				{ args: { siteDomain } }
+			);
+		case 'author':
+			return translate(
+				'As an author on %(siteDomain)s, you will be able to publish and edit your own posts.',
+				{ args: { siteDomain } }
+			);
+		case 'shop_manager':
+			return translate(
+				'As a store manager on %(siteDomain)s, you will be able to handle the daily operations of the store.',
+				{ args: { siteDomain } }
+			);
+		case 'contributor':
+			return translate(
+				'As a contributor on %(siteDomain)s, you will be able to write and manage your own posts.',
+				{ args: { siteDomain } }
+			);
+		case 'subscriber':
+			return translate(
+				'As a subscriber on %(siteDomain)s, you will be able to manage your profile.',
+				{ args: { siteDomain } }
+			);
+		case 'viewer':
+			return translate(
+				'As a viewer on %(siteDomain)s, you will be able to view the private site.',
+				{ args: { siteDomain } }
+			);
+		case 'follower':
+			return translate(
+				'As a follower of %(siteDomain)s, you can read the latest posts in the WordPress.com Reader.',
+				{ args: { siteDomain } }
+			);
+		default:
+			return translate( 'You have been invited to join %(siteDomain)s.', {
+				args: { siteDomain },
+			} );
+	}
+}
+
+export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+
+	const user = useSelector( getCurrentUser );
+	const dashboardOptIn = useSelector( hasDashboardOptIn );
+	const emailVerificationSecret =
+		new URLSearchParams( window.location.search ).get( 'email_verification_secret' ) || undefined;
+
+	const storeName = invite?.blog_details?.title || invite?.blog_details?.domain || '';
+	const siteDomain = invite?.blog_details?.domain || '';
+	const roleName = invite?.invite?.meta?.role || 'contributor';
+	const inviteSentTo = invite?.invite?.meta?.sent_to || '';
+	const isKnownUser = invite?.invite?.meta?.known ?? false;
+
+	// Check if the invite requires a specific email that doesn't match the current user
+	const forceMatchingEmail =
+		invite?.invite?.meta?.force_matching_email && user?.email !== inviteSentTo;
+
+	// Get branding from blog_details garden info
+	const branding = getBrandingFromBlogDetails( invite?.blog_details );
+	const gardenName = invite?.blog_details?.garden?.name || null;
+	const gardenPartner = invite?.blog_details?.garden?.partner || null;
+
+	const userCardData: UserCardUser = {
+		displayName: user?.display_name || '',
+		email: user?.email || '',
+		avatarUrl: user?.avatar_URL,
+	};
+
+	const trackingProps = {
+		role: roleName,
+		garden_name: gardenName,
+		garden_partner: gardenPartner,
+		unified: true,
+	};
+
+	useEffect( () => {
+		dispatch( hideMasterbar() );
+		recordTracksEvent( 'calypso_invite_accept_load_page', {
+			...trackingProps,
+			logged_in: true,
+		} );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	const handleAccept = useCallback( async () => {
+		setIsSubmitting( true );
+		recordTracksEvent( 'calypso_invite_accept_logged_in_join_button_click', trackingProps );
+
+		try {
+			const legacyInvite = toLegacyInvite( invite );
+			await dispatch( acceptInvite( legacyInvite, emailVerificationSecret ) );
+			const redirectUrl = getRedirectAfterAccept( legacyInvite, dashboardOptIn );
+			navigate( redirectUrl );
+		} catch ( error ) {
+			setIsSubmitting( false );
+			const errorMessage = error instanceof Error ? error.message : undefined;
+			dispatch(
+				errorNotice( errorMessage || translate( 'There was a problem accepting the invitation.' ) )
+			);
+		}
+	}, [ dispatch, invite, emailVerificationSecret, dashboardOptIn, trackingProps, translate ] );
+
+	const handleDecline = useCallback( () => {
+		recordTracksEvent( 'calypso_invite_accept_logged_in_decline_button_click', trackingProps );
+		dispatch( infoNotice( translate( 'You declined to join.' ), { displayOnNextPage: true } ) );
+		page( '/' );
+	}, [ dispatch, trackingProps, translate ] );
+
+	const getLoginUrl = useCallback( () => {
+		let loginUrl = login( { redirectTo: window.location.href } );
+		if ( inviteSentTo ) {
+			loginUrl += '&email_address=' + encodeURIComponent( inviteSentTo );
+		}
+		return loginUrl;
+	}, [ inviteSentTo ] );
+
+	const handleSwitchAccount = useCallback( () => {
+		recordTracksEvent( 'calypso_invite_accept_logged_in_sign_in_link_click', trackingProps );
+		navigate( getLoginUrl() );
+	}, [ trackingProps, getLoginUrl ] );
+
+	const title = translate( 'Start managing %(storeName)s', {
+		args: { storeName },
+	} );
+
+	const description = getRoleDescription( roleName, siteDomain, translate );
+
+	// Build logo element for TopBar
+	const topBarLogo = branding?.logo?.src ? (
+		<img
+			src={ branding.logo.src }
+			alt={ branding.logo.alt }
+			width={ branding.logo.width }
+			height={ branding.logo.height }
+		/>
+	) : undefined;
+
+	const heading = <Step.Heading text={ title } subText={ description } />;
+
+	const topBar = <Step.TopBar logo={ topBarLogo } />;
+
+	// Show error state when invite requires a specific email that doesn't match
+	if ( forceMatchingEmail ) {
+		return (
+			<EmailMismatchScreen
+				inviteSentTo={ inviteSentTo }
+				isKnownUser={ isKnownUser }
+				topBarLogo={ topBarLogo }
+				trackingProps={ trackingProps }
+			/>
+		);
+	}
+
+	return (
+		<>
+			<DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />
+			<BodySectionCssClass bodyClass={ [ 'is-section-accept-invite-unified' ] } />
+			<Step.CenteredColumnLayout
+				columnWidth={ 4 }
+				heading={ heading }
+				verticalAlign="center"
+				topBar={ topBar }
+			>
+				<UserCard user={ userCardData } size="large" />
+				<div className="accept-invite-consent-wrapper">
+					<ConsentText>
+						{ translate(
+							"By clicking join, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and to {{syncLink}}sync your site's data{{/syncLink}} with WordPress.com.",
+							{
+								components: {
+									tosLink: (
+										<a
+											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+											target="_blank"
+											rel="noreferrer"
+										/>
+									),
+									syncLink: (
+										<a
+											href={ localizeUrl(
+												'https://jetpack.com/support/what-data-does-jetpack-sync/'
+											) }
+											target="_blank"
+											rel="noreferrer"
+										/>
+									),
+								},
+							}
+						) }
+					</ConsentText>
+				</div>
+				<ActionButtons
+					primaryLabel={
+						isSubmitting
+							? getAcceptButtonLabels( roleName, translate ).accepting
+							: getAcceptButtonLabels( roleName, translate ).accept
+					}
+					primaryOnClick={ handleAccept }
+					primaryLoading={ isSubmitting }
+					secondaryLabel={ translate( 'Cancel', { context: 'button' } ) }
+					secondaryOnClick={ handleDecline }
+					tertiaryLabel={ translate( 'Log in with another account' ) }
+					tertiaryOnClick={ handleSwitchAccount }
+				/>
+			</Step.CenteredColumnLayout>
+		</>
+	);
+}
+
+export default AcceptInviteScreen;

--- a/client/my-sites/invites-unified/screens/email-mismatch-screen.tsx
+++ b/client/my-sites/invites-unified/screens/email-mismatch-screen.tsx
@@ -1,0 +1,76 @@
+import { Step } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
+import DocumentHead from 'calypso/components/data/document-head';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { navigate } from 'calypso/lib/navigate';
+import { login } from 'calypso/lib/paths';
+
+import './style.scss';
+
+interface EmailMismatchScreenProps {
+	inviteSentTo: string;
+	isKnownUser: boolean;
+	topBarLogo?: React.ReactNode;
+	trackingProps: Record< string, unknown >;
+}
+
+export function EmailMismatchScreen( {
+	inviteSentTo,
+	isKnownUser,
+	topBarLogo,
+	trackingProps,
+}: EmailMismatchScreenProps ) {
+	const translate = useTranslate();
+
+	const getLoginUrl = useCallback( () => {
+		let loginUrl = login( { redirectTo: window.location.href } );
+		if ( inviteSentTo ) {
+			loginUrl += '&email_address=' + encodeURIComponent( inviteSentTo );
+		}
+		return loginUrl;
+	}, [ inviteSentTo ] );
+
+	const handleSignIn = useCallback( () => {
+		recordTracksEvent( 'calypso_invite_accept_logged_in_sign_in_link_click', trackingProps );
+		navigate( getLoginUrl() );
+	}, [ trackingProps, getLoginUrl ] );
+
+	const title = translate( 'This invite is only valid for %(email)s', {
+		args: { email: inviteSentTo },
+	} );
+
+	const description = translate(
+		'Please sign in with the correct account to accept this invitation.'
+	);
+
+	const signInButtonLabel = isKnownUser
+		? translate( 'Sign in as %(email)s', {
+				args: { email: inviteSentTo },
+		  } )
+		: translate( 'Register as %(email)s', {
+				args: { email: inviteSentTo },
+		  } );
+
+	const heading = <Step.Heading text={ title } subText={ description } />;
+	const topBar = <Step.TopBar logo={ topBarLogo } />;
+
+	return (
+		<>
+			<DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />
+			<BodySectionCssClass bodyClass={ [ 'is-section-accept-invite-unified' ] } />
+			<Step.CenteredColumnLayout
+				columnWidth={ 4 }
+				heading={ heading }
+				verticalAlign="center"
+				topBar={ topBar }
+			>
+				<ActionButtons primaryLabel={ signInButtonLabel } primaryOnClick={ handleSignIn } />
+			</Step.CenteredColumnLayout>
+		</>
+	);
+}
+
+export default EmailMismatchScreen;

--- a/client/my-sites/invites-unified/screens/email-mismatch-screen.tsx
+++ b/client/my-sites/invites-unified/screens/email-mismatch-screen.tsx
@@ -1,4 +1,5 @@
 import { Step } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
@@ -26,9 +27,9 @@ export function EmailMismatchScreen( {
 	const translate = useTranslate();
 
 	const getLoginUrl = useCallback( () => {
-		let loginUrl = login( { redirectTo: window.location.href } );
+		const loginUrl = login( { redirectTo: window.location.href } );
 		if ( inviteSentTo ) {
-			loginUrl += '&email_address=' + encodeURIComponent( inviteSentTo );
+			return addQueryArgs( loginUrl, { email_address: inviteSentTo } );
 		}
 		return loginUrl;
 	}, [ inviteSentTo ] );

--- a/client/my-sites/invites-unified/screens/style.scss
+++ b/client/my-sites/invites-unified/screens/style.scss
@@ -1,0 +1,10 @@
+// Remove layout padding for the unified invite accept screen
+body.is-section-accept-invite-unified {
+	.layout__content {
+		padding: 0 !important;
+	}
+}
+
+.accept-invite-consent-wrapper {
+	margin-bottom: 1.5rem;
+}

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -126,16 +126,21 @@ jest.mock( 'calypso/lib/navigate', () => ( {
 	navigate: ( url: string ) => mockNavigate( url ),
 } ) );
 
+const mockWooBranding = {
+	logo: {
+		src: 'https://example.com/woo-logo.png',
+		alt: 'Woo',
+		width: 100,
+		height: 30,
+	},
+};
+
 jest.mock( 'calypso/lib/partner-branding', () => ( {
-	CIAB_PARTNERS: {
-		woo: {
-			logo: {
-				src: 'https://example.com/woo-logo.png',
-				alt: 'Woo',
-				width: 100,
-				height: 30,
-			},
-		},
+	getCiabConfigFromGarden: ( partner: string, name: string ) => {
+		if ( partner === 'woo' && name === 'commerce' ) {
+			return mockWooBranding;
+		}
+		return null;
 	},
 } ) );
 

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -1,0 +1,553 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { AcceptInviteScreen } from '../accept-invite-screen';
+import type { Invite } from '../../types';
+
+// Mock external dependencies
+jest.mock(
+	'@automattic/calypso-router',
+	() => ( {
+		__esModule: true,
+		default: jest.fn(),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock(
+	'@automattic/i18n-utils',
+	() => ( {
+		localizeUrl: ( url: string ) => url,
+	} ),
+	{ virtual: true }
+);
+
+jest.mock(
+	'@automattic/onboarding',
+	() => ( {
+		Step: {
+			Heading: ( { text, subText }: { text: string; subText: string } ) => (
+				<div data-testid="step-heading">
+					<h1>{ text }</h1>
+					<p>{ subText }</p>
+				</div>
+			),
+			TopBar: ( { logo }: { logo?: React.ReactNode } ) => (
+				<div data-testid="step-topbar">{ logo }</div>
+			),
+			CenteredColumnLayout: ( {
+				children,
+				heading,
+				topBar,
+			}: {
+				children: React.ReactNode;
+				heading: React.ReactNode;
+				topBar: React.ReactNode;
+			} ) => (
+				<div data-testid="step-layout">
+					{ topBar }
+					{ heading }
+					{ children }
+				</div>
+			),
+		},
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( 'calypso/components/connect-screen/action-buttons', () => ( {
+	ActionButtons: ( {
+		primaryLabel,
+		primaryOnClick,
+		primaryLoading,
+		secondaryLabel,
+		secondaryOnClick,
+		tertiaryLabel,
+		tertiaryOnClick,
+	}: {
+		primaryLabel: string;
+		primaryOnClick: () => void;
+		primaryLoading: boolean;
+		secondaryLabel: string;
+		secondaryOnClick: () => void;
+		tertiaryLabel: string;
+		tertiaryOnClick: () => void;
+	} ) => (
+		<div data-testid="action-buttons">
+			<button data-testid="primary-button" onClick={ primaryOnClick } disabled={ primaryLoading }>
+				{ primaryLabel }
+			</button>
+			<button data-testid="secondary-button" onClick={ secondaryOnClick }>
+				{ secondaryLabel }
+			</button>
+			<button data-testid="tertiary-button" onClick={ tertiaryOnClick }>
+				{ tertiaryLabel }
+			</button>
+		</div>
+	),
+} ) );
+
+jest.mock( 'calypso/components/connect-screen/consent-text', () => ( {
+	ConsentText: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="consent-text">{ children }</div>
+	),
+} ) );
+
+jest.mock( 'calypso/components/connect-screen/user-card', () => ( {
+	UserCard: ( { user }: { user: { displayName: string; email: string } } ) => (
+		<div data-testid="user-card">
+			<span data-testid="user-display-name">{ user.displayName }</span>
+			<span data-testid="user-email">{ user.email }</span>
+		</div>
+	),
+} ) );
+
+jest.mock( 'calypso/components/data/document-head', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/layout/body-section-css-class', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+const mockRecordTracksEvent = jest.fn();
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: ( ...args: unknown[] ) => mockRecordTracksEvent( ...args ),
+} ) );
+
+const mockNavigate = jest.fn();
+jest.mock( 'calypso/lib/navigate', () => ( {
+	navigate: ( url: string ) => mockNavigate( url ),
+} ) );
+
+jest.mock( 'calypso/lib/partner-branding', () => ( {
+	CIAB_PARTNERS: {
+		woo: {
+			logo: {
+				src: 'https://example.com/woo-logo.png',
+				alt: 'Woo',
+				width: 100,
+				height: 30,
+			},
+		},
+	},
+} ) );
+
+jest.mock( 'calypso/lib/paths', () => ( {
+	login: ( { redirectTo }: { redirectTo: string } ) =>
+		`/log-in?redirect_to=${ encodeURIComponent( redirectTo ) }`,
+} ) );
+
+const mockGetRedirectAfterAccept = jest.fn( () => '/redirect-url' );
+jest.mock( 'calypso/my-sites/invites/utils', () => ( {
+	getRedirectAfterAccept: ( ...args: Parameters< typeof mockGetRedirectAfterAccept > ) =>
+		mockGetRedirectAfterAccept( ...args ),
+} ) );
+
+const mockDispatch = jest.fn();
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+} ) );
+
+const mockGetCurrentUser = jest.fn();
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUser: ( state: unknown ) => mockGetCurrentUser( state ),
+} ) );
+
+jest.mock( 'calypso/state/dashboard/selectors/has-dashboard-opt-in', () => ( {
+	hasDashboardOptIn: () => false,
+} ) );
+
+const mockAcceptInvite = jest.fn();
+jest.mock( 'calypso/state/invites/actions', () => ( {
+	acceptInvite: ( ...args: unknown[] ) => mockAcceptInvite( ...args ),
+} ) );
+
+jest.mock( 'calypso/state/notices/actions', () => ( {
+	infoNotice: jest.fn(),
+	errorNotice: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/ui/actions', () => ( {
+	hideMasterbar: jest.fn( () => ( { type: 'HIDE_MASTERBAR' } ) ),
+} ) );
+
+jest.mock( '../email-mismatch-screen', () => ( {
+	__esModule: true,
+	default: ( { inviteSentTo }: { inviteSentTo: string } ) => (
+		<div data-testid="email-mismatch-screen">Email mismatch: { inviteSentTo }</div>
+	),
+} ) );
+
+jest.mock( '../style.scss', () => ( {} ) );
+
+const mockStore = configureStore();
+
+const createInvite = ( overrides: Partial< Invite > = {} ): Invite =>
+	( {
+		inviteKey: 'test-invite-key',
+		activationKey: 'test-activation-key',
+		blog_details: {
+			title: 'Test Store',
+			domain: 'test.store',
+			URL: 'https://test.store',
+			admin_url: 'https://test.store/wp-admin',
+			is_vip: false,
+			...overrides.blog_details,
+		},
+		invite: {
+			blog_id: '123',
+			meta: {
+				role: 'administrator',
+				sent_to: 'invited@example.com',
+				known: false,
+				force_matching_email: false,
+				...overrides.invite?.meta,
+			},
+			...overrides.invite,
+		},
+		...overrides,
+	} ) as Invite;
+
+const defaultUser = {
+	ID: 1,
+	display_name: 'Test User',
+	email: 'test@example.com',
+	avatar_URL: 'https://example.com/avatar.jpg',
+};
+
+const createStore = () => mockStore( {} );
+
+const setupUser = ( userOverrides = {} ) => {
+	const user = { ...defaultUser, ...userOverrides };
+	mockGetCurrentUser.mockReturnValue( user );
+	return user;
+};
+
+describe( 'AcceptInviteScreen', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockAcceptInvite.mockReturnValue( { type: 'ACCEPT_INVITE' } );
+		mockDispatch.mockImplementation( ( action: unknown ) => {
+			if ( typeof action === 'function' ) {
+				return action();
+			}
+			return action;
+		} );
+		setupUser();
+	} );
+
+	describe( 'rendering', () => {
+		test( 'renders the user card with current user info', () => {
+			const store = createStore();
+			const invite = createInvite();
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect( screen.getByTestId( 'user-card' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'user-display-name' ) ).toHaveTextContent( 'Test User' );
+			expect( screen.getByTestId( 'user-email' ) ).toHaveTextContent( 'test@example.com' );
+		} );
+
+		test( 'renders action buttons', () => {
+			const store = createStore();
+			const invite = createInvite();
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect( screen.getByTestId( 'primary-button' ) ).toHaveTextContent( 'Join' );
+			expect( screen.getByTestId( 'secondary-button' ) ).toHaveTextContent( 'Cancel' );
+			expect( screen.getByTestId( 'tertiary-button' ) ).toHaveTextContent(
+				'Log in with another account'
+			);
+		} );
+	} );
+
+	describe( 'role-based button labels', () => {
+		test( 'shows "Follow" button for follower role', () => {
+			const store = createStore();
+			const invite = createInvite( {
+				invite: {
+					blog_id: '123',
+					invite_slug: 'test',
+					meta: { role: 'follower', sent_to: 'test@example.com', blog_id: 123 },
+				},
+			} );
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect( screen.getByTestId( 'primary-button' ) ).toHaveTextContent( 'Follow' );
+		} );
+	} );
+
+	describe( 'role descriptions', () => {
+		test( 'shows administrator description', () => {
+			const store = createStore();
+			const invite = createInvite( {
+				invite: {
+					blog_id: '123',
+					invite_slug: 'test',
+					meta: { role: 'administrator', sent_to: 'test@example.com', blog_id: 123 },
+				},
+			} );
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect( screen.getByText( /manage all aspects of the store/i ) ).toBeInTheDocument();
+		} );
+
+		test( 'shows follower description', () => {
+			const store = createStore();
+			const invite = createInvite( {
+				invite: {
+					blog_id: '123',
+					invite_slug: 'test',
+					meta: { role: 'follower', sent_to: 'test@example.com', blog_id: 123 },
+				},
+			} );
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect(
+				screen.getByText( /read the latest posts in the WordPress.com Reader/i )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'email mismatch', () => {
+		test( 'shows EmailMismatchScreen when force_matching_email is true and emails differ', () => {
+			setupUser( { email: 'different@example.com' } );
+			const store = createStore();
+			const invite = createInvite( {
+				invite: {
+					blog_id: '123',
+					invite_slug: 'test',
+					meta: {
+						role: 'administrator',
+						sent_to: 'invited@example.com',
+						force_matching_email: true,
+						blog_id: 123,
+					},
+				},
+			} );
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect( screen.getByTestId( 'email-mismatch-screen' ) ).toBeInTheDocument();
+			expect( screen.getByText( /invited@example.com/i ) ).toBeInTheDocument();
+		} );
+
+		test( 'does not show EmailMismatchScreen when emails match', () => {
+			setupUser( { email: 'invited@example.com' } );
+			const store = createStore();
+			const invite = createInvite( {
+				invite: {
+					blog_id: '123',
+					invite_slug: 'test',
+					meta: {
+						role: 'administrator',
+						sent_to: 'invited@example.com',
+						force_matching_email: true,
+						blog_id: 123,
+					},
+				},
+			} );
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect( screen.queryByTestId( 'email-mismatch-screen' ) ).not.toBeInTheDocument();
+			expect( screen.getByTestId( 'action-buttons' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'accept flow', () => {
+		test( 'calls acceptInvite and navigates on success', async () => {
+			const store = createStore();
+			const invite = createInvite();
+			mockAcceptInvite.mockReturnValue( () => Promise.resolve() );
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			fireEvent.click( screen.getByTestId( 'primary-button' ) );
+
+			await waitFor( () => {
+				expect( mockAcceptInvite ).toHaveBeenCalled();
+				expect( mockNavigate ).toHaveBeenCalledWith( '/redirect-url' );
+			} );
+		} );
+
+		test( 'tracks join button click', async () => {
+			const store = createStore();
+			const invite = createInvite();
+			mockAcceptInvite.mockReturnValue( () => Promise.resolve() );
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			fireEvent.click( screen.getByTestId( 'primary-button' ) );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_invite_accept_logged_in_join_button_click',
+				expect.objectContaining( { role: 'administrator', unified: true } )
+			);
+		} );
+	} );
+
+	describe( 'decline flow', () => {
+		test( 'redirects to home on decline', () => {
+			const page = require( '@automattic/calypso-router' ).default;
+			const store = createStore();
+			const invite = createInvite();
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			fireEvent.click( screen.getByTestId( 'secondary-button' ) );
+
+			expect( page ).toHaveBeenCalledWith( '/' );
+		} );
+
+		test( 'tracks decline button click', () => {
+			const store = createStore();
+			const invite = createInvite();
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			fireEvent.click( screen.getByTestId( 'secondary-button' ) );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_invite_accept_logged_in_decline_button_click',
+				expect.objectContaining( { role: 'administrator', unified: true } )
+			);
+		} );
+	} );
+
+	describe( 'switch account flow', () => {
+		test( 'navigates to login URL on switch account click', () => {
+			const store = createStore();
+			const invite = createInvite();
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			fireEvent.click( screen.getByTestId( 'tertiary-button' ) );
+
+			expect( mockNavigate ).toHaveBeenCalledWith( expect.stringContaining( '/log-in' ) );
+		} );
+
+		test( 'tracks switch account click', () => {
+			const store = createStore();
+			const invite = createInvite();
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			fireEvent.click( screen.getByTestId( 'tertiary-button' ) );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_invite_accept_logged_in_sign_in_link_click',
+				expect.objectContaining( { role: 'administrator', unified: true } )
+			);
+		} );
+	} );
+
+	describe( 'tracking', () => {
+		test( 'tracks page load on mount', () => {
+			const store = createStore();
+			const invite = createInvite();
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_invite_accept_load_page',
+				expect.objectContaining( { logged_in: true, unified: true } )
+			);
+		} );
+	} );
+
+	describe( 'CIAB branding', () => {
+		test( 'shows logo for Woo commerce garden sites', () => {
+			const store = createStore();
+			const invite = createInvite( {
+				blog_details: {
+					title: 'Woo Store',
+					domain: 'woo.store',
+					URL: 'https://woo.store',
+					is_garden_site: true,
+					garden: {
+						partner: 'woo',
+						name: 'commerce',
+					},
+				},
+			} );
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			const logo = screen.getByRole( 'img' );
+			expect( logo ).toHaveAttribute( 'src', 'https://example.com/woo-logo.png' );
+			expect( logo ).toHaveAttribute( 'alt', 'Woo' );
+		} );
+	} );
+} );

--- a/client/my-sites/invites-unified/test/controller.test.tsx
+++ b/client/my-sites/invites-unified/test/controller.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getQueryArg } from '@wordpress/url';
+import wpcom from 'calypso/lib/wp';
+import { maybeUseUnifiedInvite } from '../controller';
+
+jest.mock( '@wordpress/url', () => ( {
+	getQueryArg: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		get: jest.fn(),
+	},
+} ) );
+
+// Mock the UnifiedInviteAccept component
+jest.mock( '../index', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="unified-invite">UnifiedInviteAccept</div>,
+} ) );
+
+const mockGetQueryArg = getQueryArg as jest.Mock;
+const mockWpcomGet = wpcom.req.get as jest.Mock;
+
+describe( 'maybeUseUnifiedInvite', () => {
+	let context: {
+		params: Record< string, string >;
+		inviteData?: unknown;
+		useUnifiedInvite?: boolean;
+		primary?: React.ReactNode;
+	};
+	let next: jest.Mock;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetQueryArg.mockReturnValue( undefined );
+
+		context = {
+			params: {
+				site_id: '123',
+				invitation_key: 'abc123',
+			},
+		};
+		next = jest.fn();
+	} );
+
+	test( 'calls next() immediately when legacy=1 query param is present', async () => {
+		mockGetQueryArg.mockImplementation( ( _url: string, param: string ) => {
+			if ( param === 'legacy' ) {
+				return '1';
+			}
+			return undefined;
+		} );
+
+		await maybeUseUnifiedInvite( context as never, next );
+
+		expect( next ).toHaveBeenCalled();
+		expect( mockWpcomGet ).not.toHaveBeenCalled();
+		expect( context.useUnifiedInvite ).toBeUndefined();
+	} );
+
+	test( 'fetches invite data and uses unified flow for CIAB sites', async () => {
+		const ciabInviteData = {
+			blog_details: {
+				is_garden_site: true,
+				garden: {
+					partner: 'woo',
+					name: 'commerce',
+				},
+			},
+		};
+		mockWpcomGet.mockResolvedValue( ciabInviteData );
+
+		await maybeUseUnifiedInvite( context as never, next );
+
+		expect( mockWpcomGet ).toHaveBeenCalledWith( '/sites/123/invites/abc123' );
+		expect( context.inviteData ).toEqual( ciabInviteData );
+		expect( context.useUnifiedInvite ).toBe( true );
+		expect( context.primary ).toBeDefined();
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	test( 'uses unified flow when unified=1 query param is present', async () => {
+		mockGetQueryArg.mockImplementation( ( _url: string, param: string ) => {
+			if ( param === 'unified' ) {
+				return '1';
+			}
+			return undefined;
+		} );
+
+		const nonCiabInviteData = {
+			blog_details: {
+				is_garden_site: false,
+			},
+		};
+		mockWpcomGet.mockResolvedValue( nonCiabInviteData );
+
+		await maybeUseUnifiedInvite( context as never, next );
+
+		expect( context.useUnifiedInvite ).toBe( true );
+		expect( context.primary ).toBeDefined();
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	test( 'does not use unified flow for non-CIAB sites without unified param', async () => {
+		const nonCiabInviteData = {
+			blog_details: {
+				is_garden_site: false,
+			},
+		};
+		mockWpcomGet.mockResolvedValue( nonCiabInviteData );
+
+		await maybeUseUnifiedInvite( context as never, next );
+
+		expect( context.inviteData ).toEqual( nonCiabInviteData );
+		expect( context.useUnifiedInvite ).toBeUndefined();
+		expect( context.primary ).toBeUndefined();
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	test( 'falls back to legacy flow on API error', async () => {
+		mockWpcomGet.mockRejectedValue( new Error( 'API Error' ) );
+
+		await maybeUseUnifiedInvite( context as never, next );
+
+		expect( context.useUnifiedInvite ).toBeUndefined();
+		expect( context.primary ).toBeUndefined();
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	test( 'passes correct params to UnifiedInviteAccept', async () => {
+		context.params = {
+			site_id: '456',
+			invitation_key: 'xyz789',
+			activation_key: 'activation123',
+			auth_key: 'auth456',
+		};
+
+		const ciabInviteData = {
+			blog_details: {
+				is_garden_site: true,
+				garden: {
+					partner: 'woo',
+					name: 'commerce',
+				},
+			},
+		};
+		mockWpcomGet.mockResolvedValue( ciabInviteData );
+
+		await maybeUseUnifiedInvite( context as never, next );
+
+		expect( context.primary ).toBeDefined();
+		// The component is rendered with the correct props (verified by the mock being called)
+		expect( context.useUnifiedInvite ).toBe( true );
+	} );
+} );

--- a/client/my-sites/invites-unified/test/index.test.tsx
+++ b/client/my-sites/invites-unified/test/index.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { UnifiedInviteAccept } from '../index';
+
+const mockRedirect = jest.fn();
+jest.mock(
+	'@automattic/calypso-router',
+	() => ( {
+		redirect: ( url: string ) => mockRedirect( url ),
+		__esModule: true,
+		default: {
+			redirect: ( url: string ) => mockRedirect( url ),
+		},
+	} ),
+	{ virtual: true }
+);
+
+// Mock AcceptInviteScreen to simplify testing
+jest.mock( '../screens/accept-invite-screen', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="accept-invite-screen">AcceptInviteScreen</div>,
+} ) );
+
+const mockStore = configureStore();
+
+const defaultProps = {
+	siteId: '123',
+	inviteKey: 'abc123',
+	inviteData: {
+		blog_details: {
+			title: 'Test Store',
+			domain: 'test.store',
+		},
+		invite: {
+			meta: {
+				role: 'administrator',
+			},
+		},
+	},
+};
+
+describe( 'UnifiedInviteAccept', () => {
+	beforeEach( () => {
+		mockRedirect.mockClear();
+	} );
+
+	test( 'redirects to legacy flow when user is not logged in', () => {
+		const store = mockStore( {
+			currentUser: {
+				id: null,
+			},
+		} );
+
+		render(
+			<Provider store={ store }>
+				<UnifiedInviteAccept { ...defaultProps } />
+			</Provider>
+		);
+
+		expect( mockRedirect ).toHaveBeenCalledWith( '/accept-invite/123/abc123?legacy=1' );
+	} );
+
+	test( 'renders AcceptInviteScreen when user is logged in', () => {
+		const store = mockStore( {
+			currentUser: {
+				id: 1,
+			},
+		} );
+
+		render(
+			<Provider store={ store }>
+				<UnifiedInviteAccept { ...defaultProps } />
+			</Provider>
+		);
+
+		expect( mockRedirect ).not.toHaveBeenCalled();
+		expect( screen.getByTestId( 'accept-invite-screen' ) ).toBeInTheDocument();
+	} );
+
+	test( 'includes activationKey and authKey in legacy redirect path', () => {
+		const store = mockStore( {
+			currentUser: {
+				id: null,
+			},
+		} );
+
+		render(
+			<Provider store={ store }>
+				<UnifiedInviteAccept { ...defaultProps } activationKey="activation123" authKey="auth456" />
+			</Provider>
+		);
+
+		expect( mockRedirect ).toHaveBeenCalledWith(
+			'/accept-invite/123/abc123/activation123/auth456?legacy=1'
+		);
+	} );
+} );

--- a/client/my-sites/invites-unified/types.ts
+++ b/client/my-sites/invites-unified/types.ts
@@ -1,0 +1,60 @@
+export interface InviteGarden {
+	name: string;
+	partner: string;
+}
+
+export interface InviteBlogDetails {
+	domain: string;
+	title: string;
+	URL: string;
+	is_vip?: boolean;
+	admin_url?: string;
+	is_garden_site?: boolean;
+	garden?: InviteGarden;
+}
+
+export interface InviteSite {
+	ID: number;
+	URL: string;
+	title: string;
+	domain: string;
+	is_wpforteams_site?: boolean;
+	is_vip?: boolean;
+	admin_url?: string;
+	is_garden?: boolean;
+	garden_name?: string;
+	garden_partner?: string;
+}
+
+export interface InviteMeta {
+	role: string;
+	sent_to: string;
+	blog_id: number;
+	is_external?: boolean;
+	force_matching_email?: boolean;
+	known?: boolean;
+}
+
+export interface InviteDetails {
+	invite_slug: string;
+	blog_id: string;
+	meta: InviteMeta;
+}
+
+export interface Inviter {
+	ID: number;
+	name: string;
+	avatar_URL?: string;
+}
+
+export interface Invite {
+	inviteKey: string;
+	activationKey?: string;
+	invite: InviteDetails;
+	inviter?: Inviter;
+	blog_details?: InviteBlogDetails;
+	// Legacy fields for compatibility
+	site?: InviteSite;
+	role?: string;
+	sentTo?: string;
+}

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -26,6 +26,11 @@ export function redirectWithoutLocaleifLoggedIn( context, next ) {
 }
 
 export function acceptInvite( context, next ) {
+	// Skip if unified invite flow is handling this request
+	if ( context.useUnifiedInvite ) {
+		return next();
+	}
+
 	const acceptedInvite = store.get( 'invite_accepted' );
 	if ( acceptedInvite ) {
 		debug( 'invite_accepted is set in localStorage' );
@@ -69,6 +74,7 @@ export function acceptInvite( context, next ) {
 				authKey={ context.params.auth_key }
 				locale={ context.params.locale }
 				path={ context.path }
+				prefetchedInvite={ context.inviteData }
 			/>
 		</>
 	);

--- a/client/my-sites/invites/index.js
+++ b/client/my-sites/invites/index.js
@@ -1,11 +1,16 @@
 import page from '@automattic/calypso-router';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { maybeUseUnifiedInvite } from '../invites-unified/controller';
 import { acceptInvite, redirectWithoutLocaleifLoggedIn } from './controller';
 
 export default () => {
 	const locale = getLanguageRouteParam( 'locale' );
 
+	// Invite routes with unified flow check
+	// maybeUseUnifiedInvite checks for CIAB sites or ?unified=1 flag
+	// If unified should be used, it renders the unified UI
+	// Otherwise, it calls next() and the legacy acceptInvite runs
 	page(
 		[
 			`/accept-invite/:site_id/:invitation_key/${ locale }`,
@@ -13,6 +18,7 @@ export default () => {
 			`/accept-invite/:site_id/:invitation_key/:activation_key/:auth_key/${ locale }`,
 		],
 		redirectWithoutLocaleifLoggedIn,
+		maybeUseUnifiedInvite,
 		acceptInvite,
 		makeLayout,
 		clientRender

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -43,10 +43,37 @@ class InviteAccept extends Component {
 			logged_in: !! this.props.user,
 		} );
 
-		// The site ID and invite key are required, so only fetch if set
-		if ( this.props.siteId && this.props.inviteKey ) {
+		// Use prefetched data if available, otherwise fetch
+		if ( this.props.prefetchedInvite ) {
+			this.handlePrefetchedInvite();
+		} else if ( this.props.siteId && this.props.inviteKey ) {
 			this.fetchInvite();
 		}
+	}
+
+	handlePrefetchedInvite() {
+		const { prefetchedInvite, inviteKey, activationKey, authKey } = this.props;
+		const invite = {
+			...normalizeInvite( prefetchedInvite ),
+			activationKey,
+			authKey,
+			inviteKey,
+		};
+
+		if ( invite?.site?.is_wpforteams_site ) {
+			this.props.hideMasterbar();
+
+			recordTracksEvent( 'calypso_p2_invite_accept_load_page', {
+				site_id: invite?.site?.ID,
+				invited_by: invite?.inviter?.ID,
+				invite_date: invite?.date,
+				role: invite?.role,
+				from_marketing_campaign: !! invite?.site?.p2_signup_campaign,
+				campaign_name: invite?.site?.p2_signup_campaign || null,
+			} );
+		}
+
+		this.handleFetchInvite( false, invite );
 	}
 
 	componentWillUnmount() {

--- a/client/my-sites/invites/utils.tsx
+++ b/client/my-sites/invites/utils.tsx
@@ -129,6 +129,26 @@ export function acceptedNotice(
 				{ displayOnNextPage, isPersistent },
 			];
 
+		case 'shop_manager':
+			return [
+				<div>
+					<h3 className="invites__title">
+						{ i18n.translate( "You're now a Shop Manager of: {{site/}}", {
+							components: { site },
+						} ) }
+					</h3>
+					<p>
+						{ i18n.translate(
+							'Not sure where to start? Head on over to {{a}}Learn WordPress{{/a}}.',
+							{
+								components: { a: <a href="http://learn.wordpress.com" /> },
+							}
+						) }
+					</p>
+				</div>,
+				{ displayOnNextPage, isPersistent },
+			];
+
 		case 'subscriber':
 			return [
 				i18n.translate( "You're now a Subscriber of: {{site/}}", {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

- **Add new unified invite accept flow** (`client/my-sites/invites-unified/`) designed for CIAB (Commerce in a Box) sites with partner branding support
- **Create shared connect-screen component library** (`client/components/connect-screen/`) with reusable components: `ActionButtons`, `UserCard`, `ConsentText`, `TopBarBrand`, and `SwitchUserLink`
- **Add CIAB partner branding system** (`client/lib/partner-branding.tsx`) that maps garden partners (e.g., Woo) to branded logos and styling
- **Implement feature-flagged routing** - automatically detects CIAB sites via garden metadata and routes to unified flow, while all other sites (P2, Jetpack, Studio) continue using the legacy invite flow
- **Add comprehensive test coverage** for the unified invite controller and accept screen components
- **Handle email mismatch scenario** with a dedicated `EmailMismatchScreen` component that prompts users to sign in with the correct email

<img width="1476" height="715" alt="Captura de Tela 2026-02-04 às 01 06 16" src="https://github.com/user-attachments/assets/31aa1454-f4c6-47a7-8259-24aed5eb1387" />

## Why are these changes being made?

CIAB aims to provide a streamlined commerce experience for non-technical merchants.  This PR aimns to unify the invite layout.

This PR introduces a unified invite flow that:
- Provides a modern, full-screen centered layout using the `@automattic/onboarding` Step component
- Displays partner logos (e.g., Woo) in the header for brand consistency
- Uses TypeScript throughout for better type safety and maintainability
- Leverages shared components that can be reused for other CIAB flows (signup, login, etc.)
- Maintains zero impact on existing invite flows through feature-flag routing

## Testing Instructions

### Prerequisites
- You need **two WordPress.com accounts**: a primary account (site owner) and a secondary account (invitee)

### Steps
1. Using your primary account, create or access a CIAB store
2. Go to **Users → Invite Users** and invite your secondary account's email to manage the store (e.g., as Shop Manager or Administrator)
3. Check your secondary account's email for the invite
4. **To test locally**: Replace `wordpress.com` in the invite link with `calypso.localhost:3000` (e.g., `https://calypso.localhost:3000/accept-invite/...`)
5. **To test on Calypso Live**: Replace `wordpress.com` with the Calypso Live URL (e.g., `https://calypso.live/accept-invite/...`)
6. Log in with your secondary account if needed
7. Verify:
   - The Woo logo appears in the top bar
   - Your user info (avatar, name, email) is displayed correctly
   - The role description matches the invited role
   - The "Join" button accepts the invite successfully
   - The consent text with Terms of Service link is visible
8. **Test email mismatch**: Try accessing the invite link while logged in with an account that has a different email than the one invited. Verify the email mismatch screen appears with a "Sign in as [email]" button.

### Optional: Force unified flow for testing
Add `?unified=1` to any invite URL to force the unified flow, or `?legacy=1` to force the legacy flow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
