### PR TITLE
MCP: update config steps for cursor and claude

### DIFF
--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -35,7 +35,7 @@ function McpSetupComponent() {
 
 	// MCP client options
 	const mcpClientOptions: Array< { label: string; value: McpClient } > = [
-		{ label: 'Claude Desktop', value: 'claude' },
+		{ label: 'Claude', value: 'claude' },
 		{ label: 'Cursor', value: 'cursor' },
 		{ label: 'VS Code', value: 'vscode' },
 		{ label: 'Continue', value: 'continue' },
@@ -56,8 +56,7 @@ function McpSetupComponent() {
 	// Generate MCP configuration based on selected client
 	const generateMcpConfig = ( client: McpClient ) => {
 		const baseConfig = {
-			command: 'npx',
-			args: [ '-y', '@automattic/mcp-wpcom-remote@latest' ],
+			url: 'https://public-api.wordpress.com/wpcom/v2/mcp/v1',
 		};
 
 		switch ( client ) {
@@ -198,9 +197,7 @@ function McpSetupComponent() {
 									<ul style={ { color: '#757575', paddingInlineStart: '20px', margin: '0' } }>
 										<li>
 											<Text as="p" variant="muted">
-												{ __(
-													'Running a bridge server using the WordPress.com-specific MCP package'
-												) }
+												{ __( 'Connecting to the WordPress.com MCP endpoint' ) }
 											</Text>
 										</li>
 										<li>
@@ -250,13 +247,11 @@ function McpSetupComponent() {
 						<CardBody>
 							<VStack spacing={ 4 }>
 								<SectionHeader level={ 3 } title={ __( 'Quick Setup' ) } />
-								{ /* Quick Setup for Claude Desktop */ }
+								{ /* Quick Setup for Claude */ }
 								{ selectedMcpClient === 'claude' && (
 									<VStack spacing={ 4 }>
 										<Text as="p" variant="muted">
-											{ __(
-												'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
-											) }
+											{ __( 'For Claude users, connect WordPress.com from Claude Connectors.' ) }
 										</Text>
 										<Text as="p" variant="muted">
 											{ __( 'Installation steps:' ) }
@@ -264,28 +259,30 @@ function McpSetupComponent() {
 										<ol style={ { color: '#757575', paddingInlineStart: '20px', margin: '0' } }>
 											<li>
 												<Text as="p" variant="muted">
-													{ __( 'Click the download button' ) }
+													{ createInterpolateElement(
+														__( 'Open <link>Claude settings → Browse Connectors</link>.' ),
+														{
+															link: (
+																<ExternalLink
+																	href="https://claude.ai/settings/connectors"
+																	target="_blank"
+																/>
+															),
+														}
+													) }
 												</Text>
 											</li>
 											<li>
 												<Text as="p" variant="muted">
-													{ __( 'Double-click the downloaded file' ) }
+													{ __( 'Search for WordPress.com.' ) }
 												</Text>
 											</li>
 											<li>
 												<Text as="p" variant="muted">
-													{ __( 'Follow Claude Desktop‘s setup instructions' ) }
+													{ __( 'Select WordPress.com and follow the prompts to connect.' ) }
 												</Text>
 											</li>
 										</ol>
-										<Button
-											variant="primary"
-											href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
-											target="_blank"
-											style={ { alignSelf: 'flex-start' } }
-										>
-											{ __( 'Download MCPB File' ) }
-										</Button>
 									</VStack>
 								) }
 
@@ -299,7 +296,7 @@ function McpSetupComponent() {
 										</Text>
 										<Button
 											variant="primary"
-											href="https://cursor.com/en/install-mcp?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhdXRvbWF0dGljL21jcC13cGNvbS1yZW1vdGVAbGF0ZXN0Il19"
+											href="cursor://anysphere.cursor-deeplink/mcp/install?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9wdWJsaWMtYXBpLndvcmRwcmVzcy5jb20vd3Bjb20vdjIvbWNwL3YxIn0%3D"
 											target="_blank"
 											style={ { alignSelf: 'flex-start' } }
 										>
@@ -386,8 +383,8 @@ function McpSetupComponent() {
 										{ createInterpolateElement(
 											sprintf(
 												/* translators: %s is the package name */
-												__( '<code>%s</code> is the official WordPress.com MCP server package' ),
-												'@automattic/mcp-wpcom-remote'
+												__( '<code>%s</code> is the official WordPress.com MCP server endpoint' ),
+												'https://public-api.wordpress.com/wpcom/v2/mcp/v1'
 											),
 											{
 												code: (
@@ -401,7 +398,7 @@ function McpSetupComponent() {
 															fontSize: '13px',
 														} }
 													>
-														@automattic/mcp-wpcom-remote
+														https://public-api.wordpress.com/wpcom/v2/mcp/v1
 													</code>
 												),
 											}

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -260,7 +260,7 @@ function McpSetupComponent() {
 											<li>
 												<Text as="p" variant="muted">
 													{ createInterpolateElement(
-														/* translators: %s is the link to the Claude settings → Browse Connectors */
+														/* translators: %s is the link to the Claude settings page */
 														__( 'Open <ClaudeSettings/>.' ),
 														{
 															ClaudeSettings: (

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -260,9 +260,14 @@ function McpSetupComponent() {
 											<li>
 												<Text as="p" variant="muted">
 													{ createInterpolateElement(
-														__( 'Open <link>Claude settings → Browse Connectors</link>.' ),
+														/* translators: %s is the link to the Claude settings → Browse Connectors */
+														__( 'Open <ClaudeSettings/>.' ),
 														{
-															link: <ExternalLink href="https://claude.ai/settings/connectors" />,
+															ClaudeSettings: (
+																<ExternalLink href="https://claude.ai/settings/connectors">
+																	{ __( 'Claude settings → Browse Connectors' ) }
+																</ExternalLink>
+															),
 														}
 													) }
 												</Text>

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -190,7 +190,7 @@ function McpSetupComponent() {
 								</Text>
 								<Text as="p" variant="muted">
 									{ __(
-										'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account. It works by:'
+										'The JSON configuration below sets up a secure connection between your AI assistant and your WordPress.com account by:'
 									) }
 								</Text>
 								<VStack spacing={ 2 }>
@@ -265,11 +265,16 @@ function McpSetupComponent() {
 														{
 															ClaudeSettings: (
 																<ExternalLink href="https://claude.ai/settings/connectors">
-																	{ __( 'Claude settings → Browse Connectors' ) }
+																	{ __( 'Claude settings' ) }
 																</ExternalLink>
 															),
 														}
 													) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" variant="muted">
+													{ __( 'Click the "Browse connectors" button.' ) }
 												</Text>
 											</li>
 											<li>
@@ -291,7 +296,7 @@ function McpSetupComponent() {
 									<VStack spacing={ 4 }>
 										<Text as="p" variant="muted">
 											{ __(
-												'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
+												'For Cursor users, use the one-click install to add the WordPress.com MCP app.'
 											) }
 										</Text>
 										<Button

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -262,12 +262,7 @@ function McpSetupComponent() {
 													{ createInterpolateElement(
 														__( 'Open <link>Claude settings → Browse Connectors</link>.' ),
 														{
-															link: (
-																<ExternalLink
-																	href="https://claude.ai/settings/connectors"
-																	target="_blank"
-																/>
-															),
+															link: <ExternalLink href="https://claude.ai/settings/connectors" />,
 														}
 													) }
 												</Text>
@@ -349,7 +344,7 @@ function McpSetupComponent() {
 									help={ __(
 										'Copy this configuration and paste it into your MCP client’s settings.'
 									) }
-									style={ { minHeight: '240px' } }
+									style={ { minHeight: '160px' } }
 								/>
 								<VStack spacing={ 1 }>
 									<Text size="12px">

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -299,7 +299,7 @@ function McpSetupComponent( { path } ) {
 									</CardHeading>
 									<Text as="p" size="medium">
 										{ translate(
-											'For Cursor users, we provide a one-click setup option that will automatically configure the MCP server.'
+											'For Cursor users, use the one-click install to add the WordPress.com MCP app.'
 										) }
 									</Text>
 									<Button

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -262,16 +262,21 @@ function McpSetupComponent( { path } ) {
 										<li>
 											<Text as="p" size="medium">
 												{ createInterpolateElement(
-													translate( 'Open <link>Claude settings → Browse Connectors</link>.' ),
+													/* translators: %s is the link to the Claude settings page */
+													translate( 'Open <ClaudeSettings/>.' ),
 													{
-														link: (
-															<ExternalLink
-																href="https://claude.ai/settings/connectors"
-																target="_blank"
-															/>
+														ClaudeSettings: (
+															<ExternalLink href="https://claude.ai/settings/connectors">
+																{ translate( 'Claude settings' ) }
+															</ExternalLink>
 														),
 													}
 												) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" size="medium">
+												{ translate( 'Click the "Browse connectors" button.' ) }
 											</Text>
 										</li>
 										<li>

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -361,7 +361,7 @@ function McpSetupComponent( { path } ) {
 										help={ translate(
 											"Copy this configuration and paste it into your MCP client's settings."
 										) }
-										style={ { minHeight: '240px' } }
+										style={ { minHeight: '160px' } }
 									/>
 								</VStack>
 							</VStack>

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -58,7 +58,7 @@ function McpSetupComponent( { path } ) {
 
 	// MCP client options
 	const mcpClientOptions = [
-		{ label: 'Claude Desktop', value: 'claude' },
+		{ label: 'Claude', value: 'claude' },
 		{ label: 'Cursor', value: 'cursor' },
 		{ label: 'VS Code', value: 'vscode' },
 		{ label: 'Continue', value: 'continue' },
@@ -79,8 +79,7 @@ function McpSetupComponent( { path } ) {
 	// Generate MCP configuration based on selected client
 	const generateMcpConfig = ( client ) => {
 		const baseConfig = {
-			command: 'npx',
-			args: [ '-y', '@automattic/mcp-wpcom-remote@latest' ],
+			url: 'https://public-api.wordpress.com/wpcom/v2/mcp/v1',
 		};
 
 		switch ( client ) {
@@ -211,11 +210,7 @@ function McpSetupComponent( { path } ) {
 						</Text>
 						<VStack spacing={ 2 }>
 							<ul>
-								<li>
-									{ translate(
-										'Running a bridge server using the WordPress.com-specific MCP package'
-									) }
-								</li>
+								<li>{ translate( 'Connecting to the WordPress.com MCP endpoint' ) }</li>
 								<li>
 									{ translate(
 										'Handling OAuth 2.1 authentication to securely connect to your WordPress.com account'
@@ -249,7 +244,7 @@ function McpSetupComponent( { path } ) {
 								) }
 							/>
 
-							{ /* Quick Setup for Claude Desktop */ }
+							{ /* Quick Setup for Claude */ }
 							{ selectedMcpClient === 'claude' && (
 								<VStack spacing={ 4 } style={ { borderBottom: '1px solid #e0e0e0' } }>
 									<CardHeading tagName="h1" size={ 16 } isBold>
@@ -257,34 +252,36 @@ function McpSetupComponent( { path } ) {
 									</CardHeading>
 									<Text as="p" size="medium">
 										{ translate(
-											'For Claude Desktop users, we provide a one-click setup option using our MCP Bundle (MCPB) file.'
+											'For Claude users, connect WordPress.com from Claude Connectors.'
 										) }
 									</Text>
-									<Button
-										variant="primary"
-										href="https://github.com/Automattic/wpcom-mcp-bundle/raw/refs/heads/trunk/wordpress-com-mcp.mcpb"
-										target="_blank"
-										style={ { alignSelf: 'flex-start' } }
-									>
-										{ translate( 'Download MCPB File' ) }
-									</Button>
 									<Text as="p" size="medium">
 										{ translate( 'Installation steps:' ) }
 									</Text>
 									<ol>
 										<li>
 											<Text as="p" size="medium">
-												{ translate( 'Click the download button above' ) }
+												{ createInterpolateElement(
+													translate( 'Open <link>Claude settings → Browse Connectors</link>.' ),
+													{
+														link: (
+															<ExternalLink
+																href="https://claude.ai/settings/connectors"
+																target="_blank"
+															/>
+														),
+													}
+												) }
 											</Text>
 										</li>
 										<li>
 											<Text as="p" size="medium">
-												{ translate( 'Double-click the downloaded file' ) }
+												{ translate( 'Search for WordPress.com.' ) }
 											</Text>
 										</li>
 										<li>
 											<Text as="p" size="medium">
-												{ translate( "Follow Claude Desktop's setup instructions" ) }
+												{ translate( 'Select WordPress.com and follow the prompts to connect.' ) }
 											</Text>
 										</li>
 									</ol>
@@ -307,7 +304,7 @@ function McpSetupComponent( { path } ) {
 									</Text>
 									<Button
 										variant="primary"
-										href="https://cursor.com/en/install-mcp?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhdXRvbWF0dGljL21jcC13cGNvbS1yZW1vdGVAbGF0ZXN0Il19"
+										href="cursor://anysphere.cursor-deeplink/mcp/install?name=WordPress.com&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9wdWJsaWMtYXBpLndvcmRwcmVzcy5jb20vd3Bjb20vdjIvbWNwL3YxIn0%3D"
 										target="_blank"
 										style={ { alignSelf: 'flex-start' } }
 									>
@@ -397,8 +394,8 @@ function McpSetupComponent( { path } ) {
 								<li>
 									{ createInterpolateElement(
 										translate(
-											'<code>%s</code> is the official WordPress.com MCP server package'
-										).replace( '%s', '@automattic/mcp-wpcom-remote' ),
+											'<code>%s</code> is the official WordPress.com MCP server endpoint'
+										).replace( '%s', 'https://public-api.wordpress.com/wpcom/v2/mcp/v1' ),
 										{
 											code: (
 												<code
@@ -411,7 +408,7 @@ function McpSetupComponent( { path } ) {
 														fontSize: '13px',
 													} }
 												>
-													@automattic/mcp-wpcom-remote
+													https://public-api.wordpress.com/wpcom/v2/mcp/v1
 												</code>
 											),
 										}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/AIINT-237/update-mcp-config-steps

The manual MCP configuration now points directly at https://public-api.wordpress.com/wpcom/v2/mcp/v1, so the JSON config and supporting copy no longer mention @automattic/mcp-wpcom-remote@latest.

Quick-setup for Claude now guides users through Claude Connectors, and Cursor uses the provided deeplink for one-click install.

The same changes were applied in both Calypso (`client/me/mcp/setup.jsx`) and Dashboard (`client/dashboard/me/mcp/setup/index.tsx`) to keep behavior consistent.

## Proposed Changes

* Update MCP setup docs and configs to use the WordPress.com OAuth 2.1 MCP endpoint URL instead of the npm package.
* Refresh Claude and Cursor quick-setup flows, including the Cursor deeplink and Claude connectors steps.
* Align both Calypso and Dashboard MCP setup pages with the same configuration and copy updates.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply PR locally and build calypso
* Go to http://my.localhost:3000/me/mcp/setup and http://calypso.localhost:3000/me/mcp-setup and confirm config page works and looks as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
