### PR TITLE
Cron jobs: add Edit functionality

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1091,6 +1091,10 @@ export const siteSettingsCrontabEditRoute = createRoute( {
 	parseParams: ( params ) => ( {
 		cronId: Number( params.cronId ),
 	} ),
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		await queryClient.ensureQueryData( siteCrontabsQuery( site.ID ) );
+	},
 } ).lazy( () =>
 	import( '../../sites/settings-crontab/edit-crontab' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-crontab-edit' )( {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1078,6 +1078,27 @@ export const siteSettingsCrontabAddRoute = createRoute( {
 	)
 );
 
+export const siteSettingsCrontabEditRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Edit scheduled job' ),
+			},
+		],
+	} ),
+	getParentRoute: () => siteSettingsCrontabRoute,
+	path: '$cronId/edit',
+	parseParams: ( params ) => ( {
+		cronId: Number( params.cronId ),
+	} ),
+} ).lazy( () =>
+	import( '../../sites/settings-crontab/edit-crontab' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-crontab-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const siteSettingsTransferSiteRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -1479,6 +1500,7 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 		siteSettingsCrontabRoute.addChildren( [
 			siteSettingsCrontabIndexRoute,
 			siteSettingsCrontabAddRoute,
+			siteSettingsCrontabEditRoute,
 		] ),
 		siteSettingsRepositoriesRoute.addChildren( [
 			siteSettingsRepositoriesIndexRoute,

--- a/client/dashboard/sites/settings-crontab/crontab-form.tsx
+++ b/client/dashboard/sites/settings-crontab/crontab-form.tsx
@@ -1,14 +1,20 @@
-import { siteBySlugQuery, siteCrontabCreateMutation } from '@automattic/api-queries';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import {
+	siteBySlugQuery,
+	siteCrontabCreateMutation,
+	siteCrontabsQuery,
+	siteCrontabUpdateMutation,
+} from '@automattic/api-queries';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __experimentalVStack as VStack, Button, TextControl } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import {
 	siteRoute,
 	siteSettingsCrontabAddRoute,
+	siteSettingsCrontabEditRoute,
 	siteSettingsCrontabRoute,
 } from '../../app/router/sites';
 import { ButtonStack } from '../../components/button-stack';
@@ -16,20 +22,42 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
-import { ScheduleField } from './schedule-field';
+import { parseScheduleValue, ScheduleField } from './schedule-field';
 import type { CrontabFormData } from '@automattic/api-core';
 
-export default function CrontabForm() {
+interface CrontabFormProps {
+	cronId?: number;
+}
+
+export default function CrontabForm( { cronId }: CrontabFormProps ) {
+	const isEditMode = !! cronId;
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const navigate = useNavigate( {
-		from: siteSettingsCrontabAddRoute.fullPath,
+		from: isEditMode ? siteSettingsCrontabEditRoute.fullPath : siteSettingsCrontabAddRoute.fullPath,
 	} );
+
+	const { data: crontabs = [] } = useQuery( {
+		...siteCrontabsQuery( site.ID ),
+		enabled: isEditMode,
+	} );
+
+	const crontab = isEditMode ? crontabs.find( ( c ) => c.cron_id === cronId ) : undefined;
 
 	const [ formData, setFormData ] = useState< CrontabFormData >( {
 		schedule: 'hourly',
 		command: '',
 	} );
+
+	// Initialize form data when crontab is loaded (edit mode only)
+	useEffect( () => {
+		if ( crontab ) {
+			setFormData( {
+				schedule: parseScheduleValue( crontab.schedule ),
+				command: crontab.command,
+			} );
+		}
+	}, [ crontab ] );
 
 	const { mutate: createCrontab, isPending: isCreating } = useMutation( {
 		...siteCrontabCreateMutation( site.ID ),
@@ -41,7 +69,17 @@ export default function CrontabForm() {
 		},
 	} );
 
-	const isPending = isCreating;
+	const { mutate: updateCrontab, isPending: isUpdating } = useMutation( {
+		...siteCrontabUpdateMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'Scheduled job updated.' ),
+				error: __( 'Failed to update scheduled job.' ),
+			},
+		},
+	} );
+
+	const isPending = isEditMode ? isUpdating : isCreating;
 
 	const handleCancel = () => {
 		navigate( {
@@ -64,10 +102,20 @@ export default function CrontabForm() {
 			} );
 		};
 
-		createCrontab(
-			{ schedule: formData.schedule, command: formData.command.trim() },
-			{ onSuccess }
-		);
+		if ( isEditMode ) {
+			updateCrontab(
+				{
+					cronId,
+					params: { schedule: formData.schedule, command: formData.command.trim() },
+				},
+				{ onSuccess }
+			);
+		} else {
+			createCrontab(
+				{ schedule: formData.schedule, command: formData.command.trim() },
+				{ onSuccess }
+			);
+		}
 	};
 
 	const isValidCommand = formData.command.trim().length > 0;
@@ -115,11 +163,20 @@ export default function CrontabForm() {
 		[]
 	);
 
-	const pageTitle = __( 'Add scheduled job' );
-	const pageDescription = __(
-		'Schedule a command to run automatically at specified intervals on your site.'
-	);
-	const submitButtonLabel = __( 'Add scheduled job' );
+	// If crontab not found in edit mode, redirect back to list
+	if ( isEditMode && crontabs.length > 0 && ! crontab ) {
+		navigate( {
+			to: siteSettingsCrontabRoute.fullPath,
+			params: { siteSlug },
+		} );
+		return null;
+	}
+
+	const pageTitle = isEditMode ? __( 'Edit scheduled job' ) : __( 'Add scheduled job' );
+	const pageDescription = isEditMode
+		? __( 'Modify the schedule or command for this scheduled job.' )
+		: __( 'Schedule a command to run automatically at specified intervals on your site.' );
+	const submitButtonLabel = isEditMode ? __( 'Save changes' ) : __( 'Add scheduled job' );
 
 	return (
 		<PageLayout

--- a/client/dashboard/sites/settings-crontab/crontab-form.tsx
+++ b/client/dashboard/sites/settings-crontab/crontab-form.tsx
@@ -174,7 +174,7 @@ export default function CrontabForm( { cronId }: CrontabFormProps ) {
 
 	const pageTitle = isEditMode ? __( 'Edit scheduled job' ) : __( 'Add scheduled job' );
 	const pageDescription = isEditMode
-		? __( 'Modify the schedule or command for this scheduled job.' )
+		? __( 'Update the schedule or command for this job.' )
 		: __( 'Schedule a command to run automatically at specified intervals on your site.' );
 	const submitButtonLabel = isEditMode ? __( 'Save changes' ) : __( 'Add scheduled job' );
 

--- a/client/dashboard/sites/settings-crontab/crontab-form.tsx
+++ b/client/dashboard/sites/settings-crontab/crontab-form.tsx
@@ -1,15 +1,14 @@
 import {
 	siteBySlugQuery,
 	siteCrontabCreateMutation,
-	siteCrontabsQuery,
 	siteCrontabUpdateMutation,
 } from '@automattic/api-queries';
-import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { __experimentalVStack as VStack, Button, TextControl } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import {
 	siteRoute,
@@ -23,41 +22,33 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
 import { parseScheduleValue, ScheduleField } from './schedule-field';
-import type { CrontabFormData } from '@automattic/api-core';
+import type { Crontab, CrontabFormData } from '@automattic/api-core';
 
 interface CrontabFormProps {
-	cronId?: number;
+	crontab?: Crontab;
 }
 
-export default function CrontabForm( { cronId }: CrontabFormProps ) {
-	const isEditMode = !! cronId;
+export default function CrontabForm( { crontab }: CrontabFormProps ) {
+	const isEditMode = !! crontab;
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const navigate = useNavigate( {
 		from: isEditMode ? siteSettingsCrontabEditRoute.fullPath : siteSettingsCrontabAddRoute.fullPath,
 	} );
 
-	const { data: crontabs = [] } = useQuery( {
-		...siteCrontabsQuery( site.ID ),
-		enabled: isEditMode,
-	} );
-
-	const crontab = isEditMode ? crontabs.find( ( c ) => c.cron_id === cronId ) : undefined;
-
-	const [ formData, setFormData ] = useState< CrontabFormData >( {
-		schedule: 'hourly',
-		command: '',
-	} );
-
-	// Initialize form data when crontab is loaded (edit mode only)
-	useEffect( () => {
+	// Initialize form data once from the loaded crontab (edit mode) or defaults (add mode)
+	const [ formData, setFormData ] = useState< CrontabFormData >( () => {
 		if ( crontab ) {
-			setFormData( {
+			return {
 				schedule: parseScheduleValue( crontab.schedule ),
 				command: crontab.command,
-			} );
+			};
 		}
-	}, [ crontab ] );
+		return {
+			schedule: 'hourly',
+			command: '',
+		};
+	} );
 
 	const { mutate: createCrontab, isPending: isCreating } = useMutation( {
 		...siteCrontabCreateMutation( site.ID ),
@@ -102,10 +93,10 @@ export default function CrontabForm( { cronId }: CrontabFormProps ) {
 			} );
 		};
 
-		if ( isEditMode ) {
+		if ( isEditMode && crontab ) {
 			updateCrontab(
 				{
-					cronId,
+					cronId: crontab.cron_id,
 					params: { schedule: formData.schedule, command: formData.command.trim() },
 				},
 				{ onSuccess }
@@ -162,15 +153,6 @@ export default function CrontabForm( { cronId }: CrontabFormProps ) {
 		} ),
 		[]
 	);
-
-	// If crontab not found in edit mode, redirect back to list
-	if ( isEditMode && crontabs.length > 0 && ! crontab ) {
-		navigate( {
-			to: siteSettingsCrontabRoute.fullPath,
-			params: { siteSlug },
-		} );
-		return null;
-	}
 
 	const pageTitle = isEditMode ? __( 'Edit scheduled job' ) : __( 'Add scheduled job' );
 	const pageDescription = isEditMode

--- a/client/dashboard/sites/settings-crontab/edit-crontab.tsx
+++ b/client/dashboard/sites/settings-crontab/edit-crontab.tsx
@@ -1,0 +1,8 @@
+import { siteSettingsCrontabEditRoute } from '../../app/router/sites';
+import CrontabForm from './crontab-form';
+
+export default function EditCrontab() {
+	const { cronId } = siteSettingsCrontabEditRoute.useParams();
+
+	return <CrontabForm cronId={ Number( cronId ) } />;
+}

--- a/client/dashboard/sites/settings-crontab/edit-crontab.tsx
+++ b/client/dashboard/sites/settings-crontab/edit-crontab.tsx
@@ -1,8 +1,31 @@
-import { siteSettingsCrontabEditRoute } from '../../app/router/sites';
+import { siteBySlugQuery, siteCrontabsQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import {
+	siteRoute,
+	siteSettingsCrontabEditRoute,
+	siteSettingsCrontabRoute,
+} from '../../app/router/sites';
 import CrontabForm from './crontab-form';
 
 export default function EditCrontab() {
+	const { siteSlug } = siteRoute.useParams();
 	const { cronId } = siteSettingsCrontabEditRoute.useParams();
+	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
+	const navigate = useNavigate( { from: siteSettingsCrontabEditRoute.fullPath } );
 
-	return <CrontabForm cronId={ Number( cronId ) } />;
+	// Data is preloaded by the route loader
+	const { data: crontabs = [] } = useSuspenseQuery( siteCrontabsQuery( site.ID ) );
+	const crontab = crontabs.find( ( c ) => c.cron_id === Number( cronId ) );
+
+	// If crontab not found, redirect back to list
+	if ( ! crontab ) {
+		navigate( {
+			to: siteSettingsCrontabRoute.fullPath,
+			params: { siteSlug },
+		} );
+		return null;
+	}
+
+	return <CrontabForm crontab={ crontab } />;
 }

--- a/client/dashboard/sites/settings-crontab/index.tsx
+++ b/client/dashboard/sites/settings-crontab/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { Icon, Button, __experimentalText as Text, Tooltip } from '@wordpress/components';
+import { Icon, Button, __experimentalText as Text } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';

--- a/client/dashboard/sites/settings-crontab/index.tsx
+++ b/client/dashboard/sites/settings-crontab/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { Icon, Button, __experimentalText as Text } from '@wordpress/components';
+import { Icon, Button, __experimentalText as Text, Tooltip } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -16,7 +16,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import cronstrue from 'cronstrue';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
-import { siteSettingsCrontabAddRoute } from '../../app/router/sites';
+import { siteSettingsCrontabAddRoute, siteSettingsCrontabEditRoute } from '../../app/router/sites';
 import ConfirmModal from '../../components/confirm-modal';
 import { DataViewsCard } from '../../components/dataviews';
 import { PageHeader } from '../../components/page-header';
@@ -137,6 +137,16 @@ export default function CrontabSettings( { siteSlug }: { siteSlug: string } ) {
 			icon: <Icon icon={ copy } />,
 			callback: ( items: Crontab[] ) => {
 				handleCopyCommand( items[ 0 ].command );
+			},
+		},
+		{
+			id: 'edit',
+			label: __( 'Edit' ),
+			callback: ( items: Crontab[] ) => {
+				router.navigate( {
+					to: siteSettingsCrontabEditRoute.fullPath,
+					params: { siteSlug, cronId: items[ 0 ].cron_id },
+				} );
 			},
 		},
 		{

--- a/packages/api-core/src/site-hosting-crontab/mutators.ts
+++ b/packages/api-core/src/site-hosting-crontab/mutators.ts
@@ -9,6 +9,18 @@ export async function createCrontab( siteId: number, params: CrontabFormData ): 
 	} );
 }
 
+export async function updateCrontab(
+	siteId: number,
+	cronId: number,
+	params: CrontabFormData
+): Promise< void > {
+	await wpcom.req.put( {
+		path: `/sites/${ siteId }/hosting/crontab/${ cronId }`,
+		apiNamespace: 'wpcom/v2',
+		body: params,
+	} );
+}
+
 export async function deleteCrontab( siteId: number, cronId: number ): Promise< void > {
 	await wpcom.req.post( {
 		method: 'DELETE',

--- a/packages/api-queries/src/site-crontab.ts
+++ b/packages/api-queries/src/site-crontab.ts
@@ -1,4 +1,4 @@
-import { fetchCrontabs, createCrontab, deleteCrontab } from '@automattic/api-core';
+import { fetchCrontabs, createCrontab, updateCrontab, deleteCrontab } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 import type { CrontabFormData } from '@automattic/api-core';
@@ -12,6 +12,15 @@ export const siteCrontabsQuery = ( siteId: number ) =>
 export const siteCrontabCreateMutation = ( siteId: number ) =>
 	mutationOptions( {
 		mutationFn: ( params: CrontabFormData ) => createCrontab( siteId, params ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( siteCrontabsQuery( siteId ) );
+		},
+	} );
+
+export const siteCrontabUpdateMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( { cronId, params }: { cronId: number; params: CrontabFormData } ) =>
+			updateCrontab( siteId, cronId, params ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( siteCrontabsQuery( siteId ) );
 		},


### PR DESCRIPTION
Fixes DOTCOM-15936


## Proposed Changes
With this PR we are addind Edit functionality for cron jobs
<img width="711" height="342" alt="Screenshot 2026-02-04 at 16 27 29" src="https://github.com/user-attachments/assets/989b4e42-054f-4a8e-a66c-b470925dcf02" />
<img width="708" height="512" alt="Screenshot 2026-02-04 at 16 27 48" src="https://github.com/user-attachments/assets/d6f90055-ba24-4160-b20d-19ca249802fc" />


## Testing Instructions
0. Sandbox backend PR 202577-ghe-Automattic/wpcom
1. Create Atomic site
2. Open Settigns -> Cron
3. Create a cron job
4. Try to edit it and assert that editing works correctly
