### PR TITLE
Fix TypeError in notifications when note has no actions

### DIFF
--- a/apps/notifications/src/app/templates/body.tsx
+++ b/apps/notifications/src/app/templates/body.tsx
@@ -103,6 +103,9 @@ export const NoteBody = ( { note }: { note: Note } ) => {
 	const isApproved = useSelector( ( state ) => getIsNoteApproved( state, note ) );
 	const actions = getActions( note );
 	const hasAction = ( types: string | string[] ) => {
+		if ( ! actions ) {
+			return false;
+		}
 		const typeArray = Array.isArray( types ) ? types : [ types ];
 		return typeArray.some( ( type ) => actions.hasOwnProperty( type ) );
 	};

--- a/apps/notifications/src/panel/templates/body.jsx
+++ b/apps/notifications/src/panel/templates/body.jsx
@@ -76,7 +76,9 @@ export class NoteBody extends Component {
 		// Check if we should show the pending approval badge
 		const noteActions = getActions( this.props.note );
 		const hasAction = ( types ) =>
-			[].concat( types ).some( ( type ) => noteActions.hasOwnProperty( type ) );
+			noteActions
+				? [].concat( types ).some( ( type ) => noteActions.hasOwnProperty( type ) )
+				: false;
 		const showPendingApprovalBadge = hasAction( 'approve-comment' ) && ! this.props.isApproved;
 
 		for ( i = 0; i < blocks.length; i++ ) {


### PR DESCRIPTION
Fixes CALYPSO-2HCW

## Proposed Changes

- Add null guard in `hasAction` helper within both `body.tsx` and `body.jsx` to handle when `getActions()` returns `undefined`

## Why are these changes being made?

#108325 introduced code in `body.tsx` and `body.jsx` that calls `getActions(note)` and then immediately calls `.hasOwnProperty()` on the result. When a notification has no action blocks, `getActions()` returns `undefined`, causing a TypeError tracked as CALYPSO-2HCW.

The fix adds a null guard in the `hasAction` helper in both files — the same files where the bug was introduced.

## Testing Instructions

1. Open the WordPress.com notifications panel
2. Click on various notification types (likes, follows, comments) — verify action buttons and pending approval badges render correctly
3. If possible, trigger a notification without action blocks and verify it renders without errors
4. The fix is best validated by confirming the Sentry error stops recurring after deploy

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?