### PR TITLE
Storage dropdown appears to be misaligned

### DIFF
--- a/packages/plans-grid-next/src/_shared.scss
+++ b/packages/plans-grid-next/src/_shared.scss
@@ -47,10 +47,11 @@ $mobile-card-max-width: 440px;
 }
 
 .plans-grid-next-storage-dropdown__option {
-	display: inline-block;
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
 	line-height: 20px;
 	min-height: 30px;
-	padding-top: 5px;
 	font-size: 0.75rem;
 	text-align: start;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15841

## Proposed Changes

* Vertically align the storage dropdown

## Why are these changes being made?

* Ugly atm

## Testing Instructions

* Check both signup plans step and logged in plans grid, mobile and desktop

Screenshots:

<img width="548" height="246" alt="Screenshot 2026-01-29 at 17 31 03" src="https://github.com/user-attachments/assets/6fd3ba38-5ea7-4435-bdb1-3c0d9875451c" />
<img width="504" height="320" alt="Screenshot 2026-01-29 at 17 29 09" src="https://github.com/user-attachments/assets/cfbca85b-d6fb-4960-a57b-70e576f5069d" />
<img width="331" height="303" alt="Screenshot 2026-01-29 at 17 28 51" src="https://github.com/user-attachments/assets/a638f47b-652c-4514-9a9e-f954f5eb0cb0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
