### PR TITLE
Agents Manager: fix border radius in admin tool corners

### DIFF
--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/style.scss
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/style.scss
@@ -91,8 +91,18 @@
 		}
 	}
 
+	#wp-admin-bar-root-default {
+		#wp-admin-bar-wpcom-logo a {
+			border-top-left-radius: $main-border-radius;
+		}
+	}
+
 	#wp-admin-bar-top-secondary {
 		border-top-right-radius: $main-border-radius;
+
+		#wp-admin-bar-my-account a {
+			border-top-right-radius: $main-border-radius;
+		}
 
 		@media (max-width: 782px) {
 


### PR DESCRIPTION
Fix the top left and top right corners of the wp-admin toolbar when Agents Manager sidebar mode is enabled:

<img width="402" height="220" alt="image" src="https://github.com/user-attachments/assets/58acd1c5-3492-4bb6-bb2b-4a52e4c9fba7" />

Fixes AI-874

## Testing Instructions

- `cd apps/agents-manager`
- `yarn dev --sync`
- Open a wp-admin page with Agents Manager in sidebar mode and hover over the top left admin bar WordPress logo, and the top right user icon, and confirm that neither have a cropped border radius

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
