### PR TITLE
Notifications: Fix error with action handling

### DIFF
--- a/apps/notifications/src/panel/helpers/notes.js
+++ b/apps/notifications/src/panel/helpers/notes.js
@@ -26,7 +26,7 @@ function getActionBlock( blocks ) {
  * @returns {Object}
  */
 export function getActions( note ) {
-	return getActionBlock( note.body ).actions;
+	return getActionBlock( note.body ).actions ?? {};
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

Fixes a bug with how we're handling actions in notifications. 

Closes #108577.

Alternative fix to #108577.

## Why are these changes being made?

Actions are treated as an object, but on notifications that have no actions, that property was not set, which triggered a WSOD error:

<img width="524" height="281" alt="Screenshot 2026-02-09 at 14 37 57" src="https://github.com/user-attachments/assets/f3e80cb4-5dc1-401e-bb85-5f3c6beeb89c" />

Fixing a bug that was introduced in #108325, cc @davemart-in.

## Testing Instructions

* Open a notification with no actions (like, when someone liked your comment on a p2)
* Verify there's no WSOD error.