### PR TITLE
Sites: Update the empty state for search results

### DIFF
--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -16,7 +16,13 @@ function EmptyState( { children }: { children?: ReactNode } ) {
 	);
 }
 
-function EmptyStateWrapper( { children }: { children: ReactNode } ) {
+function EmptyStateWrapper( {
+	isBorderless = false,
+	children,
+}: {
+	isBorderless?: boolean;
+	children: ReactNode;
+} ) {
 	const cardRef = useRef< HTMLElement >( null );
 
 	// Calculate the vertical offset once on mount to set a consistent min-height.
@@ -31,7 +37,7 @@ function EmptyStateWrapper( { children }: { children: ReactNode } ) {
 	}, [] );
 
 	return (
-		<Card ref={ cardRef } className="dashboard-empty-state__wrapper">
+		<Card ref={ cardRef } className="dashboard-empty-state__wrapper" isBorderless={ isBorderless }>
 			<CardBody>
 				<VStack spacing={ 8 } alignment="center" className="dashboard-empty-state__wrapper-content">
 					{ children }

--- a/client/dashboard/sites/empty-sites-state/index.tsx
+++ b/client/dashboard/sites/empty-sites-state/index.tsx
@@ -8,12 +8,21 @@ import { useAnalytics } from '../../app/analytics';
 import EmptyState from '../../components/empty-state';
 import OfferCard from '../../components/offer-card';
 import { wpcomLink } from '../../utils/link';
+import type { ReactNode } from 'react';
 
 const CONTEXT = 'dashboard-sites';
 const EMPTY_STATE_REF = 'dashboard-sites-empty-state';
 const EMPTY_STATE_CTA_ID = 'dashboard-sites-empty-state';
 
-export default function EmptySitesState() {
+export default function EmptySitesState( {
+	title,
+	description,
+	isBorderless,
+}: {
+	title: string;
+	description: ReactNode;
+	isBorderless?: boolean;
+} ) {
 	const { recordTracksEvent } = useAnalytics();
 
 	const trackEmptyStateActionClick = ( action: string ) => {
@@ -43,13 +52,11 @@ export default function EmptySitesState() {
 	};
 
 	return (
-		<EmptyState.Wrapper>
+		<EmptyState.Wrapper isBorderless={ isBorderless }>
 			<EmptyState>
 				<EmptyState.Header>
-					<EmptyState.Title>{ __( 'You don’t have any sites yet' ) }</EmptyState.Title>
-					<EmptyState.Description>
-						{ __( 'Start a site and begin creating, coding, or exploring what WordPress can do.' ) }
-					</EmptyState.Description>
+					<EmptyState.Title>{ title }</EmptyState.Title>
+					<EmptyState.Description>{ description }</EmptyState.Description>
 				</EmptyState.Header>
 				<EmptyState.Content>
 					<EmptyState.ActionList>

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -6,10 +6,9 @@ import {
 	useSuspenseQuery,
 	keepPreviousData,
 } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
 import { Button, Modal } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { getISOWeek, getISOWeekYear } from 'date-fns';
 import deepmerge from 'deepmerge';
 import { useState, useEffect } from 'react';
@@ -19,7 +18,6 @@ import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
 import { sitesRoute } from '../app/router/sites';
-import { DataViewsEmptyState } from '../components/dataviews';
 import OptInSurvey from '../components/opt-in-survey';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
@@ -35,7 +33,6 @@ import {
 } from './dataviews';
 import EmptySitesState from './empty-sites-state';
 import { InviteAcceptedFlashMessage } from './invite-accepted-flash-message';
-import noSitesIllustration from './no-sites-illustration.svg';
 import { SitesNotices } from './notices';
 import { OptInWelcomeModal } from './welcome-modal';
 import type {
@@ -183,7 +180,6 @@ function filterSortAndPaginateSites( sites: Site[], view: View, totalItems: numb
 
 export default function Sites() {
 	const { recordTracksEvent } = useAnalytics();
-	const navigate = useNavigate( { from: sitesRoute.fullPath } );
 	const queryClient = useQueryClient();
 	const currentSearchParams = sitesRoute.useSearch();
 	const isRestoringAccount = !! currentSearchParams.restored;
@@ -228,24 +224,7 @@ export default function Sites() {
 		updateView( nextView );
 	};
 
-	const hasFilterOrSearch = ( view.filters && view.filters.length > 0 ) || view.search;
-
-	const emptyTitle = hasFilterOrSearch ? __( 'No sites found' ) : __( 'No sites' );
-
 	const userHasNoSites = user.site_count === 0;
-
-	let emptyDescription = __( 'Get started by creating a new site.' );
-	if ( view.search ) {
-		emptyDescription = sprintf(
-			// Translators: %s is the search term used when looking for sites by title or domain name.
-			__(
-				'Your search for “%s” did not match any sites. Try searching by the site title or domain name.'
-			),
-			view.search
-		);
-	} else if ( hasFilterOrSearch ) {
-		emptyDescription = __( 'Your search did not match any sites.' );
-	}
 
 	useEffect( () => {
 		if ( sites ) {
@@ -260,37 +239,6 @@ export default function Sites() {
 	const { data: filteredData, paginationInfo } = isEnabled( 'dashboard/v2/paginated-site-list' )
 		? filterSortAndPaginateSites( sites ?? [], view, totalItems ?? 0 )
 		: filterSortAndPaginate( sites ?? [], view, fields );
-
-	const emptyState = (
-		<DataViewsEmptyState
-			title={ emptyTitle }
-			description={ emptyDescription }
-			illustration={ <img src={ noSitesIllustration } alt="" width={ 408 } height={ 280 } /> }
-			actions={
-				<>
-					{ view.search && (
-						<Button
-							__next40pxDefaultSize
-							variant="secondary"
-							onClick={ () => {
-								navigate( {
-									search: {
-										...currentSearchParams,
-										search: undefined,
-									},
-								} );
-							} }
-						>
-							{ __( 'Clear search' ) }
-						</Button>
-					) }
-					<Button __next40pxDefaultSize variant="primary" onClick={ () => setIsModalOpen( true ) }>
-						{ __( 'Add new site' ) }
-					</Button>
-				</>
-			}
-		/>
-	);
 
 	return (
 		<>
@@ -333,13 +281,24 @@ export default function Sites() {
 						actions={ actions }
 						isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
 						isPlaceholderData={ isPlaceholderData }
-						empty={ emptyState }
+						empty={
+							<EmptySitesState
+								title={ __( 'No sites match your search' ) }
+								description={ __( 'Try again, or start a new site with the options below.' ) }
+								isBorderless
+							/>
+						}
 						paginationInfo={ paginationInfo }
 						onChangeView={ handleViewChange }
 						onResetView={ resetView }
 					/>
 				) : (
-					<EmptySitesState />
+					<EmptySitesState
+						title={ __( 'You don’t have any sites yet' ) }
+						description={ __(
+							'Start a site and begin creating, coding, or exploring what WordPress can do.'
+						) }
+					/>
 				) }
 			</PageLayout>
 			{ /* ExPlat's Evergreen A/A Test Experiment:


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-1068

## Proposed Changes

* Update the EmptyState when there are no values return from the search.
* TODO: Confirm the actions

<img width="725" height="607" alt="image" src="https://github.com/user-attachments/assets/ebf9f020-14bd-445a-9015-e0c618870ea9" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the experience of the empty state

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Search any keyword until there is no result
* Ensure the empty search state is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
