### PR TITLE
Pricing Differentiation: save experiment assignment in preferences

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -1,4 +1,6 @@
+import { useSelector } from 'react-redux';
 import { useExperiment } from 'calypso/lib/explat';
+import { getPreference } from 'calypso/state/preferences/selectors';
 
 type PlanDifferentiatorsExperimentVariant = 'control' | 'var1' | 'var1d' | 'var3' | 'var4' | 'var5';
 
@@ -63,18 +65,20 @@ type PlanDifferentiatorsExperimentResult = {
 
 interface UsePlanDifferentiatorsExperimentParams {
 	flowName?: string | null;
-	intent?: string;
 	isInSignup: boolean;
 }
 
 function usePlanDifferentiatorsExperiment( {
 	flowName,
-	intent,
 	isInSignup,
 }: UsePlanDifferentiatorsExperimentParams ): PlanDifferentiatorsExperimentResult {
-	// Eligible for onboarding signup flow or plans-default-wpcom admin intent
+	const assignmentFromPreference = useSelector( ( state ) =>
+		getPreference( state, 'calypso_pricing_differentiation_202601_v1' )
+	);
+
+	// Eligible for onboarding signup flow or when user preference is set
 	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
-	const isEligibleAdminIntent = ! isInSignup && intent === 'plans-default-wpcom';
+	const isEligibleAdminIntent = ! isInSignup && !! assignmentFromPreference;
 	const isEligible =
 		process.env.NODE_ENV !== 'test' && ( isEligibleSignupFlow || isEligibleAdminIntent );
 
@@ -82,7 +86,8 @@ function usePlanDifferentiatorsExperiment( {
 		isEligible,
 	} );
 
-	const variant = ( assignment?.variationName ?? undefined ) as
+	// Use stored assignment to avoid waiting for the API response
+	const variant = ( assignmentFromPreference || assignment?.variationName || undefined ) as
 		| PlanDifferentiatorsExperimentVariant
 		| undefined;
 
@@ -95,7 +100,7 @@ function usePlanDifferentiatorsExperiment( {
 	// var5 -> getVar5StackedSignupWpcomFeatures
 
 	return {
-		isLoading,
+		isLoading: assignmentFromPreference ? false : isLoading,
 		variant,
 		isStacked:
 			variant === 'var1' || variant === 'var1d' || variant === 'var3' || variant === 'var5',

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -1,5 +1,7 @@
-import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
 import { useExperiment } from 'calypso/lib/explat';
+import { useDispatch, useSelector } from 'calypso/state';
+import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import type { IAppState } from 'calypso/state/types';
 
@@ -73,6 +75,7 @@ function usePlanDifferentiatorsExperiment( {
 	flowName,
 	isInSignup,
 }: UsePlanDifferentiatorsExperimentParams ): PlanDifferentiatorsExperimentResult {
+	const dispatch = useDispatch();
 	const assignmentFromPreference = useSelector( ( state: IAppState ) =>
 		getPreference( state, 'calypso_pricing_differentiation_202601_v1' )
 	);
@@ -93,6 +96,13 @@ function usePlanDifferentiatorsExperiment( {
 		| undefined;
 
 	const isExperimentVariant = variant !== undefined && variant !== 'control';
+
+	// Save the assignment in user preferences once we get it
+	useEffect( () => {
+		if ( ! assignmentFromPreference && isEligibleSignupFlow && isExperimentVariant && variant ) {
+			dispatch( savePreference( 'calypso_pricing_differentiation_202601_v1', variant ) );
+		}
+	}, [ assignmentFromPreference, isEligibleSignupFlow, isExperimentVariant, variant, dispatch ] );
 
 	// Map variants to feature sets:
 	// var4 -> getLongSetSignupWpcomFeatures

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 import { useExperiment } from 'calypso/lib/explat';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import type { IAppState } from 'calypso/state/types';
 
 type PlanDifferentiatorsExperimentVariant = 'control' | 'var1' | 'var1d' | 'var3' | 'var4' | 'var5';
 
@@ -72,7 +73,7 @@ function usePlanDifferentiatorsExperiment( {
 	flowName,
 	isInSignup,
 }: UsePlanDifferentiatorsExperimentParams ): PlanDifferentiatorsExperimentResult {
-	const assignmentFromPreference = useSelector( ( state ) =>
+	const assignmentFromPreference = useSelector( ( state: IAppState ) =>
 		getPreference( state, 'calypso_pricing_differentiation_202601_v1' )
 	);
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -392,7 +392,7 @@ const PlansFeaturesMain = ( {
 		isVar1dVariant,
 		isVar4Variant,
 		isExperimentVariant,
-	} = usePlanDifferentiatorsExperiment( { flowName, intent, isInSignup } );
+	} = usePlanDifferentiatorsExperiment( { flowName, isInSignup } );
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15927

## Proposed Changes

* Save the assignment in user preferences.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* On /plans page we don't want to call the /assignments endpoint if the experiment wasn't assigned.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new user, after getting to the domains step manually assign it to one of the treatment variants.
2. Go to the plan selection step and confirm that a POST request to /preferences was made with the assignment variant.
3. Navigate to the /plans page, confirm that the assigned variation is displayed in the /plans page.
5. Create another user, but don't assign it to the experiment or assign to control.
6. Repeat step 3 and confirm that the /plans page shows the control experience.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
