### PR TITLE
MSD: add more unit test examples for form submission

### DIFF
--- a/.claude/rules/dashboard-testing.md
+++ b/.claude/rules/dashboard-testing.md
@@ -1,0 +1,40 @@
+---
+paths:
+  - "client/dashboard/**/test/**"
+---
+
+# Writing tests for dashboard screens / components
+
+Tests MUST verify user-visible behavior, not implementation details. Test what a user can see or do, not how the component is built internally.
+
+CRITICAL: consult these reference examples:
+- @client/dashboard/sites/test/index.test.tsx - DataViews assertions
+- @client/dashboard/sites/overview/test/index.test.tsx - more complex assertions for cards / sections in the screen
+- @client/dashboard/sites/settings-php/test/index.test.tsx - form submission
+
+## Setup
+
+- Put the test file under the `test/` subdirectory, with the same name as the component file but with the `.test.tsx` extension.
+- Use the component name (surrounded by `<>`) as the top-level `describe()` block.
+- Use `test()` instead of `it()` for test cases.
+- Use the custom `render()` function from @client/dashboard/test-utils.tsx — it wraps components with all required providers (QueryClient, Router, Auth, Analytics).
+- If the component uses `useSuspenseQuery()`, wait for a stable element (e.g., heading) before asserting.
+
+## Assertions
+
+- Assert on what the user sees on the screen.
+- Query by accessible role using e.g. `screen.findByRole()`, `screen.getByRole()`,  `screen.queryByRole()`, and `within()`.
+- Never query by test ID, CSS class, or DOM structure.
+- If an element isn't reachable by role, fix the component's accessibility instead.
+- Prefer simple, readable assertions over complex logic.
+
+## Mocking
+
+- DO NOT mock React components, hooks, or modules.
+- DO NOT mock TanStack queries.
+- Only mock network requests at the boundary using `nock` to intercept REST API calls to `https://public-api.wordpress.com`.
+
+## Test data
+
+- Keep test objects minimal — include only properties relevant to the test.
+- Use `as Type` to cast partial objects instead of filling unused fields.

