### PR TITLE
Connect Screen: Update text props to accept ReactNode for translations

### DIFF
--- a/client/components/connect-screen/action-buttons/index.tsx
+++ b/client/components/connect-screen/action-buttons/index.tsx
@@ -1,17 +1,18 @@
 import { Button, Spinner } from '@wordpress/components';
 import clsx from 'clsx';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
 export interface ActionButtonsProps {
-	primaryLabel: string;
+	primaryLabel: ReactNode;
 	primaryOnClick: () => void;
 	primaryLoading?: boolean;
 	primaryDisabled?: boolean;
-	secondaryLabel?: string;
+	secondaryLabel?: ReactNode;
 	secondaryOnClick?: () => void;
 	secondaryDisabled?: boolean;
-	tertiaryLabel?: string;
+	tertiaryLabel?: ReactNode;
 	tertiaryOnClick?: () => void;
 	className?: string;
 }

--- a/client/components/connect-screen/brand-header/index.tsx
+++ b/client/components/connect-screen/brand-header/index.tsx
@@ -9,8 +9,8 @@ export interface BrandHeaderProps {
 	logoAlt?: string;
 	logoWidth?: number;
 	logoHeight?: number;
-	title: string;
-	description?: string;
+	title: ReactNode;
+	description?: ReactNode;
 	className?: string;
 }
 

--- a/client/components/connect-screen/loading-screen/index.tsx
+++ b/client/components/connect-screen/loading-screen/index.tsx
@@ -1,10 +1,11 @@
 import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
 export interface LoadingScreenProps {
-	message?: string;
+	message?: ReactNode;
 	className?: string;
 }
 

--- a/client/components/connect-screen/permissions-list/index.tsx
+++ b/client/components/connect-screen/permissions-list/index.tsx
@@ -3,19 +3,20 @@ import { useState } from '@wordpress/element';
 import { chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
 export interface Permission {
 	icon?: IconType;
-	label: string;
+	label: ReactNode;
 }
 
 export interface PermissionsListProps {
-	title?: string;
+	title?: ReactNode;
 	permissions: Permission[];
 	maxVisible?: number;
-	learnMoreText?: string;
+	learnMoreText?: ReactNode;
 	learnMoreUrl?: string;
 	className?: string;
 }


### PR DESCRIPTION
Follow-up to #108370

## Proposed Changes

* Updates text props in connect-screen components from `string` to `ReactNode` type
* This allows proper support for `i18n-calypso` translations with component interpolation

**Components updated:**
- **BrandHeader** - `title` and `description`
- **ActionButtons** - `primaryLabel`, `secondaryLabel`, `tertiaryLabel`
- **PermissionsList** - `title`, `Permission.label`, `learnMoreText`
- **LoadingScreen** - `message`

## Why are these changes being made?

When using `translate()` from `i18n-calypso` with component interpolation, the return type is `ReactChild` (not `string`). For example:

```tsx
translate( 'Connect to {{strong}}WordPress.com{{/strong}}', {
  components: { strong: <strong /> }
})
```

The original `string` types would cause TypeScript errors when passing translated strings with interpolated components.

## Testing Instructions

* Run Storybook: `yarn storybook:start`
* Navigate to **client/components/ConnectScreen** in the sidebar
* Verify the new **WithReactNodeProps** story renders correctly with inline elements

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?