### PR TITLE
MSD: add view persistence to Site Settings Repositories DataViews

### DIFF
--- a/client/dashboard/sites/settings-repositories/dataviews/views.ts
+++ b/client/dashboard/sites/settings-repositories/dataviews/views.ts
@@ -1,15 +1,18 @@
-import type { SortDirection, View } from '@wordpress/dataviews';
+import type { View } from '@wordpress/dataviews';
 
 export const DEFAULT_VIEW: View = {
 	type: 'list',
 	perPage: 20,
-	page: 1,
 	sort: {
 		field: 'updated_on',
-		direction: 'desc' as SortDirection,
+		direction: 'desc',
 	},
 	fields: [ 'owner', 'branch', 'target_dir', 'auto_deploy' ],
 	titleField: 'repository',
+	layout: {
+		density: 'balanced',
+	},
+	showLevels: false,
 };
 
 export const DEFAULT_LAYOUTS = {

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -7,11 +7,11 @@ import {
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import {
 	siteDeploymentsListRoute,
 	siteRoute,
@@ -19,7 +19,7 @@ import {
 	siteSettingsRepositoriesManageRoute,
 	siteSettingsRepositoriesRoute,
 } from '../../app/router/sites';
-import { DataViewsCard } from '../../components/dataviews';
+import { DataViews, DataViewsCard } from '../../components/dataviews';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import SnackbarBackButton, {
@@ -33,7 +33,7 @@ import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callou
 import { useRepositoryFields } from './dataviews/fields';
 import { DEFAULT_VIEW, DEFAULT_LAYOUTS } from './dataviews/views';
 import { DisconnectRepositoryModalContent } from './disconnect-repository-modal-content';
-import type { RenderModalProps, View, Action } from '@wordpress/dataviews';
+import type { RenderModalProps, Action } from '@wordpress/dataviews';
 
 function RepositoriesList() {
 	const router = useRouter();
@@ -43,7 +43,12 @@ function RepositoriesList() {
 		githubInstallationsQuery()
 	);
 
-	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const searchParams = siteSettingsRepositoriesRoute.useSearch();
+	const { view, updateView, resetView } = usePersistentView( {
+		slug: 'site-settings-repositories',
+		defaultView: DEFAULT_VIEW,
+		queryParams: searchParams,
+	} );
 
 	const { data: deployments = [], isLoading: isLoadingDeployments } = useQuery(
 		codeDeploymentsQuery( site.ID )
@@ -134,7 +139,8 @@ function RepositoriesList() {
 				data={ isLoadingInstallations || githubInstallationsError ? [] : filteredData }
 				fields={ fields }
 				view={ view }
-				onChangeView={ setView }
+				onChangeView={ updateView }
+				onResetView={ resetView }
 				actions={ actions }
 				isLoading={ isLoadingDeployments || isLoadingInstallations }
 				defaultLayouts={ DEFAULT_LAYOUTS }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTMSD-895

## Proposed Changes

This PR adds view persistence to the following MSD screens: Site -> Settings -> GitHub repositories.

## Why are these changes being made?

Adding view persistence to all MSD DataViews for consistency.

## Testing Instructions

1. Open dashboard live link / sites
2. Click an Atomic site
3. Click Settings tab - > click GitHub repositories
4. Modify the view configurations; verify it's persisted upon page refresh and can be reset using the Reset view button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
