### PR TITLE
Reader: Add hideDeleted prop on SitesDropdown component

### DIFF
--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -24,6 +24,7 @@ export class SitesDropdown extends PureComponent {
 		isPlaceholder: PropTypes.bool,
 		hasMultipleSites: PropTypes.bool,
 		disabled: PropTypes.bool,
+		hideDeleted: PropTypes.bool,
 
 		// connected props
 		selectedSite: PropTypes.object,
@@ -36,6 +37,7 @@ export class SitesDropdown extends PureComponent {
 		isPlaceholder: false,
 		hasMultipleSites: false,
 		disabled: false,
+		hideDeleted: true,
 	};
 
 	constructor( props ) {
@@ -62,7 +64,11 @@ export class SitesDropdown extends PureComponent {
 
 	// Our filter prop handles siteIds, while SiteSelector's filter prop needs objects
 	siteFilter( site ) {
-		return this.props.filter( site.ID );
+		if ( this.props.hideDeleted && site.is_deleted ) {
+			return false;
+		}
+
+		return this.props.filter?.( site.ID ) ?? true;
 	}
 
 	toggleOpen() {
@@ -126,7 +132,7 @@ export class SitesDropdown extends PureComponent {
 							onSiteSelect={ this.selectSite }
 							selected={ this.state.selectedSiteId }
 							hideSelected
-							filter={ this.props.filter && this.siteFilter }
+							filter={ this.siteFilter }
 						/>
 					) }
 				</div>

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -112,4 +112,66 @@ describe( 'index', () => {
 			expect( onCloseSpy ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
+
+	describe( 'siteFilter', () => {
+		test( 'should filter out deleted sites when hideDeleted is true', () => {
+			const fakeContext = {
+				props: {
+					hideDeleted: true,
+					filter: undefined,
+				},
+			};
+
+			const deletedSite = { ID: 123, is_deleted: true };
+			const activeSite = { ID: 456, is_deleted: false };
+
+			expect( SitesDropdown.prototype.siteFilter.call( fakeContext, deletedSite ) ).toBe( false );
+			expect( SitesDropdown.prototype.siteFilter.call( fakeContext, activeSite ) ).toBe( true );
+		} );
+
+		test( 'should not filter out deleted sites when hideDeleted is false', () => {
+			const fakeContext = {
+				props: {
+					hideDeleted: false,
+					filter: undefined,
+				},
+			};
+
+			const deletedSite = { ID: 123, is_deleted: true };
+			const activeSite = { ID: 456, is_deleted: false };
+
+			expect( SitesDropdown.prototype.siteFilter.call( fakeContext, deletedSite ) ).toBe( true );
+			expect( SitesDropdown.prototype.siteFilter.call( fakeContext, activeSite ) ).toBe( true );
+		} );
+
+		test( 'should apply custom filter after hideDeleted check', () => {
+			const customFilter = jest.fn().mockReturnValue( true );
+			const fakeContext = {
+				props: {
+					hideDeleted: true,
+					filter: customFilter,
+				},
+			};
+
+			const activeSite = { ID: 456, is_deleted: false };
+
+			expect( SitesDropdown.prototype.siteFilter.call( fakeContext, activeSite ) ).toBe( true );
+			expect( customFilter ).toHaveBeenCalledWith( 456 );
+		} );
+
+		test( 'should not call custom filter for deleted sites when hideDeleted is true', () => {
+			const customFilter = jest.fn().mockReturnValue( true );
+			const fakeContext = {
+				props: {
+					hideDeleted: true,
+					filter: customFilter,
+				},
+			};
+
+			const deletedSite = { ID: 123, is_deleted: true };
+
+			expect( SitesDropdown.prototype.siteFilter.call( fakeContext, deletedSite ) ).toBe( false );
+			expect( customFilter ).not.toHaveBeenCalled();
+		} );
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes: [READ-286](https://linear.app/a8c/issue/READ-286)

## Proposed Changes

Adds `hideDeleted` prop (defaults to `true`) on `SitesDropdown` component while keeping the existing filter functionality.

We are currently using `SitesDropdown` in 3 places and this default shouldn't have any affect, rather it should improve the behavior because deleted sites selection are unexpected there as well.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make sure we don't show deleted sites where selecting them are not expected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure you have one deleted site in your Sites.
1. Go to /reader quick post and verify deleted site is not shown in dropdown (before it was showing and giving error on posting).
1. Go to /me/accounts. Verify deleted site is not shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
