### PR TITLE
Ensure a consistent plans grid for Features Gating experiment

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -1,4 +1,7 @@
 import { useExperiment } from 'calypso/lib/explat';
+import { useSelector } from 'calypso/state';
+import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
+import type { IAppState } from 'calypso/state/types';
 
 type PlanDifferentiatorsExperimentVariant = 'control' | 'var1' | 'var1d' | 'var3' | 'var4' | 'var5';
 
@@ -63,36 +66,39 @@ type PlanDifferentiatorsExperimentResult = {
 
 interface UsePlanDifferentiatorsExperimentParams {
 	flowName?: string | null;
-	intent?: string;
 	isInSignup: boolean;
+	siteId?: number | null;
 }
 
-function usePlanDifferentiatorsExperiment( {
-	flowName,
-	intent,
-	isInSignup,
-}: UsePlanDifferentiatorsExperimentParams ): PlanDifferentiatorsExperimentResult {
-	// Eligible for onboarding signup flow or plans-default-wpcom admin intent
-	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
-	const isEligibleAdminIntent = ! isInSignup && intent === 'plans-default-wpcom';
-	const isEligible =
-		process.env.NODE_ENV !== 'test' && ( isEligibleSignupFlow || isEligibleAdminIntent );
+/**
+ * Returns the control state for the experiment (no variant assigned).
+ */
+function getControlResult(): PlanDifferentiatorsExperimentResult {
+	return {
+		isLoading: false,
+		variant: undefined,
+		isStacked: false,
+		isLongSet: false,
+		isShortSet: false,
+		showDifferentiatorHeader: false,
+		useVar5Features: false,
+		useVar4Features: false,
+		useVar3Features: false,
+		useVar1Features: false,
+		isVar1dVariant: false,
+		isVar4Variant: false,
+		isExperimentVariant: false,
+	};
+}
 
-	const [ isLoading, assignment ] = useExperiment( 'calypso_pricing_differentiation_202601_v1', {
-		isEligible,
-	} );
-
-	const variant = ( assignment?.variationName ?? undefined ) as
-		| PlanDifferentiatorsExperimentVariant
-		| undefined;
-
+/**
+ * Builds the experiment result from a variant.
+ */
+function buildResultFromVariant(
+	isLoading: boolean,
+	variant: PlanDifferentiatorsExperimentVariant | undefined
+): PlanDifferentiatorsExperimentResult {
 	const isExperimentVariant = variant !== undefined && variant !== 'control';
-
-	// Map variants to feature sets:
-	// var4 -> getLongSetSignupWpcomFeatures
-	// var1, var1d -> getShortSetStackedSignupWpcomFeatures
-	// var3 -> getLongSetStackedSignupWpcomFeatures
-	// var5 -> getVar5StackedSignupWpcomFeatures
 
 	return {
 		isLoading,
@@ -110,6 +116,41 @@ function usePlanDifferentiatorsExperiment( {
 		isVar4Variant: variant === 'var4',
 		isExperimentVariant,
 	};
+}
+
+function usePlanDifferentiatorsExperiment( {
+	flowName,
+	isInSignup,
+	siteId,
+}: UsePlanDifferentiatorsExperimentParams ): PlanDifferentiatorsExperimentResult {
+	// Check if the site has the gating business Q1 flag (set when user purchased through experiment)
+	const isGatingBusinessQ1 = useSelector( ( state: IAppState ) =>
+		siteId ? getSiteOption( state, siteId, 'is_gating_business_q1' ) : false
+	);
+
+	// Determine experiment eligibility based on context:
+	// - Signup flow (no siteId): Run experiment to create/get assignment
+	// - Logged-in with siteId and is_gating_business_q1=true: Run experiment to get cached assignment
+	// - Logged-in with siteId and is_gating_business_q1=false: Don't run experiment (show control)
+	const isEligibleSignupFlow = isInSignup && flowName === 'onboarding';
+	const isEligibleExistingSite = ! isInSignup && !! siteId && !! isGatingBusinessQ1;
+	const isEligible =
+		process.env.NODE_ENV !== 'test' && ( isEligibleSignupFlow || isEligibleExistingSite );
+
+	const [ isLoading, assignment ] = useExperiment( 'calypso_pricing_differentiation_202601_v1', {
+		isEligible,
+	} );
+
+	// If user has a site but is not in the experiment (is_gating_business_q1=false), return control
+	if ( siteId && ! isGatingBusinessQ1 && ! isInSignup ) {
+		return getControlResult();
+	}
+
+	const variant = ( assignment?.variationName ?? undefined ) as
+		| PlanDifferentiatorsExperimentVariant
+		| undefined;
+
+	return buildResultFromVariant( isLoading, variant );
 }
 
 export default usePlanDifferentiatorsExperiment;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -392,7 +392,7 @@ const PlansFeaturesMain = ( {
 		isVar1dVariant,
 		isVar4Variant,
 		isExperimentVariant,
-	} = usePlanDifferentiatorsExperiment( { flowName, intent, isInSignup } );
+	} = usePlanDifferentiatorsExperiment( { flowName, isInSignup, siteId } );
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -86,6 +86,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'site_creation_flow',
 	'site_source_slug',
 	'is_difm_lite_in_progress',
+	'is_gating_business_q1',
 	'is_summer_special_2025',
 	'site_intent',
 	'site_partner_bundle',

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -45,6 +45,7 @@ export const SITE_OPTIONS = [
 	'created_at',
 	'unmapped_url',
 	'is_difm_lite_in_progress',
+	'is_gating_business_q1',
 	'is_summer_special_2025',
 	'is_domain_only',
 	'is_redirect',

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -24,6 +24,7 @@ export interface SiteOptions {
 	is_domain_only?: boolean;
 	is_redirect?: boolean;
 	is_difm_lite_in_progress?: boolean;
+	is_gating_business_q1?: boolean;
 	is_summer_special_2025?: boolean;
 	is_wpforteams_site?: boolean;
 	migration_source_site_domain?: string;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -261,6 +261,7 @@ export interface SiteDetailsOptions {
 	is_automated_transfer?: boolean;
 	is_cloud_eligible?: boolean;
 	is_difm_lite_in_progress?: boolean;
+	is_gating_business_q1?: boolean;
 	is_summer_special_2025?: boolean;
 	is_domain_only?: boolean;
 	is_mapped_domain?: boolean;


### PR DESCRIPTION
Part of #

## Proposed Changes

* Ensure consistency in the plans grid in regards of the feature gating experiment

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
