### PR TITLE
MSD: add tests for Site Overview screen

### DIFF
--- a/client/dashboard/components/callout/index.tsx
+++ b/client/dashboard/components/callout/index.tsx
@@ -26,7 +26,11 @@ function UnforwardedCallout(
 ) {
 	const isMobileViewport = useViewportMatch( 'mobile', '<' );
 	return (
-		<Card ref={ ref } className={ `dashboard-callout is-${ variant } is-image-${ imageVariant }` }>
+		<Card
+			ref={ ref }
+			role="article"
+			className={ `dashboard-callout is-${ variant } is-image-${ imageVariant }` }
+		>
 			<HStack
 				className="dashboard-callout__h-container"
 				spacing="6"

--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -239,6 +239,7 @@ export default function OverviewCard( {
 
 	return (
 		<Card
+			role="article"
 			className={ clsx( 'dashboard-overview-card', {
 				[ `dashboard-overview-card--${ intent }` ]: intent,
 				'dashboard-overview-card--disabled': isLoading || disabled,

--- a/client/dashboard/sites/overview-flex-usage-card/index.tsx
+++ b/client/dashboard/sites/overview-flex-usage-card/index.tsx
@@ -44,6 +44,7 @@ export default function OverviewFlexUsageCard( { site }: Props ) {
 
 	return (
 		<Card
+			role="article"
 			className="dashboard-overview-usage-card"
 			onMouseEnter={ () =>
 				recordTracksEvent( 'calypso_dashboard_site_overview_flex_usage_card_impression' )

--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -79,7 +79,7 @@ export default function LatestActivityCard( {
 	};
 
 	return (
-		<Card className="dashboard-overview-latest-activity-card">
+		<Card role="article" className="dashboard-overview-latest-activity-card">
 			<CardHeader>
 				<SectionHeader title={ __( 'Latest activity' ) } level={ 3 } />
 			</CardHeader>

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { render, mockPublicApi } from '../../../test-utils';
+import SiteOverview from '../index';
+import type { Site } from '@automattic/api-core';
+
+const site = {
+	ID: 1,
+	name: 'Test Site',
+	slug: 'test-site.wordpress.com',
+	URL: 'https://test-site.wordpress.com',
+	subscribers_count: 10,
+	launch_status: 'launched',
+	site_migration: {},
+	plan: {
+		product_slug: 'business-bundle',
+		product_name_short: 'Business',
+		is_free: false,
+		features: {
+			active: [ 'atomic', 'backups', 'scan', 'performance', 'full-activity-log' ],
+		},
+	},
+	options: {
+		admin_url: 'https://test-site.wordpress.com/wp-admin/',
+		created_at: '2026-01-01T00:00:00+00:00',
+	},
+} as unknown as Site;
+
+function mockSite( mockedSite: Site ) {
+	mockPublicApi()
+		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
+		.query( true )
+		.reply( 200, mockedSite );
+}
+
+describe( 'SiteOverview', () => {
+	beforeEach( () => {
+		mockPublicApi()
+			.get( '/rest/v1.1/me/preferences' )
+			.query( true )
+			.reply( 200, { calypso_preferences: {} } );
+
+		mockPublicApi().get( '/rest/v1.2/all-domains' ).query( true ).reply( 200, { domains: [] } );
+
+		mockPublicApi()
+			.get( '/rest/v1.1/domains/suggestions' )
+			.query( true )
+			.reply( 200, [ { domain_name: 'test-site.com', product_slug: 'dotcom_domain' } ] );
+
+		mockPublicApi()
+			.get( `/wpcom/v2/sites/${ site.ID }/activity` )
+			.query( true )
+			.reply( 200, { items: [] } );
+
+		mockPublicApi()
+			.get( `/wpcom/v2/sites/${ site.ID }/scan` )
+			.query( true )
+			.reply( 200, { threats: [] } );
+
+		mockPublicApi()
+			.get( `/wpcom/v2/sites/${ site.ID }/launchpad` )
+			.query( true )
+			.reply( 200, { checklist: [] } );
+
+		mockPublicApi()
+			.get( `/wpcom/v2/sites/${ site.ID }/site-profiler/pages` )
+			.query( true )
+			.reply( 200, { pages: [] } );
+
+		mockPublicApi()
+			.get( `/rest/v1.1/sites/${ site.ID }/media-storage` )
+			.query( true )
+			.reply( 200, { max_storage_bytes: 1073741824, storage_used_bytes: 100000000 } );
+
+		mockPublicApi()
+			.get( `/rest/v1.3/sites/${ site.ID }/plans` )
+			.query( true )
+			.reply( 200, {
+				1: {
+					product_id: 1,
+					product_slug: 'business-bundle',
+					product_name_short: 'Business',
+					current_plan: true,
+					original_price: { amount: 0 },
+					raw_price: 0,
+					raw_price_integer: 0,
+					raw_discount: 0,
+					raw_discount_integer: 0,
+					cost_overrides: [],
+				},
+			} );
+
+		mockPublicApi()
+			.get( `/wpcom/v2/sites/${ site.ID }/preview-links` )
+			.query( true )
+			.reply( 200, { preview_links: [] } );
+
+		mockPublicApi()
+			.get( `/wpcom/v2/sites/${ site.ID }/hosting/metrics` )
+			.query( true )
+			.reply( 200, { data: { periods: {} } } );
+
+		mockPublicApi().get( `/wpcom/v2/sites/${ site.ID }/flex-usage` ).query( true ).reply( 200, {} );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
+	it( 'renders the overview of a site with free plan', async () => {
+		mockSite( {
+			...site,
+			plan: {
+				product_slug: 'free_plan',
+				product_name_short: 'Free',
+				is_free: true,
+				features: { active: [] },
+			},
+		} as unknown as Site );
+		render( <SiteOverview siteSlug={ site.slug } /> );
+
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+		await screen.findByText( 'Free' );
+
+		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
+
+		const cards = screen.getAllByRole( 'article' );
+		expect( cards ).toHaveLength( 7 );
+		expect( cards[ 0 ] ).toHaveTextContent( 'Visibility' );
+		expect( cards[ 1 ] ).toHaveTextContent( /Upgrade to unlock.*Back up your site/ );
+		expect( cards[ 2 ] ).toHaveTextContent( 'Migrate' );
+		expect( cards[ 3 ] ).toHaveTextContent( /Upgrade to unlock.*Scan for security threats/ );
+		expect( cards[ 4 ] ).toHaveTextContent( 'Plan' );
+		expect( cards[ 5 ] ).toHaveTextContent( 'Latest activity' );
+		expect( cards[ 6 ] ).toHaveTextContent( 'The perfect domain awaits' );
+	} );
+
+	it( 'renders the overview of a site with a paid plan on Atomic', async () => {
+		mockSite( { ...site, is_wpcom_atomic: true } as Site );
+		render( <SiteOverview siteSlug={ site.slug } /> );
+
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+		await screen.findByText( 'Business' );
+
+		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
+
+		const cards = screen.getAllByRole( 'article' );
+		expect( cards ).toHaveLength( 7 );
+		expect( cards[ 0 ] ).toHaveTextContent( 'Visibility' );
+		expect( cards[ 1 ] ).toHaveTextContent( 'Last backup' );
+		expect( cards[ 2 ] ).toHaveTextContent( 'Performance' );
+		expect( cards[ 3 ] ).toHaveTextContent( 'Last scan' );
+		expect( cards[ 4 ] ).toHaveTextContent( 'Plan' );
+		expect( cards[ 5 ] ).toHaveTextContent( 'Latest activity' );
+		expect( cards[ 6 ] ).toHaveTextContent( 'The perfect domain awaits' );
+	} );
+
+	it( 'renders the overview of a site with a paid plan pending Atomic activation', async () => {
+		mockSite( { ...site, is_wpcom_atomic: false } as Site );
+		render( <SiteOverview siteSlug={ site.slug } /> );
+
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+		await screen.findByText( 'Business' );
+
+		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
+
+		const cards = screen.getAllByRole( 'article' );
+		expect( cards ).toHaveLength( 7 );
+		expect( cards[ 0 ] ).toHaveTextContent( 'Visibility' );
+		expect( cards[ 1 ] ).toHaveTextContent( /Activate to unlock.*Back up your site/ );
+		expect( cards[ 2 ] ).toHaveTextContent( /Activate to unlock.*Test site performance/ );
+		expect( cards[ 3 ] ).toHaveTextContent( /Activate to unlock.*Scan for security threats/ );
+		expect( cards[ 4 ] ).toHaveTextContent( 'Plan' );
+		expect( cards[ 5 ] ).toHaveTextContent( 'Latest activity' );
+		expect( cards[ 6 ] ).toHaveTextContent( 'The perfect domain awaits' );
+	} );
+
+	it( 'renders the overview of an unlaunched site', async () => {
+		mockSite( { ...site, launch_status: 'unlaunched' } as Site );
+		render( <SiteOverview siteSlug={ site.slug } /> );
+
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+		await screen.findByText( 'Business' );
+
+		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
+
+		const cards = screen.getAllByRole( 'article' );
+		expect( cards ).toHaveLength( 8 );
+		expect( cards[ 0 ] ).toHaveTextContent( 'Finish setting up your site' );
+		expect( cards[ 6 ] ).toHaveTextContent( /bring your vision to life/ );
+		expect( cards[ 7 ] ).toHaveTextContent( 'The perfect domain awaits' );
+	} );
+
+	it( 'renders the overview of a commerce garden site', async () => {
+		mockSite( { ...site, is_garden: true, garden_name: 'commerce' } as Site );
+		render( <SiteOverview siteSlug={ site.slug } /> );
+
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+
+		expect( screen.getByRole( 'link', { name: 'Manage store' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: /WP Admin/ } ) ).not.toBeInTheDocument();
+
+		const cards = screen.getAllByRole( 'article' );
+		expect( cards ).toHaveLength( 2 );
+		expect( cards[ 0 ] ).toHaveTextContent( 'Plan' );
+		expect( cards[ 1 ] ).toHaveTextContent( 'Visibility' );
+	} );
+
+	it( 'renders the overview of a self-hosted Jetpack connected site', async () => {
+		mockSite( {
+			...site,
+			jetpack: true,
+			jetpack_connection: true,
+			is_wpcom_atomic: false,
+		} as Site );
+		render( <SiteOverview siteSlug={ site.slug } /> );
+
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+
+		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
+
+		const cards = screen.getAllByRole( 'article' );
+		expect( cards ).toHaveLength( 6 );
+		expect( cards[ 0 ] ).toHaveTextContent( 'Visibility' );
+		expect( cards[ 1 ] ).toHaveTextContent( /Activate to unlock.*Back up your site/ );
+		expect( cards[ 2 ] ).toHaveTextContent( 'Subscribers' );
+		expect( cards[ 3 ] ).toHaveTextContent( /Activate to unlock.*Scan for security threats/ );
+		expect( cards[ 4 ] ).toHaveTextContent( 'Subscriptions' );
+		expect( cards[ 5 ] ).toHaveTextContent( 'Latest activity' );
+	} );
+
+	it( 'renders the overview of an A4A dev site', async () => {
+		mockSite( { ...site, is_wpcom_atomic: true, is_a4a_dev_site: true } as Site );
+		render( <SiteOverview siteSlug={ site.slug } /> );
+
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+		await screen.findByText( 'Business' );
+
+		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
+
+		const cards = screen.getAllByRole( 'article' );
+		expect( cards ).toHaveLength( 7 );
+		expect( cards[ 0 ] ).toHaveTextContent( 'Visibility' );
+		expect( cards[ 1 ] ).toHaveTextContent( 'Last backup' );
+		expect( cards[ 2 ] ).toHaveTextContent( 'Share' );
+		expect( cards[ 3 ] ).toHaveTextContent( 'Last scan' );
+		expect( cards[ 4 ] ).toHaveTextContent( 'Development license' );
+		expect( cards[ 5 ] ).toHaveTextContent( 'Latest activity' );
+		expect( cards[ 6 ] ).toHaveTextContent( 'The perfect domain awaits' );
+	} );
+
+	it( 'renders the overview of a site with Flex plan', async () => {
+		mockSite( { ...site, is_wpcom_flex: true } as Site );
+		render( <SiteOverview siteSlug={ site.slug } /> );
+
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+		await screen.findByText( 'Business' );
+
+		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
+
+		const cards = screen.getAllByRole( 'article' );
+		expect( cards ).toHaveLength( 7 );
+		expect( cards[ 0 ] ).toHaveTextContent( 'Last backup' );
+		expect( cards[ 1 ] ).toHaveTextContent( 'Performance' );
+		expect( cards[ 2 ] ).toHaveTextContent( 'Last scan' );
+		expect( cards[ 3 ] ).toHaveTextContent( 'Plan' );
+		expect( cards[ 4 ] ).toHaveTextContent( 'Latest activity' );
+		expect( cards[ 5 ] ).toHaveTextContent( 'Month-to-date site usage' );
+		expect( cards[ 6 ] ).toHaveTextContent( 'The perfect domain awaits' );
+	} );
+} );

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -41,7 +41,7 @@ function getCard( text: string ) {
 	return screen.getAllByRole( 'article' ).find( ( el ) => el.textContent?.includes( text ) );
 }
 
-describe( 'SiteOverview', () => {
+describe( '<SiteOverview>', () => {
 	beforeEach( () => {
 		nock( 'https://public-api.wordpress.com' )
 			.persist()
@@ -118,7 +118,7 @@ describe( 'SiteOverview', () => {
 			.reply( 200, {} );
 	} );
 
-	it( 'renders the overview of a site with free plan', async () => {
+	test( 'renders the overview of a site with free plan', async () => {
 		mockSite( {
 			...site,
 			plan: {
@@ -144,7 +144,7 @@ describe( 'SiteOverview', () => {
 		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
-	it( 'renders the overview of a site with a paid plan on Atomic', async () => {
+	test( 'renders the overview of a site with a paid plan on Atomic', async () => {
 		mockSite( { ...site, is_wpcom_atomic: true } as Site );
 		render( <SiteOverview siteSlug={ site.slug } /> );
 
@@ -162,7 +162,7 @@ describe( 'SiteOverview', () => {
 		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
-	it( 'renders the overview of a site with a paid plan pending Atomic activation', async () => {
+	test( 'renders the overview of a site with a paid plan pending Atomic activation', async () => {
 		mockSite( { ...site, is_wpcom_atomic: false } as Site );
 		render( <SiteOverview siteSlug={ site.slug } /> );
 
@@ -180,7 +180,7 @@ describe( 'SiteOverview', () => {
 		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
-	it( 'renders the overview of an unlaunched site', async () => {
+	test( 'renders the overview of an unlaunched site', async () => {
 		mockSite( { ...site, launch_status: 'unlaunched' } as Site );
 		render( <SiteOverview siteSlug={ site.slug } /> );
 
@@ -194,7 +194,7 @@ describe( 'SiteOverview', () => {
 		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
-	it( 'renders the overview of a commerce garden site', async () => {
+	test( 'renders the overview of a commerce garden site', async () => {
 		mockSite( { ...site, is_garden: true, garden_name: 'commerce' } as Site );
 		render( <SiteOverview siteSlug={ site.slug } /> );
 
@@ -207,7 +207,7 @@ describe( 'SiteOverview', () => {
 		expect( getCard( 'Visibility' ) ).toBeVisible();
 	} );
 
-	it( 'renders the overview of a self-hosted Jetpack connected site', async () => {
+	test( 'renders the overview of a self-hosted Jetpack connected site', async () => {
 		mockSite( {
 			...site,
 			jetpack: true,
@@ -228,7 +228,7 @@ describe( 'SiteOverview', () => {
 		expect( getCard( 'Latest activity' ) ).toBeVisible();
 	} );
 
-	it( 'renders the overview of an A4A dev site', async () => {
+	test( 'renders the overview of an A4A dev site', async () => {
 		mockSite( { ...site, is_wpcom_atomic: true, is_a4a_dev_site: true } as Site );
 		render( <SiteOverview siteSlug={ site.slug } /> );
 
@@ -246,7 +246,7 @@ describe( 'SiteOverview', () => {
 		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
-	it( 'renders the overview of a site with Flex plan', async () => {
+	test( 'renders the overview of a site with Flex plan', async () => {
 		mockSite( { ...site, is_wpcom_flex: true } as Site );
 		render( <SiteOverview siteSlug={ site.slug } /> );
 

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -114,10 +114,6 @@ describe( 'SiteOverview', () => {
 			.reply( 200, {} );
 	} );
 
-	afterEach( () => {
-		nock.cleanAll();
-	} );
-
 	it( 'renders the overview of a site with free plan', async () => {
 		mockSite( {
 			...site,

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -128,8 +128,8 @@ describe( '<SiteOverview>', () => {
 				features: { active: [] },
 			},
 		} as unknown as Site );
-		render( <SiteOverview siteSlug={ site.slug } /> );
 
+		render( <SiteOverview siteSlug={ site.slug } /> );
 		await screen.findByRole( 'heading', { name: 'Test Site' } );
 		await screen.findByText( 'Free' );
 
@@ -146,8 +146,8 @@ describe( '<SiteOverview>', () => {
 
 	test( 'renders the overview of a site with a paid plan on Atomic', async () => {
 		mockSite( { ...site, is_wpcom_atomic: true } as Site );
-		render( <SiteOverview siteSlug={ site.slug } /> );
 
+		render( <SiteOverview siteSlug={ site.slug } /> );
 		await screen.findByRole( 'heading', { name: 'Test Site' } );
 		await screen.findByText( 'Business' );
 
@@ -164,8 +164,8 @@ describe( '<SiteOverview>', () => {
 
 	test( 'renders the overview of a site with a paid plan pending Atomic activation', async () => {
 		mockSite( { ...site, is_wpcom_atomic: false } as Site );
-		render( <SiteOverview siteSlug={ site.slug } /> );
 
+		render( <SiteOverview siteSlug={ site.slug } /> );
 		await screen.findByRole( 'heading', { name: 'Test Site' } );
 		await screen.findByText( 'Business' );
 
@@ -214,8 +214,8 @@ describe( '<SiteOverview>', () => {
 			jetpack_connection: true,
 			is_wpcom_atomic: false,
 		} as Site );
-		render( <SiteOverview siteSlug={ site.slug } /> );
 
+		render( <SiteOverview siteSlug={ site.slug } /> );
 		await screen.findByRole( 'heading', { name: 'Test Site' } );
 
 		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
@@ -230,8 +230,8 @@ describe( '<SiteOverview>', () => {
 
 	test( 'renders the overview of an A4A dev site', async () => {
 		mockSite( { ...site, is_wpcom_atomic: true, is_a4a_dev_site: true } as Site );
-		render( <SiteOverview siteSlug={ site.slug } /> );
 
+		render( <SiteOverview siteSlug={ site.slug } /> );
 		await screen.findByRole( 'heading', { name: 'Test Site' } );
 		await screen.findByText( 'Business' );
 
@@ -248,8 +248,8 @@ describe( '<SiteOverview>', () => {
 
 	test( 'renders the overview of a site with Flex plan', async () => {
 		mockSite( { ...site, is_wpcom_flex: true } as Site );
-		render( <SiteOverview siteSlug={ site.slug } /> );
 
+		render( <SiteOverview siteSlug={ site.slug } /> );
 		await screen.findByRole( 'heading', { name: 'Test Site' } );
 		await screen.findByText( 'Business' );
 

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -37,6 +37,10 @@ function mockSite( mockedSite: Site ) {
 		.reply( 200, mockedSite );
 }
 
+function getCard( text: string ) {
+	return screen.getAllByRole( 'article' ).find( ( el ) => el.textContent?.includes( text ) );
+}
+
 describe( 'SiteOverview', () => {
 	beforeEach( () => {
 		nock( 'https://public-api.wordpress.com' )
@@ -131,15 +135,13 @@ describe( 'SiteOverview', () => {
 
 		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
 
-		const cards = screen.getAllByRole( 'article' );
-		expect( cards ).toHaveLength( 7 );
-		expect( cards[ 0 ] ).toHaveTextContent( 'Visibility' );
-		expect( cards[ 1 ] ).toHaveTextContent( /Upgrade to unlock.*Back up your site/ );
-		expect( cards[ 2 ] ).toHaveTextContent( 'Migrate' );
-		expect( cards[ 3 ] ).toHaveTextContent( /Upgrade to unlock.*Scan for security threats/ );
-		expect( cards[ 4 ] ).toHaveTextContent( 'Plan' );
-		expect( cards[ 5 ] ).toHaveTextContent( 'Latest activity' );
-		expect( cards[ 6 ] ).toHaveTextContent( 'The perfect domain awaits' );
+		expect( getCard( 'Visibility' ) ).toBeVisible();
+		expect( getCard( 'Back up your site' ) ).toHaveTextContent( 'Upgrade to unlock' );
+		expect( getCard( 'Migrate' ) ).toBeVisible();
+		expect( getCard( 'Scan for security threats' ) ).toHaveTextContent( 'Upgrade to unlock' );
+		expect( getCard( 'Plan' ) ).toBeVisible();
+		expect( getCard( 'Latest activity' ) ).toBeVisible();
+		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
 	it( 'renders the overview of a site with a paid plan on Atomic', async () => {
@@ -151,15 +153,13 @@ describe( 'SiteOverview', () => {
 
 		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
 
-		const cards = screen.getAllByRole( 'article' );
-		expect( cards ).toHaveLength( 7 );
-		expect( cards[ 0 ] ).toHaveTextContent( 'Visibility' );
-		expect( cards[ 1 ] ).toHaveTextContent( 'Last backup' );
-		expect( cards[ 2 ] ).toHaveTextContent( 'Performance' );
-		expect( cards[ 3 ] ).toHaveTextContent( 'Last scan' );
-		expect( cards[ 4 ] ).toHaveTextContent( 'Plan' );
-		expect( cards[ 5 ] ).toHaveTextContent( 'Latest activity' );
-		expect( cards[ 6 ] ).toHaveTextContent( 'The perfect domain awaits' );
+		expect( getCard( 'Visibility' ) ).toBeVisible();
+		expect( getCard( 'Last backup' ) ).toBeVisible();
+		expect( getCard( 'Performance' ) ).toBeVisible();
+		expect( getCard( 'Last scan' ) ).toBeVisible();
+		expect( getCard( 'Plan' ) ).toBeVisible();
+		expect( getCard( 'Latest activity' ) ).toBeVisible();
+		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
 	it( 'renders the overview of a site with a paid plan pending Atomic activation', async () => {
@@ -171,15 +171,13 @@ describe( 'SiteOverview', () => {
 
 		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
 
-		const cards = screen.getAllByRole( 'article' );
-		expect( cards ).toHaveLength( 7 );
-		expect( cards[ 0 ] ).toHaveTextContent( 'Visibility' );
-		expect( cards[ 1 ] ).toHaveTextContent( /Activate to unlock.*Back up your site/ );
-		expect( cards[ 2 ] ).toHaveTextContent( /Activate to unlock.*Test site performance/ );
-		expect( cards[ 3 ] ).toHaveTextContent( /Activate to unlock.*Scan for security threats/ );
-		expect( cards[ 4 ] ).toHaveTextContent( 'Plan' );
-		expect( cards[ 5 ] ).toHaveTextContent( 'Latest activity' );
-		expect( cards[ 6 ] ).toHaveTextContent( 'The perfect domain awaits' );
+		expect( getCard( 'Visibility' ) ).toBeVisible();
+		expect( getCard( 'Back up your site' ) ).toHaveTextContent( 'Activate to unlock' );
+		expect( getCard( 'Test site performance' ) ).toHaveTextContent( 'Activate to unlock' );
+		expect( getCard( 'Scan for security threats' ) ).toHaveTextContent( 'Activate to unlock' );
+		expect( getCard( 'Plan' ) ).toBeVisible();
+		expect( getCard( 'Latest activity' ) ).toBeVisible();
+		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
 	it( 'renders the overview of an unlaunched site', async () => {
@@ -191,11 +189,9 @@ describe( 'SiteOverview', () => {
 
 		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
 
-		const cards = screen.getAllByRole( 'article' );
-		expect( cards ).toHaveLength( 8 );
-		expect( cards[ 0 ] ).toHaveTextContent( 'Finish setting up your site' );
-		expect( cards[ 6 ] ).toHaveTextContent( /bring your vision to life/ );
-		expect( cards[ 7 ] ).toHaveTextContent( 'The perfect domain awaits' );
+		expect( getCard( 'Finish setting up your site' ) ).toBeVisible();
+		expect( getCard( 'We’ll bring your vision to life' ) ).toBeVisible();
+		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
 	it( 'renders the overview of a commerce garden site', async () => {
@@ -207,10 +203,8 @@ describe( 'SiteOverview', () => {
 		expect( screen.getByRole( 'link', { name: 'Manage store' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'link', { name: /WP Admin/ } ) ).not.toBeInTheDocument();
 
-		const cards = screen.getAllByRole( 'article' );
-		expect( cards ).toHaveLength( 2 );
-		expect( cards[ 0 ] ).toHaveTextContent( 'Plan' );
-		expect( cards[ 1 ] ).toHaveTextContent( 'Visibility' );
+		expect( getCard( 'Plan' ) ).toBeVisible();
+		expect( getCard( 'Visibility' ) ).toBeVisible();
 	} );
 
 	it( 'renders the overview of a self-hosted Jetpack connected site', async () => {
@@ -226,14 +220,12 @@ describe( 'SiteOverview', () => {
 
 		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
 
-		const cards = screen.getAllByRole( 'article' );
-		expect( cards ).toHaveLength( 6 );
-		expect( cards[ 0 ] ).toHaveTextContent( 'Visibility' );
-		expect( cards[ 1 ] ).toHaveTextContent( /Activate to unlock.*Back up your site/ );
-		expect( cards[ 2 ] ).toHaveTextContent( 'Subscribers' );
-		expect( cards[ 3 ] ).toHaveTextContent( /Activate to unlock.*Scan for security threats/ );
-		expect( cards[ 4 ] ).toHaveTextContent( 'Subscriptions' );
-		expect( cards[ 5 ] ).toHaveTextContent( 'Latest activity' );
+		expect( getCard( 'Visibility' ) ).toBeVisible();
+		expect( getCard( 'Back up your site' ) ).toHaveTextContent( 'Activate to unlock' );
+		expect( getCard( 'Subscribers' ) ).toBeVisible();
+		expect( getCard( 'Scan for security threats' ) ).toHaveTextContent( 'Activate to unlock' );
+		expect( getCard( 'Subscriptions' ) ).toBeVisible();
+		expect( getCard( 'Latest activity' ) ).toBeVisible();
 	} );
 
 	it( 'renders the overview of an A4A dev site', async () => {
@@ -245,15 +237,13 @@ describe( 'SiteOverview', () => {
 
 		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
 
-		const cards = screen.getAllByRole( 'article' );
-		expect( cards ).toHaveLength( 7 );
-		expect( cards[ 0 ] ).toHaveTextContent( 'Visibility' );
-		expect( cards[ 1 ] ).toHaveTextContent( 'Last backup' );
-		expect( cards[ 2 ] ).toHaveTextContent( 'Share' );
-		expect( cards[ 3 ] ).toHaveTextContent( 'Last scan' );
-		expect( cards[ 4 ] ).toHaveTextContent( 'Development license' );
-		expect( cards[ 5 ] ).toHaveTextContent( 'Latest activity' );
-		expect( cards[ 6 ] ).toHaveTextContent( 'The perfect domain awaits' );
+		expect( getCard( 'Visibility' ) ).toBeVisible();
+		expect( getCard( 'Last backup' ) ).toBeVisible();
+		expect( getCard( 'Share' ) ).toBeVisible();
+		expect( getCard( 'Last scan' ) ).toBeVisible();
+		expect( getCard( 'Development license' ) ).toBeVisible();
+		expect( getCard( 'Latest activity' ) ).toBeVisible();
+		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 
 	it( 'renders the overview of a site with Flex plan', async () => {
@@ -265,14 +255,12 @@ describe( 'SiteOverview', () => {
 
 		expect( screen.getByRole( 'link', { name: /WP Admin/ } ) ).toBeVisible();
 
-		const cards = screen.getAllByRole( 'article' );
-		expect( cards ).toHaveLength( 7 );
-		expect( cards[ 0 ] ).toHaveTextContent( 'Last backup' );
-		expect( cards[ 1 ] ).toHaveTextContent( 'Performance' );
-		expect( cards[ 2 ] ).toHaveTextContent( 'Last scan' );
-		expect( cards[ 3 ] ).toHaveTextContent( 'Plan' );
-		expect( cards[ 4 ] ).toHaveTextContent( 'Latest activity' );
-		expect( cards[ 5 ] ).toHaveTextContent( 'Month-to-date site usage' );
-		expect( cards[ 6 ] ).toHaveTextContent( 'The perfect domain awaits' );
+		expect( getCard( 'Last backup' ) ).toBeVisible();
+		expect( getCard( 'Performance' ) ).toBeVisible();
+		expect( getCard( 'Last scan' ) ).toBeVisible();
+		expect( getCard( 'Plan' ) ).toBeVisible();
+		expect( getCard( 'Latest activity' ) ).toBeVisible();
+		expect( getCard( 'Month-to-date site usage' ) ).toBeVisible();
+		expect( getCard( 'The perfect domain awaits' ) ).toBeVisible();
 	} );
 } );

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -4,7 +4,7 @@
 
 import { screen } from '@testing-library/react';
 import nock from 'nock';
-import { render, mockPublicApi } from '../../../test-utils';
+import { render } from '../../../test-utils';
 import SiteOverview from '../index';
 import type { Site } from '@automattic/api-core';
 
@@ -31,7 +31,7 @@ const site = {
 } as unknown as Site;
 
 function mockSite( mockedSite: Site ) {
-	mockPublicApi()
+	nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
 		.query( true )
 		.reply( 200, mockedSite );
@@ -39,44 +39,48 @@ function mockSite( mockedSite: Site ) {
 
 describe( 'SiteOverview', () => {
 	beforeEach( () => {
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
 			.get( '/rest/v1.1/me/preferences' )
 			.query( true )
 			.reply( 200, { calypso_preferences: {} } );
 
-		mockPublicApi().get( '/rest/v1.2/all-domains' ).query( true ).reply( 200, { domains: [] } );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/all-domains' )
+			.query( true )
+			.reply( 200, { domains: [] } );
 
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/domains/suggestions' )
 			.query( true )
 			.reply( 200, [ { domain_name: 'test-site.com', product_slug: 'dotcom_domain' } ] );
 
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
 			.get( `/wpcom/v2/sites/${ site.ID }/activity` )
 			.query( true )
 			.reply( 200, { items: [] } );
 
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
 			.get( `/wpcom/v2/sites/${ site.ID }/scan` )
 			.query( true )
 			.reply( 200, { threats: [] } );
 
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
 			.get( `/wpcom/v2/sites/${ site.ID }/launchpad` )
 			.query( true )
 			.reply( 200, { checklist: [] } );
 
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
 			.get( `/wpcom/v2/sites/${ site.ID }/site-profiler/pages` )
 			.query( true )
 			.reply( 200, { pages: [] } );
 
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
 			.get( `/rest/v1.1/sites/${ site.ID }/media-storage` )
 			.query( true )
 			.reply( 200, { max_storage_bytes: 1073741824, storage_used_bytes: 100000000 } );
 
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
 			.get( `/rest/v1.3/sites/${ site.ID }/plans` )
 			.query( true )
 			.reply( 200, {
@@ -94,17 +98,20 @@ describe( 'SiteOverview', () => {
 				},
 			} );
 
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
 			.get( `/wpcom/v2/sites/${ site.ID }/preview-links` )
 			.query( true )
 			.reply( 200, { preview_links: [] } );
 
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
 			.get( `/wpcom/v2/sites/${ site.ID }/hosting/metrics` )
 			.query( true )
 			.reply( 200, { data: { periods: {} } } );
 
-		mockPublicApi().get( `/wpcom/v2/sites/${ site.ID }/flex-usage` ).query( true ).reply( 200, {} );
+		nock( 'https://public-api.wordpress.com' )
+			.get( `/wpcom/v2/sites/${ site.ID }/flex-usage` )
+			.query( true )
+			.reply( 200, {} );
 	} );
 
 	afterEach( () => {

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -4,7 +4,7 @@
 
 import { screen, waitFor, within } from '@testing-library/react';
 import nock from 'nock';
-import { render } from '../../test-utils';
+import { render, mockPublicApi } from '../../test-utils';
 import Sites from '../index';
 import type { Site, User } from '@automattic/api-core';
 
@@ -35,21 +35,12 @@ const mockSites = [
 
 describe( 'Sites', () => {
 	beforeEach( () => {
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/rest/v1.2/read/teams' )
-			.query( true )
-			.reply( 200, { teams: [] } );
-
-		nock( 'https://public-api.wordpress.com' )
-			.persist()
+		mockPublicApi().get( '/rest/v1.2/read/teams' ).query( true ).reply( 200, { teams: [] } );
+		mockPublicApi()
 			.get( '/rest/v1.1/me/preferences' )
 			.query( true )
 			.reply( 200, { calypso_preferences: {} } );
-
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/rest/v1.2/me/sites' )
-			.query( true )
-			.reply( 200, { sites: mockSites } );
+		mockPublicApi().get( '/rest/v1.2/me/sites' ).query( true ).reply( 200, { sites: mockSites } );
 	} );
 
 	afterEach( () => {

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -4,7 +4,7 @@
 
 import { screen, waitFor, within } from '@testing-library/react';
 import nock from 'nock';
-import { render, mockPublicApi } from '../../test-utils';
+import { render } from '../../test-utils';
 import Sites from '../index';
 import type { Site, User } from '@automattic/api-core';
 
@@ -35,12 +35,21 @@ const mockSites = [
 
 describe( 'Sites', () => {
 	beforeEach( () => {
-		mockPublicApi().get( '/rest/v1.2/read/teams' ).query( true ).reply( 200, { teams: [] } );
-		mockPublicApi()
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/read/teams' )
+			.query( true )
+			.reply( 200, { teams: [] } );
+
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
 			.get( '/rest/v1.1/me/preferences' )
 			.query( true )
 			.reply( 200, { calypso_preferences: {} } );
-		mockPublicApi().get( '/rest/v1.2/me/sites' ).query( true ).reply( 200, { sites: mockSites } );
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/sites' )
+			.query( true )
+			.reply( 200, { sites: mockSites } );
 	} );
 
 	afterEach( () => {

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -52,10 +52,6 @@ describe( 'Sites', () => {
 			.reply( 200, { sites: mockSites } );
 	} );
 
-	afterEach( () => {
-		nock.cleanAll();
-	} );
-
 	it( 'renders Add new site button', async () => {
 		render( <Sites />, {
 			user: {

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -33,7 +33,7 @@ const mockSites = [
 	} as Site,
 ];
 
-describe( 'Sites', () => {
+describe( '<Sites>', () => {
 	beforeEach( () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/read/teams' )
@@ -52,7 +52,7 @@ describe( 'Sites', () => {
 			.reply( 200, { sites: mockSites } );
 	} );
 
-	it( 'renders Add new site button', async () => {
+	test( 'renders Add new site button', async () => {
 		render( <Sites />, {
 			user: {
 				site_count: mockSites.length,
@@ -62,7 +62,7 @@ describe( 'Sites', () => {
 		expect( await screen.findByRole( 'button', { name: 'Add new site' } ) ).toBeVisible();
 	} );
 
-	it( 'renders empty state when the user has no sites', async () => {
+	test( 'renders empty state when the user has no sites', async () => {
 		render( <Sites />, {
 			user: {
 				site_count: 0,
@@ -76,7 +76,7 @@ describe( 'Sites', () => {
 		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders DataViews when the user has sites', async () => {
+	test( 'renders DataViews when the user has sites', async () => {
 		render( <Sites />, {
 			user: {
 				site_count: 13, // more than 12 sites to force the table layout

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createRouter, createRootRoute } from '@tanstack/react-router';
 import { render as testingLibraryRender } from '@testing-library/react';
+import nock from 'nock';
 import { Suspense } from 'react';
 import { type AnalyticsClient, AnalyticsProvider } from './app/analytics';
 import { AuthContext } from './app/auth';
@@ -70,4 +71,8 @@ export function render( ui: React.ReactElement, options: RenderOptions = {} ): R
 		recordTracksEvent,
 		recordPageView,
 	};
+}
+
+export function mockPublicApi() {
+	return nock( 'https://public-api.wordpress.com' ).persist();
 }

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createRouter, createRootRoute } from '@tanstack/react-router';
 import { render as testingLibraryRender } from '@testing-library/react';
-import nock from 'nock';
 import { Suspense } from 'react';
 import { type AnalyticsClient, AnalyticsProvider } from './app/analytics';
 import { AuthContext } from './app/auth';
@@ -71,8 +70,4 @@ export function render( ui: React.ReactElement, options: RenderOptions = {} ): R
 		recordTracksEvent,
 		recordPageView,
 	};
-}
-
-export function mockPublicApi() {
-	return nock( 'https://public-api.wordpress.com' ).persist();
 }


### PR DESCRIPTION
Part of DOTMSD-1069

## Proposed Changes

Added tests for MSD Site Overview screen, focusing on which cards are shown on each site type.

I also added `role="article"` to the `<Card>`s so that I can query them in tests by role.

## Why are these changes being made?

Make AI-assisted development in the Dashboard more confident by adding tests to screens.

## Testing Instructions

Verify CI passes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
