### PR TITLE
Add .in domain contact document verification support

### DIFF
--- a/client/dashboard/domains/domain-contact-verification/index.tsx
+++ b/client/dashboard/domains/domain-contact-verification/index.tsx
@@ -1,3 +1,7 @@
+import {
+	extractTld,
+	getContactVerificationTldConfig,
+} from '@automattic/api-core/src/domain-contact-verification';
 import { domainWhoisQuery, domainContactVerificationMutation } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {
@@ -34,6 +38,9 @@ export default function DomainContactVerification() {
 		domainContactVerificationMutation( domainName )
 	);
 	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
+
+	const tld = extractTld( domainName );
+	const tldConfig = getContactVerificationTldConfig( tld );
 
 	if ( ! registrantWhoisData ) {
 		return null;
@@ -121,31 +128,52 @@ export default function DomainContactVerification() {
 	};
 
 	const renderInstructions = () => {
+		const hasAcceptedDocuments = tldConfig.acceptedDocuments.length > 0;
+
 		return (
 			<>
-				<Text as="p">
-					{ createInterpolateElement(
-						__(
-							'Please verify that the above information is correct and either <link>update</link> it or provide a photo of a document on which the above name and address are clearly visible. Some of the accepted documents are:'
-						),
-						{
-							link: (
-								<RouterLinkButton
-									variant="link"
-									to={ domainContactInfoRoute.fullPath }
-									params={ { domainName } }
-								/>
+				{ hasAcceptedDocuments ? (
+					<Text as="p">
+						{ createInterpolateElement(
+							__(
+								'Please verify that the above information is correct and either <link>update</link> it or provide a photo of a document on which the above name and address are clearly visible. Some of the accepted documents are:'
 							),
-						}
-					) }
-				</Text>
-				<ul>
-					<li>{ __( 'Valid drivers’ license' ) }</li>
-					<li>{ __( 'Valid national ID cards (for non-UK residents)' ) }</li>
-					<li>{ __( 'Utility bills (last 3 months)' ) }</li>
-					<li>{ __( 'Bank statement (last 3 months)' ) }</li>
-					<li>{ __( 'HMRC tax notification (last 3 months)' ) }</li>
-				</ul>
+							{
+								link: (
+									<RouterLinkButton
+										variant="link"
+										to={ domainContactInfoRoute.fullPath }
+										params={ { domainName } }
+									/>
+								),
+							}
+						) }
+					</Text>
+				) : (
+					<Text as="p">
+						{ createInterpolateElement(
+							__(
+								'Please verify that the above information is correct and either <link>update</link> it or upload a valid identification document.'
+							),
+							{
+								link: (
+									<RouterLinkButton
+										variant="link"
+										to={ domainContactInfoRoute.fullPath }
+										params={ { domainName } }
+									/>
+								),
+							}
+						) }
+					</Text>
+				) }
+				{ hasAcceptedDocuments && (
+					<ul>
+						{ tldConfig.acceptedDocuments.map( ( doc ) => (
+							<li key={ doc }>{ doc }</li>
+						) ) }
+					</ul>
+				) }
 				<Text>
 					{ __(
 						'Please upload a photo of the document on which the above name and address are clearly visible.'
@@ -201,11 +229,7 @@ export default function DomainContactVerification() {
 							title={ __( 'Additional contact verification required for your domain' ) }
 							level={ 3 }
 						/>
-						<Text as="p">
-							{ __(
-								'Nominet, the organization that manages .uk domains, requires us to verify the contact information of your domain.'
-							) }
-						</Text>
+						<Text as="p">{ tldConfig.registryDescription }</Text>
 						{ renderContactInformation() }
 						{ renderInstructions() }
 						<FormFileUpload

--- a/client/dashboard/domains/domain-contact-verification/index.tsx
+++ b/client/dashboard/domains/domain-contact-verification/index.tsx
@@ -1,7 +1,4 @@
-import {
-	extractTld,
-	getContactVerificationTldConfig,
-} from '@automattic/api-core/src/domain-contact-verification';
+import { extractTld, getContactVerificationTldConfig } from '@automattic/api-core';
 import { domainWhoisQuery, domainContactVerificationMutation } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import {

--- a/client/dashboard/domains/domain-overview/contact-verification-notice.tsx
+++ b/client/dashboard/domains/domain-overview/contact-verification-notice.tsx
@@ -1,0 +1,26 @@
+import { extractTld, getContactVerificationTldConfig } from '@automattic/api-core';
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { domainContactVerificationRoute } from '../../app/router/domains';
+import Notice from '../../components/notice';
+import RouterLinkButton from '../../components/router-link-button';
+
+export default function ContactVerificationNotice( { domainName }: { domainName: string } ) {
+	const tld = extractTld( domainName );
+	const tldConfig = getContactVerificationTldConfig( tld );
+
+	return (
+		<Notice variant="warning" title={ __( 'Contact verification required' ) }>
+			<VStack spacing={ 4 }>
+				<Text>{ tldConfig.registryDescription }</Text>
+				<RouterLinkButton
+					variant="link"
+					to={ domainContactVerificationRoute.fullPath }
+					params={ { domainName } }
+				>
+					{ __( 'Verify your contact information' ) }
+				</RouterLinkButton>
+			</VStack>
+		</Notice>
+	);
+}

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -23,6 +23,7 @@ import { formatDate } from '../../utils/datetime';
 import { getDomainRenewalUrl, isTldInMaintenance } from '../../utils/domain';
 import { TLDMaintenanceNotice } from '../maintenance-notice';
 import Actions from './actions';
+import ContactVerificationNotice from './contact-verification-notice';
 import FeaturedCards from './featured-cards';
 import IcannSuspensionNotice from './icann-suspension-notice';
 import DomainOverviewSettings from './settings';
@@ -128,6 +129,9 @@ export default function DomainOverview() {
 				) }
 				{ domain.is_pending_icann_verification && (
 					<IcannSuspensionNotice domainName={ domain.domain } />
+				) }
+				{ domain.contact_document_verification_request && (
+					<ContactVerificationNotice domainName={ domain.domain } />
 				) }
 				{ domain.subtype.id !== DomainSubtype.DOMAIN_TRANSFER && (
 					<>

--- a/client/dashboard/utils/domain-permissions.ts
+++ b/client/dashboard/utils/domain-permissions.ts
@@ -47,8 +47,12 @@ const checkNotPendingWhoisUpdate: DomainCheckFunction = ( domain: Domain ) =>
 const checkCanManageDnsRecords: DomainCheckFunction = ( domain: Domain ) =>
 	!! domain.can_manage_dns_records;
 
-const checkNominetPendingOrSuspended: DomainCheckFunction = ( domain: Domain ) =>
-	domain.nominet_pending_contact_verification_request || domain.nominet_domain_suspended;
+const checkContactDocumentVerificationRequired: DomainCheckFunction = ( domain: Domain ) =>
+	domain.contact_document_verification_request === 'pending' ||
+	domain.contact_document_verification_request === 'suspended' ||
+	// Backwards compat for .uk until backend migrates
+	domain.nominet_pending_contact_verification_request ||
+	domain.nominet_domain_suspended;
 
 export const PermissionCheck = {
 	INBOUND_TRANSFER: 'inbound-transfer',
@@ -188,7 +192,7 @@ const DOMAIN_PERMISSION_CHECKS = {
 				),
 		},
 		{
-			check: checkNominetPendingOrSuspended,
+			check: checkContactDocumentVerificationRequired,
 			getErrorMessage: () => __( 'This domain does not require contact verification.' ),
 		},
 	],

--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -122,6 +122,7 @@ export type ResponseDomain = {
 	name: string;
 	nominetDomainSuspended: boolean;
 	nominetPendingContactVerificationRequest: boolean;
+	contactDocumentVerificationRequest?: 'pending' | 'suspended';
 	owner: string;
 	partnerDomain: boolean;
 	pendingRegistration: boolean;

--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -1,3 +1,7 @@
+import {
+	extractTld,
+	getContactVerificationTldConfig,
+} from '@automattic/api-core/src/domain-contact-verification';
 import { Button } from '@automattic/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -53,38 +57,54 @@ const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
 	};
 
 	const renderDescription = () => {
-		const { contactInformationUpdateLink } = props;
+		const { contactInformationUpdateLink, selectedDomainName } = props;
+		const tld = extractTld( selectedDomainName );
+		const tldConfig = getContactVerificationTldConfig( tld );
+		const hasAcceptedDocuments = tldConfig.acceptedDocuments.length > 0;
 
 		return (
 			<div>
-				<p>
-					{ translate(
-						'Nominet, the organization that manages .uk domains, requires us to verify the contact information of your domain.'
-					) }
-				</p>
+				<p>{ tldConfig.registryDescription }</p>
 				<p>{ translate( 'This is your current contact information:' ) }</p>
 				{ renderContactInformation() }
-				<p>
-					{ translate(
-						'Please verify that the above information is correct and either {{a}}update it{{/a}} or provide a photo of a document on which the above name and address are clearly visible. Some of the accepted documents are:',
-						{
-							components: {
-								a: contactInformationUpdateLink ? (
-									<a href={ contactInformationUpdateLink } />
-								) : (
-									<span />
-								),
-							},
-						}
-					) }
-				</p>
-				<ul>
-					<li>{ translate( "Valid drivers' license" ) }</li>
-					<li>{ translate( 'Valid national ID cards (for non-UK residents)' ) }</li>
-					<li>{ translate( 'Utility bills (last 3 months)' ) }</li>
-					<li>{ translate( 'Bank statement (last 3 months)' ) }</li>
-					<li>{ translate( 'HMRC tax notification (last 3 months)' ) }</li>
-				</ul>
+				{ hasAcceptedDocuments ? (
+					<p>
+						{ translate(
+							'Please verify that the above information is correct and either {{a}}update it{{/a}} or provide a photo of a document on which the above name and address are clearly visible. Some of the accepted documents are:',
+							{
+								components: {
+									a: contactInformationUpdateLink ? (
+										<a href={ contactInformationUpdateLink } />
+									) : (
+										<span />
+									),
+								},
+							}
+						) }
+					</p>
+				) : (
+					<p>
+						{ translate(
+							'Please verify that the above information is correct and either {{a}}update it{{/a}} or upload a valid identification document.',
+							{
+								components: {
+									a: contactInformationUpdateLink ? (
+										<a href={ contactInformationUpdateLink } />
+									) : (
+										<span />
+									),
+								},
+							}
+						) }
+					</p>
+				) }
+				{ hasAcceptedDocuments && (
+					<ul>
+						{ tldConfig.acceptedDocuments.map( ( doc ) => (
+							<li key={ doc }>{ doc }</li>
+						) ) }
+					</ul>
+				) }
 				<p>
 					{ translate(
 						'Click on the button below to upload up to three documents and then click on the "Submit" button. You can upload images (JPEG or PNG) and/or PDF files up to 5MB each.'

--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -1,7 +1,4 @@
-import {
-	extractTld,
-	getContactVerificationTldConfig,
-} from '@automattic/api-core/src/domain-contact-verification';
+import { extractTld, getContactVerificationTldConfig } from '@automattic/api-core';
 import { Button } from '@automattic/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -629,8 +629,13 @@ const Settings = ( {
 			return null;
 		}
 
-		// Show the card only if the domain requires a verification from Nominet (or if it has been already suspended)
-		if ( ! domain.nominetDomainSuspended && ! domain.nominetPendingContactVerificationRequest ) {
+		const showContactVerification =
+			domain.contactDocumentVerificationRequest === 'pending' ||
+			domain.contactDocumentVerificationRequest === 'suspended' ||
+			domain.nominetPendingContactVerificationRequest ||
+			domain.nominetDomainSuspended;
+
+		if ( ! showContactVerification ) {
 			return null;
 		}
 

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -153,6 +153,7 @@ export const createSiteDomainObject = ( domain ) => {
 		nominetPendingContactVerificationRequest: Boolean(
 			domain.nominet_pending_contact_verification_request
 		),
+		contactDocumentVerificationRequest: domain.contact_document_verification_request ?? undefined,
 		owner: String( domain.owner ),
 		partnerDomain: Boolean( domain.partner_domain ),
 		pendingRegistration: Boolean( domain.pending_registration ),

--- a/docs/plans/2026-02-06-in-domain-contact-verification-design.md
+++ b/docs/plans/2026-02-06-in-domain-contact-verification-design.md
@@ -1,0 +1,308 @@
+# .in Domain Contact Document Verification
+
+**Linear issue:** DOTOBRD-399
+**Date:** 2026-02-06
+
+## Overview
+
+Extend the existing .uk contact verification flow to support .in domains (and future TLDs) across both the Dashboard (MSD) and Calypso (My Sites). Introduces a new generic `contact_document_verification_request` domain flag, a TLD configuration map for dynamic UI copy, and backend changes for post-registration triggers, Zendesk tickets, and emails.
+
+## Acceptance criteria
+
+1. When registering a new .in domain, collect and store the user's additional contact information (any identification document as image/PDF).
+2. When the document is collected, create a Zendesk ticket with it (same flow as .uk).
+3. For new .in domain purchases, send an email from the domain registration flow asking the customer to open the MSD interface and upload docs.
+4. When a user updates the contact information for a .in domain, set the `contact_document_verification_request` flag to `pending`, triggering the document upload flow and email reminder.
+
+## Architecture decisions
+
+- **New generic flag over reusing Nominet flags.** A single optional enum field `contact_document_verification_request` with values `"pending"` and `"suspended"` replaces the two Nominet-specific booleans for new TLDs. Existing Nominet flags remain for backwards compatibility until the backend migrates .uk.
+- **TLD configuration map over backend-driven content.** A frontend config maps TLDs to registry info and accepted document lists. Simpler than coordinating backend content delivery, and easy to extend.
+- **Same API endpoint.** `POST /domains/{domain}/contact-verification` handles file uploads and Zendesk ticket creation for all TLDs. No new endpoints needed.
+- **Email triggered from post-registration async job.** Not from Keysystems webhooks. The `domains-post-register.php` async job (runs ~10 minutes after registration) sets the flag and sends the email.
+- **No Keysystems webhook changes for .in.** The existing webhook handler remains .uk-only. For .in, the flag and email are triggered from the post-registration flow and contact info update flow.
+
+---
+
+## Frontend changes
+
+### 1. New shared TLD config
+
+**New file:** `packages/api-core/src/domain-contact-verification/tld-config.ts`
+
+```typescript
+interface ContactVerificationTldConfig {
+  registryName: string;
+  registryDescription: string;
+  acceptedDocuments: string[];
+}
+
+const contactVerificationTldConfig: Record<string, ContactVerificationTldConfig> = {
+  uk: {
+    registryName: 'Nominet',
+    registryDescription:
+      'Nominet, the organization that manages .uk domains, requires us to verify the contact information of your domain.',
+    acceptedDocuments: [
+      "Valid drivers' license",
+      'Valid national ID cards (for non-UK residents)',
+      'Utility bills (last 3 months)',
+      'Bank statement (last 3 months)',
+      'HMRC tax notification (last 3 months)',
+    ],
+  },
+  in: {
+    registryName: 'NIXI',
+    registryDescription:
+      'NIXI, the organization that manages .in domains, requires us to verify the contact information of your domain.',
+    acceptedDocuments: [], // Accept any doc for now; update when requirements are finalized
+  },
+};
+```
+
+**Fallback behavior:**
+- Unknown TLD: generic copy ("The registry requires us to verify the contact information of your domain.")
+- Empty `acceptedDocuments`: show "Please upload a valid identification document." instead of a bullet list.
+
+### 2. Domain type updates
+
+**`packages/api-core/src/domain/types.ts`** - Add to `Domain` interface:
+
+```typescript
+contact_document_verification_request?: 'pending' | 'suspended';
+```
+
+**`packages/domains-table/src/utils/assembler.ts`** - Map to camelCase:
+
+```typescript
+contactDocumentVerificationRequest: domain.contact_document_verification_request ?? undefined,
+```
+
+**`client/state/sites/domains/assembler.js`** - Same camelCase mapping:
+
+```javascript
+contactDocumentVerificationRequest: domain.contact_document_verification_request ?? undefined,
+```
+
+**`client/lib/domains/types.ts`** - Add to legacy type:
+
+```typescript
+contactDocumentVerificationRequest?: 'pending' | 'suspended';
+```
+
+### 3. Dashboard (MSD) changes
+
+**`client/dashboard/utils/domain-permissions.ts`** - Update permission check:
+
+```typescript
+const checkContactDocumentVerificationRequired: DomainCheckFunction = (domain) =>
+  domain.contact_document_verification_request === 'pending' ||
+  domain.contact_document_verification_request === 'suspended' ||
+  // Backwards compat for .uk until backend migrates
+  domain.nominet_pending_contact_verification_request ||
+  domain.nominet_domain_suspended;
+```
+
+Replace `checkNominetPendingOrSuspended` with `checkContactDocumentVerificationRequired` in the `CONTACT_VERIFICATION` permission checks.
+
+**`client/dashboard/domains/domain-contact-verification/index.tsx`** - Use TLD config:
+
+- Extract TLD from `domainName`.
+- Look up config from TLD map, fall back to generic.
+- Replace hardcoded Nominet text in the description with `config.registryDescription`.
+- Conditionally render accepted documents list only if `config.acceptedDocuments.length > 0`.
+- If empty, show generic message: "Please upload a valid identification document."
+
+### 4. Calypso (My Sites) changes
+
+**`client/my-sites/domains/domain-management/settings/index.tsx`** - Update display condition in `renderContactVerificationSection()` to also check `contactDocumentVerificationRequest`:
+
+```typescript
+const showContactVerification =
+  domain.contactDocumentVerificationRequest === 'pending' ||
+  domain.contactDocumentVerificationRequest === 'suspended' ||
+  domain.nominetPendingContactVerificationRequest ||
+  domain.nominetDomainSuspended;
+```
+
+**`client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx`** - Use TLD config:
+
+- Same pattern as Dashboard: extract TLD, look up config, render dynamic copy.
+- Replace hardcoded Nominet text and UK document list with config-driven content.
+
+---
+
+## Backend changes
+
+### 5. New generic flag group
+
+**New file:** `wp-content/lib/domains/domain-flags/domain-contact-document-verification-flag-group.php`
+
+```php
+class Domain_Contact_Document_Verification_Group extends Domain_Flag_Group_Base {
+    public const PENDING = 'contact_document_verification_pending';
+    public const SUSPENDED = 'contact_document_verification_suspended';
+
+    // Same pattern as Domain_Nominet_Contact_Verification_Group:
+    // - get_default_flag_value() returns current datetime
+    // - get_valid_flag_types() returns [PENDING, SUSPENDED]
+    // - should_set_flag() returns true
+    // - should_update_existing_flag() returns true
+}
+```
+
+**New file:** `wp-content/lib/domains/domain-flags/domain-contact-document-verification-flags-manager.php`
+
+Same pattern as `Domain_Nominet_Contact_Verification_Flags_Manager`: only one flag at a time (delete-before-set).
+
+**Update:** `wp-content/lib/domains/domain-flags/domain-flags.php` - Register the new manager in `FLAG_MANAGER_CLASSES`.
+
+### 6. Expose new flag in API response
+
+**Update:** `wp-content/admin-plugins/domains/domain-management-domain.php` (~line 512)
+
+Add alongside existing Nominet flags:
+
+```php
+$contact_document_verification_manager = DI::get(Domain_Contact_Document_Verification_Flags_Manager::class);
+$pending = $contact_document_verification_manager->get_flag_value(
+    $wpcom_domain->name,
+    Domain_Contact_Document_Verification_Group::PENDING
+);
+$suspended = $contact_document_verification_manager->get_flag_value(
+    $wpcom_domain->name,
+    Domain_Contact_Document_Verification_Group::SUSPENDED
+);
+
+if (!empty($pending)) {
+    $this->contact_document_verification_request = 'pending';
+} elseif (!empty($suspended)) {
+    $this->contact_document_verification_request = 'suspended';
+} else {
+    $this->contact_document_verification_request = null;
+}
+```
+
+Add the property to the class:
+
+```php
+public $contact_document_verification_request = null;
+```
+
+### 7. Zendesk ticket - make TLD-aware
+
+**Update:** `public.api/rest/wpcom-json-endpoints/class.wpcom-store-domains-api-endpoints.php`
+
+In `create_zendesk_ticket()`, replace the hardcoded Nominet-specific ticket message with TLD-aware content:
+
+- For `.uk`: keep current Nominet copy and document list.
+- For `.in`: generic message ("The registry requires contact verification for this domain.") without a specific document list.
+- The subject, tags, Zendesk group, and custom fields remain the same for all TLDs.
+
+### 8. Set pending flag on contact info update for .in domains
+
+**Update:** `public.api/rest/wpcom-json-endpoints/class.wpcom-store-domains-api-endpoints.php`
+
+In `WPCOM_JSON_API_Domains_Update_Whois_Endpoint::callback()` (and the v1.1 variant), after a successful `Domains_API::update_whois()` call for a .in domain:
+
+1. Set the `contact_document_verification_request` flag to `pending`.
+2. Send the manual verification email with a link to the contact verification page.
+
+```php
+$result = Domains_API::update_whois( $domain, $contact_information, $transfer_lock );
+
+if ( ! is_wp_error( $result ) ) {
+    $wpcom_domain = new WPCOM_Domain( $domain );
+    if ( $wpcom_domain->get_tld() === 'in' ) {
+        $contact_document_verification_manager = DI::get( Domain_Contact_Document_Verification_Flags_Manager::class );
+        $contact_document_verification_manager->set_flag(
+            $domain,
+            Domain_Contact_Document_Verification_Group::PENDING
+        );
+
+        Domain_Emails::process_event(
+            $domain,
+            Domain_Email_Event::DOMAIN_MANUAL_VERIFICATION,
+            [ 'recipient' => $whois_email ]
+        );
+    }
+}
+```
+
+This ensures that every time a .in domain's contact info changes, the user must re-verify with document upload.
+
+### 9. Set pending flag and send email on .in domain registration
+
+**Update:** `async-jobs/includes/domains-post-register.php`
+
+This async job runs ~10 minutes after domain registration. It already has `$tld_spec` and `$domain` in scope, and fires `DOMAIN_ACTIVATED` emails at line 67.
+
+After the existing `DOMAIN_ACTIVATED` email logic (line 67), add a check for .in domains:
+
+```php
+// Existing code (line 65-68):
+if ( $tld_spec->icann_emails_are_handled_by_automattic() ) {
+    Domain_Emails::process_event( $domain, Domain_Email_Event::DOMAIN_ACTIVATED );
+}
+
+// NEW: Set contact document verification flag for .in domains
+if ( 0 === substr_compare( $domain, '.in', -3 ) ) {
+    $contact_document_verification_manager = WPCOM\Container\DI::get(
+        Domain_Contact_Document_Verification_Flags_Manager::class
+    );
+    $contact_document_verification_manager->set_flag(
+        $domain,
+        Domain_Contact_Document_Verification_Group::PENDING
+    );
+
+    // Fetch registrant email from WHOIS since $contact_information is not in scope
+    $whois = Domains_API::whois( $domain );
+    if ( ! is_wp_error( $whois ) && ! empty( $whois['email'] ) ) {
+        Domain_Emails::process_event(
+            $domain,
+            Domain_Email_Event::DOMAIN_MANUAL_VERIFICATION,
+            [ 'recipient' => $whois['email'] ]
+        );
+    }
+}
+```
+
+**Note:** The registrant email is fetched via `Domains_API::whois()` since `$contact_information` is not available in the async job context. The ~10 minute delay from `deferred_async_job` means WHOIS data should be available by the time this runs.
+
+**Email template update:** The existing `Domain_Email_Domain_Manual_Verification` class (`get_email_specific_props()`) sets `validation_url` to `/domains/manage/{domain}/edit`. Update to `/domains/manage/{domain}/contact-verification` so the email links to the correct page.
+
+---
+
+## File summary
+
+### Frontend (~8 files)
+
+| File | Action |
+|---|---|
+| `packages/api-core/src/domain-contact-verification/tld-config.ts` | **New** - TLD config map |
+| `packages/api-core/src/domain/types.ts` | Add `contact_document_verification_request` |
+| `packages/domains-table/src/utils/assembler.ts` | Map new field to camelCase |
+| `client/state/sites/domains/assembler.js` | Map new field to camelCase |
+| `client/lib/domains/types.ts` | Add camelCase property |
+| `client/dashboard/utils/domain-permissions.ts` | Update permission check |
+| `client/dashboard/domains/domain-contact-verification/index.tsx` | TLD-aware copy |
+| `client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx` | TLD-aware copy |
+| `client/my-sites/domains/domain-management/settings/index.tsx` | Update display condition |
+
+### Backend (~7 files)
+
+| File | Action |
+|---|---|
+| `domain-flags/domain-contact-document-verification-flag-group.php` | **New** - flag group |
+| `domain-flags/domain-contact-document-verification-flags-manager.php` | **New** - flag manager |
+| `domain-flags/domain-flags.php` | Register new manager |
+| `admin-plugins/domains/domain-management-domain.php` | Expose new flag in API |
+| `class.wpcom-store-domains-api-endpoints.php` | TLD-aware Zendesk ticket + set pending flag on contact info update for .in |
+| `async-jobs/includes/domains-post-register.php` | Set pending flag + send email for .in registrations |
+| `lib/domains/email/types/class-domain-email-domain-manual-verification.php` | Update `validation_url` to `/contact-verification` |
+
+### Not in scope
+
+- No new routes or pages
+- No new API endpoints
+- No checkout flow changes
+- No migration of .uk from Nominet flags to generic flags (future work)

--- a/packages/api-core/src/domain-contact-verification/index.ts
+++ b/packages/api-core/src/domain-contact-verification/index.ts
@@ -1,1 +1,2 @@
 export * from './mutators';
+export * from './tld-config';

--- a/packages/api-core/src/domain-contact-verification/tld-config.ts
+++ b/packages/api-core/src/domain-contact-verification/tld-config.ts
@@ -1,0 +1,41 @@
+export interface ContactVerificationTldConfig {
+	registryName: string;
+	registryDescription: string;
+	acceptedDocuments: string[];
+}
+
+const contactVerificationTldConfig: Record< string, ContactVerificationTldConfig > = {
+	uk: {
+		registryName: 'Nominet',
+		registryDescription:
+			'Nominet, the organization that manages .uk domains, requires us to verify the contact information of your domain.',
+		acceptedDocuments: [
+			"Valid drivers' license",
+			'Valid national ID cards (for non-UK residents)',
+			'Utility bills (last 3 months)',
+			'Bank statement (last 3 months)',
+			'HMRC tax notification (last 3 months)',
+		],
+	},
+	in: {
+		registryName: 'NIXI',
+		registryDescription:
+			'NIXI, the organization that manages .in domains, requires us to verify the contact information of your domain.',
+		acceptedDocuments: [],
+	},
+};
+
+const defaultConfig: ContactVerificationTldConfig = {
+	registryName: '',
+	registryDescription: 'The registry requires us to verify the contact information of your domain.',
+	acceptedDocuments: [],
+};
+
+export function getContactVerificationTldConfig( tld: string ): ContactVerificationTldConfig {
+	return contactVerificationTldConfig[ tld ] ?? defaultConfig;
+}
+
+export function extractTld( domainName: string ): string {
+	const parts = domainName.split( '.' );
+	return parts[ parts.length - 1 ] ?? '';
+}

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -79,6 +79,7 @@ export interface Domain extends DomainSummary {
 	move_to_new_site_pending: boolean;
 	nominet_pending_contact_verification_request: boolean;
 	nominet_domain_suspended: boolean;
+	contact_document_verification_request?: 'pending' | 'suspended';
 	owner: string;
 	is_pending_registration: boolean;
 	is_pending_registration_at_registry: boolean;

--- a/packages/domains-table/src/utils/assembler.ts
+++ b/packages/domains-table/src/utils/assembler.ts
@@ -157,6 +157,7 @@ export const createSiteDomainObject = ( domain: DomainData ) => {
 		nominetPendingContactVerificationRequest: Boolean(
 			domain.nominet_pending_contact_verification_request
 		),
+		contactDocumentVerificationRequest: domain.contact_document_verification_request ?? undefined,
 		owner: domain.owner,
 		partnerDomain: Boolean( domain.partner_domain ),
 		pendingRegistration: Boolean( domain.pending_registration ),


### PR DESCRIPTION
Part of DOTOBRD-399

## Proposed Changes

- Add a TLD configuration map (`tld-config.ts`) for dynamic registry descriptions and accepted document lists, supporting `.uk`, `.in`, and fallback for future TLDs
- Add `contact_document_verification_request` field to domain types and assemblers (both Dashboard and Calypso)
- Update Dashboard domain permissions to check the new generic flag alongside existing Nominet flags for backwards compatibility
- Update Dashboard and Calypso contact verification UIs to render TLD-aware copy (registry description, accepted documents list, or generic message when no documents configured)

<img width="1564" height="896" alt="image" src="https://github.com/user-attachments/assets/7e9c7ed3-bc14-4ec6-8bb8-dbc15237fe9f" />

<img width="1581" height="1018" alt="image" src="https://github.com/user-attachments/assets/faeba139-e4db-49d1-8d1e-93c17707078e" />


## Why are these changes being made?

The existing contact verification flow is hardcoded for `.uk` (Nominet) domains only. To support `.in` domain registrations (required by NIXI), we need a generic, TLD-aware approach. This PR introduces the frontend half: a shared TLD config, updated domain types, and dynamic UI rendering. The backend changes (new flag group, API exposure, Zendesk/whois/post-register triggers) are in a separate wpcom-sandbox changeset.

## Testing Instructions

- Verify that `.uk` domains with `nominet_pending_contact_verification_request` or `nominet_domain_suspended` still show the contact verification section with Nominet-specific copy and document list
- Verify that domains with `contact_document_verification_request: 'pending'` or `'suspended'` show the contact verification section with the appropriate TLD-specific copy
- For `.in` domains, verify the generic "upload a valid identification document" message is shown (no specific document list)
- Verify that domains without any verification flags do not show the contact verification section

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?