### PR TITLE
Fix crash in DomainUpsellCard when site.slug is undefined

### DIFF
--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -140,7 +140,7 @@ const DomainUpsellCardContent = ( {
 
 const DomainUpsellCard = ( { site }: { site: Site } ) => {
 	const { data: sitePlan } = useQuery( siteCurrentPlanQuery( site.ID ) );
-	if ( ! sitePlan ) {
+	if ( ! sitePlan || ! site.slug ) {
 		return null;
 	}
 


### PR DESCRIPTION
Fixes DOTMSD-1029

## Proposed Changes

* Add a guard for `site.slug` being undefined in the `DomainUpsellCard` component to prevent a `TypeError` crash.

## Why are these changes being made?

Sentry issue [CALYPSO-2GR5](https://a8c.sentry.io/issues/CALYPSO-2GR5) reports a `TypeError: Cannot read properties of undefined (reading 'split')` in the `useDomainSuggestion` hook. The `Site` TypeScript interface declares `slug` as required, but the API can return site objects without a `slug` property in certain edge cases (e.g., deleted or transitioning sites). This guard prevents the crash by returning `null` when `site.slug` is missing, consistent with the existing `sitePlan` guard.

## Testing Instructions

* Visit a site overview page for a site that might have an undefined slug (e.g., a deleted or transitioning site).
* Verify the domain upsell card does not crash.
* For normal sites with a valid slug, verify the domain upsell card still renders correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?