### PR TITLE
Add option to put payment method step before contact step in checkout

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -590,6 +590,8 @@ export default function CheckoutMainContent( {
 		return true;
 	};
 
+	const paymentMethodStepFirst = true;
+
 	const checkoutSummary = (
 		<WPCheckoutSidebarContent className="checkout-sidebar-content">
 			{ isLoading && <LoadingSidebarContent /> }
@@ -681,6 +683,40 @@ export default function CheckoutMainContent( {
 						}
 						formStatus={ formStatus }
 					/>
+
+					{ paymentMethodStepFirst && (
+						<PaymentMethodStep
+							activeStepHeader={
+								<>
+									<GoogleDomainsCopy responseCart={ responseCart } />
+									<PaymentMethodFilter
+										areStoredCardsFiltered={ areStoredCardsFiltered }
+										isBusinessCardsFilterEmpty={ isBusinessCardsFilterEmpty }
+									/>
+								</>
+							}
+							canEditStep={ canEditPaymentStep() }
+							editButtonText={ String( translate( 'Edit' ) ) }
+							editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }
+							nextStepButtonText={ String( translate( 'Continue' ) ) }
+							nextStepButtonAriaLabel={ String(
+								translate( 'Continue with the selected payment method' )
+							) }
+							validatingButtonText={ validatingButtonText }
+							validatingButtonAriaLabel={ validatingButtonText }
+							onPageLoadError={ onPageLoadError }
+							waitForPaymentMethodIds={ [ 'apple-pay', 'google-pay' ] }
+							isCompleteCallback={ () => {
+								// We want to consider this step complete only if there is a
+								// payment method selected and it does not have required fields.
+								// This will not prevent the form from being submitted because
+								// the submit button will be active as long as the last step is
+								// shown, but it will prevent the payment method step from
+								// automatically collapsing when checkout loads.
+								return Boolean( paymentMethod ) && ! paymentMethod?.hasRequiredFields;
+							} }
+						/>
+					) }
 
 					{ contactDetailsType !== 'none' && (
 						<CheckoutStep
@@ -792,37 +828,40 @@ export default function CheckoutMainContent( {
 							validatingButtonAriaLabel={ validatingButtonText }
 						/>
 					) }
-					<PaymentMethodStep
-						activeStepHeader={
-							<>
-								<GoogleDomainsCopy responseCart={ responseCart } />
-								<PaymentMethodFilter
-									areStoredCardsFiltered={ areStoredCardsFiltered }
-									isBusinessCardsFilterEmpty={ isBusinessCardsFilterEmpty }
-								/>
-							</>
-						}
-						canEditStep={ canEditPaymentStep() }
-						editButtonText={ String( translate( 'Edit' ) ) }
-						editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }
-						nextStepButtonText={ String( translate( 'Continue' ) ) }
-						nextStepButtonAriaLabel={ String(
-							translate( 'Continue with the selected payment method' )
-						) }
-						validatingButtonText={ validatingButtonText }
-						validatingButtonAriaLabel={ validatingButtonText }
-						onPageLoadError={ onPageLoadError }
-						waitForPaymentMethodIds={ [ 'apple-pay', 'google-pay' ] }
-						isCompleteCallback={ () => {
-							// We want to consider this step complete only if there is a
-							// payment method selected and it does not have required fields.
-							// This will not prevent the form from being submitted because
-							// the submit button will be active as long as the last step is
-							// shown, but it will prevent the payment method step from
-							// automatically collapsing when checkout loads.
-							return Boolean( paymentMethod ) && ! paymentMethod?.hasRequiredFields;
-						} }
-					/>
+
+					{ ! paymentMethodStepFirst && (
+						<PaymentMethodStep
+							activeStepHeader={
+								<>
+									<GoogleDomainsCopy responseCart={ responseCart } />
+									<PaymentMethodFilter
+										areStoredCardsFiltered={ areStoredCardsFiltered }
+										isBusinessCardsFilterEmpty={ isBusinessCardsFilterEmpty }
+									/>
+								</>
+							}
+							canEditStep={ canEditPaymentStep() }
+							editButtonText={ String( translate( 'Edit' ) ) }
+							editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }
+							nextStepButtonText={ String( translate( 'Continue' ) ) }
+							nextStepButtonAriaLabel={ String(
+								translate( 'Continue with the selected payment method' )
+							) }
+							validatingButtonText={ validatingButtonText }
+							validatingButtonAriaLabel={ validatingButtonText }
+							onPageLoadError={ onPageLoadError }
+							waitForPaymentMethodIds={ [ 'apple-pay', 'google-pay' ] }
+							isCompleteCallback={ () => {
+								// We want to consider this step complete only if there is a
+								// payment method selected and it does not have required fields.
+								// This will not prevent the form from being submitted because
+								// the submit button will be active as long as the last step is
+								// shown, but it will prevent the payment method step from
+								// automatically collapsing when checkout loads.
+								return Boolean( paymentMethod ) && ! paymentMethod?.hasRequiredFields;
+							} }
+						/>
+					) }
 
 					<CouponFieldArea
 						isCouponFieldVisible={ isCouponFieldVisible }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -590,7 +590,7 @@ export default function CheckoutMainContent( {
 		return true;
 	};
 
-	const paymentMethodStepFirst = true;
+	const paymentMethodStepFirst = searchParams.get( 'payment-first' ) === '1';
 
 	const checkoutSummary = (
 		<WPCheckoutSidebarContent className="checkout-sidebar-content">

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -25,6 +25,7 @@ const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
 const CheckoutPaymentMethodsWrapper = styled.div< { isLoading: boolean } >`
 	position: relative;
 	padding-top: 4px;
+	padding-bottom: 8px;
 	pointer-events: ${ ( props ) => ( props.isLoading ? 'none' : 'auto' ) };
 	> div > div:not( [disabled] ):has( + div:hover )::before,
 	> div > div[disabled]:has( + div.is-checked[disabled] )::before {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1583/checkout-add-option-to-swap-order-of-payment-method-and-billing-step

## Proposed Changes

This PR modifies checkout to provide an option so that the payment method step can be put before the billing information step. This is a proof-of-concept and not ready for production, but it's implemented with a query string so it can be tested.

Depends on:

- https://github.com/Automattic/wp-calypso/pull/108504
- https://github.com/Automattic/wp-calypso/pull/108518

Before             |  After
:-------------------------:|:-------------------------:
<img width="667" height="688" alt="Screenshot 2026-02-03 at 6 27 42 PM" src="https://github.com/user-attachments/assets/5ff3bdd3-a4df-4234-bb66-74f88cec2882" /> | <img width="680" height="684" alt="Screenshot 2026-02-03 at 6 27 09 PM" src="https://github.com/user-attachments/assets/071596c6-37fc-46fe-979d-048952086bff" />
<img width="533" height="799" alt="Screenshot 2026-02-03 at 6 28 40 PM" src="https://github.com/user-attachments/assets/f374c9f2-f561-4727-bd1d-6f8584f0180e" /> | <img width="510" height="1062" alt="Screenshot 2026-02-03 at 6 29 35 PM" src="https://github.com/user-attachments/assets/ea034c0d-88cb-4b48-8710-5dc8ec7f6385" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There are two steps in checkout: the billing information step and the payment method step. Both are required (except in some few circumstances where the billing information step is optional). These use the multi-step form functionality of the `@automattic/composite-checkout` package.

During the 2020 checkout rebuild, we decided to put the payment method step second because of the following reasons:

- Some payment method options are specific to a country (eg: PayPal is not shown in India, Ebanx replaces credit cards in Brazil, Bancontact is available in Belgium, p24 is available in Poland – see PCYsg-f5f-p2). In order to determine which payment methods to display, we need to know the user's billing country.
- When a purchase is free, we hide most payment methods and only show a credit card form for future renewals and a "Assign a payment method later" payment method. When a purchase is free due to something like credits, it's possible for the taxes to make it not free. However, we don't know the tax amount until the user has entered their billing information.

However, there's been a recent desire amongst designers and management to move the payment method selection to the first step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Add a product to your cart and visit wpcom checkout adding `?payment-first=1` to the end of the URL.

Verify that the checkout steps work as you would expect, with the payment method step first.