### PR TITLE
Unified Chat: Add query string parameters to override agent ID and version

### DIFF
--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -176,13 +176,13 @@ function AgentSetup( {
 								  }
 								: pluginContext;
 
-						// Merge in agent version via constructorArguments
+						// Merge in agent version via constructorArguments (only if specified)
 						// TODO: Remove once agenttic-client supports top-level constructorArguments
 						return {
 							...resolvedContext,
 							constructorArguments: {
 								...( resolvedContext.constructorArguments || {} ),
-								version,
+								...( version && { version } ),
 							},
 						};
 					},
@@ -195,11 +195,9 @@ function AgentSetup( {
 						pathname: currentRoute || window.location.pathname,
 						search: window.location.search,
 						environment: 'calypso',
-						// Pass agent version via clientContext for backend compatibility
+						// Pass agent version via clientContext for backend compatibility (only if specified)
 						// TODO: Remove once agenttic-client supports top-level constructorArguments
-						constructorArguments: {
-							version,
-						},
+						...( version && { constructorArguments: { version } } ),
 					} ),
 				};
 			}

--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMemo, useEffect, useState, useRef } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { createCalypsoAuthProvider } from '../../auth/calypso-auth-provider';
-import { ORCHESTRATOR_AGENT_ID, ORCHESTRATOR_AGENT_URL } from '../../constants';
+import { ORCHESTRATOR_AGENT_URL, getAgentConfig } from '../../constants';
 import { SESSION_STORAGE_KEY, getSessionId, clearSessionId } from '../../utils/agent-session';
 import { loadExternalProviders, type LoadedProviders } from '../../utils/load-external-providers';
 import AgentDock from '../agent-dock';
