### PR TITLE
Site Performance tool: improve error messages for timed out requests

### DIFF
--- a/client/dashboard/sites/performance/report-error-notice.tsx
+++ b/client/dashboard/sites/performance/report-error-notice.tsx
@@ -1,19 +1,28 @@
 import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import InlineSupportLink from '../../components/inline-support-link';
 import { Notice } from '../../components/notice';
 
 export default function ReportErrorNotice( { onRetestClick }: { onRetestClick: () => void } ) {
 	return (
 		<Notice
 			variant="error"
-			title={ __( 'An error occurred while testing your site.' ) }
+			title={ __( 'Results not available' ) }
 			actions={
 				<Button variant="primary" onClick={ onRetestClick }>
 					{ __( 'Re-run test' ) }
 				</Button>
 			}
 		>
-			{ __( 'Try running the test again or contact support if the error persists.' ) }
+			{ createInterpolateElement(
+				__(
+					'We were unable to reliably load and test your page. This could be due to a timeout, server error, or connectivity issue. Make sure your site is accessible and responding correctly. <link>Learn more about improving site speed</link>, or try running the test again.'
+				),
+				{
+					link: <InlineSupportLink supportContext="site-speed" />,
+				}
+			) }
 		</Notice>
 	);
 }

--- a/client/hosting/performance/components/ReportError.tsx
+++ b/client/hosting/performance/components/ReportError.tsx
@@ -1,6 +1,7 @@
 import { NoticeBanner } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 export const ReportError = ( { onRetestClick }: { onRetestClick(): void } ) => {
 	const translate = useTranslate();
@@ -17,7 +18,13 @@ export const ReportError = ( { onRetestClick }: { onRetestClick(): void } ) => {
 			] }
 		>
 			{ translate(
-				'An error occurred while testing your site. Try running the test again or contact support if the error persists.'
+				'We were unable to reliably load and test your page. This could be due to a timeout, server error, or connectivity issue. ' +
+					'Make sure your site is accessible and responding correctly. {{link}}Learn more about improving site speed{{/link}}, or try running the test again.',
+				{
+					components: {
+						link: <InlineSupportLink supportContext="site-speed" showIcon={ false } />,
+					},
+				}
 			) }
 		</NoticeBanner>
 	);


### PR DESCRIPTION
Fixes DOTDEV-281

## Proposed Changes

* Improved error messages in both the classic hosting dashboard (`ReportError.tsx`) and Dashboard v2 (`report-error-notice.tsx`) to provide clearer feedback when Site Performance tests fail
* Updated error message from generic "An error occurred..." to "We were unable to reliably load and test your page..." with specific cause mentions (timeout, server error, connectivity issue)
* Added a support link to site-speed documentation in both error components

## Why are these changes being made?

When the Site Performance tool fails (e.g., due to slow sites causing Lighthouse to timeout), users previously saw a generic error message. This led to confusion and unnecessary support tickets. The new message explains possible causes and provides guidance to help customers understand and address performance issues.

## Testing Instructions

#### Preparation

Add this file to `/wp-content/mu-plugins` on one of your test sites via SFTP/SSH:

```php
// mu-plugins/slowdown.php
<?php
sleep(30);
```

#### Dashboard

- Run `yarn start-dashboard` or use the Dashboard live link
- Navigate to the test site's Performance page
- Run a new test to trigger the error
- Check the error notice shows the improved message and that the support link works

| trunk | this branch |
|--------|--------|
| <img width="3424" height="2864" alt="CleanShot 2026-02-09 at 15 05 30@2x" src="https://github.com/user-attachments/assets/e9eaa84f-9fcb-4445-83e2-d8aa90fa7876" /> | <img width="3424" height="2864" alt="CleanShot 2026-02-09 at 15 05 20@2x" src="https://github.com/user-attachments/assets/8a704d6b-c7df-45a8-b237-74cdd68bc4d1" /> | 

#### Old dashboard

- Run `yarn start` or use the Calypso live link
- Navigate to the test site's Performance page
- Check the error notice shows the improved message and that the support link works

> [!NOTE]
> Because of the added delay, the site might be identified as disconnected, and in this case there's a CTA shown to Launch the site. The error can be triggered here by commenting out the sleep, loading the page, then removing the comment and starting the test.

| trunk | this branch |
|--------|--------|
| <img width="1712" height="1432" alt="image" src="https://github.com/user-attachments/assets/229ef6da-c1cf-4bd0-9e17-5112b549e4b7" /> | <img width="1712" height="1432" alt="image" src="https://github.com/user-attachments/assets/076a567e-75f6-4933-a407-99dae0fce887" /> | 

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?