### PR TITLE
AI Tools: Update the way to open the AI assistant chat

### DIFF
--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -1,7 +1,6 @@
 import { HostingFeatures } from '@automattic/api-core';
 import { bigSkyPluginMutation, bigSkyPluginQuery, siteBySlugQuery } from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -16,7 +15,6 @@ import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useHelpCenter } from '../../app/help-center';
-import { siteSettingsAIToolsRoute } from '../../app/router/sites';
 import { Card, CardBody, CardFooter } from '../../components/card';
 import ConfirmModal from '../../components/confirm-modal';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -36,9 +34,7 @@ const features = [
 ];
 
 export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
-	const navigate = useNavigate();
 	const { recordTracksEvent } = useAnalytics();
-	const currentSearchParams = siteSettingsAIToolsRoute.useSearch();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { data: pluginStatus } = useSuspenseQuery( bigSkyPluginQuery( site.ID ) );
 
@@ -48,7 +44,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 
 	const [ isConfirmModalOpen, setIsConfirmModalOpen ] = useState( false );
 
-	const { setShowHelpCenter } = useHelpCenter();
+	const { setShowHelpCenter, setNavigateToRoute } = useHelpCenter();
 
 	const mutation = useMutation( {
 		...bigSkyPluginMutation( site.ID ),
@@ -166,13 +162,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 								decoration={ <Icon icon={ help } /> }
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_ai_tool_get_answers_click' );
-									navigate( {
-										search: {
-											...currentSearchParams,
-											'help-center': 'wapuu',
-										},
-										replace: true,
-									} );
+									setNavigateToRoute( '/odie' );
 									setShowHelpCenter( true );
 								} }
 							/>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-1058

## Proposed Changes

* As mentioned https://github.com/Automattic/wp-calypso/pull/108331#discussion_r2737570794, the correct way to open the AI assistant chat is to call `setNavigateToRoute('/odie')`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix the way to open AI assistant chat

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Site Settings on your Business site
* Select "Get answers"
* Ensure it opens the AI assistant chat correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
