### PR TITLE
MCP: add list of disabled sites

### DIFF
--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -9,9 +9,13 @@ import {
 	FormTokenField,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
-import { getAccountMcpAbilities, getSiteAccountToolsEnabled } from '../../../me/mcp/utils';
+import {
+	getAccountMcpAbilities,
+	getDisabledSiteIds,
+	getSiteAccountToolsEnabled,
+} from '../../../me/mcp/utils';
 import { useAppContext } from '../../app/context';
 import { Card, CardBody } from '../../components/card';
 import ComponentViewTracker from '../../components/component-view-tracker';
@@ -47,6 +51,24 @@ function McpComponent() {
 
 	// Site selector state for disabling MCP access on specific sites
 	const [ selectedSiteIds, setSelectedSiteIds ] = useState< number[] >( [] );
+	const disabledSiteIds = getDisabledSiteIds( userSettings || {} );
+	const disabledSites = disabledSiteIds.map( ( siteId ) => {
+		const site = sites.find( ( siteEntry ) => siteEntry.ID === siteId );
+		const name = site
+			? getSiteDisplayName( site )
+			: sprintf(
+					/* translators: %s is the site ID. */
+					__( 'Site ID: %s' ),
+					String( siteId )
+			  );
+		const domain = site?.URL || '';
+
+		return {
+			id: siteId,
+			name,
+			domain,
+		};
+	} );
 
 	// Use the standard userSettingsMutation with snackbar notifications
 	const mutation = useMutation( {
@@ -198,6 +220,21 @@ function McpComponent() {
 				...( sitesPayload.length > 0 && { sites: sitesPayload } ),
 			},
 		};
+		mutation.mutate( payload as any );
+	};
+
+	const handleSiteToggle = ( siteId: number, enabled: boolean ) => {
+		const payload = {
+			mcp_abilities: {
+				sites: [
+					{
+						blog_id: siteId,
+						account_tools_enabled: enabled,
+					},
+				],
+			},
+		};
+
 		mutation.mutate( payload as any );
 	};
 
@@ -353,6 +390,26 @@ function McpComponent() {
 											</Text>
 										}
 									/>
+								) }
+								{ disabledSites.length > 0 && (
+									<VStack spacing={ 3 }>
+										<Text as="p" size="11px" weight={ 600 }>
+											{ __( 'Disabled sites' ) }
+										</Text>
+										<VStack spacing={ 2 }>
+											{ disabledSites.map( ( site ) => (
+												<ToggleControl
+													key={ site.id }
+													__nextHasNoMarginBottom
+													checked={ false }
+													disabled={ mutation.isPending }
+													onChange={ ( enabled ) => handleSiteToggle( site.id, enabled ) }
+													label={ site.name }
+													help={ site.domain }
+												/>
+											) ) }
+										</VStack>
+									</VStack>
 								) }
 							</VStack>
 						</CardBody>

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -61,7 +61,7 @@ function McpComponent() {
 					__( 'Site ID: %s' ),
 					String( siteId )
 			  );
