### PR TITLE
Reader: Update Freshly Pressed RSS feed url

### DIFF
--- a/client/reader/discover/discover-document-head.js
+++ b/client/reader/discover/discover-document-head.js
@@ -20,7 +20,7 @@ export const DiscoverDocumentHead = () => {
 			rel: 'alternate',
 			type: 'application/rss+xml',
 			title: translate( 'Discover RSS Feed' ),
-			href: 'https://public-api.wordpress.com/rest/v1.2/freshly-pressed/?format=rss',
+			href: 'https://public-api.wordpress.com/rest/v1.2/freshly-pressed/feed',
 		},
 	];
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-309](https://linear.app/a8c/issue/READ-309)

## Proposed Changes

Updated Freshly Pressed RSS feed url.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We updated the endpoint on backend.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/discover`
2. Open browser developer tools and inspect the `<head>` element
3. Verify there is a `<link rel="alternate" type="application/rss+xml" title="Discover RSS Feed" href="https://public-api.wordpress.com/rest/v1.2/freshly-pressed/feed">` tag
4. (Optional) Test with an RSS reader browser extension to verify auto discovery works
