### PR TITLE
Remove Summer Special: Gated Backups restore and scan to Business plans

### DIFF
--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -1,4 +1,4 @@
-import { WPCOM_FEATURES_BACKUPS_RESTORE } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_BACKUPS_SELF_SERVE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { CompactCard, Dialog } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -214,7 +214,7 @@ export default function WPCOMBusinessAT( {
 
 	// Check if the site has the backup restore feature
 	const hasBackupFeature = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_RESTORE )
+		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_SELF_SERVE )
 	);
 
 	useEffect( () => {

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -1,16 +1,16 @@
-import { WPCOM_FEATURES_BACKUPS } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_BACKUPS_RESTORE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { CompactCard, Dialog } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import {
-	hasBlockingHold as hasBlockingHoldFunc,
+	default as HoldList,
 	getBlockingMessages,
 	HardBlockingNotice,
-	default as HoldList,
+	hasBlockingHold as hasBlockingHoldFunc,
 } from 'calypso/blocks/eligibility-warnings/hold-list';
 import WarningList from 'calypso/blocks/eligibility-warnings/warning-list';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -31,10 +31,10 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import {
-	getAutomatedTransferStatus,
-	isEligibleForAutomatedTransfer,
-	getEligibility,
 	EligibilityData,
+	getAutomatedTransferStatus,
+	getEligibility,
+	isEligibleForAutomatedTransfer,
 } from 'calypso/state/automated-transfer/selectors';
 import { autoConfigCredentials } from 'calypso/state/jetpack/credentials/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -212,9 +212,9 @@ export default function WPCOMBusinessAT( {
 			null === getFeaturesBySiteId( state, siteId ) && ! isRequestingSiteFeatures( state, siteId )
 	);
 
-	// Check if the site has the backup feature
+	// Check if the site has the backup restore feature
 	const hasBackupFeature = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS )
