### PR TITLE
Update "other purchases" grace period notices for auto-renew

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -12,6 +12,7 @@ import {
 	isExpiring,
 	isFailedAutoRenewal,
 	isIncludedWithPlan,
+	isRenewing,
 	needsToRenewSoon,
 	isRecentMonthlyPurchase,
 	creditCardExpiresBeforeSubscription,
@@ -253,15 +254,15 @@ export function OtherRenewablePurchasesNotice( {
 			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
 		const noticeActionText = __( 'Renew all' );
 
-		if ( isInExpirationGracePeriod( currentPurchase ) ) {
-			if ( isFailedAutoRenewal( currentPurchase ) ) {
-				noticeText = createInterpolateElement(
-					__(
-						'There was a problem processing your renewal. You have <link>other upgrades</link> on this site that may also be affected. Please renew now to avoid disruption to your service.'
-					),
-					{ link }
-				);
-			} else if ( currentPurchase.is_domain_registration ) {
+		if ( isFailedAutoRenewal( currentPurchase ) ) {
+			noticeText = createInterpolateElement(
+				__(
+					'There was a problem processing your renewal. You have <link>other upgrades</link> on this site that may also be affected. Please renew now to avoid disruption to your service.'
+				),
+				{ link }
+			);
+		} else if ( isInExpirationGracePeriod( currentPurchase ) ) {
+			if ( currentPurchase.is_domain_registration ) {
 				noticeText = createInterpolateElement(
 					sprintf(
 						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago"
@@ -427,15 +428,15 @@ export function OtherRenewablePurchasesNotice( {
 		let noticeText: React.ReactNode;
 		const noticeStatus = suppressErrorStylingForCurrentPurchase ? 'info' : 'error';
 
-		if ( isInExpirationGracePeriod( currentPurchase ) ) {
-			if ( isFailedAutoRenewal( currentPurchase ) ) {
-				noticeText = createInterpolateElement(
-					__(
-						'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'
-					),
-					{ link }
-				);
-			} else if ( currentPurchase.is_domain_registration ) {
+		if ( isFailedAutoRenewal( currentPurchase ) ) {
+			noticeText = createInterpolateElement(
+				__(
+					'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'
+				),
+				{ link }
+			);
+		} else if ( isInExpirationGracePeriod( currentPurchase ) ) {
+			if ( currentPurchase.is_domain_registration ) {
 				noticeText = createInterpolateElement(
 					sprintf(
 						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
@@ -784,16 +785,16 @@ export function OtherRenewablePurchasesNotice( {
 		! anotherPurchaseIsExpiring
 	) {
 		const noticeText = ( () => {
+			if ( isFailedAutoRenewal( currentPurchase ) ) {
+				return createInterpolateElement(
+					__(
+						'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'
+					),
+					{ link }
+				);
+			}
 			// Grace period: if expiry date is past, show "expired" message instead of "will expire"
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				if ( isFailedAutoRenewal( currentPurchase ) ) {
-					return createInterpolateElement(
-						__(
-							'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'
-						),
-						{ link }
-					);
-				}
 				if ( currentPurchase.is_domain_registration ) {
 					return createInterpolateElement(
 						sprintf(

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -249,13 +249,28 @@ export function OtherRenewablePurchasesNotice( {
 			suppressErrorStylingForCurrentPurchase && suppressErrorStylingForOtherPurchases
 				? 'info'
 				: 'error';
-		const noticeActionOnClick = () =>
+		let noticeActionOnClick: ( () => void ) | undefined = () =>
 			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
-		const noticeActionText = __( 'Renew all' );
+		let noticeActionHref: string | undefined;
+		let noticeActionText = __( 'Renew all' );
 
 		if ( isInExpirationGracePeriod( currentPurchase ) ) {
-			if ( isRenewing( currentPurchase ) ) {
-				// Auto-renew ON but renewal failed - use simplified message
+			// Auto-renew ON but no payment method - show "Add Payment Method" CTA
+			if ( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type ) {
+				noticeText = createInterpolateElement(
+					__(
+						'There was a problem processing your renewal. You have <link>other upgrades</link> on this site that may also be affected. Please add a payment method to avoid disruption to your service.'
+					),
+					{ link }
+				);
+				noticeActionText = __( 'Add Payment Method' );
+				noticeActionOnClick = undefined;
+				noticeActionHref = router.buildLocation( {
+					to: changePaymentMethodRoute.fullPath,
+					params: { purchaseId: purchase.ID },
+				} ).href;
+			} else if ( isRenewing( currentPurchase ) ) {
+				// Auto-renew ON with payment method but renewal failed
 				noticeText = createInterpolateElement(
 					__(
 						'There was a problem processing your renewal. You have <link>other upgrades</link> on this site that may also be affected. Please renew now to avoid disruption to your service.'
@@ -413,6 +428,7 @@ export function OtherRenewablePurchasesNotice( {
 				setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
 				noticeStatus={ noticeStatus }
 				noticeText={ noticeText }
+				noticeActionHref={ noticeActionHref }
 				noticeActionOnClick={ noticeActionOnClick }
 				noticeActionText={ noticeActionText }
 			/>
@@ -427,10 +443,26 @@ export function OtherRenewablePurchasesNotice( {
 	) {
 		let noticeText: React.ReactNode;
 		const noticeStatus = suppressErrorStylingForCurrentPurchase ? 'info' : 'error';
+		let noticeActionOnClick: ( () => void ) | undefined;
+		let noticeActionHref: string | undefined;
+		let noticeActionText: string | undefined;
 
 		if ( isInExpirationGracePeriod( currentPurchase ) ) {
-			if ( isRenewing( currentPurchase ) ) {
-				// Auto-renew ON but renewal failed - use simplified message
+			// Auto-renew ON but no payment method
+			if ( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type ) {
+				noticeText = createInterpolateElement(
+					__(
+						'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please add a payment method to avoid disruption to your service.'
+					),
+					{ link }
+				);
+				noticeActionText = __( 'Add Payment Method' );
+				noticeActionHref = router.buildLocation( {
+					to: changePaymentMethodRoute.fullPath,
+					params: { purchaseId: purchase.ID },
+				} ).href;
+			} else if ( isRenewing( currentPurchase ) ) {
+				// Auto-renew ON with payment method but renewal failed
 				noticeText = createInterpolateElement(
 					__(
 						'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'
@@ -540,6 +572,9 @@ export function OtherRenewablePurchasesNotice( {
 				setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
 				noticeStatus={ noticeStatus }
 				noticeText={ noticeText }
+				noticeActionOnClick={ noticeActionOnClick }
+				noticeActionHref={ noticeActionHref }
+				noticeActionText={ noticeActionText }
 			/>
 		);
 	}
@@ -785,11 +820,41 @@ export function OtherRenewablePurchasesNotice( {
 		currentPurchaseIsExpiring &&
 		! anotherPurchaseIsExpiring
 	) {
+		// Handle no-payment-method case separately (needs CTA)
+		if (
+			isInExpirationGracePeriod( currentPurchase ) &&
+			currentPurchase.is_auto_renew_enabled &&
+			! currentPurchase.payment_type
+		) {
+			return (
+				<NoticeContent
+					purchase={ purchase }
+					renewableSitePurchases={ renewableSitePurchases }
+					isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
+					setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
+					noticeStatus={ suppressErrorStylingForOtherPurchases ? 'info' : 'error' }
+					noticeText={ createInterpolateElement(
+						__(
+							'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please add a payment method to avoid disruption to your service.'
+						),
+						{ link }
+					) }
+					noticeActionText={ __( 'Add Payment Method' ) }
+					noticeActionHref={
+						router.buildLocation( {
+							to: changePaymentMethodRoute.fullPath,
+							params: { purchaseId: purchase.ID },
+						} ).href
+					}
+				/>
+			);
+		}
+
 		const noticeText = ( () => {
 			// Grace period: if expiry date is past, show "expired" message instead of "will expire"
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
+				// Auto-renew ON with payment method but renewal failed
 				if ( isRenewing( currentPurchase ) ) {
-					// Auto-renew ON but renewal failed - use simplified message
 					return createInterpolateElement(
 						__(
 							'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -249,28 +249,16 @@ export function OtherRenewablePurchasesNotice( {
 			suppressErrorStylingForCurrentPurchase && suppressErrorStylingForOtherPurchases
 				? 'info'
 				: 'error';
-		let noticeActionOnClick: ( () => void ) | undefined = () =>
+		const noticeActionOnClick = () =>
 			( window.location.href = getRenewUrlForPurchases( renewableSitePurchases ) );
-		let noticeActionHref: string | undefined;
-		let noticeActionText = __( 'Renew all' );
+		const noticeActionText = __( 'Renew all' );
 
 		if ( isInExpirationGracePeriod( currentPurchase ) ) {
-			// Auto-renew ON but no payment method - show "Add Payment Method" CTA
-			if ( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type ) {
-				noticeText = createInterpolateElement(
-					__(
-						'There was a problem processing your renewal. You have <link>other upgrades</link> on this site that may also be affected. Please add a payment method to avoid disruption to your service.'
-					),
-					{ link }
-				);
-				noticeActionText = __( 'Add Payment Method' );
-				noticeActionOnClick = undefined;
-				noticeActionHref = router.buildLocation( {
-					to: changePaymentMethodRoute.fullPath,
-					params: { purchaseId: purchase.ID },
-				} ).href;
-			} else if ( isRenewing( currentPurchase ) ) {
-				// Auto-renew ON with payment method but renewal failed
+			// Auto-renew ON - renewal failed (payment issue or no payment method)
+			if (
+				isRenewing( currentPurchase ) ||
+				( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type )
+			) {
 				noticeText = createInterpolateElement(
 					__(
 						'There was a problem processing your renewal. You have <link>other upgrades</link> on this site that may also be affected. Please renew now to avoid disruption to your service.'
@@ -428,7 +416,6 @@ export function OtherRenewablePurchasesNotice( {
 				setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
 				noticeStatus={ noticeStatus }
 				noticeText={ noticeText }
-				noticeActionHref={ noticeActionHref }
 				noticeActionOnClick={ noticeActionOnClick }
 				noticeActionText={ noticeActionText }
 			/>
@@ -443,26 +430,13 @@ export function OtherRenewablePurchasesNotice( {
 	) {
 		let noticeText: React.ReactNode;
 		const noticeStatus = suppressErrorStylingForCurrentPurchase ? 'info' : 'error';
-		let noticeActionOnClick: ( () => void ) | undefined;
-		let noticeActionHref: string | undefined;
-		let noticeActionText: string | undefined;
 
 		if ( isInExpirationGracePeriod( currentPurchase ) ) {
-			// Auto-renew ON but no payment method
-			if ( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type ) {
-				noticeText = createInterpolateElement(
-					__(
-						'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please add a payment method to avoid disruption to your service.'
-					),
-					{ link }
-				);
-				noticeActionText = __( 'Add Payment Method' );
-				noticeActionHref = router.buildLocation( {
-					to: changePaymentMethodRoute.fullPath,
-					params: { purchaseId: purchase.ID },
-				} ).href;
-			} else if ( isRenewing( currentPurchase ) ) {
-				// Auto-renew ON with payment method but renewal failed
+			// Auto-renew ON - renewal failed (payment issue or no payment method)
+			if (
+				isRenewing( currentPurchase ) ||
+				( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type )
+			) {
 				noticeText = createInterpolateElement(
 					__(
 						'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'
@@ -572,9 +546,6 @@ export function OtherRenewablePurchasesNotice( {
 				setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
 				noticeStatus={ noticeStatus }
 				noticeText={ noticeText }
-				noticeActionOnClick={ noticeActionOnClick }
-				noticeActionHref={ noticeActionHref }
-				noticeActionText={ noticeActionText }
 			/>
 		);
 	}
@@ -820,41 +791,14 @@ export function OtherRenewablePurchasesNotice( {
 		currentPurchaseIsExpiring &&
 		! anotherPurchaseIsExpiring
 	) {
-		// Handle no-payment-method case separately (needs CTA)
-		if (
-			isInExpirationGracePeriod( currentPurchase ) &&
-			currentPurchase.is_auto_renew_enabled &&
-			! currentPurchase.payment_type
-		) {
-			return (
-				<NoticeContent
-					purchase={ purchase }
-					renewableSitePurchases={ renewableSitePurchases }
-					isUpcomingRenewalsDialogVisible={ isUpcomingRenewalsDialogVisible }
-					setUpcomingRenewalsDialogVisible={ setUpcomingRenewalsDialogVisible }
-					noticeStatus={ suppressErrorStylingForOtherPurchases ? 'info' : 'error' }
-					noticeText={ createInterpolateElement(
-						__(
-							'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please add a payment method to avoid disruption to your service.'
-						),
-						{ link }
-					) }
-					noticeActionText={ __( 'Add Payment Method' ) }
-					noticeActionHref={
-						router.buildLocation( {
-							to: changePaymentMethodRoute.fullPath,
-							params: { purchaseId: purchase.ID },
-						} ).href
-					}
-				/>
-			);
-		}
-
 		const noticeText = ( () => {
 			// Grace period: if expiry date is past, show "expired" message instead of "will expire"
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				// Auto-renew ON with payment method but renewal failed
-				if ( isRenewing( currentPurchase ) ) {
+				// Auto-renew ON - renewal failed (payment issue or no payment method)
+				if (
+					isRenewing( currentPurchase ) ||
+					( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type )
+				) {
 					return createInterpolateElement(
 						__(
 							'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -10,7 +10,7 @@ import { getRelativeTimeString, isWithinNext } from '../../../utils/datetime';
 import {
 	isExpired,
 	isExpiring,
-	isRenewing,
+	isFailedAutoRenewal,
 	isIncludedWithPlan,
 	needsToRenewSoon,
 	isRecentMonthlyPurchase,
@@ -254,11 +254,7 @@ export function OtherRenewablePurchasesNotice( {
 		const noticeActionText = __( 'Renew all' );
 
 		if ( isInExpirationGracePeriod( currentPurchase ) ) {
-			// Auto-renew ON - renewal failed (payment issue or no payment method)
-			if (
-				isRenewing( currentPurchase ) ||
-				( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type )
-			) {
+			if ( isFailedAutoRenewal( currentPurchase ) ) {
 				noticeText = createInterpolateElement(
 					__(
 						'There was a problem processing your renewal. You have <link>other upgrades</link> on this site that may also be affected. Please renew now to avoid disruption to your service.'
@@ -432,11 +428,7 @@ export function OtherRenewablePurchasesNotice( {
 		const noticeStatus = suppressErrorStylingForCurrentPurchase ? 'info' : 'error';
 
 		if ( isInExpirationGracePeriod( currentPurchase ) ) {
-			// Auto-renew ON - renewal failed (payment issue or no payment method)
-			if (
-				isRenewing( currentPurchase ) ||
-				( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type )
-			) {
+			if ( isFailedAutoRenewal( currentPurchase ) ) {
 				noticeText = createInterpolateElement(
 					__(
 						'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'
@@ -794,11 +786,7 @@ export function OtherRenewablePurchasesNotice( {
 		const noticeText = ( () => {
 			// Grace period: if expiry date is past, show "expired" message instead of "will expire"
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				// Auto-renew ON - renewal failed (payment issue or no payment method)
-				if (
-					isRenewing( currentPurchase ) ||
-					( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type )
-				) {
+				if ( isFailedAutoRenewal( currentPurchase ) ) {
 					return createInterpolateElement(
 						__(
 							'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -254,7 +254,15 @@ export function OtherRenewablePurchasesNotice( {
 		const noticeActionText = __( 'Renew all' );
 
 		if ( isInExpirationGracePeriod( currentPurchase ) ) {
-			if ( currentPurchase.is_domain_registration ) {
+			if ( isRenewing( currentPurchase ) ) {
+				// Auto-renew ON but renewal failed - use simplified message
+				noticeText = createInterpolateElement(
+					__(
+						'There was a problem processing your renewal. You have <link>other upgrades</link> on this site that may also be affected. Please renew now to avoid disruption to your service.'
+					),
+					{ link }
+				);
+			} else if ( currentPurchase.is_domain_registration ) {
 				noticeText = createInterpolateElement(
 					sprintf(
 						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago"
@@ -421,7 +429,15 @@ export function OtherRenewablePurchasesNotice( {
 		const noticeStatus = suppressErrorStylingForCurrentPurchase ? 'info' : 'error';
 
 		if ( isInExpirationGracePeriod( currentPurchase ) ) {
-			if ( currentPurchase.is_domain_registration ) {
+			if ( isRenewing( currentPurchase ) ) {
+				// Auto-renew ON but renewal failed - use simplified message
+				noticeText = createInterpolateElement(
+					__(
+						'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'
+					),
+					{ link }
+				);
+			} else if ( currentPurchase.is_domain_registration ) {
 				noticeText = createInterpolateElement(
 					sprintf(
 						// translators: purchaseName is the name of the product, expiry is a string like "3 months ago", and includedPurchaseName is the name of another product
@@ -772,6 +788,15 @@ export function OtherRenewablePurchasesNotice( {
 		const noticeText = ( () => {
 			// Grace period: if expiry date is past, show "expired" message instead of "will expire"
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
+				if ( isRenewing( currentPurchase ) ) {
+					// Auto-renew ON but renewal failed - use simplified message
+					return createInterpolateElement(
+						__(
+							'There was a problem processing your renewal. You also have <link>other upgrades</link> scheduled to renew soon. Please renew now to avoid disruption to your service.'
+						),
+						{ link }
+					);
+				}
 				if ( currentPurchase.is_domain_registration ) {
 					return createInterpolateElement(
 						sprintf(

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -163,11 +163,21 @@ function ExpiredRenewNotice( {
 			if ( isExpired( currentPurchase ) ) {
 				return __( 'This purchase has expired and is no longer in use.' );
 			}
-			if ( isInExpirationGracePeriod( currentPurchase ) && isRenewing( currentPurchase ) ) {
-				return __(
-					'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
-				);
+			if ( isInExpirationGracePeriod( currentPurchase ) ) {
+				// Auto-renew ON with payment method - renewal failed
+				if ( isRenewing( currentPurchase ) ) {
+					return __(
+						'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
+					);
+				}
+				// Auto-renew ON but no payment method - can't renew
+				if ( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type ) {
+					return __(
+						'There was a problem processing your renewal. Please add a payment method to avoid disruption to your service.'
+					);
+				}
 			}
+			// Auto-renew OFF or not in grace period
 			const purchaseName = currentPurchase.is_domain
 				? currentPurchase.meta ?? ''
 				: currentPurchase.product_name;

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -25,6 +25,7 @@ import {
 	creditCardHasAlreadyExpired,
 	getRenewalUrlFromPurchase,
 	isInExpirationGracePeriod,
+	isRenewing,
 	isAkismetFreeProduct,
 } from '../../../utils/purchase';
 import {
@@ -161,6 +162,11 @@ function ExpiredRenewNotice( {
 		const noticeText = ( () => {
 			if ( isExpired( currentPurchase ) ) {
 				return __( 'This purchase has expired and is no longer in use.' );
+			}
+			if ( isInExpirationGracePeriod( currentPurchase ) && isRenewing( currentPurchase ) ) {
+				return __(
+					'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
+				);
 			}
 			const purchaseName = currentPurchase.is_domain
 				? currentPurchase.meta ?? ''

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -164,16 +164,13 @@ function ExpiredRenewNotice( {
 				return __( 'This purchase has expired and is no longer in use.' );
 			}
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				// Auto-renew ON with payment method - renewal failed
-				if ( isRenewing( currentPurchase ) ) {
+				// Auto-renew ON - renewal failed (payment issue or no payment method)
+				if (
+					isRenewing( currentPurchase ) ||
+					( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type )
+				) {
 					return __(
 						'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
-					);
-				}
-				// Auto-renew ON but no payment method - can't renew
-				if ( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type ) {
-					return __(
-						'There was a problem processing your renewal. Please add a payment method to avoid disruption to your service.'
 					);
 				}
 			}

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -163,10 +163,7 @@ function ExpiredRenewNotice( {
 			if ( isExpired( currentPurchase ) ) {
 				return __( 'This purchase has expired and is no longer in use.' );
 			}
-			if (
-				isInExpirationGracePeriod( currentPurchase ) &&
-				isFailedAutoRenewal( currentPurchase )
-			) {
+			if ( isFailedAutoRenewal( currentPurchase ) ) {
 				return __(
 					'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
 				);

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -16,6 +16,7 @@ import { getRelativeTimeString } from '../../../utils/datetime';
 import { wpcomLink } from '../../../utils/link';
 import {
 	isExpired,
+	isFailedAutoRenewal,
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isCloseToExpiration,
@@ -25,7 +26,6 @@ import {
 	creditCardHasAlreadyExpired,
 	getRenewalUrlFromPurchase,
 	isInExpirationGracePeriod,
-	isRenewing,
 	isAkismetFreeProduct,
 } from '../../../utils/purchase';
 import {
@@ -163,16 +163,13 @@ function ExpiredRenewNotice( {
 			if ( isExpired( currentPurchase ) ) {
 				return __( 'This purchase has expired and is no longer in use.' );
 			}
-			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				// Auto-renew ON - renewal failed (payment issue or no payment method)
-				if (
-					isRenewing( currentPurchase ) ||
-					( currentPurchase.is_auto_renew_enabled && ! currentPurchase.payment_type )
-				) {
-					return __(
-						'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
-					);
-				}
+			if (
+				isInExpirationGracePeriod( currentPurchase ) &&
+				isFailedAutoRenewal( currentPurchase )
+			) {
+				return __(
+					'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
+				);
 			}
 			// Auto-renew OFF or not in grace period
 			const purchaseName = currentPurchase.is_domain

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -43,6 +43,23 @@ export function isRenewing( purchase: Purchase ): boolean {
 	return [ 'active', 'auto-renewing' ].includes( purchase.expiry_status );
 }
 
+/**
+ * Determines if the purchase is in a failed auto-renewal state.
+ *
+ * This occurs when the purchase is in grace period AND:
+ * - The purchase is still in "renewing" status (renewal attempted but failed), OR
+ * - Auto-renew is enabled but there's no payment method attached
+ *
+ * Use this to show "problem processing your renewal" messaging instead of
+ * generic expiry messages.
+ */
+export function isFailedAutoRenewal( purchase: Purchase ): boolean {
+	return (
+		isInExpirationGracePeriod( purchase ) &&
+		( isRenewing( purchase ) || ( purchase.is_auto_renew_enabled && ! purchase.payment_type ) )
+	);
+}
+
 export function isExpiring( purchase: Purchase ) {
 	return [ 'manual-renew', 'expiring' ].includes( purchase.expiry_status );
 }

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -44,14 +44,7 @@ export function isRenewing( purchase: Purchase ): boolean {
 }
 
 /**
- * Determines if the purchase is in a failed auto-renewal state.
- *
- * This occurs when the purchase is in grace period AND:
- * - The purchase is still in "renewing" status (renewal attempted but failed), OR
- * - Auto-renew is enabled but there's no payment method attached
- *
- * Use this to show "problem processing your renewal" messaging instead of
- * generic expiry messages.
+ * Returns true if the purchase is in grace period with a failed or missing auto-renewal.
  */
 export function isFailedAutoRenewal( purchase: Purchase ): boolean {
 	return (

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -800,6 +800,23 @@ export function isRenewing( purchase: Purchase ): boolean {
 	return [ 'active', 'autoRenewing' ].includes( purchase.expiryStatus );
 }
 
+/**
+ * Determines if the purchase is in a failed auto-renewal state.
+ *
+ * This occurs when the purchase is in grace period AND:
+ * - The purchase is still in "renewing" status (renewal attempted but failed), OR
+ * - Auto-renew is enabled but there's no payment method attached
+ *
+ * Use this to show "problem processing your renewal" messaging instead of
+ * generic expiry messages.
+ */
+export function isFailedAutoRenewal( purchase: Purchase ): boolean {
+	return (
+		isInExpirationGracePeriod( purchase ) &&
+		( isRenewing( purchase ) || ( purchase.isAutoRenewEnabled && ! hasPaymentMethod( purchase ) ) )
+	);
+}
+
 export function isWithinIntroductoryOfferPeriod( purchase: Purchase ): boolean {
 	return purchase.introductoryOffer?.isWithinPeriod ?? false;
 }

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -801,14 +801,7 @@ export function isRenewing( purchase: Purchase ): boolean {
 }
 
 /**
- * Determines if the purchase is in a failed auto-renewal state.
- *
- * This occurs when the purchase is in grace period AND:
- * - The purchase is still in "renewing" status (renewal attempted but failed), OR
- * - Auto-renew is enabled but there's no payment method attached
- *
- * Use this to show "problem processing your renewal" messaging instead of
- * generic expiry messages.
+ * Returns true if the purchase is in grace period with a failed or missing auto-renewal.
  */
 export function isFailedAutoRenewal( purchase: Purchase ): boolean {
 	return (

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -28,6 +28,7 @@ import {
 	creditCardExpiresBeforeSubscription,
 	creditCardHasAlreadyExpired,
 	getName,
+	hasPaymentMethod,
 	isCloseToExpiration,
 	isExpired,
 	isExpiring,
@@ -38,6 +39,7 @@ import {
 	isRecentMonthlyPurchase,
 	isRenewable,
 	isRechargeable,
+	isRenewing,
 	needsToRenewSoon,
 	showCreditCardExpiringWarning,
 	isPaidWithCredits,
@@ -534,13 +536,13 @@ class PurchaseNotice extends Component<
 			noticeActionText = translate( 'Renew all' );
 			noticeImpressionName = 'current-expires-soon-others-expire-soon';
 
-			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				if ( isFailedAutoRenewal( currentPurchase ) ) {
-					noticeText = translate(
-						'There was a problem processing your renewal. You have {{link}}other upgrades{{/link}} on this site that may also be affected. Please renew now to avoid disruption to your service.',
-						translateOptions
-					);
-				} else if ( isDomainRegistration( currentPurchase ) ) {
+			if ( isFailedAutoRenewal( currentPurchase ) ) {
+				noticeText = translate(
+					'There was a problem processing your renewal. You have {{link}}other upgrades{{/link}} on this site that may also be affected. Please renew now to avoid disruption to your service.',
+					translateOptions
+				);
+			} else if ( isInExpirationGracePeriod( currentPurchase ) ) {
+				if ( isDomainRegistration( currentPurchase ) ) {
 					noticeText = translate(
 						'Your %(purchaseName)s domain expired %(expiry)s, and you have {{link}}other upgrades{{/link}} on this site that will also be removed soon unless you take action.',
 						translateOptions
@@ -621,13 +623,13 @@ class PurchaseNotice extends Component<
 			noticeStatus = suppressErrorStylingForCurrentPurchase ? 'is-info' : 'is-error';
 			noticeImpressionName = 'current-expires-soon-others-renew-soon';
 
-			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				if ( isFailedAutoRenewal( currentPurchase ) ) {
-					noticeText = translate(
-						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
-						translateOptions
-					);
-				} else if ( isDomainRegistration( currentPurchase ) ) {
+			if ( isFailedAutoRenewal( currentPurchase ) ) {
+				noticeText = translate(
+					'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
+					translateOptions
+				);
+			} else if ( isInExpirationGracePeriod( currentPurchase ) ) {
+				if ( isDomainRegistration( currentPurchase ) ) {
 					noticeText = translate(
 						'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
 						translateOptions
@@ -804,15 +806,15 @@ class PurchaseNotice extends Component<
 			noticeStatus = 'is-info';
 			noticeImpressionName = 'current-expires-later-others-renew-soon';
 
-			if ( isInExpirationGracePeriod( currentPurchase ) ) {
+			if ( isFailedAutoRenewal( currentPurchase ) ) {
 				noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
-
-				if ( isFailedAutoRenewal( currentPurchase ) ) {
-					noticeText = translate(
-						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
-						translateOptions
-					);
-				} else if ( isDomainRegistration( currentPurchase ) ) {
+				noticeText = translate(
+					'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
+					translateOptions
+				);
+			} else if ( isInExpirationGracePeriod( currentPurchase ) ) {
+				noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
+				if ( isDomainRegistration( currentPurchase ) ) {
 					noticeText = translate(
 						'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
 						translateOptions
@@ -1056,12 +1058,12 @@ class PurchaseNotice extends Component<
 
 		if ( isRenewable( purchase ) ) {
 			const noticeText = ( () => {
+				if ( isFailedAutoRenewal( currentPurchase ) ) {
+					return translate(
+						'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
+					);
+				}
 				if ( isInExpirationGracePeriod( currentPurchase ) ) {
-					if ( isFailedAutoRenewal( currentPurchase ) ) {
-						return translate(
-							'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
-						);
-					}
 					// Auto-renew OFF - intentional expiry
 					const purchaseName = getName( currentPurchase );
 					const expiry = moment( currentPurchase.expiryDate ).fromNow();

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -417,6 +417,7 @@ class PurchaseNotice extends Component<
 
 	renderOtherRenewablePurchasesNotice() {
 		const {
+			changePaymentMethodPath,
 			translate,
 			moment,
 			purchase,
@@ -536,8 +537,17 @@ class PurchaseNotice extends Component<
 			noticeImpressionName = 'current-expires-soon-others-expire-soon';
 
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				if ( isRenewing( currentPurchase ) ) {
-					// Auto-renew ON but renewal failed - use simplified message
+				// Auto-renew ON but no payment method - show "Add Payment Method" CTA
+				if ( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) ) {
+					noticeText = translate(
+						'There was a problem processing your renewal. You have {{link}}other upgrades{{/link}} on this site that may also be affected. Please add a payment method to avoid disruption to your service.',
+						translateOptions
+					);
+					noticeActionOnClick = undefined;
+					noticeActionHref = changePaymentMethodPath || undefined;
+					noticeActionText = translate( 'Add Payment Method' );
+				} else if ( isRenewing( currentPurchase ) ) {
+					// Auto-renew ON with payment method but renewal failed
 					noticeText = translate(
 						'There was a problem processing your renewal. You have {{link}}other upgrades{{/link}} on this site that may also be affected. Please renew now to avoid disruption to your service.',
 						translateOptions
@@ -624,8 +634,17 @@ class PurchaseNotice extends Component<
 			noticeImpressionName = 'current-expires-soon-others-renew-soon';
 
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				if ( isRenewing( currentPurchase ) ) {
-					// Auto-renew ON but renewal failed - use simplified message
+				// Auto-renew ON but no payment method
+				if ( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) ) {
+					noticeText = translate(
+						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please add a payment method to avoid disruption to your service.',
+						translateOptions
+					);
+					noticeActionOnClick = undefined;
+					noticeActionHref = changePaymentMethodPath || undefined;
+					noticeActionText = translate( 'Add Payment Method' );
+				} else if ( isRenewing( currentPurchase ) ) {
+					// Auto-renew ON with payment method but renewal failed
 					noticeText = translate(
 						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
 						translateOptions
@@ -810,8 +829,17 @@ class PurchaseNotice extends Component<
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
 				noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
 
-				if ( isRenewing( currentPurchase ) ) {
-					// Auto-renew ON but renewal failed - use simplified message
+				// Auto-renew ON but no payment method
+				if ( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) ) {
+					noticeText = translate(
+						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please add a payment method to avoid disruption to your service.',
+						translateOptions
+					);
+					noticeActionOnClick = undefined;
+					noticeActionHref = changePaymentMethodPath || undefined;
+					noticeActionText = translate( 'Add Payment Method' );
+				} else if ( isRenewing( currentPurchase ) ) {
+					// Auto-renew ON with payment method but renewal failed
 					noticeText = translate(
 						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
 						translateOptions
@@ -1060,14 +1088,22 @@ class PurchaseNotice extends Component<
 
 		if ( isRenewable( purchase ) ) {
 			const noticeText = ( () => {
-				if ( isInExpirationGracePeriod( purchase ) ) {
-					if ( isRenewing( purchase ) ) {
+				if ( isInExpirationGracePeriod( currentPurchase ) ) {
+					// Auto-renew ON with payment method - renewal failed
+					if ( isRenewing( currentPurchase ) ) {
 						return translate(
 							'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
 						);
 					}
-					const purchaseName = getName( purchase );
-					const expiry = moment( purchase.expiryDate ).fromNow();
+					// Auto-renew ON but no payment method - can't renew
+					if ( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) ) {
+						return translate(
+							'There was a problem processing your renewal. Please add a payment method to avoid disruption to your service.'
+						);
+					}
+					// Auto-renew OFF - intentional expiry
+					const purchaseName = getName( currentPurchase );
+					const expiry = moment( currentPurchase.expiryDate ).fromNow();
 					return translate(
 						'Your %(purchaseName)s subscription expired %(expiry)s and will be removed soon unless you take action.',
 						{

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -417,7 +417,6 @@ class PurchaseNotice extends Component<
 
 	renderOtherRenewablePurchasesNotice() {
 		const {
-			changePaymentMethodPath,
 			translate,
 			moment,
 			purchase,
@@ -537,17 +536,11 @@ class PurchaseNotice extends Component<
 			noticeImpressionName = 'current-expires-soon-others-expire-soon';
 
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				// Auto-renew ON but no payment method - show "Add Payment Method" CTA
-				if ( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) ) {
-					noticeText = translate(
-						'There was a problem processing your renewal. You have {{link}}other upgrades{{/link}} on this site that may also be affected. Please add a payment method to avoid disruption to your service.',
-						translateOptions
-					);
-					noticeActionOnClick = undefined;
-					noticeActionHref = changePaymentMethodPath || undefined;
-					noticeActionText = translate( 'Add Payment Method' );
-				} else if ( isRenewing( currentPurchase ) ) {
-					// Auto-renew ON with payment method but renewal failed
+				// Auto-renew ON - renewal failed (payment issue or no payment method)
+				if (
+					isRenewing( currentPurchase ) ||
+					( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) )
+				) {
 					noticeText = translate(
 						'There was a problem processing your renewal. You have {{link}}other upgrades{{/link}} on this site that may also be affected. Please renew now to avoid disruption to your service.',
 						translateOptions
@@ -634,17 +627,11 @@ class PurchaseNotice extends Component<
 			noticeImpressionName = 'current-expires-soon-others-renew-soon';
 
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				// Auto-renew ON but no payment method
-				if ( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) ) {
-					noticeText = translate(
-						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please add a payment method to avoid disruption to your service.',
-						translateOptions
-					);
-					noticeActionOnClick = undefined;
-					noticeActionHref = changePaymentMethodPath || undefined;
-					noticeActionText = translate( 'Add Payment Method' );
-				} else if ( isRenewing( currentPurchase ) ) {
-					// Auto-renew ON with payment method but renewal failed
+				// Auto-renew ON - renewal failed (payment issue or no payment method)
+				if (
+					isRenewing( currentPurchase ) ||
+					( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) )
+				) {
 					noticeText = translate(
 						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
 						translateOptions
@@ -829,17 +816,11 @@ class PurchaseNotice extends Component<
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
 				noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
 
-				// Auto-renew ON but no payment method
-				if ( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) ) {
-					noticeText = translate(
-						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please add a payment method to avoid disruption to your service.',
-						translateOptions
-					);
-					noticeActionOnClick = undefined;
-					noticeActionHref = changePaymentMethodPath || undefined;
-					noticeActionText = translate( 'Add Payment Method' );
-				} else if ( isRenewing( currentPurchase ) ) {
-					// Auto-renew ON with payment method but renewal failed
+				// Auto-renew ON - renewal failed (payment issue or no payment method)
+				if (
+					isRenewing( currentPurchase ) ||
+					( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) )
+				) {
 					noticeText = translate(
 						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
 						translateOptions
@@ -1089,16 +1070,13 @@ class PurchaseNotice extends Component<
 		if ( isRenewable( purchase ) ) {
 			const noticeText = ( () => {
 				if ( isInExpirationGracePeriod( currentPurchase ) ) {
-					// Auto-renew ON with payment method - renewal failed
-					if ( isRenewing( currentPurchase ) ) {
+					// Auto-renew ON - renewal failed (payment issue or no payment method)
+					if (
+						isRenewing( currentPurchase ) ||
+						( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) )
+					) {
 						return translate(
 							'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
-						);
-					}
-					// Auto-renew ON but no payment method - can't renew
-					if ( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) ) {
-						return translate(
-							'There was a problem processing your renewal. Please add a payment method to avoid disruption to your service.'
 						);
 					}
 					// Auto-renew OFF - intentional expiry

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -1061,6 +1061,11 @@ class PurchaseNotice extends Component<
 		if ( isRenewable( purchase ) ) {
 			const noticeText = ( () => {
 				if ( isInExpirationGracePeriod( purchase ) ) {
+					if ( isRenewing( purchase ) ) {
+						return translate(
+							'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
+						);
+					}
 					const purchaseName = getName( purchase );
 					const expiry = moment( purchase.expiryDate ).fromNow();
 					return translate(

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -536,7 +536,13 @@ class PurchaseNotice extends Component<
 			noticeImpressionName = 'current-expires-soon-others-expire-soon';
 
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				if ( isDomainRegistration( currentPurchase ) ) {
+				if ( isRenewing( currentPurchase ) ) {
+					// Auto-renew ON but renewal failed - use simplified message
+					noticeText = translate(
+						'There was a problem processing your renewal. You have {{link}}other upgrades{{/link}} on this site that may also be affected. Please renew now to avoid disruption to your service.',
+						translateOptions
+					);
+				} else if ( isDomainRegistration( currentPurchase ) ) {
 					noticeText = translate(
 						'Your %(purchaseName)s domain expired %(expiry)s, and you have {{link}}other upgrades{{/link}} on this site that will also be removed soon unless you take action.',
 						translateOptions
@@ -618,7 +624,13 @@ class PurchaseNotice extends Component<
 			noticeImpressionName = 'current-expires-soon-others-renew-soon';
 
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				if ( isDomainRegistration( currentPurchase ) ) {
+				if ( isRenewing( currentPurchase ) ) {
+					// Auto-renew ON but renewal failed - use simplified message
+					noticeText = translate(
+						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
+						translateOptions
+					);
+				} else if ( isDomainRegistration( currentPurchase ) ) {
 					noticeText = translate(
 						'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
 						translateOptions
@@ -798,7 +810,13 @@ class PurchaseNotice extends Component<
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
 				noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
 
-				if ( isDomainRegistration( currentPurchase ) ) {
+				if ( isRenewing( currentPurchase ) ) {
+					// Auto-renew ON but renewal failed - use simplified message
+					noticeText = translate(
+						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
+						translateOptions
+					);
+				} else if ( isDomainRegistration( currentPurchase ) ) {
 					noticeText = translate(
 						'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
 						translateOptions

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -31,15 +31,14 @@ import {
 	isCloseToExpiration,
 	isExpired,
 	isExpiring,
+	isFailedAutoRenewal,
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPartnerPurchase,
 	isRecentMonthlyPurchase,
 	isRenewable,
-	isRenewing,
 	isRechargeable,
 	needsToRenewSoon,
-	hasPaymentMethod,
 	showCreditCardExpiringWarning,
 	isPaidWithCredits,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
@@ -536,11 +535,7 @@ class PurchaseNotice extends Component<
 			noticeImpressionName = 'current-expires-soon-others-expire-soon';
 
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				// Auto-renew ON - renewal failed (payment issue or no payment method)
-				if (
-					isRenewing( currentPurchase ) ||
-					( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) )
-				) {
+				if ( isFailedAutoRenewal( currentPurchase ) ) {
 					noticeText = translate(
 						'There was a problem processing your renewal. You have {{link}}other upgrades{{/link}} on this site that may also be affected. Please renew now to avoid disruption to your service.',
 						translateOptions
@@ -627,11 +622,7 @@ class PurchaseNotice extends Component<
 			noticeImpressionName = 'current-expires-soon-others-renew-soon';
 
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
-				// Auto-renew ON - renewal failed (payment issue or no payment method)
-				if (
-					isRenewing( currentPurchase ) ||
-					( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) )
-				) {
+				if ( isFailedAutoRenewal( currentPurchase ) ) {
 					noticeText = translate(
 						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
 						translateOptions
@@ -816,11 +807,7 @@ class PurchaseNotice extends Component<
 			if ( isInExpirationGracePeriod( currentPurchase ) ) {
 				noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
 
-				// Auto-renew ON - renewal failed (payment issue or no payment method)
-				if (
-					isRenewing( currentPurchase ) ||
-					( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) )
-				) {
+				if ( isFailedAutoRenewal( currentPurchase ) ) {
 					noticeText = translate(
 						'There was a problem processing your renewal. You also have {{link}}other upgrades{{/link}} scheduled to renew soon. Please renew now to avoid disruption to your service.',
 						translateOptions
@@ -1070,11 +1057,7 @@ class PurchaseNotice extends Component<
 		if ( isRenewable( purchase ) ) {
 			const noticeText = ( () => {
 				if ( isInExpirationGracePeriod( currentPurchase ) ) {
-					// Auto-renew ON - renewal failed (payment issue or no payment method)
-					if (
-						isRenewing( currentPurchase ) ||
-						( currentPurchase.isAutoRenewEnabled && ! hasPaymentMethod( currentPurchase ) )
-					) {
+					if ( isFailedAutoRenewal( currentPurchase ) ) {
 						return translate(
 							'There was a problem processing your renewal. Please renew now to avoid disruption to your service.'
 						);


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1585/update-other-purchases-grace-period-notices-for-auto-renew
Related to previous change:  https://github.com/Automattic/wp-calypso/pull/107984

## Proposed Changes

  * Add simplified messaging for failed auto-renewals: "There was a problem processing your renewal"
  * Add `isFailedAutoRenewal()` helper to consolidate detection of failed auto-renewals in grace period
  * Refactor 8 notice locations to use early-return pattern with the new helper

## Why are these changes being made?

Follow-up to #107984 (SHILL-912). During review, @fditrapani suggested simplifying messaging when auto-renew is enabled—focusing on getting users to renew rather than emphasizing expiry dates.

When auto-renew is ON and a subscription is in grace period (renewal failed), users previously saw product-specific messages with expiry dates that added complexity without helping them take action.

We should detect failed auto-renewals (grace period + AR ON) and show action-oriented messaging that:
1. Acknowledges something went wrong ("There was a problem processing your renewal")
2. Tells them what to do :"renew now/all"

  Messaging change:
  | Scenario | Before | After (AR ON) |
  |----------|--------|---------------|
  | Simple notice | "Your X subscription expired Y ago and will be removed soon unless you take action." | "There was a problem processing your renewal. Please renew now to avoid disruption to your service." |
  | Others expiring | "Your X expired Y ago, and you have other upgrades that will also be removed..." | "There was a problem processing your renewal. You have other upgrades on this site that may also be affected..." |
  | Others renewing | "Your X expired Y ago... You also have other upgrades scheduled to renew soon." | "There was a problem processing your renewal. You also have other upgrades scheduled to renew soon..." |
  
  

## Testing Instructions

### Prerequisites

- Point public-api.wordpress.com to your sandbox and sandbox store:
```php
define( 'USE_STORE_SANDBOX', true );
define( 'USE_BILLING_SANDBOX', true );
define( 'BILLINGDADDY_SANDBOX', rtrim( 'https://' . `hostname` ) );
```

- Local Calypso running with this branch loaded
- A test site with at least one subscription

### Manual Data Setup

On your wpcom sandbox, temporarily modify `store-subscription.php` around line 4648 in `Store_Subscription::to_billing_upgrade()`:

```php
// TEST SCENARIOS for SHILL-1585 - uncomment ONE at a time:

// Grace period + AR ON (should show "problem processing your renewal")
$this->expiry = gmdate( 'Y-m-d', time() - 3*DAY_IN_SECONDS ); $this->auto_renew = 1;

// Grace period + AR OFF (should show "expired 3 days ago" - unchanged behavior)
// $this->expiry = gmdate( 'Y-m-d', time() - 3*DAY_IN_SECONDS ); $this->auto_renew = 0;
```

### Test URLs

| UI | URL |
|---|---|
| Dashboard list | `/me/billing/purchases` |
| Dashboard detail | `/me/billing/purchases/{purchaseId}` |
| Classic list | `/me/purchases` |
| Classic detail | `/me/purchases/{site-slug}/{purchaseId}` |

### Test Matrix
  | Scenario | Mock Setup | Expected Message |
  |----------|------------|------------------|
  | Simple - AR ON, grace period | `auto_renew=1` simple | "There was a problem processing your renewal. Please renew now..." |
  | Simple - AR OFF, grace period | `auto_renew=0` simple  | "Your X subscription expired 3 days ago and will be removed soon..." |
  | Others expiring - AR ON | auto_renew=1 + other expiring purchase | "...You have other upgrades on this site that may also be affected..." |
  | Others renewing - AR ON | auto_renew=1 + other healthy purchase | "...You also have other upgrades scheduled to renew soon..." |
  
  

### Steps

1. Set mock data to **grace period + AR ON** scenario (uncomment first test line)
2. Load purchase detail page in both Dashboard and Classic UIs
    - Classic: /me/purchases/{site-slug}/{purchase-id}
    - Dashboard: /me/billing/purchases/{purchase-id}
3. Verify notice message matches expected text from matrix above
4. Verify CTA button shows correct label and links to correct destination:
      - AR ON + grace period: "There was a problem processing your renewal..."
      - AR OFF + grace period: "Your X subscription expired Y ago..."
      - check CTA makes sense
5. Switch mock data to **AR OFF** scenario and verify original "expired X ago" message still shows

### General Scenarios to Validate

  | State | AR | Expected Behavior |
  |-------|----|--------------------|
  | Fully expired (inactive) | - | "This purchase has expired and is no longer in use." |
  | Grace period | ON | **NEW:** "There was a problem processing your renewal..." |
  | Grace period | OFF | "Your X subscription expired Y ago and will be removed..." |
  | Expiring soon | OFF | "Your X subscription will expire on Y..." |
  | Renewing soon | ON | "Your X subscription will renew on Y..." |
  | Active (not close) | - | No notice |



### New Translation Strings (3 total)

| # | Message |
| -- | -- | 
|1 | "There was a problem processing your renewal. Please renew now to avoid disruption to your service." | 
|2 | "There was a problem processing your renewal. You have other upgrades on this site that may also be affected. Please renew now to avoid disruption to your service." | 
|3 | "There was a problem processing your renewal. You also have other upgrades scheduled to renew soon. Please renew now to avoid disruption to your service." | 

### Screenshots
<img width="1310" height="553" alt="Screenshot 2026-02-06 at 10 07 28 AM" src="https://github.com/user-attachments/assets/261fc2d8-6d21-4621-abf0-ecbcdeef9cb9" />
<img width="1310" height="553" alt="Screenshot 2026-02-06 at 10 07 56 AM" src="https://github.com/user-attachments/assets/a66f7b7c-061d-4379-87d6-0f69e9569bc6" />
<img width="1310" height="553" alt="Screenshot 2026-02-06 at 12 19 24 PM" src="https://github.com/user-attachments/assets/8f08c9d6-7753-46ad-8c92-4a15914952b7" />





## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?