### PR TITLE
ConnectScreen: Improve type definitions for PermissionsList

### DIFF
--- a/.storybook/index.scss
+++ b/.storybook/index.scss
@@ -1,9 +1,12 @@
-@import "@automattic/calypso-color-schemes";
+@import '@automattic/calypso-color-schemes';
 
 // Calypso style needs these variables
-@import "@automattic/typography/styles/variables";
-// stylelint-disable-next-line scss/at-import-no-partial-leading-underscore
-@import "../client/assets/stylesheets/shared/mixins/_breakpoints.scss";
+@import '@automattic/typography/styles/variables';
+// stylelint-disable-next-line scss/load-no-partial-leading-underscore
+@import '../client/assets/stylesheets/shared/mixins/_breakpoints.scss';
+
+// Import dashicons for Storybook
+@import url( //s0.wp.com/wp-includes/css/dashicons.min.css?v=20250127 );
 
 // Calypso style
-@import "../client/assets/stylesheets/style.scss";
+@import '../client/assets/stylesheets/style.scss';

--- a/client/components/connect-screen/permissions-list/index.tsx
+++ b/client/components/connect-screen/permissions-list/index.tsx
@@ -1,13 +1,13 @@
-import { Button, Icon } from '@wordpress/components';
+import { Button, Icon, IconType } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { check, seen, edit, cog, chevronDown } from '@wordpress/icons';
+import { chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
 
 export interface Permission {
-	icon?: 'check' | 'view' | 'edit' | 'manage';
+	icon?: IconType;
 	label: string;
 }
 
@@ -19,13 +19,6 @@ export interface PermissionsListProps {
 	learnMoreUrl?: string;
 	className?: string;
 }
-
-const ICON_MAP = {
-	check,
-	view: seen,
-	edit,
-	manage: cog,
-} as const;
 
 /**
  * Expandable permissions list with optional icons
@@ -60,10 +53,9 @@ export function PermissionsList( {
 			return <span className="connect-screen-permissions-list__icon-placeholder" />;
 		}
 
-		const icon = ICON_MAP[ permission.icon ];
 		return (
 			<span className="connect-screen-permissions-list__icon">
-				<Icon icon={ icon } size={ 20 } />
+				<Icon icon={ permission.icon } size={ 20 } />
 			</span>
 		);
 	};

--- a/client/components/connect-screen/stories/index.stories.tsx
+++ b/client/components/connect-screen/stories/index.stories.tsx
@@ -1,5 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { StoryObj, Meta } from '@storybook/react';
+import { seen, edit, cog, check, chartBar } from '@wordpress/icons';
 import { ActionButtons } from '../action-buttons';
 import { BrandHeader } from '../brand-header';
 import { ConsentText } from '../consent-text';
@@ -30,11 +31,11 @@ const mockUser = {
 };
 
 const mockPermissions = [
-	{ icon: 'view' as const, label: 'View your profile information' },
-	{ icon: 'edit' as const, label: 'Edit your posts and pages' },
-	{ icon: 'manage' as const, label: 'Manage your site settings' },
-	{ icon: 'check' as const, label: 'Access your media library' },
-	{ icon: 'view' as const, label: 'View your site statistics' },
+	{ icon: seen, label: 'View your profile information' },
+	{ icon: edit, label: 'Edit your posts and pages' },
+	{ icon: cog, label: 'Manage your site settings' },
+	{ icon: check, label: 'Access your media library' },
+	{ icon: chartBar, label: 'View your site statistics' },
 ];
 
 // BrandHeader - All variants
@@ -203,9 +204,9 @@ export const FullInviteScreen: StoryObj = {
 			<PermissionsList
 				title="As an editor, you'll be able to:"
 				permissions={ [
-					{ icon: 'edit', label: 'Create and edit posts' },
-					{ icon: 'view', label: 'View site statistics' },
-					{ icon: 'manage', label: 'Manage media uploads' },
+					{ icon: edit, label: 'Create and edit posts' },
+					{ icon: chartBar, label: 'View site statistics' },
+					{ icon: cog, label: 'Manage media uploads' },
 				] }
 			/>
 			<ActionButtons


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of  ARC-1403 ARC-1394

## Proposed Changes

* Improve the type definitions on the `PermissionsList` component to allow more arbitrarily use supported icons
* Loading DashIcons to the StoryBook client

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* `PermissionsList` originally had a small list of allowed icons, in order to allow all supported icons

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run Storybook: yarn storybook:start
* Access http://localhost:6006/?path=/story/client-components-connectscreen--permissions-list-variants
* You should see that the icons from DashIcons rendered on the permissions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
