### PR TITLE
MSD: Add test for empty Site List

### DIFF
--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -62,10 +62,24 @@ describe( 'Sites', () => {
 		expect( await screen.findByRole( 'button', { name: 'Add new site' } ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders DataViews', async () => {
+	it( 'renders empty state when the user has no sites', async () => {
 		render( <Sites />, {
 			user: {
-				site_count: 13, // to force the table layout
+				site_count: 0,
+			} as User,
+		} );
+
+		expect(
+			await screen.findByRole( 'heading', { name: /You don.t have any sites yet/ } )
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Create a site' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders DataViews when the user has sites', async () => {
+		render( <Sites />, {
+			user: {
+				site_count: 13, // more than 12 sites to force the table layout
 			} as User,
 		} );
 

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -59,7 +59,7 @@ describe( 'Sites', () => {
 	it( 'renders Add new site button', async () => {
 		render( <Sites /> );
 
-		expect( await screen.findByRole( 'button', { name: 'Add new site' } ) ).toBeInTheDocument();
+		expect( await screen.findByRole( 'button', { name: 'Add new site' } ) ).toBeVisible();
 	} );
 
 	it( 'renders empty state when the user has no sites', async () => {
@@ -71,8 +71,8 @@ describe( 'Sites', () => {
 
 		expect(
 			await screen.findByRole( 'heading', { name: /You don.t have any sites yet/ } )
-		).toBeInTheDocument();
-		expect( screen.getByRole( 'link', { name: 'Create a site' } ) ).toBeInTheDocument();
+		).toBeVisible();
+		expect( screen.getByRole( 'link', { name: 'Create a site' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
 	} );
 


### PR DESCRIPTION
Part of DOTMSD-1069

## Proposed Changes

Add test for empty site list state introduced by https://github.com/Automattic/wp-calypso/pull/107909

## Why are these changes being made?

Adding test to increase confidence.

## Testing Instructions

Verify PR pases CI.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
