### PR TITLE
e2e tests: skip more tests if daily email limit is reached

### DIFF
--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -641,4 +641,23 @@ export const tags = {
 	SETTINGS: '@settings',
 };
 
+/**
+ * Skips the current test suite if Mailosaur daily email limit is reached.
+ * Use this at the top of test.describe blocks that use fixtures requiring email verification (e.g., sitePublic).
+ *
+ * @example
+ * ```typescript
+ * test.describe( 'My Test Suite', () => {
+ *   skipIfMailosaurLimitReached();
+ *   test( 'my test', async () => { ... });
+ * });
+ * ```
+ */
+export function skipIfMailosaurLimitReached(): void {
+	test.skip(
+		envVariables.MAILOSAUR_LIMIT_REACHED,
+		'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
+	);
+}
+
 export { expect };

--- a/test/e2e/specs/authentication/authentication__apple.spec.ts
+++ b/test/e2e/specs/authentication/authentication__apple.spec.ts
@@ -1,8 +1,9 @@
 import { DataHelper } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Authentication: Apple', { tag: [ tags.AUTHENTICATION ] }, () => {
 	test.describe.configure( { mode: 'serial' } ); // Since both tests use the same Apple ID, they should not be run at the same time
+	skipIfMailosaurLimitReached();
 	test.skip(
 		DataHelper.isCalypsoProduction() === false,
 		'Skipping unless running on WordPress.com as Apple authentication requires prod callbacks'

--- a/test/e2e/specs/authentication/authentication__github.spec.ts
+++ b/test/e2e/specs/authentication/authentication__github.spec.ts
@@ -1,7 +1,8 @@
 import { DataHelper } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Authentication: GitHub', { tag: [ tags.AUTHENTICATION ] }, () => {
+	skipIfMailosaurLimitReached();
 	test.skip(
 		DataHelper.isCalypsoProduction() === false,
 		'Skipping unless running on WordPress.com as GitHub authentication requires prod callbacks'

--- a/test/e2e/specs/authentication/authentication__magic-link.spec.ts
+++ b/test/e2e/specs/authentication/authentication__magic-link.spec.ts
@@ -1,8 +1,9 @@
 import { DataHelper } from '@automattic/calypso-e2e';
 import { Message } from 'mailosaur/lib/models';
-import { tags, test, expect } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Authentication: Magic Link', { tag: [ tags.AUTHENTICATION ] }, () => {
+	skipIfMailosaurLimitReached();
 	test.skip(
 		DataHelper.isCalypsoProduction() === false,
 		'Skipping unless running on WordPress.com'

--- a/test/e2e/specs/dashboard/settings__site-visibility.spec.ts
+++ b/test/e2e/specs/dashboard/settings__site-visibility.spec.ts
@@ -1,11 +1,7 @@
-import { envVariables } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Dashboard: Site Visibility Settings', { tag: [ tags.DASHBOARD_PR ] }, () => {
-	test.skip(
-		envVariables.MAILOSAUR_LIMIT_REACHED,
-		'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
-	);
+	skipIfMailosaurLimitReached();
 
 	test( 'As a new simple site user, I can set my site visibility to Private, so that only I can see my site', async ( {
 		pageDashboard,

--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
@@ -1,5 +1,4 @@
-import { envVariables } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	'Domain: Upsell (Home)',
@@ -7,10 +6,7 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
-		test.skip(
-			envVariables.MAILOSAUR_LIMIT_REACHED,
-			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
-		);
+		skipIfMailosaurLimitReached();
 
 		test( 'As a user, I can see domain upsell on Home dashboard and proceed to checkout', async ( {
 			helperData,

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
@@ -1,11 +1,7 @@
-import { envVariables } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Domain: Upsell (Sidebar)', { tag: [ tags.CALYPSO_RELEASE ] }, () => {
-	test.skip(
-		envVariables.MAILOSAUR_LIMIT_REACHED,
-		'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
-	);
+	skipIfMailosaurLimitReached();
 
 	const planName = 'Premium';
 

--- a/test/e2e/specs/domains/domains__add.spec.ts
+++ b/test/e2e/specs/domains/domains__add.spec.ts
@@ -1,5 +1,5 @@
-import { DomainsPage, envVariables } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { DomainsPage } from '@automattic/calypso-e2e';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	'Domains: Add to current site',
@@ -7,10 +7,7 @@ test.describe(
 		tag: [ tags.CALYPSO_RELEASE ],
 	},
 	() => {
-		test.skip(
-			envVariables.MAILOSAUR_LIMIT_REACHED,
-			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
-		);
+		skipIfMailosaurLimitReached();
 
 		test( 'As a user, I can add a domain to my existing site', async ( {
 			componentDomainSearch,

--- a/test/e2e/specs/tools/import__sites-medium.spec.ts
+++ b/test/e2e/specs/tools/import__sites-medium.spec.ts
@@ -1,6 +1,5 @@
 import path from 'path';
-import { envVariables } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 const TEST_MEDIUM_EXPORT_FILE_PATH = path.join(
 	__dirname,
@@ -19,10 +18,7 @@ test.describe(
 		},
 	},
 	() => {
-		test.skip(
-			envVariables.MAILOSAUR_LIMIT_REACHED,
-			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
-		);
+		skipIfMailosaurLimitReached();
 
 		test( 'One: As a New WordPress.com free plan user with a simple site, I can use the "Medium Run Importer" link on the wp-admin Importers List page to import my content from my Medium account', async ( {
 			pageImportContentFromMedium,

--- a/test/e2e/specs/tools/import__sites-squarespace.spec.ts
+++ b/test/e2e/specs/tools/import__sites-squarespace.spec.ts
@@ -1,6 +1,5 @@
 import path from 'path';
-import { envVariables } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 const TEST_SQUARESPACE_EXPORT_FILE_PATH = path.join(
 	__dirname,
@@ -19,10 +18,7 @@ test.describe(
 		},
 	},
 	() => {
-		test.skip(
-			envVariables.MAILOSAUR_LIMIT_REACHED,
-			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
-		);
+		skipIfMailosaurLimitReached();
 
 		test( 'One: As a New WordPress.com free plan user with a simple site, I can use the "Squarespace Run Importer" link on the wp-admin Importers List page to import my content from my Squarespace site', async ( {
 			pageImportContentFromSquarespace,

--- a/test/e2e/specs/tools/import__sites-substack.spec.ts
+++ b/test/e2e/specs/tools/import__sites-substack.spec.ts
@@ -1,6 +1,5 @@
 import path from 'path';
-import { envVariables } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 const TEST_SUBSTACK_EXPORT_FILE_PATH = path.join( __dirname, 'import-files', 'substackexport.zip' );
 
@@ -15,10 +14,7 @@ test.describe(
 		},
 	},
 	() => {
-		test.skip(
-			envVariables.MAILOSAUR_LIMIT_REACHED,
-			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
-		);
+		skipIfMailosaurLimitReached();
 
 		const substackSiteURL = 'https://test.substack.com/';
 		const substackSiteName = 'Testing Product';

--- a/test/e2e/specs/tools/import__sites-wordpress.spec.ts
+++ b/test/e2e/specs/tools/import__sites-wordpress.spec.ts
@@ -1,6 +1,5 @@
 import path from 'path';
-import { envVariables } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 const TEST_WORDPRESS_EXPORT_FILE_PATH = path.join(
 	__dirname,
@@ -19,10 +18,7 @@ test.describe(
 		},
 	},
 	() => {
-		test.skip(
-			envVariables.MAILOSAUR_LIMIT_REACHED,
-			'Skipping: Mailosaur daily email limit reached (sitePublic fixture requires email verification)'
-		);
+		skipIfMailosaurLimitReached();
 
 		test( 'One: As a New WordPress.com free plan user with a simple site, I can use the "WordPress Run Importer" link on the wp-admin Importers List page to import my content from my WordPress site', async ( {
 			pageImportContentFromWordPress,

--- a/test/e2e/specs/users/invite__new-user.spec.ts
+++ b/test/e2e/specs/users/invite__new-user.spec.ts
@@ -5,9 +5,10 @@ import {
 	Roles,
 	UserSignupPage,
 } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe( 'Invite: New User', { tag: [ tags.CALYPSO_PR ] }, () => {
+	skipIfMailosaurLimitReached();
 	const role = 'Editor';
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'invited',

--- a/test/e2e/specs/users/invite__revoke.spec.ts
+++ b/test/e2e/specs/users/invite__revoke.spec.ts
@@ -1,10 +1,11 @@
 import { DataHelper, SecretsManager } from '@automattic/calypso-e2e';
-import { expect, tags, test } from '../../lib/pw-base';
+import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	'Invite: Revoke',
 	{ tag: [ tags.CALYPSO_PR, tags.CALYPSO_RELEASE, tags.DESKTOP_ONLY ] },
 	() => {
+		skipIfMailosaurLimitReached();
 		const testUser = DataHelper.getNewTestUser( {
 			usernamePrefix: 'e2eflowtestinginvite',
 		} );


### PR DESCRIPTION
Part of [QAO-224](https://linear.app/a8c/issue/QAO-224/)

## Proposed Changes

Follow-up of #108399. Skipping more tests is the daily email limit is reached. This should cut the noise and unblock the CI.
Also extracted the skip logic into a reusable function.

## Testing Instructions

1. Run any affected test and verify the setup checks the API:
```
yarn playwright test specs/domains/domains__add.spec.ts --reporter=list
```

Observe: Mailosaur email usage: X/Y

2. Verify tests skip when limit is reached:

```
MAILOSAUR_LIMIT_REACHED=true yarn playwright test specs/domains/domains__add.spec.ts --reporter=list --no-deps
```

3. Verify tests run when limit is not reached:

```
MAILOSAUR_LIMIT_REACHED=false yarn playwright test specs/domains/domains__add.spec.ts --reporter=list --no-deps
```
