### PR TITLE
Odyssey Stats: fix layout content padding-top in wp-admin

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -60,7 +60,7 @@
 
 	& .layout__content,
 	&.theme-default .focus-content .layout__content {
-		padding-top: 0;
+		padding-top: 32px;
 		padding-left: 1px;
 	}
 	// Fixed header doesn't work well for WP-Admin, as the masterbar isn't fixed.


### PR DESCRIPTION
Fixes STATS-210

## Proposed Changes

* Restore `padding-top: 32px` for the Odyssey Stats layout content in wp-admin.

## Why are these changes being made?

PR #107213 accidentally set `padding-top` to `0` for the Odyssey Stats layout content in wp-admin. This causes the content to overlap with the 32px wp-admin bar. This PR restores the correct value.

## Testing Instructions

* Open the Odyssey Stats page in wp-admin.
* Verify the layout content no longer overlaps with the admin bar.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?