### PR TITLE
Fix size of image when deleting default payment_method

### DIFF
--- a/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
@@ -49,7 +49,11 @@ const PaymentMethodDeleteDialog = ( {
 			<DialogContent className="payment-method-delete-dialog__content">
 				<div className="payment-method-delete-dialog__explanation">
 					{ isCreditCard( card ) && (
-						<img src={ getPaymentMethodImageURL( card?.card_type ) } alt="" />
+						<img
+							className="payment-method-delete-dialog__image"
+							src={ getPaymentMethodImageURL( card?.card_type ) }
+							alt=""
+						/>
 					) }
 					<p>
 						{ translate(

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -177,6 +177,10 @@ $card_width: $font-body * 3.75; // roughly 60px wide
 		align-items: flex-start;
 	}
 
+	&__image {
+		max-width: 60px;
+	}
+
 	&__header {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [SHILL-1516: Investigate implementing Ebanx Pix for recurring payments](https://linear.app/a8c/issue/SHILL-1516/investigate-implementing-ebanx-pix-for-recurring-payments)

## Proposed Changes

* Fix size of PM image in deletion modal

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* How it appears at the moment

<img width="1188" height="910" alt="Screenshot 2026-02-05 at 16 15 46" src="https://github.com/user-attachments/assets/65ec0167-9942-4f83-8a2f-16d423e695f4" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on deleting a Pix payment method from https://wordpress.com/me/purchases/payment-methods
* You should now see a better layout

<img width="988" height="508" alt="Screenshot 2026-02-05 at 17 48 12" src="https://github.com/user-attachments/assets/4958ef67-28ed-44b6-9deb-bacdd70f960f" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