+		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_RESTORE )
 	);
 
 	useEffect( () => {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -202,7 +202,7 @@ export const siteOverviewRoute = createRoute( {
 			if ( hasHostingFeature( site, HostingFeatures.SCAN ) ) {
 				queryClient.prefetchQuery( siteScanQuery( site.ID ) );
 			}
-			if ( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ) {
+			if ( hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE ) ) {
 				queryClient.prefetchQuery( siteLastBackupQuery( site.ID ) );
 			}
 			if ( site.is_a4a_dev_site ) {
@@ -447,7 +447,7 @@ export const siteBackupsRoute = createRoute( {
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		// Preload activity log backup-related entries and group counts.
-		if ( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ) {
+		if ( hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE ) ) {
 			queryClient.prefetchQuery( siteBackupActivityLogEntriesQuery( site.ID ) );
 			queryClient.prefetchQuery( siteBackupActivityLogGroupCountsQuery( site.ID ) );
 		}

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -202,7 +202,7 @@ export const siteOverviewRoute = createRoute( {
 			if ( hasHostingFeature( site, HostingFeatures.SCAN ) ) {
 				queryClient.prefetchQuery( siteScanQuery( site.ID ) );
 			}
-			if ( hasHostingFeature( site, HostingFeatures.BACKUPS ) ) {
+			if ( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ) {
 				queryClient.prefetchQuery( siteLastBackupQuery( site.ID ) );
 			}
 			if ( site.is_a4a_dev_site ) {
@@ -447,7 +447,7 @@ export const siteBackupsRoute = createRoute( {
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		// Preload activity log backup-related entries and group counts.
-		if ( hasHostingFeature( site, HostingFeatures.BACKUPS ) ) {
+		if ( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ) {
 			queryClient.prefetchQuery( siteBackupActivityLogEntriesQuery( site.ID ) );
 			queryClient.prefetchQuery( siteBackupActivityLogGroupCountsQuery( site.ID ) );
 		}

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -132,7 +132,7 @@ export function BackupsListPage() {
 	};
 	const columns = isSmallViewport ? 1 : 2;
 
-	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS );
+	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE );
 
 	const handleBackupSelection = ( backup: ActivityLogEntry | null ) => {
 		setSelectedBackup( backup );
@@ -269,7 +269,7 @@ function SiteBackups() {
 	return (
 		<HostingFeatureGatedWithCallout
 			site={ site }
-			feature={ HostingFeatures.BACKUPS }
+			feature={ HostingFeatures.BACKUPS_RESTORE }
 			fullPage
 			upsellId="site-backups"
 			upsellIcon={ backup }

--- a/client/dashboard/sites/backups/index.tsx
+++ b/client/dashboard/sites/backups/index.tsx
@@ -132,7 +132,7 @@ export function BackupsListPage() {
 	};
 	const columns = isSmallViewport ? 1 : 2;
 
-	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE );
+	const hasBackups = hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
 
 	const handleBackupSelection = ( backup: ActivityLogEntry | null ) => {
 		setSelectedBackup( backup );
@@ -269,7 +269,7 @@ function SiteBackups() {
 	return (
 		<HostingFeatureGatedWithCallout
 			site={ site }
-			feature={ HostingFeatures.BACKUPS_RESTORE }
+			feature={ HostingFeatures.BACKUPS_SELF_SERVE }
 			fullPage
 			upsellId="site-backups"
 			upsellIcon={ backup }

--- a/client/dashboard/sites/backups/test/index.test.tsx
+++ b/client/dashboard/sites/backups/test/index.test.tsx
@@ -82,7 +82,7 @@ const mockSite: Site = {
 	plan: {
 		expired: false,
 		features: {
-			active: [ HostingFeatures.BACKUPS_RESTORE ],
+			active: [ HostingFeatures.BACKUPS_SELF_SERVE ],
 		},
 	},
 	is_wpcom_atomic: true,

--- a/client/dashboard/sites/backups/test/index.test.tsx
+++ b/client/dashboard/sites/backups/test/index.test.tsx
@@ -82,7 +82,7 @@ const mockSite: Site = {
 	plan: {
 		expired: false,
 		features: {
-			active: [ HostingFeatures.BACKUPS ],
+			active: [ HostingFeatures.BACKUPS_RESTORE ],
 		},
 	},
 	is_wpcom_atomic: true,

--- a/client/dashboard/sites/hosting-feature-list/index.tsx
+++ b/client/dashboard/sites/hosting-feature-list/index.tsx
@@ -26,7 +26,7 @@ export default function HostingFeatureList( { site }: { site: Site } ) {
 			text: __( 'Advanced server settings' ),
 		},
 		{
-			feature: HostingFeatures.BACKUPS_RESTORE,
+			feature: HostingFeatures.BACKUPS_SELF_SERVE,
 			text: __( 'Backup and restore' ),
 		},
 		{

--- a/client/dashboard/sites/hosting-feature-list/index.tsx
+++ b/client/dashboard/sites/hosting-feature-list/index.tsx
@@ -26,7 +26,7 @@ export default function HostingFeatureList( { site }: { site: Site } ) {
 			text: __( 'Advanced server settings' ),
 		},
 		{
-			feature: HostingFeatures.BACKUPS,
+			feature: HostingFeatures.BACKUPS_RESTORE,
 			text: __( 'Backup and restore' ),
 		},
 		{

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -104,7 +104,7 @@ export default function BackupCard( { site }: { site: Site } ) {
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }
-			feature={ HostingFeatures.BACKUPS }
+			feature={ HostingFeatures.BACKUPS_RESTORE }
 			featureIcon={ CARD_PROPS.icon }
 			upsellId={ CARD_PROPS.tracksId }
 			upsellFeatureId="site-backups"

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -104,7 +104,7 @@ export default function BackupCard( { site }: { site: Site } ) {
 	return (
 		<HostingFeatureGatedWithOverviewCard
 			site={ site }
-			feature={ HostingFeatures.BACKUPS_RESTORE }
+			feature={ HostingFeatures.BACKUPS_SELF_SERVE }
 			featureIcon={ CARD_PROPS.icon }
 			upsellId={ CARD_PROPS.tracksId }
 			upsellFeatureId="site-backups"

--- a/client/dashboard/sites/overview-backup-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-backup-card/test/index.test.tsx
@@ -21,7 +21,7 @@ const mockSite: Site = {
 	ID: mockSiteId,
 	plan: {
 		features: {
-			active: [ HostingFeatures.BACKUPS ],
+			active: [ HostingFeatures.BACKUPS_RESTORE ],
 		},
 	},
 	is_wpcom_atomic: true,

--- a/client/dashboard/sites/overview-backup-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-backup-card/test/index.test.tsx
@@ -21,7 +21,7 @@ const mockSite: Site = {
 	ID: mockSiteId,
 	plan: {
 		features: {
-			active: [ HostingFeatures.BACKUPS_RESTORE ],
+			active: [ HostingFeatures.BACKUPS_SELF_SERVE ],
 		},
 	},
 	is_wpcom_atomic: true,

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -21,7 +21,14 @@ const site = {
 		product_name_short: 'Business',
 		is_free: false,
 		features: {
-			active: [ 'atomic', 'backups', 'scan', 'performance', 'full-activity-log' ],
+			active: [
+				'atomic',
+				'backups',
+				'backups-self-serve',
+				'scan',
+				'performance',
+				'full-activity-log',
+			],
 		},
 	},
 	options: {
@@ -207,12 +214,19 @@ describe( '<SiteOverview>', () => {
 		expect( getCard( 'Visibility' ) ).toBeVisible();
 	} );
 
-	test( 'renders the overview of a self-hosted Jetpack connected site', async () => {
+	test( 'renders the overview of a self-hosted free Jetpack connected site', async () => {
 		mockSite( {
 			...site,
 			jetpack: true,
 			jetpack_connection: true,
 			is_wpcom_atomic: false,
+			plan: {
+				...site.plan,
+				product_slug: 'jetpack_free',
+				product_name_short: 'Jetpack Free',
+				is_free: true,
+				features: { active: [] },
+			},
 		} as Site );
 
 		render( <SiteOverview siteSlug={ site.slug } /> );
@@ -221,9 +235,9 @@ describe( '<SiteOverview>', () => {
 		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
 
 		expect( getCard( 'Visibility' ) ).toBeVisible();
-		expect( getCard( 'Back up your site' ) ).toHaveTextContent( 'Activate to unlock' );
+		expect( getCard( 'Back up your site' ) ).toHaveTextContent( 'Upgrade to unlock' );
 		expect( getCard( 'Subscribers' ) ).toBeVisible();
-		expect( getCard( 'Scan for security threats' ) ).toHaveTextContent( 'Activate to unlock' );
+		expect( getCard( 'Scan for security threats' ) ).toHaveTextContent( 'Upgrade to unlock' );
 		expect( getCard( 'Subscriptions' ) ).toBeVisible();
 		expect( getCard( 'Latest activity' ) ).toBeVisible();
 	} );

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -229,7 +229,7 @@ export function EngagementStat( { value }: { value: number | null } ) {
 
 export function LastBackup( { site }: { site?: Site } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
-	const isEligible = site && hasHostingFeature( site, HostingFeatures.BACKUPS );
+	const isEligible = site && hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE );
 
 	const {
 		data: lastBackup,

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -229,7 +229,7 @@ export function EngagementStat( { value }: { value: number | null } ) {
 
 export function LastBackup( { site }: { site?: Site } ) {
 	const { ref, inView } = useInView( { triggerOnce: true, fallbackInView: true } );
-	const isEligible = site && hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE );
+	const isEligible = site && hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
 
 	const {
 		data: lastBackup,

--- a/client/dashboard/utils/test/site-features.ts
+++ b/client/dashboard/utils/test/site-features.ts
@@ -34,7 +34,7 @@ describe( 'hasPlanFeature', () => {
 describe( 'hasHostingFeature', () => {
 	it( 'should return false if the site does not have active plan', () => {
 		const site = {} as Site;
-		expect( hasHostingFeature( site, HostingFeatures.BACKUPS ) ).toBe( false );
+		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ).toBe( false );
 	} );
 
 	it( 'should return false if the plan does not have the feature', () => {
@@ -45,32 +45,32 @@ describe( 'hasHostingFeature', () => {
 				},
 			},
 		} as Site;
-		expect( hasHostingFeature( site, HostingFeatures.BACKUPS ) ).toBe( false );
+		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ).toBe( false );
 	} );
 
 	it( 'should return false if the site is hosted on WordPress.com but not Atomic yet, even though the plan has the feature', () => {
 		const site = {
 			plan: {
 				features: {
-					active: [ DotcomFeatures.ATOMIC, HostingFeatures.BACKUPS ],
+					active: [ DotcomFeatures.ATOMIC, HostingFeatures.BACKUPS_RESTORE ],
 				},
 			},
 			is_wpcom_atomic: false,
 		} as Site;
-		expect( hasHostingFeature( site, HostingFeatures.BACKUPS ) ).toBe( false );
+		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ).toBe( false );
 	} );
 
 	it( 'should return false if site is hosted on WordPress.com, and already Atomic, and the plan has the feature, but the plan already expired', () => {
 		const site = {
 			plan: {
 				features: {
-					active: [ DotcomFeatures.ATOMIC, HostingFeatures.BACKUPS ],
+					active: [ DotcomFeatures.ATOMIC, HostingFeatures.BACKUPS_RESTORE ],
 				},
 				expired: true,
 			},
 			is_wpcom_atomic: true,
 		} as Site;
-		expect( hasHostingFeature( site, HostingFeatures.BACKUPS ) ).toBe( false );
+		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ).toBe( false );
 	} );
 
 	it( 'should return true if site is not hosted on WordPress.com, and the plan has the feature', () => {

--- a/client/dashboard/utils/test/site-features.ts
+++ b/client/dashboard/utils/test/site-features.ts
@@ -34,7 +34,7 @@ describe( 'hasPlanFeature', () => {
 describe( 'hasHostingFeature', () => {
 	it( 'should return false if the site does not have active plan', () => {
 		const site = {} as Site;
-		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ).toBe( false );
+		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE ) ).toBe( false );
 	} );
 
 	it( 'should return false if the plan does not have the feature', () => {
@@ -45,32 +45,32 @@ describe( 'hasHostingFeature', () => {
 				},
 			},
 		} as Site;
-		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ).toBe( false );
+		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE ) ).toBe( false );
 	} );
 
 	it( 'should return false if the site is hosted on WordPress.com but not Atomic yet, even though the plan has the feature', () => {
 		const site = {
 			plan: {
 				features: {
-					active: [ DotcomFeatures.ATOMIC, HostingFeatures.BACKUPS_RESTORE ],
+					active: [ DotcomFeatures.ATOMIC, HostingFeatures.BACKUPS_SELF_SERVE ],
 				},
 			},
 			is_wpcom_atomic: false,
 		} as Site;
-		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ).toBe( false );
+		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE ) ).toBe( false );
 	} );
 
 	it( 'should return false if site is hosted on WordPress.com, and already Atomic, and the plan has the feature, but the plan already expired', () => {
 		const site = {
 			plan: {
 				features: {
-					active: [ DotcomFeatures.ATOMIC, HostingFeatures.BACKUPS_RESTORE ],
+					active: [ DotcomFeatures.ATOMIC, HostingFeatures.BACKUPS_SELF_SERVE ],
 				},
 				expired: true,
 			},
 			is_wpcom_atomic: true,
 		} as Site;
-		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_RESTORE ) ).toBe( false );
+		expect( hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE ) ).toBe( false );
 	} );
 
 	it( 'should return true if site is not hosted on WordPress.com, and the plan has the feature', () => {

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -1,4 +1,4 @@
-import { isJetpackBackupSlug, WPCOM_FEATURES_BACKUPS } from '@automattic/calypso-products';
+import { isJetpackBackupSlug, WPCOM_FEATURES_BACKUPS_RESTORE } from '@automattic/calypso-products';
 import Debug from 'debug';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import HasVaultPressSwitch from 'calypso/components/jetpack/has-vaultpress-switch';
@@ -20,6 +20,7 @@ import BackupUpsell from './backup-upsell';
 import BackupCloneFlow from './clone-flow';
 import BackupsPage from './main';
 import MultisiteNoBackupPlanSwitch from './multisite-no-backup-plan-switch';
+import NoBackupRestoreFeatureSwitch from './no-backup-restore-feature-switch';
 import BackupRewindFlow, { RewindFlowPurpose } from './rewind-flow';
 import WPCOMBackupUpsell from './wpcom-backup-upsell';
 import WpcomBackupUpsellPlaceholder from './wpcom-backup-upsell-placeholder';
@@ -50,7 +51,7 @@ export function showUpsellIfNoBackup( context, next ) {
 				}
 				display={ context.primary }
 				productSlugTest={ ( slug ) =>
-					isJetpackBackupSlug( slug ) || slug === WPCOM_FEATURES_BACKUPS
+					isJetpackBackupSlug( slug ) || slug === WPCOM_FEATURES_BACKUPS_RESTORE
 				}
 			>
 				{ isJetpackCloud() && <SidebarNavigation /> }
@@ -118,6 +119,21 @@ export function showUnavailableForMultisites( context, next ) {
 
 	context.primary = (
 		<MultisiteNoBackupPlanSwitch trueComponent={ message } falseComponent={ context.primary } />
+	);
+
+	next();
+}
+
+export function showUpsellIfNoBackupRestoreFeature( context, next ) {
+	debug( 'controller: showUpsellIfNoBackupRestoreFeature', context.params );
+
+	const UpsellComponent = isJetpackCloud() ? BackupUpsell : WPCOMBackupUpsell;
+
+	context.primary = (
+		<NoBackupRestoreFeatureSwitch
+			trueComponent={ <UpsellComponent /> }
+			falseComponent={ context.primary }
+		/>
 	);
 
 	next();

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -1,4 +1,7 @@
-import { isJetpackBackupSlug, WPCOM_FEATURES_BACKUPS_RESTORE } from '@automattic/calypso-products';
+import {
+	isJetpackBackupSlug,
+	WPCOM_FEATURES_BACKUPS_SELF_SERVE,
+} from '@automattic/calypso-products';
 import Debug from 'debug';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import HasVaultPressSwitch from 'calypso/components/jetpack/has-vaultpress-switch';
@@ -51,7 +54,7 @@ export function showUpsellIfNoBackup( context, next ) {
 				}
 				display={ context.primary }
 				productSlugTest={ ( slug ) =>
-					isJetpackBackupSlug( slug ) || slug === WPCOM_FEATURES_BACKUPS_RESTORE
+					isJetpackBackupSlug( slug ) || slug === WPCOM_FEATURES_BACKUPS_SELF_SERVE
 				}
 			>
 				{ isJetpackCloud() && <SidebarNavigation /> }

--- a/client/my-sites/backup/index.js
+++ b/client/my-sites/backup/index.js
@@ -13,6 +13,7 @@ import {
 	showJetpackIsDisconnected,
 	showNotAuthorizedForNonAdmins,
 	showUpsellIfNoBackup,
+	showUpsellIfNoBackupRestoreFeature,
 	showUnavailableForVaultPressSites,
 	showUnavailableForMultisites,
 } from 'calypso/my-sites/backup/controller';
@@ -101,6 +102,7 @@ export default function () {
 		backups,
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoBackup,
+		showUpsellIfNoBackupRestoreFeature,
 		wpcomAtomicTransfer( WPCOMUpsellPage ),
 		showUnavailableForVaultPressSites,
 		showJetpackIsDisconnected,

--- a/client/my-sites/backup/multisite-no-backup-plan-switch.tsx
+++ b/client/my-sites/backup/multisite-no-backup-plan-switch.tsx
@@ -1,4 +1,4 @@
-import { WPCOM_FEATURES_BACKUPS_RESTORE } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_BACKUPS_SELF_SERVE } from '@automattic/calypso-products';
 import { FunctionComponent, ReactNode, useCallback } from 'react';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import RenderSwitch from 'calypso/components/jetpack/render-switch';
@@ -26,7 +26,7 @@ const MultisiteNoBackupPlanSwitch: FunctionComponent< Props > = ( {
 		useSelector( ( state ) => siteId && isJetpackSiteMultiSite( state, siteId ) ) || false;
 
 	const hasBackupFeature = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_RESTORE )
+		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_SELF_SERVE )
 	);
 
 	const isRequesting = useSelector( ( state ) => isRequestingSiteFeatures( state, siteId ) );

--- a/client/my-sites/backup/no-backup-restore-feature-switch.tsx
+++ b/client/my-sites/backup/no-backup-restore-feature-switch.tsx
@@ -1,4 +1,4 @@
-import { WPCOM_FEATURES_BACKUPS_RESTORE } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_BACKUPS_SELF_SERVE } from '@automattic/calypso-products';
 import { FunctionComponent, ReactNode, useCallback } from 'react';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import RenderSwitch from 'calypso/components/jetpack/render-switch';
@@ -22,7 +22,7 @@ const NoBackupRestoreFeatureSwitch: FunctionComponent< Props > = ( {
 	const siteId = useSelector( getSelectedSiteId );
 
 	const hasBackupRestoreFeature = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_RESTORE )
+		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_SELF_SERVE )
 	);
 
 	const isRequesting = useSelector( ( state ) => isRequestingSiteFeatures( state, siteId ) );

--- a/client/my-sites/backup/no-backup-restore-feature-switch.tsx
+++ b/client/my-sites/backup/no-backup-restore-feature-switch.tsx
@@ -6,7 +6,6 @@ import { useSelector } from 'calypso/state';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 type Props = {
@@ -15,17 +14,14 @@ type Props = {
 	loadingComponent?: ReactNode;
 };
 
-const MultisiteNoBackupPlanSwitch: FunctionComponent< Props > = ( {
+const NoBackupRestoreFeatureSwitch: FunctionComponent< Props > = ( {
 	trueComponent,
 	falseComponent,
 	loadingComponent,
 } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 
-	const isMultiSite =
-		useSelector( ( state ) => siteId && isJetpackSiteMultiSite( state, siteId ) ) || false;
-
-	const hasBackupFeature = useSelector( ( state ) =>
+	const hasBackupRestoreFeature = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_RESTORE )
 	);
 
@@ -38,10 +34,10 @@ const MultisiteNoBackupPlanSwitch: FunctionComponent< Props > = ( {
 		[ isRequesting, siteFeatures ]
 	);
 
-	// The idea is to render the `trueComponent` if the site is multisite and doesn't have the backup feature.
+	// Render the `trueComponent` (upsell) if the site doesn't have the backup restore feature.
 	const renderCondition = useCallback(
-		() => isMultiSite && ! hasBackupFeature,
-		[ hasBackupFeature, isMultiSite ]
+		() => ! hasBackupRestoreFeature,
+		[ hasBackupRestoreFeature ]
 	);
 
 	const loadingDefaultPlaceholder = (
@@ -51,17 +47,15 @@ const MultisiteNoBackupPlanSwitch: FunctionComponent< Props > = ( {
 	);
 
 	return (
-		<>
-			<RenderSwitch
-				loadingCondition={ loadingCondition }
-				renderCondition={ renderCondition }
-				queryComponent={ <QuerySiteFeatures siteIds={ [ siteId ] } /> }
-				loadingComponent={ loadingComponent ?? loadingDefaultPlaceholder }
-				trueComponent={ trueComponent }
-				falseComponent={ falseComponent }
-			/>
-		</>
+		<RenderSwitch
+			loadingCondition={ loadingCondition }
+			renderCondition={ renderCondition }
+			queryComponent={ <QuerySiteFeatures siteIds={ [ siteId ] } /> }
+			loadingComponent={ loadingComponent ?? loadingDefaultPlaceholder }
+			trueComponent={ trueComponent }
+			falseComponent={ falseComponent }
+		/>
 	);
 };
 
-export default MultisiteNoBackupPlanSwitch;
+export default NoBackupRestoreFeatureSwitch;

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -129,7 +129,7 @@ export const TrialPlans = [
 export const DotcomFeatures = {
 	ATOMIC: 'atomic',
 	BACKUPS: 'backups',
-	BACKUPS_RESTORE: 'restore',
+	BACKUPS_SELF_SERVE: 'backups-self-serve',
 	BIG_SKY: 'big-sky',
 	DOMAIN_MAPPING: 'domain-mapping',
 	INSTALL_PLUGINS: 'install-plugins',
@@ -183,7 +183,7 @@ export type JetpackModuleSlug = ( typeof JetpackModules )[ keyof typeof JetpackM
 // mapped to the required WordPress.com plan feature.
 export const HostingFeatures = {
 	BACKUPS: DotcomFeatures.BACKUPS,
-	BACKUPS_RESTORE: DotcomFeatures.BACKUPS_RESTORE,
+	BACKUPS_SELF_SERVE: DotcomFeatures.BACKUPS_SELF_SERVE,
 	BIG_SKY: DotcomFeatures.BIG_SKY,
 	CACHING: DotcomFeatures.ATOMIC,
 	DATABASE: DotcomFeatures.SFTP,

--- a/packages/api-core/src/constants.ts
+++ b/packages/api-core/src/constants.ts
@@ -129,6 +129,7 @@ export const TrialPlans = [
 export const DotcomFeatures = {
 	ATOMIC: 'atomic',
 	BACKUPS: 'backups',
+	BACKUPS_RESTORE: 'restore',
 	BIG_SKY: 'big-sky',
 	DOMAIN_MAPPING: 'domain-mapping',
 	INSTALL_PLUGINS: 'install-plugins',
@@ -182,6 +183,7 @@ export type JetpackModuleSlug = ( typeof JetpackModules )[ keyof typeof JetpackM
 // mapped to the required WordPress.com plan feature.
 export const HostingFeatures = {
 	BACKUPS: DotcomFeatures.BACKUPS,
+	BACKUPS_RESTORE: DotcomFeatures.BACKUPS_RESTORE,
 	BIG_SKY: DotcomFeatures.BIG_SKY,
 	CACHING: DotcomFeatures.ATOMIC,
 	DATABASE: DotcomFeatures.SFTP,

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -273,6 +273,7 @@ export const WPCOM_FEATURES_AKISMET = 'akismet';
 export const WPCOM_FEATURES_ANTISPAM = 'antispam';
 export const WPCOM_FEATURES_ATOMIC = 'atomic';
 export const WPCOM_FEATURES_BACKUPS = 'backups';
+export const WPCOM_FEATURES_BACKUPS_SELF_SERVE = 'backups-self-serve';
 export const WPCOM_FEATURES_BIG_SKY = 'big-sky';
 export const WPCOM_FEATURES_BACKUPS_RESTORE = 'restore';
 export const WPCOM_FEATURES_CLASSIC_SEARCH = 'search';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- https://linear.app/a8c/issue/CHE-382/wpcom-remove-summer-special-gating-while-keeping-backups-running-for
- https://linear.app/a8c/issue/CHE-372/wpcom-deprecate-is-summer-special-2025-api-field-return-false
- https://linear.app/a8c/issue/CHE-377/jetpackwpcomsh-remove-summer-special-constants-and-dead-code-paths
- https://linear.app/a8c/issue/CHE-375/jetpackwpcomsh-remove-summer-special-cache-suffix-from-feature-caching
- https://linear.app/a8c/issue/CHE-376/jetpackwpcomsh-deprecate-is-summer-special-2025-api-field-return-false
- https://linear.app/a8c/issue/CHE-374/jetpackwpcomsh-make-plugin-and-theme-features-permanent-for-personal
## Proposed Changes

* Gated Restore backups and Scan to Business plans.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of our Summer Special cleanup

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this 202020-ghe-Automattic/wpcom to your sandbox
* On your Atomic site use this branch https://github.com/Automattic/jetpack/pull/46850
* Test with and without the summer special sticker.
* There are 3 main places to test:
* * Sites dashboard site details
* * MSD site details
* * Actual site
* We need to test that the Backups and Scan features are only available to Business users.
* Free, Personal, and Premium plans should show the necessary upgrades on Simple and Atomic.
* On Personal & Premium sites, use the Rewind debugger tool and restore a backup for a site. It should work as expected.
* On self hosted sites backups should continue to work as long as the Jetpack plan supports backups.

| Before | After |
|--------|--------|
|<img width="1525" height="1097" alt="Screenshot 2026-01-30 at 16 34 41" src="https://github.com/user-attachments/assets/7683b9fb-3165-4b58-9644-e3e9eb8e05a7" />|<img width="1519" height="1208" alt="Screenshot 2026-01-30 at 16 34 54" src="https://github.com/user-attachments/assets/f8d8b124-88a1-4b8b-bc13-84dc237b5fc3" />|
| <img width="1511" height="994" alt="Screenshot 2026-01-30 at 16 37 46" src="https://github.com/user-attachments/assets/97015c54-2ba7-4ee3-ab3f-265a33a4491d" />|<img width="1521" height="1042" alt="Screenshot 2026-01-30 at 16 37 54" src="https://github.com/user-attachments/assets/b4fcc48d-68d2-4826-a28a-c1ae5fa1f231" />|
|<img width="1527" height="1209" alt="Screenshot 2026-01-30 at 16 41 15" src="https://github.com/user-attachments/assets/a5aad055-9e46-48fe-82d6-e3e032ca7f37" />| <img width="1530" height="1221" alt="Screenshot 2026-01-30 at 16 41 25" src="https://github.com/user-attachments/assets/36df0a0a-10df-4452-921a-fa8cf1048bff" />|
| | | 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?