### PR TITLE
Claude: try to improve how it review PRs

### DIFF
--- a/.claude/rules/calypso-client.mdc
+++ b/.claude/rules/calypso-client.mdc
@@ -1,7 +1,6 @@
 ---
-description: Rules that applies for all Clients within repository
-globs: client/**
-alwaysApply: false
+paths:
+  - "client/**"
 ---
 You are an expert AI programming assistant that primarily focuses on producing clear, readable React and TypeScript code.
 You carefully provide accurate, factual, thoughtful answers, and are a genius at reasoning AI to chat, to generate code.
@@ -19,7 +18,7 @@ You create a smooth UI that is scalable and performant.
 ## Short codes
 
 Check the start of any user message for the following short codes and act appropriately:
-- ddc - short for `discuss don't code` so do not make any code changes only discuss the options until given the go ahead to make changes 
+- ddc - short for `discuss don't code` so do not make any code changes only discuss the options until given the go ahead to make changes
 - jdi - short for `just do it` so this is giving approval to go ahead and make the changes that have been discussed
 - cpd - short for `create PR description` for a given branch - you should find changes presented in current branch and create a description following this template [PULL_REQUEST_TEMPLATE.md](mdc:.github/PULL_REQUEST_TEMPLATE.md). The main branch name is `trunk`.
 
@@ -27,7 +26,7 @@ Check the start of any user message for the following short codes and act approp
 
 Before responding to any request, follow these steps:
 
-- Carefully read the instructions and research relative examples. 
+- Carefully read the instructions and research relative examples.
 - If a screenshot is provided, carefully build a layout to match the provided designs.
 - Plan for internationalization using hook `{ useTranslate } from 'i18n-calypso';`
 - Verify accessibility requirements
@@ -64,7 +63,7 @@ Before responding to any request, follow these steps:
 ## Dependencies
 
 - Use imports from [wordpress-imports.mdc](mdc:.cursor/rules/wordpress-imports.mdc)
-- Use named imports to bring in only the necessary functions or components, rather than importing the entire module. 
+- Use named imports to bring in only the necessary functions or components, rather than importing the entire module.
 
 ## Documentation
 
@@ -89,5 +88,3 @@ Remember: Always prioritize WordPress coding standards and best practices while 
 - When testing components using `@testing-library`, use query functions (`getBy*`, etc.) from the return value of `render`, not from the `screen` import.
 - Prefer `userEvent` over `fireEvent` in tests to better simulate real user interactions.
 - Use `toBeVisible` instead of `toBeInTheDocument` when asserting that an element should be visible to the user. This ensures the test checks both presence in the DOM and actual visibility, aligning with user-perceived behavior.
-
-

--- a/.claude/rules/dashboard.mdc
+++ b/.claude/rules/dashboard.mdc
@@ -1,12 +1,11 @@
 ---
-description: Rules for development in the dashboard subdirectory
-globs: client/dashboard/**
-alwaysApply: false
+paths:
+  - "client/dashboard/**"
 ---
 
 You are an expert AI programming assistant specializing in the WordPress.com Dashboard. This subdirectory implements modern web application patterns with TypeScript, TanStack Query, and TanStack Router.
 
-Use these rules on top of [calypso-client-rules.mdc](mdc:./rules/calypso-client-rules.mdc).
+IMPORTANT: Use these rules on top of [calypso-client.mdc](mdc:./calypso-client.mdc).
 
 ## Documentation
 
@@ -91,7 +90,7 @@ const { mutate: saveSetting } = useMutation( {
 `SSH access enabled.`
 `Failed to save PHP version.`
 
-// ❌ Incorrect patterns  
+// ❌ Incorrect patterns
 <Button>Save Changes.</Button>  // Has period, title case
 <p>Your settings have been saved</p>  // Missing period
 `SSH Access Enabled`  // Title case, missing period

--- a/.github/prompts/dashboard-pr-review.md
+++ b/.github/prompts/dashboard-pr-review.md
@@ -2,18 +2,9 @@
 
 ## Primary Objective
 
-Review the dashboard code for quality, correctness, and best practices.
+Verify that the PR follows the rules in `.claude/rules/dashboard.mdc`.
 
-## Project Guidelines
-
-Read `.cursor/rules/dashboard-rules.mdc` before reviewing.
-
-## Scope
-
-- **React/TypeScript**: Component props/types, hook dependencies, state management, error handling.
-- **Performance**: Unnecessary re-renders, missing memoization, large bundle imports.
-- **Accessibility**: Missing ARIA labels, keyboard navigation, focus management.
-- **API usage**: Correct endpoint usage, error states, loading states.
+Read `.claude/rules/dashboard.mdc` before reviewing.
 
 ## Method
 
@@ -27,3 +18,4 @@ Read `.cursor/rules/dashboard-rules.mdc` before reviewing.
 - Be concise.
 - Do NOT use checkboxes, todo lists, or progress indicators.
 - Only comment if there are issues worth addressing.
+- DO NOT comment on lines that are not related to the rules in `.claude/rules/dashboard.mdc`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,12 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-Before you start, please read the following files:
+Before you start, please read the following files based on the path you are working in:
 
-- @.rules/calypso-client-rules.mdc – Rules that applies for all Clients within repository
+- @.claude/rules/calypso-client.mdc
+- @.claude/rules/dashboard.mdc
 - @.rules/wordpress-imports.mdc – WordPress imports
 - @.rules/a4a-custom-rules.mdc – Rules that apply for Automattic for Agencies related development
-- @.rules/dashboard-rules.mdc – Rules that apply for Dashboard related development
 - @.rules/e2e-test-rules.mdc – Rules for E2E testing in test/e2e/ and packages/calypso-e2e
 - @.rules/pr-rules.mdc – Rules for creating pull requests
 


### PR DESCRIPTION
Trying to improve Claude bot:

- Move dashboard rules to the "correct" place that Claude expects based on the documentation (`.claude/rules`)
- Modify the prompt so that it only review that the PR follows the rules, and nothing else.