### PR TITLE
Fix userSettingsMutation mock in profile-gravatar tests

### DIFF
--- a/client/dashboard/me/profile-gravatar/test/notifications.test.tsx
+++ b/client/dashboard/me/profile-gravatar/test/notifications.test.tsx
@@ -22,10 +22,20 @@ jest.mock( '@wordpress/data', () => ( {
 	register: jest.fn(),
 } ) );
 
-jest.mock( '@automattic/api-queries', () => ( {
-	...jest.requireActual( '@automattic/api-queries' ),
-	userSettingsQuery: jest.fn(),
-} ) );
+jest.mock(
+	'@automattic/api-queries',
+	() => {
+		// Use the real updateUserSettings from api-core so nock can intercept HTTP calls
+		const { updateUserSettings } = jest.requireActual( '@automattic/api-core' );
+		return {
+			userSettingsQuery: jest.fn(),
+			userSettingsMutation: jest.fn( () => ( {
+				mutationFn: updateUserSettings,
+			} ) ),
+		};
+	},
+	{ virtual: true }
+);
 
 describe( 'GravatarProfileSection Notifications', () => {
 	beforeEach( () => {


### PR DESCRIPTION
## Proposed Changes

Fixed a failing test in the Dashboard profile-gravatar component by replacing an unreliable `jest.requireActual()` call with an explicit mock that properly integrates with nock for HTTP interception.

## Why are these changes being made?

The original test used `jest.requireActual('@automattic/api-queries')` with object spread syntax to get the real `userSettingsMutation`. This approach failed on CI with the error `userSettingsMutation is not a function`, likely due to issues with module resolution and barrel exports. The new approach explicitly provides both `userSettingsQuery` and `userSettingsMutation` mocks while using the real `updateUserSettings` from api-core, allowing nock to properly intercept HTTP calls for testing error scenarios.

## Testing Instructions

All 3 tests in `client/dashboard/me/profile-gravatar/test/notifications.test.tsx` pass successfully:
- Tests verify success notifications on successful saves
- Tests verify error notifications on API errors (400 and 500 responses)

Run: `yarn jest --config test/client/jest.config.js client/dashboard/me/profile-gravatar/test/notifications.test.tsx`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?