### PR TITLE
MSD Sites: Fix the actions position on grid view

### DIFF
--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -56,6 +56,7 @@ export function SitesDataViews( {
 						<SiteLink
 							{ ...props }
 							site={ item }
+							expanded={ view.type === 'grid' }
 							onClick={ () => recordTracksEvent( 'calypso_dashboard_sites_item_click' ) }
 						/>
 					) }

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -65,13 +65,22 @@ export const titleFieldTextOverflowStyles = {
 	whiteSpace: 'nowrap',
 } as const;
 
-export function SiteLink( { site, ...props }: ComponentProps< typeof Link > & { site: Site } ) {
+export function SiteLink( {
+	site,
+	expanded,
+	...props
+}: ComponentProps< typeof Link > & { site: Site; expanded?: boolean } ) {
 	return (
 		<Link
 			{ ...props }
 			to={ getSiteManagementUrl( site ) }
 			disabled={ site.is_deleted }
-			style={ { width: 'auto', minWidth: 'unset', textDecoration: 'none', ...props.style } }
+			style={ {
+				width: expanded ? '100%' : 'auto',
+				minWidth: 'unset',
+				textDecoration: 'none',
+				...props.style,
+			} }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix the actions position on grid view

| Before | After |
| - | - |
|<img width="381" height="44" alt="image" src="https://github.com/user-attachments/assets/a17156ab-a1e7-4e53-ab65-1e39fa34c1a7" />|<img width="386" height="40" alt="image" src="https://github.com/user-attachments/assets/f17f0897-d303-4450-84c8-4bbe38f00619" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Switch to Grid view
* Ensure the action icon `...` is on the right side

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
