### PR TITLE
Verbum Block Editor: stub unused dependencies

### DIFF
--- a/packages/verbum-block-editor/README.md
+++ b/packages/verbum-block-editor/README.md
@@ -17,14 +17,14 @@ The Verbum Block Editor stubs out heavy dependencies that are pulled in transiti
 
 ### Stubbed Modules
 
-| Module | Reason | Size Savings |
-|--------|--------|--------------|
-| `@wordpress/sync` | Collaborative editing (yjs/lib0/simple-peer) | ~500KB |
-| `@wordpress/date`, `date-fns`, `react-day-picker` | Date/time pickers | ~2.5MB |
-| `@wordpress/commands` | Command palette | ~33KB |
-| `@wordpress/components` (navigation, focal-point-picker, color-picker, palette-edit) | Unused UI components | ~250KB |
-| `showdown` | Markdown parser | ~156KB |
-| `react-easy-crop` | Image cropping | ~46KB |
+| Module                                                                                | Reason                                        | Size Savings |
+| ------------------------------------------------------------------------------------- | --------------------------------------------- | ------------ |
+| `@wordpress/sync`                                                                     | Collaborative editing (yjs/lib0/simple-peer)  | ~500KB       |
+| `@wordpress/date`, `date-fns`, `react-day-picker`                                     | Date/time pickers                             | ~2.5MB       |
+| `@wordpress/commands`                                                                  | Command palette                               | ~33KB        |
+| `@wordpress/components` (navigation, focal-point-picker, color-picker, palette-edit)   | Unused UI components                          | ~250KB       |
+| `showdown`                                                                             | Markdown parser                               | ~156KB       |
+| `react-easy-crop`                                                                      | Image cropping                                | ~46KB        |
 
 ### How It Works
 

--- a/packages/verbum-block-editor/README.md
+++ b/packages/verbum-block-editor/README.md
@@ -17,14 +17,14 @@ The Verbum Block Editor stubs out heavy dependencies that are pulled in transiti
 
 ### Stubbed Modules
 
-| Module                                                                                | Reason                                        | Size Savings |
-| ------------------------------------------------------------------------------------- | --------------------------------------------- | ------------ |
-| `@wordpress/sync`                                                                     | Collaborative editing (yjs/lib0/simple-peer)  | ~500KB       |
-| `@wordpress/date`, `date-fns`, `react-day-picker`                                     | Date/time pickers                             | ~2.5MB       |
-| `@wordpress/commands`                                                                  | Command palette                               | ~33KB        |
-| `@wordpress/components` (navigation, focal-point-picker, color-picker, palette-edit)   | Unused UI components                          | ~250KB       |
-| `showdown`                                                                             | Markdown parser                               | ~156KB       |
-| `react-easy-crop`                                                                      | Image cropping                                | ~46KB        |
+| Module                                                                               | Reason                                       | Size Savings |
+| ------------------------------------------------------------------------------------ | -------------------------------------------- | ------------ |
+| `@wordpress/sync`                                                                    | Collaborative editing (yjs/lib0/simple-peer) | ~500KB       |
+| `@wordpress/date`, `date-fns`, `react-day-picker`                                    | Date/time pickers                            | ~2.5MB       |
+| `@wordpress/commands`                                                                | Command palette                              | ~33KB        |
+| `@wordpress/components` (navigation, focal-point-picker, color-picker, palette-edit) | Unused UI components                         | ~250KB       |
+| `showdown`                                                                           | Markdown parser                              | ~156KB       |
+| `react-easy-crop`                                                                    | Image cropping                               | ~46KB        |
 
 ### How It Works
 

--- a/packages/verbum-block-editor/README.md
+++ b/packages/verbum-block-editor/README.md
@@ -11,6 +11,32 @@ Verbum Block Editor is a lightweight Gutenberg editor, tailored specifically for
 - Efficiently handles embeds by integrating all necessary API middlewares.
 - Incorporates an iframed editor to minimize CSS collisions.
 
