### PR TITLE
A4A: Add Pressable Premium plans.

### DIFF
--- a/client/a8c-for-agencies/data/client/use-fetch-client-products.ts
+++ b/client/a8c-for-agencies/data/client/use-fetch-client-products.ts
@@ -10,7 +10,7 @@ function queryClientProducts(): Promise< APIProductFamily[] > {
 	return wpcom.req
 		.get( {
 			apiNamespace: 'wpcom/v2',
-			path: '/agency-client/public/pricing',
+			path: '/agency-client/public/products',
 		} )
 		.then( ( data: APIProductFamily[] ) => {
 			const exclude = [

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -216,7 +216,7 @@ export default function PressablePlanSection( {
 		filteredPressablePlans.some( ( plan ) => plan.slug.startsWith( 'pressable-premium-' ) );
 
 	// Show premium plan section if the selected tab is premium and there are no new premium plans
-	if ( selectedTab === PLAN_CATEGORY_PREMIUM && ! hasNewPremiumPlans ) {
+	if ( selectedTab === PLAN_CATEGORY_PREMIUM && ( ! hasNewPremiumPlans || isCustomPlan ) ) {
 		return <PremiumPlanSection heading={ heading } banner={ banner } />;
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -104,22 +104,35 @@ export default function PressablePlanSection( {
 		}
 
 		if ( areSignaturePlans ) {
-			return pressablePlans.filter( ( plan ) => plan.slug.startsWith( 'pressable-signature-' ) );
+			return pressablePlans.filter(
+				( plan ) =>
+					plan.slug.startsWith( 'pressable-signature-' ) ||
+					plan.slug.startsWith( 'pressable-premium-' )
+			);
 		}
 
-		return pressablePlans.filter( ( plan ) => ! plan.slug.startsWith( 'pressable-signature-' ) );
+		return pressablePlans.filter(
+			( plan ) =>
+				! plan.slug.startsWith( 'pressable-signature-' ) ||
+				plan.slug.startsWith( 'pressable-premium-' )
+		);
 	}, [ pressablePlans, areSignaturePlans ] );
 
 	useEffect( () => {
 		if ( pressablePlans?.length ) {
-			const defaultSlug = areSignaturePlans ? 'pressable-signature-1' : 'pressable-build';
+			let defaultSlug = areSignaturePlans ? 'pressable-signature-1' : 'pressable-build';
+
+			if ( selectedTab === PLAN_CATEGORY_PREMIUM ) {
+				defaultSlug = 'pressable-premium-1';
+			}
+
 			setSelectedPlan(
 				isReferralMode
 					? pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? null
 					: pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? pressablePlans[ 0 ]
 			);
 		}
-	}, [ isReferralMode, pressablePlans, setSelectedPlan, areSignaturePlans ] );
+	}, [ isReferralMode, pressablePlans, setSelectedPlan, areSignaturePlans, selectedTab ] );
 
 	useEffect( () => {
 		if ( ! isReferralMode && existingPlan ) {
@@ -155,6 +168,7 @@ export default function PressablePlanSection( {
 					onSelectPlan={ setSelectedPlan }
 					pressablePlan={ existingPressablePlan }
 					isLoading={ ! isFetching }
+					isReferralMode={ !! isReferralMode }
 					areSignaturePlans={ areSignaturePlans }
 					selectedTab={ selectedTab }
 					setSelectedTab={ setSelectedTab }
@@ -167,6 +181,7 @@ export default function PressablePlanSection( {
 		filteredPressablePlans,
 		existingPressablePlan,
 		isFetching,
+		isReferralMode,
 		areSignaturePlans,
 		selectedTab,
 	] );
@@ -196,8 +211,12 @@ export default function PressablePlanSection( {
 
 	const isCustomPlan = ! selectedPlan;
 
-	// Show premium plan section if the selected tab is premium
-	if ( selectedTab === PLAN_CATEGORY_PREMIUM ) {
+	const hasNewPremiumPlans =
+		isReferralMode &&
+		filteredPressablePlans.some( ( plan ) => plan.slug.startsWith( 'pressable-premium-' ) );
+
+	// Show premium plan section if the selected tab is premium and there are no new premium plans
+	if ( selectedTab === PLAN_CATEGORY_PREMIUM && ! hasNewPremiumPlans ) {
 		return <PremiumPlanSection heading={ heading } banner={ banner } />;
 	}
 
@@ -266,34 +285,47 @@ export default function PressablePlanSection( {
 				) : (
 					<SimpleList
 						items={ [
-							translate(
-								'Up to {{b}}%(count)d WordPress install{{/b}}',
-								'Up to {{b}}%(count)d WordPress installs{{/b}}',
-								{
-									args: {
-										count: selectedPlanInfo?.install ?? 0,
-									},
-									count: selectedPlanInfo?.install ?? 0,
-									components: {
-										b: <b />,
-									},
-									comment: '%(count)d is the number of WordPress installs.',
-								}
-							),
-							translate(
-								'Up to {{b}}%(count)d staging site{{/b}}',
-								'Up to {{b}}%(count)d staging sites{{/b}}',
-								{
-									args: {
-										count: selectedPlanInfo?.install ?? 0,
-									},
-									count: selectedPlanInfo?.install ?? 0,
-									components: {
-										b: <b />,
-									},
-									comment: '%(count)d is the number of staging sites.',
-								}
-							),
+							...( selectedTab === PLAN_CATEGORY_PREMIUM
+								? [
+										translate( '{{b}}%(worker)d{{/b}} base PHP Workers', {
+											args: {
+												worker: selectedPlanInfo?.worker ?? 5,
+											},
+											components: {
+												b: <b />,
+											},
+										} ),
+								  ]
+								: [
+										translate(
+											'Up to {{b}}%(count)d WordPress install{{/b}}',
+											'Up to {{b}}%(count)d WordPress installs{{/b}}',
+											{
+												args: {
+													count: selectedPlanInfo?.install ?? 0,
+												},
+												count: selectedPlanInfo?.install ?? 0,
+												components: {
+													b: <b />,
+												},
+												comment: '%(count)d is the number of WordPress installs.',
+											}
+										),
+										translate(
+											'Up to {{b}}%(count)d staging site{{/b}}',
+											'Up to {{b}}%(count)d staging sites{{/b}}',
+											{
+												args: {
+													count: selectedPlanInfo?.install ?? 0,
+												},
+												count: selectedPlanInfo?.install ?? 0,
+												components: {
+													b: <b />,
+												},
+												comment: '%(count)d is the number of staging sites.',
+											}
+										),
+								  ] ),
 							translate( '{{b}}%(count)s visits{{/b}} per month*', {
 								args: {
 									count: formatNumberCompact( selectedPlanInfo?.visits ?? 0 ),

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency, formatNumberCompact } from '@automattic/number-formatters';
 import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -15,7 +16,8 @@ import getPressablePlan, {
 	PressablePlan,
 } from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
 import PlanSelectionFilter from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import HostingPlanSection from '../../common/hosting-plan-section';
 import CustomPlanCardContent from './custom-plan-card-content';
@@ -98,6 +100,8 @@ export default function PressablePlanSection( {
 
 	const selectedPlanInfo = selectedPlan ? getPressablePlan( selectedPlan.slug ) : null;
 
+	const isBDBillingSystem = useSelector( getActiveAgency )?.billing_system === 'billingdragon';
+
 	const filteredPressablePlans = useMemo( () => {
 		if ( ! pressablePlans ) {
 			return [];
@@ -107,14 +111,15 @@ export default function PressablePlanSection( {
 			return pressablePlans.filter(
 				( plan ) =>
 					plan.slug.startsWith( 'pressable-signature-' ) ||
-					plan.slug.startsWith( 'pressable-premium-' )
+					( isEnabled( 'a4a-pressable-premium-plans' ) &&
+						plan.slug.startsWith( 'pressable-premium-' ) )
 			);
 		}
 
 		return pressablePlans.filter(
 			( plan ) =>
-				! plan.slug.startsWith( 'pressable-signature-' ) ||
-				plan.slug.startsWith( 'pressable-premium-' )
+				! plan.slug.startsWith( 'pressable-signature-' ) &&
+				! plan.slug.startsWith( 'pressable-premium-' ) // We do not want to offer the new premium plans for agency with Legacy plans to reduce complexity in the UI
 		);
 	}, [ pressablePlans, areSignaturePlans ] );
 
@@ -212,6 +217,7 @@ export default function PressablePlanSection( {
 	const isCustomPlan = ! selectedPlan;
 
 	const hasNewPremiumPlans =
+		isBDBillingSystem &&
 		isReferralMode &&
 		filteredPressablePlans.some( ( plan ) => plan.slug.startsWith( 'pressable-premium-' ) );
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -291,47 +291,34 @@ export default function PressablePlanSection( {
 				) : (
 					<SimpleList
 						items={ [
-							...( selectedTab === PLAN_CATEGORY_PREMIUM
-								? [
-										translate( '{{b}}%(worker)d{{/b}} base PHP Workers', {
-											args: {
-												worker: selectedPlanInfo?.worker ?? 5,
-											},
-											components: {
-												b: <b />,
-											},
-										} ),
-								  ]
-								: [
-										translate(
-											'Up to {{b}}%(count)d WordPress install{{/b}}',
-											'Up to {{b}}%(count)d WordPress installs{{/b}}',
-											{
-												args: {
-													count: selectedPlanInfo?.install ?? 0,
-												},
-												count: selectedPlanInfo?.install ?? 0,
-												components: {
-													b: <b />,
-												},
-												comment: '%(count)d is the number of WordPress installs.',
-											}
-										),
-										translate(
-											'Up to {{b}}%(count)d staging site{{/b}}',
-											'Up to {{b}}%(count)d staging sites{{/b}}',
-											{
-												args: {
-													count: selectedPlanInfo?.install ?? 0,
-												},
-												count: selectedPlanInfo?.install ?? 0,
-												components: {
-													b: <b />,
-												},
-												comment: '%(count)d is the number of staging sites.',
-											}
-										),
-								  ] ),
+							translate(
+								'Up to {{b}}%(count)d WordPress install{{/b}}',
+								'Up to {{b}}%(count)d WordPress installs{{/b}}',
+								{
+									args: {
+										count: selectedPlanInfo?.install ?? 0,
+									},
+									count: selectedPlanInfo?.install ?? 0,
+									components: {
+										b: <b />,
+									},
+									comment: '%(count)d is the number of WordPress installs.',
+								}
+							),
+							translate(
+								'Up to {{b}}%(count)d staging site{{/b}}',
+								'Up to {{b}}%(count)d staging sites{{/b}}',
+								{
+									args: {
+										count: selectedPlanInfo?.install ?? 0,
+									},
+									count: selectedPlanInfo?.install ?? 0,
+									components: {
+										b: <b />,
+									},
+									comment: '%(count)d is the number of staging sites.',
+								}
+							),
 							translate( '{{b}}%(count)s visits{{/b}} per month*', {
 								args: {
 									count: formatNumberCompact( selectedPlanInfo?.visits ?? 0 ),
@@ -349,6 +336,14 @@ export default function PressablePlanSection( {
 									b: <b />,
 								},
 								comment: '%(storageSize)d is the size of storage in GB.',
+							} ),
+							translate( '{{b}}%(worker)d{{/b}} base PHP Workers', {
+								args: {
+									worker: selectedPlanInfo?.worker ?? 5,
+								},
+								components: {
+									b: <b />,
+								},
 							} ),
 							translate( '{{b}}Unmetered bandwidth{{/b}}', {
 								components: {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -3,6 +3,7 @@ import {
 	PLAN_CATEGORY_ENTERPRISE,
 	PLAN_CATEGORY_SIGNATURE,
 	PLAN_CATEGORY_SIGNATURE_HIGH,
+	PLAN_CATEGORY_PREMIUM,
 } from '../constants';
 
 export type PressablePlan = {
@@ -11,6 +12,7 @@ export type PressablePlan = {
 	visits: number;
 	storage: number;
 	category: string;
+	worker?: number;
 };
 
 const PLAN_DATA: Record< string, PressablePlan > = {
@@ -306,6 +308,96 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		visits: 10000000,
 		storage: 1000,
 		category: PLAN_CATEGORY_SIGNATURE_HIGH,
+	},
+
+	// [New] Pressable Premium Plans 2026-02
+	'pressable-premium-1': {
+		slug: 'pressable-premium-1',
+		install: 1,
+		visits: 150000,
+		storage: 30,
+		worker: 10,
+		category: PLAN_CATEGORY_PREMIUM,
+	},
+	'pressable-premium-2': {
+		slug: 'pressable-premium-2',
+		install: 1,
+		visits: 250000,
+		storage: 40,
+		worker: 10,
+		category: PLAN_CATEGORY_PREMIUM,
+	},
+	'pressable-premium-3': {
+		slug: 'pressable-premium-3',
+		install: 1,
+		visits: 350000,
+		storage: 50,
+		worker: 13,
+		category: PLAN_CATEGORY_PREMIUM,
+	},
+	'pressable-premium-4': {
+		slug: 'pressable-premium-4',
+		install: 1,
+		visits: 500000,
+		storage: 60,
+		worker: 15,
+		category: PLAN_CATEGORY_PREMIUM,
+	},
+	'pressable-premium-5': {
+		slug: 'pressable-premium-5',
+		install: 1,
+		visits: 750000,
+		storage: 70,
+		worker: 15,
+		category: PLAN_CATEGORY_PREMIUM,
+	},
+	'pressable-premium-6': {
+		slug: 'pressable-premium-6',
+		install: 1,
+		visits: 1000000,
+		storage: 80,
+		worker: 17,
+		category: PLAN_CATEGORY_PREMIUM,
+	},
+	'pressable-premium-7': {
+		slug: 'pressable-premium-7',
+		install: 1,
+		visits: 2000000,
+		storage: 90,
+		worker: 17,
+		category: PLAN_CATEGORY_PREMIUM,
+	},
+	'pressable-premium-8': {
+		slug: 'pressable-premium-8',
+		install: 1,
+		visits: 3000000,
+		storage: 100,
+		worker: 20,
+		category: PLAN_CATEGORY_PREMIUM,
+	},
+	'pressable-premium-9': {
+		slug: 'pressable-premium-9',
+		install: 1,
+		visits: 5000000,
+		storage: 125,
+		worker: 20,
+		category: PLAN_CATEGORY_PREMIUM,
+	},
+	'pressable-premium-10': {
+		slug: 'pressable-premium-10',
+		install: 1,
+		visits: 7000000,
+		storage: 150,
+		worker: 25,
+		category: PLAN_CATEGORY_PREMIUM,
+	},
+	'pressable-premium-11': {
+		slug: 'pressable-premium-11',
+		install: 1,
+		visits: 10000000,
+		storage: 150,
+		worker: 25,
+		category: PLAN_CATEGORY_PREMIUM,
 	},
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -397,7 +397,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 1000000,
 		storage: 80,
-		worker: 15,
+		worker: 17,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 	'pressable-premium-7': {
@@ -405,7 +405,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 2000000,
 		storage: 90,
-		worker: 15,
+		worker: 17,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 	'pressable-premium-8': {
@@ -413,7 +413,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 3000000,
 		storage: 100,
-		worker: 15,
+		worker: 20,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 	'pressable-premium-9': {
@@ -421,7 +421,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 5000000,
 		storage: 125,
-		worker: 15,
+		worker: 20,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 	'pressable-premium-10': {
@@ -429,7 +429,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 7000000,
 		storage: 150,
-		worker: 15,
+		worker: 25,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 	'pressable-premium-11': {
@@ -437,7 +437,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 10000000,
 		storage: 175,
-		worker: 15,
+		worker: 25,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 };

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -356,7 +356,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 1000000,
 		storage: 80,
-		worker: 17,
+		worker: 15,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 	'pressable-premium-7': {
@@ -364,7 +364,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 2000000,
 		storage: 90,
-		worker: 17,
+		worker: 15,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 	'pressable-premium-8': {
@@ -372,7 +372,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 3000000,
 		storage: 100,
-		worker: 20,
+		worker: 15,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 	'pressable-premium-9': {
@@ -380,7 +380,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 5000000,
 		storage: 125,
-		worker: 20,
+		worker: 15,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 	'pressable-premium-10': {
@@ -388,7 +388,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 7000000,
 		storage: 150,
-		worker: 25,
+		worker: 15,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 	'pressable-premium-11': {
@@ -396,7 +396,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 10000000,
 		storage: 150,
-		worker: 25,
+		worker: 15,
 		category: PLAN_CATEGORY_PREMIUM,
 	},
 };

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -22,6 +22,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 50000,
 		storage: 20,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-2': {
@@ -29,6 +30,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 5,
 		visits: 100000,
 		storage: 50,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-3': {
@@ -36,6 +38,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 10,
 		visits: 250000,
 		storage: 80,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-4': {
@@ -43,6 +46,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 25,
 		visits: 500000,
 		storage: 175,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-5': {
@@ -50,6 +54,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 50,
 		visits: 1000000,
 		storage: 250,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-6': {
@@ -57,6 +62,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 75,
 		visits: 1500000,
 		storage: 350,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-wp-7': {
@@ -64,6 +70,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 100,
 		visits: 2000000,
 		storage: 500,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 
@@ -73,6 +80,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 30000,
 		storage: 20,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-growth': {
@@ -80,6 +88,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 3,
 		visits: 50000,
 		storage: 30,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-advanced': {
@@ -87,6 +96,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 5,
 		visits: 75000,
 		storage: 35,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-pro': {
@@ -94,6 +104,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 10,
 		visits: 150000,
 		storage: 50,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-premium': {
@@ -101,6 +112,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 20,
 		visits: 400000,
 		storage: 80,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-business': {
@@ -108,6 +120,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 50,
 		visits: 1000000,
 		storage: 200,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-business-80': {
@@ -115,6 +128,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 80,
 		visits: 1600000,
 		storage: 275,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-business-100': {
@@ -122,6 +136,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 100,
 		visits: 2000000,
 		storage: 325,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-business-120': {
@@ -129,6 +144,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 120,
 		visits: 2400000,
 		storage: 375,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 	'pressable-business-150': {
@@ -136,6 +152,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 150,
 		visits: 3000000,
 		storage: 450,
+		worker: 10,
 		category: PLAN_CATEGORY_STANDARD,
 	},
 
@@ -145,6 +162,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 200,
 		visits: 4000000,
 		storage: 500,
+		worker: 10,
 		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-5': {
@@ -152,6 +170,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 250,
 		visits: 5000000,
 		storage: 550,
+		worker: 10,
 		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-6': {
@@ -159,6 +178,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 300,
 		visits: 6000000,
 		storage: 600,
+		worker: 10,
 		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-7': {
@@ -166,6 +186,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 350,
 		visits: 7000000,
 		storage: 700,
+		worker: 10,
 		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-8': {
@@ -173,6 +194,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 400,
 		visits: 8000000,
 		storage: 800,
+		worker: 10,
 		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-9': {
@@ -180,6 +202,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 450,
 		visits: 9000000,
 		storage: 900,
+		worker: 10,
 		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	'pressable-enterprise-10': {
@@ -187,6 +210,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 500,
 		visits: 10000000,
 		storage: 1000,
+		worker: 10,
 		category: PLAN_CATEGORY_ENTERPRISE,
 	},
 	// [New] Pressable Signature Plans 2025-06
@@ -195,6 +219,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 1,
 		visits: 30000,
 		storage: 20,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE,
 	},
 	'pressable-signature-2': {
@@ -202,6 +227,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 3,
 		visits: 50000,
 		storage: 30,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE,
 	},
 	'pressable-signature-3': {
@@ -209,6 +235,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 5,
 		visits: 75000,
 		storage: 35,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE,
 	},
 	'pressable-signature-4': {
@@ -216,6 +243,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 10,
 		visits: 150000,
 		storage: 50,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE,
 	},
 	'pressable-signature-5': {
@@ -223,6 +251,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 20,
 		visits: 400000,
 		storage: 80,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE,
 	},
 	'pressable-signature-6': {
@@ -230,6 +259,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 50,
 		visits: 1000000,
 		storage: 200,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE,
 	},
 	'pressable-signature-7': {
@@ -237,6 +267,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 80,
 		visits: 1600000,
 		storage: 275,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE,
 	},
 	'pressable-signature-8': {
@@ -244,6 +275,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 100,
 		visits: 2000000,
 		storage: 325,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE,
 	},
 	'pressable-signature-9': {
@@ -251,6 +283,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 120,
 		visits: 2400000,
 		storage: 375,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE,
 	},
 	'pressable-signature-10': {
@@ -258,6 +291,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 150,
 		visits: 3000000,
 		storage: 450,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE,
 	},
 	'pressable-signature-11': {
@@ -265,6 +299,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 200,
 		visits: 4000000,
 		storage: 500,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE_HIGH,
 	},
 	'pressable-signature-12': {
@@ -272,6 +307,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 250,
 		visits: 5000000,
 		storage: 550,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE_HIGH,
 	},
 	'pressable-signature-13': {
@@ -279,6 +315,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 300,
 		visits: 6000000,
 		storage: 600,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE_HIGH,
 	},
 	'pressable-signature-14': {
@@ -286,6 +323,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 350,
 		visits: 7000000,
 		storage: 700,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE_HIGH,
 	},
 	'pressable-signature-15': {
@@ -293,6 +331,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 400,
 		visits: 8000000,
 		storage: 800,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE_HIGH,
 	},
 	'pressable-signature-16': {
@@ -300,6 +339,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 450,
 		visits: 9000000,
 		storage: 900,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE_HIGH,
 	},
 	'pressable-signature-17': {
@@ -307,6 +347,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		install: 500,
 		visits: 10000000,
 		storage: 1000,
+		worker: 5,
 		category: PLAN_CATEGORY_SIGNATURE_HIGH,
 	},
 
@@ -395,7 +436,7 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		slug: 'pressable-premium-11',
 		install: 1,
 		visits: 10000000,
-		storage: 150,
+		storage: 175,
 		worker: 15,
 		category: PLAN_CATEGORY_PREMIUM,
 	},

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
@@ -1,5 +1,10 @@
 import { formatNumberCompact } from '@automattic/number-formatters';
-import { FILTER_TYPE_INSTALL, FILTER_TYPE_STORAGE, FILTER_TYPE_VISITS } from '../constants';
+import {
+	FILTER_TYPE_INSTALL,
+	FILTER_TYPE_STORAGE,
+	FILTER_TYPE_VISITS,
+	PLAN_CATEGORY_PREMIUM,
+} from '../constants';
 import { FilterType } from '../types';
 import { PressablePlan } from './get-pressable-plan';
 
@@ -12,7 +17,11 @@ export default function getSliderOptions(
 	return plans
 		.filter( ( plan ) => plan !== undefined )
 		.filter( ( plan ) => category === undefined || plan.category === category ) // Maybe only return plans of a specific category
-		.sort( ( planA, planB ) => planA.install - planB.install ) // Ensure our options are sorted by install count
+		.sort( ( planA, planB ) =>
+			category === PLAN_CATEGORY_PREMIUM
+				? planA.visits - planB.visits
+				: planA.install - planB.install
+		) // Ensure our options are sorted by install count
 		.map( ( plan ) => {
 			let label = '';
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -35,6 +35,7 @@ type Props = {
 	areSignaturePlans?: boolean;
 	selectedTab: string;
 	setSelectedTab: ( tab: string ) => void;
+	isReferralMode: boolean;
 };
 
 export default function PlanSelectionFilter( {
@@ -46,6 +47,7 @@ export default function PlanSelectionFilter( {
 	areSignaturePlans: areSignaturePlans = false,
 	selectedTab,
 	setSelectedTab,
+	isReferralMode,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -57,6 +59,10 @@ export default function PlanSelectionFilter( {
 	const isDesktop = useDesktopBreakpoint();
 
 	const isPremiumPlanTab = selectedTab === PLAN_CATEGORY_PREMIUM;
+
+	// Currently, we only want the premium plans for referral mode
+	const hasNewPremiumPlans =
+		isReferralMode && plans.some( ( plan ) => plan.slug.startsWith( 'pressable-premium-' ) );
 
 	const lowPlanOptions = useMemo(
 		() =>
@@ -90,6 +96,23 @@ export default function PlanSelectionFilter( {
 		[ filterType, isMobile, plans, isPremiumPlanTab, translate, areSignaturePlans ]
 	);
 
+	const premiumPlanOptions = useMemo(
+		() => [
+			...getSliderOptions(
+				filterType,
+				plans.map( ( plan ) => getPressablePlan( plan.slug ) ),
+				PLAN_CATEGORY_PREMIUM,
+				isMobile
+			),
+			{
+				label: translate( 'More' ),
+				value: null,
+				category: null,
+			},
+		],
+		[ filterType, isMobile, plans, translate ]
+	);
+
 	const onSelectOption = useCallback(
 		( option: Option ) => {
 			const plan = plans.find( ( plan ) => plan.slug === option.value ) ?? null;
@@ -103,11 +126,28 @@ export default function PlanSelectionFilter( {
 		[ dispatch, onSelectPlan, plans ]
 	);
 
-	const selectedOptionIndex = (
-		PLAN_CATEGORY_STANDARD === selectedTab || PLAN_CATEGORY_SIGNATURE === selectedTab
-			? lowPlanOptions
-			: highPlanOptions
-	).findIndex( ( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null ) );
+	const selectedOptionIndex = useMemo( () => {
+		let options = [];
+		switch ( selectedTab ) {
+			case PLAN_CATEGORY_STANDARD:
+			case PLAN_CATEGORY_SIGNATURE:
+				options = lowPlanOptions;
+				break;
+			case PLAN_CATEGORY_ENTERPRISE:
+			case PLAN_CATEGORY_SIGNATURE_HIGH:
+				options = highPlanOptions;
+				break;
+			case PLAN_CATEGORY_PREMIUM:
+				options = premiumPlanOptions;
+				break;
+			default:
+				return 0;
+		}
+
+		return options.findIndex(
+			( { value } ) => value === ( selectedPlan ? selectedPlan.slug : null )
+		);
+	}, [ selectedTab, lowPlanOptions, highPlanOptions, premiumPlanOptions, selectedPlan ] );
 
 	const onSelectFilterType = useCallback(
 		( value: FilterType ) => {
@@ -117,6 +157,21 @@ export default function PlanSelectionFilter( {
 			);
 		},
 		[ dispatch ]
+	);
+
+	const onSelectTab = useCallback(
+		( tab: string ) => {
+			setSelectedTab( tab );
+
+			if (
+				hasNewPremiumPlans &&
+				tab === PLAN_CATEGORY_PREMIUM &&
+				filterType === FILTER_TYPE_INSTALL
+			) {
+				setFilterType( FILTER_TYPE_VISITS );
+			}
+		},
+		[ filterType, hasNewPremiumPlans, setSelectedTab ]
 	);
 
 	const additionalWrapperClass =
@@ -142,11 +197,21 @@ export default function PlanSelectionFilter( {
 			const isPlanEnterpriseCategory =
 				PLAN_CATEGORY_ENTERPRISE === pressablePlan?.category ||
 				PLAN_CATEGORY_SIGNATURE_HIGH === pressablePlan?.category;
+			const isPlanPremiumCategory = PLAN_CATEGORY_PREMIUM === pressablePlan?.category;
 
 			if ( isStandardCategory && ! isPlanStandardCategory ) {
 				return categoryOptions.length - 1;
 			} else if ( isEnterpriseCategory && ! isPlanEnterpriseCategory ) {
 				return 0;
+			}
+
+			if ( isPlanPremiumCategory ) {
+				for ( let i = 0; i < categoryOptions.length; i++ ) {
+					const plan = getPressablePlan( categoryOptions[ i ].value as string );
+					if ( pressablePlan?.storage < plan?.storage ) {
+						return i;
+					}
+				}
 			}
 
 			for ( let i = 0; i < categoryOptions.length; i++ ) {
@@ -210,12 +275,17 @@ export default function PlanSelectionFilter( {
 							title: isDesktop ? translate( 'Enterprise Plans' ) : translate( 'Enterprise' ),
 						},
 				  ] ),
-			{
-				name: PLAN_CATEGORY_PREMIUM,
-				title: isDesktop ? translate( 'Premium Plans' ) : translate( 'Premium' ),
-			},
+			hasNewPremiumPlans
+				? {
+						name: PLAN_CATEGORY_PREMIUM,
+						title: isDesktop ? translate( 'Premium Plans 1-11' ) : translate( 'Premium 1-11' ),
+				  }
+				: {
+						name: PLAN_CATEGORY_PREMIUM,
+						title: isDesktop ? translate( 'Premium Plans' ) : translate( 'Premium' ),
+				  },
 		],
-		[ areSignaturePlans, disableStandardTab, translate, isDesktop ]
+		[ areSignaturePlans, isDesktop, translate, disableStandardTab, hasNewPremiumPlans ]
 	);
 
 	if ( isLoading ) {
@@ -227,7 +297,7 @@ export default function PlanSelectionFilter( {
 		);
 	}
 
-	const FilterByPicker = () => (
+	const FilterByPicker = ( { hideInstallOption }: { hideInstallOption?: boolean } ) => (
 		<div className="pressable-overview-plan-selection__filter-type">
 			<p className="pressable-overview-plan-selection__filter-label">
 				{ translate( 'Display plans by total' ) }
@@ -237,7 +307,9 @@ export default function PlanSelectionFilter( {
 				className="pressable-overview-plan-selection__filter-radio-control"
 				selected={ filterType }
 				options={ [
-					{ label: translate( 'WordPress installs' ), value: FILTER_TYPE_INSTALL },
+					...( hideInstallOption
+						? []
+						: [ { label: translate( 'WordPress installs' ), value: FILTER_TYPE_INSTALL } ] ),
 					{ label: translate( 'Traffic' ), value: FILTER_TYPE_VISITS },
 					{
 						label: isMobile ? translate( 'Storage (GB)' ) : translate( 'Storage' ),
@@ -255,7 +327,7 @@ export default function PlanSelectionFilter( {
 				key={ selectedTab } // Force re-render when selectedTab changes
 				className="pressable-overview-plan-selection__plan-category-tabpanel"
 				activeClass="pressable-overview-plan-selection__plan-category-tab-is-active"
-				onSelect={ setSelectedTab }
+				onSelect={ onSelectTab }
 				initialTabName={ selectedTab }
 				tabs={ tabs }
 			>
@@ -303,6 +375,18 @@ export default function PlanSelectionFilter( {
 									/>
 								</>
 							);
+						case PLAN_CATEGORY_PREMIUM:
+							return hasNewPremiumPlans ? (
+								<>
+									<FilterByPicker hideInstallOption />
+									<A4ASlider
+										value={ PLAN_CATEGORY_PREMIUM === selectedTab ? selectedOptionIndex : 0 }
+										onChange={ onSelectOption }
+										options={ premiumPlanOptions }
+										minimum={ getSliderMinimum( PLAN_CATEGORY_PREMIUM, premiumPlanOptions ) }
+									/>
+								</>
+							) : null;
 						default:
 							return null;
 					}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -4,7 +4,8 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	FILTER_TYPE_INSTALL,
@@ -60,9 +61,13 @@ export default function PlanSelectionFilter( {
 
 	const isPremiumPlanTab = selectedTab === PLAN_CATEGORY_PREMIUM;
 
+	const isBDBillingSystem = useSelector( getActiveAgency )?.billing_system === 'billingdragon';
+
 	// Currently, we only want the premium plans for referral mode
 	const hasNewPremiumPlans =
-		isReferralMode && plans.some( ( plan ) => plan.slug.startsWith( 'pressable-premium-' ) );
+		isBDBillingSystem &&
+		isReferralMode &&
+		plans.some( ( plan ) => plan.slug.startsWith( 'pressable-premium-' ) );
 
 	const lowPlanOptions = useMemo(
 		() =>

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -42,6 +42,7 @@
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
+		"a4a-pressable-premium-plans": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -35,6 +35,7 @@
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
+		"a4a-pressable-premium-plans": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -35,6 +35,7 @@
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
+		"a4a-pressable-premium-plans": false,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -37,6 +37,7 @@
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
+		"a4a-pressable-premium-plans": false,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,


### PR DESCRIPTION
## Proposed Changes
This pull request introduces the new "Pressable Premium" plan tier (plans 1–11) and updates the plan selection UI and logic to support these premium plans, especially in referral mode. The changes affect plan filtering, selection, sorting, and display, ensuring the new premium plans are handled distinctly from existing plans.

<img width="1028" height="427" alt="Screenshot 2026-02-13 at 11 22 23 PM" src="https://github.com/user-attachments/assets/bcb37427-1061-4761-907e-0b1c6c2b8363" />


**Key changes include:**

### Premium Plan Support and Data

* Added a new set of "Pressable Premium" plans (1–11) to the `PLAN_DATA` object in `get-pressable-plan.ts`, each with new properties such as `worker` and higher resource allocations.
* Updated the `PressablePlan` type to include an optional `worker` property, used by premium plans.

### Plan Filtering and Selection Logic

* Modified filtering logic in `PressablePlanSection` to include premium plans alongside signature plans when relevant, and adjusted default plan selection logic to account for the premium tab. [[1]](diffhunk://#diff-90afca4e8e508d38a7c96b34328bf37cab883f078e46077e4ab8c1e0f7c3657fL107-R135) [[2]](diffhunk://#diff-90afca4e8e508d38a7c96b34328bf37cab883f078e46077e4ab8c1e0f7c3657fL199-R219)
* Updated the plan selection slider and tab logic in `PlanSelectionFilter` to support premium plans, including custom sorting (by visits), option labeling, and handling the "More" option for premium plans. [[1]](diffhunk://#diff-80c75f699c7c6143cf571d37abe802650251e40fef2c02bdd00ad9164d19692cL15-R24) [[2]](diffhunk://#diff-bc6f0138019d8db85f71668664851b37df51f8ddde4630da63beaaa8e57a1a77R99-R115) [[3]](diffhunk://#diff-bc6f0138019d8db85f71668664851b37df51f8ddde4630da63beaaa8e57a1a77L106-R150)

### Referral Mode and Conditional Display

* Ensured premium plans are only available in referral mode and updated related logic throughout the plan selection and display components. [[1]](diffhunk://#diff-bc6f0138019d8db85f71668664851b37df51f8ddde4630da63beaaa8e57a1a77R63-R66) [[2]](diffhunk://#diff-90afca4e8e508d38a7c96b34328bf37cab883f078e46077e4ab8c1e0f7c3657fR184)
* Adjusted tab titles and display logic to reflect the presence of premium plans, including dynamic tab naming and hiding/showing options based on referral mode.

### UI and Display Enhancements

* Updated the UI to display premium plan-specific information, such as base PHP worker count, and adjusted the plan feature list accordingly. [[1]](diffhunk://#diff-90afca4e8e508d38a7c96b34328bf37cab883f078e46077e4ab8c1e0f7c3657fR288-R299) [[2]](diffhunk://#diff-90afca4e8e508d38a7c96b34328bf37cab883f078e46077e4ab8c1e0f7c3657fR328)
* Modified the filter picker to optionally hide the "WordPress installs" filter for premium plans, as installs are fixed at 1 for these plans. [[1]](diffhunk://#diff-bc6f0138019d8db85f71668664851b37df51f8ddde4630da63beaaa8e57a1a77L230-R300) [[2]](diffhunk://#diff-bc6f0138019d8db85f71668664851b37df51f8ddde4630da63beaaa8e57a1a77L240-R312) [[3]](diffhunk://#diff-bc6f0138019d8db85f71668664851b37df51f8ddde4630da63beaaa8e57a1a77R378-R389)

### Prop and Dependency Updates

* Passed new props such as `isReferralMode` and updated dependencies in affected components to ensure correct reactivity and behavior. [[1]](diffhunk://#diff-90afca4e8e508d38a7c96b34328bf37cab883f078e46077e4ab8c1e0f7c3657fR171) [[2]](diffhunk://#diff-bc6f0138019d8db85f71668664851b37df51f8ddde4630da63beaaa8e57a1a77R38) [[3]](diffhunk://#diff-bc6f0138019d8db85f71668664851b37df51f8ddde4630da63beaaa8e57a1a77R50)

These changes collectively enable the new premium plan tier, ensure it is surfaced correctly in the UI, and maintain compatibility with existing plan selection workflows.

## Why are these changes being made?
 
This is part of  Adding fixed-price Pressable Premium Plans to A4A (referrals only) project.

## Testing Instructions
When testing, make sure you are using agencies that are already in the BD system.

* Apply this patch to your sandbox 202757-ghe-Automattic/wpcom
* Use the A4A live link and navigate to `marketplace/hosting/pressable`
* Confirm you do not see the Premium plans.
* Enable the Referral mode.
* Confirm that you see the Premium plans.
* Disable your sandbox and confirm that you do not see the Premium plans. (These plans are only selectable if the products endpoint returns them.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?