### PR TITLE
Site selector search box

### DIFF
--- a/client/a8c-for-agencies/sections/sites/add-sites/atomic-sites-selector.tsx
+++ b/client/a8c-for-agencies/sections/sites/add-sites/atomic-sites-selector.tsx
@@ -24,7 +24,7 @@ const AtomicSitesSelector = ( {
 	return (
 		<div className="atomic-sites-selector">
 			<BaseSiteSelector
-				clasName="add-sites-from-wpcom_site-selector"
+				className="add-sites-from-wpcom__site-selector"
 				indicator
 				allSitesPath={ A4A_SITES_LINK }
 				sitesBasePath={ A4A_SITES_LINK }
@@ -33,6 +33,7 @@ const AtomicSitesSelector = ( {
 				showHiddenSites={ false }
 				showListBottomAdornment={ false }
 				isPlaceholder={ isPlaceholder }
+				forceShowSearch
 			/>
 		</div>
 	);

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -64,6 +64,7 @@ export class SiteSelector extends Component {
 		maxResults: PropTypes.number,
 		hasSiteWithPlugins: PropTypes.bool,
 		showListBottomAdornment: PropTypes.bool,
+		forceShowSearch: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -83,6 +84,7 @@ export class SiteSelector extends Component {
 		keepCurrentSection: false,
 		autoFocus: false,
 		showListBottomAdornment: true,
+		forceShowSearch: false,
 	};
 
 	state = {
@@ -416,7 +418,11 @@ export class SiteSelector extends Component {
 		const hiddenSitesCount = this.props.siteCount - this.props.visibleSiteCount;
 
 		const selectorClass = clsx( 'site-selector', 'sites-list', this.props.className, {
-			'is-large': this.props.siteCount > 6 || hiddenSitesCount > 0 || this.state.showSearch,
+			'is-large':
+				this.props.forceShowSearch ||
+				this.props.siteCount > 6 ||
+				hiddenSitesCount > 0 ||
+				this.state.showSearch,
 			'is-single': this.props.visibleSiteCount === 1,
 			'is-hover-enabled': ! this.state.isKeyboardEngaged,
 		} );


### PR DESCRIPTION
```
Part of #A4A-168

## Proposed Changes

*   Added a `forceShowSearch` prop to the `SiteSelector` component to control the visibility of the search box.
*   Modified the `SiteSelector` to always display the search box when `forceShowSearch` is `true`, overriding the default behavior of hiding it for fewer than 6 sites.
*   Enabled the `forceShowSearch` prop in the `AtomicSitesSelector` (A4A site selector) to ensure the search box is always visible.
*   Fixed a typo (`clasName` to `className`) in `AtomicSitesSelector`.

## Why are these changes being made?
*   Large agencies often manage hundreds of sites, making it difficult to locate specific sites within the "Via WordPress.com" option of the Site Selector.
*   The existing `SiteSelector` component hides the search input box by default when there are 6 or fewer sites, which is not suitable for agencies needing constant search functionality.
*   These changes ensure the search box is always visible in the A4A site selector, allowing agencies to efficiently filter sites by name and address (URL/slug), as requested in the Linear issue.

## Testing Instructions

1.  Navigate to the A4A add sites section where the `AtomicSitesSelector` is used.
2.  Verify that the search input box is always visible, regardless of the number of sites displayed.
3.  Enter search terms into the box and confirm that the list of sites filters correctly based on site name and address/URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
```

---

<a href="https://cursor.com/background-agent?bcId=bc-09f4f23b-593b-4064-b8cb-14b8b9e7ab10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09f4f23b-593b-4064-b8cb-14b8b9e7ab10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

