### PR TITLE
Onboarding: Fix domain name mismatch for new free sites

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -150,11 +150,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		theme = DEFAULT_NEWSLETTER_THEME;
 	}
 
-	const isPaidDomainItem = Boolean(
-		domainCartItem?.product_slug ||
-			( Array.isArray( domainCartItems ) && domainCartItems.some( ( el ) => el.product_slug ) )
-	);
-
 	// Default visibility is public
 	let siteVisibility = Site.Visibility.PublicIndexed;
 	const wooFlows = [ ENTREPRENEUR_FLOW ];
@@ -219,7 +214,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		const site = await createSiteWithCart(
 			flow,
 			true,
-			isPaidDomainItem,
 			theme,
 			siteVisibility,
 			urlData?.meta.title ?? selectedSiteTitle,

--- a/client/landing/stepper/hooks/use-create-site-hook.ts
+++ b/client/landing/stepper/hooks/use-create-site-hook.ts
@@ -16,7 +16,6 @@ import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 type Params = {
 	flowName: string;
 	userIsLoggedIn: boolean;
-	isPurchasingDomainItem: boolean;
 	themeSlugWithRepo: string;
 	siteVisibility: Site.Visibility;
 	siteTitle: string;
@@ -66,7 +65,6 @@ async function fillCart(
 export const createSite = async ( {
 	flowName,
 	userIsLoggedIn,
-	isPurchasingDomainItem,
 	themeSlugWithRepo,
 	siteVisibility,
 	siteTitle,
@@ -83,7 +81,6 @@ export const createSite = async ( {
 }: Params ) => {
 	const newSiteParams = getNewSiteParams( {
 		flowToCheck: flowName,
-		isPurchasingDomainItem,
 		themeSlugWithRepo,
 		siteTitle,
 		siteAccentColor,
@@ -182,7 +179,6 @@ export const useCreateSite = () => {
 			return createSite( {
 				flowName,
 				userIsLoggedIn,
-				isPurchasingDomainItem: false,
 				themeSlugWithRepo: theme,
 				siteVisibility: 1,
 				siteTitle,

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -47,6 +47,7 @@
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
+		"@automattic/domain-search": "workspace:^",
 		"@wordpress/components": "^32.1.0",
 		"@wordpress/data": "^10.23.0",
 		"@wordpress/icons": "^10.23.0",

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { NewSiteSuccessResponse, Site } from '@automattic/data-stores';
 import { SiteGoal } from '@automattic/data-stores/src/onboard';
+import { getTld } from '@automattic/domain-search';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
 import { getLocaleSlug } from 'i18n-calypso';
@@ -65,12 +66,13 @@ const getBlogNameGenerationParams = ( {
 	siteTitle,
 	flowToCheck,
 	username,
-	isPurchasingDomainItem,
 }: GetNewSiteParams ) => {
 	if ( siteUrl ) {
+		const blogName = siteUrl.replace( '.wordpress.com', '' );
+
 		return {
-			blog_name: siteUrl.replace( '.wordpress.com', '' ),
-			find_available_url: !! isPurchasingDomainItem,
+			blog_name: blogName,
+			find_available_url: !! getTld( blogName ),
 		};
 	}
 

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -72,6 +72,7 @@ const getBlogNameGenerationParams = ( {
 
 		return {
 			blog_name: blogName,
+			// If there is a TLD we need to find an underlying free subdomain in case the user wants to skip checkout.
 			find_available_url: !! getTld( blogName ),
 		};
 	}

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -23,7 +23,6 @@ const debug = debugFactory( 'calypso:signup:step-actions' );
 
 interface GetNewSiteParams {
 	flowToCheck: string;
-	isPurchasingDomainItem: boolean;
 	themeSlugWithRepo: string;
 	siteUrl?: string;
 	siteTitle: string;
@@ -144,7 +143,6 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 export const createSiteWithCart = async (
 	flowName: string,
 	userIsLoggedIn: boolean,
-	isPurchasingDomainItem: boolean,
 	themeSlugWithRepo: string,
 	siteVisibility: Site.Visibility,
 	siteTitle: string,
@@ -168,7 +166,6 @@ export const createSiteWithCart = async (
 
 	const newSiteParams = getNewSiteParams( {
 		flowToCheck: flowName,
-		isPurchasingDomainItem,
 		themeSlugWithRepo,
 		siteUrl,
 		siteTitle,

--- a/packages/onboarding/src/cart/test/index.ts
+++ b/packages/onboarding/src/cart/test/index.ts
@@ -135,19 +135,21 @@ describe( 'getNewSiteParams', () => {
 				find_available_url: false,
 			} )
 		);
+	} );
 
+	test( 'find_available_url is true when siteUrl is a custom domain', () => {
 		expect(
 			getNewSiteParams(
 				testParams( {
-					siteUrl: 'testing123.wordpress.com',
+					siteUrl: 'example.com',
 					siteTitle: 'Testing Inc.',
 					username: 'janedoe',
 				} )
 			)
 		).toEqual(
 			expect.objectContaining( {
-				blog_name: 'testing123',
-				find_available_url: false,
+				blog_name: 'example.com',
+				find_available_url: true,
 			} )
 		);
 	} );

--- a/packages/onboarding/src/cart/test/index.ts
+++ b/packages/onboarding/src/cart/test/index.ts
@@ -6,7 +6,6 @@ describe( 'getNewSiteParams', () => {
 	function testParams( partialParams: Partial< Parameters< typeof getNewSiteParams >[ 0 ] > = {} ) {
 		return {
 			flowToCheck: 'test-flow',
-			isPurchasingDomainItem: false,
 			themeSlugWithRepo: 'pub/test-theme',
 			siteTitle: 'test site title',
 			siteAccentColor: '#deface',

--- a/packages/onboarding/src/cart/test/index.ts
+++ b/packages/onboarding/src/cart/test/index.ts
@@ -14,6 +14,7 @@ describe( 'getNewSiteParams', () => {
 			siteVisibility: Visibility.Private,
 			username: 'testuser',
 			...partialParams,
+			partnerBundle: partialParams.partnerBundle ?? null,
 		} satisfies Parameters< typeof getNewSiteParams >[ 0 ];
 	}
 
@@ -126,13 +127,12 @@ describe( 'getNewSiteParams', () => {
 					siteUrl: 'testing123.wordpress.com',
 					siteTitle: 'Testing Inc.',
 					username: 'janedoe',
-					isPurchasingDomainItem: true,
 				} )
 			)
 		).toEqual(
 			expect.objectContaining( {
 				blog_name: 'testing123',
-				find_available_url: true,
+				find_available_url: false,
 			} )
 		);
 
@@ -142,7 +142,6 @@ describe( 'getNewSiteParams', () => {
 					siteUrl: 'testing123.wordpress.com',
 					siteTitle: 'Testing Inc.',
 					username: 'janedoe',
-					isPurchasingDomainItem: false,
 				} )
 			)
 		).toEqual(

--- a/packages/onboarding/tsconfig.json
+++ b/packages/onboarding/tsconfig.json
@@ -10,6 +10,7 @@
 	"references": [
 		{ "path": "../components" },
 		{ "path": "../data-stores" },
+		{ "path": "../domain-search" },
 		{ "path": "../calypso-config" }
 	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,6 +1956,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
+    "@automattic/domain-search": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@automattic/viewport": "workspace:^"
     "@storybook/addon-a11y": "npm:^8.6.14"


### PR DESCRIPTION
Part of DOTOBRD-396

## Proposed Changes

* Refactor blog name generation logic in the onboarding cart flow
* Replace `isPurchasingDomainItem` check with TLD detection using `getTld()`
* Ensure correct domain name generation for new free sites

## Why are these changes being made?

There was a mismatch between the domain name users selected and the final site URL for new free sites. The previous logic relied on checking if a domain purchase item was present, which didn't accurately reflect whether a custom domain was being used. By checking if the blog name contains a TLD instead, we can more accurately determine when to find an available URL.

## Testing Instructions

Enter `/setup`, add a domain to the cart, proceed to the plans page, and...

### Free plan

- Click "start with a free plan" in the plans step subtitle
- Click "Continue with Free plan" in the upsell modal

Verify the site URL is the free `.wordpress.com` option.

### Paid plan

Pick a paid plan in the plans step.

Verify the newly created site has the `username-xxxx.wordpress.com` format and you see the primary domain as part of the "Site: " at checkout.

### Paid plan within the upsell modal

- Click "start with a free plan" in the plans step subtitle
- Click "Get %(planName)s" in the upsell modal

Verify the newly created site has the `username-xxxx.wordpress.com` format and you see the primary domain as part of the "Site: " at checkout.