### PR TITLE
Help Center: Add course navigation if it is a course

### DIFF
--- a/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
+++ b/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
@@ -1,3 +1,4 @@
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { Link } from 'react-router-dom';
 import type { LessonNavigation } from '../../types';
@@ -25,7 +26,9 @@ export const ArticleLessonNavigation = ( {
 					<span className="help-center-article-lesson-navigation__label">
 						{ __( '← Back', __i18n_text_domain__ ) }
 					</span>
-					<span className="help-center-article-lesson-navigation__title">{ previous.title }</span>
+					<span className="help-center-article-lesson-navigation__title">
+						{ decodeEntities( previous.title ) }
+					</span>
 				</Link>
 			) }
 			{ next?.url && (
@@ -36,7 +39,9 @@ export const ArticleLessonNavigation = ( {
 					<span className="help-center-article-lesson-navigation__label">
 						{ __( 'Up next →', __i18n_text_domain__ ) }
 					</span>
-					<span className="help-center-article-lesson-navigation__title">{ next.title }</span>
+					<span className="help-center-article-lesson-navigation__title">
+						{ decodeEntities( next.title ) }
+					</span>
 				</Link>
 			) }
 		</nav>

--- a/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
+++ b/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
@@ -24,7 +24,7 @@ export const ArticleLessonNavigation = ( {
 					className="help-center-article-lesson-navigation__link help-center-article-lesson-navigation__link--previous"
 				>
 					<span className="help-center-article-lesson-navigation__label">
-						{ __( '← Back', __i18n_text_domain__ ) }
+						← { __( 'Back', __i18n_text_domain__ ) }
 					</span>
 					<span className="help-center-article-lesson-navigation__title">
 						{ decodeEntities( previous.title ) }
@@ -37,7 +37,7 @@ export const ArticleLessonNavigation = ( {
 					className="help-center-article-lesson-navigation__link help-center-article-lesson-navigation__link--next"
 				>
 					<span className="help-center-article-lesson-navigation__label">
-						{ __( 'Up next →', __i18n_text_domain__ ) }
+						{ __( 'Up next', __i18n_text_domain__ ) } →
 					</span>
 					<span className="help-center-article-lesson-navigation__title">
 						{ decodeEntities( next.title ) }

--- a/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
+++ b/packages/support-articles/src/components/help-center-article/article-lesson-navigation.tsx
@@ -1,0 +1,44 @@
+import { __ } from '@wordpress/i18n';
+import { Link } from 'react-router-dom';
+import type { LessonNavigation } from '../../types';
+
+declare const __i18n_text_domain__: string;
+
+export const ArticleLessonNavigation = ( {
+	lessonNavigation,
+}: {
+	lessonNavigation: LessonNavigation;
+} ) => {
+	const { next, previous } = lessonNavigation;
+
+	if ( ! next?.url && ! previous?.url ) {
+		return null;
+	}
+
+	return (
+		<nav className="help-center-article-lesson-navigation">
+			{ previous?.url && (
+				<Link
+					to={ `?link=${ encodeURIComponent( previous.url ) }` }
+					className="help-center-article-lesson-navigation__link help-center-article-lesson-navigation__link--previous"
+				>
+					<span className="help-center-article-lesson-navigation__label">
+						{ __( '← Back', __i18n_text_domain__ ) }
+					</span>
+					<span className="help-center-article-lesson-navigation__title">{ previous.title }</span>
+				</Link>
+			) }
+			{ next?.url && (
+				<Link
+					to={ `?link=${ encodeURIComponent( next.url ) }` }
+					className="help-center-article-lesson-navigation__link help-center-article-lesson-navigation__link--next"
+				>
+					<span className="help-center-article-lesson-navigation__label">
+						{ __( 'Up next →', __i18n_text_domain__ ) }
+					</span>
+					<span className="help-center-article-lesson-navigation__title">{ next.title }</span>
+				</Link>
+			) }
+		</nav>
+	);
+};

--- a/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
+++ b/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from '@wordpress/element';
 import { useContentFilter } from '../../hooks/use-content-filter';
 import HelpCenterFeedbackForm from '../help-center-feedback-form';
 import Placeholders from '../placeholder-lines';
+import { ArticleLessonNavigation } from './article-lesson-navigation';
 import { SupportArticleHeader } from './help-center-support-article-header';
 import type { ArticleContentProps } from '../../types';
 
@@ -32,6 +33,9 @@ const ArticleContent = ( {
 							dangerouslySetInnerHTML={ { __html: post.content } }
 							ref={ articleContentRef }
 						/>
+						{ post.lesson_navigation && (
+							<ArticleLessonNavigation lessonNavigation={ post.lesson_navigation } />
+						) }
 						<HelpCenterFeedbackForm
 							postId={ post.ID }
 							isEligibleForChat={ isEligibleForChat }

--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -625,4 +625,48 @@
 		font-size: 0.875rem;
 		color: var( --color-neutral-80 );
 	}
+
+	.help-center-article-lesson-navigation {
+		display: flex;
+		gap: 16px;
+		margin-top: 24px;
+		padding-top: 24px;
+		border-top: 1px solid var( --color-neutral-10 );
+
+		&__link {
+			display: flex;
+			flex-direction: column;
+			gap: 4px;
+			text-decoration: none;
+			flex: 1;
+
+			&:hover {
+				text-decoration: none;
+
+				.help-center-article-lesson-navigation__title {
+					text-decoration: underline;
+				}
+			}
+
+			&--previous {
+				align-items: flex-start;
+			}
+
+			&--next {
+				align-items: flex-end;
+				text-align: right;
+			}
+		}
+
+		&__label {
+			font-size: $font-body-small;
+			color: var( --color-neutral-50 );
+		}
+
+		&__title {
+			font-size: $font-body;
+			font-weight: 500;
+			color: var( --color-neutral-80 );
+		}
+	}
 }

--- a/packages/support-articles/src/types.ts
+++ b/packages/support-articles/src/types.ts
@@ -1,3 +1,13 @@
+export interface LessonNavigationLink {
+	url: string;
+	title: string;
+}
+
+export interface LessonNavigation {
+	next?: LessonNavigationLink;
+	previous?: LessonNavigationLink;
+}
+
 export interface PostObject {
 	content: string;
 	title: string;
@@ -6,6 +16,7 @@ export interface PostObject {
 	site_ID: number;
 	slug: string;
 	source?: string;
+	lesson_navigation?: LessonNavigation;
 }
 
 export interface ArticleContentProps {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-413/fix-how-video-courses-are-displayed-in-the-help-centre

### What

Added navigation at the end of a lesson of a course.

<img width="483" height="838" alt="image" src="https://github.com/user-attachments/assets/eef652cb-7299-4446-b1b9-91102ee121eb" />


### Testing steps

1. Live link or localhost
3. Search for a course in the Help Center ("create a website")
4. Enter the course and enter the first lesson.
5. Navigation should be working.

