### PR TITLE
Performance Profiler: Fix date translation

### DIFF
--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -59,8 +59,8 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 					{ translate( 'Tested on %(date)s', {
 						args: {
 							date: new Intl.DateTimeFormat( translate.localeSlug || 'en-US', {
-								month: 'long',
-								day: 'numeric',
+								dateStyle: 'long',
+								timeStyle: 'numeric',
 							} ).format( new Date( parseInt( timestamp ) * 1000 ) ),
 						},
 					} ) }

--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -60,8 +60,8 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 						args: {
 							date: new Intl.DateTimeFormat( translate.localeSlug || 'en-US', {
 								dateStyle: 'long',
-								timeStyle: 'numeric',
-							} ).format( new Date( parseInt( timestamp ) * 1000 ) ),
+								timeStyle: 'medium',
+							} ).format( new Date( timestamp ) ),
 						},
 					} ) }
 				</span>

--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -2,7 +2,6 @@ import { Popover } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, mobile, desktop, share } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
 import { useState, useRef } from 'react';
 import WPcomBadge from 'calypso/assets/images/performance-profiler/wpcom-badge.svg';
 import SectionNav from 'calypso/components/section-nav';
@@ -58,7 +57,12 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 			{ timestamp && (
 				<span>
 					{ translate( 'Tested on %(date)s', {
-						args: { date: moment( timestamp ).format( 'MMMM Do, YYYY h:mm:ss A' ) },
+						args: {
+							date: new Intl.DateTimeFormat( translate.localeSlug || 'en-US', {
+								month: 'long',
+								day: 'numeric',
+							} ).format( new Date( parseInt( timestamp ) * 1000 ) ),
+						},
 					} ) }
 				</span>
 			) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes I18N-261.

## Proposed Changes

Translate the date in the WordPress Page Speed Test header.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We were translating the string, but the date was shown in a default format.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 Visit the `en` [page](https://container-sleepy-colden.calypso.live/speed-test-tool?url=https%3A%2F%2Fsorin.blog%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MzQ4NzQ5fQ.mI1ol16cEd0maIsg-rZx1ipjzDq42D4sbDAady0GHkY) and confirm `Tested on`  is displayed correctly:

<img width="1133" height="264" alt="image" src="https://github.com/user-attachments/assets/b0eb1f84-585d-4469-9cb7-5f33dde3af41" />

Visit the `fr` [page](https://container-sleepy-colden.calypso.live/fr/speed-test-tool?url=https%3A%2F%2Fsorin.blog%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MzQ4NzQ5fQ.mI1ol16cEd0maIsg-rZx1ipjzDq42D4sbDAady0GHkY) 
<img width="1186" height="250" alt="image" src="https://github.com/user-attachments/assets/81ab7469-7fe0-4876-9912-6b4ae2ea89fc" />

__Note__: Visit the 2 pages logged out so the locale is set correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
