### PR TITLE
Dashboard: clean up redirections from /v2 and /ciab to MSD

### DIFF
--- a/client/dashboard/utils/is-dashboard-backport.ts
+++ b/client/dashboard/utils/is-dashboard-backport.ts
@@ -12,5 +12,7 @@ export function isDashboardBackport() {
 		return false;
 	}
 
-	return ! [ '/v2', '/ciab' ].some( ( path ) => window?.location?.pathname?.startsWith( path ) );
+	// At this point, it means this dashboard screen is in non-dashboard environments,
+	// so it's a backport.
+	return true;
 }

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1115,51 +1115,6 @@ export default function pages() {
 			// Allow CIAB routes under my.localhost.
 			return req.get( 'host' ).startsWith( 'my.localhost' );
 		} );
-
-		// Temporary support redirection for the /v2 route for backwards compatibility.
-		app.get( [ '/v2', '/v2/*' ], ( req, res, next ) => {
-			const host = req.get( 'host' );
-			const query = Object.keys( req.query ).length > 0 ? `?${ stringify( req.query ) }` : '';
-
-			if ( host.startsWith( 'calypso.localhost' ) ) {
-				const protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';
-				const port = host.includes( ':' ) ? host.substring( host.indexOf( ':' ) ) : ':3000';
-
-				const redirectUrl = `${ protocol }://my.localhost${ port }${ req.path.slice(
-					'/v2'.length
-				) }${ query }`;
-				return res.redirect( 301, redirectUrl );
-			}
-
-			if ( host.startsWith( 'wpcalypso.wordpress.com' ) ) {
-				const redirectUrl = `https://my.wordpress.com${ req.path.slice( '/v2'.length ) }${ query }`;
-				return res.redirect( 301, redirectUrl );
-			}
-
-			next();
-		} );
-
-		// Temporary support redirection for the /ciab route for backwards compatibility.
-		// TODO: Remove /ciab once we no longer need to support the old testing link.
-		app.get( [ '/ciab', '/ciab/*' ], ( req, res, next ) => {
-			const host = req.get( 'host' );
-			const query = Object.keys( req.query ).length > 0 ? `?${ stringify( req.query ) }` : '';
-
-			if ( host.startsWith( 'calypso.localhost' ) ) {
-				const protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';
-				const port = host.includes( ':' ) ? host.substring( host.indexOf( ':' ) ) : ':3000';
-
-				const redirectUrl = `${ protocol }://my.localhost${ port }${ req.path }${ query }`;
-				return res.redirect( 301, redirectUrl );
-			}
-
-			if ( host.startsWith( 'wpcalypso.wordpress.com' ) ) {
-				const redirectUrl = `https://my.wordpress.com${ req.path }${ query }`;
-				return res.redirect( 301, redirectUrl );
-			}
-
-			next();
-		} );
 	}
 
 	sections


### PR DESCRIPTION

Preparatory PR before adding new environment for CIAB.

## Proposed Changes

This PR removes the following redirections that were added in pgz0xU-tc-p2:

- wpcalypso.wordpress.com/v2/* => my.wordpress.com/*
- wpcalypso.wordpress.com/ciab/* => my.wordpress.com/ciab/*

This clean up is necessary before we add a new environment for CIAB, as then they will be no longer valid paths.

I checked CIAB P2 posts and we seem to have already used `my.wordpress.com/ciab` for testing and not rely on the old paths anymore.

## Why are these changes being made?

Preparing MSD-CIAB environment.

## Testing Instructions

1. Verify `<Calypso live link>` still works and loads Calypso.
1. Verify `<Dashboard live link>` still works and loads dotcom MSD.
1. Verify `<Dashboard live link>/ciab` still works and loads CIAB MSD.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?