### PR TITLE
Help Center: Fix global CSS specificity

### DIFF
--- a/apps/help-center/postcss.config.js
+++ b/apps/help-center/postcss.config.js
@@ -3,6 +3,12 @@ module.exports = {
 		require( 'postcss-prefix-selector' )( {
 			prefix: '.help-center',
 			transform: function ( prefix, selector, prefixedSelector, path ) {
+				// Agenttic UI (used by Odie/Agents Manager) ships very generic chart selectors
+				// like `.chart-container` which collide with WooCommerce Reports in wp-admin.
+				if ( selector.includes( '.chart-container' ) ) {
+					return selector.includes( prefix ) ? selector : prefixedSelector;
+				}
+
 				// The search component has very generic class that causes many bugs.
 				if ( path.includes( 'search/style.scss' ) ) {
 					return selector === '.search' ? prefixedSelector : selector;

--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -66,6 +66,7 @@
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/smooch": "^5.3.7",
+		"postcss": "^8.5.3",
 		"typescript": "^5.8.3"
 	},
 	"peerDependencies": {

--- a/packages/help-center/src/test/help-center-postcss-scoping.js
+++ b/packages/help-center/src/test/help-center-postcss-scoping.js
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ */
+
+const path = require( 'path' );
+const postcss = require( 'postcss' );
+
+const helpCenterPostcssConfig = require(
+	path.join( __dirname, '../../../../apps/help-center/postcss.config.js' )
+);
+
+describe( 'Help Center PostCSS scoping', () => {
+	it( 'prefixes `.chart-container` selectors to avoid leaking into wp-admin pages', async () => {
+		const inputCss = '.chart-container{z-index:1001;}';
+
+		const result = await postcss( helpCenterPostcssConfig.plugins ).process( inputCss, {
+			// Mimic a dependency stylesheet path.
+			from: '/tmp/node_modules/@automattic/agenttic-ui/dist/index.css',
+		} );
+
+		expect( result.css ).toContain( '.help-center .chart-container' );
+	} );
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,6 +1522,7 @@ __metadata:
     "@wordpress/icons": "npm:^10.23.0"
     "@wordpress/primitives": "npm:^4.23.0"
     clsx: "npm:^2.1.1"
+    postcss: "npm:^8.5.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-draggable: "npm:^4.4.6"


### PR DESCRIPTION
WOOPRD-1930

## Proposed Changes

- Wrap help center CSS for `.chart-container` so that it's more specific.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There was a report that in WoA sites, that the WooCommerce reports page had a clipped date picker. As I looked into this, the issue was CSS specificity, where help center styles weren't wrapped and were target `.chart-container`. One of the CSS declarations changed the reports container to have `z-index: 1001`, or much more than the date picker. 

This screenshot demonstrates me disabling the z-index that is getting applied to the Woo reports chart container. 

<img width="3800" height="3372" alt="image" src="https://github.com/user-attachments/assets/a8317d9c-b247-4d52-a22d-ff81ef1e71bd" />

Of note, the more correct fix is probably to update agenttic UI or help center generally so wrap all of the styles. I'm less familiar with testing of these things though.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `cd /Users/ericbinnion/Repos/wp-calypso/apps/help-center`
* `yarn dev --sync`
* Sandbox `widgets.wp.com`
* Load the reports page in a WoA site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