@@ -93,15 +93,18 @@ function AgentSetup( {
 	// Load external providers and initialize agent config
 	useEffect( () => {
 		const initializeAgent = async () => {
+			// Get agent configuration from query params or defaults
+			const { agentId, version } = getAgentConfig();
+
 			// Handle new chat: clear existing session and navigate to clean state
 			if ( isNewChat ) {
 				const agentManager = getAgentManager();
 
-				if ( agentManager.hasAgent( ORCHESTRATOR_AGENT_ID ) ) {
+				if ( agentManager.hasAgent( agentId ) ) {
 					// Abort any ongoing requests
-					await agentManager.abortCurrentRequest( ORCHESTRATOR_AGENT_ID );
+					await agentManager.abortCurrentRequest( agentId );
 					// Remove existing agent to start fresh
-					agentManager.removeAgent( ORCHESTRATOR_AGENT_ID );
+					agentManager.removeAgent( agentId );
 				}
 
 				// Clear stored session ID
@@ -124,7 +127,7 @@ function AgentSetup( {
 
 			// Create the agent configuration
 			const config: UseAgentChatConfig = {
-				agentId: ORCHESTRATOR_AGENT_ID,
+				agentId,
 				agentUrl: ORCHESTRATOR_AGENT_URL,
 				sessionId,
 				sessionIdStorageKey: SESSION_STORAGE_KEY,
@@ -165,14 +168,23 @@ function AgentSetup( {
 						const pluginContext = contextProvider.getClientContext();
 
 						// Resolve `contextEntries` if present
-						if ( pluginContext.contextEntries && pluginContext.contextEntries.length ) {
-							return {
-								...pluginContext,
-								contextEntries: resolveContextEntries( pluginContext.contextEntries ),
-							};
-						}
+						const resolvedContext =
+							pluginContext.contextEntries && pluginContext.contextEntries.length
+								? {
+										...pluginContext,
+										contextEntries: resolveContextEntries( pluginContext.contextEntries ),
+								  }
+								: pluginContext;
 
-						return pluginContext;
+						// Merge in agent version via constructorArguments
+						// TODO: Remove once agenttic-client supports top-level constructorArguments
+						return {
+							...resolvedContext,
+							constructorArguments: {
+								...( resolvedContext.constructorArguments || {} ),
+								version,
+							},
+						};
 					},
 				};
 			} else {
@@ -183,6 +195,11 @@ function AgentSetup( {
 						pathname: currentRoute || window.location.pathname,
 						search: window.location.search,
 						environment: 'calypso',
+						// Pass agent version via clientContext for backend compatibility
+						// TODO: Remove once agenttic-client supports top-level constructorArguments
+						constructorArguments: {
+							version,
+						},
 					} ),
 				};
 			}

--- a/packages/agents-manager/src/constants.ts
+++ b/packages/agents-manager/src/constants.ts
@@ -2,7 +2,6 @@ export const API_BASE_URL = 'https://public-api.wordpress.com';
 
 export const ORCHESTRATOR_AGENT_URL = `${ API_BASE_URL }/wpcom/v2/ai/agent`;
 export const ORCHESTRATOR_AGENT_ID = 'wp-orchestrator';
-export const ORCHESTRATOR_AGENT_VERSION = '1.0.0';
 
 export const LOCAL_TOOL_RUNNING_MESSAGE = 'local_tool_running';
 
@@ -14,13 +13,13 @@ export const LOCAL_TOOL_RUNNING_MESSAGE = 'local_tool_running';
  * - `agent`: Override the agent ID (e.g., ?agent=wpcom-workflow-support_chat)
  * - `version`: Override the agent version (e.g., ?version=1.0.25)
  */
-export function getAgentConfig(): { agentId: string; version: string } {
+export function getAgentConfig(): { agentId: string; version?: string } {
 	const urlSearchParams = new URLSearchParams( window.location.search );
 	const agentIdParam = urlSearchParams.get( 'agent' );
 	const versionParam = urlSearchParams.get( 'version' );
 
 	return {
 		agentId: agentIdParam || ORCHESTRATOR_AGENT_ID,
-		version: versionParam || ORCHESTRATOR_AGENT_VERSION,
+		version: versionParam || undefined,
 	};
 }

--- a/packages/agents-manager/src/constants.ts
+++ b/packages/agents-manager/src/constants.ts
@@ -2,5 +2,25 @@ export const API_BASE_URL = 'https://public-api.wordpress.com';
 
 export const ORCHESTRATOR_AGENT_URL = `${ API_BASE_URL }/wpcom/v2/ai/agent`;
 export const ORCHESTRATOR_AGENT_ID = 'wp-orchestrator';
+export const ORCHESTRATOR_AGENT_VERSION = '1.0.0';
 
 export const LOCAL_TOOL_RUNNING_MESSAGE = 'local_tool_running';
+
+/**
+ * Get agent configuration from query string parameters or defaults.
+ * Allows overriding agent ID and version via URL for testing purposes.
+ *
+ * Query parameters:
+ * - `agent`: Override the agent ID (e.g., ?agent=wpcom-workflow-support_chat)
+ * - `version`: Override the agent version (e.g., ?version=1.0.25)
+ */
+export function getAgentConfig(): { agentId: string; version: string } {
+	const urlSearchParams = new URLSearchParams( window.location.search );
+	const agentIdParam = urlSearchParams.get( 'agent' );
+	const versionParam = urlSearchParams.get( 'version' );
+
+	return {
+		agentId: agentIdParam || ORCHESTRATOR_AGENT_ID,
+		version: versionParam || ORCHESTRATOR_AGENT_VERSION,
+	};
+}

--- a/packages/agents-manager/src/hooks/use-conversation-list.ts
+++ b/packages/agents-manager/src/hooks/use-conversation-list.ts
@@ -16,7 +16,9 @@ interface Options {
 }
 
 export default function useConversationList( { agentId, authProvider }: Options ) {
-	const botId = createOdieBotId( agentId );
+	const urlSearchParams = new URLSearchParams( window.location.search );
+	const hasAgentParam = urlSearchParams.has( 'agent' );
+	const botId = hasAgentParam ? agentId : createOdieBotId( agentId );
 
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 

--- a/packages/agents-manager/src/hooks/use-conversation.ts
+++ b/packages/agents-manager/src/hooks/use-conversation.ts
@@ -36,10 +36,14 @@ export default function useConversation( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps -- we only want to refetch when sessionId changes
 		queryKey: [ 'agents-manager-conversation', sessionId ],
 		queryFn: async () => {
+			const urlSearchParams = new URLSearchParams( window.location.search );
+			const hasAgentParam = urlSearchParams.has( 'agent' );
+			const botId = hasAgentParam ? agentId : createOdieBotId( agentId );
+
 			return await loadAllMessagesFromServer(
 				sessionId,
 				{
-					botId: createOdieBotId( agentId ),
+					botId,
 					apiBaseUrl: API_BASE_URL,
 					authProvider,
 				},


### PR DESCRIPTION
## Proposed Changes

* Add `?agent=` and `?version=` query string parameters to allow testing different agents and versions

## Why are these changes being made?

This enables developers to test different agent configurations without code changes by simply adding query parameters to the URL.

Example usage: `?agent=wpcom-workflow-support_chat&version=1.0.25`

## Testing Instructions

1. Open Calypso
2. Add query parameters to the URL: `?agent=wpcom-workflow-support_chat&version=1.0.25`
3. Verify the agent loads correctly and the version is passed to the backend
4. Test with different agent IDs and versions
5. Verify default behavior works when no query parameters are provided
