### PR TITLE
Fix Woo hosted plans back navigation

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/test/woo-hosted-plans.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/test/woo-hosted-plans.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import { STEPS } from '../../../internals/steps';
+import wooHostedPlansFlow from '../woo-hosted-plans';
+
+jest.mock( '@automattic/onboarding', () => ( {
+	WOO_HOSTED_PLANS_FLOW: 'woo-hosted-plans',
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: () => ( {
+		get: ( key: string ) => {
+			if ( key === 'back_to' || key === 'cancel_to' ) {
+				return null;
+			}
+			if ( key === 'siteSlug' ) {
+				return 'example.com';
+			}
+			return null;
+		},
+	} ),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
+	useSite: () => ( { ID: 123 } ),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/stores', () => ( {
+	SITE_STORE: 'SITE_STORE',
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: ( mapSelect: ( select: ( store: unknown ) => unknown ) => unknown ) =>
+		mapSelect( () => ( {
+			getSiteOption: ( siteId: number, option: string ) => {
+				if ( siteId === 123 && option === 'admin_url' ) {
+					return 'https://example.com/wp-admin/';
+				}
+				return null;
+			},
+		} ) ),
+	resolveSelect: jest.fn(),
+	useDispatch: jest.fn(),
+	select: jest.fn(),
+	dispatch: jest.fn(),
+	registerStore: jest.fn(),
+	createReduxStore: jest.fn(),
+	combineReducers: jest.fn(),
+	createRegistry: jest.fn(),
+	createSelector: jest.fn( ( selector ) => selector ),
+	register: jest.fn(),
+} ) );
+
+describe( 'woo-hosted-plans flow', () => {
+	const originalLocation = window.location;
+
+	beforeEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: { ...originalLocation, assign: jest.fn() },
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: originalLocation,
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	it( 'uses the site admin url when no back_to is provided', () => {
+		const stepsProps = wooHostedPlansFlow.useStepsProps();
+		stepsProps[ STEPS.UNIFIED_PLANS.slug ].wrapperProps?.goBack?.();
+
+		expect( window.location.assign ).toHaveBeenCalledWith( 'https://example.com/wp-admin/' );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/test/woo-hosted-plans.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/test/woo-hosted-plans.test.ts
@@ -72,8 +72,8 @@ describe( 'woo-hosted-plans flow', () => {
 	} );
 
 	it( 'uses the site admin url when no back_to is provided', () => {
-		const stepsProps = wooHostedPlansFlow.useStepsProps();
-		stepsProps[ STEPS.UNIFIED_PLANS.slug ].wrapperProps?.goBack?.();
+		const stepsProps = wooHostedPlansFlow.useStepsProps?.();
+		stepsProps?.[ STEPS.UNIFIED_PLANS.slug ]?.wrapperProps?.goBack?.();
 
 		expect( window.location.assign ).toHaveBeenCalledWith( 'https://example.com/wp-admin/' );
 	} );

--- a/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/woo-hosted-plans.ts
+++ b/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/woo-hosted-plans.ts
@@ -79,10 +79,11 @@ const wooHostedPlansFlow: FlowV2< typeof initialize > = {
 			},
 			[ site?.ID ]
 		);
+		const safeAdminUrl = typeof adminUrl === 'string' ? adminUrl : null;
 
 		// Validate back_to to prevent open redirect - must not be external
 		const safeBackTo =
-			backTo && ! isExternal( backTo ) ? backTo : adminUrl || dashboardLink( '/sites' );
+			backTo && ! isExternal( backTo ) ? backTo : safeAdminUrl ?? dashboardLink( '/sites' );
 
 		return {
 			[ STEPS.UNIFIED_PLANS.slug ]: {

--- a/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/woo-hosted-plans.ts
+++ b/client/landing/stepper/declarative-flow/flows/woo-hosted-plans/woo-hosted-plans.ts
@@ -1,15 +1,17 @@
 import { WOO_HOSTED_PLANS_FLOW } from '@automattic/onboarding';
-import { resolveSelect } from '@wordpress/data';
+import { resolveSelect, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
 import { FlowV2, SubmitHandler } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { getCurrentQueryParams } from 'calypso/landing/stepper/utils/get-current-query-params';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { isExternal } from 'calypso/lib/url';
+import type { SiteSelect } from '@automattic/data-stores';
 import './style.scss';
 
 const BASE_STEPS = [ STEPS.UNIFIED_PLANS ];
@@ -64,10 +66,23 @@ const wooHostedPlansFlow: FlowV2< typeof initialize > = {
 
 	useStepsProps() {
 		const query = useQuery();
+		const site = useSite();
 		const backTo = query.get( 'back_to' ) ?? query.get( 'cancel_to' ) ?? undefined;
+		const adminUrl = useSelect(
+			( select ) => {
+				if ( ! site?.ID ) {
+					return null;
+				}
+
+				const siteStore = select( SITE_STORE ) as SiteSelect;
+				return siteStore.getSiteOption( site.ID, 'admin_url' ) ?? null;
+			},
+			[ site?.ID ]
+		);
 
 		// Validate back_to to prevent open redirect - must not be external
-		const safeBackTo = backTo && ! isExternal( backTo ) ? backTo : dashboardLink( '/sites' );
+		const safeBackTo =
+			backTo && ! isExternal( backTo ) ? backTo : adminUrl || dashboardLink( '/sites' );
 
 		return {
 			[ STEPS.UNIFIED_PLANS.slug ]: {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes WOOPRD-1942

## Proposed Changes

* Make Woo Hosted Plans back button default to the site admin URL when no `back_to`/`cancel_to` is provided.
* Add a unit test to cover the admin URL fallback behavior.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users who hit the Woo Hosted plan selection and click `< Back` were landing on `my.wordpress.com/sites` even though we already know the site. This returns them to their site’s admin instead, which is the expected destination.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Manual testing:

- Create Woo hosted site
- Click plan nudge to land in plan selection
- While on the plan selection page, hit the back button
- Verify you go to a sites dashboard
- Navigate back to plans selection
- Change URL to calypso.localhost:3000 or whatever calypso.live URL you get
- Hit back button
- Verify that you land in the admin for your site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
