### PR TITLE
Help Center: Fix initiating a logged out chat

### DIFF
--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -160,18 +160,12 @@ const userDeclaredSite: Reducer< SiteDetails | undefined, HelpCenterAction > = (
 	return state;
 };
 
-const navigateToRoute: Reducer< string | undefined, HelpCenterAction > = ( state, action ) => {
+const navigateToRoute: Reducer<
+	{ route: string | undefined; coalesceParams: boolean } | undefined,
+	HelpCenterAction
+> = ( state, action ) => {
 	if ( action.type === 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE' ) {
-		// Keep the existing parameters in the new route.
-		if ( action.coalesceParams ) {
-			const originalParams = new URLSearchParams( state );
-			const newParams = new URLSearchParams( action.route );
-			newParams.forEach( ( value, key ) => {
-				originalParams.set( key, value );
-			} );
-			return `${ action.route }?${ originalParams.toString() }`;
-		}
-		return action.route;
+		return { route: action.route, coalesceParams: action.coalesceParams };
 	}
 	return state;
 };

--- a/packages/data-stores/src/help-center/resolvers.ts
+++ b/packages/data-stores/src/help-center/resolvers.ts
@@ -24,7 +24,7 @@ export function isHelpCenterShown() {
 
 export function getHelpCenterRouterHistory() {
 	return async ( { dispatch, select }: HelpCenterThunkProps ) => {
-		const route = select.getNavigateToRoute();
+		const route = select.getNavigateToRoute()?.route;
 
 		// Don't use the history from the preferences if route is defined to avoid a race condition between restoring
 		// persisted data and setting the support doc data. Persisted values could overwrite freshly fetched data.

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -78,11 +78,22 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	}, [ location, sectionName, isUserEligibleForPaidSupport ] );
 
 	useEffect( () => {
-		if ( navigateToRoute ) {
+		if ( navigateToRoute?.route ) {
+			const { route, coalesceParams } = navigateToRoute;
 			const fullLocation = [ location.pathname, location.search, location.hash ].join( '' );
-			// On navigate once to keep the back button responsive.
-			if ( fullLocation !== navigateToRoute ) {
-				navigate( navigateToRoute );
+			// Only navigate once to keep the back button responsive.
+			if ( fullLocation !== route ) {
+				if ( coalesceParams ) {
+					const url = new URL( route, window.location.origin );
+					const originalParams = new URLSearchParams( location.search );
+					const newParams = new URLSearchParams( url.search );
+					newParams.forEach( ( value, key ) => {
+						originalParams.set( key, value );
+					} );
+					navigate( { pathname: url.pathname, search: originalParams.toString() } );
+				} else {
+					navigate( route );
+				}
 			}
 			setNavigateToRoute( null );
 		}

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -91,7 +91,12 @@ export const useGetCombinedChat = (
 		// Logged out chats don't have interactions. Only direct odie IDs.
 		const interactionHasChanged =
 			previousUuidRef.current !== currentSupportInteraction?.uuid ||
-			previousOdieIdRef.current !== odieId;
+			// If the ID has changed from something to something else, we need to clear the chat.
+			// If the ID changed from nothing to something, we need to ignore the change, because
+			// it's just a transition from an empty chat to a new one after the first message.
+			( previousOdieIdRef.current && previousOdieIdRef.current !== odieId );
+
+		previousOdieIdRef.current = odieId;
 
 		if (
 			( isOdieChatLoading && ! interactionHasChanged ) ||
@@ -104,7 +109,6 @@ export const useGetCombinedChat = (
 		}
 
 		previousUuidRef.current = currentSupportInteraction?.uuid;
-		previousOdieIdRef.current = odieId;
 
 		const supportInteractionId = currentSupportInteraction?.uuid ?? null;
 


### PR DESCRIPTION
Fixes DOTSUP-411

Follow up to https://github.com/Automattic/wp-calypso/pull/108316

## Proposed Changes

Currently, when a new Odie chat is created and assigned an ID, it's considered an event worthy of loading the chat. But there is a race condition between the availability of the ID and the effect that fetches the chat. Which makes the effect try and fetch before the ID is available and return an empty chat. Fetching is not needed at all in this case because when the user sends their first message to Odie, the chat will be assigned an ID, but it is still the same chat the user already has.

I introduced this regression (tracking Odie ID and refetching when it changes in #108316). Because clearing the Odie ID when starting a new chat was ignored and I wanted to make sure clearing the ID cleared the chat. This PR makes it one-directional; we'll only clear the chat when an ID is deleted or changed, but not when assigned (from null to truthy).

## Why are these changes being made?
Fix logged out chat.

## Testing Instructions

1. cd `apps/help-center` and run `yarn dev --sync`.
2. Sandbox widgets.wp.com and visit https://wordpress.com/support/?dotcom_support_enable_odie_answers=true.
3. Ask a question; all should work. 
4. Ask a follow-up; chat should continue.
5. Start a new chat. It should clear the chat.

### Important regression testing
1. Test while logged in. 
2. Start a chat.
3. Escalate to a human.
4. Escalation should work.
5. Start a new chat.
6. Chat should be clearned.