### PR TITLE
Stats: Add 'Last 12 months' subtitle to Posting Activity section

### DIFF
--- a/client/my-sites/stats/sections/posting-activity-section/index.jsx
+++ b/client/my-sites/stats/sections/posting-activity-section/index.jsx
@@ -48,6 +48,7 @@ class PostingActivitySection extends Component {
 
 				<div className="post-trends__heading">
 					<h3 className="post-trends__title">{ translate( 'Posting activity' ) }</h3>
+					<span className="post-trends__subtitle">{ translate( 'Last 12 months' ) }</span>
 				</div>
 				<div ref={ this.wrapperRef } className="post-trends__wrapper">
 					<div ref={ this.yearRef } className="post-trends__year">

--- a/client/my-sites/stats/sections/posting-activity-section/style.scss
+++ b/client/my-sites/stats/sections/posting-activity-section/style.scss
@@ -31,12 +31,20 @@ $lowestLevelColor: var(--color-neutral-5);
 
 .post-trends__heading {
 	display: flex;
-	justify-content: space-between;
-	align-items: center;
+	flex-direction: column;
+	align-items: flex-start;
 }
 
 .post-trends__title {
 	@include stats-section-header;
+}
+
+.post-trends__subtitle {
+	display: inline-block;
+	font-size: $font-body-small;
+	line-height: 16px;
+	color: var(--color-text-subtle);
+	font-weight: 400;
 }
 
 .post-trends__value {


### PR DESCRIPTION
Part of STATS-204

## Proposed Changes

* Add a "Last 12 months" subtitle next to the "Posting activity" heading on the Insights page.

## Why are these changes being made?

The Posting Activity heat map on the Insights page shows the last 12 months of data, but this isn't immediately obvious to users. Adding a subtitle clarifies the time range being displayed.

## Testing Instructions

1. Navigate to Stats > Insights on any site.
2. Scroll to the "Posting activity" section.
3. Verify the subtitle "Last 12 months" appears next to the heading in a lighter, smaller font.

<img width="1085" height="320" alt="image" src="https://github.com/user-attachments/assets/e6f8cb8e-0162-4b10-aae4-28eb045b00c9" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?