### PR TITLE
Hide VideoPress upsell on Business sites

### DIFF
--- a/client/my-sites/stats/features/modules/shared/stats-empty-action-video.tsx
+++ b/client/my-sites/stats/features/modules/shared/stats-empty-action-video.tsx
@@ -8,11 +8,20 @@ import {
 	JETPACK_SUPPORT_VIDEOPRESS_URL,
 	JETPACK_VIDEOPRESS_LANDING_PAGE_URL,
 } from 'calypso/my-sites/stats/const';
+import { useSelector } from 'calypso/state';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { StatsEmptyActionProps } from './';
 
 const StatsEmptyActionVideo: React.FC< StatsEmptyActionProps > = ( { from } ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
+
+	if ( isWPCOMSite ) {
+		return null;
+	}
 
 	return (
 		<EmptyStateAction


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13664

## Proposed Changes

* When visiting Stats on a new Business site that has no video upload, we show a stats component that has a VideoPress upsell. The component assumes the site is Jetpack.
* Make it not show the upsell if the site is WPCOM

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Simple or Atomic Business site
* Visit the stats page http://calypso.localhost:3000/stats/day/251997359 (my blog id there)

<img width="537" height="334" alt="Screenshot 2026-02-05 at 12 09 40" src="https://github.com/user-attachments/assets/793accd9-f957-44cd-a89e-3f31291a677c" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
