### PR TITLE
Stats: Fix misleading VideoPress button text in empty Videos module

### DIFF
--- a/client/my-sites/stats/features/modules/shared/stats-empty-action-video.tsx
+++ b/client/my-sites/stats/features/modules/shared/stats-empty-action-video.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { upload } from '@wordpress/icons';
+import { video } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import EmptyStateAction from 'calypso/my-sites/stats/components/empty-state-action';
@@ -10,14 +10,14 @@ import {
 } from 'calypso/my-sites/stats/const';
 import type { StatsEmptyActionProps } from './';
 
-const StatsEmptyActionEmail: React.FC< StatsEmptyActionProps > = ( { from } ) => {
+const StatsEmptyActionVideo: React.FC< StatsEmptyActionProps > = ( { from } ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	return (
 		<EmptyStateAction
-			icon={ upload }
-			text={ translate( 'Upload videos with VideoPress' ) }
+			icon={ video }
+			text={ translate( 'Learn more about VideoPress' ) }
 			analyticsDetails={ {
 				from: from,
 				feature: 'videopress',
@@ -35,4 +35,4 @@ const StatsEmptyActionEmail: React.FC< StatsEmptyActionProps > = ( { from } ) =>
 	);
 };
 
-export default StatsEmptyActionEmail;
+export default StatsEmptyActionVideo;


### PR DESCRIPTION
Fixes STATS-205

## Proposed Changes

* Changed the CTA button text from "Upload videos with VideoPress" to "Learn more about VideoPress"
* Replaced the `upload` icon with a `video` icon
* Fixed the component's internal name from `StatsEmptyActionEmail` to `StatsEmptyActionVideo`

## Why are these changes being made?

The "Upload videos with VideoPress" button in the empty Videos stats module was misleading — clicking it navigated to VideoPress documentation or landing page, not an actual upload interface. The upload icon reinforced the false expectation. The new text and icon accurately reflect what happens on click.

## Testing Instructions

* Navigate to Stats > Traffic on a site with no video plays data
* Verify the Videos module empty state shows "Learn more about VideoPress" with a video icon
* Click the CTA and confirm it navigates to the VideoPress documentation/landing page as expected

<img width="542" height="470" alt="image" src="https://github.com/user-attachments/assets/7e949c88-bc87-4d7d-88a2-e6ed55acb6a4" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?