### PR TITLE
MSD > Security: Enable 'Enhanced Security' for Two-step authentication

### DIFF
--- a/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/application-passwords/index.tsx
@@ -4,78 +4,92 @@ import {
 } from '@automattic/api-queries';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { Button, Icon } from '@wordpress/components';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { DataViews } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { closeSmall } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAnalytics } from '../../../../app/analytics';
 import { useLocale } from '../../../../app/locale';
-import { Card, CardHeader, CardBody } from '../../../../components/card';
+import { ActionList } from '../../../../components/action-list';
 import ConfirmModal from '../../../../components/confirm-modal';
 import InlineSupportLink from '../../../../components/inline-support-link';
 import { SectionHeader } from '../../../../components/section-header';
 import RegisterApplicationPassword from './register-application-password';
 import type { TwoStepAuthApplicationPassword } from '@automattic/api-core';
 
-const fields = ( locale: string ) => [
-	{
-		id: 'name',
-		label: __( 'Name' ),
-		getValue: ( { item }: { item: TwoStepAuthApplicationPassword } ) => item.name,
-	},
-	{
-		id: 'generated',
-		label: __( 'Generated' ),
-		getValue: ( { item }: { item: TwoStepAuthApplicationPassword } ) => {
-			const date = new Date( item.generated );
-			const formattedDate =
-				date.toLocaleDateString( locale, {
-					day: 'numeric',
-					month: 'long',
-					year: 'numeric',
-				} ) +
-				' ' +
-				date.toLocaleTimeString( locale, {
-					hour: '2-digit',
-					minute: '2-digit',
-					hour12: false,
-				} );
-			return sprintf(
+const ApplicationPasswordsList = ( {
+	item,
+	onRemove,
+}: {
+	item: TwoStepAuthApplicationPassword;
+	onRemove: () => void;
+} ) => {
+	const locale = useLocale();
+
+	const { recordTracksEvent } = useAnalytics();
+
+	const date = new Date( item.generated );
+	const formattedDate =
+		date.toLocaleDateString( locale, {
+			day: 'numeric',
+			month: 'long',
+			year: 'numeric',
+		} ) +
+		' ' +
+		date.toLocaleTimeString( locale, {
+			hour: '2-digit',
+			minute: '2-digit',
+			hour12: false,
+		} );
+
+	return (
+		<ActionList.ActionItem
+			title={ item.name }
+			description={ sprintf(
 				/* translators: %s is the date of the generated password */
 				__( 'Generated on %s' ),
 				formattedDate
-			);
-		},
-	},
-];
-
-const view = {
-	fields: [ 'generated' ],
-	type: 'list' as const,
-	titleField: 'name',
+			) }
+			actions={
+				<Button
+					variant="secondary"
+					size="compact"
+					isDestructive
+					onClick={ () => {
+						recordTracksEvent(
+							'calypso_dashboard_security_application_passwords_remove_password_dialog_open'
+						);
+						onRemove();
+					} }
+				>
+					{ __( 'Remove' ) }
+				</Button>
+			}
+		/>
+	);
 };
 
-const ApplicationPasswordsList = ( {
-	data,
-	isLoading,
-}: {
-	data: TwoStepAuthApplicationPassword[];
-	isLoading: boolean;
-} ) => {
-	const locale = useLocale();
+export default function ApplicationPasswords() {
 	const { recordTracksEvent } = useAnalytics();
+
+	const [ isAddApplicationPasswordModalOpen, setIsAddApplicationPasswordModalOpen ] =
+		useState( false );
+
+	const [ selectedKeyToRemove, setSelectedKeyToRemove ] =
+		useState< TwoStepAuthApplicationPassword | null >( null );
+
+	const { data: applicationPasswords } = useQuery( twoStepAuthApplicationPasswordsQuery() );
 
 	const { mutate: deleteApplicationPassword, isPending: isDeletingApplicationPassword } =
 		useMutation( deleteTwoStepAuthApplicationPasswordMutation() );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-
-	const [ selectedKeyToRemove, setSelectedKeyToRemove ] =
-		useState< TwoStepAuthApplicationPassword | null >( null );
 
 	const handleRemove = () => {
 		if ( selectedKeyToRemove ) {
@@ -104,87 +118,29 @@ const ApplicationPasswordsList = ( {
 
 	return (
 		<>
-			<DataViews< TwoStepAuthApplicationPassword >
-				data={ data }
-				fields={ fields( locale ) }
-				view={ view }
-				onChangeView={ () => {} }
-				getItemId={ ( item ) => item.ID }
-				paginationInfo={ { totalItems: data.length, totalPages: 1 } }
-				defaultLayouts={ { list: {} } }
-				empty={ <p>{ __( 'No application passwords added.' ) }</p> }
-				isLoading={ isLoading }
-				actions={ [
-					{
-						id: 'remove',
-						label: __( 'Remove' ),
-						icon: <Icon icon={ closeSmall } />,
-						isPrimary: true,
-						callback: ( items: TwoStepAuthApplicationPassword[] ) => {
-							const item = items[ 0 ];
-							recordTracksEvent(
-								'calypso_dashboard_security_application_passwords_remove_password_dialog_open'
-							);
-							setSelectedKeyToRemove( item );
-						},
-					},
-				] }
-			>
-				<DataViews.Layout />
-			</DataViews>
-			<ConfirmModal
-				isOpen={ !! selectedKeyToRemove }
-				confirmButtonProps={ {
-					label: __( 'Remove application password' ),
-					isBusy: isDeletingApplicationPassword,
-					disabled: isDeletingApplicationPassword,
-				} }
-				onCancel={ () => setSelectedKeyToRemove( null ) }
-				onConfirm={ handleRemove }
-			>
-				{ __( 'Are you sure you want to remove this application password?' ) }
-			</ConfirmModal>
-		</>
-	);
-};
-
-export default function ApplicationPasswords() {
-	const { recordTracksEvent } = useAnalytics();
-
-	const [ isAddApplicationPasswordModalOpen, setIsAddApplicationPasswordModalOpen ] =
-		useState( false );
-
-	const { data: applicationPasswords, isLoading } = useQuery(
-		twoStepAuthApplicationPasswordsQuery()
-	);
-
-	return (
-		<>
-			<SectionHeader
-				level={ 2 }
-				title={ __( 'Application passwords' ) }
-				description={ createInterpolateElement(
-					__(
-						'Generate a custom password for each third-party application you authorize to use your WordPress.com account. You can revoke access for an individual application here if you ever need to. <learnMoreLink />'
-					),
-					{
-						learnMoreLink: (
-							<InlineSupportLink
-								supportPostId={ 263616 }
-								supportLink={ localizeUrl(
-									'https://wordpress.com/support/security/two-step-authentication/application-specific-passwords'
-								) }
-							/>
-						),
-					}
-				) }
-			/>
-			<Card>
-				<CardHeader style={ { flexDirection: 'column', alignItems: 'stretch' } }>
-					<SectionHeader
-						level={ 3 }
-						title={ __( 'Your application passwords' ) }
-						actions={
+			<ActionList>
+				<VStack spacing={ 4 } style={ { paddingBlock: '16px' } }>
+					<HStack justify="space-between" alignment="top">
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'Application passwords' ) }
+							description={ createInterpolateElement(
+								__(
+									'Generate a custom password for each third-party application you authorize to use your WordPress.com account. <learnMoreLink />'
+								),
+								{
+									learnMoreLink: (
+										<InlineSupportLink
+											supportPostId={ 263616 }
+											supportLink={ localizeUrl(
+												'https://wordpress.com/support/security/two-step-authentication/application-specific-passwords'
+											) }
+										/>
+									),
+								}
+							) }
+						/>
+						<VStack style={ { flexShrink: 0 } }>
 							<Button
 								variant="secondary"
 								size="compact"
@@ -197,18 +153,34 @@ export default function ApplicationPasswords() {
 							>
 								{ __( 'Add application password' ) }
 							</Button>
-						}
+						</VStack>
+					</HStack>
+				</VStack>
+				{ applicationPasswords?.map( ( item ) => (
+					<ApplicationPasswordsList
+						key={ item.ID }
+						item={ item }
+						onRemove={ () => setSelectedKeyToRemove( item ) }
 					/>
-				</CardHeader>
-				<CardBody>
-					<ApplicationPasswordsList data={ applicationPasswords ?? [] } isLoading={ isLoading } />
-				</CardBody>
-			</Card>
+				) ) }
+			</ActionList>
 			{ isAddApplicationPasswordModalOpen && (
 				<RegisterApplicationPassword
 					onClose={ () => setIsAddApplicationPasswordModalOpen( false ) }
 				/>
 			) }
+			<ConfirmModal
+				isOpen={ !! selectedKeyToRemove }
+				confirmButtonProps={ {
+					label: __( 'Remove application password' ),
+					isBusy: isDeletingApplicationPassword,
+					disabled: isDeletingApplicationPassword,
+				} }
+				onCancel={ () => setSelectedKeyToRemove( null ) }
+				onConfirm={ handleRemove }
+			>
+				{ __( 'Are you sure you want to remove this application password?' ) }
+			</ConfirmModal>
 		</>
 	);
 }

--- a/client/dashboard/me/security-two-step-auth/main-page/backup-codes/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/backup-codes/index.tsx
@@ -16,41 +16,39 @@ export default function BackupCodes() {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	return (
-		<>
-			<SectionHeader
-				level={ 2 }
-				title={ __( 'Backup codes' ) }
-				description={ __(
-					'Backup codes let you access your account if you lose your phone or can’t use your authenticator app. Each code can only be used once.'
-				) }
-			/>
-			{ isBackupCodesPrinted ? (
-				<Notice variant="success">{ __( 'Backup codes have been verified.' ) }</Notice>
-			) : (
-				<Card>
-					<CardBody>
-						<VStack spacing={ 4 }>
-							<VerifyCodeForm
-								showCancelButton={ false }
-								primaryButtonText={ __( 'Verify' ) }
-								customField={ {
-									label: __( 'Type a backup code to verify' ),
-									placeholder: '12345678',
-								} }
-								actionType="create-backup-receipt"
-								onError={ () => {
-									createErrorNotice( __( 'Failed to verify backup codes.' ), {
-										type: 'snackbar',
-									} );
-								} }
-								infoNoticeText={ __(
-									'New backup codes have been generated, but need to be verified.'
-								) }
-							/>
-						</VStack>
-					</CardBody>
-				</Card>
-			) }
-		</>
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<SectionHeader
+						level={ 3 }
+						title={ __( 'Backup codes' ) }
+						description={ __(
+							'Backup codes let you access your account if you lose your phone or can’t use your authenticator app. Each code can only be used once.'
+						) }
+					/>
+					{ isBackupCodesPrinted ? (
+						<Notice variant="success">{ __( 'Backup codes have been verified.' ) }</Notice>
+					) : (
+						<VerifyCodeForm
+							showCancelButton={ false }
+							primaryButtonText={ __( 'Verify' ) }
+							customField={ {
+								label: __( 'Type a backup code to verify' ),
+								placeholder: '12345678',
+							} }
+							actionType="create-backup-receipt"
+							onError={ () => {
+								createErrorNotice( __( 'Failed to verify backup codes.' ), {
+									type: 'snackbar',
+								} );
+							} }
+							infoNoticeText={ __(
+								'New backup codes have been generated, but need to be verified.'
+							) }
+						/>
+					) }
+				</VStack>
+			</CardBody>
+		</Card>
 	);
 }

--- a/client/dashboard/me/security-two-step-auth/main-page/enhanced-security/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/enhanced-security/index.tsx
@@ -27,18 +27,28 @@ export default function EnhancedSecurity() {
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const handleChange = ( value: boolean ) => {
+	const handleChange = ( isEnabled: boolean ) => {
 		recordTracksEvent( 'calypso_dashboard_security_enhanced_security_change_click', {
-			two_step_enhanced_security: value,
+			two_step_enhanced_security: isEnabled,
 		} );
 		updateUserSettings(
-			{ two_step_enhanced_security: value },
+			{ two_step_enhanced_security: isEnabled },
 			{
 				onSuccess: () => {
-					createSuccessNotice( __( 'Settings saved.' ), { type: 'snackbar' } );
+					createSuccessNotice(
+						isEnabled
+							? __( 'Enhanced account security enabled.' )
+							: __( 'Enhanced account security disabled.' ),
+						{ type: 'snackbar' }
+					);
 				},
 				onError: () => {
-					createErrorNotice( __( 'Failed to save settings.' ), { type: 'snackbar' } );
+					createErrorNotice(
+						isEnabled
+							? __( 'Failed to enable enhanced account security.' )
+							: __( 'Failed to disable enhanced account security.' ),
+						{ type: 'snackbar' }
+					);
 				},
 			}
 		);
@@ -49,32 +59,27 @@ export default function EnhancedSecurity() {
 	}
 
 	return (
-		<>
-			<Card>
-				<CardBody>
-					<VStack spacing={ 4 }>
-						<SectionHeader title={ __( 'Enhanced account security' ) } level={ 3 } />
-						<ToggleControl
-							__nextHasNoMarginBottom
-							checked={ two_step_enhanced_security }
-							onChange={ handleChange }
-							disabled={ two_step_enhanced_security_forced || isUpdatingUserSettings }
-							label={
-								two_step_enhanced_security_forced
-									? __(
-											'Your account is currently required to use security keys (passkeys) as a second factor.'
-									  )
-									: __(
-											'Secure your account by requiring the use of security keys (passkeys) as second factor.'
-									  )
-							}
-							help={ __(
-								'Security keys (or passkeys) offer a more secure way to access your account. Whether it’s a physical device or another secure method, they make it significantly harder for unauthorized users to gain access.'
-							) }
-						/>
-					</VStack>
-				</CardBody>
-			</Card>
-		</>
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<SectionHeader title={ __( 'Enhanced account security' ) } level={ 3 } />
+					<ToggleControl
+						__nextHasNoMarginBottom
+						checked={ two_step_enhanced_security }
+						onChange={ handleChange }
+						disabled={ two_step_enhanced_security_forced || isUpdatingUserSettings }
+						label={
+							two_step_enhanced_security_forced
+								? __(
+										'Your account is currently required to use security keys (passkeys) as a second factor.'
+								  )
+								: __(
+										'Secure your account by requiring the use of security keys (passkeys) as second factor.'
+								  )
+						}
+					/>
+				</VStack>
+			</CardBody>
+		</Card>
 	);
 }

--- a/client/dashboard/me/security-two-step-auth/main-page/enhanced-security/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/enhanced-security/index.tsx
@@ -1,4 +1,8 @@
-import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
+import {
+	userSettingsQuery,
+	userSettingsMutation,
+	twoStepAuthSecurityKeysQuery,
+} from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, ToggleControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -12,6 +16,9 @@ export default function EnhancedSecurity() {
 	const { recordTracksEvent } = useAnalytics();
 
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
+	const { data: securityKeys } = useSuspenseQuery( twoStepAuthSecurityKeysQuery() );
+	const hasSecurityKeys = securityKeys?.registrations?.length > 0;
+
 	const { two_step_enhanced_security_forced, two_step_enhanced_security } = userSettings;
 
 	const { mutate: updateUserSettings, isPending: isUpdatingUserSettings } = useMutation(
@@ -36,6 +43,10 @@ export default function EnhancedSecurity() {
 			}
 		);
 	};
+
+	if ( ! hasSecurityKeys ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/client/dashboard/me/security-two-step-auth/main-page/enhanced-security/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/enhanced-security/index.tsx
@@ -1,8 +1,4 @@
-import {
-	userSettingsQuery,
-	userSettingsMutation,
-	twoStepAuthSecurityKeysQuery,
-} from '@automattic/api-queries';
+import { userSettingsQuery, userSettingsMutation } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack, ToggleControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -16,8 +12,6 @@ export default function EnhancedSecurity() {
 	const { recordTracksEvent } = useAnalytics();
 
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
-	const { data: securityKeys } = useSuspenseQuery( twoStepAuthSecurityKeysQuery() );
-	const hasSecurityKeys = securityKeys?.registrations?.length > 0;
 
 	const { two_step_enhanced_security_forced, two_step_enhanced_security } = userSettings;
 
@@ -53,10 +47,6 @@ export default function EnhancedSecurity() {
 			}
 		);
 	};
-
-	if ( ! hasSecurityKeys ) {
-		return null;
-	}
 
 	return (
 		<Card>

--- a/client/dashboard/me/security-two-step-auth/main-page/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/index.tsx
@@ -1,5 +1,4 @@
 import { smsCountryCodesQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
@@ -10,7 +9,6 @@ import Notice from '../../../components/notice';
 import TwoStepAuthActions from './actions';
 import ApplicationPasswords from './application-passwords';
 import BackupCodes from './backup-codes';
-import EnhancedSecurity from './enhanced-security';
 import SecurityKeys from './security-keys';
 import type { UserSettings } from '@automattic/api-core';
 
@@ -83,7 +81,6 @@ export default function SecurityTwoStepAuthMainPage( {
 								}
 						  ) ) }
 			</Notice>
-			{ isEnabled( 'two-factor/enhanced-security' ) && <EnhancedSecurity /> }
 			<SecurityKeys />
 			<ApplicationPasswords />
 			<BackupCodes />

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -4,16 +4,18 @@ import {
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { Button, Icon } from '@wordpress/components';
+import {
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { DataViews } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { closeSmall } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAnalytics } from '../../../../app/analytics';
-import { Card, CardHeader, CardBody } from '../../../../components/card';
+import { ActionList } from '../../../../components/action-list';
 import ConfirmModal from '../../../../components/confirm-modal';
 import InlineSupportLink from '../../../../components/inline-support-link';
 import { SectionHeader } from '../../../../components/section-header';
@@ -24,29 +26,96 @@ import type { UserTwoStepAuthSecurityKeys } from '@automattic/api-core';
 
 type SecurityKeyRegistration = UserTwoStepAuthSecurityKeys[ 'registrations' ][ number ];
 
-const fields = [
-	{
-		id: 'name',
-		label: __( 'Name' ),
-		getValue: ( { item }: { item: SecurityKeyRegistration } ) => item.name,
-	},
-];
+const SecurityKeyItem = ( {
+	item,
+	onRemove,
+}: {
+	item: SecurityKeyRegistration;
+	onRemove: () => void;
+} ) => {
+	const { recordTracksEvent } = useAnalytics();
 
-const view = {
-	fields: [],
-	type: 'list' as const,
-	titleField: 'name',
+	const handleRemoveClick = () => {
+		recordTracksEvent(
+			'calypso_dashboard_security_two_step_auth_security_keys_remove_key_dialog_open'
+		);
+		onRemove();
+	};
+
+	return (
+		<ActionList.ActionItem
+			title={ item.name }
+			actions={
+				<Button variant="secondary" size="compact" isDestructive onClick={ handleRemoveClick }>
+					{ __( 'Remove' ) }
+				</Button>
+			}
+		/>
+	);
 };
 
 const SecurityKeysList = ( {
 	data,
-	isLoading,
+	onRemoveKey,
+	onAddKey,
 }: {
 	data: SecurityKeyRegistration[];
-	isLoading: boolean;
+	onRemoveKey: ( item: SecurityKeyRegistration ) => void;
+	onAddKey: () => void;
 } ) => {
+	const isBrowserSupported = isWebAuthnSupported();
+
+	return (
+		<ActionList>
+			<VStack spacing={ 4 } style={ { paddingBlock: '16px' } }>
+				<HStack justify="space-between" alignment="top">
+					<SectionHeader
+						level={ 3 }
+						title={ __( 'Security keys' ) }
+						description={
+							isBrowserSupported
+								? createInterpolateElement(
+										__(
+											'Security keys offer a more robust form of two-step authentication. <learnMoreLink />'
+										),
+										{
+											learnMoreLink: (
+												<InlineSupportLink supportContext="two-step-authentication-security-key" />
+											),
+										}
+								  )
+								: __(
+										'Your browser doesn‘t support the FIDO2 security key standard yet. To use a second factor security key to sign in please try a supported browser like Chrome, Safari, or Firefox.'
+								  )
+						}
+					/>
+					{ isBrowserSupported && (
+						<VStack style={ { flexShrink: 0 } }>
+							<Button variant="secondary" size="compact" onClick={ onAddKey }>
+								{ __( 'Register key' ) }
+							</Button>
+						</VStack>
+					) }
+				</HStack>
+			</VStack>
+			{ data?.map( ( item ) => (
+				<SecurityKeyItem key={ item.id } item={ item } onRemove={ () => onRemoveKey( item ) } />
+			) ) }
+		</ActionList>
+	);
+};
+
+export default function SecurityKeys() {
 	const { recordTracksEvent } = useAnalytics();
 	const { createErrorNotice } = useDispatch( noticesStore );
+
+	const [ isAddKeyModalOpen, setIsAddKeyModalOpen ] = useState( false );
+	const [ selectedKeyToRemove, setSelectedKeyToRemove ] =
+		useState< SecurityKeyRegistration | null >( null );
+
+	const { data: securityKeys } = useQuery( twoStepAuthSecurityKeysQuery() );
+
+	const registrations = securityKeys?.registrations ?? [];
 
 	const { mutate: deleteSecurityKey, isPending: isDeletingSecurityKey } = useMutation( {
 		...deleteTwoStepAuthSecurityKeyMutation(),
@@ -57,8 +126,9 @@ const SecurityKeysList = ( {
 		},
 	} );
 
-	const [ selectedKeyToRemove, setSelectedKeyToRemove ] =
-		useState< SecurityKeyRegistration | null >( null );
+	const handleRemoveKey = ( item: SecurityKeyRegistration ) => {
+		setSelectedKeyToRemove( item );
+	};
 
 	const handleRemove = () => {
 		recordTracksEvent( 'calypso_dashboard_security_two_step_auth_security_keys_remove_key_click' );
@@ -81,36 +151,22 @@ const SecurityKeysList = ( {
 		}
 	};
 
+	const handleAddKey = () => {
+		setIsAddKeyModalOpen( true );
+		recordTracksEvent(
+			'calypso_dashboard_security_two_step_auth_security_keys_register_key_modal_open'
+		);
+	};
+
 	return (
 		<>
-			<DataViews< SecurityKeyRegistration >
-				data={ data }
-				fields={ fields }
-				view={ view }
-				onChangeView={ () => {} }
-				getItemId={ ( item ) => item.id }
-				paginationInfo={ { totalItems: data.length, totalPages: 1 } }
-				defaultLayouts={ { list: {} } }
-				empty={ <p>{ __( 'No security keys registered.' ) }</p> }
-				isLoading={ isLoading }
-				actions={ [
-					{
-						id: 'remove',
-						label: __( 'Remove' ),
-						icon: <Icon icon={ closeSmall } />,
-						isPrimary: true,
-						callback: ( items: SecurityKeyRegistration[] ) => {
-							const item = items[ 0 ];
-							recordTracksEvent(
-								'calypso_dashboard_security_two_step_auth_security_keys_remove_key_dialog_open'
-							);
-							setSelectedKeyToRemove( item );
-						},
-					},
-				] }
-			>
-				<DataViews.Layout />
-			</DataViews>
+			<SecurityKeysList
+				data={ registrations }
+				onRemoveKey={ handleRemoveKey }
+				onAddKey={ handleAddKey }
+			/>
+			{ isEnabled( 'two-factor/enhanced-security' ) && <EnhancedSecurity /> }
+			{ isAddKeyModalOpen && <RegisterKey onClose={ () => setIsAddKeyModalOpen( false ) } /> }
 			<ConfirmModal
 				isOpen={ !! selectedKeyToRemove }
 				confirmButtonProps={ {
@@ -123,74 +179,6 @@ const SecurityKeysList = ( {
 			>
 				{ __( 'Are you sure you want to remove this security key?' ) }
 			</ConfirmModal>
-		</>
-	);
-};
-
-export default function SecurityKeys() {
-	const { recordTracksEvent } = useAnalytics();
-
-	const [ isAddKeyModalOpen, setIsAddKeyModalOpen ] = useState( false );
-
-	const { data: securityKeys, isLoading } = useQuery( twoStepAuthSecurityKeysQuery() );
-
-	const registrations = securityKeys?.registrations ?? [];
-
-	const isBrowserSupported = isWebAuthnSupported();
-
-	return (
-		<>
-			<SectionHeader
-				level={ 2 }
-				title={ __( 'Security keys' ) }
-				description={
-					isBrowserSupported
-						? createInterpolateElement(
-								__(
-									'Security keys offer a more robust form of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser. <learnMoreLink />'
-								),
-								{
-									learnMoreLink: (
-										<InlineSupportLink supportContext="two-step-authentication-security-key" />
-									),
-								}
-						  )
-						: __(
-								'Your browser doesn‘t support the FIDO2 security key standard yet. To use a second factor security key to sign in please try a supported browser like Chrome, Safari, or Firefox.'
-						  )
-				}
-			/>
-			{ isBrowserSupported && (
-				<>
-					<Card>
-						<CardHeader style={ { flexDirection: 'column', alignItems: 'stretch' } }>
-							<SectionHeader
-								level={ 3 }
-								title={ __( 'Your security keys' ) }
-								actions={
-									<Button
-										variant="secondary"
-										size="compact"
-										onClick={ () => {
-											setIsAddKeyModalOpen( true );
-											recordTracksEvent(
-												'calypso_dashboard_security_two_step_auth_security_keys_register_key_modal_open'
-											);
-										} }
-									>
-										{ __( 'Register key' ) }
-									</Button>
-								}
-							/>
-						</CardHeader>
-						<CardBody>
-							<SecurityKeysList data={ registrations } isLoading={ isLoading } />
-						</CardBody>
-					</Card>
-					{ isEnabled( 'two-factor/enhanced-security' ) && <EnhancedSecurity /> }
-					{ isAddKeyModalOpen && <RegisterKey onClose={ () => setIsAddKeyModalOpen( false ) } /> }
-				</>
-			) }
 		</>
 	);
 }

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -165,7 +165,9 @@ export default function SecurityKeys() {
 				onRemoveKey={ handleRemoveKey }
 				onAddKey={ handleAddKey }
 			/>
-			{ isEnabled( 'two-factor/enhanced-security' ) && <EnhancedSecurity /> }
+			{ isEnabled( 'two-factor/enhanced-security' ) && registrations.length > 0 && (
+				<EnhancedSecurity />
+			) }
 			{ isAddKeyModalOpen && <RegisterKey onClose={ () => setIsAddKeyModalOpen( false ) } /> }
 			<ConfirmModal
 				isOpen={ !! selectedKeyToRemove }

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -2,6 +2,7 @@ import {
 	twoStepAuthSecurityKeysQuery,
 	deleteTwoStepAuthSecurityKeyMutation,
 } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Button, Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -17,6 +18,7 @@ import ConfirmModal from '../../../../components/confirm-modal';
 import InlineSupportLink from '../../../../components/inline-support-link';
 import { SectionHeader } from '../../../../components/section-header';
 import { isWebAuthnSupported } from '../../utils';
+import EnhancedSecurity from '../enhanced-security';
 import RegisterKey from './register-key';
 import type { UserTwoStepAuthSecurityKeys } from '@automattic/api-core';
 
@@ -185,6 +187,7 @@ export default function SecurityKeys() {
 							<SecurityKeysList data={ registrations } isLoading={ isLoading } />
 						</CardBody>
 					</Card>
+					{ isEnabled( 'two-factor/enhanced-security' ) && <EnhancedSecurity /> }
 					{ isAddKeyModalOpen && <RegisterKey onClose={ () => setIsAddKeyModalOpen( false ) } /> }
 				</>
 			) }

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -4,10 +4,12 @@ import {
 } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Button, Icon } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAnalytics } from '../../../../app/analytics';
 import { Card, CardHeader, CardBody } from '../../../../components/card';
@@ -42,13 +44,13 @@ const SecurityKeysList = ( {
 	isLoading: boolean;
 } ) => {
 	const { recordTracksEvent } = useAnalytics();
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const { mutate: deleteSecurityKey, isPending: isDeletingSecurityKey } = useMutation( {
 		...deleteTwoStepAuthSecurityKeyMutation(),
 		meta: {
 			snackbar: {
 				success: __( 'Security key deleted.' ),
-				error: __( 'Failed to delete security key.' ),
 			},
 		},
 	} );
@@ -62,6 +64,13 @@ const SecurityKeysList = ( {
 			deleteSecurityKey(
 				{ credential_id: selectedKeyToRemove.id },
 				{
+					onError: ( error ) => {
+						let errorMessage = __( 'Failed to delete security key.' );
+						if ( error instanceof Error ) {
+							errorMessage = error.message;
+						}
+						createErrorNotice( errorMessage, { type: 'snackbar' } );
+					},
 					onSettled: () => {
 						setSelectedKeyToRemove( null );
 					},

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -25,7 +25,8 @@
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
-		"wordpress-ai-tools": true
+		"wordpress-ai-tools": true,
+		"two-factor/enhanced-security": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -24,7 +24,8 @@
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
-		"wordpress-ai-tools": true
+		"wordpress-ai-tools": true,
+		"two-factor/enhanced-security": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -22,7 +22,8 @@
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
-		"wordpress-ai-tools": true
+		"wordpress-ai-tools": true,
+		"two-factor/enhanced-security": false
 	},
 	"enable_all_sections": false,
 	"site_filter": [],

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -22,7 +22,8 @@
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,
 		"mcp-settings": true,
-		"wordpress-ai-tools": true
+		"wordpress-ai-tools": true,
+		"two-factor/enhanced-security": true
 	},
 	"enable_all_sections": false,
 	"site_filter": [],


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/DOTMSD-883/make-it-clear-that-enhanced-account-security-is-enabled

We will enable this on production if everything works as expected on staging. 

## Proposed Changes

* Enable the "Enhanced Security" feature flag for Two-step authentication in development, horizon, and stage environments in the Dashboard.
* Add conditional rendering to the Enhanced Security component - only show when the user has security keys registered
* Improve error handling in the Security Keys component to display custom error messages from the API

## Why are these changes being made?

* The Enhanced Security feature allows users to require security keys (passkeys) as a second factor for authentication. This PR enables the feature in non-production environments and ensures it only displays when users have security keys registered, preventing confusion for users who haven't set up security keys yet. Additionally, it improves error handling by displaying more specific error messages when a security key is deleted.

## Testing Instructions

* Use an account that is non-a8c to test the feature fully
* Open the Dashboard live link
* Go to Profile > Security > Two-step authentication > Enable Two-step if not setup already > Verify the screen looks as shown below

<img width="751" height="402" alt="Screenshot 2026-03-09 at 11 44 20 AM" src="https://github.com/user-attachments/assets/aad4257f-0485-46c9-91fe-3f6d7a780381" />

* Go to https://wordpress.com/me/security/two-step > Add a security key. This is done as there is an issue if we try to delete the security key that is added not added from "WordPress.com" > Refresh the live link > Verify you can see a new section "Enhanced account security" as shown below

<img width="751" height="565" alt="Screenshot 2026-03-09 at 11 44 50 AM" src="https://github.com/user-attachments/assets/32b18430-0537-45e6-abf5-755668446054" />

* Refresh the page: https://wordpress.com/me/security/two-step > Enable the "Enhanced account security" > Refresh the live link > Verify you can see a new section "Enhanced account security" as shown below

<img width="751" height="565" alt="Screenshot 2026-03-09 at 11 44 59 AM" src="https://github.com/user-attachments/assets/1ff6e6e7-3e0e-4c97-b0e1-2a237a866ea7" />


* Try to delete the security key from the live link > Verify that the following error is shown

<img width="536" height="86" alt="Screenshot 2026-02-05 at 4 29 07 PM" src="https://github.com/user-attachments/assets/ab6c7809-24ed-4503-9804-e1582193842b" />

* Disable the "Enhanced account security" > Verify it works as expected > Delete the security key > Verify it works as expected and the "Enhanced account security"  is hidden as it requires a security key to be added to be enabled. Adding the security key should restore the section. Note: if you add a security key from the live link and enable the "Enhanced account security", you can still be able to delete the security key as the RP ID doesn't match: fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qzr%2Qgjb%2Qfgrc%2Qfrphevgl%2Qxrl%2Qqryrgr%2Qi1%2Q1%2Qraqcbvag.cuc%3Se%3Q05431oon%26zb%3Q1526%26sv%3Q38%2329-og

* Open your a8c account > Verify the toggle is disabled

<img width="751" height="592" alt="Screenshot 2026-03-09 at 11 45 18 AM" src="https://github.com/user-attachments/assets/3f66e6b6-0f17-4b38-a4b7-362b404fd642" />

We have also updated the success and error notice texts:

<img width="288" height="82" alt="Screenshot 2026-02-06 at 9 27 55 AM" src="https://github.com/user-attachments/assets/808b967d-627d-45b6-8c29-6447135f1527" />

<img width="293" height="91" alt="Screenshot 2026-02-06 at 9 28 06 AM" src="https://github.com/user-attachments/assets/8836c2ce-3fad-47f9-96f3-4882fc4c97a9" />

<img width="345" height="62" alt="Screenshot 2026-02-06 at 9 28 58 AM" src="https://github.com/user-attachments/assets/c053dcbb-736d-4270-a311-1e4f51695960" />

<img width="347" height="70" alt="Screenshot 2026-02-06 at 9 29 38 AM" src="https://github.com/user-attachments/assets/f33dd572-3a8a-4d80-b2b3-141a6d393422" />

Updated `Application password` and `Backup codes` section

<img width="751" height="421" alt="Screenshot 2026-03-09 at 11 45 31 AM" src="https://github.com/user-attachments/assets/acc774ec-ec75-4811-a978-1c2fa459d156" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?