### PR TITLE
Fix intermittent failures of dashboard unit tests by adding mock cache methods

### DIFF
--- a/client/dashboard/components/time-mismatch-notice/test/index.tsx
+++ b/client/dashboard/components/time-mismatch-notice/test/index.tsx
@@ -13,7 +13,14 @@ jest.mock( '@automattic/api-queries', () => ( {
 } ) );
 
 jest.mock( '@tanstack/react-query', () => ( {
-	QueryClient: jest.fn().mockImplementation( () => ( {} ) ),
+	QueryClient: jest.fn().mockImplementation( () => ( {
+		getQueryCache: jest.fn( () => ( {
+			subscribe: jest.fn( () => jest.fn() ),
+		} ) ),
+		getMutationCache: jest.fn( () => ( {
+			subscribe: jest.fn( () => jest.fn() ),
+		} ) ),
+	} ) ),
 	QueryClientProvider: ( { children }: { children: React.ReactNode } ) => children,
 	useSuspenseQuery: jest.fn(),
 	useMutation: jest.fn(),

--- a/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
@@ -40,7 +40,14 @@ jest.mock( '@automattic/api-queries', () => ( {
 } ) );
 
 jest.mock( '@tanstack/react-query', () => ( {
-	QueryClient: jest.fn().mockImplementation( () => ( {} ) ),
+	QueryClient: jest.fn().mockImplementation( () => ( {
+		getQueryCache: jest.fn( () => ( {
+			subscribe: jest.fn( () => jest.fn() ),
+		} ) ),
+		getMutationCache: jest.fn( () => ( {
+			subscribe: jest.fn( () => jest.fn() ),
+		} ) ),
+	} ) ),
 	QueryClientProvider: ( { children }: { children: React.ReactNode } ) => children,
 	useQuery: jest.fn( () => ( { data: { ID: 1, slug: 'production-site' }, isLoading: false } ) ),
 	useMutation: jest.fn( () => ( {

--- a/client/dashboard/sites/staging-site-sync-dropdown/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/test/index.test.tsx
@@ -26,8 +26,12 @@ jest.mock( '@automattic/api-queries', () => ( {
 
 jest.mock( '@tanstack/react-query', () => ( {
 	QueryClient: jest.fn().mockImplementation( () => ( {
-		getQueryCache: jest.fn( () => ( { subscribe: jest.fn() } ) ),
-		getMutationCache: jest.fn( () => ( { subscribe: jest.fn() } ) ),
+		getQueryCache: jest.fn( () => ( {
+			subscribe: jest.fn( () => jest.fn() ),
+		} ) ),
+		getMutationCache: jest.fn( () => ( {
+			subscribe: jest.fn( () => jest.fn() ),
+		} ) ),
 	} ) ),
 	QueryClientProvider: ( { children }: { children: React.ReactNode } ) => children,
 	useQuery: jest.fn( () => ( {

--- a/client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx
@@ -27,7 +27,14 @@ jest.mock( '@automattic/api-queries', () => ( {
 } ) );
 
 jest.mock( '@tanstack/react-query', () => ( {
-	QueryClient: jest.fn().mockImplementation( () => ( {} ) ),
+	QueryClient: jest.fn().mockImplementation( () => ( {
+		getQueryCache: jest.fn( () => ( {
+			subscribe: jest.fn( () => jest.fn() ),
+		} ) ),
+		getMutationCache: jest.fn( () => ( {
+			subscribe: jest.fn( () => jest.fn() ),
+		} ) ),
+	} ) ),
 	QueryClientProvider: ( { children }: { children: React.ReactNode } ) => children,
 	useQuery: jest.fn( () => ( {
 		data: undefined,


### PR DESCRIPTION
## Proposed Changes

Add `getQueryCache` and `getMutationCache` methods to the mock `QueryClient` in 4 dashboard test files.

## Why are these changes being made?

The mock QueryClient was returning an empty object, which caused errors when components tried to subscribe to cache events. Specifically, `AuthProvider` uses `queryClient.getQueryCache().subscribe()` and `queryClient.getMutationCache().subscribe()` to handle authentication errors. Without these methods, tests would fail intermittently.

## Testing Instructions

All 4 modified tests pass:
- `client/dashboard/components/time-mismatch-notice/test/index.tsx` (6 tests)
- `client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx`
- `client/dashboard/sites/staging-site-sync-dropdown/test/index.test.tsx`
- `client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx`

Run: `yarn run test-client --testPathPattern="time-mismatch-notice|staging-site"`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you tested the feature in relevant test environments?