### PR TITLE
MSD Plugins: Fix the position of Plugin up to update text

### DIFF
--- a/client/dashboard/plugins/manage/components/plugins-header-actions.tsx
+++ b/client/dashboard/plugins/manage/components/plugins-header-actions.tsx
@@ -19,23 +19,21 @@ export const PluginsHeaderActions = ( {
 }: PluginsHeaderActionsProps ) => {
 	const hasUpdates = updateCount > 0;
 
-	if ( hasUpdates ) {
-		return (
-			<Button variant="tertiary" size="compact" onClick={ onFilterUpdates }>
-				<Text>
-					{ sprintf(
-						// translators: %d is the number of plugins with an update available.
-						__( 'Updates available (%d)' ),
-						updateCount
-					) }
-				</Text>
-			</Button>
-		);
-	}
+	const renderText = () => {
+		if ( hasUpdates ) {
+			return sprintf(
+				// translators: %d is the number of plugins with an update available.
+				__( 'Updates available (%d)' ),
+				updateCount
+			);
+		}
+
+		return isSitesWithThisPluginView ? __( 'Plugin up to date' ) : __( 'Plugins up to date' );
+	};
 
 	return (
-		<Text>
-			{ isSitesWithThisPluginView ? __( 'Plugin up to date' ) : __( 'Plugins up to date' ) }
-		</Text>
+		<Button variant="tertiary" size="compact" disabled={ ! hasUpdates } onClick={ onFilterUpdates }>
+			<Text>{ renderText() }</Text>
+		</Button>
 	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix the position of Plugin up to update text on plugins dataviews. It would be better to keep using Button for consistent styles

| Before | After |
| - | - |
|<img width="195" height="61" alt="image" src="https://github.com/user-attachments/assets/9e3ba6db-0181-4d6e-9ba0-000bba1ea4c8" />|<img width="195" height="56" alt="image" src="https://github.com/user-attachments/assets/1e4fc481-a30d-48ce-843f-85044ff8236b" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plugins
* Select a plugin without updates
* Ensure the position of the "Plugin up to date" is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
