### PR TITLE
Hide Calypso opt-in banners behind feature flag

### DIFF
--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -53,7 +53,7 @@ class MySitesNavigation extends Component {
 			<GlobalSidebar
 				path={ this.props.path }
 				footer={
-					this.props.isDashboardToggleEnabled &&
+					this.props.showOptInBanner &&
 					! this.props.isGlobalSidebarCollapsed && <HostingDashboardOptInBanner />
 				}
 			>
@@ -94,7 +94,8 @@ export default withCurrentRoute(
 				isGlobalSidebarVisible: shouldShowGlobalSidebar,
 				isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar,
 				isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar,
-				isDashboardToggleEnabled: isDashboardToggleEnabled( state ),
+				showOptInBanner:
+					config.isEnabled( 'dashboard/opt-in-banners' ) && isDashboardToggleEnabled( state ),
 			};
 		},
 		{

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -21,11 +21,11 @@ interface Props {
 	path: string;
 	isCollapsed: boolean;
 	hasOptIn: boolean;
-	isDashboardToggleEnabled: boolean;
+	showOptInBanner: boolean;
 }
 const managePluginsPattern = /^\/plugins\/(manage|active|inactive|updates)/;
 
-const PluginsSidebar = ( { path, isCollapsed, hasOptIn, isDashboardToggleEnabled }: Props ) => {
+const PluginsSidebar = ( { path, isCollapsed, hasOptIn, showOptInBanner }: Props ) => {
 	const translate = useTranslate();
 
 	const [ previousPath, setPreviousPath ] = useState( path );
@@ -47,7 +47,7 @@ const PluginsSidebar = ( { path, isCollapsed, hasOptIn, isDashboardToggleEnabled
 					"Enhance your site's features with plugins, or schedule updates to fit your needs."
 				)
 			}
-			footer={ isDashboardToggleEnabled && ! isCollapsed && <HostingDashboardOptInBanner /> }
+			footer={ showOptInBanner && ! isCollapsed && <HostingDashboardOptInBanner /> }
 		>
 			<SidebarMenu>
 				{ ! ( isEnabled( 'plugins/universal-header' ) && hasOptIn ) && (
@@ -120,7 +120,7 @@ export default withCurrentRoute(
 		return {
 			isCollapsed: shouldShowCollapsedGlobalSidebar,
 			hasOptIn: hasDashboardOptIn( state ),
-			isDashboardToggleEnabled: isDashboardToggleEnabled( state ),
+			showOptInBanner: isEnabled( 'dashboard/opt-in-banners' ) && isDashboardToggleEnabled( state ),
 		};
 	} )( PluginsSidebar )
 );

--- a/client/sites/components/sites-dashboard-banners/use-dashboard-opt-in-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-dashboard-opt-in-banner.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useSelector } from 'react-redux';
 import HostingDashboardOptInBanner from 'calypso/my-sites/hosting-dashboard-opt-in-banner';
@@ -11,7 +12,7 @@ export function useDashboardOptInBanner() {
 	return {
 		id,
 		shouldShow() {
-			return ! isDesktop && dashboardEnabled;
+			return isEnabled( 'dashboard/opt-in-banners' ) && ! isDesktop && dashboardEnabled;
 		},
 		render() {
 			return <HostingDashboardOptInBanner isMobile />;

--- a/config/development.json
+++ b/config/development.json
@@ -53,6 +53,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/paginated-site-list": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,6 +28,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/paginated-site-list": true,

--- a/config/production.json
+++ b/config/production.json
@@ -40,6 +40,7 @@
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/paginated-site-list": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,6 +38,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/paginated-site-list": true,

--- a/config/test.json
+++ b/config/test.json
@@ -115,6 +115,7 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"wpcom-user-bootstrap": false,
+		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,6 +38,7 @@
 		"checkout/vgs-ebanx": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/v2/paginated-site-list": true,


### PR DESCRIPTION
Fixes of DOTMSD-1080

## Proposed Changes

* Add `dashboard/opt-in-banners` feature flag (off in all configs)
* Gate `HostingDashboardOptInBanner` rendering in Calypso sidebar, plugins sidebar, and mobile sites view

## Why are these changes being made?

Stop advertising the multi-site dashboard opt-in in Calypso. The dashboard toggle in account settings and dashboard preferences remains functional — only the promotional banners are hidden.

## Testing Instructions

* Start dev server, confirm no opt-in banners appear in:
  * Calypso sidebar (when expanded)
  * Plugins sidebar
  * Mobile sites view
* Verify account settings form still shows at `/me/account`
* Verify dashboard preferences toggle still shows at `/me/preferences`
* Set `dashboard/opt-in-banners` to `true` in `config/development.json` and confirm banners reappear

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?