+## Bundle Size Optimization
+
+The Verbum Block Editor stubs out heavy dependencies that are pulled in transitively by the Gutenberg editor but aren't needed for the comment editing use case. This reduces the bundle size by ~50% (from 4.2 MiB to 2.1 MiB).
+
+### Stubbed Modules
+
+| Module | Reason | Size Savings |
+|--------|--------|--------------|
+| `@wordpress/sync` | Collaborative editing (yjs/lib0/simple-peer) | ~500KB |
+| `@wordpress/date`, `date-fns`, `react-day-picker` | Date/time pickers | ~2.5MB |
+| `@wordpress/commands` | Command palette | ~33KB |
+| `@wordpress/components` (navigation, focal-point-picker, color-picker, palette-edit) | Unused UI components | ~250KB |
+| `showdown` | Markdown parser | ~156KB |
+| `react-easy-crop` | Image cropping | ~46KB |
+
+### How It Works
+
+The webpack config uses `NormalModuleReplacementPlugin` to replace these modules with a consolidated stub file (`src/stubs/index.js`) that exports no-op functions and null components.
+
+### Adding New Stubs
+
+1. Identify unused modules via bundle analysis (`yarn build --analyze`)
+2. Add the module pattern to `modulesToStub` in `webpack.config.js`
+3. Add any required exports to `src/stubs/index.js`
+4. Test the comment editor to ensure no regressions
+
 ## Development
 
 This package can be utilized in two primary ways:

--- a/packages/verbum-block-editor/src/stubs/index.js
+++ b/packages/verbum-block-editor/src/stubs/index.js
@@ -22,62 +22,60 @@ function warnStubUsed( name ) {
 	}
 }
 
