### PR TITLE
Add already-member screen for the unified invite design

### DIFF
--- a/client/my-sites/invites-unified/controller.tsx
+++ b/client/my-sites/invites-unified/controller.tsx
@@ -4,6 +4,15 @@ import wpcom from 'calypso/lib/wp';
 import UnifiedInviteAccept from './index';
 import type { InviteBlogDetails } from './types';
 
+interface ApiError {
+	error: string;
+	message: string;
+	data?: {
+		garden_name?: string;
+		garden_partner?: string;
+	};
+}
+
 /**
  * Determine if unified invite flow should be used
  * Currently enabled for CIAB sites or when ?unified=1 is present
@@ -30,9 +39,34 @@ function shouldUseUnifiedFlow( blogDetails?: InviteBlogDetails ): boolean {
 }
 
 /**
- * Middleware that checks if unified invite flow should be used
- * If unified should be used, renders the unified UI and sets a flag to skip legacy controller
- * Otherwise, calls next() to let the legacy acceptInvite controller run
+ * Check if the API error indicates the user is already a member
+ */
+function isAlreadyMemberError( error: unknown ): error is ApiError {
+	if ( typeof error !== 'object' || error === null || ! ( 'error' in error ) ) {
+		return false;
+	}
+	const apiError = error as ApiError;
+	return apiError.error === 'already_member' || apiError.error === 'already_subscribed';
+}
+
+/**
+ * Build a minimal InviteBlogDetails from the error response's garden data.
+ */
+function getBlogDetailsFromError( apiError: ApiError ): InviteBlogDetails | undefined {
+	const { garden_name, garden_partner } = apiError.data || {};
+	if ( ! garden_name || ! garden_partner ) {
+		return undefined;
+	}
+
+	return {
+		is_garden_site: true,
+		garden: { name: garden_name, partner: garden_partner },
+	} as InviteBlogDetails;
+}
+
+/**
+ * Middleware that checks if unified invite flow should be used.
+ * Fetches invite data and delegates rendering to the unified component.
  */
 export async function maybeUseUnifiedInvite( context: Context, next: () => void ) {
 	const { site_id: siteId, invitation_key: inviteKey } = context.params;
@@ -54,8 +88,26 @@ export async function maybeUseUnifiedInvite( context: Context, next: () => void 
 		}
 
 		return next();
-	} catch {
-		// On error, fallback to legacy flow (it handles errors gracefully)
+	} catch ( error: unknown ) {
+		// Handle "already a member" errors in unified flow.
+		// The error response may include garden data we use to determine if the site is CIAB.
+		if ( isAlreadyMemberError( error ) ) {
+			const blogDetails = getBlogDetailsFromError( error );
+
+			if ( shouldUseUnifiedFlow( blogDetails ) ) {
+				context.inviteError = {
+					error: error.error,
+					message: error.message,
+				};
+				context.inviteData = { blog_details: blogDetails };
+
+				renderUnifiedInvite( context );
+				context.useUnifiedInvite = true;
+				return next();
+			}
+		}
+
+		// On other errors, fallback to legacy flow (it handles errors gracefully)
 		return next();
 	}
 }
@@ -78,6 +130,7 @@ function renderUnifiedInvite( context: Context ) {
 			activationKey={ activationKey }
 			authKey={ authKey }
 			inviteData={ context.inviteData }
+			inviteError={ context.inviteError }
 		/>
 	);
 }

--- a/client/my-sites/invites-unified/controller.tsx
+++ b/client/my-sites/invites-unified/controller.tsx
@@ -1,6 +1,7 @@
 import { type Context } from '@automattic/calypso-router';
 import { getQueryArg } from '@wordpress/url';
 import wpcom from 'calypso/lib/wp';
+import { isAlreadyMemberError } from './utils';
 import UnifiedInviteAccept from './index';
 import type { InviteBlogDetails } from './types';
 
@@ -36,17 +37,6 @@ function shouldUseUnifiedFlow( blogDetails?: InviteBlogDetails ): boolean {
 			blogDetails?.garden?.partner === 'woo' &&
 			blogDetails?.garden?.name === 'commerce'
 	);
