### PR TITLE
Help Center: Fix minimized help center button style

### DIFF
--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -18,7 +18,7 @@
 	}
 
 	&.is-minimized {
-		.help-center__container-header {
+		.help-center__container-header {	
 			.help-center-header__text {
 				flex: unset;
 				cursor: pointer;
@@ -27,6 +27,8 @@
 	}
 
 	.help-center__container-header {
+		background-color: var(--studio-white);
+		border: none;
 		border-bottom: 1px solid $gray-100;
 		border-radius: 16px;
 		border-bottom-right-radius: 0;


### PR DESCRIPTION
## Summary

- Fixes the minimized Help Center header by adding a white background and removing the default button border

Fixes: https://linear.app/a8c/issue/DSGCOM-427/fix-minimized-help-center

Before:
<img width="525" height="162" alt="image" src="https://github.com/user-attachments/assets/f18b104b-bf30-49b8-a5ed-98146140a691" />


After:
<img width="501" height="158" alt="image" src="https://github.com/user-attachments/assets/5876cd5b-929c-4497-a84d-b27281b97180" />


## Test plan

- [ ] Open Help Center on http://my.localhost:3000/sites and minimize it
- [ ] Verify the minimized header has a white background and no extra border