### PR TITLE
Cron Jobs: Make sure cron jobs don't display in old dashboard

### DIFF
--- a/client/dashboard/sites/settings-crontab/summary.tsx
+++ b/client/dashboard/sites/settings-crontab/summary.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { scheduled } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { hasHostingFeature } from '../../utils/site-features';
 import type { Site } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
@@ -23,10 +24,18 @@ export default function CrontabSettingsSummary( {
 		enabled: hasSshFeature,
 	} );
 
+	if ( isDashboardBackport() ) {
+		return null;
+	}
+
+	if ( ! hasSshFeature ) {
+		return null;
+	}
+
 	const crontabCount = crontabs?.length ?? 0;
 
 	const badges = [
-		hasSshFeature && {
+		{
 			text:
 				crontabCount > 0
 					? sprintf(
@@ -37,7 +46,7 @@ export default function CrontabSettingsSummary( {
 					: __( 'No scheduled jobs' ),
 			intent: crontabCount > 0 ? ( 'success' as const ) : undefined,
 		},
-	].filter( ( badge ) => !! badge );
+	];
 
 	return (
 		<RouterLinkSummaryButton

--- a/client/dashboard/sites/settings-crontab/summary.tsx
+++ b/client/dashboard/sites/settings-crontab/summary.tsx
@@ -28,14 +28,12 @@ export default function CrontabSettingsSummary( {
 		return null;
 	}
 
-	if ( ! hasSshFeature ) {
-		return null;
-	}
-
 	const crontabCount = crontabs?.length ?? 0;
 
 	const badges = [
-		{
+		// If SSH feature is not enabled, don't show the badge
+		// Note: we should not `if (! hasSshFeature) { return null; }` above, because we have `Upgrade plan` screen to engage users to upgrade their plan.
+		hasSshFeature && {
 			text:
 				crontabCount > 0
 					? sprintf(
@@ -46,7 +44,7 @@ export default function CrontabSettingsSummary( {
 					: __( 'No scheduled jobs' ),
 			intent: crontabCount > 0 ? ( 'success' as const ) : undefined,
 		},
-	];
+	].filter( ( badge ) => !! badge );
 
 	return (
 		<RouterLinkSummaryButton


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to p7DVsv-oKR-p2#comment-55376

## Proposed Changes

This PR ensures that `Cron` setting is only available in the MSD:

<img width="880" height="657" alt="Screenshot 2026-02-09 at 3 17 00 PM" src="https://github.com/user-attachments/assets/66db7a86-844f-4137-9215-27b5c745333c" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use the Calypso Live Link
* Ensure you have an Atomic site with SFTP feature enabled
* Navigate to `https://wordpress.com/sites/{yourAtomicSite}/settings`
* Confirm that the Cron setting does not display there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?