### PR TITLE
Checkout: validate any active step before submit

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -145,6 +145,7 @@ This component's props are:
 - `activeStepContent?: React.ReactNode`. Displays as the content of the step when it is active. It is also displayed when the step is inactive but is hidden by CSS.
 - `completeStepContent?: React.ReactNode`. Displays as the content of the step when it is inactive and complete as defined by the `isCompleteCallback`.
 - `isCompleteCallback: () => boolean | Promise<boolean>`. Used to determine if a step is complete for purposes of validation. Note that this is not called for the last step!
+- `skipValidationOnSubmit?: boolean`. If true, this step will not be validated when the submit button is clicked. Defaults to false. This is useful for steps like the payment method step that have their own validation logic and should not block form submission. The [PaymentMethodStep](#PaymentMethodStep) has this set to true by default.
 - `editButtonAriaLabel?: string`. Used to fill in the `aria-label` attribute for the "Edit" button if one exists.
 - `nextStepButtonAriaLabel?: string`. Used to fill in the `aria-label` attribute for the "Continue" button if one exists.
 - `canEditStep?: boolean`. If false, the step will never show an "Edit" button. Defaults to true.

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -668,8 +668,9 @@ export function CheckoutFormSubmit( {
 	submitButton?: ReactNode;
 	onPageLoadError?: CheckoutPageErrorCallback;
 } ) {
-	const { state } = useContext( CheckoutStepGroupContext );
+	const { state, actions } = useContext( CheckoutStepGroupContext );
 	const { activeStepNumber, totalSteps, stepCompleteStatus } = state;
+	const { getStepCompleteCallback, setStepCompleteStatus } = actions;
 	const isThereAnotherNumberedStep = activeStepNumber < totalSteps;
 	const areAllStepsComplete = Object.values( stepCompleteStatus ).every(
 		( isComplete ) => isComplete === true
@@ -682,6 +683,50 @@ export function CheckoutFormSubmit( {
 	const submitWrapperRef = useCustomPropertyForHeight< HTMLDivElement >(
 		customPropertyForSubmitButtonHeight
 	);
+
+	// Wrap validateForm to first validate any active step before submission
+	const wrappedValidateForm = useCallback( async () => {
+		// Only validate if there's an actual active step (within the range of registered steps)
+		const hasActiveStep = activeStepNumber > 0 && activeStepNumber <= totalSteps;
+
+		if ( hasActiveStep ) {
+			// If the active step is incomplete, validate it before proceeding.
+			// Also validate if it's a completed step that's not the last step (since the
+			// user may have gone back to edit it and we need to revalidate the changes).
+			const isLastStep = activeStepNumber === totalSteps;
+			const isActiveStepIncomplete = ! stepCompleteStatus[ activeStepNumber ];
+			const isCompletedNonFinalStep = ! isLastStep;
+
+			if ( isActiveStepIncomplete || isCompletedNonFinalStep ) {
+				debug( `Validating active step ${ activeStepNumber } before submission` );
+				const stepCompleteCallback = getStepCompleteCallback( activeStepNumber );
+				const isStepComplete = await stepCompleteCallback();
+				debug( `Active step ${ activeStepNumber } validation result: ${ isStepComplete }` );
+
+				if ( ! isStepComplete ) {
+					// Step validation failed, don't proceed with submission
+					return false;
+				}
+
+				// Step validated successfully, mark it as complete
+				setStepCompleteStatus( { [ activeStepNumber ]: true } );
+			}
+		}
+
+		// Now run the payment method validation if provided
+		if ( validateForm ) {
+			return await validateForm();
+		}
+
+		return true;
+	}, [
+		activeStepNumber,
+		totalSteps,
+		stepCompleteStatus,
+		getStepCompleteCallback,
+		setStepCompleteStatus,
+		validateForm,
+	] );
 
 	const isDisabled = ( () => {
 		if ( disableSubmitButton ) {
@@ -704,7 +749,7 @@ export function CheckoutFormSubmit( {
 			{ submitButtonHeader || null }
 			{ submitButton || (
 				<CheckoutSubmitButton
-					validateForm={ validateForm }
+					validateForm={ wrappedValidateForm }
 					disabled={ isDisabled }
 					onLoadError={ onSubmitButtonLoadError }
 				/>

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -65,6 +65,7 @@ const CheckoutStepGroupContext = createContext< CheckoutStepGroupStore >( {
 		totalSteps: 0,
 		stepIdMap: {},
 		stepCompleteCallbackMap: {},
+		stepSkipValidationOnSubmitMap: {},
 	},
 	actions: {
 		makeStepActive: noop,
@@ -98,6 +99,7 @@ function createCheckoutStepGroupState(): CheckoutStepGroupState {
 		stepCompleteStatus: {},
 		stepIdMap: {},
 		stepCompleteCallbackMap: {},
+		stepSkipValidationOnSubmitMap: {},
 	};
 }
 
@@ -164,10 +166,12 @@ function createCheckoutStepGroupActions(
 	const setStepCompleteCallback = (
 		stepNumber: number,
 		stepId: string,
-		callback: StepCompleteCallback
+		callback: StepCompleteCallback,
+		skipValidationOnSubmit?: boolean
 	) => {
 		state.stepIdMap[ stepId ] = stepNumber;
 		state.stepCompleteCallbackMap[ stepNumber ] = callback;
+		state.stepSkipValidationOnSubmitMap[ stepNumber ] = skipValidationOnSubmit ?? false;
 	};
 
 	const getStepCompleteCallback = ( stepNumber: number ) => {
@@ -487,6 +491,7 @@ export const CheckoutStep = ( {
 	nextStepButtonAriaLabel,
 	validatingButtonText,
 	validatingButtonAriaLabel,
+	skipValidationOnSubmit,
 	onPageLoadError,
 }: CheckoutStepProps ) => {
 	const { __ } = useI18n();
@@ -520,7 +525,7 @@ export const CheckoutStep = ( {
 		setFormReady();
 		return completeResult;
 	};
-	setStepCompleteCallback( stepNumber, stepId, goToNextStep );
+	setStepCompleteCallback( stepNumber, stepId, goToNextStep, skipValidationOnSubmit );
 
 	const classNames = [
 		'checkout-step',
@@ -669,7 +674,7 @@ export function CheckoutFormSubmit( {
 	onPageLoadError?: CheckoutPageErrorCallback;
 } ) {
 	const { state, actions } = useContext( CheckoutStepGroupContext );
-	const { activeStepNumber, totalSteps, stepCompleteStatus } = state;
+	const { activeStepNumber, totalSteps, stepCompleteStatus, stepSkipValidationOnSubmitMap } = state;
 	const { getStepCompleteCallback, setStepCompleteStatus } = actions;
 	const isThereAnotherNumberedStep = activeStepNumber < totalSteps;
 	const areAllStepsComplete = Object.values( stepCompleteStatus ).every(
@@ -690,14 +695,11 @@ export function CheckoutFormSubmit( {
 		const hasActiveStep = activeStepNumber > 0 && activeStepNumber <= totalSteps;
 
 		if ( hasActiveStep ) {
-			// If the active step is incomplete, validate it before proceeding.
-			// Also validate if it's a completed step that's not the last step (since the
-			// user may have gone back to edit it and we need to revalidate the changes).
-			const isLastStep = activeStepNumber === totalSteps;
-			const isActiveStepIncomplete = ! stepCompleteStatus[ activeStepNumber ];
-			const isCompletedNonFinalStep = ! isLastStep;
+			// Check if this step should skip validation on submit
+			const shouldSkipValidation = stepSkipValidationOnSubmitMap[ activeStepNumber ];
 
-			if ( isActiveStepIncomplete || isCompletedNonFinalStep ) {
+			if ( ! shouldSkipValidation ) {
+				// Validate the active step (whether it's complete or incomplete)
 				debug( `Validating active step ${ activeStepNumber } before submission` );
 				const stepCompleteCallback = getStepCompleteCallback( activeStepNumber );
 				const isStepComplete = await stepCompleteCallback();
@@ -723,6 +725,7 @@ export function CheckoutFormSubmit( {
 		activeStepNumber,
 		totalSteps,
 		stepCompleteStatus,
+		stepSkipValidationOnSubmitMap,
 		getStepCompleteCallback,
 		setStepCompleteStatus,
 		validateForm,

--- a/packages/composite-checkout/src/components/default-steps.tsx
+++ b/packages/composite-checkout/src/components/default-steps.tsx
@@ -21,5 +21,6 @@ export function getDefaultPaymentMethodStep( {
 			/>
 		),
 		completeStepContent: <CheckoutPaymentMethods summary isComplete />,
+		skipValidationOnSubmit: true,
 	};
 }

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -24,6 +24,7 @@ export interface CheckoutStepProps {
 	nextStepButtonAriaLabel?: string;
 	validatingButtonText?: string;
 	validatingButtonAriaLabel?: string;
+	skipValidationOnSubmit?: boolean;
 	onPageLoadError?: CheckoutPageErrorCallback;
 }
 
@@ -291,6 +292,7 @@ export interface CheckoutStepGroupState {
 	stepCompleteStatus: CheckoutStepCompleteStatus;
 	stepIdMap: StepIdMap;
 	stepCompleteCallbackMap: StepCompleteCallbackMap;
+	stepSkipValidationOnSubmitMap: Record< number, boolean >;
 }
 
 export interface CheckoutStepGroupActions {
@@ -303,7 +305,8 @@ export interface CheckoutStepGroupActions {
 	setStepCompleteCallback: (
 		stepNumber: number,
 		stepId: string,
-		callback: StepCompleteCallback
+		callback: StepCompleteCallback,
+		skipValidationOnSubmit?: boolean
 	) => void;
 	getStepCompleteCallback: ( stepNumber: number ) => StepCompleteCallback;
 	setTotalSteps: ( totalSteps: number ) => void;

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -922,6 +922,78 @@ describe( 'Checkout', () => {
 
 			expect( processor ).toHaveBeenCalled();
 		} );
+
+		it( 'skips validation for a step with skipValidationOnSubmit set to true', async () => {
+			const stepCallback = jest.fn();
+			stepCallback.mockResolvedValue( false ); // Step validation would fail
+			const processor = jest.fn().mockResolvedValue( makeErrorResponse( 'good' ) );
+
+			render(
+				<MyCheckout
+					steps={ [
+						{
+							id: 'skip-validation-step',
+							className: 'skip-validation-step',
+							hasStepNumber: true,
+							titleContent: <span>Skip Validation Step</span>,
+							activeStepContent: <span>Skip validation content</span>,
+							completeStepContent: <span>Skip validation complete</span>,
+							isCompleteCallback: stepCallback,
+							skipValidationOnSubmit: true,
+							getEditButtonAriaLabel: () => 'Edit skip validation step',
+							getNextStepButtonAriaLabel: () => 'Continue',
+						},
+					] }
+					paymentProcessor={ processor }
+				/>
+			);
+
+			const submitButton = screen.getByText( 'Pay Please' );
+			const user = userEvent.setup();
+			await user.click( submitButton );
+
+			// Payment processor should be called even though step validation would fail
+			expect( processor ).toHaveBeenCalled();
+			// Step callback should not be called during submit validation
+			expect( stepCallback ).not.toHaveBeenCalled();
+		} );
+
+		it( 'validates a step without skipValidationOnSubmit and blocks submission if invalid', async () => {
+			const stepCallback = jest.fn();
+			stepCallback.mockResolvedValue( false ); // Step validation fails
+			const processor = jest.fn().mockResolvedValue( makeErrorResponse( 'good' ) );
+
+			render(
+				<MyCheckout
+					steps={ [
+						{
+							id: 'normal-step',
+							className: 'normal-step',
+							hasStepNumber: true,
+							titleContent: <span>Normal Step</span>,
+							activeStepContent: <span>Normal content</span>,
+							completeStepContent: <span>Normal complete</span>,
+							isCompleteCallback: stepCallback,
+							getEditButtonAriaLabel: () => 'Edit normal step',
+							getNextStepButtonAriaLabel: () => 'Continue',
+						},
+					] }
+					paymentProcessor={ processor }
+				/>
+			);
+
+			const submitButton = screen.getByText( 'Pay Please' );
+			const user = userEvent.setup();
+			await user.click( submitButton );
+
+			// Step callback should be called for validation
+			await waitFor( () => {
+				expect( stepCallback ).toHaveBeenCalled();
+			} );
+
+			// Payment processor should NOT be called because validation failed
+			expect( processor ).not.toHaveBeenCalled();
+		} );
 	} );
 } );
 
@@ -1040,6 +1112,7 @@ function createStepObjectConverter( paymentData ) {
 					isCompleteCallback={ () => stepObject.isCompleteCallback( { paymentData } ) }
 					editButtonAriaLabel={ stepObject.getEditButtonAriaLabel() }
 					nextStepButtonAriaLabel={ stepObject.getNextStepButtonAriaLabel() }
+					skipValidationOnSubmit={ stepObject.skipValidationOnSubmit }
 					className={ stepObject.className }
 				/>
 			);

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -791,6 +791,57 @@ describe( 'Checkout', () => {
 				expect( getByText( 'Possibly Complete isComplete true' ) ).toBeInTheDocument();
 			} );
 		} );
+
+		it( 'validates an active completed non-final step when continuing', async () => {
+			// This test verifies that when a step is marked complete but is still active
+			// (e.g., user went back to edit it), attempting to proceed past it will
+			// revalidate the step instead of skipping validation.
+			const firstStepCallback = jest.fn();
+			firstStepCallback.mockResolvedValue( true );
+
+			const { getAllByText, getByText } = render(
+				<MyCheckout
+					steps={ [
+						{
+							id: 'editable-step',
+							className: 'editable-step',
+							hasStepNumber: true,
+							titleContent: <span>First Step</span>,
+							activeStepContent: <span>First step content</span>,
+							completeStepContent: <span>First step complete</span>,
+							isCompleteCallback: firstStepCallback,
+							getEditButtonAriaLabel: () => 'Edit first step',
+							getNextStepButtonAriaLabel: () => 'Continue',
+						},
+						steps[ 1 ], // Contact step
+					] }
+				/>
+			);
+
+			const user = userEvent.setup();
+
+			// Complete the first step (moves to second step)
+			const firstContinue = getAllByText( 'Continue' )[ 0 ];
+			await user.click( firstContinue );
+
+			await waitFor( () => {
+				expect( firstStepCallback ).toHaveBeenCalledTimes( 1 );
+			} );
+
+			// Go back to the first step
+			const editButton = getByText( 'Edit' );
+			await user.click( editButton );
+
+			// The first step is now active but marked complete. Click Continue again.
+			// This should revalidate the step (call the callback again).
+			const continueAgain = getAllByText( 'Continue' )[ 0 ];
+			await user.click( continueAgain );
+
+			// Verify the callback was called again for revalidation
+			await waitFor( () => {
+				expect( firstStepCallback ).toHaveBeenCalledTimes( 2 );
+			} );
+		} );
 	} );
 
 	describe( 'submitting the form', function () {


### PR DESCRIPTION
Fixes [SHILL-1596](https://linear.app/a8c/issue/SHILL-1596)

Part of https://linear.app/a8c/issue/SHILL-1583/checkout-add-option-to-swap-order-of-payment-method-and-billing-step

## Proposed Changes

The main purpose of this change is to make sure all checkout steps are validated and completed when the submit button is pressed. This PR changes the submit button so that if any step is active, it will always call the function to validate that step before moving forward with the submission process. That will happen _even if_ the step was previously marked as complete.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In https://github.com/Automattic/wp-calypso/pull/108450 I'm swapping the order of the payment method step in checkout so that it optionally comes before the billing information step. However, this creates a problem: the billing info step no longer has a "Continue" button which is what we used to validate and save its info since it's now the last step. If the billing information step was already complete and has been edited and is still active when the user presses the submit button, the info in the step's fields will be ignored. 

We need to modify the submit button behavior so that if any step is active, we try to complete that step before allowing the submission to go through; it already verifies that every step is complete, but a step can be complete and have unsaved changes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR should not actually change any visible behavior and there are automated tests. However, it's important to test for regressions.

You'll want to try the following steps with and without autocomplete. Therefore you'll need to use an account which has at least one saved credit card and saved billing details and an account without them. 

Alternatively you can disable both on the server by applying this patch to your sandbox while `public-api.wordpress.com` is pointing to your sandbox:

<details>

```diff
diff --git a/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-checkout-endpoints.php b/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-checkout-endpoints.php
index 0d5fa41ab95..0f1cb56990a 100644
--- a/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-checkout-endpoints.php
+++ b/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-checkout-endpoints.php
@@ -229,10 +229,11 @@ class WPCOM_JSON_API_Checkout_Payment_Methods_Endpoint_V1_2 extends WPCOM_JSON_A
                $options->include_expired = $args['expired'] === 'include';
                $options->consolidate_by_upi_id = true;
                $repository = \A8C\Billingdaddy\Container::get_stored_payment_method_repository();
-               $payment_methods = $repository->get_stored_payment_method_objects_for_user(
-                       (int) get_current_user_id(),
-                       $options
-               );
+               // $payment_methods = $repository->get_stored_payment_method_objects_for_user(
+               //      (int) get_current_user_id(),
+               //      $options
+               // );
+               $payment_methods = [];

                $results = array();
                foreach ( $payment_methods as $payment_method ) {
diff --git a/wp-content/admin-plugins/wpcom-billing/class.wpcom-store-api.php b/wp-content/admin-plugins/wpcom-billing/class.wpcom-store-api.php
index f05d490d997..77a2da80009 100644
--- a/wp-content/admin-plugins/wpcom-billing/class.wpcom-store-api.php
+++ b/wp-content/admin-plugins/wpcom-billing/class.wpcom-store-api.php
@@ -17,7 +17,8 @@ class WPCOM_Store_API {
        public static function get_contact_information( $user_id ) {
                require_lib( 'domains/domain-registration-states' );

-               $domain_contact_information = Domain_Contact_Information_Mapper::find_by_user_id( $user_id );
+               // $domain_contact_information = Domain_Contact_Information_Mapper::find_by_user_id( $user_id );
+               $domain_contact_information = null;

                if ( null !== $domain_contact_information ) {
                        $state_code = Domain_Registration_States::get_state_code_from_name_in_english( $domain_contact_information->get_country_code(), $domain_contact_information->get_state_name() );
```

</details>

1. Add a product to your cart and visit checkout.
1. Verify that autocomplete still works as it did before this PR (it should complete both steps if there is a saved card and saved contact details).
1. In the billing info step, enter an invalid postal code and make sure that you can't submit it.
