### PR TITLE
Purchase Management: Use payment_expiry_date for credit cards

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -11,6 +11,7 @@ import {
 import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { isAfter, parseISO, startOfDay } from 'date-fns';
 import { isAkismetPro500Plan } from './akismet';
 import { isWithinLast, isWithinNext, getDateFromCreditCardExpiry } from './datetime';
 import { isGSuiteProductSlug } from './gsuite';
@@ -144,19 +145,17 @@ export function creditCardExpiresBeforeSubscription( purchase: Purchase ): boole
 
 	// Use payment_expiry_date if available for more accurate expiry checking
 	if ( purchase.payment_expiry_date ) {
-		return (
-			new Date( purchase.expiry_date ).getTime() >
-			new Date( purchase.payment_expiry_date ).getTime()
-		);
+		// Both dates are in UTC (YYYY-MM-DD format), parse and compare them
+		return isAfter( parseISO( purchase.expiry_date ), parseISO( purchase.payment_expiry_date ) );
 	}
 
 	// Fall back to payment_expiry for backward compatibility
 	if ( ! purchase.payment_expiry ) {
 		return false;
 	}
-	return (
-		new Date( purchase.expiry_date ).getTime() >
-		getDateFromCreditCardExpiry( purchase.payment_expiry ).getTime()
+	return isAfter(
+		parseISO( purchase.expiry_date ),
+		getDateFromCreditCardExpiry( purchase.payment_expiry )
 	);
 }
 
@@ -176,14 +175,18 @@ export function creditCardHasAlreadyExpired( purchase: Purchase ): boolean {
 
 	// Use payment_expiry_date if available for more accurate expiry checking
 	if ( purchase.payment_expiry_date ) {
-		return new Date().getTime() > new Date( purchase.payment_expiry_date ).getTime();
+		// Compare current UTC date with payment expiry date (both YYYY-MM-DD in UTC)
+		return isAfter( startOfDay( new Date() ), parseISO( purchase.payment_expiry_date ) );
 	}
 
 	// Fall back to payment_expiry for backward compatibility
 	if ( ! purchase.payment_expiry ) {
 		return false;
 	}
-	return new Date().getTime() > getDateFromCreditCardExpiry( purchase.payment_expiry ).getTime();
+	return isAfter(
+		startOfDay( new Date() ),
+		getDateFromCreditCardExpiry( purchase.payment_expiry )
+	);
 }
 
 export function isTransferredOwnership(

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -129,7 +129,7 @@ export function isCloseToExpiration( purchase: Purchase ): boolean {
 }
 
 export function creditCardExpiresBeforeSubscription( purchase: Purchase ): boolean {
-	if ( 'credit_card' !== purchase.payment_type || ! purchase.payment_expiry ) {
+	if ( 'credit_card' !== purchase.payment_type ) {
 		return false;
 	}
 	// For 100 years plans, the credit card will probably always expire before
@@ -141,17 +141,27 @@ export function creditCardExpiresBeforeSubscription( purchase: Purchase ): boole
 	) {
 		return false;
 	}
-	if (
+
+	// Use payment_expiry_date if available for more accurate expiry checking
+	if ( purchase.payment_expiry_date ) {
+		return (
+			new Date( purchase.expiry_date ).getTime() >
+			new Date( purchase.payment_expiry_date ).getTime()
+		);
+	}
+
+	// Fall back to payment_expiry for backward compatibility
+	if ( ! purchase.payment_expiry ) {
+		return false;
+	}
+	return (
 		new Date( purchase.expiry_date ).getTime() >
 		getDateFromCreditCardExpiry( purchase.payment_expiry ).getTime()
-	) {
-		return true;
-	}
-	return false;
+	);
 }
 
 export function creditCardHasAlreadyExpired( purchase: Purchase ): boolean {
-	if ( 'credit_card' !== purchase.payment_type || ! purchase.payment_expiry ) {
+	if ( 'credit_card' !== purchase.payment_type ) {
 		return false;
 	}
 	// For 100 years plans, the credit card will probably always expire before
@@ -163,10 +173,17 @@ export function creditCardHasAlreadyExpired( purchase: Purchase ): boolean {
 	) {
 		return false;
 	}
-	if ( new Date().getTime() > getDateFromCreditCardExpiry( purchase.payment_expiry ).getTime() ) {
-		return true;
+
+	// Use payment_expiry_date if available for more accurate expiry checking
+	if ( purchase.payment_expiry_date ) {
+		return new Date().getTime() > new Date( purchase.payment_expiry_date ).getTime();
 	}
-	return false;
+
+	// Fall back to payment_expiry for backward compatibility
+	if ( ! purchase.payment_expiry ) {
+		return false;
+	}
+	return new Date().getTime() > getDateFromCreditCardExpiry( purchase.payment_expiry ).getTime();
 }
 
 export function isTransferredOwnership(

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -859,14 +859,14 @@ export function creditCardExpiresBeforeSubscription( purchase: Purchase ) {
 	if (
 		! isPaidWithCreditCard( purchase ) ||
 		! hasCreditCardData( purchase ) ||
-		! ( ! is100Year( purchase ) || isCloseToExpiration( purchase ) )
+		( is100Year( purchase ) && ! isCloseToExpiration( purchase ) )
 	) {
 		return false;
 	}
 
 	// Use paymentExpiryDate if available for more accurate expiry checking
 	if ( purchase.paymentExpiryDate ) {
-		return moment( purchase.paymentExpiryDate ).isBefore( purchase.expiryDate );
+		return moment( purchase.paymentExpiryDate ).isBefore( purchase.expiryDate, 'day' );
 	}
 
 	// Fall back to credit card expiry date for backward compatibility
@@ -880,17 +880,17 @@ export function creditCardHasAlreadyExpired( purchase: Purchase ) {
 		return false;
 	}
 
-	if ( ! ( ! is100Year( purchase ) || isCloseToExpiration( purchase ) ) ) {
+	if ( is100Year( purchase ) && ! isCloseToExpiration( purchase ) ) {
 		return false;
 	}
 
 	// Use paymentExpiryDate if available for more accurate expiry checking
 	if ( purchase.paymentExpiryDate ) {
-		return moment( purchase.paymentExpiryDate ).isBefore( moment() );
+		return moment( purchase.paymentExpiryDate ).isBefore( moment(), 'day' );
 	}
 
 	// Fall back to credit card expiry date for backward compatibility
-	return moment( creditCard.expiryDate, 'MM/YY' ).isBefore( moment.now(), 'months' );
+	return moment( creditCard.expiryDate, 'MM/YY' ).isBefore( moment(), 'months' );
 }
 
 export function shouldRenderExpiringCreditCard( purchase: Purchase ) {

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -856,24 +856,41 @@ export function canReenableAutoRenewal( purchase: Purchase ): boolean {
 export function creditCardExpiresBeforeSubscription( purchase: Purchase ) {
 	const creditCard = purchase?.payment?.creditCard;
 
-	return (
-		isPaidWithCreditCard( purchase ) &&
-		hasCreditCardData( purchase ) &&
-		( ! is100Year( purchase ) || isCloseToExpiration( purchase ) ) &&
-		moment( creditCard?.expiryDate, 'MM/YY' ).isBefore( purchase.expiryDate, 'months' )
-	);
+	if (
+		! isPaidWithCreditCard( purchase ) ||
+		! hasCreditCardData( purchase ) ||
+		! ( ! is100Year( purchase ) || isCloseToExpiration( purchase ) )
+	) {
+		return false;
+	}
+
+	// Use paymentExpiryDate if available for more accurate expiry checking
+	if ( purchase.paymentExpiryDate ) {
+		return moment( purchase.paymentExpiryDate ).isBefore( purchase.expiryDate );
+	}
+
+	// Fall back to credit card expiry date for backward compatibility
+	return moment( creditCard?.expiryDate, 'MM/YY' ).isBefore( purchase.expiryDate, 'months' );
 }
 
 export function creditCardHasAlreadyExpired( purchase: Purchase ) {
 	const creditCard = purchase?.payment?.creditCard;
 
-	return (
-		creditCard &&
-		isPaidWithCreditCard( purchase ) &&
-		hasCreditCardData( purchase ) &&
-		( ! is100Year( purchase ) || isCloseToExpiration( purchase ) ) &&
-		moment( creditCard.expiryDate, 'MM/YY' ).isBefore( moment.now(), 'months' )
-	);
+	if ( ! creditCard || ! isPaidWithCreditCard( purchase ) || ! hasCreditCardData( purchase ) ) {
+		return false;
+	}
+
+	if ( ! ( ! is100Year( purchase ) || isCloseToExpiration( purchase ) ) ) {
+		return false;
+	}
+
+	// Use paymentExpiryDate if available for more accurate expiry checking
+	if ( purchase.paymentExpiryDate ) {
+		return moment( purchase.paymentExpiryDate ).isBefore( moment() );
+	}
+
+	// Fall back to credit card expiry date for backward compatibility
+	return moment( creditCard.expiryDate, 'MM/YY' ).isBefore( moment.now(), 'months' );
 }
 
 export function shouldRenderExpiringCreditCard( purchase: Purchase ) {
@@ -887,6 +904,12 @@ export function shouldRenderExpiringCreditCard( purchase: Purchase ) {
 }
 
 export function monthsUntilCardExpires( purchase: Purchase ) {
+	// Use paymentExpiryDate if available for more accurate expiry checking
+	if ( purchase.paymentExpiryDate ) {
+		return moment( purchase.paymentExpiryDate ).diff( moment(), 'months' );
+	}
+
+	// Fall back to credit card expiry date for backward compatibility
 	const creditCard = purchase.payment.creditCard;
 	const expiry = moment( creditCard?.expiryDate, 'MM/YY' );
 	return expiry.diff( moment(), 'months' );

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -353,7 +353,18 @@ export interface Purchase {
 	payment_card_type: string | undefined;
 	payment_card_processor: string | undefined;
 	payment_details: string | undefined;
+
+	/**
+	 * The expiry date in MM/YY if the payment method has one.
+	 *
+	 * Use `payment_expiry_date` if possible as it will be more accurate.
+	 */
 	payment_expiry: string | undefined;
+
+	/**
+	 * The expiry date in ISO 8601 (YYYY-MM-DD) if the payment method has one.
+	 */
+	payment_expiry_date: string | undefined;
 
 	/**
 	 * True if this subscription can be upgraded to a different one.

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -23,6 +23,7 @@ export function createPurchaseObject( purchase: RawPurchase ): Purchase {
 		domainRegistrationAgreementUrl: purchase.domain_registration_agreement_url || null,
 		blogCreatedDate: purchase.blog_created_date,
 		expiryDate: purchase.expiry_date,
+		paymentExpiryDate: purchase.payment_expiry_date,
 		expiryStatus: snakeToCamelCase( purchase.expiry_status ),
 		iapPurchaseManagementLink: purchase.iap_purchase_management_link,
 		includedDomain: purchase.included_domain,

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -38,6 +38,12 @@ export interface Purchase {
 
 	domainRegistrationAgreementUrl: string | null;
 	expiryDate: string;
+
+	/**
+	 * The expiry date in ISO 8601 (YYYY-MM-DD) if the payment method has one.
+	 */
+	paymentExpiryDate: string | undefined;
+
 	expiryStatus: string;
 	iapPurchaseManagementLink: string | null;
 	id: number;
@@ -243,6 +249,11 @@ export interface PurchasePayment {
 	countryCode: string | undefined | null;
 	countryName: string | undefined;
 	storedDetailsId: string | number | undefined | null;
+	/**
+	 * The expiry date in MM/YY if the payment method has one.
+	 *
+	 * Use `paymentExpiryDate` on the Purchase if possible as it will be more accurate.
+	 */
 	expiryDate?: string;
 	creditCard?: PurchasePaymentCreditCard;
 	paymentPartner?: string;
@@ -257,6 +268,11 @@ export type PurchasePaymentWithPayPal = PurchasePayment & {
 	countryName: string | undefined;
 	storedDetailsId: string | number;
 	type: string;
+	/**
+	 * The expiry date in MM/YY if the payment method has one.
+	 *
+	 * Use `paymentExpiryDate` on the Purchase if possible as it will be more accurate.
+	 */
 	expiryDate: string;
 };
 
@@ -279,5 +295,10 @@ export interface PurchasePaymentCreditCard {
 	displayBrand: string | null;
 	processor: string;
 	number: string;
+	/**
+	 * The expiry date in MM/YY if the payment method has one.
+	 *
+	 * Use `paymentExpiryDate` on the Purchase if possible as it will be more accurate.
+	 */
 	expiryDate: string;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1578/credit-card-expiry-fields-past-2070-can-be-incorrectly-interpreted-in

Before             |  After
:-------------------------:|:-------------------------:
<img width="1075" height="420" alt="before-cc-date-fix" src="https://github.com/user-attachments/assets/7dabe8bf-9d53-4e88-9295-6bd99a9d7785" /> | <img width="1078" height="428" alt="after-cc-date-fix" src="https://github.com/user-attachments/assets/1c009de5-b86b-40c1-b7a1-9daa4c9d2d0e" />


## Proposed Changes

This PR modifies the code that deals with credit card expiration dates in the calypso and Multi Site Dashboard payment method management functions so that they rely on the `payment_expiry_date` property of the purchase data rather than the `payment_expiry` field. The latter is in the format `MM/YY` and the former is `YYYY-MM-DD` and therefore includes the millenium.

Depends on 201884-ghe-Automattic/wpcom which adds `payment_expiry_date`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current purchase data returned by the upgrades endpoints have `payment_expiry` but for a credit card this is formatted as `MM/YY` which can be ambiguous, especially as we start having expiration dates later than 2070 (see pNPgK-8es-p2). It would be better to use an unambiguous date.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Add a credit card to your account with an expiry date past 2070. Then assign it to an active subscription. You can do this all at the same time by using checkout with a test card.

Visit the purchase management pages `/me/purchases` for your account and view the subscription. Make sure that it doesn't say the payment method is expired.

Also check the purchase management pages in the Multi Site Dashboard (http://my.localhost:3000/me/billing/purchases/) for the same thing (note that these were not really broken to begin with but this should be more accurate).

See pNPgK-8es-p2 for a user which has a card like this already.