### PR TITLE
Suggested follows dialog - consider isLoading in check to close modal.

### DIFF
--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -55,8 +55,8 @@ const ReaderSuggestedFollowsDialog = ( {
 		enabled: prefetch || isVisible,
 	} );
 
-	const hasData = Array.isArray( data ) && data?.length > 0;
-	const shouldCloseModal = isFetched && isVisible && ! isLoading && ! hasData;
+	const hasData = Array.isArray( data ) && data.length > 0;
+	const shouldCloseModal = isFetched && isVisible && ! hasData && ! isLoading;
 
 	useEffect( () => {
 		if ( isVisible && resourceType ) {

--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -55,8 +55,8 @@ const ReaderSuggestedFollowsDialog = ( {
 		enabled: prefetch || isVisible,
 	} );
 
-	const hasData = Array.isArray( data ) && data.length > 0;
-	const shouldCloseModal = isFetched && isVisible && ! hasData;
+	const hasData = Array.isArray( data ) && data?.length > 0;
+	const shouldCloseModal = isFetched && isVisible && ! isLoading && ! hasData;
 
 	useEffect( () => {
 		if ( isVisible && resourceType ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/READ-312/reader-discover-recommended-modal-flashes-on-subscriber

## Proposed Changes

* adds `&& ! isLoading` to the shouldCloseModal condition.
    * Currently isFetched updates to `true` before `data` is updated. So only checking this gives a false sense that we fetched everything but have no data. `isLoading` seems to remain true until data is set, so lets ensure we wait for that to turn falsy before closing the modal. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The modal closing prematurely when subscribing on the discover recommendations page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to discover recommendations
* scroll down
* click "subscribe" for a site that has not been loaded yet
* verify the modal appears, loads, and remains open. vs. on production where it appears, loads, and closes before showing the newly fetched data.
* compare vs. production. this is not always reproduce-able and once at sites data for suggested follows is loaded this issue does not happen (likely why it doesn't seem to happen on full post page or blog feed page).
* continue smoke testing recommended follows dialogue by subscribing in various places this appears such as discover recommended and full post page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
