### PR TITLE
Fix deployment list layout when Latest deployment badge is shown

### DIFF
--- a/client/dashboard/sites/deployments-list/dataviews/fields.tsx
+++ b/client/dashboard/sites/deployments-list/dataviews/fields.tsx
@@ -80,7 +80,6 @@ export function useFields( {
 							<Text title={ commit_message }>{ commit_message }</Text>
 							<HStack spacing={ 3 } alignment="left" style={ { width: 'max-content' } }>
 								<ExternalLink
-									style={ { flexShrink: 0 } }
 									href={ `https://github.com/${ installation }/${ repo }/commit/${ commit_sha }` }
 								>
 									<Text
@@ -91,10 +90,8 @@ export function useFields( {
 										{ shortSha }
 									</Text>
 								</ExternalLink>
-								<div style={ { flexShrink: 0 } }>
-									<BranchDisplay branchName={ item.branch_name } />
-								</div>
-								<HStack spacing={ 1.5 } alignment="left" style={ { width: 'auto', flexShrink: 0 } }>
+								<BranchDisplay branchName={ item.branch_name } />
+								<HStack spacing={ 1.5 } alignment="left" style={ { width: 'auto' } }>
 									<img
 										src={ author.avatar_url }
 										alt={ author.name }
@@ -106,9 +103,7 @@ export function useFields( {
 										{ author.name }
 									</Text>
 								</HStack>
-								{ item.is_active_deployment && (
-									<Badge style={ { flexShrink: 0 } }>{ __( 'Latest Deployment' ) }</Badge>
-								) }
+								{ item.is_active_deployment && <Badge>{ __( 'Latest Deployment' ) }</Badge> }
 							</HStack>
 						</VStack>
 					);

--- a/client/dashboard/sites/deployments-list/dataviews/fields.tsx
+++ b/client/dashboard/sites/deployments-list/dataviews/fields.tsx
@@ -107,7 +107,7 @@ export function useFields( {
 									</Text>
 								</HStack>
 								{ item.is_active_deployment && (
-									<Badge style={ { flexShrink: 0 } }>{ __( 'Latest deployment' ) }</Badge>
+									<Badge style={ { flexShrink: 0 } }>{ __( 'Latest Deployment' ) }</Badge>
 								) }
 							</HStack>
 						</VStack>

--- a/client/dashboard/sites/deployments-list/dataviews/fields.tsx
+++ b/client/dashboard/sites/deployments-list/dataviews/fields.tsx
@@ -78,8 +78,9 @@ export function useFields( {
 					return (
 						<VStack spacing={ 1 }>
 							<Text title={ commit_message }>{ commit_message }</Text>
-							<HStack spacing={ 3 } alignment="left" style={ { width: 'auto' } }>
+							<HStack spacing={ 3 } alignment="left" style={ { width: 'max-content' } }>
 								<ExternalLink
+									style={ { flexShrink: 0 } }
 									href={ `https://github.com/${ installation }/${ repo }/commit/${ commit_sha }` }
 								>
 									<Text
@@ -90,8 +91,10 @@ export function useFields( {
 										{ shortSha }
 									</Text>
 								</ExternalLink>
-								<BranchDisplay branchName={ item.branch_name } />
-								<HStack spacing={ 1.5 } alignment="left" style={ { width: 'auto' } }>
+								<div style={ { flexShrink: 0 } }>
+									<BranchDisplay branchName={ item.branch_name } />
+								</div>
+								<HStack spacing={ 1.5 } alignment="left" style={ { width: 'auto', flexShrink: 0 } }>
 									<img
 										src={ author.avatar_url }
 										alt={ author.name }
@@ -103,7 +106,9 @@ export function useFields( {
 										{ author.name }
 									</Text>
 								</HStack>
-								{ item.is_active_deployment && <Badge>{ __( 'Latest deployment' ) }</Badge> }
+								{ item.is_active_deployment && (
+									<Badge style={ { flexShrink: 0 } }>{ __( 'Latest deployment' ) }</Badge>
+								) }
 							</HStack>
 						</VStack>
 					);


### PR DESCRIPTION
Fixes DOTDEV-283

## Proposed Changes

- Changed second-row HStack from `width: 'auto'` to `width: 'max-content'` so the column expands to fit content naturally instead of compressing elements
- Added `flexShrink: 0` to each metadata element (commit, branch, author, latest badge) to prevent flex compression

## Why are these changes being made?

The "Latest deployment" badge was causing all elements in the commit metadata row to squeeze together. The HStack's default `width: auto` constrains the container, and WordPress components apply `min-width: 0` to all flex children by default, allowing them to shrink below content size. These changes ensure each element maintains its natural width.

## Testing Instructions

1. Run `yarn start-dashboard`
2. Navigate to a site's Deployments page
3. Check that rows with the "Latest deployment" badge show all elements (SHA, branch name, author, badge) at full width without truncation
4. Check that rows without the badge still render correctly
5. Test with longer branch names to confirm the column expands appropriately

| trunk | this branch |
|--------|--------|
| <img width="3424" height="2864" alt="CleanShot 2026-02-06 at 13 30 52@2x" src="https://github.com/user-attachments/assets/6f5b1f16-782c-414f-aa00-45df9aa0ec49" /> | <img width="3424" height="2864" alt="CleanShot 2026-02-06 at 13 29 59@2x" src="https://github.com/user-attachments/assets/ba28ca25-a0c3-4620-ade1-aa22c56a157e" /> | 

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?