### PR TITLE
Checkout: Move refund notice out of Read more section

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -112,9 +112,9 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 				{ ! isGiftPurchase && <AdditionalTermsOfServiceInCart /> }
 				{ ! isGiftPurchase && <ThirdPartyPluginsTermsOfService cart={ cart } /> }
 				{ ! isGiftPurchase && <TitanTermsOfService cart={ cart } /> }
+				{ shouldShowRefundPolicy && <RefundPolicies cart={ cart } /> }
 
 				<CheckoutTermsReadMore>
-					{ shouldShowRefundPolicy && <RefundPolicies cart={ cart } /> }
 					{ shouldShowBundledDomainNotice && <BundledDomainNotice cart={ cart } /> }
 					{ shouldShowInternationalFeeNotice && <InternationalFeeNotice /> }
 					{ shouldShowJetpackSocialAdvancedPricingDisclaimer && (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-334/improve-visibility-of-domain-refund-window-information-at-checkout

## Proposed Changes

This PR moves the refund period notice in checkout out of the "Read more" section of checkout.

Before             |  After
:-------------------------:|:-------------------------:
<img width="625" height="462" alt="Screenshot 2026-02-02 at 12 28 00 PM" src="https://github.com/user-attachments/assets/94f138a9-71eb-434a-8afc-255f6f37a6a3" /> | <img width="612" height="451" alt="Screenshot 2026-02-02 at 12 28 46 PM" src="https://github.com/user-attachments/assets/518075c3-6687-41d3-8045-40467b3211da" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Folks were complaining that the notices at the bottom of checkout were too noisy so we implemented a "Read more" collapsable section to help (see https://github.com/Automattic/wp-calypso/pull/87554). However, this has lead to folks complaining that they cannot see the refund period. We should remove the refund period from the collapsable section and make it always visible.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Add a product to your cart and visit checkout.
- Scroll to the bottom of checkout and make sure that you see a line item above the submit button that mentions the refund period.