### PR TITLE
MSD Domains: Update the empty state for search results

### DIFF
--- a/client/dashboard/components/empty-state/index.tsx
+++ b/client/dashboard/components/empty-state/index.tsx
@@ -16,7 +16,13 @@ function EmptyState( { children }: { children?: ReactNode } ) {
 	);
 }
 
-function EmptyStateWrapper( { children }: { children: ReactNode } ) {
+function EmptyStateWrapper( {
+	isBorderless = false,
+	children,
+}: {
+	isBorderless?: boolean;
+	children: ReactNode;
+} ) {
 	const cardRef = useRef< HTMLElement >( null );
 
 	// Calculate the vertical offset once on mount to set a consistent min-height.
@@ -31,7 +37,7 @@ function EmptyStateWrapper( { children }: { children: ReactNode } ) {
 	}, [] );
 
 	return (
-		<Card ref={ cardRef } className="dashboard-empty-state__wrapper">
+		<Card ref={ cardRef } className="dashboard-empty-state__wrapper" isBorderless={ isBorderless }>
 			<CardBody>
 				<VStack spacing={ 8 } alignment="center" className="dashboard-empty-state__wrapper-content">
 					{ children }

--- a/client/dashboard/domains/empty-domains-state/index.tsx
+++ b/client/dashboard/domains/empty-domains-state/index.tsx
@@ -3,10 +3,20 @@ import { __ } from '@wordpress/i18n';
 import { Icon, search, globe } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
 import EmptyState from '../../components/empty-state';
-import OfferCard from '../../components/offer-card';
 import { wpcomLink } from '../../utils/link';
+import type { ReactNode } from 'react';
 
-export default function EmptyDomainsState() {
+export default function EmptyDomainsState( {
+	title,
+	description,
+	isBorderless,
+	children,
+}: {
+	title: string;
+	description: ReactNode;
+	isBorderless?: boolean;
+	children?: ReactNode;
+} ) {
 	const { recordTracksEvent } = useAnalytics();
 
 	const trackEmptyStateActionClick = ( action: string ) => {
@@ -23,18 +33,12 @@ export default function EmptyDomainsState() {
 		trackEmptyStateActionClick( 'transfer-domain' );
 	};
 
-	const handleOfferClick = () => {
-		trackEmptyStateActionClick( 'offer' );
-	};
-
 	return (
-		<EmptyState.Wrapper>
+		<EmptyState.Wrapper isBorderless={ isBorderless }>
 			<EmptyState>
 				<EmptyState.Header>
-					<EmptyState.Title>{ __( 'Add your first domain name' ) }</EmptyState.Title>
-					<EmptyState.Description>
-						{ __( 'Establish a unique online identity for your site.' ) }
-					</EmptyState.Description>
+					<EmptyState.Title>{ title }</EmptyState.Title>
+					<EmptyState.Description>{ description }</EmptyState.Description>
 				</EmptyState.Header>
 				<EmptyState.Content>
 					<EmptyState.ActionList>
@@ -73,7 +77,7 @@ export default function EmptyDomainsState() {
 							}
 						/>
 					</EmptyState.ActionList>
-					<OfferCard onClick={ handleOfferClick } />
+					{ children }
 				</EmptyState.Content>
 			</EmptyState>
 		</EmptyState.Wrapper>

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -3,11 +3,13 @@ import { domainsQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../app/analytics';
 import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
 import { domainsIndexRoute } from '../app/router/domains';
 import { DataViews, DataViewsCard } from '../components/dataviews';
+import OfferCard from '../components/offer-card';
 import { OptInWelcome } from '../components/opt-in-welcome';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
@@ -38,6 +40,7 @@ const defaultView = {
 };
 
 function Domains() {
+	const { recordTracksEvent } = useAnalytics();
 	const { user } = useAuth();
 	const { queries } = useAppContext();
 	const fields = useFields( { showPrimaryDomainBadge: false } );
@@ -82,7 +85,18 @@ function Domains() {
 			}
 		>
 			{ ! hasDomains ? (
-				<EmptyDomainsState />
+				<EmptyDomainsState
+					title={ __( 'Add your first domain name' ) }
+					description={ __( 'Establish a unique online identity for your site.' ) }
+				>
+					<OfferCard
+						onClick={ () =>
+							recordTracksEvent( 'calypso_domains_dashboard_empty_state_action_click', {
+								action: 'offer',
+							} )
+						}
+					/>
+				</EmptyDomainsState>
 			) : (
 				<DataViewsCard>
 					<DataViews< DomainSummary >
@@ -96,6 +110,13 @@ function Domains() {
 						paginationInfo={ paginationInfo }
 						getItemId={ getDomainId }
 						defaultLayouts={ DEFAULT_LAYOUTS }
+						empty={
+							<EmptyDomainsState
+								title={ __( 'No domains match your search' ) }
+								description={ __( 'Try again, or add a new domain with the options below.' ) }
+								isBorderless
+							/>
+						}
 					/>
 				</DataViewsCard>
 			) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTMSD-1067

## Proposed Changes

* Update the EmptyState when there are no values return from the search

<img width="736" height="355" alt="image" src="https://github.com/user-attachments/assets/f7d6e231-9942-4617-90af-c79fab572dc0" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the experience of the empty state

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains
* Search any keyword until there is no result
* Ensure the empty search state is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
