### PR TITLE
Agents Manager: fix persistent route load order

### DIFF
--- a/packages/agents-manager/src/components/unified-ai-agent/index.tsx
+++ b/packages/agents-manager/src/components/unified-ai-agent/index.tsx
@@ -1,11 +1,14 @@
 import { getAgentManager } from '@automattic/agenttic-client';
+import { AgentsManagerSelect } from '@automattic/data-stores';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSelect } from '@wordpress/data';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ORCHESTRATOR_AGENT_ID } from '../../constants';
 import { useAgentsManagerContext } from '../../contexts';
 import '../../types'; // Import for Window type augmentation
 import { useEmptyViewSuggestions } from '../../hooks/use-empty-view-suggestions';
+import { AGENTS_MANAGER_STORE } from '../../stores';
 import { getSessionId, clearSessionId } from '../../utils/agent-session';
 import { createAgentConfig } from '../../utils/create-agent-config';
 import { loadExternalProviders, type LoadedProviders } from '../../utils/load-external-providers';
@@ -22,7 +25,18 @@ export interface UnifiedAIAgentProps {
 
 const queryClient = new QueryClient();
 
-export default function UnifiedAIAgent( props: UnifiedAIAgentProps ): JSX.Element {
+export default function UnifiedAIAgent( props: UnifiedAIAgentProps ): JSX.Element | null {
+	// Wait for the store to load before rendering PersistentRouter
+	// This ensures router history is restored from persisted state
+	const { hasLoaded: isStoreReady } = useSelect( ( select ) => {
+		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
+		return store.getAgentsManagerState();
+	}, [] );
+
+	if ( ! isStoreReady ) {
+		return null;
+	}
+
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<PersistentRouter>


### PR DESCRIPTION
When the agents manager loaded in wp-admin, it didn't restore the last visited route (e.g., history page), always starting at the root instead. This worked correctly in Calypso.

The problem was a race condition, where `PersistentRouter` created its history immediately on mount, but the store resolver that fetches persisted router history from the REST API hadn't run yet. By the time `AgentDock` triggered the resolver, the router was already initialized with default empty history

We add a check for the store before rendering `PersistentRouter`. This should also fix a problem I've seen in Calypso where if you do reload the history page it doesn't populate the list.

Fixes BSKY-1567

## Why are these changes being made?

Fix route persistence in wp-admin.

## Testing Instructions

* Build Calypso
* `cd apps/agents-manager && yarn dev --sync`
* In Calypso, switch Agents Manager to the history and reload the page. Confirm the history is restored and populated with data
* On a simple site access wp-admin and perform the same test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
