### PR TITLE
Agents Manager: Restore agent ID and version query param override

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -147,7 +147,7 @@ export default function AgentDock( {
 
 			// Sync local session ID with the server's
 			if ( sessionId !== serverSessionId ) {
-				setSessionId( serverSessionId );
+				setSessionId( serverSessionId, agentId );
 				navigate( '/chat', { state: { sessionId: serverSessionId }, replace: true } );
 			}
 		},
@@ -200,7 +200,7 @@ export default function AgentDock( {
 		},
 		// This ensures the same session ID is used between Big Sky and Calypso agents,
 		// so that messages will be stored in the same conversation.
-		getSessionId: () => sessionId || getStoredSessionId(),
+		getSessionId: () => sessionId || getStoredSessionId( agentId ),
 		setIsBuildingSite,
 		setThinkingMessage,
 	} );
@@ -225,7 +225,7 @@ export default function AgentDock( {
 			const sessionId = conversation.session_id || '';
 
 			abortCurrentRequest();
-			setSessionId( sessionId );
+			setSessionId( sessionId, agentId );
 			navigate( '/chat', { state: { sessionId } } );
 		}
 	};

--- a/packages/agents-manager/src/utils/agent-session.ts
+++ b/packages/agents-manager/src/utils/agent-session.ts
@@ -47,7 +47,7 @@ export function getSessionId( agentId?: string ): string {
 			}
 
 			// Session expired, clear it
-			localStorage.removeItem( SESSION_STORAGE_KEY );
+			localStorage.removeItem( key );
 		}
 	} catch ( error ) {
 		// eslint-disable-next-line no-console

--- a/packages/agents-manager/src/utils/agent-session.ts
+++ b/packages/agents-manager/src/utils/agent-session.ts
@@ -9,6 +9,7 @@
  * 3. Client stores UUID in localStorage via setSessionId()
  * 4. Subsequent loads: retrieve UUID from localStorage
  */
+import { ORCHESTRATOR_AGENT_ID } from '../constants';
 
 export const SESSION_STORAGE_KEY = 'agents-manager-session-id';
 const SESSION_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -16,6 +17,13 @@ const SESSION_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
 /**
  * Session storage format.
  */
+export function getSessionStorageKey( agentId?: string ): string {
+	if ( agentId && agentId !== ORCHESTRATOR_AGENT_ID ) {
+		return `${ SESSION_STORAGE_KEY }-${ agentId }`;
+	}
+	return SESSION_STORAGE_KEY;
+}
+
 interface StoredSession {
 	sessionId: string;
 	timestamp: number;
@@ -26,9 +34,10 @@ interface StoredSession {
  * Returns empty string if no session exists or session expired.
  * @returns The current session ID, or an empty string if no valid session exists.
  */
-export function getSessionId(): string {
+export function getSessionId( agentId?: string ): string {
 	try {
-		const stored = localStorage.getItem( SESSION_STORAGE_KEY );
+		const key = getSessionStorageKey( agentId );
+		const stored = localStorage.getItem( key );
 		if ( stored ) {
 			const session: StoredSession = JSON.parse( stored );
 
@@ -54,13 +63,13 @@ export function getSessionId(): string {
  * Save session ID to localStorage.
  * @param sessionId - The session ID to save.
  */
-export function setSessionId( sessionId: string ): void {
+export function setSessionId( sessionId: string, agentId?: string ): void {
 	try {
 		const session: StoredSession = {
 			sessionId,
 			timestamp: Date.now(),
 		};
-		localStorage.setItem( SESSION_STORAGE_KEY, JSON.stringify( session ) );
+		localStorage.setItem( getSessionStorageKey( agentId ), JSON.stringify( session ) );
 	} catch ( error ) {
 		// eslint-disable-next-line no-console
 		console.error( '[agent-session] Error storing session ID:', error );
@@ -71,9 +80,9 @@ export function setSessionId( sessionId: string ): void {
  * Reset to a new chat (clear session).
  * Returns empty string - server will generate UUID on first message.
  */
-export function clearSessionId(): void {
+export function clearSessionId( agentId?: string ): void {
 	try {
-		localStorage.removeItem( SESSION_STORAGE_KEY );
+		localStorage.removeItem( getSessionStorageKey( agentId ) );
 	} catch ( error ) {
 		// eslint-disable-next-line no-console
 		console.error( '[agent-session] Error clearing session ID:', error );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

Restore [PR](https://github.com/Automattic/wp-calypso/pull/108421) that adds agent ID and version query param override broken by [PR](https://github.com/Automattic/wp-calypso/pull/108229)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This enables developers to test different agent configurations without code changes by simply adding query parameters to the URL.

Example usage: `?agent=wpcom-workflow-support_chat&version=1.0.25`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Media Library
2. Add query parameters to the URL: `?agent=wpcom-workflow-support_chat&version=1.0.25`
3. Send a message in the Unified Chat
4. Verify the agent by checking in the Network Tab > filter by `https://public-api.wordpress.com/wpcom/v2/ai/agent`
<img width="681" height="329" alt="image" src="https://github.com/user-attachments/assets/13db1be5-e763-4175-b01a-a1f3f16d2f0c" />

5. Test without the agent param it should use `wp-orchestrator` as default
6. Test Image Studio it should work as expected


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
