### PR TITLE
e2e tests: Remove blob reporter to fix TeamCity artifact size limit

### DIFF
--- a/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
+++ b/.teamcity/_self/CalypsoE2ETestsBuildTemplate.kt
@@ -244,7 +244,6 @@ object CalypsoE2ETestsBuildTemplate : Template({
 
   	artifactRules = """
 		test/e2e/output => %PROJECT%/output
-		test/e2e/blob-report => blob-report
 	""".trimIndent()
   
   	failureConditions {

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -31,7 +31,6 @@ const reporter: ReporterDescription[] = [
 
 if ( process.env.CI ) {
 	reporter.push( [ 'list' ] );
-	reporter.push( [ 'blob' ] );
 }
 
 // All end-to-end tests use a custom user agent containing this string.


### PR DESCRIPTION
Part of QAO-225

## Proposed Changes

- Remove the Playwright blob reporter from E2E test configuration
- Remove the blob-report artifact rule from TeamCity build template

## Why are these changes being made?

TeamCity failed to publish E2E test artifacts because the blob report zip file exceeded the configured maximum artifact size (392 MB vs 286 MB limit). The blob reporter creates comprehensive zip files containing all test artifacts (screenshots, videos, traces), which grow large when many tests fail.

The blob reporter is primarily used for merging sharded test results, but the current CI configuration doesn't use sharding or the merge-reports step. The HTML, JUnit, and CTRF reporters remain available for debugging failed tests.

## Testing Instructions

- Verify E2E tests still run and publish artifacts correctly on PR checks
- Confirm the HTML report is still accessible for debugging test failures
