### PR TITLE
Split cancel from refund on me/purchases

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -686,6 +686,16 @@ class CancelPurchaseForm extends Component {
 			return translate( 'Remove product' );
 		}
 
+		if ( flowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW ) {
+			if ( isPlan( purchase ) ) {
+				return translate( 'Cancel plan' );
+			}
+			if ( isSubscription( purchase ) ) {
+				return translate( 'Cancel subscription' );
+			}
+			return translate( 'Cancel product' );
+		}
+
 		if ( hasAmountAvailableToRefund( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
 				return translate( 'Cancel domain and refund' );

--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -49,6 +49,7 @@ export interface CancelPurchaseButtonProps {
 	isLinkStyle?: boolean;
 	isInline?: boolean;
 	flowTypeOverride?: string;
+	onCancelInitiated?: () => void;
 	activeSubscriptions: Array< { id: number; productName: string } >;
 	onCancellationStart: null | ( () => void );
 	onCancellationComplete: () => void;
@@ -89,6 +90,10 @@ class CancelPurchaseButton extends Component<
 	};
 
 	handleCancelPurchaseClick = async () => {
+		if ( this.props.onCancelInitiated ) {
+			this.props.onCancelInitiated();
+		}
+
 		// For all purchases, including domain registrations, show the survey first
 		// The API call will happen at the end of the survey flow
 
@@ -167,7 +172,7 @@ class CancelPurchaseButton extends Component<
 			! willShowDomainOptionsRadioButtons( this.props.includedDomainPurchase, this.props.purchase );
 		const text = ( () => {
 			if ( this.props.textVariant === 'remove-plan-and-claim-refund' ) {
-				return translate( 'Remove plan and claim refund' );
+				return translate( 'Remove plan and claim refund.' );
 			}
 
 			if ( includedDomainPurchase && needsDomainOptionsStep ) {

--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -99,17 +99,7 @@ class CancelPurchaseButton extends Component<
 			// We're in the domain options step, show survey directly
 			this.props.onCancellationComplete();
 		} else {
-			const needsDomainOptionsStep =
-				this.props.includedDomainPurchase &&
-				willShowDomainOptionsRadioButtons( this.props.includedDomainPurchase, this.props.purchase );
-
-			if ( needsDomainOptionsStep ) {
-				// Step 1: Show domain options step
-				this.props.onCancellationStart( this.props.cancelIntentOverride );
-			} else {
-				// Step 2: Show survey directly (API call will happen in survey)
-				this.props.onCancellationStart( this.props.cancelIntentOverride );
-			}
+			this.props.onCancellationStart( this.props.cancelIntentOverride );
 		}
 	};
 
@@ -159,9 +149,7 @@ class CancelPurchaseButton extends Component<
 	render() {
 		const { purchase, translate, cancelBundledDomain, includedDomainPurchase } = this.props;
 
-		const onClick = ( () => {
-			return this.handleCancelPurchaseClick;
-		} )();
+		const onClick = this.handleCancelPurchaseClick;
 
 		const needsDomainOptionsStep =
 			this.props.includedDomainPurchase &&

--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -48,6 +48,7 @@ export interface CancelPurchaseButtonProps {
 	textVariant?: string;
 	isLinkStyle?: boolean;
 	isInline?: boolean;
+	flowTypeOverride?: string;
 	activeSubscriptions: Array< { id: number; productName: string } >;
 	onCancellationStart: null | ( () => void );
 	onCancellationComplete: () => void;
@@ -232,7 +233,7 @@ class CancelPurchaseButton extends Component<
 						onSurveyComplete={ this.handleSurveyComplete }
 						downgradeClick={ this.props.downgradeClick }
 						freeMonthOfferClick={ this.props.freeMonthOfferClick }
-						flowType={ getPurchaseCancellationFlowType( purchase ) }
+						flowType={ this.props.flowTypeOverride ?? getPurchaseCancellationFlowType( purchase ) }
 						cancelBundledDomain={ cancelBundledDomain }
 						includedDomainPurchase={ includedDomainPurchase }
 						cancellationInProgress={ isLoading }

--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -12,6 +12,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import CancelJetpackForm from 'calypso/components/marketing-survey/cancel-jetpack-form';
 import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
+import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
 import DomainCancellationSurvey from 'calypso/components/marketing-survey/cancel-purchase-form/domain-cancellation-survey';
 import {
 	getName,
@@ -48,10 +49,9 @@ export interface CancelPurchaseButtonProps {
 	textVariant?: string;
 	isLinkStyle?: boolean;
 	isInline?: boolean;
-	flowTypeOverride?: string;
-	onCancelInitiated?: () => void;
+	cancelIntentOverride?: 'refund' | 'autorenew';
 	activeSubscriptions: Array< { id: number; productName: string } >;
-	onCancellationStart: null | ( () => void );
+	onCancellationStart: null | ( ( intent?: 'refund' | 'autorenew' ) => void );
 	onCancellationComplete: () => void;
 	onSurveyComplete: () => void;
 	// Props from parent component
@@ -90,10 +90,6 @@ class CancelPurchaseButton extends Component<
 	};
 
 	handleCancelPurchaseClick = async () => {
-		if ( this.props.onCancelInitiated ) {
-			this.props.onCancelInitiated();
-		}
-
 		// For all purchases, including domain registrations, show the survey first
 		// The API call will happen at the end of the survey flow
 
@@ -109,10 +105,10 @@ class CancelPurchaseButton extends Component<
 
 			if ( needsDomainOptionsStep ) {
 				// Step 1: Show domain options step
-				this.props.onCancellationStart();
+				this.props.onCancellationStart( this.props.cancelIntentOverride );
 			} else {
 				// Step 2: Show survey directly (API call will happen in survey)
-				this.props.onCancellationStart();
+				this.props.onCancellationStart( this.props.cancelIntentOverride );
 			}
 		}
 	};
@@ -205,6 +201,12 @@ class CancelPurchaseButton extends Component<
 			this.props;
 
 		const planName = getName( purchase );
+		let flowType = getPurchaseCancellationFlowType( purchase );
+		if ( this.props.cancelIntentOverride === 'refund' ) {
+			flowType = CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
+		} else if ( this.props.cancelIntentOverride === 'autorenew' ) {
+			flowType = CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
+		}
 
 		const wrapperClassName = this.props.isInline
 			? 'cancel-purchase__button-wrapper cancel-purchase__button-wrapper--inline'
@@ -238,7 +240,7 @@ class CancelPurchaseButton extends Component<
 						onSurveyComplete={ this.handleSurveyComplete }
 						downgradeClick={ this.props.downgradeClick }
 						freeMonthOfferClick={ this.props.freeMonthOfferClick }
-						flowType={ this.props.flowTypeOverride ?? getPurchaseCancellationFlowType( purchase ) }
+						flowType={ flowType }
 						cancelBundledDomain={ cancelBundledDomain }
 						includedDomainPurchase={ includedDomainPurchase }
 						cancellationInProgress={ isLoading }
@@ -253,7 +255,7 @@ class CancelPurchaseButton extends Component<
 						isVisible={ showDialog }
 						onClose={ this.closeDialog }
 						onSurveyComplete={ this.props.onSurveyComplete }
-						flowType={ getPurchaseCancellationFlowType( purchase ) }
+						flowType={ flowType }
 						isAkismet={ isAkismet }
 						cancellationInProgress={ isLoading }
 					/>

--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -45,6 +45,9 @@ export interface CancelPurchaseButtonProps {
 	cancelBundledDomain: boolean;
 	includedDomainPurchase: Purchases.Purchase;
 	disabled?: boolean;
+	textOverride?: string;
+	isLinkStyle?: boolean;
+	isInline?: boolean;
 	activeSubscriptions: Array< { id: number; productName: string } >;
 	onCancellationStart: null | ( () => void );
 	onCancellationComplete: () => void;
@@ -161,31 +164,33 @@ class CancelPurchaseButton extends Component<
 		const needsDomainOptionsStep =
 			this.props.includedDomainPurchase &&
 			! willShowDomainOptionsRadioButtons( this.props.includedDomainPurchase, this.props.purchase );
-		const text = ( () => {
-			if ( includedDomainPurchase && needsDomainOptionsStep ) {
-				return translate( 'Continue with cancellation' );
-			}
-
-			if ( hasAmountAvailableToRefund( purchase ) ) {
-				if ( isDomainRegistration( purchase ) ) {
-					return translate( 'Cancel domain and refund' );
+		const text =
+			this.props.textOverride ??
+			( () => {
+				if ( includedDomainPurchase && needsDomainOptionsStep ) {
+					return translate( 'Continue with cancellation' );
 				}
+
+				if ( hasAmountAvailableToRefund( purchase ) ) {
+					if ( isDomainRegistration( purchase ) ) {
+						return translate( 'Cancel domain and refund' );
+					}
+					if ( isSubscription( purchase ) ) {
+						return translate( 'Cancel subscription' );
+					}
+					if ( isOneTimePurchase( purchase ) ) {
+						return translate( 'Cancel and refund' );
+					}
+				}
+
+				if ( isDomainRegistration( purchase ) ) {
+					return translate( 'Cancel domain' );
+				}
+
 				if ( isSubscription( purchase ) ) {
 					return translate( 'Cancel subscription' );
 				}
-				if ( isOneTimePurchase( purchase ) ) {
-					return translate( 'Cancel and refund' );
-				}
-			}
-
-			if ( isDomainRegistration( purchase ) ) {
-				return translate( 'Cancel domain' );
-			}
-
-			if ( isSubscription( purchase ) ) {
-				return translate( 'Cancel subscription' );
-			}
-		} )();
+			} )();
 
 		const disableButtons = this.state.disabled || this.props.disabled;
 		const { isJetpack, isAkismet, purchaseListUrl, activeSubscriptions, isLoading, showDialog } =
@@ -193,17 +198,25 @@ class CancelPurchaseButton extends Component<
 
 		const planName = getName( purchase );
 
+		const wrapperClassName = this.props.isInline
+			? 'cancel-purchase__button-wrapper cancel-purchase__button-wrapper--inline'
+			: 'cancel-purchase__button-wrapper';
+		const buttonClassName = this.props.isLinkStyle
+			? 'cancel-purchase__button cancel-purchase__button--link'
+			: 'cancel-purchase__button';
+
 		return (
-			<div className="cancel-purchase__button-wrapper">
+			<div className={ wrapperClassName }>
 				<Button
-					className="cancel-purchase__button"
+					className={ buttonClassName }
 					disabled={ disableButtons }
 					busy={ isLoading }
-					scary
+					scary={ ! this.props.isLinkStyle }
 					onClick={
 						this.shouldHandleMarketplaceSubscriptions() ? this.showMarketplaceDialog : onClick
 					}
-					primary
+					primary={ ! this.props.isLinkStyle }
+					borderless={ this.props.isLinkStyle }
 				>
 					{ text }
 				</Button>

--- a/client/me/purchases/cancel-purchase/button.tsx
+++ b/client/me/purchases/cancel-purchase/button.tsx
@@ -45,7 +45,7 @@ export interface CancelPurchaseButtonProps {
 	cancelBundledDomain: boolean;
 	includedDomainPurchase: Purchases.Purchase;
 	disabled?: boolean;
-	textOverride?: string;
+	textVariant?: string;
 	isLinkStyle?: boolean;
 	isInline?: boolean;
 	activeSubscriptions: Array< { id: number; productName: string } >;
@@ -164,33 +164,35 @@ class CancelPurchaseButton extends Component<
 		const needsDomainOptionsStep =
 			this.props.includedDomainPurchase &&
 			! willShowDomainOptionsRadioButtons( this.props.includedDomainPurchase, this.props.purchase );
-		const text =
-			this.props.textOverride ??
-			( () => {
-				if ( includedDomainPurchase && needsDomainOptionsStep ) {
-					return translate( 'Continue with cancellation' );
-				}
+		const text = ( () => {
+			if ( this.props.textVariant === 'remove-plan-and-claim-refund' ) {
+				return translate( 'Remove plan and claim refund' );
+			}
 
-				if ( hasAmountAvailableToRefund( purchase ) ) {
-					if ( isDomainRegistration( purchase ) ) {
-						return translate( 'Cancel domain and refund' );
-					}
-					if ( isSubscription( purchase ) ) {
-						return translate( 'Cancel subscription' );
-					}
-					if ( isOneTimePurchase( purchase ) ) {
-						return translate( 'Cancel and refund' );
-					}
-				}
+			if ( includedDomainPurchase && needsDomainOptionsStep ) {
+				return translate( 'Continue with cancellation' );
+			}
 
+			if ( hasAmountAvailableToRefund( purchase ) ) {
 				if ( isDomainRegistration( purchase ) ) {
-					return translate( 'Cancel domain' );
+					return translate( 'Cancel domain and refund' );
 				}
-
 				if ( isSubscription( purchase ) ) {
 					return translate( 'Cancel subscription' );
 				}
-			} )();
+				if ( isOneTimePurchase( purchase ) ) {
+					return translate( 'Cancel and refund' );
+				}
+			}
+
+			if ( isDomainRegistration( purchase ) ) {
+				return translate( 'Cancel domain' );
+			}
+
+			if ( isSubscription( purchase ) ) {
+				return translate( 'Cancel subscription' );
+			}
+		} )();
 
 		const disableButtons = this.state.disabled || this.props.disabled;
 		const { isJetpack, isAkismet, purchaseListUrl, activeSubscriptions, isLoading, showDialog } =

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -7,9 +7,11 @@ import type { Purchases } from '@automattic/data-stores';
 const CancelPurchaseFeatureList = ( {
 	purchase,
 	cancellationFeatures,
+	useRefundableWpcomCopy = false,
 }: {
 	purchase: Purchases.Purchase;
 	cancellationFeatures: string[];
+	useRefundableWpcomCopy?: boolean;
 } ) => {
 	const translate = useTranslate();
 
@@ -20,7 +22,7 @@ const CancelPurchaseFeatureList = ( {
 	return (
 		<div className="cancel-purchase__features">
 			<p>
-				{ isRefundable( purchase )
+				{ isRefundable( purchase ) || ! useRefundableWpcomCopy
 					? translate(
 							'By canceling the %(productName)s plan, these features will no longer be available on your site:',
 							{

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,7 +1,7 @@
 import { getFeatureByKey } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { getName, isRefundable } from 'calypso/lib/purchases';
+import { getName } from 'calypso/lib/purchases';
 import type { Purchases } from '@automattic/data-stores';
 
 const CancelPurchaseFeatureList = ( {
@@ -22,7 +22,7 @@ const CancelPurchaseFeatureList = ( {
 	return (
 		<div className="cancel-purchase__features">
 			<p>
-				{ isRefundable( purchase ) || ! useRefundableWpcomCopy
+				{ ! useRefundableWpcomCopy
 					? translate(
 							'By canceling the %(productName)s plan, these features will no longer be available on your site:',
 							{

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -27,6 +27,7 @@ import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
+import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	getName,
@@ -329,9 +330,14 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		this.setState( { isLoading: true } );
 
 		try {
-			const result = await this.submitCancelAndRefundPurchase( this.props.purchase );
+			const shouldUseAutoRenewFlow = this.shouldUseAutoRenewFlow( this.props.purchase );
+			const result = shouldUseAutoRenewFlow
+				? await this.cancelPurchase( this.props.purchase )
+				: await this.submitCancelAndRefundPurchase( this.props.purchase );
 			if ( result.success ) {
-				const refundable = hasAmountAvailableToRefund( this.props.purchase );
+				const refundable = shouldUseAutoRenewFlow
+					? false
+					: hasAmountAvailableToRefund( this.props.purchase );
 				await this.handleMarketplaceSubscriptions( refundable );
 				this.props.refreshSitePlans( this.props.purchase.siteId );
 				this.props.clearPurchases();
@@ -590,6 +596,15 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		return null;
 	};
 
+	shouldUseAutoRenewFlow = ( purchase: Purchases.Purchase ) => {
+		return Boolean(
+			config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
+				hasAmountAvailableToRefund( purchase ) &&
+				isPlan( purchase ) &&
+				isWpComPlan( purchase?.productSlug )
+		);
+	};
+
 	getCancelPurchaseButtonProps = () => {
 		const {
 			purchase,
@@ -617,6 +632,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			siteSlug,
 			cancelBundledDomain: this.state.cancelBundledDomain,
 			purchaseListUrl: purchaseListUrl ?? purchasesRoot,
+			flowTypeOverride: this.shouldUseAutoRenewFlow( purchase )
+				? CANCEL_FLOW_TYPE.CANCEL_AUTORENEW
+				: undefined,
 			activeSubscriptions: this.getActiveMarketplaceSubscriptions(),
 			onCancellationStart: this.onCancellationStart,
 			onCancellationComplete: this.onCancellationComplete,
@@ -912,7 +930,11 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						isVisible={ this.state.surveyShown }
 						onClose={ () => this.setState( { surveyShown: false } ) }
 						onSurveyComplete={ this.onSurveyComplete }
-						flowType={ getPurchaseCancellationFlowType( purchase ) }
+						flowType={
+							this.shouldUseAutoRenewFlow( purchase )
+								? CANCEL_FLOW_TYPE.CANCEL_AUTORENEW
+								: getPurchaseCancellationFlowType( purchase )
+						}
 						cancelBundledDomain={ this.state.cancelBundledDomain }
 						includedDomainPurchase={ this.props.includedDomainPurchase }
 						cancellationInProgress={ this.state.isLoading }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -661,19 +661,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			includedDomainPurchase &&
 			! willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase );
 
-		const refundAmountString = this.renderRefundAmountString(
-			purchase,
-			this.state.cancelBundledDomain,
-			includedDomainPurchase
-		);
-		const shouldShowRefundEligibilityNotice = Boolean(
-			config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
-				refundAmountString &&
-				isPlan( purchase ) &&
-				isWpComPlan( purchase?.productSlug )
-		);
-		const cancelButtonProps = this.getCancelPurchaseButtonProps();
-
 		return (
 			<>
 				{ shouldShowDomainOptionsInline && (
@@ -693,13 +680,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				) }
 
 				<BackupRetentionOptionOnCancelPurchase purchase={ purchase } />
-
-				{ shouldShowRefundEligibilityNotice && refundAmountString && (
-					<RefundEligibilityNotice
-						refundAmount={ refundAmountString }
-						cancelButtonProps={ cancelButtonProps }
-					/>
-				) }
 
 				<CancelPurchaseRefundInformation
 					purchase={ purchase }
@@ -903,6 +883,19 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			} );
 		}
 
+		const refundAmountString = this.renderRefundAmountString(
+			purchase,
+			this.state.cancelBundledDomain,
+			this.props.includedDomainPurchase
+		);
+		const shouldShowRefundEligibilityNotice = Boolean(
+			config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
+				refundAmountString &&
+				isPlan( purchase ) &&
+				isWpComPlan( purchase?.productSlug )
+		);
+		const cancelButtonProps = this.getCancelPurchaseButtonProps();
+
 		return (
 			<>
 				{ ! isJetpack && ! isAkismet && ! isDomainRegistrationPurchase && (
@@ -943,6 +936,13 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						headerText={ heading }
 						align="left"
 					/>
+
+					{ shouldShowRefundEligibilityNotice && refundAmountString && (
+						<RefundEligibilityNotice
+							refundAmount={ refundAmountString }
+							cancelButtonProps={ cancelButtonProps }
+						/>
+					) }
 
 					<div className="cancel-purchase__inner-wrapper">
 						<div className="cancel-purchase__left">

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -92,6 +92,7 @@ export interface CancelPurchaseState {
 	domainConfirmationConfirmed: boolean;
 	showDomainOptionsStep: boolean;
 	showDialog: boolean;
+	cancelIntent: 'refund' | 'autorenew' | null;
 }
 
 export interface CancelPurchaseActions {
@@ -148,6 +149,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		showDomainOptionsStep: false,
 		// Cancellation state moved from button component
 		showDialog: false,
+		cancelIntent: null,
 	};
 
 	componentDidMount() {
@@ -330,12 +332,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		this.setState( { isLoading: true } );
 
 		try {
-			const shouldUseAutoRenewFlow = this.shouldUseAutoRenewFlow( this.props.purchase );
-			const result = shouldUseAutoRenewFlow
+			const isAutoRenewIntent = this.state.cancelIntent === 'autorenew';
+			const result = isAutoRenewIntent
 				? await this.cancelPurchase( this.props.purchase )
 				: await this.submitCancelAndRefundPurchase( this.props.purchase );
 			if ( result.success ) {
-				const refundable = shouldUseAutoRenewFlow
+				const refundable = isAutoRenewIntent
 					? false
 					: hasAmountAvailableToRefund( this.props.purchase );
 				await this.handleMarketplaceSubscriptions( refundable );
@@ -355,7 +357,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			this.props.errorNotice( ( error as Error ).message );
 		} finally {
 			// Reset loading state
-			this.setState( { surveyShown: false, isLoading: false } );
+			this.setState( { surveyShown: false, isLoading: false, cancelIntent: null } );
 		}
 	};
 
@@ -363,6 +365,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		this.setState( {
 			showDialog: false,
 			isLoading: false,
+			cancelIntent: null,
 		} );
 	};
 
@@ -601,6 +604,22 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		);
 	};
 
+	getCancelFlowType = ( purchase: Purchases.Purchase ) => {
+		if ( ! this.shouldUseAutoRenewFlow( purchase ) ) {
+			return getPurchaseCancellationFlowType( purchase );
+		}
+
+		if ( this.state.cancelIntent === 'refund' ) {
+			return CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
+		}
+
+		if ( this.state.cancelIntent === 'autorenew' ) {
+			return CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
+		}
+
+		return CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
+	};
+
 	getCancelPurchaseButtonProps = () => {
 		const {
 			purchase,
@@ -628,9 +647,14 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			siteSlug,
 			cancelBundledDomain: this.state.cancelBundledDomain,
 			purchaseListUrl: purchaseListUrl ?? purchasesRoot,
-			flowTypeOverride: this.shouldUseAutoRenewFlow( purchase )
-				? CANCEL_FLOW_TYPE.CANCEL_AUTORENEW
-				: undefined,
+			flowTypeOverride: this.getCancelFlowType( purchase ),
+			onCancelInitiated: () => {
+				if ( this.shouldUseAutoRenewFlow( purchase ) ) {
+					this.setState( { cancelIntent: 'autorenew' } );
+				} else if ( this.state.cancelIntent ) {
+					this.setState( { cancelIntent: null } );
+				}
+			},
 			activeSubscriptions: this.getActiveMarketplaceSubscriptions(),
 			onCancellationStart: this.onCancellationStart,
 			onCancellationComplete: this.onCancellationComplete,
@@ -847,11 +871,14 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						siteSlug={ this.props.siteSlug }
 						cancelBundledDomain={ cancelBundledDomain }
 						purchaseListUrl={ this.props.purchaseListUrl ?? purchasesRoot }
-						flowTypeOverride={
-							this.shouldUseAutoRenewFlow( purchase )
-								? CANCEL_FLOW_TYPE.CANCEL_AUTORENEW
-								: undefined
-						}
+						flowTypeOverride={ this.getCancelFlowType( purchase ) }
+						onCancelInitiated={ () => {
+							if ( this.shouldUseAutoRenewFlow( purchase ) ) {
+								this.setState( { cancelIntent: 'autorenew' } );
+							} else if ( this.state.cancelIntent ) {
+								this.setState( { cancelIntent: null } );
+							}
+						} }
 						activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
 						onCancellationComplete={ this.onCancellationComplete }
 						onSurveyComplete={ this.onSurveyComplete }
@@ -929,11 +956,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						isVisible={ this.state.surveyShown }
 						onClose={ () => this.setState( { surveyShown: false } ) }
 						onSurveyComplete={ this.onSurveyComplete }
-						flowType={
-							this.shouldUseAutoRenewFlow( purchase )
-								? CANCEL_FLOW_TYPE.CANCEL_AUTORENEW
-								: getPurchaseCancellationFlowType( purchase )
-						}
+						flowType={ this.getCancelFlowType( purchase ) }
 						cancelBundledDomain={ this.state.cancelBundledDomain }
 						includedDomainPurchase={ this.props.includedDomainPurchase }
 						cancellationInProgress={ this.state.isLoading }
@@ -969,6 +992,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						<RefundEligibilityNotice
 							refundAmount={ refundAmountString }
 							cancelButtonProps={ cancelButtonProps }
+							onRefundCancelInitiated={ () => this.setState( { cancelIntent: 'refund' } ) }
 						/>
 					) }
 

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -649,7 +649,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		);
 	};
 
-	renderMainContent = () => {
+	renderMainContent = ( options?: { useRefundableWpcomCopy?: boolean } ) => {
 		const { purchase, isJetpackPurchase, includedDomainPurchase, atomicTransfer } = this.props;
 		const plan = getPlan( purchase?.productSlug );
 
@@ -689,6 +689,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				<CancelPurchaseFeatureList
 					purchase={ purchase }
 					cancellationFeatures={ cancellationFeatures }
+					useRefundableWpcomCopy={ options?.useRefundableWpcomCopy }
 				/>
 
 				{ cancellationFeatures.length
@@ -948,7 +949,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						<div className="cancel-purchase__left">
 							{ this.state.showDomainOptionsStep
 								? this.renderDomainOptionsContent()
-								: this.renderMainContent() }
+								: this.renderMainContent( {
+										useRefundableWpcomCopy: shouldShowRefundEligibilityNotice,
+								  } ) }
 						</div>
 
 						<div className="cancel-purchase__right">

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -1,7 +1,9 @@
+import config from '@automattic/calypso-config';
 import {
 	isDomainRegistration,
 	isDomainTransfer,
 	isPlan,
+	isWpComPlan,
 	hasMarketplaceProduct,
 	isJetpackPlan,
 	isJetpackProduct,
@@ -664,7 +666,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			this.state.cancelBundledDomain,
 			includedDomainPurchase
 		);
-		const shouldShowRefundEligibilityNotice = Boolean( refundAmountString && isPlan( purchase ) );
+		const shouldShowRefundEligibilityNotice = Boolean(
+			config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
+				refundAmountString &&
+				isPlan( purchase ) &&
+				isWpComPlan( purchase?.productSlug )
+		);
 		const cancelButtonProps = this.getCancelPurchaseButtonProps();
 
 		return (

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -68,6 +68,7 @@ import AtomicRevertChanges from './atomic-revert-changes';
 import CancelPurchaseButton from './button';
 import CancelPurchaseDomainOptions, { willShowDomainOptionsRadioButtons } from './domain-options';
 import CancelPurchaseFeatureList from './feature-list';
+import RefundEligibilityNotice from './refund-eligibility-notice';
 import CancelPurchaseRefundInformation from './refund-information';
 import type { Purchases, SiteDetails } from '@automattic/data-stores';
 import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
@@ -581,7 +582,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		return null;
 	};
 
-	renderCancelButton = () => {
+	getCancelPurchaseButtonProps = () => {
 		const {
 			purchase,
 			includedDomainPurchase,
@@ -601,28 +602,32 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				isPlan( purchase ) ) ||
 			( isDomainRegistrationPurchase && ! this.state.domainConfirmationConfirmed );
 
-		return (
-			<CancelPurchaseButton
-				purchase={ purchase }
-				includedDomainPurchase={ includedDomainPurchase }
-				disabled={ isDisabled }
-				siteSlug={ siteSlug }
-				cancelBundledDomain={ this.state.cancelBundledDomain }
-				purchaseListUrl={ purchaseListUrl ?? purchasesRoot }
-				activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
-				onCancellationStart={ this.onCancellationStart }
-				onCancellationComplete={ this.onCancellationComplete }
-				onSurveyComplete={ this.onSurveyComplete }
-				moment={ this.props.moment }
-				// Cancellation state props
-				showDialog={ this.state.showDialog }
-				isLoading={ this.state.isLoading }
-				onDialogClose={ this.onDialogClose }
-				onSetLoading={ this.onSetLoading }
-				downgradeClick={ this.downgradeClick }
-				freeMonthOfferClick={ this.freeMonthOfferClick }
-			/>
-		);
+		return {
+			purchase,
+			includedDomainPurchase,
+			disabled: isDisabled,
+			siteSlug,
+			cancelBundledDomain: this.state.cancelBundledDomain,
+			purchaseListUrl: purchaseListUrl ?? purchasesRoot,
+			activeSubscriptions: this.getActiveMarketplaceSubscriptions(),
+			onCancellationStart: this.onCancellationStart,
+			onCancellationComplete: this.onCancellationComplete,
+			onSurveyComplete: this.onSurveyComplete,
+			moment: this.props.moment,
+			// Cancellation state props
+			showDialog: this.state.showDialog,
+			isLoading: this.state.isLoading,
+			onDialogClose: this.onDialogClose,
+			onSetLoading: this.onSetLoading,
+			downgradeClick: this.downgradeClick,
+			freeMonthOfferClick: this.freeMonthOfferClick,
+		};
+	};
+
+	renderCancelButton = () => {
+		const cancelButtonProps = this.getCancelPurchaseButtonProps();
+
+		return <CancelPurchaseButton { ...cancelButtonProps } />;
 	};
 
 	renderKeepSubscriptionButton = () => {
@@ -654,6 +659,14 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			includedDomainPurchase &&
 			! willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase );
 
+		const refundAmountString = this.renderRefundAmountString(
+			purchase,
+			this.state.cancelBundledDomain,
+			includedDomainPurchase
+		);
+		const shouldShowRefundEligibilityNotice = Boolean( refundAmountString && isPlan( purchase ) );
+		const cancelButtonProps = this.getCancelPurchaseButtonProps();
+
 		return (
 			<>
 				{ shouldShowDomainOptionsInline && (
@@ -673,6 +686,13 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				) }
 
 				<BackupRetentionOptionOnCancelPurchase purchase={ purchase } />
+
+				{ shouldShowRefundEligibilityNotice && refundAmountString && (
+					<RefundEligibilityNotice
+						refundAmount={ refundAmountString }
+						cancelButtonProps={ cancelButtonProps }
+					/>
+				) }
 
 				<CancelPurchaseRefundInformation
 					purchase={ purchase }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -656,7 +656,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			siteSlug,
 			cancelBundledDomain: this.state.cancelBundledDomain,
 			purchaseListUrl: purchaseListUrl ?? purchasesRoot,
-			cancelIntentOverride: this.shouldUseAutoRenewFlow( purchase ) ? 'autorenew' : undefined,
+			cancelIntentOverride: this.shouldUseAutoRenewFlow( purchase )
+				? ( 'autorenew' as const )
+				: undefined,
 			activeSubscriptions: this.getActiveMarketplaceSubscriptions(),
 			onCancellationStart: this.onCancellationStart,
 			onCancellationComplete: this.onCancellationComplete,
@@ -873,7 +875,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						siteSlug={ this.props.siteSlug }
 						cancelBundledDomain={ cancelBundledDomain }
 						purchaseListUrl={ this.props.purchaseListUrl ?? purchasesRoot }
-						cancelIntentOverride={ this.state.cancelIntent ?? undefined }
+						cancelIntentOverride={
+							this.state.cancelIntent !== null ? this.state.cancelIntent : undefined
+						}
 						activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
 						onCancellationComplete={ this.onCancellationComplete }
 						onSurveyComplete={ this.onSurveyComplete }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -515,8 +515,14 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			this.state.cancelBundledDomain,
 			includedDomainPurchase
 		);
+		const shouldUseDefaultFullText = Boolean(
+			config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
+				refundAmountString &&
+				isPlan( purchase ) &&
+				isWpComPlan( purchase?.productSlug )
+		);
 
-		if ( refundAmountString ) {
+		if ( refundAmountString && ! shouldUseDefaultFullText ) {
 			return translate(
 				'If you confirm this cancellation, you will receive a {{span}}refund of %(refundText)s{{/span}}, and your subscription will be removed immediately.',
 				{

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -939,10 +939,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		// When a plan has an included domain that can be cancelled together,
 		// show the higher (full) refund amount in the notice since the user
 		// can get this amount by choosing to cancel both.
+		const includedDomainHasRadioButtons =
+			this.props.includedDomainPurchase &&
+			willShowDomainOptionsRadioButtons( this.props.includedDomainPurchase, purchase );
 		const refundAmountString = this.renderRefundAmountString(
 			purchase,
-			willShowDomainOptionsRadioButtons( this.props.includedDomainPurchase, purchase ) ||
-				this.state.cancelBundledDomain,
+			includedDomainHasRadioButtons || this.state.cancelBundledDomain,
 			this.props.includedDomainPurchase
 		);
 		const shouldShowRefundEligibilityNotice =

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -217,7 +217,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		} ) );
 	};
 
-	onCancellationStart = () => {
+	onCancellationStart = ( intent?: 'refund' | 'autorenew' ) => {
 		const { includedDomainPurchase, purchase, isJetpack, isAkismet, isDomainRegistrationPurchase } =
 			this.props;
 
@@ -227,8 +227,17 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			return;
 		}
 
+		if ( intent && this.state.cancelIntent !== intent ) {
+			this.setState( { cancelIntent: intent } );
+		}
+
+		const shouldUseAutoRenewFlow = this.shouldUseAutoRenewFlow( purchase );
+		const effectiveIntent = intent ?? this.state.cancelIntent;
+		const shouldSkipDomainOptions = shouldUseAutoRenewFlow && effectiveIntent !== 'refund';
+
 		// Only show domain options as a separate step if radio buttons will be displayed
 		if (
+			! shouldSkipDomainOptions &&
 			includedDomainPurchase &&
 			willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase )
 		) {
@@ -647,14 +656,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			siteSlug,
 			cancelBundledDomain: this.state.cancelBundledDomain,
 			purchaseListUrl: purchaseListUrl ?? purchasesRoot,
-			flowTypeOverride: this.getCancelFlowType( purchase ),
-			onCancelInitiated: () => {
-				if ( this.shouldUseAutoRenewFlow( purchase ) ) {
-					this.setState( { cancelIntent: 'autorenew' } );
-				} else if ( this.state.cancelIntent ) {
-					this.setState( { cancelIntent: null } );
-				}
-			},
+			cancelIntentOverride: this.shouldUseAutoRenewFlow( purchase ) ? 'autorenew' : undefined,
 			activeSubscriptions: this.getActiveMarketplaceSubscriptions(),
 			onCancellationStart: this.onCancellationStart,
 			onCancellationComplete: this.onCancellationComplete,
@@ -871,14 +873,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						siteSlug={ this.props.siteSlug }
 						cancelBundledDomain={ cancelBundledDomain }
 						purchaseListUrl={ this.props.purchaseListUrl ?? purchasesRoot }
-						flowTypeOverride={ this.getCancelFlowType( purchase ) }
-						onCancelInitiated={ () => {
-							if ( this.shouldUseAutoRenewFlow( purchase ) ) {
-								this.setState( { cancelIntent: 'autorenew' } );
-							} else if ( this.state.cancelIntent ) {
-								this.setState( { cancelIntent: null } );
-							}
-						} }
+						cancelIntentOverride={ this.state.cancelIntent ?? undefined }
 						activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
 						onCancellationComplete={ this.onCancellationComplete }
 						onSurveyComplete={ this.onSurveyComplete }
@@ -992,7 +987,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						<RefundEligibilityNotice
 							refundAmount={ refundAmountString }
 							cancelButtonProps={ cancelButtonProps }
-							onRefundCancelInitiated={ () => this.setState( { cancelIntent: 'refund' } ) }
 						/>
 					) }
 

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -987,12 +987,14 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						align="left"
 					/>
 
-					{ shouldShowRefundEligibilityNotice && refundAmountString && (
-						<RefundEligibilityNotice
-							refundAmount={ refundAmountString }
-							cancelButtonProps={ cancelButtonProps }
-						/>
-					) }
+					{ shouldShowRefundEligibilityNotice &&
+						refundAmountString &&
+						! this.state.showDomainOptionsStep && (
+							<RefundEligibilityNotice
+								refundAmount={ refundAmountString }
+								cancelButtonProps={ cancelButtonProps }
+							/>
+						) }
 
 					<div className="cancel-purchase__inner-wrapper">
 						<div className="cancel-purchase__left">

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -521,14 +521,10 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			this.state.cancelBundledDomain,
 			includedDomainPurchase
 		);
-		const shouldUseDefaultFullText = Boolean(
-			config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
-				refundAmountString &&
-				isPlan( purchase ) &&
-				isWpComPlan( purchase?.productSlug )
-		);
+		const shouldDisplayRefundNotice =
+			Boolean( refundAmountString ) && this.shouldUseAutoRenewFlow( purchase );
 
-		if ( refundAmountString && ! shouldUseDefaultFullText ) {
+		if ( refundAmountString && ! shouldDisplayRefundNotice ) {
 			return translate(
 				'If you confirm this cancellation, you will receive a {{span}}refund of %(refundText)s{{/span}}, and your subscription will be removed immediately.',
 				{
@@ -708,6 +704,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 				<CancelPurchaseRefundInformation
 					purchase={ purchase }
 					isJetpackPurchase={ isJetpackPurchase }
+					useAutoRenewFlow={ this.shouldUseAutoRenewFlow( purchase ) }
 				/>
 
 				<CancelPurchaseFeatureList
@@ -850,6 +847,11 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						siteSlug={ this.props.siteSlug }
 						cancelBundledDomain={ cancelBundledDomain }
 						purchaseListUrl={ this.props.purchaseListUrl ?? purchasesRoot }
+						flowTypeOverride={
+							this.shouldUseAutoRenewFlow( purchase )
+								? CANCEL_FLOW_TYPE.CANCEL_AUTORENEW
+								: undefined
+						}
 						activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
 						onCancellationComplete={ this.onCancellationComplete }
 						onSurveyComplete={ this.onSurveyComplete }
@@ -913,12 +915,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			this.state.cancelBundledDomain,
 			this.props.includedDomainPurchase
 		);
-		const shouldShowRefundEligibilityNotice = Boolean(
-			config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
-				refundAmountString &&
-				isPlan( purchase ) &&
-				isWpComPlan( purchase?.productSlug )
-		);
+		const shouldShowRefundEligibilityNotice =
+			Boolean( refundAmountString ) && this.shouldUseAutoRenewFlow( purchase );
+
 		const cancelButtonProps = this.getCancelPurchaseButtonProps();
 
 		return (

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -936,9 +936,13 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			} );
 		}
 
+		// When a plan has an included domain that can be cancelled together,
+		// show the higher (full) refund amount in the notice since the user
+		// can get this amount by choosing to cancel both.
 		const refundAmountString = this.renderRefundAmountString(
 			purchase,
-			this.state.cancelBundledDomain,
+			willShowDomainOptionsRadioButtons( this.props.includedDomainPurchase, purchase ) ||
+				this.state.cancelBundledDomain,
 			this.props.includedDomainPurchase
 		);
 		const shouldShowRefundEligibilityNotice =

--- a/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -7,13 +7,11 @@ import type moment from 'moment';
 interface RefundEligibilityNoticeProps {
 	refundAmount: string;
 	cancelButtonProps: CancelPurchaseButtonProps & { moment: typeof moment };
-	onRefundCancelInitiated: () => void;
 }
 
 const RefundEligibilityNotice = ( {
 	refundAmount,
 	cancelButtonProps,
-	onRefundCancelInitiated,
 }: RefundEligibilityNoticeProps ) => {
 	const translate = useTranslate();
 
@@ -32,7 +30,7 @@ const RefundEligibilityNotice = ( {
 					textVariant="remove-plan-and-claim-refund"
 					isLinkStyle
 					isInline
-					onCancelInitiated={ onRefundCancelInitiated }
+					cancelIntentOverride="refund"
 				/>
 			</p>
 		</Notice>

--- a/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -27,7 +27,7 @@ const RefundEligibilityNotice = ( {
 				) }{ ' ' }
 				<CancelPurchaseButton
 					{ ...cancelButtonProps }
-					textOverride={ translate( 'Remove plan and claim refund.' ) }
+					textVariant="remove-plan-and-claim-refund"
 					isLinkStyle
 					isInline
 				/>

--- a/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -7,11 +7,13 @@ import type moment from 'moment';
 interface RefundEligibilityNoticeProps {
 	refundAmount: string;
 	cancelButtonProps: CancelPurchaseButtonProps & { moment: typeof moment };
+	onRefundCancelInitiated: () => void;
 }
 
 const RefundEligibilityNotice = ( {
 	refundAmount,
 	cancelButtonProps,
+	onRefundCancelInitiated,
 }: RefundEligibilityNoticeProps ) => {
 	const translate = useTranslate();
 
@@ -30,6 +32,7 @@ const RefundEligibilityNotice = ( {
 					textVariant="remove-plan-and-claim-refund"
 					isLinkStyle
 					isInline
+					onCancelInitiated={ onRefundCancelInitiated }
 				/>
 			</p>
 		</Notice>

--- a/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -1,0 +1,39 @@
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
+import CancelPurchaseButton from './button';
+import type { CancelPurchaseButtonProps } from './button';
+import type moment from 'moment';
+
+interface RefundEligibilityNoticeProps {
+	refundAmount: string;
+	cancelButtonProps: CancelPurchaseButtonProps & { moment: typeof moment };
+}
+
+const RefundEligibilityNotice = ( {
+	refundAmount,
+	cancelButtonProps,
+}: RefundEligibilityNoticeProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<Notice className="cancel-purchase__refund-eligibility-notice" showDismiss={ false }>
+			<p className="cancel-purchase__refund-eligibility-text">
+				{ translate(
+					"You're eligible for a %(refundText)s refund if you remove your plan now. Your features will be unavailable right away.",
+					{
+						args: { refundText: refundAmount },
+						context: 'refundText is a monetary amount in the form "[currency-symbol][amount]"',
+					}
+				) }{ ' ' }
+				<CancelPurchaseButton
+					{ ...cancelButtonProps }
+					textOverride={ translate( 'Remove plan and claim refund.' ) }
+					isLinkStyle
+					isInline
+				/>
+			</p>
+		</Notice>
+	);
+};
+
+export default RefundEligibilityNotice;

--- a/client/me/purchases/cancel-purchase/refund-information.tsx
+++ b/client/me/purchases/cancel-purchase/refund-information.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { isDomainRegistration } from '@automattic/calypso-products';
 import { Purchases } from '@automattic/data-stores';
 import i18n from 'i18n-calypso';

--- a/client/me/purchases/cancel-purchase/refund-information.tsx
+++ b/client/me/purchases/cancel-purchase/refund-information.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { isDomainRegistration } from '@automattic/calypso-products';
+import { isDomainRegistration, isWpComPlan } from '@automattic/calypso-products';
 import { Purchases } from '@automattic/data-stores';
 import i18n from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -52,7 +52,21 @@ const CancelPurchaseRefundInformation = ( {
 			}
 		}
 
-		if ( isSubscription( purchase ) ) {
+		if (
+			isSubscription( purchase ) &&
+			config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
+			isWpComPlan( purchase?.productSlug )
+		) {
+			text = i18n.translate(
+				"When you cancel your subscription, you'll be able to use %(productName)s until your subscription expires. " +
+					'Once it expires, it will be automatically removed from your site.',
+				{
+					args: {
+						productName: getName( purchase ),
+					},
+				}
+			);
+		} else if ( isSubscription( purchase ) ) {
 			text = [
 				i18n.translate(
 					"We're sorry to hear the %(productName)s plan didn't fit your current needs, but thank you for giving it a try.",

--- a/client/me/purchases/cancel-purchase/refund-information.tsx
+++ b/client/me/purchases/cancel-purchase/refund-information.tsx
@@ -1,5 +1,4 @@
-import config from '@automattic/calypso-config';
-import { isDomainRegistration, isWpComPlan } from '@automattic/calypso-products';
+import { isDomainRegistration } from '@automattic/calypso-products';
 import { Purchases } from '@automattic/data-stores';
 import i18n from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -20,12 +19,14 @@ export interface CancelPurchaseRefundInformationConnectedProps {
 export interface CancelPurchaseRefundInformationProps {
 	purchase: Purchases.Purchase;
 	isJetpackPurchase: boolean;
+	useAutoRenewFlow?: boolean;
 }
 
 const CancelPurchaseRefundInformation = ( {
 	purchase,
 	isGravatarRestrictedDomain,
 	isJetpackPurchase,
+	useAutoRenewFlow,
 }: CancelPurchaseRefundInformationProps & CancelPurchaseRefundInformationConnectedProps ) => {
 	const { refundPeriodInDays } = purchase;
 	let text;
@@ -52,11 +53,7 @@ const CancelPurchaseRefundInformation = ( {
 			}
 		}
 
-		if (
-			isSubscription( purchase ) &&
-			config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
-			isWpComPlan( purchase?.productSlug )
-		) {
+		if ( isSubscription( purchase ) && useAutoRenewFlow ) {
 			text = i18n.translate(
 				"When you cancel your subscription, you'll be able to use %(productName)s until your subscription expires. " +
 					'Once it expires, it will be automatically removed from your site.',

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -219,9 +219,10 @@
 	display: inline;
 }
 
-.cancel-purchase__button--link {
+.cancel-purchase__refund-eligibility-notice .cancel-purchase__button.cancel-purchase__button--link {
+	margin: 0;
 	background: none;
-	color: var(--color-link);
+	color: var(--color-text-inverted);
 	font-size: inherit;
 	font-weight: 400;
 	height: auto;
@@ -231,7 +232,7 @@
 
 	&:hover,
 	&:focus {
-		color: var(--color-link-dark);
+		color: var(--color-text-inverted);
 	}
 }
 

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -205,6 +205,10 @@
 
 .cancel-purchase__refund-eligibility-notice {
 	margin: 16px 0;
+
+	.calypso-notice__icon-wrapper {
+	    background: var(--color-primary);
+	}
 }
 
 .cancel-purchase__refund-eligibility-text {

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -203,6 +203,34 @@
 	}
 }
 
+.cancel-purchase__refund-eligibility-notice {
+	margin: 16px 0;
+}
+
+.cancel-purchase__refund-eligibility-text {
+	margin: 0;
+}
+
+.cancel-purchase__button-wrapper--inline {
+	display: inline;
+}
+
+.cancel-purchase__button--link {
+	background: none;
+	color: var(--color-link);
+	font-size: inherit;
+	font-weight: 400;
+	height: auto;
+	line-height: inherit;
+	padding: 0;
+	text-decoration: underline;
+
+	&:hover,
+	&:focus {
+		color: var(--color-link-dark);
+	}
+}
+
 .cancel-purchase__button {
 	@include breakpoint-deprecated( "<660px" ) {
 		width: 100%;
@@ -275,4 +303,3 @@
 		}
 	}
 }
-

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -47,6 +47,8 @@
 }
 
 .cancel-purchase__domain-options {
+	margin-bottom: 16px;
+
 	.card {
 		margin: 16px 0;
 	}

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -209,7 +209,7 @@
 	margin: 16px 0;
 
 	.calypso-notice__icon-wrapper {
-	    background: var(--color-primary);
+		background: var(--color-primary);
 	}
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -43,7 +43,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/refund-eligibility-notice": true,
+		"calypso/refund-eligibility-notice": false,
 		"checkout/checkout-version": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,

--- a/config/development.json
+++ b/config/development.json
@@ -43,6 +43,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/refund-eligibility-notice": true,
 		"checkout/checkout-version": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15961

## Proposed Changes

* Separate cancellations from refunds for WPCOM plans in the old purchases management
* The idea is that when users are within their refund period, we do not offer cancel without refund, and this is industry standard

## Why are these changes being made?
*

## Testing Instructions

When visiting the purchase details screen from Calypso, add ?flags=calypso/refund-eligibility-notice to enable the new behavior.

There are two reasons for the flag:
- I'd like to deploy it and iterate on some issues that the old cancel flow currently has before enabling it
- I'd like to ensure the control behavior works
- It's possible that we'll experiment it

The new screens:

<img width="45%" alt="eligibility-notice-refund-options" src="https://github.com/user-attachments/assets/c6a32dd4-5c51-4114-87c8-d839b32281ff" />

With domains refundable on the backend (the amount is already correct):
<img width="45%" alt="eligibility-notice-1" src="https://github.com/user-attachments/assets/8d14289b-a702-4d98-b0ba-60deeccb111a" />

When Cancel is clicked (note - no mention of refund and the final result is disabling the automatic renewal, cancelling without plan removal and refund):
<img width="45%" alt="cancel-plan-no-refund" src="https://github.com/user-attachments/assets/dc65c4f0-a535-459b-a45f-3ab2088f7b01" />

When Refund is clicked:
<img width="45%" alt="cancel-plan-and-refund" src="https://github.com/user-attachments/assets/3bc8690a-aba0-44a4-b367-888406e3d9a0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
