### PR TITLE
Reader: Adds "New Subscription" page

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -10,6 +10,7 @@ import FeedError from 'calypso/reader/feed-error';
 import StreamComponent from 'calypso/reader/following/main';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { recordTrack } from 'calypso/reader/stats';
+import { getCurrentTabFromURL } from 'calypso/reader/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getLastPath } from 'calypso/state/reader-ui/selectors';
 import { toggleReaderSidebarFollowing } from 'calypso/state/reader-ui/sidebar/actions';
@@ -25,6 +26,8 @@ import {
 	setPageTitle,
 	getStartDate,
 } from './controller-helper';
+import { NEW_SUBSCRIPTION_TABS } from './new-subscription';
+import { isDiscoverV3Enabled } from './utils';
 
 const analyticsPageTitle = 'Reader';
 
@@ -94,6 +97,25 @@ export function following( context, next ) {
 		onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 		feedId: context.params.feed_id,
 	} );
+	next();
+}
+
+export function loadNewSubscriptionPage( context, next ) {
+	if ( isDiscoverV3Enabled() ) {
+		const selectedTab = getCurrentTabFromURL(
+			context.path,
+			'reader/new',
+			NEW_SUBSCRIPTION_TABS.ADD_NEW
+		);
+		context.primary = (
+			<AsyncLoad require="calypso/reader/new-subscription" selectedTab={ selectedTab } />
+		);
+
+		trackPageLoad( '/reader/new', 'Reader > New Subscription', 'reader-new-subscription' );
+	} else {
+		page.redirect( '/reader/subscriptions' );
+	}
+
 	next();
 }
 
