### PR TITLE
Fix TypeError in MasterbarLoggedIn.renderProfileMenu when user is null

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -646,6 +646,11 @@ class MasterbarLoggedIn extends Component {
 
 	renderProfileMenu() {
 		const { translate, user, isGlobalSidebarVisible, siteAdminUrl } = this.props;
+
+		if ( ! user ) {
+			return null;
+		}
+
 		const profileActions = [
 			{
 				label: (

--- a/client/layout/masterbar/test/logged-in.jsx
+++ b/client/layout/masterbar/test/logged-in.jsx
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import MasterbarLoggedIn from '../logged-in';
+
+// Mock heavy or unrelated child components to keep the test focused.
+jest.mock( 'calypso/components/async-load', () => () => null );
+jest.mock( '../masterbar-notifications/notifications-button', () => () => (
+	<div data-testid="notifications" />
+) );
+jest.mock( 'calypso/components/gravatar', () => ( { user } ) => (
+	<div data-testid="gravatar" data-user={ user?.display_name } />
+) );
+
+const mockStore = configureStore();
+
+function getBaseState( userOverride ) {
+	return {
+		ui: {
+			section: { group: 'sites' },
+			selectedSiteId: 1,
+			layoutFocus: { current: 'content' },
+			route: { path: { current: '/home' } },
+		},
+		currentUser: {
+			id: userOverride === null ? null : 1,
+			capabilities: { 1: { manage_options: true } },
+			user:
+				userOverride === null
+					? null
+					: userOverride ?? {
+							ID: 1,
+							display_name: 'Test User',
+							username: 'testuser',
+							email: 'test@example.com',
+							primary_blog: 1,
+							primary_blog_url: 'https://example.wordpress.com',
+							site_count: 1,
+							visible_site_count: 1,
+					  },
+		},
+		sites: {
+			items: {
+				1: {
+					ID: 1,
+					URL: 'https://example.wordpress.com',
+					title: 'Test Site',
+					plan: { product_slug: 'free_plan' },
+					options: {},
+				},
+			},
+			plans: { 1: {} },
+			domains: { items: {} },
+			connection: { items: {} },
+		},
+		preferences: {
+			remoteValues: {},
+			localValues: {},
+		},
+		purchases: { data: [] },
+		productsList: { items: {} },
+		siteSettings: { items: {} },
+		media: { queries: {} },
+		adminMenu: {},
+		support: { isSupportSession: false },
+		route: { path: { current: '/home' }, query: { current: {} } },
+	};
+}
+
+function renderMasterbar( stateOverrides = {} ) {
+	const state = { ...getBaseState( stateOverrides.user ), ...stateOverrides };
+	const store = mockStore( state );
+
+	return render(
+		<Provider store={ store }>
+			<MasterbarLoggedIn
+				section="my-sites"
+				setNextLayoutFocus={ jest.fn() }
+				activateNextLayoutFocus={ jest.fn() }
+				loadHelpCenterIcon={ false }
+			/>
+		</Provider>
+	);
+}
+
+describe( 'MasterbarLoggedIn', () => {
+	describe( 'renderProfileMenu', () => {
+		it( 'should render the profile menu when user is available', () => {
+			renderMasterbar();
+			expect( screen.getByText( /Howdy/ ) ).toBeVisible();
+		} );
+
+		it( 'should not crash when user is null', () => {
+			renderMasterbar( { user: null } );
+			expect( screen.queryByText( /Howdy/ ) ).not.toBeInTheDocument();
+		} );
+	} );
+} );


### PR DESCRIPTION
 Fixes CALYPSO-297Z                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                               
 ## Proposed Changes                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                               
  - Add a null guard in MasterbarLoggedIn.renderProfileMenu() to return null when the user prop is not yet available
  - Add test coverage for the profile menu rendering with and without a user

  ## Why are these changes being made?

  getCurrentUser() can return null before user data has finished loading from the Redux store. When this happens, renderProfileMenu() attempts to access user.display_name and user.username, which throws a TypeError: Cannot read properties of null (reading
  'display_name').

  This error has been tracked as https://a8c.sentry.io/issues/CALYPSO-297Z since March 2025.

 The fix gracefully skips rendering the profile menu until the user object is available. This is safe because there is nothing meaningful to display without user data — the menu shows the user's display name, username, and gravatar, all of which require the user object.

 ## Testing Instructions

  1. Open the WordPress.com dashboard while logged in
  2. Verify the masterbar profile menu ("Howdy, ...") renders correctly
  3. The fix addresses a race condition during initial page load, so it is best validated by confirming the Sentry error stops recurring after deploy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
