### PR TITLE
Plans grid: adjust the tooltip height and fix widows

### DIFF
--- a/packages/plans-grid-next/src/components/plans-2023-tooltip.tsx
+++ b/packages/plans-grid-next/src/components/plans-2023-tooltip.tsx
@@ -4,6 +4,19 @@ import { TranslateResult } from 'i18n-calypso';
 import { Dispatch, PropsWithChildren, SetStateAction, useRef } from 'react';
 import { hasTouch } from '../lib/touch-detect';
 
+/**
+ * Prevents widows by replacing the last space with a non-breaking space.
+ * @param text - The text to process
+ * @returns The text with the last space replaced with a non-breaking space
+ */
+const preventWidows = ( text: TranslateResult ): TranslateResult => {
+	if ( typeof text !== 'string' ) {
+		return text;
+	}
+	// Replace the last space with a non-breaking space to prevent widows
+	return text.replace( /\s+(\S+)$/, '\u00A0$1' );
+};
+
 const HoverAreaContainer = styled.span``;
 
 const StyledTooltip = styled( Tooltip )`
@@ -11,7 +24,7 @@ const StyledTooltip = styled( Tooltip )`
 		background: var( --color-masterbar-background );
 		text-align: start;
 		border-radius: 4px;
-		min-height: 32px;
+		min-height: 16px;
 		width: 210px;
 		align-items: center;
 		font-style: normal;
@@ -56,6 +69,7 @@ export const Plans2023Tooltip = ( {
 	};
 
 	const isVisible = activeTooltipId === id;
+	const processedText = preventWidows( text );
 
 	return (
 		<>
@@ -76,7 +90,7 @@ export const Plans2023Tooltip = ( {
 				hideArrow
 				showOnMobile={ showOnMobile }
 			>
-				{ text }
+				{ processedText }
 			</StyledTooltip>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15842

## Proposed Changes

* Reduce the minimal height for the tooltip to accommodate shorter strings.
* Handle widows in tooltips by keeping the last two words together.

|Before|After|
|---|---|
|<img width="266" height="96" alt="Screenshot 2026-01-30 at 00 13 47" src="https://github.com/user-attachments/assets/48c2b55f-3fd6-42c8-988d-1acec21d7ad6" /><img width="266" height="96" alt="Screenshot 2026-01-30 at 00 12 53" src="https://github.com/user-attachments/assets/6e30fd95-0f6c-49f4-8cd9-4eb07163effa" />|<img width="266" height="96" alt="Screenshot 2026-01-30 at 00 11 53" src="https://github.com/user-attachments/assets/2fb18eb4-9ff8-4454-843d-e6611de8b20c" /><img width="266" height="96" alt="Screenshot 2026-01-30 at 00 13 02" src="https://github.com/user-attachments/assets/d7bcb913-50c7-4053-b552-d4c30ce5ca1e" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Based on the feedback from the CfT.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plans/{your site} and check the tooltip appearance.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
