### PR TITLE
Agents Manager: fixes for Jetpack

### DIFF
--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-jetpack.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-jetpack.scss
@@ -1,5 +1,10 @@
-body.wp-admin.agents-manager-sidebar-container--sidebar-open:not(.modal-open) {
-	&:is([class*="jetpack_page_"], .toplevel_page_jetpack, .tools_page_advertising) {
+body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) {
+	&:is(
+			[class*='jetpack_page_'],
+			[class*='plugins_page_wpcom-'],
+			.toplevel_page_jetpack,
+			.tools_page_advertising
+		) {
 		#wpwrap {
 			background-color: inherit;
 			position: inherit;
@@ -7,6 +12,12 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not(.modal-open) {
 
 		#wpbody {
 			padding-left: 0;
+		}
+	}
+
+	&.plugins_page_wpcom-install-plugin {
+		#wpwrap #wpcontent {
+			min-height: inherit;
 		}
 	}
 }

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-jetpack.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-jetpack.scss
@@ -1,7 +1,14 @@
-.agents-manager-sidebar-container--sidebar-open {
-	&.jetpack_page_my-jetpack {
+body.wp-admin.agents-manager-sidebar-container--sidebar-open:not(.modal-open) {
+	&.jetpack_page_jetpack-search,
+	&.jetpack_page_my-jetpack,
+	&.toplevel_page_jetpack {
 		#wpwrap {
 			background-color: inherit;
+			position: inherit;
+		}
+
+		#wpbody {
+			padding-left: 0;
 		}
 	}
 }

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-jetpack.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-jetpack.scss
@@ -1,0 +1,7 @@
+.agents-manager-sidebar-container--sidebar-open {
+	&.jetpack_page_my-jetpack {
+		#wpwrap {
+			background-color: inherit;
+		}
+	}
+}

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-jetpack.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-jetpack.scss
@@ -1,8 +1,5 @@
 body.wp-admin.agents-manager-sidebar-container--sidebar-open:not(.modal-open) {
-	&.jetpack_page_akismet-key-config,
-	&.jetpack_page_jetpack-search,
-	&.jetpack_page_my-jetpack,
-	&.toplevel_page_jetpack {
+	&:is([class*="jetpack_page_"], .toplevel_page_jetpack, .tools_page_advertising) {
 		#wpwrap {
 			background-color: inherit;
 			position: inherit;

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-jetpack.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/fixes-jetpack.scss
@@ -1,4 +1,5 @@
 body.wp-admin.agents-manager-sidebar-container--sidebar-open:not(.modal-open) {
+	&.jetpack_page_akismet-key-config,
 	&.jetpack_page_jetpack-search,
 	&.jetpack_page_my-jetpack,
 	&.toplevel_page_jetpack {

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -164,6 +164,7 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not(.modal-open) {
 
 // Import fixes for specific pages. This is done after the base styles are applied to ensure the fixes are applied after the base styles.
 @import './fixes-woocommerce.scss';
+@import './fixes-jetpack.scss';
 
 /* Calypso */
 body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-container {

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -167,7 +167,7 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not(.modal-open) {
 @import './fixes-jetpack.scss';
 
 /* Calypso */
-body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-container {
+body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-container:not(.wp-admin) {
 	@include sidebar-base( '#wpcom #content' );
 
 	#content {


### PR DESCRIPTION
Various fixes for Jetpack pages when a docked Agents Manager is visible.

<img width="2454" height="488" alt="image" src="https://github.com/user-attachments/assets/08c8aee8-0b39-42e8-9f78-c170670e6045" />

Fixes AI-860
Fixes AI-861
Fixes AI-862

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `cd apps/agents-manager`
* `yarn dev --sync`
* Visit various Jetpack pages
  * Tools > Advertising - no border and full width (see first screenshot)
  * Activity Pub - no gap on the left of the content
* Install Big Sky using the new local instructions and test Jetpack pages there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
