### PR TITLE
A4A: Fix track event name for Pressable offer banner.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
@@ -33,15 +33,22 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 			( new Date() <= new Date( '2026-04-30T23:59:59.999Z' ) && pressableOwnership !== 'agency' ) );
 
 	const onToggleView = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_pressable_promo_offer_2026_toggle_view', {
+				event_type: ! isExpanded ? 'collapse' : 'expand',
+			} )
+		);
 		setIsExpanded( ( isExpanded ) => ! isExpanded );
-	}, [] );
+	}, [ dispatch, isExpanded ] );
 
 	const onViewEligiblePlansClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'a4a_pressable_promo_offer_2026_view_eligible_plans_click' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_pressable_promo_offer_2026_view_eligible_plans_click' )
+		);
 	}, [ dispatch ] );
 
 	const onSeeFullTermClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'a4a_pressable_promo_offer_2026_see_full_terms_click' ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_pressable_promo_offer_2026_see_full_terms_click' ) );
 	}, [ dispatch ] );
 
 	if ( ! shouldShowOffer ) {


### PR DESCRIPTION
Context: p1769627849636419/1769503294.183519-slack-C047ACYM8UQ

## Proposed Changes
Track events for Calypso should always start with `calypso_`; otherwise, the event is ignored.

## Why are these changes being made?

* It is important we track the event.

## Testing Instructions

* Use the A4A live link and navigate to `/marketplace/hosting` page
* View the toggle, click any CTAs.
* Confirm you see the track events firing. You can inspect for any network requests going to `http://pixel.wp.com/t.gif`


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?