-		const domain = site?.URL || '';
+		const domain = site?.URL ? site.URL.replace( /^https?:\/\//, '' ) : '';
 
 		return {
 			id: siteId,
@@ -392,10 +392,14 @@ function McpComponent() {
 									/>
 								) }
 								{ disabledSites.length > 0 && (
-									<VStack spacing={ 3 }>
-										<Text as="p" size="11px" weight={ 600 }>
-											{ __( 'Disabled sites' ) }
-										</Text>
+									<VStack spacing={ 4 }>
+										<SectionHeader
+											level={ 3 }
+											title={ __( 'Sites with disabled MCP access' ) }
+											description={ __(
+												'Sites with disabled MCP access are not accessible to AI assistants.'
+											) }
+										/>
 										<VStack spacing={ 2 }>
 											{ disabledSites.map( ( site ) => (
 												<ToggleControl

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -41,7 +41,7 @@ function McpComponent( { path } ) {
 	const disabledSites = disabledSiteIds.map( ( siteId ) => {
 		const site = sites.find( ( siteEntry ) => siteEntry.ID === siteId );
 		const name = site?.name || translate( 'Site ID: %(siteId)s', { args: { siteId } } );
-		const domain = site?.URL || '';
+		const domain = site?.URL ? site.URL.replace( /^https?:\/\//, '' ) : '';
 
 		return {
 			id: siteId,

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -22,7 +22,7 @@ import ReauthRequired from 'calypso/me/reauth-required';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { SectionHeader } from '../../dashboard/components/section-header';
 import PreferencesLoginSiteDropdown from '../../dashboard/me/preferences-primary-site/site-dropdown';
-import { getAccountMcpAbilities, getSiteAccountToolsEnabled } from './utils';
+import { getAccountMcpAbilities, getDisabledSiteIds, getSiteAccountToolsEnabled } from './utils';
 
 function McpComponent( { path } ) {
 	const translate = useTranslate();
@@ -37,6 +37,18 @@ function McpComponent( { path } ) {
 
 	// Site selector state for disabling MCP access on specific sites
 	const [ selectedSiteId, setSelectedSiteId ] = useState( '' );
+	const disabledSiteIds = getDisabledSiteIds( userSettings || {} );
+	const disabledSites = disabledSiteIds.map( ( siteId ) => {
+		const site = sites.find( ( siteEntry ) => siteEntry.ID === siteId );
+		const name = site?.name || translate( 'Site ID: %(siteId)s', { args: { siteId } } );
+		const domain = site?.URL || '';
+
+		return {
+			id: siteId,
+			name,
+			domain,
+		};
+	} );
 
 	// Reauth state
 	const [ reauthRequired, setReauthRequired ] = useState( false );
@@ -319,6 +331,30 @@ function McpComponent( { path } ) {
 											</Text>
 										}
 									/>
+								) }
+								{ disabledSites.length > 0 && (
+									<VStack spacing={ 4 }>
+										<SectionHeader
+											level={ 3 }
+											title={ translate( 'Sites with disabled MCP access' ) }
+											description={ translate(
+												'Sites with disabled MCP access are not accessible to AI assistants.'
+											) }
+										/>
+										<VStack>
+											{ disabledSites.map( ( site ) => (
+												<ToggleControl
+													key={ site.id }
+													__nextHasNoMarginBottom
+													checked={ false }
+													disabled={ mutation.isPending }
+													onChange={ ( enabled ) => handleSiteToggle( site.id, enabled ) }
+													label={ site.name }
+													help={ site.domain }
+												/>
+											) ) }
+										</VStack>
+									</VStack>
 								) }
 							</VStack>
 						</CardBody>

--- a/client/me/mcp/utils.js
+++ b/client/me/mcp/utils.js
@@ -71,3 +71,21 @@ export function getSiteAccountToolsEnabled( userSettings, siteId ) {
 	// Default to true (enabled) if no entry exists
 	return true;
 }
+
+/**
+ * Get site IDs where MCP access is disabled at the site level
+ * @param {Object} userSettings - The user settings object
+ * @returns {number[]} Site IDs with account tools disabled
+ */
+export function getDisabledSiteIds( userSettings ) {
+	if ( userSettings?.sites ) {
+		return userSettings.sites
+			.filter( ( site ) => site.account_tools_enabled === false )
+			.map( ( site ) => site.blog_id );
+	}
+
+	const mcpSites = userSettings?.mcp_abilities?.sites || [];
+	return mcpSites
+		.filter( ( site ) => site.account_tools_enabled === false )
+		.map( ( site ) => site.blog_id );
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/AIINT-238/mcp-access-show-disabled-sites

MCP Access on current dashboard - http://calypso.localhost:3000/me/mcp

https://github.com/user-attachments/assets/59eff892-23f9-4fe8-8bc4-02a9ef7a1bbe

MCP Access on new dashboard - http://my.localhost:3000/me/mcp

https://github.com/user-attachments/assets/96de617a-3290-4992-aef3-279695015fbb

## Proposed Changes

* Adds list of disabled sites with toggle to re-enable MCP access

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test disabling/re-enabling like video on http://my.localhost:3000/me/mcp and http://calypso.localhost:3000/me/mcp

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
