### PR TITLE
Agents Manager: Fix picker-related styles

### DIFF
--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -85,7 +85,7 @@
 	}
 }
 
-body.wp-admin.agents-manager-sidebar-container--sidebar-open:not(.modal-open) {
+body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) {
 	@include wp-admin-sidebar-open-specific( $admin-menu-width-classic );
 	@include notice-panel-open( '#wpnt-notes-panel2' );
 
@@ -101,7 +101,7 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not(.modal-open) {
 		border: 1px solid $border-color;
 		border-bottom: none;
 		box-sizing: border-box;
-		height: calc( var(--masterbar-height) + 1px );
+		height: calc( var( --masterbar-height ) + 1px );
 	}
 
 	#adminmenuback,
@@ -186,7 +186,7 @@ body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-c
 			border: 1px solid $border-color;
 			border-bottom: none;
 			box-sizing: border-box;
-			height: calc( var(--masterbar-height) + 1px );
+			height: calc( var( --masterbar-height ) + 1px );
 
 			.masterbar__section.masterbar__section--left {
 				overflow: hidden;
@@ -285,12 +285,16 @@ body.site-editor-php.agents-manager-sidebar-container {
 }
 
 // Fix for the search categories fixed top position on the plugins marketplace page
-.agents-manager-sidebar-container--sidebar-open .layout__secondary ~ .layout__primary .plugins-browser--site-view .search-categories.fixed-top {
+.agents-manager-sidebar-container--sidebar-open
+	.layout__secondary
+	~ .layout__primary
+	.plugins-browser--site-view
+	.search-categories.fixed-top {
 	top: calc( $admin-bar-height + $layout-spacing + 1px );
 	left: -174px;
 	padding-top: 11px;
 	max-width: 1028px;
-	border-bottom: 1px solid var(--color-neutral-5);
+	border-bottom: 1px solid var( --color-neutral-5 );
 
 	&::after {
 		display: none;
@@ -311,7 +315,7 @@ body.post-php.agents-manager-sidebar-container {
 	}
 }
 
-body:not(.modal-open) .agents-manager-chat--docked {
+body:not( .modal-open ) .agents-manager-chat--docked {
 	visibility: hidden;
 	position: fixed;
 	top: 0;
@@ -441,7 +445,7 @@ body:not(.modal-open) .agents-manager-chat--docked {
 /* Agenttic UI: Styles for both docked and undocked chat */
 .agenttic {
 	.Message-module_message ul {
-		margin-left: var(--spacing-2);
+		margin-left: var( --spacing-2 );
 	}
 
 	.Messages-module_container {
@@ -454,6 +458,24 @@ body:not(.modal-open) .agents-manager-chat--docked {
 		.EmptyView-module_container {
 			height: auto;
 			padding-block: 8px;
+		}
+
+		.big-sky__completed-plan:first-child {
+			margin-top: 0;
+		}
+
+		.big-sky-next-step-button {
+			margin-top: 20px;
+		}
+
+		// Add spacing after picker messages when followed by a message without completed-plan
+		.Message-module_message:has(
+				.big-sky__dock__menu__variation-picker,
+				.big-sky__dock__menu__pattern-picker
+			):has( + .Message-module_message ):not(
+				:has( + .Message-module_message .big-sky__completed-plan )
+			) {
+			margin-bottom: 24px;
 		}
 	}
 
@@ -570,7 +592,7 @@ body:not(.modal-open) .agents-manager-chat--docked {
 				&:hover {
 					color: $white;
 					background-color: #cc1818;
-					filter: brightness(90%);
+					filter: brightness( 90% );
 				}
 			}
 
@@ -612,17 +634,13 @@ body:not(.modal-open) .agents-manager-chat--docked {
 		max-width: 190px;
 	}
 
-	.big-sky__chat-actions::before:not(.has-confirmation-actions),
-	.big-sky__chat-actions::after:not(.has-confirmation-actions) {
-		backdrop-filter: blur(8px);
-		content: "";
+	.big-sky__chat-actions::before:not( .has-confirmation-actions ),
+	.big-sky__chat-actions::after:not( .has-confirmation-actions ) {
+		backdrop-filter: blur( 8px );
+		content: '';
 		height: 100%;
 		left: 0;
-		mask: linear-gradient(
-			to left,
-			rgba(255, 255, 255, 0.1),
-			rgba(255, 255, 255, 1)
-		);
+		mask: linear-gradient( to left, rgba( 255, 255, 255, 0.1 ), rgba( 255, 255, 255, 1 ) );
 		position: fixed;
 		top: 0;
 		width: 20px;
@@ -631,11 +649,7 @@ body:not(.modal-open) .agents-manager-chat--docked {
 	}
 
 	.big-sky__chat-actions::after {
-		mask: linear-gradient(
-			to right,
-			rgba(255, 255, 255, 0.1),
-			rgba(255, 255, 255, 1)
-		);
+		mask: linear-gradient( to right, rgba( 255, 255, 255, 0.1 ), rgba( 255, 255, 255, 1 ) );
 		left: auto;
 		right: 0;
 	}
@@ -881,7 +895,7 @@ body:not(.modal-open) .agents-manager-chat--docked {
 
 	ul {
 		list-style: disc;
-		margin-top: var(--spacing-3);
+		margin-top: var( --spacing-3 );
 	}
 
 	.Messages-module_container.Messages-module_emptyState {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of AI-847

## Proposed Changes

* Fix picker-related styles
* Format code

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See AI-847

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* The pickers' layout in a new convo has been fixed:

| Before | After |
| - | - |
| <img width="387" height="530" alt="截圖 2026-02-06 凌晨2 08 31" src="https://github.com/user-attachments/assets/e9207d7a-938c-4fdb-8f18-a42da6d25fd1" /> | <img width="387" height="530" alt="截圖 2026-02-06 凌晨2 10 38" src="https://github.com/user-attachments/assets/6883f9e1-d617-4d5e-917e-64be6690ae55" /> |

* The pickers' layout in a past convo has been fixed:

| Before | After |
| - | - |
| <img width="387" height="530" alt="截圖 2026-02-06 凌晨2 08 05" src="https://github.com/user-attachments/assets/5b0ecc50-be8b-424b-a24f-6efd32ecb868" /> | <img width="387" height="530" alt="截圖 2026-02-06 凌晨2 07 19" src="https://github.com/user-attachments/assets/c2a6ddf9-8e80-4680-86cb-a7fd5d8cd588" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
