### PR TITLE
MSD: Replace msd dashboard type with dotcom

### DIFF
--- a/client/dashboard/domains/empty-domains-state/actions.tsx
+++ b/client/dashboard/domains/empty-domains-state/actions.tsx
@@ -1,10 +1,11 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, search, globe } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
 import { useAnalytics } from '../../app/analytics';
 import { useAppContext } from '../../app/context';
 import EmptyState from '../../components/empty-state';
-import { wpcomLink } from '../../utils/link';
+import { getCurrentDashboard, wpcomLink } from '../../utils/link';
 
 function SearchDomainsActionItem( { url }: { url: string } ) {
 	const { recordTracksEvent } = useAnalytics();
@@ -17,7 +18,7 @@ function SearchDomainsActionItem( { url }: { url: string } ) {
 			actions={
 				<Button
 					variant="secondary"
-					href={ wpcomLink( url ) }
+					href={ addQueryArgs( wpcomLink( url ), { dashboard: getCurrentDashboard() } ) }
 					onClick={ () =>
 						recordTracksEvent( 'calypso_domains_dashboard_empty_state_action_click', {
 							action: 'search-domains',
@@ -71,7 +72,9 @@ function ConnectDomainActionItem() {
 			actions={
 				<Button
 					variant="secondary"
-					href={ wpcomLink( '/setup/domain/use-my-domain' ) }
+					href={ addQueryArgs( wpcomLink( '/setup/domain/use-my-domain' ), {
+						dashboard: getCurrentDashboard(),
+					} ) }
 					onClick={ () =>
 						recordTracksEvent( 'calypso_domains_dashboard_empty_state_action_click', {
 							action: 'transfer-domain',

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -34,15 +34,15 @@ export function a4aLink( path: string ) {
 
 /**
  * Dashboard type identifier.
- * undefined represents the default (main MSD dashboard).
+ * undefined represents the default (main `dotcom` MSD dashboard).
  */
-export type DashboardType = 'ciab' | 'msd';
+export type DashboardType = 'ciab' | 'dotcom';
 
 /**
  * Returns the dashboard type from a string.
  */
 export function getDashboardFromString( dashboard?: string ): DashboardType | null {
-	if ( dashboard === 'ciab' || dashboard === 'msd' ) {
+	if ( dashboard === 'ciab' || dashboard === 'dotcom' ) {
 		return dashboard;
 	}
 
@@ -98,7 +98,9 @@ function getDashboardFromReferrer(): DashboardType | null {
  * Priority: query param → current path → referrer → defaults to MSD
  */
 export function getCurrentDashboard(): DashboardType {
-	return getDashboardFromQuery() ?? getDashboardFromPath() ?? getDashboardFromReferrer() ?? 'msd';
+	return (
+		getDashboardFromQuery() ?? getDashboardFromPath() ?? getDashboardFromReferrer() ?? 'dotcom'
+	);
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/108277, https://github.com/Automattic/wp-calypso/pull/108424

## Proposed Changes

* The value of the `DashboardType` should be either `dotcom` and `ciab` so this PR proposes to replace `msd` with `dotcom`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Both dashboard-dotcom and dashboard-ciab are the multi-site dashboard (MSD). The name of the MSD should depend on the `slug` of the app instead of the dashboard type.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains
* Click Add domain name > Search domain names
* Ensure you can see the `dashboard=dotcom` in the URL
* Go to /ciab/domains
* Click Add domain name > Search domain names
* Ensure you can see the `dashboard=ciab` in the URL

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
