### PR TITLE
Add Blueprint new plans and save ID on data store

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router-dom';
 import { getPHPVersions } from 'calypso/data/php-versions';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getBlueprintID } from '../../lib/blueprint';
 import { initializeWordPressPlayground } from '../../lib/initialize-playground';
 import { PlaygroundError } from '../playground-error';
 import type { PlaygroundClient } from '../../lib/types';
@@ -24,6 +25,7 @@ export function PlaygroundIframe( {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const [ playgroundError, setPlaygroundError ] = useState< string | null >( null );
 	const { setBlueprint } = useDispatch( ONBOARD_STORE );
+	const [ query ] = useSearchParams();
 
 	const createNewPlayground = () => {
 		// Clear the 'playground' parameter from the URL
@@ -44,7 +46,13 @@ export function PlaygroundIframe( {
 		initializeWordPressPlayground( iframeRef.current, recommendedPHPVersion, setSearchParams )
 			.then( ( result ) => {
 				setPlaygroundClient( result.client );
-				setBlueprint( result.blueprint );
+
+				const id = getBlueprintID( query );
+
+				if ( id ) {
+					// Save the Blueprint library ID to the store
+					setBlueprint( { id } );
+				}
 			} )
 			.catch( ( error ) => {
 				if ( error.message === 'WordPress installation has failed.' ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
@@ -7,7 +7,7 @@ jest.mock( '../lib/resolve-remote-blueprint-standalone', () => ( {
 	ZipFilesystem: jest.fn(),
 } ) );
 
-import { getBlueprint } from '../lib/blueprint';
+import { getBlueprint, getBlueprintID, getBlueprintLabelForTracking } from '../lib/blueprint';
 import { resolveRemoteBlueprint } from '../lib/resolve-remote-blueprint-standalone';
 
 const DEFAULT_BLUEPRINT = {
@@ -84,8 +84,15 @@ function createMockBlueprintBundle( blueprintJson ) {
 }
 
 describe( 'getBlueprint', () => {
+	let consoleWarnSpy: jest.SpyInstance;
+
 	beforeEach( () => {
-		jest.resetAllMocks();
+		jest.restoreAllMocks();
+		consoleWarnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		consoleWarnSpy.mockRestore();
 	} );
 
 	it( 'returns default blueprint if WordPress is installed', async () => {
@@ -228,7 +235,173 @@ describe( 'getBlueprint', () => {
 					'https://example.com/blueprint.json'
 				);
 				expect( blueprint ).toEqual( REMOTE_BLUEPRINT );
+				expect( consoleWarnSpy ).toHaveBeenCalledTimes( 1 );
+				expect( consoleWarnSpy ).toHaveBeenCalledWith(
+					'Loading blueprint from https://example.com/blueprint.json but please migrate to blueprint library (https://blueprintlibrary.wordpress.com)'
+				);
 			} );
 		}
 	);
+} );
+
+describe( 'getBlueprintID', () => {
+	beforeEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'returns blueprint ID from direct blueprint parameter when it is a number', () => {
+		const params = new URLSearchParams( 'blueprint=12345' );
+		const id = getBlueprintID( params );
+		expect( id ).toBe( '12345' );
+	} );
+
+	it( 'returns blueprint ID from blueprint-url parameter when host matches BLUEPRINT_LIB_HOST', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://blueprintlibrary.wordpress.com?blueprint=67890' );
+		const id = getBlueprintID( params );
+		expect( id ).toBe( '67890' );
+	} );
+
+	it( 'returns null when blueprint-url host does not match BLUEPRINT_LIB_HOST', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://example.com?blueprint=12345' );
+		const id = getBlueprintID( params );
+		expect( id ).toBeNull();
+	} );
+
+	it( 'returns null when blueprint parameter is not a number', () => {
+		const params = new URLSearchParams( 'blueprint=woocommerce' );
+		const id = getBlueprintID( params );
+		expect( id ).toBeNull();
+	} );
+
+	it( 'returns null when blueprint parameter is empty', () => {
+		const params = new URLSearchParams( 'blueprint=' );
+		const id = getBlueprintID( params );
+		expect( id ).toBeNull();
+	} );
+
+	it( 'returns null when no blueprint parameters are provided', () => {
+		const params = new URLSearchParams();
+		const id = getBlueprintID( params );
+		expect( id ).toBeNull();
+	} );
+
+	it( 'prioritizes blueprint-url over direct blueprint parameter when both are present', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://blueprintlibrary.wordpress.com?blueprint=11111' );
+		params.set( 'blueprint', '22222' );
+		const id = getBlueprintID( params );
+		expect( id ).toBe( '11111' );
+	} );
+
+	it( 'falls back to direct blueprint parameter when blueprint-url is invalid', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://example.com?blueprint=invalid' );
+		params.set( 'blueprint', '99999' );
+		const id = getBlueprintID( params );
+		expect( id ).toBe( '99999' );
+	} );
+
+	it( 'returns null when blueprint-url has valid host but no blueprint parameter', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://blueprintlibrary.wordpress.com?other=value' );
+		const id = getBlueprintID( params );
+		expect( id ).toBeNull();
+	} );
+
+	it( 'returns null when blueprint-url has valid host but blueprint parameter is not a number', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://blueprintlibrary.wordpress.com?blueprint=notanumber' );
+		const id = getBlueprintID( params );
+		expect( id ).toBeNull();
+	} );
+} );
+
+describe( 'getBlueprintLabelForTracking', () => {
+	beforeEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'returns "unknown" for non-numeric predefined blueprint names like "woocommerce"', () => {
+		// getBlueprintID only returns numeric IDs, so "woocommerce" returns null
+		const params = new URLSearchParams( 'blueprint=woocommerce' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( 'unknown' );
+	} );
+
+	it( 'returns predefined blueprint name for "2024" theme', () => {
+		const params = new URLSearchParams( 'blueprint=2024' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( '2024' );
+	} );
+
+	it( 'returns predefined blueprint name for "2023" theme', () => {
+		const params = new URLSearchParams( 'blueprint=2023' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( '2023' );
+	} );
+
+	it( 'returns "unknown" for non-numeric predefined blueprint names like "design1"', () => {
+		// getBlueprintID only returns numeric IDs, so "design1" returns null
+		const params = new URLSearchParams( 'blueprint=design1' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( 'unknown' );
+	} );
+
+	it( 'returns "bpl-" prefixed label for numeric blueprint ID', () => {
+		const params = new URLSearchParams( 'blueprint=12345' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( 'bpl-12345' );
+	} );
+
+	it( 'returns "bpl-" prefixed label for blueprint library ID from blueprint-url', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://blueprintlibrary.wordpress.com?blueprint=67890' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( 'bpl-67890' );
+	} );
+
+	it( 'returns "unknown" when no blueprint parameters are provided', () => {
+		const params = new URLSearchParams();
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( 'unknown' );
+	} );
+
+	it( 'returns "unknown" when blueprint-url host does not match BLUEPRINT_LIB_HOST', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://example.com?blueprint=12345' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( 'unknown' );
+	} );
+
+	it( 'returns "unknown" when blueprint parameter is not a valid predefined name or number', () => {
+		const params = new URLSearchParams( 'blueprint=invalidname' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( 'unknown' );
+	} );
+
+	it( 'prioritizes blueprint-url over direct blueprint parameter', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://blueprintlibrary.wordpress.com?blueprint=99999' );
+		params.set( 'blueprint', 'woocommerce' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( 'bpl-99999' );
+	} );
+
+	it( 'returns "unknown" when blueprint-url is invalid and fallback is non-numeric', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://example.com?blueprint=invalid' );
+		params.set( 'blueprint', 'woocommerce' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( 'unknown' );
+	} );
+
+	it( 'falls back to numeric blueprint ID when blueprint-url is invalid', () => {
+		const params = new URLSearchParams();
+		params.set( 'blueprint-url', 'https://example.com?blueprint=invalid' );
+		params.set( 'blueprint', '55555' );
+		const label = getBlueprintLabelForTracking( params );
+		expect( label ).toBe( 'bpl-55555' );
+	} );
 } );

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -259,7 +259,7 @@ export const usePlanTypesWithIntent = ( {
 			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		case 'plans-playground':
-			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		case 'plans-playground-premium':
 			// This plan intent is currently not utilized but will be soon


### PR DESCRIPTION
The Blueprint ID is stored in the data store rather than in the bundle. Blueprint Library URL ID is now performed by the same `getBlueprintID()` function:

1. `http://calypso.localhost:3000/setup/onboarding/playground/?blueprint-url=https%3A%2F%2Fblueprintlibrary.wordpress.com%2F%3Fblueprint%3D834`
2. `http://calypso.localhost:3000/setup/onboarding/playground/?blueprint=834` <- shortcut as in `resolveBlueprintFromURL` before
3. `http://calypso.localhost:3000/setup/onboarding/playground/?blueprint=design1` default blueprints
4. A warning for an external URL not `blueprintlibrary.wordpress.com` is still generated

## Proposed Changes

* Save Blueprint ID on the data store
* Select only usable plans

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the various links
* Be sure the ID is saved
* Run a complete flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
