### PR TITLE
CIAB: Don’t allow site address changes

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -258,7 +258,10 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 				isEligible: ( item: DomainSummary ) => {
 					const site = sitesByBlogId[ item.blog_id ];
 					return (
-						!! site && ! site?.is_wpcom_atomic && item.subtype.id === DomainSubtype.DEFAULT_ADDRESS
+						!! site &&
+						! site?.is_wpcom_atomic &&
+						! site?.is_garden &&
+						item.subtype.id === DomainSubtype.DEFAULT_ADDRESS
 					);
 				},
 				RenderModal: ( { items, closeModal = noop } ) => {

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -60,6 +60,11 @@ function SiteDomains() {
 		fields
 	);
 
+	// Hide actions column when no domain has eligible actions.
+	const hasEligibleActions = filteredData?.some( ( item ) =>
+		actions.some( ( action ) => action.isEligible === undefined || action.isEligible( item ) )
+	);
+
 	return (
 		<PageLayout
 			header={ <PageHeader title={ __( 'Domains' ) } actions={ <AddDomainButton /> } /> }
@@ -94,7 +99,7 @@ function SiteDomains() {
 					onChangeView={ updateView }
 					onResetView={ resetView }
 					view={ view }
-					actions={ actions }
+					actions={ hasEligibleActions ? actions : [] }
 					search
 					paginationInfo={ paginationInfo }
 					getItemId={ getDomainId }

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -61,7 +61,7 @@ function SiteDomains() {
 	);
 
 	// Hide actions column when no domain has eligible actions.
-	const hasEligibleActions = filteredData?.some( ( item ) =>
+	const hasEligibleActions = siteDomains?.some( ( item ) =>
 		actions.some( ( action ) => action.isEligible === undefined || action.isEligible( item ) )
 	);
 


### PR DESCRIPTION
Remove the ability to change the default site address for CIAB sites.

Since this means there may be no "actions" to take I'm also hiding that column conditionally because it didn't look super great otherwise.

## Testing

Site Overview => Domains => Action List

____

ARC-1408