### PR TITLE
Setup site with AI: design changes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
@@ -71,9 +71,13 @@ const SetupYourSiteAIStep: StepType = ( { navigation } ) => {
 			heading={
 				<Step.Heading
 					text={ translate( 'Set up your site' ) }
-					subText={ translate(
-						"No matter what you want to do, there's an easy way to get started."
-					) }
+					subText={ i18n.fixMe( {
+						text: "Whatever you're making, there's an easy way to get started.",
+						newCopy: translate( "Whatever you're making, there's an easy way to get started." ),
+						oldCopy: translate(
+							"No matter what you want to do, there's an easy way to get started."
+						),
+					} ) }
 				/>
 			}
 		>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
@@ -1,8 +1,8 @@
 import { BigSkyLogo, SummaryButton } from '@automattic/components';
 import { Step } from '@automattic/onboarding';
 import { __experimentalVStack as VStack, Icon } from '@wordpress/components';
-import { code } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { layout } from '@wordpress/icons';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteData } from '../../../../hooks/use-site-data';
 import type { Step as StepType } from '../../types';
@@ -39,16 +39,24 @@ const SetupYourSiteAIStep: StepType = ( { navigation } ) => {
 		<VStack alignment="top" spacing={ 3 }>
 			<SummaryButton
 				title={ translate( 'Build with AI' ) }
-				description={ translate( 'Prompt, edit, and launch a site in just a few clicks.' ) }
+				description={ i18n.fixMe( {
+					text: 'Describe your idea and let AI help you refine your site.',
+					newCopy: translate( 'Describe your idea and let AI help you refine your site.' ),
+					oldCopy: translate( 'Prompt, edit, and launch a site in just a few clicks.' ),
+				} ) }
 				decoration={ <BigSkyLogo.CentralLogo heartless /> }
 				onClick={ handleBuildWithAI }
 			/>
 			<SummaryButton
-				title={ translate( 'Start with a blank site' ) }
+				title={ i18n.fixMe( {
+					text: 'Manual setup',
+					newCopy: translate( 'Manual setup' ),
+					oldCopy: translate( 'Start with a blank site' ),
+				} ) }
 				description={ translate(
 					'Get started instantly with a simple, ready-to-go WordPress site.'
 				) }
-				decoration={ <Icon icon={ code } /> }
+				decoration={ <Icon icon={ layout } /> }
 				onClick={ handleBlankSite }
 			/>
 		</VStack>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/style.scss
@@ -10,6 +10,10 @@
 		.summary-button-title{
 			font-weight: 500;
 		}
+
+		.summary-button-description {
+			text-align: start;
+		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/style.scss
@@ -8,6 +8,7 @@
 		}
 
 		.summary-button-title{
+			text-align: start;
 			font-weight: 500;
 		}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTCOM-15887

| Before  | After |
| ------------- | ------------- |
| <img width="894" height="933" alt="Screenshot 2026-01-28 at 20 18 22" src="https://github.com/user-attachments/assets/d0671a1a-b460-47f7-bbde-4b84f9451777" />  | <img width="900" height="934" alt="Screenshot 2026-01-28 at 20 18 32" src="https://github.com/user-attachments/assets/0805cf0d-e725-4552-9a6b-7f7e4c3ab2a8" />  |

## Proposed Changes

* Modify copy and icon for the second option

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to the big-sky group of the experiment: 22433-explat-experiment.
* Purchase a personal plan.
* Compare the post checkout step copy with the design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?