### PR TITLE
MSD: add view persistence to Site Scan DataViews

### DIFF
--- a/client/dashboard/sites/scan-active/index.tsx
+++ b/client/dashboard/sites/scan-active/index.tsx
@@ -1,9 +1,11 @@
 import { siteScanQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
-import { DataViewsEmptyState } from '../../components/dataviews';
+import { usePersistentView } from '../../app/hooks/use-persistent-view';
+import { siteScanActiveThreatsRoute } from '../../app/router/sites';
+import { DataViews, DataViewsEmptyState } from '../../components/dataviews';
 import { useTimeSince } from '../../components/time-since';
 import { getActions } from './dataviews/actions';
 import { getFields } from './dataviews/fields';
@@ -17,33 +19,44 @@ interface ActiveThreatsDataViewsProps {
 	gmtOffset?: number;
 }
 
+const defaultView: View = {
+	type: 'table',
+	fields: [ 'severity', 'threat', 'first_detected', 'auto_fix' ],
+	perPage: 10,
+	sort: {
+		field: 'severity',
+		direction: 'desc',
+	},
+	layout: {
+		density: 'balanced',
+		styles: {
+			threat: {
+				minWidth: '500px',
+			},
+			first_detected: {
+				maxWidth: '175px',
+				minWidth: '140px',
+			},
+		},
+	},
+	showLevels: false,
+};
+
 export function ActiveThreatsDataViews( {
 	site,
 	timezoneString,
 	gmtOffset,
 }: ActiveThreatsDataViewsProps ) {
-	const [ view, setView ] = useState< View >( {
-		type: 'table',
-		fields: [ 'severity', 'threat', 'first_detected', 'auto_fix' ],
-		perPage: 10,
-		sort: { field: 'severity', direction: 'desc' },
-		layout: {
-			styles: {
-				threat: {
-					minWidth: '500px',
-				},
-				first_detected: {
-					maxWidth: '175px',
-					minWidth: '140px',
-				},
-			},
-		},
-	} );
-
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const { data: scan, isLoading } = useQuery( siteScanQuery( site.ID ) );
 	const threats = scan?.threats?.filter( ( threat ) => threat.status === 'current' ) || [];
 
+	const searchParams = siteScanActiveThreatsRoute.useSearch();
+	const { view, updateView, resetView } = usePersistentView( {
+		slug: 'site-scan-active',
+		defaultView,
+		queryParams: searchParams,
+	} );
 	const fields = getFields( timezoneString, gmtOffset );
 	const actions = useMemo( () => getActions( site, selection.length ), [ site, selection.length ] );
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( threats, view, fields );
@@ -100,7 +113,8 @@ export function ActiveThreatsDataViews( {
 			getItemId={ ( item ) => item.id.toString() }
 			isLoading={ isLoading }
 			onChangeSelection={ setSelection }
-			onChangeView={ setView }
+			onChangeView={ updateView }
+			onResetView={ resetView }
 			paginationInfo={ paginationInfo }
 			searchLabel={ __( 'Search' ) }
 			selection={ selection }

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -74,6 +74,10 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 	};
 
 	const handleTabChange = ( tab: 'active' | 'history' ) => {
+		if ( scanTab === tab ) {
+			return;
+		}
+
 		if ( tab === 'active' ) {
 			router.navigate( { to: `/sites/${ siteSlug }/scan/active` } );
 		} else {


### PR DESCRIPTION
Fixes DOTMSD-893

## Proposed Changes

This PR adds view persistence to the following MSD screens:

- Site -> Scan -> Active threats
- Site -> Scan -> History

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Adding view persistence to all MSD DataViews for consistency.

## Testing Instructions

1. Open dashboard live link / sites
2. Click an Atomic site
3. Click Scan tab
4. Visit the Active threats tab:
     - Modify the view configurations; verify it's persisted upon page refresh and can be reset using the Reset view button
4. Visit the History tab:
     - Modify the view configurations; verify it's persisted upon page refresh and can be reset using the Reset view button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