@@ -319,7 +341,7 @@ export async function siteSubscriptionsManager( context, next ) {
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
 	context.primary = <AsyncLoad require="calypso/reader/site-subscriptions-manager" />;
-	return next();
+	next();
 }
 
 export async function siteSubscription( context, next ) {
@@ -347,7 +369,7 @@ export async function siteSubscription( context, next ) {
 			transition={ context.query.transition === 'true' }
 		/>
 	);
-	return next();
+	next();
 }
 
 export async function commentSubscriptionsManager( context, next ) {
@@ -359,7 +381,7 @@ export async function commentSubscriptionsManager( context, next ) {
 	context.primary = (
 		<AsyncLoad require="calypso/reader/site-subscriptions-manager/comment-subscriptions-manager" />
 	);
-	return next();
+	next();
 }
 
 export async function pendingSubscriptionsManager( context, next ) {
@@ -371,7 +393,7 @@ export async function pendingSubscriptionsManager( context, next ) {
 	context.primary = (
 		<AsyncLoad require="calypso/reader/site-subscriptions-manager/pending-subscriptions-manager" />
 	);
-	return next();
+	next();
 }
 
 /**

--- a/client/reader/discover/components/navigation/index.tsx
+++ b/client/reader/discover/components/navigation/index.tsx
@@ -99,6 +99,7 @@ const DiscoverNavigation = ( { selectedTab }: Props ) => {
 		<SectionNav
 			className="discover-navigation"
 			selectedText={ selectedTabData?.title }
+			variation="minimal"
 			enforceTabsView
 		>
 			<NavTabs hasHorizontalScroll>

--- a/client/reader/discover/components/navigation/style.scss
+++ b/client/reader/discover/components/navigation/style.scss
@@ -1,11 +1,5 @@
 .is-discover-stream {
 	.discover-navigation {
-		&.section-nav {
-			box-shadow: none;
-			border-bottom: 1px solid var( --color-border-subtle );
-			margin-bottom: 24px;
-		}
-
 		.section-nav-tabs__list {
 			overflow-x: auto;
 		}

--- a/client/reader/discover/index.node.js
+++ b/client/reader/discover/index.node.js
@@ -2,14 +2,15 @@ import { getAnyLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import DiscoverHeaderAndNavigation from 'calypso/reader/discover/components/header-and-navigation';
 import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
+import { getCurrentTabFromURL } from 'calypso/reader/utils';
 import renderHeaderSection from '../lib/header-section';
 import { DiscoverDocumentHead } from './discover-document-head';
 import { FRESHLY_PRESSED_TAB } from './helper';
-import { getLocalizedRoutes, getCurrentTab } from './routes';
+import { getLocalizedRoutes, DISCOVER_PREFIX } from './routes';
 
 const discoverSsr = ( context, next ) => {
 	context.renderHeaderSection = renderHeaderSection;
-	const selectedTab = getCurrentTab( context.path, FRESHLY_PRESSED_TAB );
+	const selectedTab = getCurrentTabFromURL( context.path, DISCOVER_PREFIX, FRESHLY_PRESSED_TAB );
 
 	context.primary = (
 		<>

--- a/client/reader/discover/index.web.js
+++ b/client/reader/discover/index.web.js
@@ -16,13 +16,14 @@ import {
 	trackScrollPage,
 } from 'calypso/reader/controller-helper';
 import { recordTrack } from 'calypso/reader/stats';
+import { getCurrentTabFromURL } from 'calypso/reader/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import renderHeaderSection from '../lib/header-section';
 import { DiscoverDocumentHead } from './discover-document-head';
 import { FRESHLY_PRESSED_TAB } from './helper';
-import { getPrivateRoutes, getDiscoverRoutes, getCurrentTab } from './routes';
+import { getPrivateRoutes, getDiscoverRoutes, DISCOVER_PREFIX } from './routes';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
@@ -34,7 +35,7 @@ const discover = ( context, next ) => {
 	const state = context.store.getState();
 	const currentRoute = getCurrentRoute( state );
 	const currentQueryArgs = new URLSearchParams( getCurrentQueryArguments( state ) ).toString();
-	const selectedTab = getCurrentTab( context.path, FRESHLY_PRESSED_TAB );
+	const selectedTab = getCurrentTabFromURL( context.path, DISCOVER_PREFIX, FRESHLY_PRESSED_TAB );
 
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 	recordTrack(

--- a/client/reader/discover/routes/index.ts
+++ b/client/reader/discover/routes/index.ts
@@ -1,8 +1,6 @@
-import { removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
-
 type Route = { path: string; requiresAuth?: boolean };
-const DISCOVER_PREFIX = 'discover';
-const DEFAULT_TAB = 'recommended';
+export const DISCOVER_PREFIX = 'discover';
+export const DEFAULT_DISCOVER_TAB = 'recommended';
 
 /**
  * The routes for the discover page.
@@ -44,19 +42,4 @@ export const getPrivateRoutes = ( anyLangParam: string, routes: Route[] = ROUTES
 
 export const getDiscoverRoutes = ( langParam: string | undefined ) => {
 	return getLocalizedRoutes( langParam, ROUTES );
-};
-
-export const getCurrentTab = ( fullPath: string, defaultTab: string = DEFAULT_TAB ) => {
-	const pathWithoutQuery = fullPath.split( '?' )[ 0 ];
-	const cleanedPath = removeLocaleFromPathLocaleInFront( pathWithoutQuery );
-	const path = cleanedPath
-		.split( `/${ DISCOVER_PREFIX }` )
-		.filter( ( path ) => path !== '' )
-		?.at( 0 );
-
-	if ( ! path ) {
-		return defaultTab;
-	}
-
-	return path.replace( /^\//, '' );
 };

--- a/client/reader/discover/routes/test/index.test.ts
+++ b/client/reader/discover/routes/test/index.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentTab, getLocalizedRoutes, getPrivateRoutes } from '..';
+import { getLocalizedRoutes, getPrivateRoutes } from '..';
 
 describe( 'getLocalizedRoutes', () => {
 	it( 'returns the routes with the locale prefix', () => {
@@ -34,23 +34,5 @@ describe( 'getLocalizedRoutes', () => {
 		const routes = getPrivateRoutes( 'en', privateRoutes );
 
 		expect( routes ).toEqual( [ '/en/discover/private', '/discover/private' ] );
-	} );
-} );
-
-describe( 'getCurrentTab', () => {
-	it( 'returns the current tab', () => {
-		expect( getCurrentTab( '/discover/firstposts' ) ).toEqual( 'firstposts' );
-	} );
-
-	it( 'ignores the locale', () => {
-		expect( getCurrentTab( '/en/discover/firstposts' ) ).toEqual( 'firstposts' );
-	} );
-
-	it( 'ignores the query params', () => {
-		expect( getCurrentTab( '/discover/firstposts?foo=bar' ) ).toEqual( 'firstposts' );
-	} );
-
-	it( 'returns the default tab when there is no tab', () => {
-		expect( getCurrentTab( '/discover', 'my-default-tab' ) ).toEqual( 'my-default-tab' );
 	} );
 } );

--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -27,6 +27,7 @@ import {
 	pendingSubscriptionsManager,
 	setupReadRoutes,
 	setBeforePrimary,
+	loadNewSubscriptionPage,
 } from './controller';
 import { userProfile } from './user-profile/controller';
 
@@ -58,6 +59,17 @@ export default async function (): Promise< void > {
 		setBeforePrimary,
 		setSelectedSiteIdByOrigin,
 		following,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		[ '/reader/new', '/reader/new/reddit' ],
+		redirectLoggedOutToSignup,
+		sidebar,
+		setBeforePrimary,
+		setSelectedSiteIdByOrigin,
+		loadNewSubscriptionPage,
 		makeLayout,
 		clientRender
 	);

--- a/client/reader/new-subscription/index.tsx
+++ b/client/reader/new-subscription/index.tsx
@@ -1,0 +1,91 @@
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import NavigationHeader from 'calypso/components/navigation-header';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import ReaderMain from '../components/reader-main';
+
+interface Tab {
+	slug: string;
+	title: TranslateResult;
+	path: string;
+}
+
+enum Tabs {
+	ADD_NEW = 'add-new',
+	REDDIT = 'reddit',
+}
+
+export const NEW_SUBSCRIPTION_TABS: typeof Tabs = Tabs;
+
+interface ReaderNewSubscriptionPageProps {
+	selectedTab: Tabs;
+}
+
+export default function ReaderNewSubscriptionPage(
+	props: ReaderNewSubscriptionPageProps
+): JSX.Element {
+	const { selectedTab } = props;
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const pathPrefix: string = 'reader/new';
+	const NEW_SUBSCRIPTION_TABS: Tab[] = [
+		{
+			slug: Tabs.ADD_NEW,
+			title: translate( 'Add new' ),
+			path: `/${ pathPrefix }`,
+		},
+		{
+			slug: Tabs.REDDIT,
+			title: translate( 'Reddit' ),
+			path: `/${ pathPrefix }/reddit`,
+		},
+	];
+	const TAB_COMPONENTS: Record< Tabs, JSX.Element > = {
+		[ Tabs.ADD_NEW ]: <p>Add new subscription</p>,
+		[ Tabs.REDDIT ]: <p>Add Reddit subscription</p>,
+	};
+
+	function recordTabClick( tabSlug: string ): void {
+		recordAction( 'click_new_subscription_tab' );
+		recordGaEvent( 'Clicked New Subscription Tab' );
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_new_subscription_tab_clicked', { tabSlug } )
+		);
+	}
+
+	return (
+		<ReaderMain>
+			<DocumentHead title={ translate( 'New Subscription' ) } />
+
+			<NavigationHeader
+				title={ translate( 'New Subscription' ) }
+				subtitle={ translate( 'Subscribe to new blogs, newsletters, and RSS feeds.' ) }
+			/>
+
+			<SectionNav className="new-subscription-navigation" variation="minimal" enforceTabsView>
+				<NavTabs>
+					{ NEW_SUBSCRIPTION_TABS.map(
+						( tab: Tab ): JSX.Element => (
+							<NavItem
+								key={ tab.slug }
+								selected={ selectedTab === tab.slug }
+								path={ tab.path }
+								onClick={ () => recordTabClick( tab.slug ) }
+							>
+								{ tab.title }
+							</NavItem>
+						)
+					) }
+				</NavTabs>
+			</SectionNav>
+
+			{ TAB_COMPONENTS[ selectedTab ] }
+		</ReaderMain>
+	);
+}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -3,7 +3,7 @@
 // Reader-specific tweaks to components
 
 // Overrides default 720px width
-.is-reader-page .following.main,
+.is-reader-page .main,
 .is-reader-page .tag-stream__main.main {
 	max-width: 768px;
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -3,7 +3,7 @@
 // Reader-specific tweaks to components
 
 // Overrides default 720px width
-.is-reader-page .main,
+.is-reader-page .following.main,
 .is-reader-page .tag-stream__main.main {
 	max-width: 768px;
 

--- a/client/reader/test/utils.ts
+++ b/client/reader/test/utils.ts
@@ -55,7 +55,7 @@ describe( 'reader utils', () => {
 		} );
 	} );
 
-	describe( 'getCurrentTab', () => {
+	describe( 'getCurrentTabFromURL', () => {
 		it( 'returns the current tab', () => {
 			expect(
 				getCurrentTabFromURL( '/discover/firstposts', DISCOVER_PREFIX, FRESHLY_PRESSED_TAB )

--- a/client/reader/test/utils.ts
+++ b/client/reader/test/utils.ts
@@ -1,6 +1,8 @@
 import page from '@automattic/calypso-router';
 import { AppState } from 'calypso/types';
-import { getSafeImageUrlForReader, showSelectedPost } from '../utils';
+import { FRESHLY_PRESSED_TAB } from '../discover/helper';
+import { DISCOVER_PREFIX } from '../discover/routes';
+import { getSafeImageUrlForReader, showSelectedPost, getCurrentTabFromURL } from '../utils';
 
 jest.mock( '@automattic/calypso-router', () => jest.fn() );
 
@@ -50,6 +52,32 @@ describe( 'reader utils', () => {
 		test( 'returns the Photon url if it is not from a trusted host', () => {
 			const url = 'https://www.example.com/image.jpg';
 			expect( getSafeImageUrlForReader( url ) ).not.toEqual( url );
+		} );
+	} );
+
+	describe( 'getCurrentTab', () => {
+		it( 'returns the current tab', () => {
+			expect(
+				getCurrentTabFromURL( '/discover/firstposts', DISCOVER_PREFIX, FRESHLY_PRESSED_TAB )
+			).toEqual( 'firstposts' );
+		} );
+
+		it( 'ignores the locale', () => {
+			expect(
+				getCurrentTabFromURL( '/en/discover/firstposts', DISCOVER_PREFIX, FRESHLY_PRESSED_TAB )
+			).toEqual( 'firstposts' );
+		} );
+
+		it( 'ignores the query params', () => {
+			expect(
+				getCurrentTabFromURL( '/discover/firstposts?foo=bar', DISCOVER_PREFIX, FRESHLY_PRESSED_TAB )
+			).toEqual( 'firstposts' );
+		} );
+
+		it( 'returns the default tab when there is no tab', () => {
+			expect( getCurrentTabFromURL( '/discover', DISCOVER_PREFIX, 'my-default-tab' ) ).toEqual(
+				'my-default-tab'
+			);
 		} );
 	} );
 } );

--- a/client/reader/utils.ts
+++ b/client/reader/utils.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { safeImageUrl, getUrlParts } from '@automattic/calypso-url';
+import { removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
 import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { Dispatch } from 'redux';
 import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
@@ -160,4 +161,26 @@ export function setUrlQuery( key: string, value: string, pathname: string = '' )
 
 export function isDiscoverV3Enabled(): boolean {
 	return isEnabled( 'reader/discover-v3' );
+}
+
+/**
+ * Extracts the current tab from a URL path by removing locale and prefix information.
+ */
+export function getCurrentTabFromURL(
+	fullPath: string,
+	prefix: string,
+	defaultTab: string
+): string {
+	const pathWithoutQuery = fullPath.split( '?' )[ 0 ];
+	const cleanedPath = removeLocaleFromPathLocaleInFront( pathWithoutQuery );
+	const path = cleanedPath
+		.split( `/${ prefix }` )
+		.filter( ( path ) => path !== '' )
+		?.at( 0 );
+
+	if ( ! path ) {
+		return defaultTab;
+	}
+
+	return path.replace( /^\//, '' );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-2](https://linear.app/a8c/issue/READ-2)

## Proposed Changes

Adds new subscription page behind the feature flag.

<img width="2006" height="1196" alt="image" src="https://github.com/user-attachments/assets/8c077d38-d81e-490d-9bf6-c4cedc0a78e4" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of Discovery v3 project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/reader/new`.
1. Verify that it redirects to "Manage Subscription" page if feature flag is not enabled.
1. Go to `/reader/new?flags=reader/discover-v3`.
1. Verify the new page is visible and tabs are working.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
