### PR TITLE
Fixup fetching, dupe messages

### DIFF
--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -72,6 +72,8 @@ export const useGetCombinedChat = (
 		sessionId,
 		botSlug
 	);
+	const [ isFetchingConversation, setIsFetchingConversation ] = useState( false );
+
 	const { startNewInteraction } = useManageSupportInteraction();
 	const isUploadingUnsentMessages = useIsMutating( {
 		mutationKey: [ 'send-zendesk-messages' ],
@@ -106,6 +108,7 @@ export const useGetCombinedChat = (
 		if (
 			( isOdieChatLoading && ! interactionHasChanged ) ||
 			isLoadingCurrentSupportInteraction ||
+			isFetchingConversation ||
 			isUploadingUnsentMessages ||
 			isLoadingCanConnectToZendesk ||
 			( chatStatus !== 'loading' && ! interactionHasChanged )
@@ -150,6 +153,7 @@ export const useGetCombinedChat = (
 		}
 
 		if ( conversationId && ( isChatLoaded || refreshingAfterReconnect ) ) {
+			setIsFetchingConversation( true );
 			getZendeskConversation( conversationId )
 				?.then( ( conversation ) => {
 					if ( conversation ) {
@@ -194,6 +198,7 @@ export const useGetCombinedChat = (
 				} )
 				.finally( () => {
 					setRefreshingAfterReconnect( false );
+					setIsFetchingConversation( false );
 				} );
 		}
 	}, [
@@ -202,6 +207,7 @@ export const useGetCombinedChat = (
 		refreshingAfterReconnect,
 		isUploadingUnsentMessages,
 		isChatLoaded,
+		isFetchingConversation,
 		conversationId,
 		odieId,
 		currentSupportInteraction,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #DOTCOM-15953

| Before  | After |
| ------------- | ------------- |
|  <img width="1691" height="887" alt="Screenshot 2026-02-04 at 19 10 56" src="https://github.com/user-attachments/assets/86f1c2d3-0a65-4de2-97bb-f6e99aba3056" /> | <img width="1686" height="836" alt="Screenshot 2026-02-04 at 19 11 22" src="https://github.com/user-attachments/assets/a2cc283f-8a98-43de-8ce4-374abc476f53" />  |

## Proposed Changes

* Avoid execution while zendesk messages are being fetched

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To prevent bad UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Have multiple chats with more than one message to odie, and more than one message to escalated human support
* Reload and go though the conversations.
* Odie messages should stay at the top and not get mixed up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
