### PR TITLE
MSD: guard missing site.slug when current user can't manage site

### DIFF
--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -6,6 +6,12 @@ import { isCommerceGarden, isSelfHostedJetpackConnected, isP2 } from '../utils/s
 import type { Site, User } from '@automattic/api-core';
 
 export function canManageSite( site: Site ) {
+	// Edge case: slug can be missing when the current user does not have
+	// permission to manage the site.
+	if ( ! site.slug ) {
+		return false;
+	}
+
 	if ( site.is_deleted || ! site.capabilities?.manage_options ) {
 		return false;
 	}

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -1,5 +1,4 @@
 import { domainSuggestionsQuery, siteCurrentPlanQuery } from '@automattic/api-queries';
-import { captureException } from '@automattic/calypso-sentry';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalText as Text } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -23,14 +22,7 @@ const requiresPlanUpgrade = ( site: Site ) => {
 };
 
 const useDomainSuggestion = ( site: Site ) => {
-	// Temporary debugging. See: https://github.com/Automattic/wp-calypso/pull/108256
-	if ( site.slug === undefined ) {
-		captureException( new Error( 'site.slug is undefined in useDomainSuggestion()' ), {
-			extra: { site },
-		} );
-	}
-
-	const search = site.slug?.split( '.' )[ 0 ] ?? '';
+	const search = site.slug.split( '.' )[ 0 ];
 	const { data: allDomainSuggestions } = useQuery(
 		domainSuggestionsQuery( search, {
 			vendor: 'domain-upsell',


### PR DESCRIPTION
Fixes DOTMSD-1029

## Proposed Changes

I have been investigating this Sentry case, with the help of https://github.com/Automattic/wp-calypso/pull/108256. If you see some sample Sentry events that were triggered, the site object indeed does not have the `slug` field in the response.

After some intense debugging session with Claude, the `/rest/v1.1/sites/:siteSlug` can be accessed without a valid token (try it on incognito!) It will return [no_member_fields](https://github.com/Automattic/jetpack/blob/ff0c0c478d34ae5137fb19a5f6bc3bec80f18939/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php#L110) which does not include the `slug` field.

So, I believe what happened is that somehow, the browser tries to open a site overview page with an expired token. I have not been able to reproduce this to be honest; I tried clearing my cookies but the site immediately went to reauth-required screen. Maybe a race condition / SSR or something? In any case, I think this change is pretty harmless 😄 

## Why are these changes being made?

Fixing a bug.

## Testing Instructions

Go to `/sites/:siteSlug`; verify no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
