### PR TITLE
Fix flaky domains-table unit tests

### DIFF
--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row-actions.tsx
@@ -5,16 +5,25 @@ import page from '@automattic/calypso-router';
 import { screen, act } from '@testing-library/react';
 import { renderWithProvider } from '../../test-utils';
 import { ResponseDomain } from '../../utils/types';
-import { DomainsTableStateContext, useGenerateDomainsTableState } from '../domains-table';
+import { DomainsTableStateContext } from '../domains-table';
 import { DomainsTableRowActions } from '../domains-table-row-actions';
 
 jest.mock( '@automattic/calypso-router' );
 
-const render = ( el, props ) =>
+// Mock context value to avoid network requests from useGenerateDomainsTableState hooks
+const mockContextValue = {
+	onDomainAction: jest.fn(),
+	userCanSetPrimaryDomains: false,
+	updatingDomain: null,
+	domainStatusPurchaseActions: undefined,
+	hasConnectableSites: false,
+};
+
+const render = ( el ) =>
 	renderWithProvider( el, {
 		wrapper: function Wrapper( { children } ) {
 			return (
-				<DomainsTableStateContext.Provider value={ useGenerateDomainsTableState( props ) }>
+				<DomainsTableStateContext.Provider value={ mockContextValue as any }>
 					{ children }
 				</DomainsTableStateContext.Provider>
 			);
@@ -34,7 +43,7 @@ const defaultProps = {
 };
 
 test( 'when settings action is clicked it should show the settings page', async () => {
-	render( <DomainsTableRowActions { ...defaultProps } />, defaultProps );
+	render( <DomainsTableRowActions { ...defaultProps } /> );
 
 	const domainAction = screen.getByRole( 'button', {
 		name: 'Domain actions',
@@ -51,7 +60,7 @@ test( 'when settings action is clicked it should show the settings page', async 
 } );
 
 test( 'when dns action is clicked it should show the dns page', async () => {
-	render( <DomainsTableRowActions { ...defaultProps } />, defaultProps );
+	render( <DomainsTableRowActions { ...defaultProps } /> );
 
 	const domainAction = screen.getByRole( 'button', {
 		name: 'Domain actions',
@@ -68,7 +77,7 @@ test( 'when dns action is clicked it should show the dns page', async () => {
 } );
 
 test( 'when contact action is clicked it should show the contact page', async () => {
-	render( <DomainsTableRowActions { ...defaultProps } />, defaultProps );
+	render( <DomainsTableRowActions { ...defaultProps } /> );
 
 	const domainAction = screen.getByRole( 'button', {
 		name: 'Domain actions',
@@ -96,7 +105,7 @@ test( 'when transfer action is clicked it should show the transfer page', async 
 		domain: transferDomain,
 	};
 
-	render( <DomainsTableRowActions { ...props } />, props );
+	render( <DomainsTableRowActions { ...props } /> );
 
 	const domainAction = screen.getByRole( 'button', {
 		name: 'Domain actions',

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -16,11 +16,19 @@ import { DomainsTableRow } from '../domains-table-row';
 
 const siteSlug = 'site123.com';
 
+// Mock fetchBulkActionStatus to prevent network requests
+const mockFetchBulkActionStatus = jest.fn().mockResolvedValue( {} );
+
 const render = ( el, props ) =>
 	renderWithProvider( el, {
 		wrapper: function Wrapper( { children } ) {
 			return (
-				<DomainsTableStateContext.Provider value={ useGenerateDomainsTableState( props ) }>
+				<DomainsTableStateContext.Provider
+					value={ useGenerateDomainsTableState( {
+						...props,
+						fetchBulkActionStatus: mockFetchBulkActionStatus,
+					} ) }
+				>
 					<table>
 						<tbody>{ children }</tbody>
 					</table>


### PR DESCRIPTION
## Proposed Changes

- Replace `useGenerateDomainsTableState()` hook call with static mock context value in domains-table-row-actions tests
- Mock only the context properties that the component actually uses

## Why are these changes being made?

The test was calling `useGenerateDomainsTableState()` which triggered internal react-query hooks (`useQueries` and `useBulkDomainUpdateStatusQuery`). These hooks made network requests that weren't properly mocked, causing intermittent `TypeError: Reflect.has called on non-object` errors from MSW interceptors. Replacing the hook with a static mock eliminates all network requests, making tests deterministic.

## Testing Instructions

Run the tests multiple times to verify stability:
```bash
cd packages/domains-table
yarn jest src/domains-table/__tests__/domains-table-row-actions.tsx
```

All 4 tests pass consistently across multiple runs.