### PR TITLE
Fix webpack-rtl-plugin test timeout

### DIFF
--- a/packages/webpack-rtl-plugin/test/index.js
+++ b/packages/webpack-rtl-plugin/test/index.js
@@ -63,7 +63,8 @@ describe( 'Webpack RTL Plugin', () => {
 						}
 						done();
 					} );
-				} )
+				} ),
+			30000
 		);
 
 		it( 'should create a second bundle', () => {


### PR DESCRIPTION
## Proposed Changes

* Increase Jest test timeout from 5s to 30s in webpack-rtl-plugin

## Why are these changes being made?

The webpack-rtl-plugin tests run webpack compilation in `beforeAll` hooks. On CI, this can exceed the default 5s Jest timeout, causing flaky test failures.

## Testing Instructions

* Run `yarn jest --config packages/webpack-rtl-plugin/jest.config.js`
* Tests should pass consistently
