### PR TITLE
Adjust Stats plan quantity display in Billing History and Receipts

### DIFF
--- a/client/dashboard/me/billing-history/utils.tsx
+++ b/client/dashboard/me/billing-history/utils.tsx
@@ -1,4 +1,4 @@
-import { formatCurrency } from '@automattic/number-formatters';
+import { formatCurrency, formatNumber } from '@automattic/number-formatters';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	isDIFMProduct,
@@ -6,6 +6,7 @@ import {
 	isTitanMail,
 	isTieredVolumeSpaceAddon,
 	isJetpackSearch,
+	isJetpackStatsPaidProductSlug,
 } from '../../utils/purchase';
 import type { Receipt, ReceiptItem } from '@automattic/api-core';
 import type { IntroductoryOfferTerms } from '@automattic/shopping-cart';
@@ -153,6 +154,22 @@ function renderJetpackSearchQuantitySummary( licensedQuantity: number, isRenewal
 	);
 }
 
+function renderJetpackStatsQuantitySummary( licensedQuantity: number, isRenewal: boolean ) {
+	if ( isRenewal ) {
+		return sprintf(
+			/* translators: %s: formatted number of views per month */
+			__( 'Renewal for %s views per month' ),
+			formatNumber( licensedQuantity )
+		);
+	}
+
+	return sprintf(
+		/* translators: %s: formatted number of views per month */
+		__( 'Purchase for %s views per month' ),
+		formatNumber( licensedQuantity )
+	);
+}
+
 function renderSpaceAddOnquantitySummary( licensedQuantity: number, isRenewal: boolean ) {
 	if ( isRenewal ) {
 		return sprintf(
@@ -222,6 +239,10 @@ export function renderTransactionQuantitySummary( {
 
 	if ( isJetpackSearch( product ) ) {
 		return renderJetpackSearchQuantitySummary( licensedQuantity, isRenewal );
+	}
+
+	if ( isJetpackStatsPaidProductSlug( wpcom_product_slug ) ) {
+		return renderJetpackStatsQuantitySummary( licensedQuantity, isRenewal );
 	}
 
 	if ( isGoogleWorkspace( product ) || isTitanMail( product ) ) {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -458,6 +458,22 @@ export function isJetpackSearch( product: ObjectWithProductSlug ): boolean {
 		: false;
 }
 
+const JETPACK_STATS_PAID_PRODUCT_SLUGS = [
+	'jetpack_stats_bi_yearly',
+	'jetpack_stats_yearly',
+	'jetpack_stats_monthly',
+	'jetpack_stats_pwyw_yearly',
+] as const;
+
+/**
+ * Checks if a product slug is a paid Jetpack Stats product.
+ */
+export function isJetpackStatsPaidProductSlug( productSlug: string | undefined ): boolean {
+	return productSlug
+		? ( JETPACK_STATS_PAID_PRODUCT_SLUGS as readonly string[] ).includes( productSlug )
+		: false;
+}
+
 export function isJetpackT1SecurityPlan( purchase: Purchase ): boolean {
 	const securityT1Slugs = [
 		JetpackPlans.PLAN_JETPACK_SECURITY_T1_YEARLY,

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -5,8 +5,9 @@ import {
 	isTitanMail,
 	isTieredVolumeSpaceAddon,
 	isJetpackSearch,
+	isJetpackStatsPaidProductSlug,
 } from '@automattic/calypso-products';
-import { formatCurrency } from '@automattic/number-formatters';
+import { formatCurrency, formatNumber } from '@automattic/number-formatters';
 import { LocalizeProps, useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
@@ -230,6 +231,24 @@ function renderJetpackSearchQuantitySummary(
 	} );
 }
 
+function renderJetpackStatsQuantitySummary(
+	licensed_quantity: number,
+	isRenewal: boolean,
+	translate: LocalizeProps[ 'translate' ]
+) {
+	if ( isRenewal ) {
+		return translate( 'Renewal for %(quantity)s views per month', {
+			args: { quantity: formatNumber( licensed_quantity ) },
+			comment: '%(quantity)s is the number of views per month for Jetpack Stats',
+		} );
+	}
+
+	return translate( 'Purchase for %(quantity)s views per month', {
+		args: { quantity: formatNumber( licensed_quantity ) },
+		comment: '%(quantity)s is the number of views per month for Jetpack Stats',
+	} );
+}
+
 function renderSpaceAddOnquantitySummary(
 	licensed_quantity: number,
 	isRenewal: boolean,
@@ -309,6 +328,10 @@ export function renderTransactionQuantitySummary(
 
 	if ( isJetpackSearch( product ) ) {
 		return renderJetpackSearchQuantitySummary( licensed_quantity, isRenewal, translate );
+	}
+
+	if ( isJetpackStatsPaidProductSlug( wpcom_product_slug ) ) {
+		return renderJetpackStatsQuantitySummary( licensed_quantity, isRenewal, translate );
 	}
 
 	if ( isGoogleWorkspace( product ) || isTitanMail( product ) ) {


### PR DESCRIPTION
This PR changes the display of Jetpack Stats plans on the Billing History and Receipts page to use "views" instead of "items". For example, instead of describing a plan as "100000 items" it displays it as "100,000 views".

Reported on Linear here:
https://linear.app/a8c/issue/JETH-9313/stats-stats-upgrades-confusing-on-purchase-page

Before:

<img width="1033" height="969" alt="stats-before" src="https://github.com/user-attachments/assets/25776b3b-c609-4a36-8df9-8404a49bc608" />



After:
<img width="1324" height="859" alt="SCR-20260207-iipe" src="https://github.com/user-attachments/assets/8ae3458f-4c66-4bef-aa3e-accfeecd1153" />



## Proposed Changes

* Adjust the display of Stats plans by changing "items" to "views" and adding proper formatting.

## Why are these changes being made?

- To fix an inconsistency in how the numbers are displayed in the Billing History and Receipts.
 
## Testing Instructions

Make sure your WordPress.com account has a paid Jetpack Stats plan:

- Navigate to /me/purchases/billing (billing history page)
- Verify Jetpack Stats shows "Purchase for 250,000 views per month" (or the number from the plan you added)
- Click on a Jetpack Stats receipt at /me/purchases/billing/{id}
- Verify the line item shows the correct format with formatted numbers (commas)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ x ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
