### PR TITLE
Agents manager: fix marketplace floating header

### DIFF
--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -284,6 +284,19 @@ body.site-editor-php.agents-manager-sidebar-container {
 	}
 }
 
+// Fix for the search categories fixed top position on the plugins marketplace page
+.agents-manager-sidebar-container--sidebar-open .layout__secondary ~ .layout__primary .plugins-browser--site-view .search-categories.fixed-top {
+	top: calc( $admin-bar-height + $layout-spacing + 1px );
+	left: -174px;
+	padding-top: 11px;
+	max-width: 1028px;
+	border-bottom: 1px solid var(--color-neutral-5);
+
+	&::after {
+		display: none;
+	}
+}
+
 /* Page editor */
 body.post-php.agents-manager-sidebar-container {
 	@include sidebar-base( '.edit-post-layout' );


### PR DESCRIPTION
If you have the docked agents manager open on the plugins marketplace you get this overlap when you scroll down the page:

<img width="2254" height="284" alt="image" src="https://github.com/user-attachments/assets/9a4de730-4da2-4616-9ca9-bb828e72e04d" />

There are quite a few hard-coded numbers in here. I haven't found anything better at the moment.

Fixes AI-851

## Why are these changes being made?

* CSS fix for plugin marketplace

## Testing Instructions

* Run Calypso locally
* Go to plugin marketplace on a site (for example http://calypso.localhost:3000/plugins/[SITE])
* Open docked agents manager
* Scroll down the main page so the plugin header floats
* Confirm that it now fits into the agents manager frame

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
