### PR TITLE
Dashboard: clean up dashboard/v2 feature flag

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -1,16 +1,11 @@
 import { persistQueryClientPromise } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { initSentry } from '@automattic/calypso-sentry';
-import {
-	isSupportSession,
-	maybeInitializeSupportSession,
-} from '@automattic/calypso-support-session';
+import { maybeInitializeSupportSession } from '@automattic/calypso-support-session';
 import { createRoot } from 'react-dom/client';
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/commands/build-style/style.css';
 import loadDevHelpers from 'calypso/lib/load-dev-helpers';
 import wpcom from 'calypso/lib/wp';
-import isDashboardEnv from '../utils/is-dashboard-env';
 import { loadPreferencesHelper } from './dev-tools/preferences';
 import Layout from './layout';
 import limitTotalSnackbars from './snackbars/limit-total-snackbars';
@@ -19,10 +14,6 @@ import type { AppConfig } from './context';
 import './style.scss';
 
 function boot( config: AppConfig ) {
-	if ( ! isDashboardEnv() && ! isEnabled( 'dashboard/v2' ) && ! isSupportSession() ) {
-		throw new Error( 'Multi-site Dashboard is not enabled' );
-	}
-
 	maybeInitializeSupportSession( wpcom );
 	loadDevHelpers();
 	loadPreferencesHelper();

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1092,7 +1092,7 @@ export default function pages() {
 	}
 
 	// Multi-site Dashboard routing for development {calypso.localhost, wpcalypso.wordpress.com}.
-	if ( calypsoEnv !== 'production' && config.isEnabled( 'dashboard/v2' ) ) {
+	if ( [ 'development', 'wpcalypso' ].includes( calypsoEnv ) ) {
 		const handleRoute = ( section, sectionPath, entrypoint, reqFilter ) => {
 			app.get(
 				pathToRegExp( sectionPath ),
@@ -1107,13 +1107,15 @@ export default function pages() {
 		DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
 			handleRoute( DASHBOARD_SECTION_DEFINITION, route, 'entry-dashboard-dotcom', ( req ) => {
 				// Allow dashboard routes under my.localhost.
-				return req.get( 'host' ).startsWith( 'my.localhost' );
+				const host = req.get( 'host' ) || '';
+				return host.startsWith( 'my.localhost' );
 			} );
 		} );
 
 		handleRoute( DASHBOARD_CIAB_SECTION_DEFINITION, '/ciab', 'entry-dashboard-ciab', ( req ) => {
 			// Allow CIAB routes under my.localhost.
-			return req.get( 'host' ).startsWith( 'my.localhost' );
+			const host = req.get( 'host' ) || '';
+			return host.startsWith( 'my.localhost' );
 		} );
 
 		// Temporary support redirection for the /v2 route for backwards compatibility.

--- a/client/state/dashboard/selectors/has-dashboard-forced-opt-in.ts
+++ b/client/state/dashboard/selectors/has-dashboard-forced-opt-in.ts
@@ -4,10 +4,6 @@ import type { HostingDashboardOptIn } from '@automattic/api-core';
 import type { AppState } from 'calypso/types';
 
 export const hasDashboardForcedOptIn = ( state: AppState ): boolean => {
-	if ( ! isEnabled( 'dashboard/v2' ) ) {
-		return false;
-	}
-
 	const preference = getPreference( state, 'hosting-dashboard-opt-in' ) as
 		| HostingDashboardOptIn
 		| undefined;

--- a/client/state/dashboard/selectors/has-dashboard-opt-in.ts
+++ b/client/state/dashboard/selectors/has-dashboard-opt-in.ts
@@ -4,10 +4,6 @@ import type { HostingDashboardOptIn } from '@automattic/api-core';
 import type { AppState } from 'calypso/types';
 
 export const hasDashboardOptIn = ( state: AppState ): boolean => {
-	if ( ! isEnabled( 'dashboard/v2' ) ) {
-		return false;
-	}
-
 	const preference = getPreference( state, 'hosting-dashboard-opt-in' ) as
 		| HostingDashboardOptIn
 		| undefined;

--- a/client/state/dashboard/selectors/is-dashboard-toggle-enabled.ts
+++ b/client/state/dashboard/selectors/is-dashboard-toggle-enabled.ts
@@ -9,10 +9,6 @@ const OLDEST_ELIGIBLE_USER: number = config( 'dashboard_opt_in_oldest_eligible_u
  * before 22 December 2025 can manually opt in or out.
  */
 export const isDashboardToggleEnabled = ( state: AppState ): boolean => {
-	if ( ! config.isEnabled( 'dashboard/v2' ) ) {
-		return false;
-	}
-
 	const user = getCurrentUser( state ); // Ensure current user is loaded.
 	if ( ! user || user.ID > OLDEST_ELIGIBLE_USER ) {
 		return false;

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -15,7 +15,6 @@
 		"always_use_logout_url": true,
 		"ciab/allow-domain-features": true,
 		"cookie-banner": false,
-		"dashboard/v2": false,
 		"dashboard/v2/paginated-site-list": true,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -14,7 +14,6 @@
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": false,
 		"cookie-banner": false,
-		"dashboard/v2": false,
 		"dashboard/v2/paginated-site-list": true,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -14,7 +14,6 @@
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": false,
 		"cookie-banner": true,
-		"dashboard/v2": false,
 		"dashboard/v2/paginated-site-list": true,
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -14,7 +14,6 @@
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": false,
 		"cookie-banner": false,
-		"dashboard/v2": false,
 		"dashboard/v2/paginated-site-list": true,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,

--- a/config/development.json
+++ b/config/development.json
@@ -53,7 +53,6 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/paginated-site-list": true,
 		"design-picker/use-assembler-styles": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,7 +28,6 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/paginated-site-list": true,
 		"design-picker/use-assembler-styles": true,

--- a/config/production.json
+++ b/config/production.json
@@ -40,7 +40,6 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/v2": true,
 		"dashboard/v2/paginated-site-list": true,
 		"dashboard/v2/backport/site-overview": true,
 		"domain-transfer-redesign": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,7 +38,6 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/paginated-site-list": true,
 		"dev/preferences-helper": true,

--- a/config/test.json
+++ b/config/test.json
@@ -114,7 +114,6 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"wpcom-user-bootstrap": false,
-		"dashboard/v2": true
+		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,7 +38,6 @@
 		"checkout/vgs-ebanx": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
-		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/paginated-site-list": true,
 		"design-picker/use-assembler-styles": true,


### PR DESCRIPTION
Part of DOTMSD-1072

Preparatory PR before adding new environment for CIAB.

## Proposed Changes

I believe the `dashboard/v2` feature flag is now confusing to read, after we migrated from `/v2` path to the new `my.*` subdomain and new environments. It's `true` in the old Calypso environments and `false` in the new `dashboard-` environments, making it hard to understand.

In this PR, I'm proposing to remove it altogether, now that we have launched MSD routes.

## Why are these changes being made?

To avoid further confusion when adding new environment and logic for CIAB.

## Testing Instructions

1. Check out branch locally, run `yarn start`, verify you can access `calypso.localhost` and `my.localhost` as usual.
1. Check out branch locally, run `yarn start-dashboard`, verify you can access `my.localhost` as usual.
1. Verify the `Calypso live` link works.
2. Verify the `Dashboard live` link works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
