### PR TITLE
Domain Only Search: Move Use Domain I Own link to the top right

### DIFF
--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -56,9 +56,9 @@
 
 	@mixin unstick {
 		position: absolute;
-		top: 9px;
+		top: 20px;
 		left: 56px;
-		right: 16px;
+		right: 20px;
 		padding: 0;
 		border: none;
 		margin: 0;

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -389,6 +389,7 @@ const DomainSearchUI = (
 		<StepWrapper
 			{ ...props }
 			className="step-wrapper--domain-search"
+			isSticky={ false }
 			hideSkip
 			customizedActionButtons={ getUseDomainIOwnLink() }
 			headerText={ headerText }


### PR DESCRIPTION
Addresses DOMAINS-2035.

## Proposed changes

Moves the "Use a domain I own" link to the top right so it doesn't conflict with the minicart.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1170" height="2532" alt="my localhost_3000_start_domain_domain-only(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/f76c77a7-8830-4617-85cb-6675705cafde" /> | <img width="1170" height="2532" alt="my localhost_3000_start_domain_domain-only(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/447a7a93-ce35-4dc5-97c6-5c087eb4c672" /> |

## Testing Instructions
Enter `/start/domain`, select a domain and verify you can proceed on mobile instead of being blocked by the "Use a domain I own" bottom bar.