### PR TITLE
Fix Delete Site "Manage Purchases" link to navigate to site-specific purchases

### DIFF
--- a/client/sites/settings/administration/tools/delete-site/delete-site-warnings.jsx
+++ b/client/sites/settings/administration/tools/delete-site/delete-site-warnings.jsx
@@ -2,9 +2,9 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
-import { purchasesRoot } from 'calypso/me/purchases/paths';
+import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
 
-function DeleteSiteWarnings( { p2HubP2Count, isAtomicRemovalInProgress, isTrialSite = false } ) {
+function DeleteSiteWarnings( { siteSlug, p2HubP2Count, isAtomicRemovalInProgress, isTrialSite = false } ) {
 	const translate = useTranslate();
 
 	const getButtons = () => {
@@ -20,14 +20,14 @@ function DeleteSiteWarnings( { p2HubP2Count, isAtomicRemovalInProgress, isTrialS
 			);
 		} else if ( isTrialSite ) {
 			return (
-				<Button primary href={ purchasesRoot }>
+				<Button primary href={ getPurchaseListUrlFor( siteSlug ) }>
 					{ translate( 'Cancel trial', { context: 'button label' } ) }
 				</Button>
 			);
 		}
 
 		return (
-			<Button primary href={ purchasesRoot }>
+			<Button primary href={ getPurchaseListUrlFor( siteSlug ) }>
 				{ translate( 'Manage purchases', { context: 'button label' } ) }
 			</Button>
 		);
@@ -76,6 +76,7 @@ function DeleteSiteWarnings( { p2HubP2Count, isAtomicRemovalInProgress, isTrialS
 }
 
 DeleteSiteWarnings.propTypes = {
+	siteSlug: PropTypes.string.isRequired,
 	p2HubP2Count: PropTypes.number,
 	isAtomicRemovalInProgress: PropTypes.bool,
 	isTrialSite: PropTypes.bool,

--- a/client/sites/settings/administration/tools/delete-site/delete-site-warnings.jsx
+++ b/client/sites/settings/administration/tools/delete-site/delete-site-warnings.jsx
@@ -4,7 +4,12 @@ import PropTypes from 'prop-types';
 import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
 
-function DeleteSiteWarnings( { siteSlug, p2HubP2Count, isAtomicRemovalInProgress, isTrialSite = false } ) {
+function DeleteSiteWarnings( {
+	siteSlug,
+	p2HubP2Count,
+	isAtomicRemovalInProgress,
+	isTrialSite = false,
+} ) {
 	const translate = useTranslate();
 
 	const getButtons = () => {

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -230,6 +230,7 @@ class DeleteSite extends Component {
 					</PanelCard>
 				) : (
 					<DeleteSiteWarnings
+						siteSlug={ this.props.siteSlug }
 						isAtomicRemovalInProgress={ isAtomicRemovalInProgress }
 						p2HubP2Count={ this.props.p2HubP2Count }
 						isTrialSite={ this.props.isTrialSite }


### PR DESCRIPTION
Fixes #[CHE-145](https://linear.app/a8c/issue/CHE-145)

## Proposed Changes

* Replace `purchasesRoot` (`/me/purchases`) with `getPurchaseListUrlFor( siteSlug )` (`/purchases/subscriptions/{siteSlug}`) in the Delete Site warnings component
* Thread `siteSlug` prop from the parent `DeleteSite` component (already available via `getSelectedSiteSlug`) into `DeleteSiteWarnings`
* Both "Manage purchases" and "Cancel trial" buttons now link to the site-specific purchases page

## Why are these changes being made?

When users with active subscriptions try to delete a site, clicking "Manage purchases" takes them to `/me/purchases` (all purchases across all sites). For users with multiple subscriptions, this makes it difficult to find the specific subscription they need to cancel before deleting the site.

This fix updates the link to navigate to `/purchases/subscriptions/{siteSlug}`, which shows only the purchases for the site being deleted. This matches the existing pattern used in the Dashboard site delete modal and the Leave Site flow.

## Testing Instructions

1. Navigate to a site with active paid subscriptions
2. Go to **Site Settings > Delete Site** (`/sites/settings/site/{site-slug}/delete-site`)
3. Verify the "Unable to delete site" warning appears
4. Click **"Manage purchases"** button
5. **Expected:** Redirect to `/purchases/subscriptions/{site-slug}` (site-specific purchases)
6. **Not expected:** Redirect to `/me/purchases` (all purchases)

**Also test the trial site flow:**
1. Navigate to a site with an active/expired trial
2. Go to **Site Settings > Delete Site**
3. Click **"Cancel trial"** button
4. Verify redirect goes to the site-specific purchases page

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility (keyboard navigation, screen readers)?