--- a/.cursor/rules/dashboard-testing.mdc
+++ b/.cursor/rules/dashboard-testing.mdc
@@ -1,0 +1,41 @@
+---
+description: Rules for writing tests for dashboard screen / components
+globs: client/dashboard/**/test/**
+alwaysApply: false
+---
+
+# Writing tests for dashboard screens / components
+
+Tests MUST verify user-visible behavior, not implementation details. Test what a user can see or do, not how the component is built internally.
+
+CRITICAL: consult these reference examples:
+- @client/dashboard/sites/test/index.test.tsx - DataViews assertions
+- @client/dashboard/sites/overview/test/index.test.tsx - more complex assertions for cards / sections in the screen
+- @client/dashboard/sites/settings-php/test/index.test.tsx - form submission
+
+## Setup
+
+- Put the test file under the `test/` subdirectory, with the same name as the component file but with the `.test.tsx` extension.
+- Use the component name (surrounded by `<>`) as the top-level `describe()` block.
+- Use `test()` instead of `it()` for test cases.
+- Use the custom `render()` function from @client/dashboard/test-utils.tsx — it wraps components with all required providers (QueryClient, Router, Auth, Analytics).
+- If the component uses `useSuspenseQuery()`, wait for a stable element (e.g., heading) before asserting.
+
+## Assertions
+
+- Assert on what the user sees on the screen.
+- Query by accessible role using e.g. `screen.findByRole()`, `screen.getByRole()`,  `screen.queryByRole()`, and `within()`.
+- Never query by test ID, CSS class, or DOM structure.
+- If an element isn't reachable by role, fix the component's accessibility instead.
+- Prefer simple, readable assertions over complex logic.
+
+## Mocking
+
+- DO NOT mock React components, hooks, or modules.
+- DO NOT mock TanStack queries.
+- Only mock network requests at the boundary using `nock` to intercept REST API calls to `https://public-api.wordpress.com`.
+
+## Test data
+
+- Keep test objects minimal — include only properties relevant to the test.
+- Use `as Type` to cast partial objects instead of filling unused fields.

--- a/client/dashboard/sites/settings-php/test/index.test.tsx
+++ b/client/dashboard/sites/settings-php/test/index.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import PHPVersionSettings from '../index';
+import type { Site } from '@automattic/api-core';
+
+const site = {
+	ID: 1,
+	slug: 'test-site.wordpress.com',
+	is_wpcom_atomic: true,
+	plan: {
+		product_slug: 'business-bundle',
+		product_name_short: 'Business',
+		is_free: false,
+		features: {
+			active: [ 'atomic', 'sftp' ],
+		},
+	},
+} as Site;
+
+function mockSite( mockedSite: Site ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
+		.query( true )
+		.reply( 200, mockedSite );
+}
+
+function mockPHPVersion( version: string ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/wpcom/v2/sites/${ site.ID }/hosting/php-version` )
+		.query( true )
+		.reply( 200, version );
+}
+
+function mockPHPVersionSaved( expectedVersion: string ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.post( `/wpcom/v2/sites/${ site.ID }/hosting/php-version`, ( body ) => {
+			expect( body ).toEqual( { version: expectedVersion } );
+			return true;
+		} )
+		.reply( 200 );
+}
+
+describe( '<PHPVersionSettings>', () => {
+	test( 'renders and saves the form for a site that has the hosting feature', async () => {
+		const user = userEvent.setup();
+
+		mockSite( site );
+		mockPHPVersion( '8.2' );
+
+		render( <PHPVersionSettings siteSlug={ site.slug } /> );
+		await screen.findByRole( 'heading', { name: 'PHP' } );
+
+		const versionSelect = await screen.findByRole( 'combobox', { name: 'PHP version' } );
+		expect( versionSelect ).toHaveDisplayValue( '8.2' );
+
+		await user.selectOptions( versionSelect, '8.3' );
+		const scope = mockPHPVersionSaved( '8.3' );
+
+		const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+		await user.click( saveButton );
+
+		await waitFor( () => {
+			expect( scope.isDone() ).toBe( true );
+		} );
+	} );
+
+	test( 'renders upsell when the site does not have the plan feature', async () => {
+		mockSite( {
+			...site,
+			plan: {
+				product_slug: 'personal-bundle',
+				product_name_short: 'Personal',
+				is_free: false,
+				features: { active: [] },
+			},
+		} as unknown as Site );
+
+		render( <PHPVersionSettings siteSlug={ site.slug } /> );
+		await screen.findByRole( 'heading', { name: 'PHP' } );
+
+		expect(
+			screen.getByText( 'Sites on the Personal plan run on our recommended PHP version.' )
+		).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Upgrade plan' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders activation callout when the site has the plan feature but is not Atomic', async () => {
+		mockSite( { ...site, is_wpcom_atomic: false } as Site );
+
+		render( <PHPVersionSettings siteSlug={ site.slug } /> );
+		await screen.findByRole( 'heading', { name: 'PHP' } );
+
+		expect( screen.getByRole( 'button', { name: 'Activate' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import WordPressSettings from '../index';
+import type { Site } from '@automattic/api-core';
+
+const site = {
+	ID: 123,
+	slug: 'test-site.wordpress.com',
+	options: {
+		software_version: '6.8.1',
+	},
+} as Site;
+
+function mockSite( mockedSite: Site ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
+		.query( true )
+		.reply( 200, mockedSite );
+}
+
+function mockWordPressVersion( version: string ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version` )
+		.query( true )
+		.reply( 200, version );
+}
+
+function mockWordPressVersionSaved( expectedVersion: string ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.post( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version`, ( body ) => {
+			expect( body ).toEqual( { version: expectedVersion } );
+			return true;
+		} )
+		.reply( 200 );
+}
+
+describe( '<WordPressSettings>', () => {
+	test( 'renders and saves the form for a staging site', async () => {
+		const user = userEvent.setup();
+
+		mockSite( { ...site, is_wpcom_staging_site: true } as Site );
+		mockWordPressVersion( 'latest' );
+
+		render( <WordPressSettings siteSlug={ site.slug } /> );
+		await screen.findByRole( 'heading', { name: 'WordPress' } );
+
+		const versionSelect = await screen.findByRole( 'combobox', { name: 'WordPress version' } );
+		expect( versionSelect ).toHaveDisplayValue( '6.8.1 (Latest)' );
+
+		await user.selectOptions( versionSelect, '6.8.1 (Beta)' );
+		const scope = mockWordPressVersionSaved( 'beta' );
+
+		const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+		await user.click( saveButton );
+
+		await waitFor( () => {
+			expect( scope.isDone() ).toBe( true );
+		} );
+	} );
+
+	test( 'renders notice for a non-staging site', async () => {
+		mockSite( { ...site, is_wpcom_staging_site: false } as Site );
+
+		render( <WordPressSettings siteSlug={ site.slug } /> );
+		await screen.findByRole( 'heading', { name: 'WordPress' } );
+
+		expect(
+			screen.getByText( /Every WordPress.com site runs the latest WordPress version/ )
+		).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders staging site suggestion for Atomic non-staging sites', async () => {
+		mockSite( {
+			...site,
+			is_wpcom_staging_site: false,
+			is_wpcom_atomic: true,
+		} as Site );
+
+		render( <WordPressSettings siteSlug={ site.slug } /> );
+		await screen.findByRole( 'heading', { name: 'WordPress' } );
+
+		expect( screen.getByText( /Switch to a staging site to test a beta version/ ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Part of DOTMSD-1069

## Proposed Changes

This PR adds more tests to as reference files on how to test form submission:

- `sites/settings-php`
- `sites/settings-wordpress`

I also collect all the wisdom into `{.claude, .cursor}/rules/dashboard-testing.md`.

This PR also updates the existing `sites/settings-visibility` so that it conforms to the rule, for consistency.

## Why are these changes being made?

Increases confidence in MSD development while using AI assistance.

## Testing Instructions

Verify CI passes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
