### PR TITLE
Reader post actions: Remove border and padding

### DIFF
--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -5,9 +5,6 @@
 	gap: 12px;
 	list-style: none;
 	margin: 0;
-	padding: 16px 0;
-	border-top: 1px solid var( --color-neutral-5 );
-	border-bottom: 1px solid var( --color-neutral-5 );
 
 	.reader-post-actions__item {
 		display: flex;
@@ -16,8 +13,8 @@
 		button {
 			margin: 0;
 			padding: 8px 16px;
-			background: var( --color-surface );
-			border: 1px solid var( --color-neutral-10 );
+			background: var(--color-surface);
+			border: 1px solid var(--color-neutral-10);
 			border-radius: 4px;
 			transition: all 0.2s ease;
 			cursor: pointer;
@@ -65,11 +62,11 @@
 
 		// Hover states
 		.freshly-pressed:hover {
-			color: var( --color-link );
-			--color-foreground: var( --color-link );
+			color: var(--color-link);
+			--color-foreground: var(--color-link);
 
 			svg {
-				fill: var( --color-link );
+				fill: var(--color-link);
 				opacity: 1;
 			}
 		}


### PR DESCRIPTION
## Proposed changes

Removed border and padding to reduce vertical height and clean up the interface:

| Before | After |
| --- | --- |
| <img width="2556" height="1800" alt="calypso localhost_3000_reader (1)" src="https://github.com/user-attachments/assets/7ead6b3b-3caa-4770-ad96-e2e0d4919bd4" /> | <img width="2556" height="1800" alt="calypso localhost_3000_reader (1)" src="https://github.com/user-attachments/assets/7513dbde-572c-4a23-8592-c33cf8eb29e2" /> |