### PR TITLE
A4A: Add Pressable promo offer event on the Overview page.

### DIFF
--- a/client/a8c-for-agencies/components/upcoming-event/index.tsx
+++ b/client/a8c-for-agencies/components/upcoming-event/index.tsx
@@ -12,11 +12,10 @@ const UpcomingEvent = ( {
 	title,
 	subtitle,
 	descriptions,
-	cta,
+	ctas,
 	logoUrl,
 	logoElement,
 	imageUrl,
-	trackEventName,
 	dateClassName,
 	imageClassName,
 	extraContent,
@@ -59,10 +58,6 @@ const UpcomingEvent = ( {
 		return `${ date.from.format( 'YYYY-MM-DD' ) }/${ date.to.format( 'YYYY-MM-DD' ) }`;
 	}, [ date ] );
 
-	const handleRegisterClick = (): void => {
-		dispatch( recordTracksEvent( trackEventName ) );
-	};
-
 	return (
 		<div className="a4a-event">
 			<div className="a4a-event__content">
@@ -86,15 +81,22 @@ const UpcomingEvent = ( {
 				</div>
 
 				<div className="a4a-event__footer">
-					<Button
-						className="a4a-event__button"
-						variant="secondary"
-						target="_blank"
-						href={ cta.url }
-						onClick={ handleRegisterClick }
-					>
-						{ cta.label }
-					</Button>
+					{ ctas.map( ( cta ) => {
+						return (
+							<Button
+								key={ `cta-${ cta.url }` }
+								className="a4a-event__button"
+								variant={ cta.variant as 'link' | 'primary' | 'secondary' | 'tertiary' }
+								target={ cta.isExternal ? '_blank' : undefined }
+								href={ cta.url }
+								onClick={ () => dispatch( recordTracksEvent( cta.trackEventName ) ) }
+							>
+								{ cta.label }
+								{ cta.isExternal && ' ↗' }
+							</Button>
+						);
+					} ) }
+
 					{ extraContent }
 				</div>
 			</div>

--- a/client/a8c-for-agencies/components/upcoming-event/types.ts
+++ b/client/a8c-for-agencies/components/upcoming-event/types.ts
@@ -11,12 +11,14 @@ export type UpcomingEventProps = {
 	logoUrl?: string;
 	logoElement?: React.ReactNode;
 	imageUrl?: string;
-	trackEventName: string;
 	dateClassName?: string;
 	imageClassName?: string;
-	cta: {
+	ctas: {
 		label: string;
 		url: string;
-	};
+		trackEventName: string;
+		variant: string;
+		isExternal?: boolean;
+	}[];
 	extraContent?: React.ReactNode;
 };

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -1,61 +1,67 @@
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useMemo } from 'react';
-import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
+import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { UpcomingEventProps } from 'calypso/a8c-for-agencies/components/upcoming-event/types';
-import WooLogo from 'calypso/assets/images/a8c-for-agencies/events/woo-logo.svg';
+import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
+import PressableLogo from 'calypso/assets/images/a8c-for-agencies/events/pressable-logo.svg';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
 export const useUpcomingEvents = () => {
 	const translate = useTranslate();
 	const localizedMoment = useLocalizedMoment();
 
+	const agency = useSelector( getActiveAgency );
+
+	const pressableOwnership = usePressableOwnershipType();
+
+	const shouldShowPressablePromoOffer =
+		agency?.billing_system === 'billingdragon' && pressableOwnership !== 'agency';
+
 	return useMemo( () => {
 		const eventsData: UpcomingEventProps[] = [
-			{
-				id: 'a4a-woo-2025-12-22',
-				date: {
-					from: moment( '2025-12-22' ),
-					to: moment( '2026-01-05' ),
-				},
-				displayDate: translate( 'Update as soon as possible' ),
-				title: translate( 'Action Needed: Critical WooCommerce Update Available' ),
-				subtitle: translate( 'WooCommerce' ),
-				descriptions: [
-					translate(
-						'A Store API vulnerability has been identified in WooCommerce versions 8.1 through 10.4.2, and a patch is now available. Client sites hosted with Automattic have been automatically patched. Please update WooCommerce on all client sites to the latest version (10.4.3) as soon as possible. We currently have no evidence of the vulnerability being used or exploited outside of our own security testing program.'
-					),
-				],
-				cta: {
-					label: translate( 'Read the announcement and FAQ ↗' ),
-					url: 'https://developer.woocommerce.com/2025/12/22/store-api-vulnerability-patched-in-woocommerce-8-1/',
-				},
-				logoUrl: WooLogo,
-				trackEventName: 'calypso_a4a_overview_events_a4a_woo_2025_12_22_click',
-				dateClassName: 'a4a-event__date--critical',
-			},
-			{
-				id: 'a4a-partner-survey-2025-12-03',
-				date: {
-					from: moment( '2026-01-01' ),
-					to: moment( '2026-01-01' ),
-				},
-				displayDate: translate( 'Open until January 1, 2026' ),
-				title: translate( 'Automattic for Agencies Partner Survey' ),
-				subtitle: translate( 'Automattic for Agencies' ),
-				descriptions: [
-					translate(
-						'We invite you to share your input in our short Automattic for Agencies Partner Survey. Your feedback will help us better understand your experience with Automattic for Agencies and the products you use across our ecosystem. The survey is anonymous, and your insights will guide how we shape next year’s incentives, tools, and product improvements to create more value for your agency and clients.'
-					),
-				],
-				cta: {
-					label: translate( 'Take the survey now! ↗' ),
-					url: 'https://usabi.li/do/b8fc6strv3hm/tnzgph',
-				},
-				logoElement: <A4ALogo size={ 64 } />,
-				trackEventName: 'calypso_a4a_overview_events_a4a_partner_survey_2025_12_03_click',
-				dateClassName: 'a4a-event__date--neutral',
-			},
+			...( shouldShowPressablePromoOffer
+				? [
+						{
+							id: 'a4a-pressable-promo-offer-2026-01-29',
+							date: {
+								from: moment( '2026-01-27' ),
+								to: moment( '2026-04-30' ),
+							},
+							displayDate: translate( 'Jan 27—April 30, 2026' ),
+							title: translate(
+								'Limited time offer: Get up to 6 months of free Pressable hosting on new plans!'
+							),
+							subtitle: translate( 'Automattic for Agencies & Pressable' ),
+							descriptions: [
+								translate(
+									'Enjoy up to 6 months free on Pressable Signature and Premium Plans with Automattic for Agencies. Choose annual billing for 6 months free or monthly billing for 3 months free, while still earning revenue share and reseller incentives.'
+								),
+							],
+							ctas: [
+								{
+									variant: 'primary',
+									label: translate( 'View promo details' ),
+									url: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+									trackEventName:
+										'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_view_click',
+								},
+								{
+									variant: 'secondary',
+									label: translate( 'See full terms' ),
+									url: 'https://pressable.com/legal/hosting-promotion-terms',
+									isExternal: true,
+									trackEventName:
+										'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_view_terms_click',
+								},
+							],
+							logoUrl: PressableLogo,
+							dateClassName: 'a4a-event__date--pressable',
+						},
+				  ]
+				: [] ),
 		];
 
 		return eventsData.filter( ( event ) => {
@@ -63,5 +69,5 @@ export const useUpcomingEvents = () => {
 			const today = localizedMoment().startOf( 'day' );
 			return eventDate.isSameOrAfter( today );
 		} );
-	}, [ localizedMoment, translate ] );
+	}, [ localizedMoment, shouldShowPressablePromoOffer, translate ] );
 };


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-2036/pressable-incentive-overview-page-announcement

<img width="1030" height="306" alt="Screenshot 2026-01-29 at 4 31 16 PM" src="https://github.com/user-attachments/assets/dd292813-005b-437e-995c-938593f6059e" />


## Proposed Changes
This pull request updates the upcoming events feature to support multiple call-to-action (CTA) buttons per event and introduces a new, conditional promotional event for Pressable hosting. The changes modernize the event display, enhance tracking, and add flexibility for event actions.

**Support for Multiple CTAs in Events:**

- Refactored the `UpcomingEvent` component and its props to replace the single `cta` field and `trackEventName` with a `ctas` array, allowing each event to display multiple CTA buttons, each with its own label, URL, tracking event name, button variant, and external link indicator. [[1]](diffhunk://#diff-a056b726c47accefac0c84c15bae22695ad0da4588530696d63dda88b44ad59eL15-L19) [[2]](diffhunk://#diff-779d281606e1c6c306b0b3b7565433bad989684e6ba47c6b514e3d5f4e54030fL14-R22)
- Updated the event rendering logic so that each CTA button dispatches its own tracking event and can be styled individually; also displays an external link icon if applicable.

**New Conditional Pressable Promo Event:**

- Added logic in `use-upcoming-events.tsx` to conditionally show a new Pressable hosting promotion event, based on agency billing system and ownership type, featuring two CTAs: one for promo details and one for terms.

**Code Cleanup and Removal of Deprecated Logic:**

- Removed the now-obsolete `trackEventName` prop and single-CTA handling from event types and the component. [[1]](diffhunk://#diff-a056b726c47accefac0c84c15bae22695ad0da4588530696d63dda88b44ad59eL62-L65) [[2]](diffhunk://#diff-779d281606e1c6c306b0b3b7565433bad989684e6ba47c6b514e3d5f4e54030fL14-R22)

These changes improve flexibility for event actions, enable richer event promotions, and ensure more granular event tracking.

## Why are these changes being made?

* This is to highlight the promo to our agencies.

## Testing Instructions

* **You need an Agency account that is in the BD system and has not purchased Pressable plans before.**
* Use the A4A live link and navigate to `/overview` page.
* Confirm you see the Pressable promo event.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
