### PR TITLE
MCP settings: fix toggle labels

### DIFF
--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -303,11 +303,7 @@ function McpComponent() {
 								__nextHasNoMarginBottom
 								checked={ anyToolsEnabled }
 								onChange={ handleMasterToggle }
-								label={
-									<Text>
-										{ anyToolsEnabled ? __( 'Disable AI Access' ) : __( 'Enable AI Access' ) }
-									</Text>
-								}
+								label={ <Text>{ __( 'Enable AI access' ) }</Text> }
 							/>
 						</VStack>
 					</CardBody>
@@ -345,13 +341,7 @@ function McpComponent() {
 										checked={ allSelectedSitesEnabled }
 										disabled={ mutation.isPending }
 										onChange={ handleAllSitesToggle }
-										label={
-											<Text>
-												{ allSelectedSitesEnabled
-													? __( 'Disable AI access for selected sites' )
-													: __( 'Enable AI access for selected sites' ) }
-											</Text>
-										}
+										label={ <Text>{ __( 'Enable AI access for selected sites' ) }</Text> }
 									/>
 								) }
 							</VStack>

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -263,13 +263,7 @@ function McpComponent( { path } ) {
 									__nextHasNoMarginBottom
 									checked={ anyToolsEnabled }
 									onChange={ handleMasterToggle }
-									label={
-										<Text weight="bold">
-											{ anyToolsEnabled
-												? translate( 'Disable MCP Tool Access' )
-												: translate( 'Enable MCP Tool Access' ) }
-										</Text>
-									}
+									label={ <Text weight="bold">{ translate( 'Enable MCP Tool Access' ) }</Text> }
 								/>
 								{ anyToolsEnabled && (
 									<Button variant="secondary" href="/me/mcp-setup">
@@ -312,11 +306,7 @@ function McpComponent( { path } ) {
 										disabled={ mutation.isPending }
 										onChange={ ( enabled ) => handleSiteToggle( selectedSiteId, enabled ) }
 										label={
-											<Text weight="bold">
-												{ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId )
-													? translate( 'Disable MCP access for this site' )
-													: translate( 'Enable MCP access for this site' ) }
-											</Text>
+											<Text weight="bold">{ translate( 'Enable MCP access for this site' ) }</Text>
 										}
 									/>
 								) }


### PR DESCRIPTION
Fixes confusing labels on toggles on the MCP settings screens (both "classic" Calypso and in Hosting Dashboard).

On this screenshot the toggle is enabled but the label says "disable" and vice versa. That's very confusing and how toggle labels should look like:
<img width="667" height="140" alt="Screenshot 2026-01-29 at 15 46 24" src="https://github.com/user-attachments/assets/3acedd44-713c-4acd-93e3-0ac4eb865259" />

The [ARIA Guide says](https://www.w3.org/WAI/ARIA/apg/patterns/switch/) explicitly about the "switch" pattern:

> Important: it is critical the label on a switch does not change when its state changes.

In this PR I'm changing all the offending toggles to say just "enable".

Even saying the "enable" verb might be suboptimal. Another variant would be to just describe the thing that is either on or off: "AI Access", "MCP Tool Access".

Browsing through the macOS System Settings.app, I see that they often describe a toggle for a large feature without a verb:

<img width="477" height="117" alt="Screenshot 2026-01-30 at 9 03 41" src="https://github.com/user-attachments/assets/ae85048a-1ab4-438e-b4c1-b38a4731f580" />

And in other cases, they practically never say "enable" but prefer a more specific verb:

<img width="473" height="113" alt="Screenshot 2026-01-29 at 15 40 18" src="https://github.com/user-attachments/assets/817d3317-0bb9-4d9f-972d-678f290ee8d6" />

