### PR TITLE
Claude: update denied paths to focus on secrets

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,28 +1,17 @@
 {
 	"permissions": {
 		"deny": [
-			"Read(node_modules/**)",
-			"Read(vendor/**)",
-			"Read(build/**)",
-			"Read(public/**)",
-			"Read(**/dist/**)",
-			"Read(coverage/**)",
-			"Read(.webpack-cache/**)",
-			"Read(.cache/**)",
-			"Read(.tsc-cache/**)",
-			"Read(**/*.tsbuildinfo)",
-			"Read(yarn.lock)",
-			"Read(composer.lock)",
+			"Read(.env)",
+			"Read(.env.*)",
+			"Read(**/.envrc)",
+			"Read(**/*.pem)",
+			"Read(**/id_rsa)",
+			"Read(**/id_rsa.*)",
 			"Read(config/secrets.json)",
 			"Read(config/*.local.json)",
-			"Read(**/*.log)",
-			"Read(playwright-report/**)",
-			"Read(test-results*.xml)",
-			"Read(*xunit_*.xml)",
-			"Read(desktop/e2e/logs/**)",
-			"Read(desktop/e2e/screenshots/**)",
-			"Read(*.rdb)",
-			"Read(*.db)"
+			"Read(desktop/resource/certificates/*)",
+			"Read(packages/calypso-e2e/dist/**)",
+			"Read(packages/calypso-e2e/src/secrets/*)"
 		]
 	}
 }


### PR DESCRIPTION
I posted about this at p4TIVU-b4L-p2

## Proposed Changes

* Remove unnecessary deny patterns for build artifacts, caches, and lock files
* Add deny patterns for security-sensitive files: `.env`, certificates, SSH keys, secrets

## Why are these changes being made?

The previous deny list blocked build artifacts and caches which Claude may legitimately need to read for debugging. The updated list focuses on actual secrets and credentials that should never be exposed.

I don't see an equivalent file for cursor/codex

## Testing Instructions

* Verify Claude can read files in `node_modules/`, `build/`, `yarn.lock` etc.
* Verify Claude cannot read secrets: try a prompt like `Read @packages/calypso-e2e/src/secrets/encrypted.enc`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?