### PR TITLE
Composite checkout: add completeAllSteps

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-prefill-checkout-contact-form.ts
+++ b/client/my-sites/checkout/src/hooks/use-prefill-checkout-contact-form.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { useSetStepComplete } from '@automattic/composite-checkout';
+import { useCompleteAllSteps } from '@automattic/composite-checkout';
 import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import { useDispatch as useWordPressDataDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
@@ -21,7 +21,7 @@ function useCachedContactDetailsForCheckoutForm(
 ): boolean {
 	const countriesList = useCountryList();
 	const reduxDispatch = useReduxDispatch();
-	const setStepCompleteStatus = useSetStepComplete();
+	const completeAllSteps = useCompleteAllSteps();
 	const [ isComplete, setComplete ] = useState( false );
 	const didFillForm = useRef( false );
 
@@ -85,7 +85,7 @@ function useCachedContactDetailsForCheckoutForm(
 				if ( cachedContactDetails.countryCode ) {
 					setShouldShowContactDetailsValidationErrors?.( false );
 					debug( 'Contact details are populated; attempting to auto-complete all steps' );
-					return setStepCompleteStatus( 'payment-method-step' );
+					return completeAllSteps();
 				}
 				return false;
 			} )
@@ -123,7 +123,7 @@ function useCachedContactDetailsForCheckoutForm(
 	}, [
 		setShouldShowContactDetailsValidationErrors,
 		reduxDispatch,
-		setStepCompleteStatus,
+		completeAllSteps,
 		cachedContactDetails,
 		arePostalCodesSupported,
 		loadDomainContactDetailsFromCache,

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -297,6 +297,10 @@ A React Hook that will return a function to set a step to be the active step. On
 
 A React Hook that will return a function to set a step to "complete". Only works within a step but it does not have to be the targeted step. The returned function looks like `( stepId: string ) => Promise< boolean >;`. Calling this function is similar to pressing the "Continue" button on the specified step; it will call the `isCompleteCallback` prop of the step and only succeed if the callback succeeds. In addition, all previous incomplete steps will be marked as complete in the same way, and the process will fail and stop at the first step whose `isCompleteCallback` fails. The resolved Promise will return true if all the requested steps were completed and false if any of them failed.
 
+### useCompleteAllSteps
+
+A React Hook that will return a function to attempt to complete all steps in the current `CheckoutStepGroup`. Only works within a step. The returned function looks like `() => Promise< boolean >;`. Calling this function will attempt to complete each step in order by calling each step's `isCompleteCallback` prop, ignoring steps that are already complete. The process will fail and stop at the first step whose `isCompleteCallback` fails. The resolved Promise will return true if all steps were completed successfully and false if any step failed.
+
 ### useTogglePaymentMethod
 
 A React Hook that returns a function which can be called to enable or disable a payment method from the list of payment methods provided to [CheckoutProvider](#CheckoutProvider). Only works within `CheckoutProvider`.

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -12,6 +12,7 @@ import {
 	useIsStepActive,
 	useIsStepComplete,
 	useSetStepComplete,
+	useCompleteAllSteps,
 	useMakeStepActive,
 	createCheckoutStepGroupStore,
 } from './components/checkout-steps';
@@ -71,6 +72,7 @@ export {
 	usePaymentProcessors,
 	useProcessPayment,
 	useSetStepComplete,
+	useCompleteAllSteps,
 	useTogglePaymentMethod,
 	useTransactionStatus,
 	useMakeStepActive,

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -273,6 +273,8 @@ export type StepCompleteCallbackMap = Record< string, StepCompleteCallback >;
 
 export type SetStepComplete = ( stepId: string ) => Promise< boolean >;
 
+export type CompleteAllSteps = () => Promise< boolean >;
+
 export type MakeStepActive = ( stepId: string ) => Promise< boolean >;
 
 export type CheckoutStepCompleteStatus = Record< string, boolean >;
@@ -295,6 +297,7 @@ export interface CheckoutStepGroupActions {
 	setActiveStepNumber: ( stepNumber: number ) => void;
 	setStepCompleteStatus: ( newStatus: CheckoutStepCompleteStatus ) => void;
 	setStepComplete: SetStepComplete;
+	completeAllSteps: CompleteAllSteps;
 	makeStepActive: MakeStepActive;
 	getStepNumberFromId: ( stepId: string ) => number | undefined;
 	setStepCompleteCallback: (


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1599/composite-checkout-add-completeallsteps
Part of https://linear.app/a8c/issue/SHILL-1583/checkout-add-option-to-swap-order-of-payment-method-and-billing-step

## Proposed Changes

This PR adds a new hook to the `@automattic/composite-checkout` package, `useCompleteAllSteps()`, which returns a function that will attempt to complete all the steps in the current `CheckoutStepGroup`. This then uses that hook to replace the call to `useSetStepComplete()` in wpcom checkout's autocomplete code.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Checkout attempts to autocomplete both of its steps when it loads. The first step is the billing details and the second step is the payment method selection. The way this works is by calling the function returned by `useSetStepComplete()`, targeting the last step (the payment method step). When attempting to complete a step, it will first attempt to complete all previous steps, so by targeting the last step, we will try to complete both of them.

However, in https://github.com/Automattic/wp-calypso/pull/108450 there will be an option to swap the order of the steps. This breaks the autocomplete behavior because we will now be targeting the first step with `useSetStepComplete()`. While it would be possible to conditionally decide which step to target, it's much cleaner to simply have a hook that works for all steps.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Automated tests are included but you can test this manually.

- Use an account that's purchased something with a credit card before, so you have cached contact details and a saved credit card.
- Add a product to your cart and visit checkout.
- Verify that both steps in checkout are automatically collapsed.