### PR TITLE
CIAB domains: Fix "Transfer to WordPress.com" link in the MSD dahboard

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -174,9 +174,6 @@ function UseMyDomain( props ) {
 			return wpcomAvailabilityErrors;
 		}
 
-		// `blog_id` is needed when a user arrives from a CIAB store, in which case `selectedSite` is not loaded yet
-		const blogId = selectedSite?.ID ?? getQueryArgs( stepLocation.search )?.blog_id;
-
 		const availabilityData = await wpcom
 			.domain( filteredDomainName )
 			.isAvailable( { apiVersion: '1.3', blog_id: selectedSiteId, is_cart_pre_check: false } );

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -173,9 +173,12 @@ function UseMyDomain( props ) {
 			return wpcomAvailabilityErrors;
 		}
 
+		// `blog_id` is needed when a user arrives from a CIAB store, in which case `selectedSite` is not loaded yet
+		const blogId = selectedSite?.ID ?? getQueryArgs( stepLocation.search )?.blog_id;
+
 		const availabilityData = await wpcom
 			.domain( filteredDomainName )
-			.isAvailable( { apiVersion: '1.3', blog_id: selectedSite?.ID, is_cart_pre_check: false } );
+			.isAvailable( { apiVersion: '1.3', blog_id: blogId, is_cart_pre_check: false } );
 
 		return {
 			availabilityData,

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -32,7 +32,7 @@ import wpcom from 'calypso/lib/wp';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { isUpdatingPrimaryDomain } from 'calypso/state/sites/domains/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import UseMyDomainInput from './domain-input';
 import DomainTransferOrConnect from './transfer-or-connect';
 
@@ -47,7 +47,6 @@ function UseMyDomain( props ) {
 		onTransfer,
 		dashboard,
 		selectedSite,
-		selectedSiteId,
 		transferDomainUrl,
 		initialMode,
 		onNextStep,
@@ -176,7 +175,7 @@ function UseMyDomain( props ) {
 
 		const availabilityData = await wpcom
 			.domain( filteredDomainName )
-			.isAvailable( { apiVersion: '1.3', blog_id: selectedSiteId, is_cart_pre_check: false } );
+			.isAvailable( { apiVersion: '1.3', blog_id: selectedSite?.ID, is_cart_pre_check: false } );
 
 		return {
 			availabilityData,
@@ -195,7 +194,6 @@ function UseMyDomain( props ) {
 		selectedSite,
 		registerNowAction,
 		dashboard,
-		selectedSiteId,
 	] );
 
 	const setTransferStepsAndLockStatus = useCallback(
@@ -508,6 +506,5 @@ export default connect( ( state ) => ( {
 	dashboard:
 		getDashboardFromString( getCurrentQueryArguments( state )?.dashboard?.toString() ) ?? undefined,
 	selectedSite: getSelectedSite( state ),
-	selectedSiteId: getSelectedSiteId( state ),
 	updatingPrimaryDomain: isUpdatingPrimaryDomain( state, getSelectedSite( state )?.ID ),
 } ) )( UseMyDomain );

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -32,7 +32,7 @@ import wpcom from 'calypso/lib/wp';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { isUpdatingPrimaryDomain } from 'calypso/state/sites/domains/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import UseMyDomainInput from './domain-input';
 import DomainTransferOrConnect from './transfer-or-connect';
 
@@ -47,6 +47,7 @@ function UseMyDomain( props ) {
 		onTransfer,
 		dashboard,
 		selectedSite,
+		selectedSiteId,
 		transferDomainUrl,
 		initialMode,
 		onNextStep,
@@ -178,7 +179,7 @@ function UseMyDomain( props ) {
 
 		const availabilityData = await wpcom
 			.domain( filteredDomainName )
-			.isAvailable( { apiVersion: '1.3', blog_id: blogId, is_cart_pre_check: false } );
+			.isAvailable( { apiVersion: '1.3', blog_id: selectedSiteId, is_cart_pre_check: false } );
 
 		return {
 			availabilityData,
@@ -197,6 +198,7 @@ function UseMyDomain( props ) {
 		selectedSite,
 		registerNowAction,
 		dashboard,
+		selectedSiteId,
 	] );
 
 	const setTransferStepsAndLockStatus = useCallback(
@@ -509,5 +511,6 @@ export default connect( ( state ) => ( {
 	dashboard:
 		getDashboardFromString( getCurrentQueryArguments( state )?.dashboard?.toString() ) ?? undefined,
 	selectedSite: getSelectedSite( state ),
+	selectedSiteId: getSelectedSiteId( state ),
 	updatingPrimaryDomain: isUpdatingPrimaryDomain( state, getSelectedSite( state )?.ID ),
 } ) )( UseMyDomain );

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -219,9 +219,6 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 						initialMode: 'transfer-domain',
 						dashboard: getCurrentDashboard(),
 						back_to: redirectToDashboardLink(),
-						// this is needed because when the user arrives on `/setup/domain/use-my-domain`,
-						// the `selectedSite` property is not loaded yet and there's no blog ID to check
-						blog_id: domain.blog_id.toString(),
 					};
 
 					if ( siteSlug ) {

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -6,6 +6,7 @@ import { useRouter } from '@tanstack/react-router';
 import { useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs } from '@wordpress/url';
 import { useMemo, Suspense, lazy } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import {
@@ -14,12 +15,12 @@ import {
 	domainContactInfoRoute,
 	domainConnectionSetupRoute,
 	domainTransferRoute,
-	domainTransferToAnyUserRoute,
 	domainTransferToOtherSiteRoute,
 	domainsContactInfoRoute,
 } from '../../app/router/domains';
 import { isDomainRenewable, canSetAsPrimary, getDomainRenewalUrl } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
+import { getCurrentDashboard, redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { AutoRenewModal } from './auto-renew-modal';
 import type { DomainSummary, Site, User } from '@automattic/api-core';
 import type { Action } from '@wordpress/dataviews';
@@ -212,13 +213,25 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				supportsBulk: false,
 				callback: ( items: DomainSummary[] ) => {
 					const domain = items[ 0 ];
+					const siteSlug = sitesByBlogId[ domain.blog_id ]?.slug ?? domain.site_slug;
+					const queryArgs: Record< string, string > = {
+						initialQuery: domain.domain,
+						initialMode: 'transfer-domain',
+						dashboard: getCurrentDashboard(),
+						back_to: redirectToDashboardLink(),
+						// this is needed because when the user arrives on `/setup/domain/use-my-domain`,
+						// the `selectedSite` property is not loaded yet and there's no blog ID to check
+						blog_id: domain.blog_id.toString(),
+					};
 
-					router.navigate( {
-						to: domainTransferToAnyUserRoute.fullPath,
-						params: {
-							domainName: domain.domain,
-						},
-					} );
+					if ( siteSlug ) {
+						queryArgs.siteSlug = siteSlug;
+					}
+
+					window.location.href = addQueryArgs(
+						wpcomLink( '/setup/domain/use-my-domain' ),
+						queryArgs
+					);
 				},
 				isEligible: ( item: DomainSummary ) => {
 					return isTransferrableToWpcom( item );

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -25,8 +25,9 @@ import {
 	persistSignupDestination,
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
-import { useDispatch as useReduxDispatch } from 'calypso/state';
+import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import { useQuery } from '../../../hooks/use-query';
 import { useSiteData } from '../../../hooks/use-site-data';
 import { ONBOARD_STORE } from '../../../stores';
@@ -61,12 +62,16 @@ const domain: FlowV2< typeof initialize > = {
 	initialize,
 	useAssertConditions() {
 		const { site, siteSlug } = useSiteData();
+		const selectedSite = useSelector( getSelectedSite );
 
 		if ( ! siteSlug ) {
 			return { state: AssertConditionState.SUCCESS };
 		}
 
-		return { state: site ? AssertConditionState.SUCCESS : AssertConditionState.CHECKING };
+		// We want to render the step only if the site and selected site are in the Redux store
+		return {
+			state: site && selectedSite ? AssertConditionState.SUCCESS : AssertConditionState.CHECKING,
+		};
 	},
 	useStepNavigation( currentStepSlug, navigate ) {
 		const {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMAINS-2031](https://linear.app/a8c/issue/DOMAINS-2031)

## Proposed Changes

This PR fixes the "Transfer to WordPress.com" menu link for domains connected to a site in MSD/CIAB.

### Screenshots

- Menu location

<img width="1400" height="1031" alt="Screenshot 2026-01-29 at 18 02 10" src="https://github.com/user-attachments/assets/2b49a512-23d0-4b3f-a5f7-22f7b2bef436" />

| Destination before | Destination after |
| --- | --- |
| <img width="1400" height="1031" alt="Screenshot 2026-01-29 at 18 03 45" src="https://github.com/user-attachments/assets/f03ff269-82da-4526-bb35-3526a182993a" /> | <img width="1400" height="1031" alt="Screenshot 2026-01-29 at 18 05 49" src="https://github.com/user-attachments/assets/6d2fff5e-f8e1-4137-ac5c-b9b9c568c411" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The link previously took users to the "Transfer to another user" page, which is incorrect. Now it takes users to the "Use a domain I own" page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the live Calypso link or build this branch locally
- Open the domains list page for a site in MSD/CIAB
  - Choose a site that has a domain connection
- Click on the "Transfer to WordPress.com" menu item
- Ensure you are redirected to the "Use a domain I own" Calypso page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
