### PR TITLE
Search card: Replace sparkle emoji with arrow-up SVG icon

### DIFF
--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -134,7 +134,9 @@ if ( ! function_exists( 'get_support_search_link_for_query' ) ) {
 						<?php if ( $enable_odie_answers ) : ?>
 							<input id="support-search-input" type="input" data-post-loading-text="<?php echo esc_html( __( 'Ask us anything', 'happy-blocks' ) ); ?>" name="odie-query" placeholder="<?php echo esc_html( __( 'Loading...', 'happy-blocks' ) ); ?>"/>
 							<button type="submit" class="search-submit-button" aria-label="<?php echo esc_attr( __( 'Search', 'happy-blocks' ) ); ?>">
-								✨
+								<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+									<path d="M12.2197 5C12.4186 5 12.6094 5.07902 12.75 5.21967L17 9.46967C17.2929 9.76256 17.2929 10.2374 17 10.5303C16.7071 10.8232 16.2322 10.8232 15.9393 10.5303L12.9697 7.56067V18.25C12.9697 18.6642 12.6339 19 12.2197 19C11.8055 19 11.4697 18.6642 11.4697 18.25V7.56065L8.5 10.5303C8.2071 10.8232 7.73223 10.8232 7.43934 10.5303C7.14644 10.2374 7.14645 9.76256 7.43934 9.46967L11.6894 5.21967C11.83 5.07902 12.0208 5 12.2197 5Z" fill="currentColor"/>
+								</svg>
 							</button>
 						<?php else : ?>
 							<input id="support-search-input" type="search" name="s" placeholder="<?php echo esc_html( __( 'Search questions, guides, courses', 'happy-blocks' ) ); ?>"/>

--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -310,6 +310,12 @@ $breakpoint-desktop: 1440px; //Desktop size.
 			&:hover svg {
 				fill: #3858e9;
 			}
+
+			&.search-submit-button {
+				background-color: var( --color-primary );
+				color: var(--color-white);
+				border-radius: 100%;
+			}
 		}
 
 		.search-terms {


### PR DESCRIPTION
## Summary
- Replaces the ✨ sparkle emoji in the Odie search submit button with a proper arrow-up SVG icon
- Styles the submit button with `background-color: var(--color-primary)`, `color: var(--color-primary-foreground)`, and `border-radius: var(--radius-full)`

Fixes: https://linear.app/a8c/issue/DSGCOM-426/replace-sparkly-icon

## Test plan
- [ ] Verify the arrow-up icon renders correctly in the Odie search input button
- [ ] Verify button styling (primary background, foreground color, round shape)
- [ ] Verify the regular search icon (non-Odie path) is unaffected