### PR TITLE
Reader: Fix embeds on Quick Post

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -9,7 +9,7 @@ import { EmbedRequestParams } from '@automattic/verbum-block-editor/src/api';
 import { useMutation } from '@tanstack/react-query';
 // @ts-expect-error - No declaration file for heading block.
 import * as heading from '@wordpress/block-library/build-module/heading';
-import { createBlock, parse, serialize, unregisterBlockType } from '@wordpress/blocks';
+import { createBlock, parse, serialize } from '@wordpress/blocks';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -3,7 +3,9 @@ import {
 	Editor,
 	loadBlocksWithCustomizations,
 	loadTextFormatting,
+	addApiMiddleware,
 } from '@automattic/verbum-block-editor';
+import { EmbedRequestParams } from '@automattic/verbum-block-editor/src/api';
 import { useMutation } from '@tanstack/react-query';
 // @ts-expect-error - No declaration file for heading block.
 import * as heading from '@wordpress/block-library/build-module/heading';
@@ -29,7 +31,17 @@ import './style.scss';
 // Initialize the editor blocks and text formatting.
 loadBlocksWithCustomizations( [ heading ] );
 loadTextFormatting( [ heading.name ] );
-unregisterBlockType( 'core/embed' );
+
+// Add API middleware for embeds.
+// This redirects `/wp-json/oembed/1.0/proxy` requests to the WordPress.com embed API.
+// Because we are not using verbum editor in site context.
+addApiMiddleware(
+	( embedURL: string ): EmbedRequestParams => ( {
+		path: '/verbum/embed',
+		query: `embed_url=${ encodeURIComponent( embedURL ) }`,
+		apiNamespace: 'wpcom/v2',
+	} )
+);
 
 export default function QuickPost(): JSX.Element | null {
 	const translate = useTranslate();

--- a/client/reader/components/quick-post/test/index.test.tsx
+++ b/client/reader/components/quick-post/test/index.test.tsx
@@ -47,6 +47,7 @@ jest.mock( '@automattic/verbum-block-editor', () => {
 		),
 		loadBlocksWithCustomizations: jest.fn(),
 		loadTextFormatting: jest.fn(),
+		addApiMiddleware: jest.fn(),
 	};
 } );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes: [READ-275](https://linear.app/a8c/issue/READ-275/quick-post-re-enable-embed-blocks)

## Proposed Changes

- Use Verbum Editor API middleware to forward all Quick Post embed requests to verbum API instead of looking for `wp-json/oembed/1.0/proxy` endpoint.
- Fix Quick Post editor which limits the max height to `800px`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Verbum Editor by default looks for `wp-json/oembed/1.0/proxy` endpoint which doesn't work in Reader case so we are forwarding requests to the alternative `/wpcom/v2/verbum/embed` API.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /reader. Verify embed are not working in Quick Post.
1. Checkout this Jetpack PR (https://github.com/Automattic/jetpack/pull/46824) on sandbox if not merged.
1. Checkout this PR or use Calypso Live.
1. Verify that embeds are working fine now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
