### PR TITLE
Cron tab: Improve UI for rendering scheduled crons

### DIFF
--- a/client/dashboard/sites/settings-crontab/add-crontab.tsx
+++ b/client/dashboard/sites/settings-crontab/add-crontab.tsx
@@ -16,7 +16,7 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
-import ScheduleField from './schedule-field';
+import { ScheduleField } from './schedule-field';
 
 interface AddCrontabFormData {
 	schedule: string;

--- a/client/dashboard/sites/settings-crontab/index.tsx
+++ b/client/dashboard/sites/settings-crontab/index.tsx
@@ -6,13 +6,19 @@ import {
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { Icon, Button } from '@wordpress/components';
+import {
+	Icon,
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { scheduled, trash, copy } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import cronstrue from 'cronstrue';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { siteSettingsCrontabAddRoute } from '../../app/router/sites';
@@ -24,50 +30,6 @@ import { hasHostingFeature } from '../../utils/site-features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
 import type { Crontab } from '@automattic/api-core';
 import type { View } from '@wordpress/dataviews';
-
-function formatSchedule( schedule: string ): string {
-	// Handle predefined schedules
-	if ( schedule === 'hourly' ) {
-		return __( 'Every hour' );
-	}
-	if ( schedule === 'daily' ) {
-		return __( 'Daily' );
-	}
-	if ( schedule === 'weekly' ) {
-		return __( 'Weekly' );
-	}
-
-	// Handle shorthand notation
-	const shorthandMatch = schedule.match( /^(\d+)([hdw])$/ );
-	if ( shorthandMatch ) {
-		const num = parseInt( shorthandMatch[ 1 ], 10 );
-		const freq = shorthandMatch[ 2 ];
-		if ( freq === 'h' ) {
-			return sprintf(
-				/* translators: %d is the number of times per hour */
-				__( '%d times per hour' ),
-				num
-			);
-		}
-		if ( freq === 'd' ) {
-			return sprintf(
-				/* translators: %d is the number of times per day */
-				__( '%d times per day' ),
-				num
-			);
-		}
-		if ( freq === 'w' ) {
-			return sprintf(
-				/* translators: %d is the number of times per week */
-				__( '%d times per week' ),
-				num
-			);
-		}
-	}
-
-	// Return raw cron expression for standard cron format
-	return schedule;
-}
 
 const DEFAULT_VIEW: View = {
 	type: 'table',
@@ -128,9 +90,14 @@ export default function CrontabSettings( { siteSlug }: { siteSlug: string } ) {
 		{
 			id: 'schedule',
 			label: __( 'Schedule' ),
-			getValue: ( { item }: { item: Crontab } ) => formatSchedule( item.schedule ),
+			getValue: ( { item }: { item: Crontab } ) => item.schedule,
 			render: ( { item }: { item: Crontab } ) => (
-				<span title={ item.schedule }>{ formatSchedule( item.schedule ) }</span>
+				<HStack spacing={ 2 }>
+					<span style={ { flex: 'none' } }>{ item.schedule }</span>
+					<Text variant="muted" size="small">
+						({ cronstrue.toString( item.schedule, { verbose: true } ) })
+					</Text>
+				</HStack>
 			),
 			enableGlobalSearch: true,
 		},

--- a/client/dashboard/sites/settings-crontab/index.tsx
+++ b/client/dashboard/sites/settings-crontab/index.tsx
@@ -6,12 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import {
-	Icon,
-	Button,
-	__experimentalHStack as HStack,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Icon, Button, __experimentalText as Text } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -92,12 +87,9 @@ export default function CrontabSettings( { siteSlug }: { siteSlug: string } ) {
 			label: __( 'Schedule' ),
 			getValue: ( { item }: { item: Crontab } ) => item.schedule,
 			render: ( { item }: { item: Crontab } ) => (
-				<HStack spacing={ 2 }>
-					<span style={ { flex: 'none' } }>{ item.schedule }</span>
-					<Text variant="muted" size="small">
-						({ cronstrue.toString( item.schedule, { verbose: true } ) })
-					</Text>
-				</HStack>
+				<Text variant="muted" size="small">
+					{ cronstrue.toString( item.schedule, { verbose: true } ) }
+				</Text>
 			),
 			enableGlobalSearch: true,
 		},

--- a/client/dashboard/sites/settings-crontab/schedule-field.tsx
+++ b/client/dashboard/sites/settings-crontab/schedule-field.tsx
@@ -85,24 +85,24 @@ function formatSchedulePreview(
 	customFrequency: CustomFrequency
 ): string {
 	if ( scheduleType === 'hourly' ) {
-		return __( 'Runs once every hour' );
+		return __( 'Runs once every hour.' );
 	}
 	if ( scheduleType === 'daily' ) {
-		return __( 'Runs once per day' );
+		return __( 'Runs once per day.' );
 	}
 	if ( scheduleType === 'weekly' ) {
-		return __( 'Runs once per week' );
+		return __( 'Runs once per week.' );
 	}
 
 	// Custom schedule
 	if ( customFrequency === 'h' ) {
 		if ( customNumber === 1 ) {
-			return __( 'Runs once per hour' );
+			return __( 'Runs once per hour.' );
 		}
 		const interval = Math.floor( 60 / customNumber );
 		return sprintf(
 			/* translators: %1$d is the number of times, %2$d is the interval in minutes */
-			__( 'Runs %1$d times per hour (every %2$d minutes)' ),
+			__( 'Runs %1$d times per hour (every %2$d minutes).' ),
 			customNumber,
 			interval
 		);
@@ -114,19 +114,19 @@ function formatSchedulePreview(
 		const interval = Math.floor( 24 / customNumber );
 		return sprintf(
 			/* translators: %1$d is the number of times, %2$d is the interval in hours */
-			__( 'Runs %1$d times per day (every %2$d hours)' ),
+			__( 'Runs %1$d times per day (every %2$d hours).' ),
 			customNumber,
 			interval
 		);
 	}
 	if ( customFrequency === 'w' ) {
 		if ( customNumber === 1 ) {
-			return __( 'Runs once per week' );
+			return __( 'Runs once per week.' );
 		}
 		const interval = Math.floor( 7 / customNumber );
 		return sprintf(
 			/* translators: %1$d is the number of times, %2$d is the interval in days */
-			__( 'Runs %1$d times per week (every %2$d days)' ),
+			__( 'Runs %1$d times per week (every %2$d days).' ),
 			customNumber,
 			interval
 		);
@@ -202,6 +202,9 @@ export default function ScheduleField( { value, onChange, disabled }: ScheduleFi
 			{ preview && (
 				<Text variant="muted" size="small">
 					{ preview }
+					<div>
+						{ __( 'The specific execution time is randomized to prevent system overload.' ) }
+					</div>
 				</Text>
 			) }
 		</VStack>

--- a/client/dashboard/sites/settings-crontab/schedule-field.tsx
+++ b/client/dashboard/sites/settings-crontab/schedule-field.tsx
@@ -109,7 +109,7 @@ function formatSchedulePreview(
 	}
 	if ( customFrequency === 'd' ) {
 		if ( customNumber === 1 ) {
-			return __( 'Runs once per day' );
+			return __( 'Runs once per day.' );
 		}
 		const interval = Math.floor( 24 / customNumber );
 		return sprintf(
@@ -135,7 +135,7 @@ function formatSchedulePreview(
 	return '';
 }
 
-export default function ScheduleField( { value, onChange, disabled }: ScheduleFieldProps ) {
+export function ScheduleField( { value, onChange, disabled }: ScheduleFieldProps ) {
 	const parsed = useMemo( () => parseScheduleValue( value ), [ value ] );
 
 	const { scheduleType, customNumber, customFrequency } = parsed;
@@ -200,11 +200,9 @@ export default function ScheduleField( { value, onChange, disabled }: ScheduleFi
 				</HStack>
 			) }
 			{ preview && (
-				<Text variant="muted" size="small">
-					{ preview }
-					<div>
-						{ __( 'The specific execution time is randomized to prevent system overload.' ) }
-					</div>
+				<Text variant="muted" size={ 12 }>
+					{ preview }{ ' ' }
+					{ __( 'The specific execution time is randomized to prevent system overload.' ) }
 				</Text>
 			) }
 		</VStack>

--- a/client/package.json
+++ b/client/package.json
@@ -137,6 +137,7 @@
 		"cookie-parser": "^1.4.7",
 		"core-js-bundle": "^3.6.4",
 		"creditcards": "^3.1.0",
+		"cronstrue": "^3.11.0",
 		"csv-parse": "^5.1.0",
 		"d3-array": "^2.4.0",
 		"d3-axis": "^1.0.12",

--- a/packages/api-core/src/site-hosting-crontab/mutators.ts
+++ b/packages/api-core/src/site-hosting-crontab/mutators.ts
@@ -1,21 +1,15 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { Crontab, CreateCrontabParams } from './types';
+import type { CreateCrontabParams } from './types';
 
 export async function createCrontab(
 	siteId: number,
 	params: CreateCrontabParams
-): Promise< Crontab > {
-	const response = await wpcom.req.post( {
+): Promise< void > {
+	await wpcom.req.post( {
 		path: `/sites/${ siteId }/hosting/crontab`,
 		apiNamespace: 'wpcom/v2',
 		body: params,
 	} );
-
-	return {
-		cron_id: response.cron_id,
-		schedule: params.schedule,
-		command: params.command,
-	};
 }
 
 export async function deleteCrontab( siteId: number, cronId: number ): Promise< void > {

--- a/packages/api-queries/src/site-crontab.ts
+++ b/packages/api-queries/src/site-crontab.ts
@@ -12,13 +12,8 @@ export const siteCrontabsQuery = ( siteId: number ) =>
 export const siteCrontabCreateMutation = ( siteId: number ) =>
 	mutationOptions( {
 		mutationFn: ( params: CreateCrontabParams ) => createCrontab( siteId, params ),
-		onSuccess: ( newCrontab ) => {
-			queryClient.setQueryData( siteCrontabsQuery( siteId ).queryKey, ( currentCrontabs ) => {
-				if ( ! currentCrontabs ) {
-					return [ newCrontab ];
-				}
-				return [ ...currentCrontabs, newCrontab ];
-			} );
+		onSuccess: () => {
+			queryClient.invalidateQueries( siteCrontabsQuery( siteId ) );
 		},
 	} );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15406,6 +15406,7 @@ __metadata:
     cookie-parser: "npm:^1.4.7"
     core-js-bundle: "npm:^3.6.4"
     creditcards: "npm:^3.1.0"
+    cronstrue: "npm:^3.11.0"
     csv-parse: "npm:^5.1.0"
     d3-array: "npm:^2.4.0"
     d3-axis: "npm:^1.0.12"
@@ -17027,6 +17028,15 @@ __metadata:
     parse-int: "npm:^1.0.0"
     parse-year: "npm:^1.0.0"
   checksum: c3fe8349d5b7f894f126c58d4b4534c025f32e7da418d1e870da171615dad3a9627aeeab36ac8a88d422613980bb5e7af3c42d453bc62aa00f38466bd26687c4
+  languageName: node
+  linkType: hard
+
+"cronstrue@npm:^3.11.0":
+  version: 3.11.0
+  resolution: "cronstrue@npm:3.11.0"
+  bin:
+    cronstrue: bin/cli.js
+  checksum: 16ecc85750b55df41f16e0f2f10bef81f8954bbcdfc31912e66e2f46cdb0e33c059a7645e9d01080a3f0739d9d88a2a93cb86811597adc07b44255bc94bf118c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes DOTCOM-15893

## Proposed Changes
I added `cronstrue` lib to render human-readable cron times.
Also added description to be explicit that the specific time of execution is randomized.

## Why are these changes being made?
While creating new cron - we send "Daily' etc, but backend stores it as raw cron format. After discussion with implementors of the API - it seems that we had to try to do our best to make UI good with the state of things which we have right now. 
The discussion - p9o2xV-5WN-p2#comment-12339
I was thinkign about what we can do and I propose to go with the first step as:
1. Explicitly add description to the creation form (UI can be improved later) that the time is randomized
2. Render human-readable information about raw cron times 
See screenshots below.

As the second step, I am going to continue the conversation (p9o2xV-5WN-p2#comment-12339) and try to convince teh team that it will be more rational if they store the requested format at teh server, alongside the command and raw cron time. Hopefully that they will agree and we will make UI much more better. But ATM, what I proposed, I suppose is teh best option, what we can do.


## Testing Instructions
1. Create Atomic Site
4. Open site "Setting" tab -> "Cron" -> "Add scheduled cron"
5. Assert that you see additional description<br /><img width="1449" height="586" alt="Screenshot 2026-01-30 at 17 11 30" src="https://github.com/user-attachments/assets/cf36d7d4-bc6e-41af-9569-d984deb8f7bb" />
6. Add new cron job
7. Assert that you see raw cron tiem and also human-readable description<br /><img width="662" height="59" alt="Screenshot 2026-01-30 at 17 12 51" src="https://github.com/user-attachments/assets/42d40eac-4a4c-4d39-8815-aef3e3ec6ede" />