### PR TITLE
Help Center: Lazy load A4A and deps

### DIFF
--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -48,8 +48,15 @@ function getIndividualConfig( options = {} ) {
 				requestToExternal( request ) {
 					// The extraction logic will only extract a package if requestToExternal
 					// explicitly returns undefined for the given request. Null
-					// shortcuts the logic such that react-i18n will be bundled.
+					// shortcuts the logic such that the package will be bundled instead.
 					if ( request === '@wordpress/react-i18n' ) {
+						return null;
+					}
+
+					// Bundle @wordpress/dataviews and @wordpress/ui instead of externalizing.
+					// These are only used by HelpCenterA4AContactForm which is lazy-loaded,
+					// so we don't want them listed as dependencies for the main entry point.
+					if ( request === '@wordpress/dataviews' || request === '@wordpress/ui' ) {
 						return null;
 					}
 				},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Work by @heavyweight 

Fixes https://linear.app/a8c/issue/DOTCOM-15941/help-center-not-loading-logged-out

## Proposed Changes

The A4A (Automattic for Agencies) contact form is now lazy-loaded via React.lazy() + Suspense. This code-splits @wordpress/dataviews and @wordpress/ui into a separate chunk that only loads when needed (only for A4A users).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Help Center was not loading on /support due to enqueuing problems

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn dev --sync` from `apps/help-center`
* Test logged out Help Center in search here https://wordpress.com/support/?dotcom_support_enable_odie_answers=true
* All should work fine

