### PR TITLE
Notifications v2: Show Needs approval badge to the comment notification

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -31,6 +31,7 @@
 		"@automattic/calypso-router": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
+		"@automattic/ui": "workspace:^",
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/data": "^10.23.0",

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@automattic/ui';
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
@@ -14,7 +15,9 @@ import {
 	update,
 } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useSelector } from 'react-redux';
 import { html } from '../../panel/indices-to-html';
+import getIsNoteNeedApproval from '../../panel/state/selectors/get-is-note-need-approval';
 import NoteIcon from '../note-icon';
 import type { Note } from '../types';
 import type { Field } from '@wordpress/dataviews';
@@ -105,12 +108,21 @@ export function getFields(): Field< Note >[] {
 		{
 			id: 'info',
 			label: __( 'Info' ),
-			render: ( { item } ) => {
+			render: function NoteInfo( { item } ) {
+				const isNeedApproval = useSelector(
+					( state ) => item && getIsNoteNeedApproval( state, item )
+				);
+
 				return (
 					<HStack spacing={ 1 }>
 						<RelativeDate timestamp={ item.timestamp } />
 						<span>•</span>
 						<span>{ item.title }</span>
+						{ isNeedApproval && (
+							<Badge intent="warning" style={ { marginInlineStart: '4px' } }>
+								{ __( 'Needs approval' ) }
+							</Badge>
+						) }
 					</HStack>
 				);
 			},

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@automattic/ui';
 import {
 	__experimentalDivider as Divider,
 	__experimentalHStack as HStack,
@@ -8,7 +9,7 @@ import {
 	Navigator,
 	useNavigator,
 } from '@wordpress/components';
-import { isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
@@ -18,6 +19,7 @@ import actions from '../../panel/state/actions';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getIsNoteApproved from '../../panel/state/selectors/get-is-note-approved';
+import getIsNoteNeedApproval from '../../panel/state/selectors/get-is-note-need-approval';
 import getIsNoteRead from '../../panel/state/selectors/get-is-note-read';
 import { getFilters } from '../../panel/templates/filters';
 import ActionDropdown from '../templates/action-dropdown';
@@ -84,6 +86,7 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 	);
 
 	const isApproved = useSelector( ( state ) => note && getIsNoteApproved( state, note ) );
+	const isNeedApproval = useSelector( ( state ) => note && getIsNoteNeedApproval( state, note ) );
 	const isRead = useSelector( ( state ) => note && getIsNoteRead( state, note ) );
 
 	useNoteNavigationViaKeyboardShortcuts( { visibleNotes, note } );
@@ -110,6 +113,7 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 						<Heading level={ 3 } size={ 15 } weight={ 500 }>
 							{ note.title }
 						</Heading>
+						{ isNeedApproval && <Badge intent="warning">{ __( 'Needs approval' ) }</Badge> }
 					</HStack>
 					<HStack justify="flex-end" style={ { width: 'auto' } }>
 						<ActionDropdown note={ note } goBack={ goBack } />

--- a/apps/notifications/src/panel/state/selectors/get-is-note-need-approval.js
+++ b/apps/notifications/src/panel/state/selectors/get-is-note-need-approval.js
@@ -1,0 +1,15 @@
+import { getActions } from '../../helpers/notes';
+import getNotes from './get-notes';
+
+export const getIsNoteNeedApproval = ( notesState, note ) => {
+	const noteApprovals = notesState.noteApprovals;
+
+	if ( noteApprovals.hasOwnProperty( note.id ) ) {
+		return ! noteApprovals[ note.id ];
+	}
+
+	const actionMeta = getActions( note );
+	return actionMeta && false === actionMeta[ 'approve-comment' ];
+};
+
+export default ( state, note ) => getIsNoteNeedApproval( getNotes( state ), note );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,6 +1772,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
+    "@automattic/ui": "workspace:^"
     "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
     "@wordpress/components": "npm:^30.9.0"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DSGCOM-398

## Proposed Changes

* Show "Needs approval" badge to the comment notification

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The state of the comment that needs approval is not clear

#### List

<img width="436" height="76" alt="image" src="https://github.com/user-attachments/assets/9a750543-2d54-44ca-a4bf-618c616fd40d" />

#### Details

<img width="456" height="61" alt="image" src="https://github.com/user-attachments/assets/0a73e996-0028-40f6-8085-110236140d78" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites on MSD
* Open the notification
* Switch to the Comment tab
* Ensure you can see the badge "Needs approval" on the comment that needs approval
* Select the notification
* Ensure you can see the badge on the header as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
