### PR TITLE
Fix flaky staging-site-sync-dropdown unit test

### DIFF
--- a/client/dashboard/sites/staging-site-sync-dropdown/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/test/index.test.tsx
@@ -25,13 +25,21 @@ jest.mock( '@automattic/api-queries', () => ( {
 } ) );
 
 jest.mock( '@tanstack/react-query', () => ( {
-	QueryClient: jest.fn().mockImplementation( () => ( {} ) ),
+	QueryClient: jest.fn().mockImplementation( () => ( {
+		getQueryCache: jest.fn( () => ( { subscribe: jest.fn() } ) ),
+		getMutationCache: jest.fn( () => ( { subscribe: jest.fn() } ) ),
+	} ) ),
 	QueryClientProvider: ( { children }: { children: React.ReactNode } ) => children,
 	useQuery: jest.fn( () => ( {
 		data: false, // Default to false for isStagingSiteDeletionInProgress
 		isLoading: false,
 		refetch: jest.fn(),
 	} ) ),
+	defaultShouldDehydrateQuery: jest.fn( () => true ),
+} ) );
+
+jest.mock( '@tanstack/react-query-persist-client', () => ( {
+	persistQueryClient: jest.fn( () => [ jest.fn(), Promise.resolve() ] ),
 } ) );
 
 jest.mock( '../../../utils/site-staging-site', () => ( {


### PR DESCRIPTION
## Summary
- Fix intermittent test failure in `staging-site-sync-dropdown/test/index.test.tsx`

The test was failing with `TypeError: props.queryClient.getQueryCache is not a function` because:
1. `@automattic/api-queries/query-client.ts` calls `persistQueryClient()` at module load time
2. `persistQueryClient` needs `queryClient.getQueryCache()` and `queryClient.getMutationCache()` methods
3. The test's `QueryClient` mock returned `{}` without these methods

This adds the missing methods to the QueryClient mock and mocks `@tanstack/react-query-persist-client` to prevent real persist logic from running during tests.


## How has this been tested?
Ran the test locally: `yarn test-client --testPathPattern='staging-site-sync-dropdown'`