-}
-
-/**
- * Check if the API error indicates the user is already a member
- */
-function isAlreadyMemberError( error: unknown ): error is ApiError {
-	if ( typeof error !== 'object' || error === null || ! ( 'error' in error ) ) {
-		return false;
-	}
-	const apiError = error as ApiError;
-	return apiError.error === 'already_member' || apiError.error === 'already_subscribed';
 }
 
 /**
@@ -91,13 +81,14 @@ export async function maybeUseUnifiedInvite( context: Context, next: () => void 
 	} catch ( error: unknown ) {
 		// Handle "already a member" errors in unified flow.
 		// The error response may include garden data we use to determine if the site is CIAB.
-		if ( isAlreadyMemberError( error ) ) {
-			const blogDetails = getBlogDetailsFromError( error );
+		const apiError = error as ApiError;
+		if ( apiError.error && isAlreadyMemberError( apiError.error ) ) {
+			const blogDetails = getBlogDetailsFromError( apiError );
 
 			if ( shouldUseUnifiedFlow( blogDetails ) ) {
 				context.inviteError = {
-					error: error.error,
-					message: error.message,
+					error: apiError.error,
+					message: apiError.message,
 				};
 				context.inviteData = { blog_details: blogDetails };
 

--- a/client/my-sites/invites-unified/index.tsx
+++ b/client/my-sites/invites-unified/index.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import AcceptInviteScreen from './screens/accept-invite-screen';
 import AlreadyMemberScreen from './screens/already-member-screen';
+import { isAlreadyMemberError } from './utils';
 import type { Invite, InviteBlogDetails, InviteError } from './types';
 
 /**
@@ -46,7 +47,7 @@ export function UnifiedInviteAccept( {
 	}
 
 	// Already a member → show already-member screen
-	if ( inviteError?.error === 'already_member' || inviteError?.error === 'already_subscribed' ) {
+	if ( inviteError?.error && isAlreadyMemberError( inviteError.error ) ) {
 		const blogDetails = ( inviteData as { blog_details?: InviteBlogDetails } )?.blog_details;
 		return <AlreadyMemberScreen blogDetails={ blogDetails } />;
 	}

--- a/client/my-sites/invites-unified/index.tsx
+++ b/client/my-sites/invites-unified/index.tsx
@@ -2,7 +2,8 @@ import page from '@automattic/calypso-router';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import AcceptInviteScreen from './screens/accept-invite-screen';
-import type { Invite } from './types';
+import AlreadyMemberScreen from './screens/already-member-screen';
+import type { Invite, InviteBlogDetails, InviteError } from './types';
 
 /**
  * Build the legacy invite path for fallback redirects
@@ -24,7 +25,8 @@ interface UnifiedInviteAcceptProps {
 	inviteKey: string;
 	activationKey?: string;
 	authKey?: string;
-	inviteData: Record< string, unknown >;
+	inviteData?: Record< string, unknown >;
+	inviteError?: InviteError;
 }
 
 export function UnifiedInviteAccept( {
@@ -33,6 +35,7 @@ export function UnifiedInviteAccept( {
 	activationKey,
 	authKey,
 	inviteData,
+	inviteError,
 }: UnifiedInviteAcceptProps ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
@@ -40,6 +43,12 @@ export function UnifiedInviteAccept( {
 	if ( ! isLoggedIn ) {
 		page.redirect( buildLegacyPath( siteId, inviteKey, activationKey, authKey ) );
 		return null;
+	}
+
+	// Already a member → show already-member screen
+	if ( inviteError?.error === 'already_member' || inviteError?.error === 'already_subscribed' ) {
+		const blogDetails = ( inviteData as { blog_details?: InviteBlogDetails } )?.blog_details;
+		return <AlreadyMemberScreen blogDetails={ blogDetails } />;
 	}
 
 	const invite = { ...inviteData, inviteKey, activationKey } as Invite;

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -257,7 +257,12 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 	return (
 		<>
 			<DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />
-			<BodySectionCssClass bodyClass={ [ 'is-section-accept-invite-unified' ] } />
+			<BodySectionCssClass
+				bodyClass={ [
+					'is-section-accept-invite-unified',
+					...( branding?.fontStyle === 'system' ? [ 'is-ciab-font-system' ] : [] ),
+				] }
+			/>
 			<Step.CenteredColumnLayout
 				columnWidth={ 4 }
 				heading={ heading }

--- a/client/my-sites/invites-unified/screens/already-member-screen.tsx
+++ b/client/my-sites/invites-unified/screens/already-member-screen.tsx
@@ -1,0 +1,97 @@
+import { Step } from '@automattic/onboarding';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { UserCard, type UserCardUser } from 'calypso/components/connect-screen/user-card';
+import DocumentHead from 'calypso/components/data/document-head';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { navigate } from 'calypso/lib/navigate';
+import { getCiabConfigFromGarden } from 'calypso/lib/partner-branding';
+import { login } from 'calypso/lib/paths';
+import { useDispatch } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { hideMasterbar } from 'calypso/state/ui/actions';
+import type { InviteBlogDetails } from '../types';
+
+import './style.scss';
+
+interface AlreadyMemberScreenProps {
+	blogDetails?: InviteBlogDetails;
+}
+
+export function AlreadyMemberScreen( { blogDetails }: AlreadyMemberScreenProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const user = useSelector( getCurrentUser );
+
+	const gardenName = blogDetails?.garden?.name || null;
+	const gardenPartner = blogDetails?.garden?.partner || null;
+
+	const trackingProps = {
+		garden_name: gardenName,
+		garden_partner: gardenPartner,
+		unified: true,
+	};
+
+	useEffect( () => {
+		dispatch( hideMasterbar() );
+		recordTracksEvent( 'calypso_invite_already_member_load_page', {
+			...trackingProps,
+			logged_in: true,
+		} );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	const handleSwitchAccount = useCallback( () => {
+		recordTracksEvent( 'calypso_invite_already_member_switch_account_click', trackingProps );
+		navigate( login( { redirectTo: window.location.href } ) );
+	}, [ trackingProps ] );
+
+	const userCardData: UserCardUser = {
+		displayName: user?.display_name || '',
+		email: user?.email || '',
+		avatarUrl: user?.avatar_URL,
+	};
+
+	const branding = blogDetails?.garden
+		? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name )
+		: null;
+
+	const topBarLogo = branding?.logo?.src ? (
+		<img
+			src={ branding.logo.src }
+			alt={ branding.logo.alt }
+			width={ branding.logo.width }
+			height={ branding.logo.height }
+		/>
+	) : undefined;
+
+	const title = translate( 'You are already a member of this site' );
+	const description = translate( 'Would you like to accept the invite with a different account?' );
+
+	const heading = <Step.Heading text={ title } subText={ description } />;
+	const topBar = <Step.TopBar logo={ topBarLogo } />;
+
+	return (
+		<>
+			<DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />
+			<BodySectionCssClass bodyClass={ [ 'is-section-accept-invite-unified' ] } />
+			<Step.CenteredColumnLayout
+				columnWidth={ 4 }
+				heading={ heading }
+				verticalAlign="center"
+				topBar={ topBar }
+			>
+				<UserCard user={ userCardData } size="large" />
+				<div className="already-member-screen-switch-account">
+					<Button variant="link" onClick={ handleSwitchAccount }>
+						{ translate( 'Log in with a different account' ) }
+					</Button>
+				</div>
+			</Step.CenteredColumnLayout>
+		</>
+	);
+}
+
+export default AlreadyMemberScreen;

--- a/client/my-sites/invites-unified/screens/already-member-screen.tsx
+++ b/client/my-sites/invites-unified/screens/already-member-screen.tsx
@@ -76,7 +76,12 @@ export function AlreadyMemberScreen( { blogDetails }: AlreadyMemberScreenProps )
 	return (
 		<>
 			<DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />
-			<BodySectionCssClass bodyClass={ [ 'is-section-accept-invite-unified' ] } />
+			<BodySectionCssClass
+				bodyClass={ [
+					'is-section-accept-invite-unified',
+					...( branding?.fontStyle === 'system' ? [ 'is-ciab-font-system' ] : [] ),
+				] }
+			/>
 			<Step.CenteredColumnLayout
 				columnWidth={ 4 }
 				heading={ heading }

--- a/client/my-sites/invites-unified/screens/already-member-screen.tsx
+++ b/client/my-sites/invites-unified/screens/already-member-screen.tsx
@@ -1,7 +1,7 @@
 import { Step } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { UserCard, type UserCardUser } from 'calypso/components/connect-screen/user-card';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -29,11 +29,14 @@ export function AlreadyMemberScreen( { blogDetails }: AlreadyMemberScreenProps )
 	const gardenName = blogDetails?.garden?.name || null;
 	const gardenPartner = blogDetails?.garden?.partner || null;
 
-	const trackingProps = {
-		garden_name: gardenName,
-		garden_partner: gardenPartner,
-		unified: true,
-	};
+	const trackingProps = useMemo(
+		() => ( {
+			garden_name: gardenName,
+			garden_partner: gardenPartner,
+			unified: true,
+		} ),
+		[ gardenName, gardenPartner ]
+	);
 
 	useEffect( () => {
 		dispatch( hideMasterbar() );

--- a/client/my-sites/invites-unified/screens/style.scss
+++ b/client/my-sites/invites-unified/screens/style.scss
@@ -8,3 +8,8 @@ body.is-section-accept-invite-unified {
 .accept-invite-consent-wrapper {
 	margin-bottom: 1.5rem;
 }
+
+.already-member-screen-switch-account {
+	margin-top: 1.5rem;
+	text-align: center;
+}

--- a/client/my-sites/invites-unified/screens/style.scss
+++ b/client/my-sites/invites-unified/screens/style.scss
@@ -1,7 +1,16 @@
+@import "@wordpress/base-styles/variables";
+
 // Remove layout padding for the unified invite accept screen
 body.is-section-accept-invite-unified {
 	.layout__content {
 		padding: 0 !important;
+	}
+}
+
+// CIAB partner branding: override heading font to system font
+body.is-section-accept-invite-unified.is-ciab-font-system {
+	.wp-brand-font {
+		font-family: $default-font;
 	}
 }
 

--- a/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { AlreadyMemberScreen } from '../already-member-screen';
+
+jest.mock(
+	'@automattic/onboarding',
+	() => ( {
+		Step: {
+			Heading: ( { text, subText }: { text: string; subText: string } ) => (
+				<div data-testid="step-heading">
+					<h1>{ text }</h1>
+					<p>{ subText }</p>
+				</div>
+			),
+			TopBar: ( { logo }: { logo?: React.ReactNode } ) => (
+				<div data-testid="step-topbar">{ logo }</div>
+			),
+			CenteredColumnLayout: ( {
+				children,
+				heading,
+				topBar,
+			}: {
+				children: React.ReactNode;
+				heading: React.ReactNode;
+				topBar: React.ReactNode;
+			} ) => (
+				<div data-testid="step-layout">
+					{ topBar }
+					{ heading }
+					{ children }
+				</div>
+			),
+		},
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( {
+		children,
+		onClick,
+		variant,
+	}: {
+		children: React.ReactNode;
+		onClick: () => void;
+		variant: string;
+	} ) => (
+		<button data-testid="switch-account-button" data-variant={ variant } onClick={ onClick }>
+			{ children }
+		</button>
+	),
+} ) );
+
+jest.mock( 'calypso/components/connect-screen/user-card', () => ( {
+	UserCard: ( { user }: { user: { displayName: string; email: string } } ) => (
+		<div data-testid="user-card">
+			<span data-testid="user-display-name">{ user.displayName }</span>
+			<span data-testid="user-email">{ user.email }</span>
+		</div>
+	),
+} ) );
+
+jest.mock( 'calypso/components/data/document-head', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/layout/body-section-css-class', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+const mockRecordTracksEvent = jest.fn();
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: ( ...args: unknown[] ) => mockRecordTracksEvent( ...args ),
+} ) );
+
+const mockNavigate = jest.fn();
+jest.mock( 'calypso/lib/navigate', () => ( {
+	navigate: ( url: string ) => mockNavigate( url ),
+} ) );
+
+jest.mock( 'calypso/lib/partner-branding', () => ( {
+	getCiabConfigFromGarden: ( partner: string, name: string ) => {
+		if ( partner === 'woo' && name === 'commerce' ) {
+			return {
+				logo: {
+					src: 'https://example.com/woo-logo.png',
+					alt: 'Woo',
+					width: 100,
+					height: 30,
+				},
+			};
+		}
+		return null;
+	},
+} ) );
+
+jest.mock( 'calypso/lib/paths', () => ( {
+	login: ( { redirectTo }: { redirectTo: string } ) =>
+		`/log-in?redirect_to=${ encodeURIComponent( redirectTo ) }`,
+} ) );
+
+const mockGetCurrentUser = jest.fn();
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUser: ( state: unknown ) => mockGetCurrentUser( state ),
+} ) );
+
+const mockDispatch = jest.fn();
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+} ) );
+
+jest.mock( 'calypso/state/ui/actions', () => ( {
+	hideMasterbar: jest.fn( () => ( { type: 'HIDE_MASTERBAR' } ) ),
+} ) );
+
+jest.mock( '../style.scss', () => ( {} ) );
+
+const mockStore = configureStore();
+
+const defaultUser = {
+	ID: 1,
+	display_name: 'Mike Tillman',
+	email: 'mike.tillman@gmail.com',
+	avatar_URL: 'https://example.com/avatar.jpg',
+};
+
+const createStore = () => mockStore( {} );
+
+const setupUser = ( userOverrides = {} ) => {
+	const user = { ...defaultUser, ...userOverrides };
+	mockGetCurrentUser.mockReturnValue( user );
+	return user;
+};
+
+describe( 'AlreadyMemberScreen', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockDispatch.mockReturnValue( undefined );
+		setupUser();
+	} );
+
+	describe( 'rendering', () => {
+		test( 'renders the title and description', () => {
+			const store = createStore();
+
+			render(
+				<Provider store={ store }>
+					<AlreadyMemberScreen />
+				</Provider>
+			);
+
+			expect( screen.getByText( 'You are already a member of this site' ) ).toBeVisible();
+			expect(
+				screen.getByText( 'Would you like to accept the invite with a different account?' )
+			).toBeVisible();
+		} );
+
+		test( 'renders the user card with current user info', () => {
+			const store = createStore();
+
+			render(
+				<Provider store={ store }>
+					<AlreadyMemberScreen />
+				</Provider>
+			);
+
+			expect( screen.getByTestId( 'user-card' ) ).toBeVisible();
+			expect( screen.getByTestId( 'user-display-name' ) ).toHaveTextContent( 'Mike Tillman' );
+			expect( screen.getByTestId( 'user-email' ) ).toHaveTextContent( 'mike.tillman@gmail.com' );
+		} );
+
+		test( 'renders "Log in with a different account" link button', () => {
+			const store = createStore();
+
+			render(
+				<Provider store={ store }>
+					<AlreadyMemberScreen />
+				</Provider>
+			);
+
+			const button = screen.getByTestId( 'switch-account-button' );
+			expect( button ).toHaveTextContent( 'Log in with a different account' );
+			expect( button ).toHaveAttribute( 'data-variant', 'link' );
+		} );
+
+		test( 'shows branding logo for Woo commerce garden sites', () => {
+			const store = createStore();
+
+			render(
+				<Provider store={ store }>
+					<AlreadyMemberScreen
+						blogDetails={ {
+							title: '',
+							domain: '',
+							URL: '',
+							is_garden_site: true,
+							garden: { partner: 'woo', name: 'commerce' },
+						} }
+					/>
+				</Provider>
+			);
+
+			const logo = screen.getByRole( 'img' );
+			expect( logo ).toHaveAttribute( 'src', 'https://example.com/woo-logo.png' );
+			expect( logo ).toHaveAttribute( 'alt', 'Woo' );
+		} );
+	} );
+
+	describe( 'switch account flow', () => {
+		test( 'navigates to login URL on switch account click', async () => {
+			const user = userEvent.setup();
+			const store = createStore();
+
+			render(
+				<Provider store={ store }>
+					<AlreadyMemberScreen />
+				</Provider>
+			);
+
+			await user.click( screen.getByText( 'Log in with a different account' ) );
+
+			expect( mockNavigate ).toHaveBeenCalledWith( expect.stringContaining( '/log-in' ) );
+		} );
+
+		test( 'tracks switch account click', async () => {
+			const user = userEvent.setup();
+			const store = createStore();
+
+			render(
+				<Provider store={ store }>
+					<AlreadyMemberScreen />
+				</Provider>
+			);
+
+			await user.click( screen.getByText( 'Log in with a different account' ) );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_invite_already_member_switch_account_click',
+				expect.objectContaining( { unified: true } )
+			);
+		} );
+	} );
+
+	describe( 'tracking', () => {
+		test( 'tracks page load on mount', () => {
+			const store = createStore();
+
+			render(
+				<Provider store={ store }>
+					<AlreadyMemberScreen
+						blogDetails={ {
+							title: '',
+							domain: '',
+							URL: '',
+							is_garden_site: true,
+							garden: { partner: 'woo', name: 'commerce' },
+						} }
+					/>
+				</Provider>
+			);
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_invite_already_member_load_page',
+				expect.objectContaining( {
+					logged_in: true,
+					unified: true,
+					garden_name: 'commerce',
+					garden_partner: 'woo',
+				} )
+			);
+		} );
+	} );
+} );

--- a/client/my-sites/invites-unified/test/controller.test.tsx
+++ b/client/my-sites/invites-unified/test/controller.test.tsx
@@ -28,6 +28,7 @@ describe( 'maybeUseUnifiedInvite', () => {
 	let context: {
 		params: Record< string, string >;
 		inviteData?: unknown;
+		inviteError?: unknown;
 		useUnifiedInvite?: boolean;
 		primary?: React.ReactNode;
 	};
@@ -154,5 +155,95 @@ describe( 'maybeUseUnifiedInvite', () => {
 		expect( context.primary ).toBeDefined();
 		// The component is rendered with the correct props (verified by the mock being called)
 		expect( context.useUnifiedInvite ).toBe( true );
+	} );
+
+	describe( 'already a member errors', () => {
+		test( 'uses unified flow for already_member error with unified flag', async () => {
+			mockGetQueryArg.mockImplementation( ( _url: string, param: string ) => {
+				if ( param === 'unified' ) {
+					return '1';
+				}
+				return undefined;
+			} );
+
+			const apiError = {
+				error: 'already_member',
+				message: 'You are already a member of this site',
+			};
+			mockWpcomGet.mockRejectedValue( apiError );
+
+			await maybeUseUnifiedInvite( context as never, next );
+
+			expect( context.useUnifiedInvite ).toBe( true );
+			expect( context.inviteError ).toEqual( {
+				error: 'already_member',
+				message: 'You are already a member of this site',
+			} );
+			expect( context.primary ).toBeDefined();
+			expect( next ).toHaveBeenCalled();
+		} );
+
+		test( 'uses unified flow for already_subscribed error with unified flag', async () => {
+			mockGetQueryArg.mockImplementation( ( _url: string, param: string ) => {
+				if ( param === 'unified' ) {
+					return '1';
+				}
+				return undefined;
+			} );
+
+			const apiError = {
+				error: 'already_subscribed',
+				message: 'You are already a follower of this site',
+			};
+			mockWpcomGet.mockRejectedValue( apiError );
+
+			await maybeUseUnifiedInvite( context as never, next );
+
+			expect( context.useUnifiedInvite ).toBe( true );
+			expect( context.primary ).toBeDefined();
+			expect( next ).toHaveBeenCalled();
+		} );
+
+		test( 'uses unified flow for already_member error with garden data', async () => {
+			const apiError = {
+				error: 'already_member',
+				message: 'You are already a member of this site',
+				data: {
+					garden_name: 'commerce',
+					garden_partner: 'woo',
+				},
+			};
+			mockWpcomGet.mockRejectedValue( apiError );
+
+			await maybeUseUnifiedInvite( context as never, next );
+
+			expect( context.useUnifiedInvite ).toBe( true );
+			expect( context.inviteError ).toEqual( {
+				error: 'already_member',
+				message: 'You are already a member of this site',
+			} );
+			expect( context.inviteData ).toEqual( {
+				blog_details: {
+					is_garden_site: true,
+					garden: { name: 'commerce', partner: 'woo' },
+				},
+			} );
+			expect( context.primary ).toBeDefined();
+			expect( next ).toHaveBeenCalled();
+		} );
+
+		test( 'falls back to legacy for already_member error without garden data or unified flag', async () => {
+			const apiError = {
+				error: 'already_member',
+				message: 'You are already a member of this site',
+			};
+			mockWpcomGet.mockRejectedValue( apiError );
+
+			await maybeUseUnifiedInvite( context as never, next );
+
+			expect( context.useUnifiedInvite ).toBeUndefined();
+			expect( context.primary ).toBeUndefined();
+			expect( next ).toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/client/my-sites/invites-unified/test/index.test.tsx
+++ b/client/my-sites/invites-unified/test/index.test.tsx
@@ -26,6 +26,11 @@ jest.mock( '../screens/accept-invite-screen', () => ( {
 	default: () => <div data-testid="accept-invite-screen">AcceptInviteScreen</div>,
 } ) );
 
+jest.mock( '../screens/already-member-screen', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="already-member-screen">AlreadyMemberScreen</div>,
+} ) );
+
 const mockStore = configureStore();
 
 const defaultProps = {
@@ -98,5 +103,49 @@ describe( 'UnifiedInviteAccept', () => {
 		expect( mockRedirect ).toHaveBeenCalledWith(
 			'/accept-invite/123/abc123/activation123/auth456?legacy=1'
 		);
+	} );
+
+	test( 'renders AlreadyMemberScreen for already_member error', () => {
+		const store = mockStore( { currentUser: { id: 1 } } );
+
+		render(
+			<Provider store={ store }>
+				<UnifiedInviteAccept
+					{ ...defaultProps }
+					inviteError={ { error: 'already_member', message: 'Already a member' } }
+				/>
+			</Provider>
+		);
+
+		expect( screen.getByTestId( 'already-member-screen' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'accept-invite-screen' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders AlreadyMemberScreen for already_subscribed error', () => {
+		const store = mockStore( { currentUser: { id: 1 } } );
+
+		render(
+			<Provider store={ store }>
+				<UnifiedInviteAccept
+					{ ...defaultProps }
+					inviteError={ { error: 'already_subscribed', message: 'Already subscribed' } }
+				/>
+			</Provider>
+		);
+
+		expect( screen.getByTestId( 'already-member-screen' ) ).toBeVisible();
+	} );
+
+	test( 'renders AcceptInviteScreen when there is no error', () => {
+		const store = mockStore( { currentUser: { id: 1 } } );
+
+		render(
+			<Provider store={ store }>
+				<UnifiedInviteAccept { ...defaultProps } />
+			</Provider>
+		);
+
+		expect( screen.queryByTestId( 'already-member-screen' ) ).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'accept-invite-screen' ) ).toBeVisible();
 	} );
 } );

--- a/client/my-sites/invites-unified/types.ts
+++ b/client/my-sites/invites-unified/types.ts
@@ -58,3 +58,8 @@ export interface Invite {
 	role?: string;
 	sentTo?: string;
 }
+
+export interface InviteError {
+	error: string;
+	message: string;
+}

--- a/client/my-sites/invites-unified/utils.ts
+++ b/client/my-sites/invites-unified/utils.ts
@@ -1,0 +1,8 @@
+const ALREADY_MEMBER_ERRORS = [ 'already_member', 'already_subscribed' ];
+
+/**
+ * Check if an error string indicates the user is already a member
+ */
+export function isAlreadyMemberError( error: string ): boolean {
+	return ALREADY_MEMBER_ERRORS.includes( error );
+}