-// Generic null component - works for most React component stubs
-export const NullComponent = () => {
-	warnStubUsed( 'NullComponent' );
+// Factory for named null components - works for most React component stubs
+const createNullComponent = ( name ) => () => {
+	warnStubUsed( name );
 	return null;
 };
 
-// Common exports that various modules expect
-export const noop = ( ...args ) => {
-	if ( args.length > 0 ) {
-		warnStubUsed( 'noop (called with arguments)' );
-	}
+// Factory for named no-op functions
+const createNoop = ( name ) => () => {
+	warnStubUsed( name );
 };
 
 // @wordpress/sync exports
-export const createSyncProvider = noop;
-export const connectIndexDb = noop;
-export const getSyncProvider = noop;
-export const createWebRTCConnection = noop;
+export const createSyncProvider = createNoop( 'createSyncProvider' );
+export const connectIndexDb = createNoop( 'connectIndexDb' );
+export const getSyncProvider = createNoop( 'getSyncProvider' );
+export const createWebRTCConnection = createNoop( 'createWebRTCConnection' );
 
 // @wordpress/commands exports
 export const store = { name: 'core/commands' };
-export const useCommand = noop;
-export const useCommandLoader = noop;
-export const CommandMenu = NullComponent;
+export const useCommand = createNoop( 'useCommand' );
+export const useCommandLoader = createNoop( 'useCommandLoader' );
+export const CommandMenu = createNullComponent( 'CommandMenu' );
 export const privateApis = {};
 
 // @wordpress/components/calendar exports
-export const DateCalendar = NullComponent;
-export const DateRangeCalendar = NullComponent;
+export const DateCalendar = createNullComponent( 'DateCalendar' );
+export const DateRangeCalendar = createNullComponent( 'DateRangeCalendar' );
 export class TZDate extends Date {}
 
 // @wordpress/components/date-time exports
-export const DateTimePicker = NullComponent;
-export const DatePicker = NullComponent;
-export const TimePicker = NullComponent;
+export const DateTimePicker = createNullComponent( 'DateTimePicker' );
+export const DatePicker = createNullComponent( 'DatePicker' );
+export const TimePicker = createNullComponent( 'TimePicker' );
 
 // @wordpress/components/color-picker exports
-export const ColorPicker = NullComponent;
-export const Picker = NullComponent;
+export const ColorPicker = createNullComponent( 'ColorPicker' );
+export const Picker = createNullComponent( 'Picker' );
 
 // @wordpress/components/navigation exports
-export const NavigableMenu = NullComponent;
-export const NavigableToolbar = NullComponent;
-export const NavigationBackButton = NullComponent;
-export const NavigationGroup = NullComponent;
-export const NavigationItem = NullComponent;
-export const NavigationMenu = NullComponent;
+export const NavigableMenu = createNullComponent( 'NavigableMenu' );
+export const NavigableToolbar = createNullComponent( 'NavigableToolbar' );
+export const NavigationBackButton = createNullComponent( 'NavigationBackButton' );
+export const NavigationGroup = createNullComponent( 'NavigationGroup' );
+export const NavigationItem = createNullComponent( 'NavigationItem' );
+export const NavigationMenu = createNullComponent( 'NavigationMenu' );
 
 // @wordpress/components misc exports
-export const FocalPointPicker = NullComponent;
-export const PaletteEdit = NullComponent;
+export const FocalPointPicker = createNullComponent( 'FocalPointPicker' );
+export const PaletteEdit = createNullComponent( 'PaletteEdit' );
 
 // @wordpress/block-editor date picker exports
-export const DateFormatPicker = NullComponent;
-export const PublishDateTimePicker = NullComponent;
-export const PrivatePublishDateTimePicker = NullComponent;
+export const DateFormatPicker = createNullComponent( 'DateFormatPicker' );
+export const PublishDateTimePicker = createNullComponent( 'PublishDateTimePicker' );
+export const PrivatePublishDateTimePicker = createNullComponent( 'PrivatePublishDateTimePicker' );
 
 // showdown Markdown converter stub
 export class Converter {

--- a/packages/verbum-block-editor/src/stubs/index.js
+++ b/packages/verbum-block-editor/src/stubs/index.js
@@ -30,7 +30,7 @@ export const privateApis = {};
 // @wordpress/components/calendar exports
 export const DateCalendar = NullComponent;
 export const DateRangeCalendar = NullComponent;
-export const TZDate = Date;
+export class TZDate extends Date {}
 
 // @wordpress/components/date-time exports
 export const DateTimePicker = NullComponent;

--- a/packages/verbum-block-editor/src/stubs/index.js
+++ b/packages/verbum-block-editor/src/stubs/index.js
@@ -1,0 +1,69 @@
+/**
+ * Consolidated stubs for unused heavy modules.
+ *
+ * This is a JS file (not TS) because it's used as a replacement for
+ * node_modules files that aren't run through the TypeScript loader.
+ *
+ * These stubs replace large transitive dependencies that aren't needed
+ * in the verbum block editor comment context, reducing bundle size by ~50%.
+ */
+
+// Generic null component - works for most React component stubs
+export const NullComponent = () => null;
+
+// Common exports that various modules expect
+export const noop = () => {};
+
+// @wordpress/sync exports
+export const createSyncProvider = noop;
+export const connectIndexDb = noop;
+export const getSyncProvider = noop;
+export const createWebRTCConnection = noop;
+
+// @wordpress/commands exports
+export const store = { name: 'core/commands' };
+export const useCommand = noop;
+export const useCommandLoader = noop;
+export const CommandMenu = NullComponent;
+export const privateApis = {};
+
+// @wordpress/components/calendar exports
+export const DateCalendar = NullComponent;
+export const DateRangeCalendar = NullComponent;
+export const TZDate = Date;
+
+// @wordpress/components/date-time exports
+export const DateTimePicker = NullComponent;
+export const DatePicker = NullComponent;
+export const TimePicker = NullComponent;
+
+// @wordpress/components/color-picker exports
+export const ColorPicker = NullComponent;
+export const Picker = NullComponent;
+
+// @wordpress/components/navigation exports
+export const NavigableMenu = NullComponent;
+export const NavigableToolbar = NullComponent;
+export const NavigationBackButton = NullComponent;
+export const NavigationGroup = NullComponent;
+export const NavigationItem = NullComponent;
+export const NavigationMenu = NullComponent;
+
+// @wordpress/components misc exports
+export const FocalPointPicker = NullComponent;
+export const PaletteEdit = NullComponent;
+
+// @wordpress/block-editor date picker exports
+export const DateFormatPicker = NullComponent;
+export const PublishDateTimePicker = NullComponent;
+export const PrivatePublishDateTimePicker = NullComponent;
+
+// showdown Markdown converter stub
+export class Converter {
+	makeHtml( text ) {
+		return text;
+	}
+}
+
+// Default export with Converter for `import showdown from 'showdown'; new showdown.Converter()`
+export default { Converter };

--- a/packages/verbum-block-editor/src/stubs/index.js
+++ b/packages/verbum-block-editor/src/stubs/index.js
@@ -8,11 +8,32 @@
  * in the verbum block editor comment context, reducing bundle size by ~50%.
  */
 
+const warned = new Set();
+
+/**
+ * Warn if a stub is used.
+ * @param {string} name - The name of the stub.
+ */
+function warnStubUsed( name ) {
+	if ( process.env.NODE_ENV !== 'production' && ! warned.has( name ) ) {
+		warned.add( name );
+		// eslint-disable-next-line no-console
+		console.warn( `[verbum-block-editor] Stubbed module invoked: ${ name }` );
+	}
+}
+
 // Generic null component - works for most React component stubs
-export const NullComponent = () => null;
+export const NullComponent = () => {
+	warnStubUsed( 'NullComponent' );
+	return null;
+};
 
 // Common exports that various modules expect
-export const noop = () => {};
+export const noop = ( ...args ) => {
+	if ( args.length > 0 ) {
+		warnStubUsed( 'noop (called with arguments)' );
+	}
+};
 
 // @wordpress/sync exports
 export const createSyncProvider = noop;
@@ -61,6 +82,7 @@ export const PrivatePublishDateTimePicker = NullComponent;
 // showdown Markdown converter stub
 export class Converter {
 	makeHtml( text ) {
+		warnStubUsed( 'showdown.Converter.makeHtml' );
 		return text;
 	}
 }

--- a/packages/verbum-block-editor/webpack.config.js
+++ b/packages/verbum-block-editor/webpack.config.js
@@ -20,19 +20,19 @@ const modulesToStub = [
 	/^date-fns/,
 	/^@date-fns\/tz/,
 	/^react-day-picker/,
-	/@wordpress\/components\/build-module\/date-time/,
-	/@wordpress\/components\/build-module\/calendar/,
-	/@wordpress\/block-editor\/build-module\/components\/date-format-picker/,
-	/@wordpress\/block-editor\/build-module\/components\/publish-date-time-picker/,
+	/@wordpress\/components\/build-module\/date-time(?:$|\/)/,
+	/@wordpress\/components\/build-module\/calendar(?:$|\/)/,
+	/@wordpress\/block-editor\/build-module\/components\/date-format-picker(?:$|\/)/,
+	/@wordpress\/block-editor\/build-module\/components\/publish-date-time-picker(?:$|\/)/,
 
 	// Command palette (~33KB)
 	/^@wordpress\/commands$/,
 
 	// Unused @wordpress/components (~250KB total)
-	/@wordpress\/components\/build-module\/navigation/,
-	/@wordpress\/components\/build-module\/focal-point-picker/,
-	/@wordpress\/components\/build-module\/color-picker/,
-	/@wordpress\/components\/build-module\/palette-edit/,
+	/@wordpress\/components\/build-module\/navigation(?:$|\/)/,
+	/@wordpress\/components\/build-module\/focal-point-picker(?:$|\/)/,
+	/@wordpress\/components\/build-module\/color-picker(?:$|\/)/,
+	/@wordpress\/components\/build-module\/palette-edit(?:$|\/)/,
 
 	// Other unused libraries
 	/^showdown$/, // Markdown parser (~156KB)

--- a/packages/verbum-block-editor/webpack.config.js
+++ b/packages/verbum-block-editor/webpack.config.js
@@ -2,19 +2,45 @@ const path = require( 'path' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const webpack = require( 'webpack' );
 
-/* Arguments to this function replicate webpack's so this config can be used on the command line,
- * with individual options overridden by command line args.
- * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
- * @see {@link https://webpack.js.org/api/cli/}
- * @param   {Object}  env                           environment options
- * @param   {string}  env.source                    plugin slugs, comma separated list
- * @param   {Object}  argv                          options map
- * @param   {string}  argv.entry                    entry path
- * @returns {Object}                                webpack config
+/**
+ * Consolidated stub that replaces all unused heavy modules.
  */
+const stubModule = path.join( __dirname, 'src', 'stubs', 'index.js' );
+
+/**
+ * Modules to stub out for bundle size reduction.
+ * These are transitive dependencies not needed for the comment editor.
+ */
+const modulesToStub = [
+	// Collaborative editing (~500KB with yjs/lib0/simple-peer)
+	/^@wordpress\/sync$/,
+
+	// Date/time functionality (~2.5MB total with date-fns, moment-timezone)
+	/^@wordpress\/date$/,
+	/^date-fns/,
+	/^@date-fns\/tz/,
+	/^react-day-picker/,
+	/@wordpress\/components\/build-module\/date-time/,
+	/@wordpress\/components\/build-module\/calendar/,
+	/@wordpress\/block-editor\/build-module\/components\/date-format-picker/,
+	/@wordpress\/block-editor\/build-module\/components\/publish-date-time-picker/,
+
+	// Command palette (~33KB)
+	/^@wordpress\/commands$/,
+
+	// Unused @wordpress/components (~250KB total)
+	/@wordpress\/components\/build-module\/navigation/,
+	/@wordpress\/components\/build-module\/focal-point-picker/,
+	/@wordpress\/components\/build-module\/color-picker/,
+	/@wordpress\/components\/build-module\/palette-edit/,
+
+	// Other unused libraries
+	/^showdown$/, // Markdown parser (~156KB)
+	/^react-easy-crop$/, // Image cropping (~46KB)
+];
+
 function getWebpackConfig( env = { source: '' }, argv = {} ) {
 	const outputPath = path.join( __dirname, 'dist' );
-
 	const webpackConfig = getBaseWebpackConfig( env, argv );
 
 	return {
@@ -26,13 +52,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 		output: {
 			...webpackConfig.output,
 			path: outputPath,
-			// Unfortunately, we can't set the name to `[name].js` for the
-			// dev env because at runtime we'd also need a way to detect
-			// if the env was dev or prod, as the file is enqueued in WP
-			// and there's no way to do that now. The simpler alternative
-			// is to generate a .min.js for dev and prod, even though the
-			// file is not really minified in the dev env.
-			filename: '[name].min.js', // dynamic filename
+			filename: '[name].min.js',
 			library: 'verbumBlockEditor',
 		},
 		externals: {
@@ -43,6 +63,17 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			new webpack.DefinePlugin( {
 				'process.env.IS_GUTENBERG_PLUGIN': true,
 			} ),
+
+			// Ignore moment.js locales
+			new webpack.IgnorePlugin( {
+				resourceRegExp: /^\.\/locale$/,
+				contextRegExp: /moment$/,
+			} ),
+
+			// Replace all stubbed modules with consolidated stub
+			...modulesToStub.map(
+				( pattern ) => new webpack.NormalModuleReplacementPlugin( pattern, stubModule )
+			),
 		],
 	};
 }


### PR DESCRIPTION
## Proposed Changes

* Create a stub file that returns `noop` components and functions
* Replace heavy unused dependencies on bundle

## Why are these changes being made?

The block editor is a hefty 4.21 MiB when bundled.

This is very large overhead to add in some places like on the front end of a site or in the Reader. Most of this is unused code since the Verbum block editor is meant to be a super light-weight version. Since we can't remove these dependencies due to how they are tightly coupled to the editor the next best thing I believe is replacing them with empty components and functions during bundle.

Doing this brings our bundle size down to 2.14 MiB a 49% reduction.

## Testing Instructions

1. From this branch run `cd packages/verbum-block-editor/ && yarn upload`
2. Sandbox `widgets.wp.com`
3. Go view a simple site with comments enabled
4. Click on the comment box and allow the editor to load.
5. Test the editor and make sure there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
