### PR TITLE
Agents manager: fix font size undocked

### DIFF
--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -624,6 +624,10 @@ body:not(.modal-open) .agents-manager-chat--docked {
 	}
 }
 
+.agents-manager-chat ul {
+	margin-left: var(--spacing-2);
+}
+
 /* Agenttic UI: Styles for the docked chat */
 .agents-manager-chat--docked .agenttic {
 	.ConversationView-module_container {
@@ -855,6 +859,17 @@ body:not(.modal-open) .agents-manager-chat--docked {
 .agents-manager-chat--undocked .agenttic.Chat-module_container.Chat-module_floating {
 	// Fix the undocked chat overlapping with the nav menu
 	z-index: 9999;
+
+	p {
+		font-size: inherit;
+		line-height: inherit;
+		margin: inherit;
+	}
+
+	ul {
+		list-style: disc;
+		margin-top: var(--spacing-3);
+	}
 
 	.Messages-module_container.Messages-module_emptyState {
 		padding-bottom: 0;

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -427,6 +427,10 @@ body:not(.modal-open) .agents-manager-chat--docked {
 
 /* Agenttic UI: Styles for both docked and undocked chat */
 .agenttic {
+	.Message-module_message ul {
+		margin-left: var(--spacing-2);
+	}
+
 	.Messages-module_container {
 		padding-bottom: 24px;
 
@@ -622,10 +626,6 @@ body:not(.modal-open) .agents-manager-chat--docked {
 		left: auto;
 		right: 0;
 	}
-}
-
-.agents-manager-chat ul {
-	margin-left: var(--spacing-2);
 }
 
 /* Agenttic UI: Styles for the docked chat */


### PR DESCRIPTION
The font size in the undocked agents manager in wp-admin is not the same as when docked. This is particularly noticeable when a list is shown.

<img width="798" height="1092" alt="image" src="https://github.com/user-attachments/assets/f5ccc828-27b6-45bc-b968-0afcaaff6b34" />

To:

<img width="786" height="1062" alt="image" src="https://github.com/user-attachments/assets/8c1cf589-08f6-4c4f-8e38-8bfc417da1ca" />

It also fixes this:

<img width="452" height="254" alt="image" src="https://github.com/user-attachments/assets/ae1d7000-fb96-4634-a408-e25036763789" />

This is caused by styles from wp-admin overriding the manager. This PR fixes that, and also fixes the margins of lists in Calypso:

<img width="706" height="716" alt="image" src="https://github.com/user-attachments/assets/76c9d8e8-d9de-4fa8-a0db-6721c04ffdb9" />

To:

<img width="682" height="628" alt="image" src="https://github.com/user-attachments/assets/e3364ad2-c7f8-422e-8b98-8bfec093e99c" />

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes AI-844

## Why are these changes being made?

* Fix styles

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run Calypso locally, open a page that isnt the site editor, open agents manager, and type `suggest some better fonts`. You should get a list of suggestions. Confirm this looks like the screenshots (sensible margins) in both docked and undocked
* `cd apps/agents-manager`
* `yarn dev --sync`
* Perform the same checks in wp-admin, specifically checking the font size is consistent in both docked and undocked

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
