### PR TITLE
MSD: Add empty state for searches with no results.

### DIFF
--- a/client/dashboard/components/dataviews/dataviews-empty-state-layout.tsx
+++ b/client/dashboard/components/dataviews/dataviews-empty-state-layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 
 interface DataViewsEmptyStateLayoutProps {
 	title: string;
-	description: string;
+	description: ReactNode;
 	children?: ReactNode;
 	isBorderless?: boolean;
 }

--- a/client/dashboard/emails/empty-mailboxes-state/index.tsx
+++ b/client/dashboard/emails/empty-mailboxes-state/index.tsx
@@ -1,14 +1,12 @@
 import { useNavigate } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, search, globe } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
 import EmptyState from '../../components/empty-state';
-import InlineSupportLink from '../../components/inline-support-link';
 import OfferCard from '../../components/offer-card';
 
-export default function EmptyMailboxesState() {
+function EmailActions() {
 	const { recordTracksEvent } = useAnalytics();
 	const navigate = useNavigate();
 
@@ -28,66 +26,69 @@ export default function EmptyMailboxesState() {
 		navigate( { to: '/emails/add-forwarder' } );
 	};
 
+	return (
+		<>
+			<EmptyState.ActionItem
+				title={ __( 'Add mailbox' ) }
+				description={ __( 'Get a full inbox for sending and receiving mail with your domain.' ) }
+				decoration={ <Icon icon={ search } size={ 24 } fill="#1E1E1E" /> }
+				actions={
+					<Button
+						variant="primary"
+						onClick={ handleAddMailboxClick }
+						size="compact"
+						__next40pxDefaultSize
+					>
+						{ __( 'Add mailbox' ) }
+					</Button>
+				}
+			/>
+			<EmptyState.ActionItem
+				title={ __( 'Add email forwarder' ) }
+				description={ __( 'Forward emails sent to your domain address to another inbox you use.' ) }
+				decoration={ <Icon icon={ globe } size={ 24 } fill="#1E1E1E" /> }
+				actions={
+					<Button
+						variant="secondary"
+						onClick={ handleAddForwarderClick }
+						size="compact"
+						__next40pxDefaultSize
+					>
+						{ __( 'Set up a forwarder' ) }
+					</Button>
+				}
+			/>
+		</>
+	);
+}
+
+function EmptyMailboxesStateUpsell() {
+	const { recordTracksEvent } = useAnalytics();
+
 	const handleOfferClick = () => {
-		trackEmptyStateActionClick( 'offer' );
+		recordTracksEvent( 'calypso_emails_dashboard_empty_mailboxes_state_action_click', {
+			action: 'offer',
+		} );
 	};
 
+	return <OfferCard onClick={ handleOfferClick } />;
+}
+
+export function EmptyMailboxesSearchStateContent() {
 	return (
-		<EmptyState.Wrapper>
-			<EmptyState>
-				<EmptyState.Header>
-					<EmptyState.Title>{ __( 'Set up email for your domain' ) }</EmptyState.Title>
-					<EmptyState.Description>
-						{ createInterpolateElement(
-							__(
-								'Create a mailbox or set up a forwarder for an email address using your domain. <learnMoreLink/>'
-							),
-							{
-								learnMoreLink: <InlineSupportLink supportContext="emails" />,
-							}
-						) }
-					</EmptyState.Description>
-				</EmptyState.Header>
-				<EmptyState.Content>
-					<EmptyState.ActionList>
-						<EmptyState.ActionItem
-							title={ __( 'Add mailbox' ) }
-							description={ __(
-								'Get a full inbox for sending and receiving mail with your domain.'
-							) }
-							decoration={ <Icon icon={ search } size={ 24 } fill="#1E1E1E" /> }
-							actions={
-								<Button
-									variant="primary"
-									onClick={ handleAddMailboxClick }
-									size="compact"
-									__next40pxDefaultSize
-								>
-									{ __( 'Add mailbox' ) }
-								</Button>
-							}
-						/>
-						<EmptyState.ActionItem
-							title={ __( 'Add email forwarder' ) }
-							description={ __(
-								'Forward emails sent to your domain address to another inbox you use.'
-							) }
-							decoration={ <Icon icon={ globe } size={ 24 } fill="#1E1E1E" /> }
-							actions={
-								<Button
-									variant="secondary"
-									onClick={ handleAddForwarderClick }
-									size="compact"
-									__next40pxDefaultSize
-								>
-									{ __( 'Set up a forwarder' ) }
-								</Button>
-							}
-						/>
-					</EmptyState.ActionList>
-					<OfferCard onClick={ handleOfferClick } />
-				</EmptyState.Content>
-			</EmptyState>
-		</EmptyState.Wrapper>
+		<EmptyState.ActionList>
+			<EmailActions />
+		</EmptyState.ActionList>
+	);
+}
+
+export function EmptyMailboxesStateContent() {
+	return (
+		<>
+			<EmptyState.ActionList>
+				<EmailActions />
+			</EmptyState.ActionList>
+			<EmptyMailboxesStateUpsell />
+		</>
 	);
 }

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -4,18 +4,23 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
 import { addEmailForwarderRoute, chooseDomainRoute, emailsRoute } from '../app/router/emails';
-import { DataViews, DataViewsCard } from '../components/dataviews';
+import { DataViews, DataViewsCard, DataViewsEmptyStateLayout } from '../components/dataviews';
+import InlineSupportLink from '../components/inline-support-link';
 import { OptInWelcome } from '../components/opt-in-welcome';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import UnusedMailboxNotice from './components/unused-mailbox-notice';
 import { DEFAULT_VIEW, getFields, useActions } from './dataviews';
 import EmptyDomainsState from './empty-domains-state';
-import EmptyMailboxesState from './empty-mailboxes-state';
+import {
+	EmptyMailboxesStateContent,
+	EmptyMailboxesSearchStateContent,
+} from './empty-mailboxes-state';
 import { mapMailboxToEmail } from './mappers/mailbox-to-email-mapper';
 import type { Email } from './types';
 
@@ -97,7 +102,21 @@ function Emails() {
 		}
 
 		if ( hasNoEmails ) {
-			return <EmptyMailboxesState />;
+			return (
+				<DataViewsEmptyStateLayout
+					title={ __( 'Set up email for your domain' ) }
+					description={ createInterpolateElement(
+						__(
+							'Create a mailbox or set up a forwarder for an email address using your domain. <learnMoreLink/>'
+						),
+						{
+							learnMoreLink: <InlineSupportLink supportContext="emails" />,
+						}
+					) }
+				>
+					<EmptyMailboxesStateContent />
+				</DataViewsEmptyStateLayout>
+			);
 		}
 
 		return (
@@ -115,6 +134,15 @@ function Emails() {
 					actions={ actions }
 					defaultLayouts={ { table: {} } }
 					paginationInfo={ paginationInfo }
+					empty={
+						<DataViewsEmptyStateLayout
+							title={ __( 'No emails match your search' ) }
+							description={ __( 'Try again, or continue with the options below.' ) }
+							isBorderless
+						>
+							<EmptyMailboxesSearchStateContent />
+						</DataViewsEmptyStateLayout>
+					}
 				/>
 			</DataViewsCard>
 		);


### PR DESCRIPTION
Fixes: DOTMSD-1066.
Builds on #108508

## Proposed Changes

This implements the empty search views for emails on top of #108508.

## Why are these changes being made?

When a users searches a view and doesn't find any results, we want to provide them with a better experience.

## Testing Instructions

With no mailboxes or forwards,
- Visit `/emails`
- Expect to see an empty state,
- Click the buttons

with a mailbox or forward,
- Visit `/emails`
- Add filters/search
- Expect to see the no search results empty state.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
