### PR TITLE
A4A: Change behavior of Marketplace on header collapse.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-compact-on-scroll.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-compact-on-scroll.ts
@@ -1,9 +1,5 @@
 import { useCallback, useRef, useState, useEffect } from 'react';
 
-const SCROLL_THRESHOLD_PERCENTAGE = 0.2;
-const SCROLL_THRESHOLD_NORMAL_BUFFER = 5;
-const SCROLL_THRESHOLD_COMPACT_BUFFER = 15;
-
 const TABS_GAP = 39;
 const MINIMUM_COMPACT_HEIGHT = 74; // Header height
 
@@ -54,23 +50,11 @@ export default function useCompactOnScroll() {
 			const scrollPosition = event.currentTarget.scrollTop;
 			const isScrollingDown = scrollPosition > lastScrollPosition;
 
-			const normalHeight = ref.current?.clientHeight ?? 0;
-
-			const normalScrollThreshold = normalHeight * SCROLL_THRESHOLD_PERCENTAGE;
-
-			if (
-				isScrollingDown &&
-				! isCompact &&
-				scrollPosition > normalScrollThreshold + SCROLL_THRESHOLD_NORMAL_BUFFER
-			) {
+			if ( isScrollingDown && ! isCompact ) {
 				setIsCompact( true );
 				setIsTransitioning( true );
 				ref.current?.addEventListener( 'transitionend', onTransitionEnd );
-			} else if (
-				! isScrollingDown &&
-				isCompact &&
-				scrollPosition < normalScrollThreshold - SCROLL_THRESHOLD_COMPACT_BUFFER
-			) {
+			} else if ( ! isScrollingDown && scrollPosition === 0 ) {
 				setIsCompact( false );
 				setIsTransitioning( true );
 				ref.current?.addEventListener( 'transitionend', onTransitionEnd );


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-653/marketplace-the-hosting-page-header-has-some-scrolling-bug

## Proposed Changes
This pull request simplifies the scroll behavior logic in the `useCompactOnScroll` hook by removing unnecessary scroll threshold calculations and buffers. Now, the compact header state toggles based solely on scroll direction and whether the scroll position is at the top.

Key logic simplifications:

* Removed the `SCROLL_THRESHOLD_PERCENTAGE`, `SCROLL_THRESHOLD_NORMAL_BUFFER`, and `SCROLL_THRESHOLD_COMPACT_BUFFER` constants and all related threshold calculations, reducing complexity in the scroll handling logic.
* Updated the conditions for toggling the compact state: the header now becomes compact when scrolling down and expands only when scrolling up to the very top (`scrollPosition === 0`).

* When scroll position is not 0 and scrolling down.
<img width="1681" height="663" alt="Screenshot 2026-01-29 at 2 37 44 PM" src="https://github.com/user-attachments/assets/ec62d607-9be2-4b67-b8ba-3a3746452924" />
* When scroll position is 0
<img width="1583" height="387" alt="Screenshot 2026-01-29 at 2 37 49 PM" src="https://github.com/user-attachments/assets/e21e39c3-29db-49a4-b5f2-5d58cad0b22c" />


## Why are these changes being made?

* Improves user experience.

## Testing Instructions

* Use the A4A live link and navigate to `/marketplace/hosting` page.
* Test the header collapse behavior to ensure it works properly on scroll. The main change is that the header expands only when the scroll position is 0.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
