### PR TITLE
DNS: Hide email setup when not using WordPress.com nameservers

### DIFF
--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -364,7 +364,7 @@ export default function DomainDns() {
 					</DataViews>
 				) }
 			</DataViewsCard>
-			<EmailSetup />
+			{ domain.has_wpcom_nameservers && <EmailSetup /> }
 			<RestoreDefaultARecords
 				onConfirm={ handleRestoreDefaultARecords }
 				onCancel={ () => setIsRestoreDefaultARecordsDialogOpen( false ) }

--- a/client/dashboard/domains/domain-dns/test/index.test.tsx
+++ b/client/dashboard/domains/domain-dns/test/index.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import { DomainSubtype, type Domain } from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import DomainDns from '../index';
+
+const domainName = 'example.com';
+
+jest.mock( '../../../app/router/domains', () => ( {
+	...jest.requireActual( '../../../app/router/domains' ),
+	domainRoute: {
+		useParams: () => ( { domainName: 'example.com' } ),
+	},
+} ) );
+
+const getDefaultDomainData = ( customProps: Partial< Domain > = {} ): Domain =>
+	( {
+		domain: domainName,
+		has_wpcom_nameservers: true,
+		subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Domain Registration' },
+		...customProps,
+	} ) as Domain;
+
+const mockDomainApiRequest = ( domainData: Domain ) =>
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.2/domain-details/${ domainName }` )
+		.reply( 200, domainData );
+
+afterEach( () => nock.cleanAll() );
+
+describe( 'DomainDns', () => {
+	test( 'shows EmailSetup when domain has WordPress.com nameservers', async () => {
+		mockDomainApiRequest( getDefaultDomainData( { has_wpcom_nameservers: true } ) );
+
+		render( <DomainDns /> );
+
+		expect( await screen.findByText( 'Email setup' ) ).toBeInTheDocument();
+	} );
+
+	test( 'hides EmailSetup when domain does not have WordPress.com nameservers', async () => {
+		mockDomainApiRequest( getDefaultDomainData( { has_wpcom_nameservers: false } ) );
+
+		render( <DomainDns /> );
+
+		expect( await screen.findByText( 'Add record' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Email setup' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -394,7 +394,9 @@ class DnsRecords extends Component {
 							selectedDomain={ selectedDomain }
 							selectedDomainName={ selectedDomainName }
 						/>
-						<EmailSetup selectedDomainName={ selectedDomainName } />
+						{ this.hasWpcomNameservers() && (
+							<EmailSetup selectedDomainName={ selectedDomainName } />
+						) }
 					</>
 				) : (
 					<InfoNotice redesigned={ false } text={ selectedDomain?.cannotManageDnsRecordsReason } />


### PR DESCRIPTION
Closes [DOMENG-282](https://linear.app/a8c/issue/DOMENG-282/disable-dns-records-page-for-domains-using-external-nameservers)

## Proposed Changes

* Hide the EmailSetup component on the DNS records page when the domain is not using WordPress.com nameservers
* Applies to both the Calypso interface and the MSD

## Why are these changes being made?

* DNS records configured through the EmailSetup component won't take effect when the domain uses external nameservers
* Hiding the component avoids user confusion and provides a cleaner experience

## Testing Instructions

* Navigate to a domain's DNS records page that uses WordPress.com nameservers → EmailSetup section should be visible
* Navigate to a domain's DNS records page that uses external nameservers → EmailSetup section should be hidden
* Test both in the Calypso interface and the MSD.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?