### PR TITLE
Replace moment library in advertising section for showing credits data

### DIFF
--- a/client/my-sites/promote-post-i2/hooks/use-credit-expiration-lines.ts
+++ b/client/my-sites/promote-post-i2/hooks/use-credit-expiration-lines.ts
@@ -1,7 +1,16 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
 import { ReactNode, useMemo } from 'react';
+
+function formatExpirationDate( expires: string, shortText: boolean, locale: string ): string {
+	const date = new Date( expires );
+	if ( isNaN( date.getTime() ) ) {
+		return expires;
+	}
+	const dateStyle = shortText ? 'short' : 'long';
+	return new Intl.DateTimeFormat( locale, { dateStyle } ).format( date );
+}
 
 /**
  * Custom hook to get formatted expiration lines for credits
@@ -11,6 +20,7 @@ export const useCreditExpirationLines = (
 	shortText: boolean
 ): ReactNode[] | null => {
 	const translate = useTranslate();
+	const locale = useLocale();
 
 	return useMemo( () => {
 		if ( ! sortedHistory || sortedHistory.length === 0 ) {
@@ -19,7 +29,7 @@ export const useCreditExpirationLines = (
 
 		if ( sortedHistory.length === 1 ) {
 			const firstItem = sortedHistory[ 0 ];
-			const firstDate = moment( firstItem.expires ).format( shortText ? 'L' : 'LL' );
+			const firstDate = formatExpirationDate( firstItem.expires, shortText, locale );
 			const firstAmount = formatCurrency( firstItem.amount, 'USD', { isSmallestUnit: true } );
 
 			return [
@@ -32,7 +42,7 @@ export const useCreditExpirationLines = (
 		const header = translate( 'You have several credit assignations:' );
 		const items = sortedHistory.map( ( item ) => {
 			const amount = formatCurrency( item.amount, 'USD', { isSmallestUnit: true } );
-			const date = moment( item.expires ).format( shortText ? 'L' : 'LL' );
+			const date = formatExpirationDate( item.expires, shortText, locale );
 			return shortText
 				? translate( '%(amount)s expiring on %(date)s', {
 						args: { amount, date },
@@ -43,5 +53,5 @@ export const useCreditExpirationLines = (
 		} );
 
 		return [ header, ...items ];
-	}, [ sortedHistory, shortText, translate ] );
+	}, [ sortedHistory, shortText, translate, locale ] );
 };


### PR DESCRIPTION
## Proposed Changes

* Replace moment lib used when obtaining the expiring date to just INTL.date

## Why are these changes being made?
- It seems we cannot use F,j, Y as formats when loading calypso in Jetpack. There is some kind of replacement done that only affects EN-US users. Other translations are unaffected.

-  I believe the root cause is in script-loader.php’s wp_default_packages_vendor, where WordPress sets `'LL' => get_option( 'date_format', __( 'F j, Y' ) )`, injecting a PHP format string into moment’s longDateFormat. I haven’t managed to reproduce this locally, so I’m switching to Intl.DateTimeFormat to remove the moment dependency.


## Testing Instructions
- Assign yourself some credits, including some credits that would expire soon. Ask me with your wpcom_id in slack if you need those assignments and I'll add them for you
- Gio to the [advertising](http://calypso.localhost:3000/advertising/javiolmo89.wordpress.com) section and check the credits. It might take a few mins to appear

<img width="1559" height="275" alt="image" src="https://github.com/user-attachments/assets/5d51018e-1b01-497f-991d-1be94af22ee7" />

It should still look correctly formatted for EN-US. 

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
