### PR TITLE
Update ToS in the login form

### DIFF
--- a/client/login/wp-login/hooks/get-heading-subtext.tsx
+++ b/client/login/wp-login/hooks/get-heading-subtext.tsx
@@ -26,7 +26,7 @@ const getHeadingSubText = ( {
 	const tos = (
 		<span className="wp-login__one-login-layout-tos">
 			{ translate(
-				'Just a little reminder that by continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				'By continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 				{
 					components: {
 						tosLink: (

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -44,7 +44,7 @@ describe( '#signupStep User', () => {
 		);
 
 		expect( getSubHeaderEl( container ) ).toHaveTextContent(
-			'Just a little reminder that by continuing with any of the options below'
+			'By continuing with any of the options below'
 		);
 	} );
 
@@ -60,7 +60,7 @@ describe( '#signupStep User', () => {
 		);
 
 		expect( getSubHeaderEl( container ) ).toHaveTextContent(
-			'Just a little reminder that by continuing with any of the options below'
+			'By continuing with any of the options below'
 		);
 	} );
 
@@ -86,7 +86,7 @@ describe( '#signupStep User', () => {
 			);
 
 			expect( getSubHeaderEl( container ) ).toHaveTextContent(
-				'Just a little reminder that by continuing with any of the options below'
+				'By continuing with any of the options below'
 			);
 		} );
 
@@ -111,7 +111,7 @@ describe( '#signupStep User', () => {
 			);
 
 			expect( getSubHeaderEl( container ) ).toHaveTextContent(
-				'Just a little reminder that by continuing with any of the options below'
+				'By continuing with any of the options below'
 			);
 		} );
 	} );

--- a/test/e2e/specs/authentication/authentication__tos.spec.ts
+++ b/test/e2e/specs/authentication/authentication__tos.spec.ts
@@ -25,7 +25,7 @@ test.describe( 'Authentication: TOS', { tag: [ tags.AUTHENTICATION ] }, () => {
 			await expect(
 				page.getByText(
 					// WARNING! Please contact the legal team if this text changes!
-					'Just a little reminder that by continuing with any of the options below, you agree to our Terms of Service and Privacy Policy.'
+					'By continuing with any of the options below, you agree to our Terms of Service and have read our Privacy Policy.'
 				)
 			).toBeVisible();
 		} );


### PR DESCRIPTION
Part of M4R73CH-1633

## Proposed Changes

* Legal request to update this sentence

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to log-in
* Confirm the sentence is correct and the links remain  unchanged
<img width="1069" height="659" alt="Screenshot 2026-02-03 at 12 08 47" src="https://github.com/user-attachments/assets/99efe246-92df-43c8-8635-f78b6f455029" />
* Tests should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
