### PR TITLE
Dashboard: add multi-hostname support via hostname_allowlist

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -13,6 +13,7 @@
 	"survicate_enabled": false,
 	"survicate_enabled_at_help_center": true,
 	"hostname": false,
+	"hostname_allowlist": false,
 	"i18n_default_locale_slug": "en",
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",
 	"login_url": false,

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -4,6 +4,7 @@
 	"favicon_url": "/calypso/images/favicons/favicon-development.ico",
 	"client_slug": "browser",
 	"hostname": "my.localhost",
+	"hostname_allowlist": [ "my.localhost", "my.woo.localhost" ],
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
 	"wpcom_signup_id": "39911",

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -4,6 +4,7 @@
 	"favicon_url": "/calypso/images/favicons/favicon-wpcalypso.ico",
 	"client_slug": "browser",
 	"hostname": "my.wordpress.com",
+	"hostname_allowlist": [ "my.wordpress.com", "my.woo.com" ],
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -4,6 +4,7 @@
 	"favicon_url": "//s1.wp.com/i/favicon.ico",
 	"client_slug": "browser",
 	"hostname": "my.wordpress.com",
+	"hostname_allowlist": [ "my.wordpress.com", "my.woo.com" ],
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -4,6 +4,7 @@
 	"favicon_url": "/calypso/images/favicons/favicon-staging.ico",
 	"client_slug": "browser",
 	"hostname": "my.wordpress.com",
+	"hostname_allowlist": [ "my.wordpress.com", "my.woo.com" ],
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/development.json
+++ b/config/development.json
@@ -5,6 +5,7 @@
 	"client_slug": "browser",
 	"protocol": "http",
 	"hostname": "calypso.localhost",
+	"hostname_allowlist": [ "calypso.localhost", "my.localhost", "my.woo.localhost" ],
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
Part of DOTMSD-1078

## Proposed Changes

* Add `hostname_allowlist` config key to dashboard environments (production, stage, horizon, development)
* Add `customizeClientDataForRequest()` in `client/server/render/index.js` to shallow-clone clientData with overridden `hostname` when the request arrives on an allowed alternate domain
* Add `hostname_allowlist: false` default in `config/_shared.json` so non-dashboard envs are unaffected

## Why are these changes being made?

The Dashboard needs to be served behind a reverse proxy where requests arrive from multiple domains (e.g. `my.wordpress.com` and `my.woo.com`). Currently `hostname` is a single static string set at server startup. This change adds per-request hostname awareness validated against an allowlist, so the browser receives the correct hostname in `configData`.

## Testing Instructions

* Verify primary hostname behavior is unchanged — accessing `my.localhost:3000` in dev should work as before
* Test alternate hostname: `curl -H 'Host: my.woo.localhost:3000' http://localhost:3000/` and verify `configData` in the HTML contains `"hostname":"my.woo.localhost"` (requires adding `my.woo.localhost` to dev allowlist)
* Verify non-dashboard envs (calypso.localhost) are completely unaffected — `hostname_allowlist` defaults to `false`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?