### PR TITLE
Pricing Differentiation: load the experiment based on the site sticker

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -1,4 +1,6 @@
+import { useSelector } from 'react-redux';
 import { useExperiment } from 'calypso/lib/explat';
+import { getPreference } from 'calypso/state/preferences/selectors';
 
 type PlanDifferentiatorsExperimentVariant = 'control' | 'var1' | 'var1d' | 'var3' | 'var4' | 'var5';
 
@@ -63,18 +65,20 @@ type PlanDifferentiatorsExperimentResult = {
 
 interface UsePlanDifferentiatorsExperimentParams {
 	flowName?: string | null;
-	intent?: string;
 	isInSignup: boolean;
 }
 
 function usePlanDifferentiatorsExperiment( {
 	flowName,
-	intent,
 	isInSignup,
 }: UsePlanDifferentiatorsExperimentParams ): PlanDifferentiatorsExperimentResult {
-	// Eligible for onboarding signup flow or plans-default-wpcom admin intent
+	const assignmentFromPreference = useSelector( ( state ) =>
+		getPreference( state, 'calypso_pricing_differentiation_202601_v1' )
+	);
+
+	// Eligible for onboarding signup flow or when user preference is set
 	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
-	const isEligibleAdminIntent = ! isInSignup && intent === 'plans-default-wpcom';
+	const isEligibleAdminIntent = ! isInSignup && !! assignmentFromPreference;
 	const isEligible =
 		process.env.NODE_ENV !== 'test' && ( isEligibleSignupFlow || isEligibleAdminIntent );
 
@@ -82,7 +86,8 @@ function usePlanDifferentiatorsExperiment( {
 		isEligible,
 	} );
 
-	const variant = ( assignment?.variationName ?? undefined ) as
+	// Use stored assignment to avoid waiting for the API response
+	const variant = ( assignmentFromPreference || assignment?.variationName || undefined ) as
 		| PlanDifferentiatorsExperimentVariant
 		| undefined;
 
@@ -95,7 +100,7 @@ function usePlanDifferentiatorsExperiment( {
 	// var5 -> getVar5StackedSignupWpcomFeatures
 
 	return {
-		isLoading,
+		isLoading: assignmentFromPreference ? false : isLoading,
 		variant,
 		isStacked:
 			variant === 'var1' || variant === 'var1d' || variant === 'var3' || variant === 'var5',

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -89,7 +89,7 @@ function usePlanDifferentiatorsExperiment( {
 		isEligible,
 	} );
 
-	const variant = ( assignment?.variationName || undefined ) as
+	const variant = ( assignment?.variationName ?? undefined ) as
 		| PlanDifferentiatorsExperimentVariant
 		| undefined;
 

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -1,5 +1,5 @@
-import { useSelector } from 'react-redux';
 import { useExperiment } from 'calypso/lib/explat';
+import { useSelector } from 'calypso/state';
 import getSite from 'calypso/state/sites/selectors/get-site';
 import type { IAppState } from 'calypso/state/types';
 

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -89,7 +89,6 @@ function usePlanDifferentiatorsExperiment( {
 		isEligible,
 	} );
 
-	// Use stored assignment to avoid waiting for the API response
 	const variant = ( assignment?.variationName || undefined ) as
 		| PlanDifferentiatorsExperimentVariant
 		| undefined;

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -1,6 +1,8 @@
+import { useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
 import { useExperiment } from 'calypso/lib/explat';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import getSite from 'calypso/state/sites/selectors/get-site';
 import type { IAppState } from 'calypso/state/types';
 
 type PlanDifferentiatorsExperimentVariant = 'control' | 'var1' | 'var1d' | 'var3' | 'var4' | 'var5';
@@ -67,19 +69,32 @@ type PlanDifferentiatorsExperimentResult = {
 interface UsePlanDifferentiatorsExperimentParams {
 	flowName?: string | null;
 	isInSignup: boolean;
+	siteId?: number | null;
 }
 
 function usePlanDifferentiatorsExperiment( {
 	flowName,
 	isInSignup,
+	siteId,
 }: UsePlanDifferentiatorsExperimentParams ): PlanDifferentiatorsExperimentResult {
+	const site = useSelector( ( state: IAppState ) => getSite( state, siteId ) );
+
+	// Use a ref to "lock in" the gating flag once it's been set to true.
+	// This prevents the flag from becoming undefined if site data is refetched
+	// without this field included in the response.
+	const gatingFlagRef = useRef< boolean >( false );
+	if ( site?.options?.is_gating_business_q1 === true ) {
+		gatingFlagRef.current = true;
+	}
+	const hasGatingFlag = gatingFlagRef.current;
+
 	const assignmentFromPreference = useSelector( ( state: IAppState ) =>
-		getPreference( state, 'calypso_pricing_differentiation_202601_v1' )
+		hasGatingFlag ? getPreference( state, 'calypso_pricing_differentiation_202601_v1' ) : null
 	);
 
 	// Eligible for onboarding signup flow or when user preference is set
 	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
-	const isEligibleAdminIntent = ! isInSignup && !! assignmentFromPreference;
+	const isEligibleAdminIntent = ! isInSignup && hasGatingFlag && !! assignmentFromPreference;
 	const isEligible =
 		process.env.NODE_ENV !== 'test' && ( isEligibleSignupFlow || isEligibleAdminIntent );
 

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -77,7 +77,7 @@ function usePlanDifferentiatorsExperiment( {
 }: UsePlanDifferentiatorsExperimentParams ): PlanDifferentiatorsExperimentResult {
 	const site = useSelector( ( state: IAppState ) => getSite( state, siteId ) );
 
-	const hasGatingFlag = site?.options.is_gating_business_q1;
+	const hasGatingFlag = !! site?.options?.is_gating_business_q1;
 
 	// Eligible for onboarding signup flow or when site flag is set
 	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 import { useExperiment } from 'calypso/lib/explat';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import type { IAppState } from 'calypso/state/types';
 
 type PlanDifferentiatorsExperimentVariant = 'control' | 'var1' | 'var1d' | 'var3' | 'var4' | 'var5';
 
@@ -72,7 +73,7 @@ function usePlanDifferentiatorsExperiment( {
 	flowName,
 	isInSignup,
 }: UsePlanDifferentiatorsExperimentParams ): PlanDifferentiatorsExperimentResult {
-	const assignmentFromPreference = useSelector( ( state ) =>
+	const assignmentFromPreference = useSelector( ( state: IAppState ) =>
 		getPreference( state, 'calypso_pricing_differentiation_202601_v1' )
 	);
 

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -1,7 +1,5 @@
-import { useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
 import { useExperiment } from 'calypso/lib/explat';
-import { getPreference } from 'calypso/state/preferences/selectors';
 import getSite from 'calypso/state/sites/selectors/get-site';
 import type { IAppState } from 'calypso/state/types';
 
@@ -79,22 +77,11 @@ function usePlanDifferentiatorsExperiment( {
 }: UsePlanDifferentiatorsExperimentParams ): PlanDifferentiatorsExperimentResult {
 	const site = useSelector( ( state: IAppState ) => getSite( state, siteId ) );
 
-	// Use a ref to "lock in" the gating flag once it's been set to true.
-	// This prevents the flag from becoming undefined if site data is refetched
-	// without this field included in the response.
-	const gatingFlagRef = useRef< boolean >( false );
-	if ( site?.options?.is_gating_business_q1 === true ) {
-		gatingFlagRef.current = true;
-	}
-	const hasGatingFlag = gatingFlagRef.current;
+	const hasGatingFlag = site?.options.is_gating_business_q1;
 
-	const assignmentFromPreference = useSelector( ( state: IAppState ) =>
-		hasGatingFlag ? getPreference( state, 'calypso_pricing_differentiation_202601_v1' ) : null
-	);
-
-	// Eligible for onboarding signup flow or when user preference is set
+	// Eligible for onboarding signup flow or when site flag is set
 	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
-	const isEligibleAdminIntent = ! isInSignup && hasGatingFlag && !! assignmentFromPreference;
+	const isEligibleAdminIntent = ! isInSignup && hasGatingFlag;
 	const isEligible =
 		process.env.NODE_ENV !== 'test' && ( isEligibleSignupFlow || isEligibleAdminIntent );
 
@@ -103,7 +90,7 @@ function usePlanDifferentiatorsExperiment( {
 	} );
 
 	// Use stored assignment to avoid waiting for the API response
-	const variant = ( assignmentFromPreference || assignment?.variationName || undefined ) as
+	const variant = ( assignment?.variationName || undefined ) as
 		| PlanDifferentiatorsExperimentVariant
 		| undefined;
 
@@ -116,7 +103,7 @@ function usePlanDifferentiatorsExperiment( {
 	// var5 -> getVar5StackedSignupWpcomFeatures
 
 	return {
-		isLoading: assignmentFromPreference ? false : isLoading,
+		isLoading,
 		variant,
 		isStacked:
 			variant === 'var1' || variant === 'var1d' || variant === 'var3' || variant === 'var5',

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -392,7 +392,7 @@ const PlansFeaturesMain = ( {
 		isVar1dVariant,
 		isVar4Variant,
 		isExperimentVariant,
-	} = usePlanDifferentiatorsExperiment( { flowName, isInSignup } );
+	} = usePlanDifferentiatorsExperiment( { flowName, isInSignup, siteId } );
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -392,7 +392,7 @@ const PlansFeaturesMain = ( {
 		isVar1dVariant,
 		isVar4Variant,
 		isExperimentVariant,
-	} = usePlanDifferentiatorsExperiment( { flowName, intent, isInSignup } );
+	} = usePlanDifferentiatorsExperiment( { flowName, isInSignup } );
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -86,6 +86,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'site_creation_flow',
 	'site_source_slug',
 	'is_difm_lite_in_progress',
+	'is_gating_business_q1',
 	'is_summer_special_2025',
 	'site_intent',
 	'site_partner_bundle',

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -45,6 +45,7 @@ export const SITE_OPTIONS = [
 	'created_at',
 	'unmapped_url',
 	'is_difm_lite_in_progress',
+	'is_gating_business_q1',
 	'is_summer_special_2025',
 	'is_domain_only',
 	'is_redirect',

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -24,6 +24,7 @@ export interface SiteOptions {
 	is_domain_only?: boolean;
 	is_redirect?: boolean;
 	is_difm_lite_in_progress?: boolean;
+	is_gating_business_q1?: boolean;
 	is_summer_special_2025?: boolean;
 	is_wpforteams_site?: boolean;
 	migration_source_site_domain?: string;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -261,6 +261,7 @@ export interface SiteDetailsOptions {
 	is_automated_transfer?: boolean;
 	is_cloud_eligible?: boolean;
 	is_difm_lite_in_progress?: boolean;
+	is_gating_business_q1?: boolean;
 	is_summer_special_2025?: boolean;
 	is_domain_only?: boolean;
 	is_mapped_domain?: boolean;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15927

## Proposed Changes

* Load the experiment assignment only if the site sticker is present.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid making the assignment call in an incorrect scenario.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new user, after getting to the domains step manually assign it to one of the treatment variants.
2. Finish the onboarding flow and navigate to the /plans page, confirm that the treatment experience is being shown. 
3. Remove the site gating sticker and clear the experiment assignment from local storage.
4. Navigate to the /plans page, confirm that the control is displayed in the /plans page and no call is made to `/wpcom/v2/experiments/0.1.0/assignments/calypso` API endpoint with `experiment_name=calypso_pricing_differentiation_202601_v1`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