### PR DESCRIPTION
Related to ARC-1470

## Proposed Changes

- Add an "Already a Member" screen for the unified invite flow, shown when the API returns `already_member` or `already_subscribed` errors
- Handle already-member API errors in the middleware controller, extracting garden data from the error response to determine CIAB branding
- Add `InviteError` type for passing error state from the controller to the component

## Why are these changes being made?

When a user who is already a member of a CIAB site clicks an invite link, the API returns an error. Previously this fell through to the legacy flow. This change catches those errors and shows a dedicated screen within the unified invite experience, keeping the user in the new design.

## Testing Instructions

Since the `already_member` error only occurs when the user is already a member of the site, you need to mock the API response:

1. Open the invite accept page for a CIAB site (e.g., `/accept-invite/{SITE_ID}/{TOKEN}?unified=1`)
2. Update the `/rest/v1.1/sites/{SITE_ID}/invites/{TOKEN}` endpoint and mock it to return an error response:
   ```json
   {
     "error": "already_member",
     "message": "You are already a member of this site",
     "data": {
       "garden_name": "commerce",
       "garden_partner": "woo"
     }
   }
   ```
  - Update the `callback` method on `class.wpcom-json-api-get-invite-endpoint.php` to return the code below:
  ```
    return $this->add_site_data_to_error(
	    new WP_Error( 'already_subscribed', __( 'You are already subscribed to this site.' ), 400 ),
	    $blog_id
    );
   ``` 
   Make sure the mocked response returns an HTTP 400 status code.
3. Verify you see the "You are already a member of this site" screen with the Woo branding logo
4. Verify the "Log in with a different account" link navigates to the login page

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
