### PR TITLE
Add Survicate survey support to the Multi-site Dashboard

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -73,6 +73,7 @@ module.exports = {
 							'!@automattic/ui',
 							'!@automattic/urls',
 							'!@automattic/js-utils',
+							'!@automattic/survicate',
 							'!@automattic/viewport',
 							'!@automattic/browser-data-collector',
 							// Please do not add exceptions which pull in Calypso code/concepts.

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -15,6 +15,7 @@ import { AuthProvider, useAuth } from './auth';
 import { AppProvider } from './context';
 import { I18nProvider } from './i18n';
 import { getRouter } from './router';
+import { SurvicateProvider } from './survicate';
 import type { AppConfig } from './context';
 
 function AnalyticsProviderWithClient( {
@@ -66,7 +67,9 @@ function Layout( { config }: { config: AppConfig } ) {
 				<AuthProvider>
 					<I18nProvider>
 						<AnalyticsProviderWithClient router={ router }>
-							<RouterProvider router={ router } context={ { config } } />
+							<SurvicateProvider>
+								<RouterProvider router={ router } context={ { config } } />
+							</SurvicateProvider>
 						</AnalyticsProviderWithClient>
 					</I18nProvider>
 				</AuthProvider>

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -15,7 +15,7 @@ import { AuthProvider, useAuth } from './auth';
 import { AppProvider } from './context';
 import { I18nProvider } from './i18n';
 import { getRouter } from './router';
-import { SurvicateProvider } from './survicate';
+import { useSurvicate } from './survicate';
 import type { AppConfig } from './context';
 
 function AnalyticsProviderWithClient( {
@@ -55,6 +55,8 @@ function AnalyticsProviderWithClient( {
 		[ router ]
 	);
 
+	useSurvicate();
+
 	return <AnalyticsProvider client={ analyticsClient }>{ children }</AnalyticsProvider>;
 }
 
@@ -67,9 +69,7 @@ function Layout( { config }: { config: AppConfig } ) {
 				<AuthProvider>
 					<I18nProvider>
 						<AnalyticsProviderWithClient router={ router }>
-							<SurvicateProvider>
-								<RouterProvider router={ router } context={ { config } } />
-							</SurvicateProvider>
+							<RouterProvider router={ router } context={ { config } } />
 						</AnalyticsProviderWithClient>
 					</I18nProvider>
 				</AuthProvider>

--- a/client/dashboard/app/survicate/index.tsx
+++ b/client/dashboard/app/survicate/index.tsx
@@ -7,27 +7,22 @@ import {
 	setSurvicateVisitorTraits,
 	SURVICATE_WORKSPACE_ID,
 } from '@automattic/survicate';
-import { isMobile } from '@automattic/viewport';
+import { useViewportMatch } from '@wordpress/compose';
 import { useEffect } from 'react';
 import { useAuth } from '../auth';
-
-function getLocaleFromUser( user: { locale_variant?: string; language?: string } ): string {
-	type ComputedAttributes = { localeSlug?: string; localeVariant?: string };
-	const u = user as typeof user & ComputedAttributes;
-	return u.localeVariant || u.localeSlug || user.locale_variant || user.language || 'en';
-}
+import { useLocale } from '../locale';
 
 export function useSurvicate() {
 	const { user } = useAuth();
+	const locale = useLocale();
+	const isMobile = useViewportMatch( 'mobile', '<' );
 
 	useEffect( () => {
 		if ( ! config( 'survicate_enabled' ) ) {
 			return;
 		}
 
-		const locale = getLocaleFromUser( user );
-
-		if ( ! shouldLoadSurvicate( { locale, isMobile: !! isMobile() } ) ) {
+		if ( ! shouldLoadSurvicate( { locale, isMobile } ) ) {
 			return;
 		}
 
@@ -49,5 +44,5 @@ export function useSurvicate() {
 			.catch( () => {
 				// Script failed to load — nothing to do.
 			} );
-	}, [ user ] );
+	}, [ user, locale, isMobile ] );
 }

--- a/client/dashboard/app/survicate/index.tsx
+++ b/client/dashboard/app/survicate/index.tsx
@@ -21,7 +21,7 @@ export function SurvicateProvider( { children }: { children: React.ReactNode } )
 	const { user } = useAuth();
 
 	useEffect( () => {
-		if ( ! config.isEnabled( 'survicate_enabled' ) ) {
+		if ( ! config( 'survicate_enabled' ) ) {
 			return;
 		}
 

--- a/client/dashboard/app/survicate/index.tsx
+++ b/client/dashboard/app/survicate/index.tsx
@@ -1,0 +1,55 @@
+// eslint-disable-next-line no-restricted-imports
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import {
+	shouldLoadSurvicate,
+	loadSurvicateScript,
+	setSurvicateVisitorTraits,
+	SURVICATE_WORKSPACE_ID,
+} from '@automattic/survicate';
+import { isMobile } from '@automattic/viewport';
+import { useEffect } from 'react';
+import { useAuth } from '../auth';
+
+function getLocaleFromUser( user: { locale_variant?: string; language?: string } ): string {
+	type ComputedAttributes = { localeSlug?: string; localeVariant?: string };
+	const u = user as typeof user & ComputedAttributes;
+	return u.localeVariant || u.localeSlug || user.locale_variant || user.language || 'en';
+}
+
+export function SurvicateProvider( { children }: { children: React.ReactNode } ) {
+	const { user } = useAuth();
+
+	useEffect( () => {
+		if ( ! config.isEnabled( 'survicate_enabled' ) ) {
+			return;
+		}
+
+		const locale = getLocaleFromUser( user );
+
+		if ( ! shouldLoadSurvicate( { locale, isMobile: !! isMobile() } ) ) {
+			return;
+		}
+
+		loadSurvicateScript( SURVICATE_WORKSPACE_ID )
+			.then( () => {
+				if ( ! user.email ) {
+					recordTracksEvent( 'calypso_survicate_user_not_available_error', {
+						user_exists: true,
+						user_has_email: false,
+						referrer: document.referrer || '',
+						pathname: window.location.pathname || '',
+						hostname: window.location.hostname || '',
+					} );
+					return;
+				}
+
+				setSurvicateVisitorTraits( { email: user.email } );
+			} )
+			.catch( () => {
+				// Script failed to load — nothing to do.
+			} );
+	}, [ user ] );
+
+	return children;
+}

--- a/client/dashboard/app/survicate/index.tsx
+++ b/client/dashboard/app/survicate/index.tsx
@@ -26,8 +26,14 @@ export function useSurvicate() {
 			return;
 		}
 
+		const controller = new AbortController();
+
 		loadSurvicateScript( SURVICATE_WORKSPACE_ID )
 			.then( () => {
+				if ( controller.signal.aborted ) {
+					return;
+				}
+
 				if ( ! user.email ) {
 					recordTracksEvent( 'calypso_survicate_user_not_available_error', {
 						user_exists: true,
@@ -44,5 +50,9 @@ export function useSurvicate() {
 			.catch( () => {
 				// Script failed to load — nothing to do.
 			} );
+
+		return () => {
+			controller.abort();
+		};
 	}, [ user, locale, isMobile ] );
 }

--- a/client/dashboard/app/survicate/index.tsx
+++ b/client/dashboard/app/survicate/index.tsx
@@ -45,7 +45,8 @@ export function useSurvicate() {
 					return;
 				}
 
-				setSurvicateVisitorTraits( { email: user.email } );
+				const cleanupTraits = setSurvicateVisitorTraits( { email: user.email } );
+				controller.signal.addEventListener( 'abort', cleanupTraits );
 			} )
 			.catch( () => {
 				// Script failed to load — nothing to do.

--- a/client/dashboard/app/survicate/index.tsx
+++ b/client/dashboard/app/survicate/index.tsx
@@ -17,7 +17,7 @@ function getLocaleFromUser( user: { locale_variant?: string; language?: string }
 	return u.localeVariant || u.localeSlug || user.locale_variant || user.language || 'en';
 }
 
-export function SurvicateProvider( { children }: { children: React.ReactNode } ) {
+export function useSurvicate() {
 	const { user } = useAuth();
 
 	useEffect( () => {
@@ -50,6 +50,4 @@ export function SurvicateProvider( { children }: { children: React.ReactNode } )
 				// Script failed to load — nothing to do.
 			} );
 	}, [ user ] );
-
-	return children;
 }

--- a/client/dashboard/app/survicate/test/index.test.tsx
+++ b/client/dashboard/app/survicate/test/index.test.tsx
@@ -11,8 +11,8 @@ import {
 	setSurvicateVisitorTraits,
 	SURVICATE_WORKSPACE_ID,
 } from '@automattic/survicate';
-import { isMobile } from '@automattic/viewport';
 import { renderHook } from '@testing-library/react';
+import { useViewportMatch } from '@wordpress/compose';
 import React from 'react';
 import { AuthContext } from '../../auth';
 import { useSurvicate } from '../index';
@@ -38,15 +38,16 @@ jest.mock( '@automattic/survicate', () => ( {
 	SURVICATE_WORKSPACE_ID: 'test-workspace-id',
 } ) );
 
-jest.mock( '@automattic/viewport', () => ( {
-	isMobile: jest.fn(),
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useViewportMatch: jest.fn(),
 } ) );
 
 const mockedConfig = jest.mocked( config );
 const mockedShouldLoad = jest.mocked( shouldLoadSurvicate );
 const mockedLoadScript = jest.mocked( loadSurvicateScript );
 const mockedSetTraits = jest.mocked( setSurvicateVisitorTraits );
-const mockedIsMobile = jest.mocked( isMobile );
+const mockedUseViewportMatch = jest.mocked( useViewportMatch );
 const mockedRecordTracksEvent = jest.mocked( recordTracksEvent );
 
 function createUser( overrides: Partial< User > = {} ): User {
@@ -84,7 +85,7 @@ describe( 'useSurvicate', () => {
 	test( 'loads script when all conditions are met', async () => {
 		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( true );
-		mockedIsMobile.mockReturnValue( false );
+		mockedUseViewportMatch.mockReturnValue( false );
 
 		const user = createUser();
 		renderWithAuth( user );
@@ -105,31 +106,10 @@ describe( 'useSurvicate', () => {
 		expect( mockedLoadScript ).not.toHaveBeenCalled();
 	} );
 
-	test( 'skips loading when locale is non-English', () => {
-		mockedConfig.mockReturnValue( true );
-		mockedShouldLoad.mockReturnValue( false );
-
-		const user = createUser( { language: 'fr' } );
-		renderWithAuth( user );
-
-		expect( mockedLoadScript ).not.toHaveBeenCalled();
-	} );
-
-	test( 'skips loading on mobile devices', () => {
-		mockedConfig.mockReturnValue( true );
-		mockedShouldLoad.mockReturnValue( false );
-		mockedIsMobile.mockReturnValue( true );
-
-		const user = createUser();
-		renderWithAuth( user );
-
-		expect( mockedLoadScript ).not.toHaveBeenCalled();
-	} );
-
 	test( 'fires error event when user has no email', async () => {
 		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( true );
-		mockedIsMobile.mockReturnValue( false );
+		mockedUseViewportMatch.mockReturnValue( false );
 
 		const user = createUser( { email: '' } );
 		renderWithAuth( user );
@@ -151,7 +131,7 @@ describe( 'useSurvicate', () => {
 	test( 'handles script load failure gracefully', async () => {
 		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( true );
-		mockedIsMobile.mockReturnValue( false );
+		mockedUseViewportMatch.mockReturnValue( false );
 		mockedLoadScript.mockRejectedValue( new Error( 'Failed to load' ) );
 
 		const user = createUser();
@@ -167,7 +147,7 @@ describe( 'useSurvicate', () => {
 	test( 'passes correct locale and isMobile to shouldLoadSurvicate', () => {
 		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( false );
-		mockedIsMobile.mockReturnValue( true );
+		mockedUseViewportMatch.mockReturnValue( true );
 
 		const user = createUser( { language: 'pt-br' } );
 		renderWithAuth( user );

--- a/client/dashboard/app/survicate/test/index.test.tsx
+++ b/client/dashboard/app/survicate/test/index.test.tsx
@@ -78,7 +78,7 @@ describe( 'SurvicateProvider', () => {
 	} );
 
 	test( 'loads script when all conditions are met', async () => {
-		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( true );
 		mockedIsMobile.mockReturnValue( false );
 
@@ -98,7 +98,7 @@ describe( 'SurvicateProvider', () => {
 	} );
 
 	test( 'skips loading when config flag is disabled', () => {
-		mockedConfig.isEnabled.mockReturnValue( false );
+		mockedConfig.mockReturnValue( false );
 
 		const user = createUser();
 		renderWithAuth(
@@ -112,7 +112,7 @@ describe( 'SurvicateProvider', () => {
 	} );
 
 	test( 'skips loading when locale is non-English', () => {
-		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( false );
 
 		const user = createUser( { language: 'fr' } );
@@ -127,7 +127,7 @@ describe( 'SurvicateProvider', () => {
 	} );
 
 	test( 'skips loading on mobile devices', () => {
-		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( false );
 		mockedIsMobile.mockReturnValue( true );
 
@@ -143,7 +143,7 @@ describe( 'SurvicateProvider', () => {
 	} );
 
 	test( 'fires error event when user has no email', async () => {
-		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( true );
 		mockedIsMobile.mockReturnValue( false );
 
@@ -170,7 +170,7 @@ describe( 'SurvicateProvider', () => {
 	} );
 
 	test( 'renders children', () => {
-		mockedConfig.isEnabled.mockReturnValue( false );
+		mockedConfig.mockReturnValue( false );
 
 		const user = createUser();
 		const { getByText } = renderWithAuth(
@@ -184,7 +184,7 @@ describe( 'SurvicateProvider', () => {
 	} );
 
 	test( 'handles script load failure gracefully', async () => {
-		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( true );
 		mockedIsMobile.mockReturnValue( false );
 		mockedLoadScript.mockRejectedValue( new Error( 'Failed to load' ) );
@@ -205,7 +205,7 @@ describe( 'SurvicateProvider', () => {
 	} );
 
 	test( 'passes correct locale and isMobile to shouldLoadSurvicate', () => {
-		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( false );
 		mockedIsMobile.mockReturnValue( true );
 

--- a/client/dashboard/app/survicate/test/index.test.tsx
+++ b/client/dashboard/app/survicate/test/index.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// eslint-disable-next-line no-restricted-imports
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import {
+	shouldLoadSurvicate,
+	loadSurvicateScript,
+	setSurvicateVisitorTraits,
+	SURVICATE_WORKSPACE_ID,
+} from '@automattic/survicate';
+import { isMobile } from '@automattic/viewport';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { AuthContext } from '../../auth';
+import { SurvicateProvider } from '../index';
+import type { User } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/calypso-config', () => {
+	const fn = jest.fn();
+	return Object.assign( fn, {
+		__esModule: true,
+		default: fn,
+		isEnabled: jest.fn(),
+	} );
+} );
+
+jest.mock( '@automattic/survicate', () => ( {
+	shouldLoadSurvicate: jest.fn(),
+	loadSurvicateScript: jest.fn(),
+	setSurvicateVisitorTraits: jest.fn(),
+	SURVICATE_WORKSPACE_ID: 'test-workspace-id',
+} ) );
+
+jest.mock( '@automattic/viewport', () => ( {
+	isMobile: jest.fn(),
+} ) );
+
+const mockedConfig = jest.mocked( config );
+const mockedShouldLoad = jest.mocked( shouldLoadSurvicate );
+const mockedLoadScript = jest.mocked( loadSurvicateScript );
+const mockedSetTraits = jest.mocked( setSurvicateVisitorTraits );
+const mockedIsMobile = jest.mocked( isMobile );
+const mockedRecordTracksEvent = jest.mocked( recordTracksEvent );
+
+function createUser( overrides: Partial< User > = {} ): User {
+	return {
+		ID: 1,
+		display_name: 'Test User',
+		username: 'testuser',
+		email: 'test@example.com',
+		primary_blog: 123,
+		primary_blog_url: 'https://test.wordpress.com',
+		language: 'en',
+		locale_variant: '',
+		site_count: 1,
+		visible_site_count: 1,
+		...overrides,
+	} as User;
+}
+
+function renderWithAuth( user: User, children: React.ReactNode ) {
+	return render(
+		<AuthContext.Provider value={ { user, logout: jest.fn() } }>{ children }</AuthContext.Provider>
+	);
+}
+
+describe( 'SurvicateProvider', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockedLoadScript.mockResolvedValue( undefined );
+	} );
+
+	test( 'loads script when all conditions are met', async () => {
+		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedShouldLoad.mockReturnValue( true );
+		mockedIsMobile.mockReturnValue( false );
+
+		const user = createUser();
+		renderWithAuth(
+			user,
+			<SurvicateProvider>
+				<div>child</div>
+			</SurvicateProvider>
+		);
+
+		// Flush microtasks so the loadSurvicateScript promise resolves
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( mockedLoadScript ).toHaveBeenCalledWith( SURVICATE_WORKSPACE_ID );
+		expect( mockedSetTraits ).toHaveBeenCalledWith( { email: 'test@example.com' } );
+	} );
+
+	test( 'skips loading when config flag is disabled', () => {
+		mockedConfig.isEnabled.mockReturnValue( false );
+
+		const user = createUser();
+		renderWithAuth(
+			user,
+			<SurvicateProvider>
+				<div>child</div>
+			</SurvicateProvider>
+		);
+
+		expect( mockedLoadScript ).not.toHaveBeenCalled();
+	} );
+
+	test( 'skips loading when locale is non-English', () => {
+		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedShouldLoad.mockReturnValue( false );
+
+		const user = createUser( { language: 'fr' } );
+		renderWithAuth(
+			user,
+			<SurvicateProvider>
+				<div>child</div>
+			</SurvicateProvider>
+		);
+
+		expect( mockedLoadScript ).not.toHaveBeenCalled();
+	} );
+
+	test( 'skips loading on mobile devices', () => {
+		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedShouldLoad.mockReturnValue( false );
+		mockedIsMobile.mockReturnValue( true );
+
+		const user = createUser();
+		renderWithAuth(
+			user,
+			<SurvicateProvider>
+				<div>child</div>
+			</SurvicateProvider>
+		);
+
+		expect( mockedLoadScript ).not.toHaveBeenCalled();
+	} );
+
+	test( 'fires error event when user has no email', async () => {
+		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedShouldLoad.mockReturnValue( true );
+		mockedIsMobile.mockReturnValue( false );
+
+		const user = createUser( { email: '' } );
+		renderWithAuth(
+			user,
+			<SurvicateProvider>
+				<div>child</div>
+			</SurvicateProvider>
+		);
+
+		// Flush promises
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( mockedLoadScript ).toHaveBeenCalled();
+		expect( mockedSetTraits ).not.toHaveBeenCalled();
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_survicate_user_not_available_error',
+			expect.objectContaining( {
+				user_exists: true,
+				user_has_email: false,
+			} )
+		);
+	} );
+
+	test( 'renders children', () => {
+		mockedConfig.isEnabled.mockReturnValue( false );
+
+		const user = createUser();
+		const { getByText } = renderWithAuth(
+			user,
+			<SurvicateProvider>
+				<div>test child content</div>
+			</SurvicateProvider>
+		);
+
+		expect( getByText( 'test child content' ) ).toBeVisible();
+	} );
+
+	test( 'handles script load failure gracefully', async () => {
+		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedShouldLoad.mockReturnValue( true );
+		mockedIsMobile.mockReturnValue( false );
+		mockedLoadScript.mockRejectedValue( new Error( 'Failed to load' ) );
+
+		const user = createUser();
+
+		// Should not throw
+		renderWithAuth(
+			user,
+			<SurvicateProvider>
+				<div>child</div>
+			</SurvicateProvider>
+		);
+
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( mockedSetTraits ).not.toHaveBeenCalled();
+	} );
+
+	test( 'passes correct locale and isMobile to shouldLoadSurvicate', () => {
+		mockedConfig.isEnabled.mockReturnValue( true );
+		mockedShouldLoad.mockReturnValue( false );
+		mockedIsMobile.mockReturnValue( true );
+
+		const user = createUser( { language: 'pt-br' } );
+		renderWithAuth(
+			user,
+			<SurvicateProvider>
+				<div>child</div>
+			</SurvicateProvider>
+		);
+
+		expect( mockedShouldLoad ).toHaveBeenCalledWith( {
+			locale: 'pt-br',
+			isMobile: true,
+		} );
+	} );
+} );

--- a/client/dashboard/app/survicate/test/index.test.tsx
+++ b/client/dashboard/app/survicate/test/index.test.tsx
@@ -12,10 +12,10 @@ import {
 	SURVICATE_WORKSPACE_ID,
 } from '@automattic/survicate';
 import { isMobile } from '@automattic/viewport';
-import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import React from 'react';
 import { AuthContext } from '../../auth';
-import { SurvicateProvider } from '../index';
+import { useSurvicate } from '../index';
 import type { User } from '@automattic/api-core';
 
 jest.mock( '@automattic/calypso-analytics', () => ( {
@@ -65,13 +65,17 @@ function createUser( overrides: Partial< User > = {} ): User {
 	} as User;
 }
 
-function renderWithAuth( user: User, children: React.ReactNode ) {
-	return render(
-		<AuthContext.Provider value={ { user, logout: jest.fn() } }>{ children }</AuthContext.Provider>
-	);
+function renderWithAuth( user: User ) {
+	return renderHook( () => useSurvicate(), {
+		wrapper: ( { children } ) => (
+			<AuthContext.Provider value={ { user, logout: jest.fn() } }>
+				{ children }
+			</AuthContext.Provider>
+		),
+	} );
 }
 
-describe( 'SurvicateProvider', () => {
+describe( 'useSurvicate', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockedLoadScript.mockResolvedValue( undefined );
@@ -83,12 +87,7 @@ describe( 'SurvicateProvider', () => {
 		mockedIsMobile.mockReturnValue( false );
 
 		const user = createUser();
-		renderWithAuth(
-			user,
-			<SurvicateProvider>
-				<div>child</div>
-			</SurvicateProvider>
-		);
+		renderWithAuth( user );
 
 		// Flush microtasks so the loadSurvicateScript promise resolves
 		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
@@ -101,12 +100,7 @@ describe( 'SurvicateProvider', () => {
 		mockedConfig.mockReturnValue( false );
 
 		const user = createUser();
-		renderWithAuth(
-			user,
-			<SurvicateProvider>
-				<div>child</div>
-			</SurvicateProvider>
-		);
+		renderWithAuth( user );
 
 		expect( mockedLoadScript ).not.toHaveBeenCalled();
 	} );
@@ -116,12 +110,7 @@ describe( 'SurvicateProvider', () => {
 		mockedShouldLoad.mockReturnValue( false );
 
 		const user = createUser( { language: 'fr' } );
-		renderWithAuth(
-			user,
-			<SurvicateProvider>
-				<div>child</div>
-			</SurvicateProvider>
-		);
+		renderWithAuth( user );
 
 		expect( mockedLoadScript ).not.toHaveBeenCalled();
 	} );
@@ -132,12 +121,7 @@ describe( 'SurvicateProvider', () => {
 		mockedIsMobile.mockReturnValue( true );
 
 		const user = createUser();
-		renderWithAuth(
-			user,
-			<SurvicateProvider>
-				<div>child</div>
-			</SurvicateProvider>
-		);
+		renderWithAuth( user );
 
 		expect( mockedLoadScript ).not.toHaveBeenCalled();
 	} );
@@ -148,12 +132,7 @@ describe( 'SurvicateProvider', () => {
 		mockedIsMobile.mockReturnValue( false );
 
 		const user = createUser( { email: '' } );
-		renderWithAuth(
-			user,
-			<SurvicateProvider>
-				<div>child</div>
-			</SurvicateProvider>
-		);
+		renderWithAuth( user );
 
 		// Flush promises
 		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
@@ -169,20 +148,6 @@ describe( 'SurvicateProvider', () => {
 		);
 	} );
 
-	test( 'renders children', () => {
-		mockedConfig.mockReturnValue( false );
-
-		const user = createUser();
-		const { getByText } = renderWithAuth(
-			user,
-			<SurvicateProvider>
-				<div>test child content</div>
-			</SurvicateProvider>
-		);
-
-		expect( getByText( 'test child content' ) ).toBeVisible();
-	} );
-
 	test( 'handles script load failure gracefully', async () => {
 		mockedConfig.mockReturnValue( true );
 		mockedShouldLoad.mockReturnValue( true );
@@ -192,12 +157,7 @@ describe( 'SurvicateProvider', () => {
 		const user = createUser();
 
 		// Should not throw
-		renderWithAuth(
-			user,
-			<SurvicateProvider>
-				<div>child</div>
-			</SurvicateProvider>
-		);
+		renderWithAuth( user );
 
 		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
@@ -210,12 +170,7 @@ describe( 'SurvicateProvider', () => {
 		mockedIsMobile.mockReturnValue( true );
 
 		const user = createUser( { language: 'pt-br' } );
-		renderWithAuth(
-			user,
-			<SurvicateProvider>
-				<div>child</div>
-			</SurvicateProvider>
-		);
+		renderWithAuth( user );
 
 		expect( mockedShouldLoad ).toHaveBeenCalledWith( {
 			locale: 'pt-br',

--- a/client/dashboard/app/survicate/test/index.test.tsx
+++ b/client/dashboard/app/survicate/test/index.test.tsx
@@ -80,6 +80,7 @@ describe( 'useSurvicate', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockedLoadScript.mockResolvedValue( undefined );
+		mockedSetTraits.mockReturnValue( jest.fn() );
 	} );
 
 	test( 'loads script when all conditions are met', async () => {

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -31,6 +31,13 @@ jest.mock( '@automattic/i18n-utils', () => ( {
 	localizeUrl: ( url ) => url,
 } ) );
 
+jest.mock( '@automattic/survicate', () => ( {
+	shouldLoadSurvicate: jest.fn(),
+	loadSurvicateScript: jest.fn(),
+	isSurvicateScriptLoaded: jest.fn(),
+	SURVICATE_WORKSPACE_ID: 'test-workspace-id',
+} ) );
+
 jest.mock( 'debug', () => () => jest.fn() );
 
 jest.mock( '@wordpress/react-i18n', () => ( {
@@ -45,6 +52,11 @@ jest.mock( 'react-router-dom', () => ( {
 
 import { getCurrentUser, recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
+import {
+	shouldLoadSurvicate,
+	loadSurvicateScript,
+	isSurvicateScriptLoaded,
+} from '@automattic/survicate';
 import { isMobile } from '@automattic/viewport';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -56,19 +68,9 @@ import { HelpCenterRequiredContextProvider } from '../../../../packages/help-cen
 const flushPromises = () => new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
 describe( 'survicate', () => {
-	let mockScript;
-	let mockScriptElement;
-	let originalCreateElement;
-	let originalGetElementsByTagName;
 	let mayWeLoadSurvicateScript;
 	let addSurvicate;
 	let isUserOnAnonymousPaths;
-
-	beforeAll( () => {
-		// Set up DOM mocks
-		originalCreateElement = document.createElement;
-		originalGetElementsByTagName = document.getElementsByTagName;
-	} );
 
 	beforeEach( () => {
 		// Reset all mocks
@@ -89,38 +91,10 @@ describe( 'survicate', () => {
 			writable: true,
 		} );
 
-		// Mock DOM methods
-		mockScript = {
-			src: '',
-			async: false,
-			onload: null,
-			onerror: null,
-		};
-
-		mockScriptElement = {
-			parentNode: {
-				insertBefore: jest.fn(),
-			},
-		};
-
-		document.createElement = jest.fn( ( tagName ) => {
-			if ( tagName === 'script' ) {
-				return mockScript;
-			}
-			return originalCreateElement.call( document, tagName );
-		} );
-
-		document.getElementsByTagName = jest.fn( ( tagName ) => {
-			if ( tagName === 'script' ) {
-				return [ mockScriptElement ];
-			}
-			return originalGetElementsByTagName.call( document, tagName );
-		} );
-
 		// Reset global survicate object
 		global._sva = undefined;
 
-		// Set up fresh module imports (after DOM mocks so the package picks them up)
+		// Set up fresh module imports
 		jest.isolateModules( () => {
 			const survicateModule = require( 'calypso/lib/analytics/survicate' );
 			mayWeLoadSurvicateScript = survicateModule.mayWeLoadSurvicateScript;
@@ -138,10 +112,6 @@ describe( 'survicate', () => {
 	} );
 
 	afterAll( () => {
-		// Restore original DOM methods
-		document.createElement = originalCreateElement;
-		document.getElementsByTagName = originalGetElementsByTagName;
-
 		// Clean up document and window objects
 		document.body.innerHTML = '';
 		window.location = null;
@@ -191,22 +161,27 @@ describe( 'survicate', () => {
 			getLocaleSlug.mockReturnValue( 'en' );
 			isMobile.mockReturnValue( false );
 			config.mockReturnValue( true );
+			shouldLoadSurvicate.mockReturnValue( true );
+			isSurvicateScriptLoaded.mockReturnValue( false );
+			loadSurvicateScript.mockResolvedValue();
 		} );
 
 		test( 'should not load script for non-English languages', () => {
+			shouldLoadSurvicate.mockReturnValue( false );
 			getLocaleSlug.mockReturnValue( 'fr' );
 
 			addSurvicate();
 
-			expect( document.createElement ).not.toHaveBeenCalled();
+			expect( loadSurvicateScript ).not.toHaveBeenCalled();
 		} );
 
 		test( 'should not load script for non-English languages starting with different prefix', () => {
+			shouldLoadSurvicate.mockReturnValue( false );
 			getLocaleSlug.mockReturnValue( 'es-ES' );
 
 			addSurvicate();
 
-			expect( document.createElement ).not.toHaveBeenCalled();
+			expect( loadSurvicateScript ).not.toHaveBeenCalled();
 		} );
 
 		test( 'should load script for English language variants', () => {
@@ -214,15 +189,16 @@ describe( 'survicate', () => {
 
 			addSurvicate();
 
-			expect( document.createElement ).toHaveBeenCalledWith( 'script' );
+			expect( loadSurvicateScript ).toHaveBeenCalledWith( 'test-workspace-id' );
 		} );
 
 		test( 'should not load script on mobile devices', () => {
+			shouldLoadSurvicate.mockReturnValue( false );
 			isMobile.mockReturnValue( true );
 
 			addSurvicate();
 
-			expect( document.createElement ).not.toHaveBeenCalled();
+			expect( loadSurvicateScript ).not.toHaveBeenCalled();
 		} );
 
 		test( 'should not load script when survicate is disabled', () => {
@@ -230,21 +206,13 @@ describe( 'survicate', () => {
 
 			addSurvicate();
 
-			expect( document.createElement ).not.toHaveBeenCalled();
+			expect( loadSurvicateScript ).not.toHaveBeenCalled();
 		} );
 
-		test( 'should create script element with correct properties', () => {
+		test( 'should call loadSurvicateScript with workspace ID', () => {
 			addSurvicate();
 
-			expect( document.createElement ).toHaveBeenCalledWith( 'script' );
-			expect( mockScript.src ).toBe(
-				'https://survey.survicate.com/workspaces/e4794374cce15378101b63de24117572/web_surveys.js'
-			);
-			expect( mockScript.async ).toBe( true );
-			expect( mockScriptElement.parentNode.insertBefore ).toHaveBeenCalledWith(
-				mockScript,
-				mockScriptElement
-			);
+			expect( loadSurvicateScript ).toHaveBeenCalledWith( 'test-workspace-id' );
 		} );
 
 		test( 'should set visitor traits when script loads successfully with logged-in user', async () => {
@@ -258,9 +226,6 @@ describe( 'survicate', () => {
 			};
 
 			addSurvicate();
-
-			// Simulate script load
-			mockScript.onload();
 			await flushPromises();
 
 			expect( global._sva.setVisitorTraits ).toHaveBeenCalledWith( {
@@ -277,9 +242,6 @@ describe( 'survicate', () => {
 			};
 
 			addSurvicate();
-
-			// Simulate script load
-			mockScript.onload();
 			await flushPromises();
 
 			expect( global._sva.setVisitorTraits ).not.toHaveBeenCalled();
@@ -293,9 +255,6 @@ describe( 'survicate', () => {
 			};
 
 			addSurvicate();
-
-			// Simulate script load
-			mockScript.onload();
 			await flushPromises();
 
 			expect( recordTracksEvent ).toHaveBeenCalledWith(
@@ -321,9 +280,6 @@ describe( 'survicate', () => {
 			};
 
 			addSurvicate();
-
-			// Simulate script load
-			mockScript.onload();
 			await flushPromises();
 
 			expect( global._sva.setVisitorTraits ).not.toHaveBeenCalled();
@@ -340,9 +296,6 @@ describe( 'survicate', () => {
 			};
 
 			addSurvicate();
-
-			// Simulate script load
-			mockScript.onload();
 			await flushPromises();
 
 			expect( recordTracksEvent ).toHaveBeenCalledWith(
@@ -367,9 +320,6 @@ describe( 'survicate', () => {
 			global._sva = undefined;
 
 			addSurvicate();
-
-			// Simulate script load - should not throw error
-			mockScript.onload();
 			await expect( flushPromises() ).resolves.toBeUndefined();
 		} );
 
@@ -382,17 +332,13 @@ describe( 'survicate', () => {
 			global._sva = {}; // No setVisitorTraits method
 
 			addSurvicate();
-
-			// Simulate script load - should not throw error
-			mockScript.onload();
 			await expect( flushPromises() ).resolves.toBeUndefined();
 		} );
 
 		test( 'should handle script load error', async () => {
-			addSurvicate();
+			loadSurvicateScript.mockRejectedValue( new Error( 'load failed' ) );
 
-			// Simulate script error - should not throw
-			mockScript.onerror();
+			addSurvicate();
 			await expect( flushPromises() ).resolves.toBeUndefined();
 		} );
 
@@ -411,23 +357,22 @@ describe( 'survicate', () => {
 			jest.spyOn( global, 'setTimeout' );
 
 			addSurvicate();
-			mockScript.onload();
 			await flushPromises();
 
 			expect( setTimeout ).toHaveBeenCalledWith( expect.any( Function ), 1000 );
 		} );
 
 		test( 'should not load script twice when called multiple times', () => {
-			// First call should create script
+			// First call should load script
 			addSurvicate();
-			expect( document.createElement ).toHaveBeenCalledTimes( 1 );
+			expect( loadSurvicateScript ).toHaveBeenCalledTimes( 1 );
 
-			// Reset the mock to track subsequent calls
-			document.createElement.mockClear();
-
-			// Second call should not create another script
+			// Second call: script is now "loaded"
+			isSurvicateScriptLoaded.mockReturnValue( true );
 			addSurvicate();
-			expect( document.createElement ).not.toHaveBeenCalled();
+
+			// loadSurvicateScript should still have been called only once
+			expect( loadSurvicateScript ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		test( 'should set visitor traits when user is not on anonymous paths', async () => {
@@ -447,9 +392,6 @@ describe( 'survicate', () => {
 			};
 
 			addSurvicate();
-
-			// Simulate script load
-			mockScript.onload();
 			await flushPromises();
 
 			expect( global._sva.setVisitorTraits ).toHaveBeenCalledWith( {
@@ -472,18 +414,14 @@ describe( 'survicate', () => {
 				setVisitorTraits: jest.fn(),
 			};
 
-			// First call - loads script
+			// Script is already loaded
+			isSurvicateScriptLoaded.mockReturnValue( true );
+
 			addSurvicate();
-			mockScript.onload();
 			await flushPromises();
 
-			// Clear the mock to track subsequent calls
-			global._sva.setVisitorTraits.mockClear();
-
-			// Second call - should retry setting visitor traits without loading script again
-			addSurvicate();
-
-			// Should have called setVisitorTraits again via setTimeout
+			// Should have called setVisitorTraits via setTimeout without loading script again
+			expect( loadSurvicateScript ).not.toHaveBeenCalled();
 			expect( global._sva.setVisitorTraits ).toHaveBeenCalledWith( {
 				email: 'test@example.com',
 			} );

--- a/client/lib/analytics/test/survicate.js
+++ b/client/lib/analytics/test/survicate.js
@@ -53,6 +53,8 @@ import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { HelpCenterMoreResources } from '../../../../packages/help-center/src/components/help-center-more-resources';
 import { HelpCenterRequiredContextProvider } from '../../../../packages/help-center/src/contexts/HelpCenterContext';
 
+const flushPromises = () => new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
 describe( 'survicate', () => {
 	let mockScript;
 	let mockScriptElement;
@@ -87,14 +89,6 @@ describe( 'survicate', () => {
 			writable: true,
 		} );
 
-		// Set up fresh module imports
-		jest.isolateModules( () => {
-			const survicateModule = require( 'calypso/lib/analytics/survicate' );
-			mayWeLoadSurvicateScript = survicateModule.mayWeLoadSurvicateScript;
-			addSurvicate = survicateModule.addSurvicate;
-			isUserOnAnonymousPaths = survicateModule.isUserOnAnonymousPaths;
-		} );
-
 		// Mock DOM methods
 		mockScript = {
 			src: '',
@@ -125,6 +119,14 @@ describe( 'survicate', () => {
 
 		// Reset global survicate object
 		global._sva = undefined;
+
+		// Set up fresh module imports (after DOM mocks so the package picks them up)
+		jest.isolateModules( () => {
+			const survicateModule = require( 'calypso/lib/analytics/survicate' );
+			mayWeLoadSurvicateScript = survicateModule.mayWeLoadSurvicateScript;
+			addSurvicate = survicateModule.addSurvicate;
+			isUserOnAnonymousPaths = survicateModule.isUserOnAnonymousPaths;
+		} );
 
 		// Mock setTimeout to be synchronous for testing
 		jest.spyOn( global, 'setTimeout' ).mockImplementation( ( fn ) => fn() );
@@ -245,7 +247,7 @@ describe( 'survicate', () => {
 			);
 		} );
 
-		test( 'should set visitor traits when script loads successfully with logged-in user', () => {
+		test( 'should set visitor traits when script loads successfully with logged-in user', async () => {
 			const mockUser = {
 				email: 'test@example.com',
 			};
@@ -259,6 +261,7 @@ describe( 'survicate', () => {
 
 			// Simulate script load
 			mockScript.onload();
+			await flushPromises();
 
 			expect( global._sva.setVisitorTraits ).toHaveBeenCalledWith( {
 				email: 'test@example.com',
@@ -266,7 +269,7 @@ describe( 'survicate', () => {
 			expect( recordTracksEvent ).not.toHaveBeenCalled();
 		} );
 
-		test( 'should not set visitor traits when user is not logged in', () => {
+		test( 'should not set visitor traits when user is not logged in', async () => {
 			getCurrentUser.mockReturnValue( null );
 
 			global._sva = {
@@ -277,11 +280,12 @@ describe( 'survicate', () => {
 
 			// Simulate script load
 			mockScript.onload();
+			await flushPromises();
 
 			expect( global._sva.setVisitorTraits ).not.toHaveBeenCalled();
 		} );
 
-		test( 'should log error when user is not logged in', () => {
+		test( 'should log error when user is not logged in', async () => {
 			getCurrentUser.mockReturnValue( null );
 
 			global._sva = {
@@ -292,6 +296,7 @@ describe( 'survicate', () => {
 
 			// Simulate script load
 			mockScript.onload();
+			await flushPromises();
 
 			expect( recordTracksEvent ).toHaveBeenCalledWith(
 				'calypso_survicate_user_not_available_error',
@@ -305,7 +310,7 @@ describe( 'survicate', () => {
 			);
 		} );
 
-		test( 'should not set visitor traits when user has no email', () => {
+		test( 'should not set visitor traits when user has no email', async () => {
 			const mockUser = {
 				id: 123,
 			};
@@ -319,11 +324,12 @@ describe( 'survicate', () => {
 
 			// Simulate script load
 			mockScript.onload();
+			await flushPromises();
 
 			expect( global._sva.setVisitorTraits ).not.toHaveBeenCalled();
 		} );
 
-		test( 'should log error when user has no email', () => {
+		test( 'should log error when user has no email', async () => {
 			const mockUser = {
 				id: 123,
 			};
@@ -337,6 +343,7 @@ describe( 'survicate', () => {
 
 			// Simulate script load
 			mockScript.onload();
+			await flushPromises();
 
 			expect( recordTracksEvent ).toHaveBeenCalledWith(
 				'calypso_survicate_user_not_available_error',
@@ -350,7 +357,7 @@ describe( 'survicate', () => {
 			);
 		} );
 
-		test( 'should handle case when _sva object is not available', () => {
+		test( 'should handle case when _sva object is not available', async () => {
 			const mockUser = {
 				email: 'test@example.com',
 			};
@@ -362,10 +369,11 @@ describe( 'survicate', () => {
 			addSurvicate();
 
 			// Simulate script load - should not throw error
-			expect( () => mockScript.onload() ).not.toThrow();
+			mockScript.onload();
+			await expect( flushPromises() ).resolves.toBeUndefined();
 		} );
 
-		test( 'should handle case when _sva exists but setVisitorTraits is not available', () => {
+		test( 'should handle case when _sva exists but setVisitorTraits is not available', async () => {
 			const mockUser = {
 				email: 'test@example.com',
 			};
@@ -376,17 +384,19 @@ describe( 'survicate', () => {
 			addSurvicate();
 
 			// Simulate script load - should not throw error
-			expect( () => mockScript.onload() ).not.toThrow();
+			mockScript.onload();
+			await expect( flushPromises() ).resolves.toBeUndefined();
 		} );
 
-		test( 'should handle script load error', () => {
+		test( 'should handle script load error', async () => {
 			addSurvicate();
 
 			// Simulate script error - should not throw
-			expect( () => mockScript.onerror() ).not.toThrow();
+			mockScript.onerror();
+			await expect( flushPromises() ).resolves.toBeUndefined();
 		} );
 
-		test( 'should use setTimeout for setting visitor traits', () => {
+		test( 'should use setTimeout for setting visitor traits', async () => {
 			const mockUser = {
 				email: 'test@example.com',
 			};
@@ -402,6 +412,7 @@ describe( 'survicate', () => {
 
 			addSurvicate();
 			mockScript.onload();
+			await flushPromises();
 
 			expect( setTimeout ).toHaveBeenCalledWith( expect.any( Function ), 1000 );
 		} );
@@ -419,7 +430,7 @@ describe( 'survicate', () => {
 			expect( document.createElement ).not.toHaveBeenCalled();
 		} );
 
-		test( 'should set visitor traits when user is not on anonymous paths', () => {
+		test( 'should set visitor traits when user is not on anonymous paths', async () => {
 			const mockUser = {
 				email: 'test@example.com',
 			};
@@ -439,13 +450,14 @@ describe( 'survicate', () => {
 
 			// Simulate script load
 			mockScript.onload();
+			await flushPromises();
 
 			expect( global._sva.setVisitorTraits ).toHaveBeenCalledWith( {
 				email: 'test@example.com',
 			} );
 		} );
 
-		test( 'should retry setting visitor traits when script is already loaded', () => {
+		test( 'should retry setting visitor traits when script is already loaded', async () => {
 			const mockUser = {
 				email: 'test@example.com',
 			};
@@ -463,6 +475,7 @@ describe( 'survicate', () => {
 			// First call - loads script
 			addSurvicate();
 			mockScript.onload();
+			await flushPromises();
 
 			// Clear the mock to track subsequent calls
 			global._sva.setVisitorTraits.mockClear();

--- a/client/package.json
+++ b/client/package.json
@@ -71,6 +71,7 @@
 		"@automattic/state-utils": "workspace:^",
 		"@automattic/subscriber": "workspace:^",
 		"@automattic/support-articles": "workspace:^",
+		"@automattic/survicate": "workspace:^",
 		"@automattic/tree-select": "workspace:^",
 		"@automattic/ui": "workspace:^",
 		"@automattic/urls": "workspace:^",

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -3,6 +3,7 @@
 	"env_id": "dashboard-development",
 	"favicon_url": "/calypso/images/favicons/favicon-development.ico",
 	"client_slug": "browser",
+	"survicate_enabled": true,
 	"hostname": "my.localhost",
 	"hostname_allowlist": [ "my.localhost", "my.woo.localhost" ],
 	"i18n_default_locale_slug": "en",

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -3,6 +3,7 @@
 	"env_id": "dashboard-horizon",
 	"favicon_url": "/calypso/images/favicons/favicon-wpcalypso.ico",
 	"client_slug": "browser",
+	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.com" ],
 	"i18n_default_locale_slug": "en",

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -3,6 +3,7 @@
 	"env_id": "dashboard-production",
 	"favicon_url": "//s1.wp.com/i/favicon.ico",
 	"client_slug": "browser",
+	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.com" ],
 	"i18n_default_locale_slug": "en",

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -3,6 +3,7 @@
 	"env_id": "dashboard-stage",
 	"favicon_url": "/calypso/images/favicons/favicon-staging.ico",
 	"client_slug": "browser",
+	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
 	"hostname_allowlist": [ "my.wordpress.com", "my.woo.com" ],
 	"i18n_default_locale_slug": "en",

--- a/packages/load-script/test/load-script-promise.js
+++ b/packages/load-script/test/load-script-promise.js
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { loadScript } from '../src';
+import { removeAllScriptCallbacks } from '../src/callback-handler';
+
+describe( 'loadScript promise API', () => {
+	afterEach( () => {
+		removeAllScriptCallbacks();
+		// Clean up any injected script elements.
+		document.head.querySelectorAll( 'script' ).forEach( ( el ) => el.remove() );
+	} );
+
+	function getInjectedScript( url ) {
+		return document.head.querySelector( `script[src="${ url }"]` );
+	}
+
+	test( 'should resolve when the script loads successfully', async () => {
+		const url = 'https://example.com/script.js';
+		const promise = loadScript( url );
+
+		const script = getInjectedScript( url );
+		expect( script ).not.toBeNull();
+
+		// Simulate browser firing onload.
+		script.onload( { target: script } );
+
+		await expect( promise ).resolves.toBeUndefined();
+	} );
+
+	test( 'should reject when the script fails to load', async () => {
+		const url = 'https://example.com/bad-script.js';
+		const promise = loadScript( url );
+
+		const script = getInjectedScript( url );
+		script.onerror( { target: script } );
+
+		await expect( promise ).rejects.toThrow( `Failed to load script "${ url }"` );
+	} );
+
+	test( 'should not create a second script element for the same URL', () => {
+		const url = 'https://example.com/dedup.js';
+
+		loadScript( url );
+		loadScript( url );
+
+		const scripts = document.head.querySelectorAll( `script[src="${ url }"]` );
+		expect( scripts ).toHaveLength( 1 );
+	} );
+
+	test( 'should resolve both promises when the same URL is requested concurrently', async () => {
+		const url = 'https://example.com/concurrent.js';
+
+		const promise1 = loadScript( url );
+		const promise2 = loadScript( url );
+
+		const script = getInjectedScript( url );
+		script.onload( { target: script } );
+
+		await expect( promise1 ).resolves.toBeUndefined();
+		await expect( promise2 ).resolves.toBeUndefined();
+	} );
+} );

--- a/packages/survicate/README.md
+++ b/packages/survicate/README.md
@@ -1,0 +1,37 @@
+# @automattic/survicate
+
+Shared utilities for integrating [Survicate](https://survicate.com/) surveys into WordPress.com clients.
+
+This package extracts the core Survicate logic (condition checks, script loading, and visitor trait setting) so that multiple clients (Calypso, Multi-site Dashboard, etc.) can share the same implementation.
+
+## Usage
+
+```ts
+import {
+	shouldLoadSurvicate,
+	loadSurvicateScript,
+	setSurvicateVisitorTraits,
+	SURVICATE_WORKSPACE_ID,
+} from '@automattic/survicate';
+
+// 1. Check whether Survicate should load (English locale, non-mobile).
+if ( ! shouldLoadSurvicate( { locale: 'en', isMobile: false } ) ) {
+	return;
+}
+
+// 2. Inject the Survicate script tag.
+await loadSurvicateScript( SURVICATE_WORKSPACE_ID );
+
+// 3. Set visitor traits for targeting.
+setSurvicateVisitorTraits( { email: 'user@example.com' } );
+```
+
+## Exports
+
+| Export | Description |
+| --- | --- |
+| `shouldLoadSurvicate( options )` | Returns `true` if locale starts with `en` and `isMobile` is `false`. |
+| `loadSurvicateScript( workspaceId )` | Injects the Survicate script tag. Deduplicates concurrent calls. |
+| `isSurvicateScriptLoaded()` | Returns whether the script is loaded or loading. |
+| `setSurvicateVisitorTraits( traits )` | Sets visitor traits (e.g. email) on the global `_sva` object. |
+| `SURVICATE_WORKSPACE_ID` | The WordPress.com Survicate workspace identifier. |

--- a/packages/survicate/README.md
+++ b/packages/survicate/README.md
@@ -28,10 +28,10 @@ setSurvicateVisitorTraits( { email: 'user@example.com' } );
 
 ## Exports
 
-| Export | Description |
-| --- | --- |
-| `shouldLoadSurvicate( options )` | Returns `true` if locale starts with `en` and `isMobile` is `false`. |
-| `loadSurvicateScript( workspaceId )` | Injects the Survicate script tag. Deduplicates concurrent calls. |
-| `isSurvicateScriptLoaded()` | Returns whether the script is loaded or loading. |
-| `setSurvicateVisitorTraits( traits )` | Sets visitor traits (e.g. email) on the global `_sva` object. |
-| `SURVICATE_WORKSPACE_ID` | The WordPress.com Survicate workspace identifier. |
+| Export                                | Description                                                          |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| `shouldLoadSurvicate( options )`      | Returns `true` if locale starts with `en` and `isMobile` is `false`. |
+| `loadSurvicateScript( workspaceId )`  | Injects the Survicate script tag. Deduplicates concurrent calls.     |
+| `isSurvicateScriptLoaded()`           | Returns whether the script is loaded or loading.                     |
+| `setSurvicateVisitorTraits( traits )` | Sets visitor traits (e.g. email) on the global `_sva` object.        |
+| `SURVICATE_WORKSPACE_ID`              | The WordPress.com Survicate workspace identifier.                    |

--- a/packages/survicate/jest.config.js
+++ b/packages/survicate/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+};

--- a/packages/survicate/package.json
+++ b/packages/survicate/package.json
@@ -38,6 +38,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/load-script": "workspace:^",
 		"tslib": "^2.8.1"
 	},
 	"devDependencies": {

--- a/packages/survicate/package.json
+++ b/packages/survicate/package.json
@@ -1,0 +1,47 @@
+{
+	"name": "@automattic/survicate",
+	"version": "1.0.0",
+	"description": "Survicate survey integration for WordPress.com clients.",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"sideEffects": false,
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
+	"exports": {
+		".": {
+			"calypso:src": "./src/index.ts",
+			"types": "./dist/types/index.d.ts",
+			"import": "./dist/esm/index.js",
+			"require": "./dist/cjs/index.js"
+		}
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/survicate"
+	},
+	"files": [
+		"dist",
+		"src"
+	],
+	"types": "dist/types",
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"tslib": "^2.8.1"
+	},
+	"devDependencies": {
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^5.8.3"
+	}
+}

--- a/packages/survicate/src/conditions.ts
+++ b/packages/survicate/src/conditions.ts
@@ -1,0 +1,17 @@
+export const SURVICATE_WORKSPACE_ID = 'e4794374cce15378101b63de24117572';
+
+/**
+ * Checks whether Survicate should be loaded based on locale and device type.
+ * Survicate is only loaded for English locales on non-mobile devices.
+ */
+export function shouldLoadSurvicate( options: { locale: string; isMobile: boolean } ): boolean {
+	if ( ! options.locale.startsWith( 'en' ) ) {
+		return false;
+	}
+
+	if ( options.isMobile ) {
+		return false;
+	}
+
+	return true;
+}

--- a/packages/survicate/src/conditions.ts
+++ b/packages/survicate/src/conditions.ts
@@ -4,12 +4,18 @@ export const SURVICATE_WORKSPACE_ID = 'e4794374cce15378101b63de24117572';
  * Checks whether Survicate should be loaded based on locale and device type.
  * Survicate is only loaded for English locales on non-mobile devices.
  */
-export function shouldLoadSurvicate( options: { locale: string; isMobile: boolean } ): boolean {
-	if ( ! options.locale.startsWith( 'en' ) ) {
+export function shouldLoadSurvicate( {
+	locale,
+	isMobile,
+}: {
+	locale: string;
+	isMobile: boolean;
+} ): boolean {
+	if ( ! locale.startsWith( 'en' ) ) {
 		return false;
 	}
 
-	if ( options.isMobile ) {
+	if ( isMobile ) {
 		return false;
 	}
 

--- a/packages/survicate/src/index.ts
+++ b/packages/survicate/src/index.ts
@@ -1,3 +1,3 @@
 export { shouldLoadSurvicate, SURVICATE_WORKSPACE_ID } from './conditions';
 export { isSurvicateScriptLoaded, loadSurvicateScript } from './load-script';
-export { setSurvicateVisitorTraits } from './visitor-traits';
+export { setSurvicateVisitorTraits, addSurvicateSurveyClosedListener } from './visitor-traits';

--- a/packages/survicate/src/index.ts
+++ b/packages/survicate/src/index.ts
@@ -1,7 +1,3 @@
 export { shouldLoadSurvicate, SURVICATE_WORKSPACE_ID } from './conditions';
-export {
-	loadSurvicateScript,
-	isSurvicateScriptLoaded,
-	resetSurvicateScriptState,
-} from './load-script';
+export { loadSurvicateScript } from './load-script';
 export { setSurvicateVisitorTraits } from './visitor-traits';

--- a/packages/survicate/src/index.ts
+++ b/packages/survicate/src/index.ts
@@ -1,0 +1,7 @@
+export { shouldLoadSurvicate, SURVICATE_WORKSPACE_ID } from './conditions';
+export {
+	loadSurvicateScript,
+	isSurvicateScriptLoaded,
+	resetSurvicateScriptState,
+} from './load-script';
+export { setSurvicateVisitorTraits } from './visitor-traits';

--- a/packages/survicate/src/index.ts
+++ b/packages/survicate/src/index.ts
@@ -1,3 +1,3 @@
 export { shouldLoadSurvicate, SURVICATE_WORKSPACE_ID } from './conditions';
 export { isSurvicateScriptLoaded, loadSurvicateScript } from './load-script';
-export { setSurvicateVisitorTraits, addSurvicateSurveyClosedListener } from './visitor-traits';
+export { setSurvicateVisitorTraits } from './visitor-traits';

--- a/packages/survicate/src/index.ts
+++ b/packages/survicate/src/index.ts
@@ -1,3 +1,3 @@
 export { shouldLoadSurvicate, SURVICATE_WORKSPACE_ID } from './conditions';
-export { loadSurvicateScript } from './load-script';
+export { isSurvicateScriptLoaded, loadSurvicateScript } from './load-script';
 export { setSurvicateVisitorTraits } from './visitor-traits';

--- a/packages/survicate/src/load-script.ts
+++ b/packages/survicate/src/load-script.ts
@@ -1,6 +1,13 @@
 import { loadScript } from '@automattic/load-script';
 
 /**
+ * Checks whether the Survicate script is already loaded on the page.
+ */
+export function isSurvicateScriptLoaded(): boolean {
+	return typeof window._sva !== 'undefined';
+}
+
+/**
  * Loads the Survicate survey script for the given workspace.
  * Deduplication is handled by @automattic/load-script.
  */

--- a/packages/survicate/src/load-script.ts
+++ b/packages/survicate/src/load-script.ts
@@ -1,0 +1,46 @@
+let loadPromise: Promise< void > | null = null;
+
+/**
+ * Dynamically injects the Survicate script tag into the page.
+ * Prevents duplicate loading across multiple calls. Returns the same promise
+ * if called while a load is already in progress.
+ */
+export function loadSurvicateScript( workspaceId: string ): Promise< void > {
+	if ( loadPromise ) {
+		return loadPromise;
+	}
+
+	loadPromise = new Promise( ( resolve, reject ) => {
+		const s = document.createElement( 'script' );
+		s.src = `https://survey.survicate.com/workspaces/${ workspaceId }/web_surveys.js`;
+		s.async = true;
+
+		s.onload = () => {
+			resolve();
+		};
+
+		s.onerror = () => {
+			loadPromise = null;
+			reject( new Error( 'Failed to load Survicate script' ) );
+		};
+
+		const firstScript = document.getElementsByTagName( 'script' )[ 0 ];
+		firstScript.parentNode?.insertBefore( s, firstScript );
+	} );
+
+	return loadPromise;
+}
+
+/**
+ * Returns whether the Survicate script has already been loaded or is loading.
+ */
+export function isSurvicateScriptLoaded(): boolean {
+	return loadPromise !== null;
+}
+
+/**
+ * Resets the internal loaded state. Only intended for testing.
+ */
+export function resetSurvicateScriptState(): void {
+	loadPromise = null;
+}

--- a/packages/survicate/src/load-script.ts
+++ b/packages/survicate/src/load-script.ts
@@ -1,5 +1,4 @@
 import { loadScript } from '@automattic/load-script';
-import { addSurvicateSurveyClosedListener } from './visitor-traits';
 
 /**
  * Checks whether the Survicate script is already loaded on the page.
@@ -13,9 +12,5 @@ export function isSurvicateScriptLoaded(): boolean {
  * Deduplication is handled by @automattic/load-script.
  */
 export function loadSurvicateScript( workspaceId: string ): Promise< void > {
-	return loadScript(
-		`https://survey.survicate.com/workspaces/${ workspaceId }/web_surveys.js`
-	).then( () => {
-		addSurvicateSurveyClosedListener();
-	} );
+	return loadScript( `https://survey.survicate.com/workspaces/${ workspaceId }/web_surveys.js` );
 }

--- a/packages/survicate/src/load-script.ts
+++ b/packages/survicate/src/load-script.ts
@@ -1,4 +1,5 @@
 import { loadScript } from '@automattic/load-script';
+import { addSurvicateSurveyClosedListener } from './visitor-traits';
 
 /**
  * Checks whether the Survicate script is already loaded on the page.
@@ -12,5 +13,9 @@ export function isSurvicateScriptLoaded(): boolean {
  * Deduplication is handled by @automattic/load-script.
  */
 export function loadSurvicateScript( workspaceId: string ): Promise< void > {
-	return loadScript( `https://survey.survicate.com/workspaces/${ workspaceId }/web_surveys.js` );
+	return loadScript(
+		`https://survey.survicate.com/workspaces/${ workspaceId }/web_surveys.js`
+	).then( () => {
+		addSurvicateSurveyClosedListener();
+	} );
 }

--- a/packages/survicate/src/load-script.ts
+++ b/packages/survicate/src/load-script.ts
@@ -1,46 +1,9 @@
-let loadPromise: Promise< void > | null = null;
+import { loadScript } from '@automattic/load-script';
 
 /**
- * Dynamically injects the Survicate script tag into the page.
- * Prevents duplicate loading across multiple calls. Returns the same promise
- * if called while a load is already in progress.
+ * Loads the Survicate survey script for the given workspace.
+ * Deduplication is handled by @automattic/load-script.
  */
 export function loadSurvicateScript( workspaceId: string ): Promise< void > {
-	if ( loadPromise ) {
-		return loadPromise;
-	}
-
-	loadPromise = new Promise( ( resolve, reject ) => {
-		const s = document.createElement( 'script' );
-		s.src = `https://survey.survicate.com/workspaces/${ workspaceId }/web_surveys.js`;
-		s.async = true;
-
-		s.onload = () => {
-			resolve();
-		};
-
-		s.onerror = () => {
-			loadPromise = null;
-			reject( new Error( 'Failed to load Survicate script' ) );
-		};
-
-		const firstScript = document.getElementsByTagName( 'script' )[ 0 ];
-		firstScript.parentNode?.insertBefore( s, firstScript );
-	} );
-
-	return loadPromise;
-}
-
-/**
- * Returns whether the Survicate script has already been loaded or is loading.
- */
-export function isSurvicateScriptLoaded(): boolean {
-	return loadPromise !== null;
-}
-
-/**
- * Resets the internal loaded state. Only intended for testing.
- */
-export function resetSurvicateScriptState(): void {
-	loadPromise = null;
+	return loadScript( `https://survey.survicate.com/workspaces/${ workspaceId }/web_surveys.js` );
 }

--- a/packages/survicate/src/test/conditions.test.ts
+++ b/packages/survicate/src/test/conditions.test.ts
@@ -1,0 +1,32 @@
+import { shouldLoadSurvicate, SURVICATE_WORKSPACE_ID } from '../conditions';
+
+describe( 'SURVICATE_WORKSPACE_ID', () => {
+	test( 'should be the expected workspace ID', () => {
+		expect( SURVICATE_WORKSPACE_ID ).toBe( 'e4794374cce15378101b63de24117572' );
+	} );
+} );
+
+describe( 'shouldLoadSurvicate', () => {
+	test( 'should return true for English locale on desktop', () => {
+		expect( shouldLoadSurvicate( { locale: 'en', isMobile: false } ) ).toBe( true );
+	} );
+
+	test( 'should return true for English language variants', () => {
+		expect( shouldLoadSurvicate( { locale: 'en-US', isMobile: false } ) ).toBe( true );
+		expect( shouldLoadSurvicate( { locale: 'en-GB', isMobile: false } ) ).toBe( true );
+	} );
+
+	test( 'should return false for non-English locales', () => {
+		expect( shouldLoadSurvicate( { locale: 'fr', isMobile: false } ) ).toBe( false );
+		expect( shouldLoadSurvicate( { locale: 'es-ES', isMobile: false } ) ).toBe( false );
+		expect( shouldLoadSurvicate( { locale: 'pt-br', isMobile: false } ) ).toBe( false );
+	} );
+
+	test( 'should return false on mobile devices', () => {
+		expect( shouldLoadSurvicate( { locale: 'en', isMobile: true } ) ).toBe( false );
+	} );
+
+	test( 'should return false for non-English on mobile', () => {
+		expect( shouldLoadSurvicate( { locale: 'fr', isMobile: true } ) ).toBe( false );
+	} );
+} );

--- a/packages/survicate/src/test/load-script.test.ts
+++ b/packages/survicate/src/test/load-script.test.ts
@@ -1,170 +1,22 @@
-/**
- * @jest-environment jsdom
- */
+jest.mock( '@automattic/load-script', () => ( {
+	loadScript: jest.fn( () => Promise.resolve() ),
+} ) );
 
-import {
-	loadSurvicateScript,
-	isSurvicateScriptLoaded,
-	resetSurvicateScriptState,
-} from '../load-script';
+import { loadScript } from '@automattic/load-script';
+import { loadSurvicateScript } from '../load-script';
 
 describe( 'loadSurvicateScript', () => {
-	let mockScript: {
-		src: string;
-		async: boolean;
-		onload: ( () => void ) | null;
-		onerror: ( () => void ) | null;
-	};
-	let mockScriptElement: { parentNode: { insertBefore: jest.Mock } };
-	let originalCreateElement: typeof document.createElement;
-	let originalGetElementsByTagName: typeof document.getElementsByTagName;
+	test( 'should call loadScript with the correct Survicate URL', async () => {
+		await loadSurvicateScript( 'test-workspace-id' );
 
-	beforeAll( () => {
-		originalCreateElement = document.createElement;
-		originalGetElementsByTagName = document.getElementsByTagName;
-	} );
-
-	beforeEach( () => {
-		resetSurvicateScriptState();
-
-		mockScript = {
-			src: '',
-			async: false,
-			onload: null,
-			onerror: null,
-		};
-
-		mockScriptElement = {
-			parentNode: {
-				insertBefore: jest.fn(),
-			},
-		};
-
-		document.createElement = jest.fn( ( tagName: string ) => {
-			if ( tagName === 'script' ) {
-				return mockScript as unknown as HTMLScriptElement;
-			}
-			return originalCreateElement.call( document, tagName );
-		} );
-
-		document.getElementsByTagName = jest.fn( ( tagName: string ) => {
-			if ( tagName === 'script' ) {
-				return [ mockScriptElement ] as unknown as HTMLCollectionOf< Element >;
-			}
-			return originalGetElementsByTagName.call( document, tagName );
-		} );
-	} );
-
-	afterAll( () => {
-		document.createElement = originalCreateElement;
-		document.getElementsByTagName = originalGetElementsByTagName;
-	} );
-
-	test( 'should create a script element with correct URL', () => {
-		loadSurvicateScript( 'test-workspace-id' );
-
-		expect( document.createElement ).toHaveBeenCalledWith( 'script' );
-		expect( mockScript.src ).toBe(
+		expect( loadScript ).toHaveBeenCalledWith(
 			'https://survey.survicate.com/workspaces/test-workspace-id/web_surveys.js'
 		);
-		expect( mockScript.async ).toBe( true );
 	} );
 
-	test( 'should insert script into the DOM', () => {
-		loadSurvicateScript( 'test-id' );
+	test( 'should propagate errors from loadScript', async () => {
+		( loadScript as jest.Mock ).mockRejectedValueOnce( new Error( 'load failed' ) );
 
-		expect( mockScriptElement.parentNode.insertBefore ).toHaveBeenCalledWith(
-			mockScript,
-			mockScriptElement
-		);
-	} );
-
-	test( 'should resolve when script loads successfully', async () => {
-		const promise = loadSurvicateScript( 'test-id' );
-
-		mockScript.onload?.();
-
-		await expect( promise ).resolves.toBeUndefined();
-	} );
-
-	test( 'should reject when script fails to load', async () => {
-		const promise = loadSurvicateScript( 'test-id' );
-
-		mockScript.onerror?.();
-
-		await expect( promise ).rejects.toThrow( 'Failed to load Survicate script' );
-	} );
-
-	test( 'should not load script twice', async () => {
-		const firstPromise = loadSurvicateScript( 'test-id' );
-		mockScript.onload?.();
-		await firstPromise;
-
-		const secondPromise = loadSurvicateScript( 'test-id' );
-		await expect( secondPromise ).resolves.toBeUndefined();
-
-		// createElement should only be called once
-		expect( document.createElement ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	test( 'should report loaded immediately after load is initiated', () => {
-		expect( isSurvicateScriptLoaded() ).toBe( false );
-
-		loadSurvicateScript( 'test-id' );
-
-		expect( isSurvicateScriptLoaded() ).toBe( true );
-	} );
-
-	test( 'should return the same promise for concurrent calls', () => {
-		const promise1 = loadSurvicateScript( 'test-id' );
-		const promise2 = loadSurvicateScript( 'test-id' );
-
-		expect( promise1 ).toBe( promise2 );
-		expect( document.createElement ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	test( 'should reset loaded state on failure so retry is possible', async () => {
-		const promise = loadSurvicateScript( 'test-id' );
-		mockScript.onerror?.();
-
-		try {
-			await promise;
-		} catch {
-			// Expected rejection
-		}
-
-		expect( isSurvicateScriptLoaded() ).toBe( false );
-	} );
-} );
-
-describe( 'resetSurvicateScriptState', () => {
-	test( 'should reset the loaded state', async () => {
-		const originalCreateElement = document.createElement;
-		const originalGetElementsByTagName = document.getElementsByTagName;
-
-		const mockScript = {
-			src: '',
-			async: false,
-			onload: null as ( () => void ) | null,
-			onerror: null as ( () => void ) | null,
-		};
-		document.createElement = jest.fn( () => mockScript as unknown as HTMLScriptElement );
-		document.getElementsByTagName = jest.fn(
-			() =>
-				[ { parentNode: { insertBefore: jest.fn() } } ] as unknown as HTMLCollectionOf< Element >
-		);
-
-		const promise = loadSurvicateScript( 'test-id' );
-		mockScript.onload?.();
-		await promise;
-
-		expect( isSurvicateScriptLoaded() ).toBe( true );
-
-		resetSurvicateScriptState();
-
-		expect( isSurvicateScriptLoaded() ).toBe( false );
-
-		document.createElement = originalCreateElement;
-		document.getElementsByTagName = originalGetElementsByTagName;
+		await expect( loadSurvicateScript( 'test-id' ) ).rejects.toThrow( 'load failed' );
 	} );
 } );

--- a/packages/survicate/src/test/load-script.test.ts
+++ b/packages/survicate/src/test/load-script.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+	loadSurvicateScript,
+	isSurvicateScriptLoaded,
+	resetSurvicateScriptState,
+} from '../load-script';
+
+describe( 'loadSurvicateScript', () => {
+	let mockScript: {
+		src: string;
+		async: boolean;
+		onload: ( () => void ) | null;
+		onerror: ( () => void ) | null;
+	};
+	let mockScriptElement: { parentNode: { insertBefore: jest.Mock } };
+	let originalCreateElement: typeof document.createElement;
+	let originalGetElementsByTagName: typeof document.getElementsByTagName;
+
+	beforeAll( () => {
+		originalCreateElement = document.createElement;
+		originalGetElementsByTagName = document.getElementsByTagName;
+	} );
+
+	beforeEach( () => {
+		resetSurvicateScriptState();
+
+		mockScript = {
+			src: '',
+			async: false,
+			onload: null,
+			onerror: null,
+		};
+
+		mockScriptElement = {
+			parentNode: {
+				insertBefore: jest.fn(),
+			},
+		};
+
+		document.createElement = jest.fn( ( tagName: string ) => {
+			if ( tagName === 'script' ) {
+				return mockScript as unknown as HTMLScriptElement;
+			}
+			return originalCreateElement.call( document, tagName );
+		} );
+
+		document.getElementsByTagName = jest.fn( ( tagName: string ) => {
+			if ( tagName === 'script' ) {
+				return [ mockScriptElement ] as unknown as HTMLCollectionOf< Element >;
+			}
+			return originalGetElementsByTagName.call( document, tagName );
+		} );
+	} );
+
+	afterAll( () => {
+		document.createElement = originalCreateElement;
+		document.getElementsByTagName = originalGetElementsByTagName;
+	} );
+
+	test( 'should create a script element with correct URL', () => {
+		loadSurvicateScript( 'test-workspace-id' );
+
+		expect( document.createElement ).toHaveBeenCalledWith( 'script' );
+		expect( mockScript.src ).toBe(
+			'https://survey.survicate.com/workspaces/test-workspace-id/web_surveys.js'
+		);
+		expect( mockScript.async ).toBe( true );
+	} );
+
+	test( 'should insert script into the DOM', () => {
+		loadSurvicateScript( 'test-id' );
+
+		expect( mockScriptElement.parentNode.insertBefore ).toHaveBeenCalledWith(
+			mockScript,
+			mockScriptElement
+		);
+	} );
+
+	test( 'should resolve when script loads successfully', async () => {
+		const promise = loadSurvicateScript( 'test-id' );
+
+		mockScript.onload?.();
+
+		await expect( promise ).resolves.toBeUndefined();
+	} );
+
+	test( 'should reject when script fails to load', async () => {
+		const promise = loadSurvicateScript( 'test-id' );
+
+		mockScript.onerror?.();
+
+		await expect( promise ).rejects.toThrow( 'Failed to load Survicate script' );
+	} );
+
+	test( 'should not load script twice', async () => {
+		const firstPromise = loadSurvicateScript( 'test-id' );
+		mockScript.onload?.();
+		await firstPromise;
+
+		const secondPromise = loadSurvicateScript( 'test-id' );
+		await expect( secondPromise ).resolves.toBeUndefined();
+
+		// createElement should only be called once
+		expect( document.createElement ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'should report loaded immediately after load is initiated', () => {
+		expect( isSurvicateScriptLoaded() ).toBe( false );
+
+		loadSurvicateScript( 'test-id' );
+
+		expect( isSurvicateScriptLoaded() ).toBe( true );
+	} );
+
+	test( 'should return the same promise for concurrent calls', () => {
+		const promise1 = loadSurvicateScript( 'test-id' );
+		const promise2 = loadSurvicateScript( 'test-id' );
+
+		expect( promise1 ).toBe( promise2 );
+		expect( document.createElement ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'should reset loaded state on failure so retry is possible', async () => {
+		const promise = loadSurvicateScript( 'test-id' );
+		mockScript.onerror?.();
+
+		try {
+			await promise;
+		} catch {
+			// Expected rejection
+		}
+
+		expect( isSurvicateScriptLoaded() ).toBe( false );
+	} );
+} );
+
+describe( 'resetSurvicateScriptState', () => {
+	test( 'should reset the loaded state', async () => {
+		const originalCreateElement = document.createElement;
+		const originalGetElementsByTagName = document.getElementsByTagName;
+
+		const mockScript = {
+			src: '',
+			async: false,
+			onload: null as ( () => void ) | null,
+			onerror: null as ( () => void ) | null,
+		};
+		document.createElement = jest.fn( () => mockScript as unknown as HTMLScriptElement );
+		document.getElementsByTagName = jest.fn(
+			() =>
+				[ { parentNode: { insertBefore: jest.fn() } } ] as unknown as HTMLCollectionOf< Element >
+		);
+
+		const promise = loadSurvicateScript( 'test-id' );
+		mockScript.onload?.();
+		await promise;
+
+		expect( isSurvicateScriptLoaded() ).toBe( true );
+
+		resetSurvicateScriptState();
+
+		expect( isSurvicateScriptLoaded() ).toBe( false );
+
+		document.createElement = originalCreateElement;
+		document.getElementsByTagName = originalGetElementsByTagName;
+	} );
+} );

--- a/packages/survicate/src/test/visitor-traits.test.ts
+++ b/packages/survicate/src/test/visitor-traits.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { setSurvicateVisitorTraits } from '../visitor-traits';
+
+describe( 'setSurvicateVisitorTraits', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		window._sva = undefined;
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		window._sva = undefined;
+	} );
+
+	test( 'should set visitor traits after a 1000ms delay', () => {
+		const setVisitorTraits = jest.fn();
+		window._sva = { setVisitorTraits };
+
+		setSurvicateVisitorTraits( { email: 'test@example.com' } );
+
+		// Should not be called immediately
+		expect( setVisitorTraits ).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime( 1000 );
+
+		expect( setVisitorTraits ).toHaveBeenCalledWith( { email: 'test@example.com' } );
+	} );
+
+	test( 'should not throw when _sva is undefined', () => {
+		window._sva = undefined;
+
+		setSurvicateVisitorTraits( { email: 'test@example.com' } );
+
+		expect( () => jest.advanceTimersByTime( 1000 ) ).not.toThrow();
+	} );
+
+	test( 'should not throw when setVisitorTraits is not available', () => {
+		window._sva = {};
+
+		setSurvicateVisitorTraits( { email: 'test@example.com' } );
+
+		expect( () => jest.advanceTimersByTime( 1000 ) ).not.toThrow();
+	} );
+
+	test( 'should not call setVisitorTraits before the delay', () => {
+		const setVisitorTraits = jest.fn();
+		window._sva = { setVisitorTraits };
+
+		setSurvicateVisitorTraits( { email: 'test@example.com' } );
+
+		jest.advanceTimersByTime( 999 );
+		expect( setVisitorTraits ).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime( 1 );
+		expect( setVisitorTraits ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/packages/survicate/src/test/visitor-traits.test.ts
+++ b/packages/survicate/src/test/visitor-traits.test.ts
@@ -6,25 +6,23 @@ import { setSurvicateVisitorTraits } from '../visitor-traits';
 
 describe( 'setSurvicateVisitorTraits', () => {
 	beforeEach( () => {
-		jest.useFakeTimers();
 		window._sva = undefined;
 	} );
 
 	afterEach( () => {
-		jest.useRealTimers();
 		window._sva = undefined;
 	} );
 
-	test( 'should set visitor traits after a 1000ms delay', () => {
+	test( 'should set visitor traits when SurvicateReady fires', () => {
 		const setVisitorTraits = jest.fn();
 		window._sva = { setVisitorTraits };
 
 		setSurvicateVisitorTraits( { email: 'test@example.com' } );
 
-		// Should not be called immediately
+		// Should not be called before the event fires
 		expect( setVisitorTraits ).not.toHaveBeenCalled();
 
-		jest.advanceTimersByTime( 1000 );
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
 
 		expect( setVisitorTraits ).toHaveBeenCalledWith( { email: 'test@example.com' } );
 	} );
@@ -34,7 +32,7 @@ describe( 'setSurvicateVisitorTraits', () => {
 
 		setSurvicateVisitorTraits( { email: 'test@example.com' } );
 
-		expect( () => jest.advanceTimersByTime( 1000 ) ).not.toThrow();
+		expect( () => window.dispatchEvent( new Event( 'SurvicateReady' ) ) ).not.toThrow();
 	} );
 
 	test( 'should not throw when setVisitorTraits is not available', () => {
@@ -42,19 +40,42 @@ describe( 'setSurvicateVisitorTraits', () => {
 
 		setSurvicateVisitorTraits( { email: 'test@example.com' } );
 
-		expect( () => jest.advanceTimersByTime( 1000 ) ).not.toThrow();
+		expect( () => window.dispatchEvent( new Event( 'SurvicateReady' ) ) ).not.toThrow();
 	} );
 
-	test( 'should not call setVisitorTraits before the delay', () => {
+	test( 'should not call setVisitorTraits before the event fires', () => {
 		const setVisitorTraits = jest.fn();
 		window._sva = { setVisitorTraits };
 
 		setSurvicateVisitorTraits( { email: 'test@example.com' } );
 
-		jest.advanceTimersByTime( 999 );
 		expect( setVisitorTraits ).not.toHaveBeenCalled();
 
-		jest.advanceTimersByTime( 1 );
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
+		expect( setVisitorTraits ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'should return a cleanup function that removes the listener', () => {
+		const setVisitorTraits = jest.fn();
+		window._sva = { setVisitorTraits };
+
+		const cleanup = setSurvicateVisitorTraits( { email: 'test@example.com' } );
+
+		cleanup();
+
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
+		expect( setVisitorTraits ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should only fire once due to { once: true }', () => {
+		const setVisitorTraits = jest.fn();
+		window._sva = { setVisitorTraits };
+
+		setSurvicateVisitorTraits( { email: 'test@example.com' } );
+
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
+
 		expect( setVisitorTraits ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/packages/survicate/src/visitor-traits.ts
+++ b/packages/survicate/src/visitor-traits.ts
@@ -1,0 +1,25 @@
+declare global {
+	interface Window {
+		_sva?: {
+			setVisitorTraits?: ( traits: Record< string, string > ) => void;
+			addEventListener?: ( event: string, handler: () => void ) => void;
+			removeEventListener?: ( event: string, handler: () => void ) => void;
+			invokeEvent?: ( event: string ) => void;
+			destroyVisitor?: () => void;
+		};
+	}
+}
+
+const VISITOR_TRAITS_DELAY_MS = 1000;
+
+/**
+ * Sets Survicate visitor traits (e.g. email) on the global `_sva` object.
+ * Includes a delay to allow the Survicate SDK to initialize after script load.
+ */
+export function setSurvicateVisitorTraits( traits: { email: string } ): void {
+	setTimeout( () => {
+		if ( typeof window._sva !== 'undefined' && window._sva.setVisitorTraits ) {
+			window._sva.setVisitorTraits( traits );
+		}
+	}, VISITOR_TRAITS_DELAY_MS );
+}

--- a/packages/survicate/src/visitor-traits.ts
+++ b/packages/survicate/src/visitor-traits.ts
@@ -13,7 +13,6 @@ declare global {
 /**
  * Sets Survicate visitor traits (e.g. email) on the global `_sva` object.
  * Waits for the `SurvicateReady` window event before setting traits.
- *
  * @returns A cleanup function that removes the event listener.
  */
 export function setSurvicateVisitorTraits( traits: { email: string } ): () => void {
@@ -28,21 +27,4 @@ export function setSurvicateVisitorTraits( traits: { email: string } ): () => vo
 	return () => {
 		window.removeEventListener( 'SurvicateReady', handler );
 	};
-}
-
-/**
- * Adds a listener for the survey_closed event and destroys the visitor if the survey is closed.
- */
-export function addSurvicateSurveyClosedListener(): void {
-	window.addEventListener(
-		'SurvicateReady',
-		function () {
-			if ( typeof window._sva !== 'undefined' && window._sva?.addEventListener ) {
-				window._sva?.addEventListener( 'survey_closed', function () {
-					window._sva?.destroyVisitor?.();
-				} );
-			}
-		},
-		{ once: true }
-	);
 }

--- a/packages/survicate/src/visitor-traits.ts
+++ b/packages/survicate/src/visitor-traits.ts
@@ -12,25 +12,37 @@ declare global {
 
 /**
  * Sets Survicate visitor traits (e.g. email) on the global `_sva` object.
- * Includes a delay to allow the Survicate SDK to initialize after script load.
+ * Waits for the `SurvicateReady` window event before setting traits.
+ *
+ * @returns A cleanup function that removes the event listener.
  */
-export function setSurvicateVisitorTraits( traits: { email: string } ): void {
-	window.addEventListener( 'SurvicateReady', function () {
+export function setSurvicateVisitorTraits( traits: { email: string } ): () => void {
+	const handler = function () {
 		if ( typeof window._sva !== 'undefined' && window._sva.setVisitorTraits ) {
 			window._sva.setVisitorTraits( traits );
 		}
-	} );
+	};
+
+	window.addEventListener( 'SurvicateReady', handler, { once: true } );
+
+	return () => {
+		window.removeEventListener( 'SurvicateReady', handler );
+	};
 }
 
 /**
  * Adds a listener for the survey_closed event and destroys the visitor if the survey is closed.
  */
 export function addSurvicateSurveyClosedListener(): void {
-	window.addEventListener( 'SurvicateReady', function () {
-		if ( typeof window._sva !== 'undefined' && window._sva?.addEventListener ) {
-			window._sva?.addEventListener( 'survey_closed', function () {
-				window._sva?.destroyVisitor?.();
-			} );
-		}
-	} );
+	window.addEventListener(
+		'SurvicateReady',
+		function () {
+			if ( typeof window._sva !== 'undefined' && window._sva?.addEventListener ) {
+				window._sva?.addEventListener( 'survey_closed', function () {
+					window._sva?.destroyVisitor?.();
+				} );
+			}
+		},
+		{ once: true }
+	);
 }

--- a/packages/survicate/src/visitor-traits.ts
+++ b/packages/survicate/src/visitor-traits.ts
@@ -10,16 +10,27 @@ declare global {
 	}
 }
 
-const VISITOR_TRAITS_DELAY_MS = 1000;
-
 /**
  * Sets Survicate visitor traits (e.g. email) on the global `_sva` object.
  * Includes a delay to allow the Survicate SDK to initialize after script load.
  */
 export function setSurvicateVisitorTraits( traits: { email: string } ): void {
-	setTimeout( () => {
+	window.addEventListener( 'SurvicateReady', function () {
 		if ( typeof window._sva !== 'undefined' && window._sva.setVisitorTraits ) {
 			window._sva.setVisitorTraits( traits );
 		}
-	}, VISITOR_TRAITS_DELAY_MS );
+	} );
+}
+
+/**
+ * Adds a listener for the survey_closed event and destroys the visitor if the survey is closed.
+ */
+export function addSurvicateSurveyClosedListener(): void {
+	window.addEventListener( 'SurvicateReady', function () {
+		if ( typeof window._sva !== 'undefined' && window._sva?.addEventListener ) {
+			window._sva?.addEventListener( 'survey_closed', function () {
+				window._sva?.destroyVisitor?.();
+			} );
+		}
+	} );
 }

--- a/packages/survicate/tsconfig-cjs.json
+++ b/packages/survicate/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/survicate/tsconfig.json
+++ b/packages/survicate/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -54,6 +54,7 @@
 		{ "path": "./sites" },
 		{ "path": "./state-utils" },
 		{ "path": "./subscriber" },
+		{ "path": "./survicate" },
 		{ "path": "./tree-select" },
 		{ "path": "./ui" },
 		{ "path": "./viewport" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,7 +2297,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/survicate@workspace:packages/survicate":
+"@automattic/survicate@workspace:^, @automattic/survicate@workspace:packages/survicate":
   version: 0.0.0-use.local
   resolution: "@automattic/survicate@workspace:packages/survicate"
   dependencies:
@@ -14874,6 +14874,7 @@ __metadata:
     "@automattic/state-utils": "workspace:^"
     "@automattic/subscriber": "workspace:^"
     "@automattic/support-articles": "workspace:^"
+    "@automattic/survicate": "workspace:^"
     "@automattic/tree-select": "workspace:^"
     "@automattic/ui": "workspace:^"
     "@automattic/urls": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,6 +2297,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/survicate@workspace:packages/survicate":
+  version: 0.0.0-use.local
+  resolution: "@automattic/survicate@workspace:packages/survicate"
+  dependencies:
+    "@automattic/calypso-typescript-config": "workspace:^"
+    tslib: "npm:^2.8.1"
+    typescript: "npm:^5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "@automattic/tree-select@workspace:^, @automattic/tree-select@workspace:packages/tree-select":
   version: 0.0.0-use.local
   resolution: "@automattic/tree-select@workspace:packages/tree-select"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,6 +2302,7 @@ __metadata:
   resolution: "@automattic/survicate@workspace:packages/survicate"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/load-script": "workspace:^"
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.3"
   languageName: unknown


### PR DESCRIPTION
Related to DOTCOM-15998

## Proposed Changes

- Create `@automattic/survicate` shared package extracting core Survicate logic (script loading, visitor traits, condition checks) from `client/lib/analytics/survicate.js`.
- Refactor Calypso's survicate module to consume the shared package — public API and behavior unchanged.
- Add `SurvicateProvider` to the MSD layout stack, loading surveys under the same conditions as Calypso (English locale, desktop, `survicate_enabled` config flag).

## Why are these changes being made?

The Multi-site Dashboard currently has no Survicate integration. Rather than duplicating the existing Calypso implementation, this extracts the core logic into a shared package so both clients use the same code and stay in sync.

## Testing Instructions

- Verify existing Calypso Survicate tests pass: `yarn test-client client/lib/analytics/test/survicate.js`
- Verify shared package tests pass: `npx jest packages/survicate/src/test/ --config packages/survicate/jest.config.js`
- Verify MSD provider tests pass: `yarn test-client client/dashboard/app/survicate/test/index.test.tsx`
- Run `yarn start-dashboard`, log in with an English locale on desktop, and confirm the Survicate script tag appears in the DOM (`survey.survicate.com` in Network tab).
- Switch to a non-English locale or resize to mobile viewport and confirm the script does not load.

Open your test environment, adding `test_survey2=true` to the URL to load survicate:

- Calypso:

	<img width="1395" height="922" alt="image" src="https://github.com/user-attachments/assets/4a32eb02-ae2c-4354-b641-98aa2cc0e3a5" />


- MSD:

	<img width="1448" height="870" alt="image" src="https://github.com/user-attachments/assets/9f4a9339-91c8-4f16-a809-e1d72aee26b6" />



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?