### PR TITLE
e2e: After publish, treat a 404 page as an error page

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -909,8 +909,8 @@ export class EditorPage {
 		 * Closure to confirm that post is shown on screen as expected.
 		 *
 		 * In rare cases, visiting the post immediately after it has been published can result
-		 * in the post not being visible to the public yet. In such cases, an error message is
-		 * instead shown to the user.
+		 * in the post not being visible to the public yet. In such cases, an error message or
+		 * 404 page is instead shown to the user.
 		 *
 		 * When used in conjunction with `reloadAndRetry` this method will reload the page
 		 * multiple times to ensure the post content is shown.
@@ -918,7 +918,14 @@ export class EditorPage {
 		 * @param page
 		 */
 		async function confirmPostShown( page: Page ): Promise< void > {
-			await page.getByRole( 'main' ).waitFor( { timeout: timeout } );
+			const main = page.getByRole( 'main' );
+			await main.waitFor( { timeout: timeout } );
+
+			const error404 = main.locator( 'div.error-404' );
+			if ( ( await error404.count() ) > 0 ) {
+				await page.waitForTimeout( 1000 ); // Give it a second before retrying.
+				throw new Error( 'Post not found - 404 error displayed' );
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

In `EditorPage.publish()`'s existing check for an error page, treat the 404 page as an error page too.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There's already code in the EditorPage.publish() method to try reloading the page a few times if it gets an error page. We've been seeing some intermittent failures lately that have a transient 404 "Nothing here" page being returned that isn't being treated as an error page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* It's pretty intermittent. I suppose you could hack the code here to load a bad URL instead of the real one to force a 404 and see if it reloads a few times before failing the test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
