### PR TITLE
Tests: clean up nock after each test instead of after all

### DIFF
--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -31,10 +31,6 @@ const createErrorInfo = ( stack = 'at SomeComponent' ): ErrorInfo => ( {
 } );
 
 describe( 'handleOnCatch', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	it( 'does not log or capture benign inaccessible Jetpack error', () => {
 		const error = new Error( 'The Jetpack site is inaccessible or returned an error' );
 		error.name = 'ParseError';

--- a/client/dashboard/app/snackbars/test/index.tsx
+++ b/client/dashboard/app/snackbars/test/index.tsx
@@ -60,7 +60,6 @@ describe( 'Snackbars', () => {
 	let mockSubscribe: jest.Mock;
 
 	beforeEach( () => {
-		jest.clearAllMocks();
 		hasSubscription = false;
 
 		currentNotices = [

--- a/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
+++ b/client/dashboard/components/logs-activity-formatted-block/test/index.test.tsx
@@ -45,7 +45,6 @@ describe( 'FormattedBlock renderer', () => {
 	beforeEach( () => {
 		mockedIsJetpackCloud.mockReturnValue( false );
 		mockedIsA8CForAgencies.mockReturnValue( false );
-		jest.clearAllMocks();
 	} );
 
 	test( 'renders string content as-is', () => {
@@ -103,7 +102,6 @@ describe( 'Link blocks', () => {
 	beforeEach( () => {
 		mockedIsJetpackCloud.mockReturnValue( false );
 		mockedIsA8CForAgencies.mockReturnValue( false );
-		jest.clearAllMocks();
 	} );
 
 	test.each( [
@@ -147,7 +145,6 @@ describe( 'Post blocks', () => {
 	beforeEach( () => {
 		mockedIsJetpackCloud.mockReturnValue( false );
 		mockedIsA8CForAgencies.mockReturnValue( false );
-		jest.clearAllMocks();
 	} );
 
 	test( 'links to the trash page when post is trashed', () => {
@@ -200,7 +197,6 @@ describe( 'Comment blocks', () => {
 	beforeEach( () => {
 		mockedIsJetpackCloud.mockReturnValue( false );
 		mockedIsA8CForAgencies.mockReturnValue( false );
-		jest.clearAllMocks();
 	} );
 
 	test( 'links to the comment anchor on Calypso', () => {
@@ -240,7 +236,6 @@ describe( 'Person blocks', () => {
 	beforeEach( () => {
 		mockedIsJetpackCloud.mockReturnValue( false );
 		mockedIsA8CForAgencies.mockReturnValue( false );
-		jest.clearAllMocks();
 	} );
 
 	test( 'links to the people editor on Calypso', () => {
@@ -281,7 +276,6 @@ describe( 'Plugin blocks', () => {
 		mockedIsJetpackCloud.mockReturnValue( false );
 		mockedIsA8CForAgencies.mockReturnValue( false );
 		mockedIsDashboardBackport.mockReturnValue( false );
-		jest.clearAllMocks();
 	} );
 
 	test( 'renders an external link when not in the backport', () => {
@@ -348,7 +342,6 @@ describe( 'Theme blocks', () => {
 	beforeEach( () => {
 		mockedIsJetpackCloud.mockReturnValue( false );
 		mockedIsA8CForAgencies.mockReturnValue( false );
-		jest.clearAllMocks();
 	} );
 
 	test( 'renders relative link for wordpress.com themes', () => {

--- a/client/dashboard/components/logs-activity/test/activity-event.test.tsx
+++ b/client/dashboard/components/logs-activity/test/activity-event.test.tsx
@@ -54,7 +54,6 @@ describe( 'ActivityEvent', () => {
 	beforeEach( () => {
 		mockedIsJetpackCloud.mockReturnValue( false );
 		mockedIsA8CForAgencies.mockReturnValue( false );
-		jest.clearAllMocks();
 	} );
 
 	it( 'renders the summary and plain content text', () => {

--- a/client/dashboard/components/time-mismatch-notice/test/index.tsx
+++ b/client/dashboard/components/time-mismatch-notice/test/index.tsx
@@ -53,10 +53,6 @@ describe( 'TimeMismatchNotice', () => {
 		jest.spyOn( Date.prototype, 'getTimezoneOffset' ).mockReturnValue( mockTimezoneOffsetMinutes );
 	} );
 
-	afterEach( () => {
-		jest.restoreAllMocks();
-	} );
-
 	test( 'does not render if siteTime matches local timezone offset', () => {
 		useSuspenseQuery.mockReturnValue( { data: null } );
 

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connect-card.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connect-card.test.tsx
@@ -21,10 +21,6 @@ describe( 'DomainConnectCard', () => {
 		registrar_url: null,
 	};
 
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'Basic Rendering', () => {
 		test( 'renders the card with basic elements', () => {
 			render( <DomainConnectCard { ...defaultProps } /> );

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-setup.test.tsx
@@ -60,10 +60,6 @@ describe( 'DomainConnectionSetup', () => {
 		isUpdatingConnectionMode: false,
 	};
 
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'Domain Connect Available', () => {
 		test( 'renders Domain Connect card by default when DC is available and mode is null', () => {
 			const domainMappingStatus = createMockDomainMappingStatus( { mode: null } );

--- a/client/dashboard/domains/domain-connection-setup/test/domain-propagation-status.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-propagation-status.test.tsx
@@ -36,10 +36,6 @@ const createMockPropagationStatus = (
 describe( 'DomainPropagationStatus', () => {
 	const mockUseQuery = useQuery as jest.MockedFunction< typeof useQuery >;
 
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'Successful data loading', () => {
 		test( 'renders component with title when data is loaded', () => {
 			const mockData = createMockPropagationStatus();

--- a/client/dashboard/domains/domain-forwarding/test/add.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/add.test.tsx
@@ -3,7 +3,6 @@
  */
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import nock from 'nock';
 import { render } from '../../../test-utils';
 import DomainForwardingForm from '../form';
 import type { FormData } from '../form';
@@ -30,8 +29,6 @@ function renderForm( props: TestFormProps = {} ) {
 
 	return render( <DomainForwardingForm { ...defaultProps } /> );
 }
-
-afterEach( () => nock.cleanAll() );
 
 test( 'renders domain forwarding form with correct fields', async () => {
 	renderForm();

--- a/client/dashboard/domains/domain-forwarding/test/edit.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/edit.test.tsx
@@ -3,7 +3,6 @@
  */
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import nock from 'nock';
 import { render } from '../../../test-utils';
 import DomainForwardingForm from '../form';
 import type { FormData } from '../form';
@@ -29,8 +28,6 @@ function renderEditForm( props: TestFormProps = {} ) {
 
 	return render( <DomainForwardingForm { ...defaultProps } /> );
 }
-
-afterEach( () => nock.cleanAll() );
 
 test( 'renders edit form with pre-filled subdomain forwarding data', async () => {
 	const initialData = {

--- a/client/dashboard/domains/domain-glue-records/test/delete-modal.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/delete-modal.tsx
@@ -42,8 +42,6 @@ const mockDeleteDomainGlueRecordApiRequest = ( {
 		.reply( responseCode );
 };
 
-afterEach( () => nock.cleanAll() );
-
 test( 'renders delete modal with correct title and buttons', async () => {
 	renderDeleteModal();
 

--- a/client/dashboard/domains/domain-glue-records/test/index.test.tsx
+++ b/client/dashboard/domains/domain-glue-records/test/index.test.tsx
@@ -40,8 +40,6 @@ const mockFetchDomainGlueRecordsApiRequest = ( {
 		.reply( responseCode, data );
 };
 
-afterEach( () => nock.cleanAll() );
-
 test( 'renders glue records table with data', async () => {
 	mockFetchDomainGlueRecordsApiRequest();
 

--- a/client/dashboard/domains/name-servers/test/form.test.tsx
+++ b/client/dashboard/domains/name-servers/test/form.test.tsx
@@ -28,10 +28,6 @@ describe( 'NameServersForm', () => {
 		defaultNameServers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
 	};
 
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'Basic Rendering', () => {
 		it( 'renders form with nameserver fields', () => {
 			render( <NameServersForm { ...defaultProps } /> );

--- a/client/dashboard/me/notifications-comments/device-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-comments/device-settings/test/index.test.tsx
@@ -59,8 +59,6 @@ const mockGetDevicesApiAndReply = ( data: Partial< UserNotificationDevice[] > ) 
 
 describe( 'DevicesSettings', () => {
 	beforeEach( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
 		//Snackbar requires window.scrollTo to be defined
 		window.scrollTo = jest.fn();
 	} );

--- a/client/dashboard/me/notifications-comments/email-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-comments/email-settings/test/index.test.tsx
@@ -48,8 +48,6 @@ const mockUpdateSettingsApiAndReply = ( data: InputUserNotificationSettings ) =>
 
 describe( 'EmailSettings', () => {
 	beforeEach( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
 		//Snackbar requires window.scrollTo to be defined
 		window.scrollTo = jest.fn();
 	} );

--- a/client/dashboard/me/notifications-comments/web-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-comments/web-settings/test/index.test.tsx
@@ -48,8 +48,6 @@ const mockUpdateSettingsApiAndReply = ( data: InputUserNotificationSettings ) =>
 
 describe( 'WebSettings', () => {
 	beforeEach( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
 		//Snackbar requires window.scrollTo to be defined
 		window.scrollTo = jest.fn();
 	} );

--- a/client/dashboard/me/notifications-emails/pause-all-emails/test/index.test.tsx
+++ b/client/dashboard/me/notifications-emails/pause-all-emails/test/index.test.tsx
@@ -31,8 +31,6 @@ const pauseCheckbox = () => {
 
 describe( 'PauseAllEmails', () => {
 	beforeAll( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
 		// Snackbar component requires it to work and jest doesn't mock it
 		window.scrollTo = jest.fn();
 	} );

--- a/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
@@ -97,8 +97,6 @@ describe( 'SubscriptionSettings', () => {
 		};
 
 	beforeEach( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
 		//Snackbar requires window.scrollTo to be defined
 		window.scrollTo = jest.fn();
 	} );

--- a/client/dashboard/me/notifications-extras/test/index.test.tsx
+++ b/client/dashboard/me/notifications-extras/test/index.test.tsx
@@ -70,14 +70,8 @@ const notificationSnackBar = () => {
 
 describe( 'NotificationsExtras', () => {
 	beforeEach( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
 		// Snackbar requires window.scrollTo to be defined
 		window.scrollTo = jest.fn();
-	} );
-
-	afterEach( () => {
-		nock.cleanAll();
 	} );
 
 	it( 'renders the page header and sections correctly', async () => {

--- a/client/dashboard/me/notifications-sites/browser-notification-card/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/browser-notification-card/test/index.test.tsx
@@ -24,8 +24,6 @@ describe( 'BrowserNotificationCard', () => {
 	};
 
 	beforeEach( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
 		window.scrollTo = jest.fn();
 
 		Object.defineProperty( window, 'navigator', {

--- a/client/dashboard/me/notifications-sites/paused-notification-notice/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/paused-notification-notice/test/index.test.tsx
@@ -8,11 +8,6 @@ import { render } from '../../../../test-utils';
 import { PausedNotificationNotice } from '../index';
 
 describe( 'PausedNotificationNotice', () => {
-	beforeEach( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
-	} );
-
 	it( 'renders the notice when the browser notifications are blocked', async () => {
 		nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/me/settings' ).reply( 200, {
 			subscription_delivery_email_blocked: true,

--- a/client/dashboard/me/notifications-sites/site-settings/device-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/device-settings/test/index.test.tsx
@@ -140,9 +140,6 @@ const mockGetDevicesApiAndReply = ( devices: UserNotificationDevice[] ) => {
 
 describe( 'DevicesSettings', () => {
 	beforeEach( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
-
 		//Snackbar requires window.scrollTo to be defined
 		window.scrollTo = jest.fn();
 	} );

--- a/client/dashboard/me/notifications-sites/site-settings/email-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/email-settings/test/index.test.tsx
@@ -102,9 +102,6 @@ const buildEmailNotificationSettings = (
 
 describe( 'EmailSettings', () => {
 	beforeEach( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
-
 		// nock.ls
 		//Snackbar requires window.scrollTo to be defined
 		window.scrollTo = jest.fn();

--- a/client/dashboard/me/notifications-sites/site-settings/web-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-sites/site-settings/web-settings/test/index.test.tsx
@@ -102,9 +102,6 @@ const buildWebNotificationSettings = (
 
 describe( 'WebSettings', () => {
 	beforeEach( () => {
-		nock.disableNetConnect();
-		nock.cleanAll();
-
 		//Snackbar requires window.scrollTo to be defined
 		window.scrollTo = jest.fn();
 	} );

--- a/client/dashboard/me/preferences-default-landing/test/index.test.tsx
+++ b/client/dashboard/me/preferences-default-landing/test/index.test.tsx
@@ -62,7 +62,6 @@ function renderPreferencesDefaultLanding() {
 }
 
 afterEach( () => {
-	jest.clearAllMocks();
 	const { rawUserPreferencesQuery } = require( '@automattic/api-queries' );
 	rawUserPreferencesQuery.mockClear();
 } );

--- a/client/dashboard/me/preferences-language/test/index.test.tsx
+++ b/client/dashboard/me/preferences-language/test/index.test.tsx
@@ -21,10 +21,6 @@ const renderWithUserData = ( userData = {} ) => {
 };
 
 describe( 'PreferencesLanguageForm', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'Field visibility logic', () => {
 		it( 'renders basic interface elements', async () => {
 			renderWithUserData( {

--- a/client/dashboard/me/preferences-language/test/languages.test.ts
+++ b/client/dashboard/me/preferences-language/test/languages.test.ts
@@ -9,10 +9,6 @@ import {
 } from '../languages';
 
 describe( 'languages utilities', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'languagesAsOptions', () => {
 		it( 'should transform languages into options format', () => {
 			// Test with real languages data

--- a/client/dashboard/me/preferences-primary-site/test/index.test.tsx
+++ b/client/dashboard/me/preferences-primary-site/test/index.test.tsx
@@ -95,7 +95,6 @@ function renderPreferencesPrimarySite() {
 }
 
 afterEach( () => {
-	jest.clearAllMocks();
 	mockSitesQuery.mockClear();
 } );
 

--- a/client/dashboard/me/profile-deletion/test/account-deletion-modal.test.tsx
+++ b/client/dashboard/me/profile-deletion/test/account-deletion-modal.test.tsx
@@ -16,10 +16,6 @@ const defaultProps = {
 };
 
 describe( 'AccountDeletionModal', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	it( 'renders the alternatives screen by default', () => {
 		render( <AccountDeletionModal { ...defaultProps } /> );
 

--- a/client/dashboard/me/profile-gravatar/test/notifications.test.tsx
+++ b/client/dashboard/me/profile-gravatar/test/notifications.test.tsx
@@ -39,7 +39,6 @@ jest.mock(
 
 describe( 'GravatarProfileSection Notifications', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
 		( useDispatch as jest.Mock ).mockReturnValue( {
 			createSuccessNotice: mockCreateSuccessNotice,
 			createErrorNotice: mockCreateErrorNotice,

--- a/client/dashboard/me/profile-gravatar/test/validation.test.tsx
+++ b/client/dashboard/me/profile-gravatar/test/validation.test.tsx
@@ -15,8 +15,6 @@ jest.mock( '@automattic/api-queries', () => ( {
 
 describe( 'GravatarProfileSection Form Validation', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
-
 		const { userSettingsQuery } = require( '@automattic/api-queries' );
 		userSettingsQuery.mockReturnValue( {
 			queryKey: [ 'me', 'settings' ],

--- a/client/dashboard/me/profile-personal-details/test/email-section.test.tsx
+++ b/client/dashboard/me/profile-personal-details/test/email-section.test.tsx
@@ -38,15 +38,8 @@ const renderWithUserData = ( userData = mockUserSettings, props = defaultProps )
 
 describe( 'EmailSection', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
-		nock.cleanAll();
-
 		const emailValidator = require( 'email-validator' );
 		emailValidator.validate.mockReturnValue( true );
-	} );
-
-	afterEach( () => {
-		nock.cleanAll();
 	} );
 
 	it( 'renders email input field', async () => {

--- a/client/dashboard/me/profile-personal-details/test/index.test.tsx
+++ b/client/dashboard/me/profile-personal-details/test/index.test.tsx
@@ -5,7 +5,6 @@
 import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import nock from 'nock';
 import { render } from '../../../test-utils';
 import {
 	mockUserSettings,
@@ -86,10 +85,8 @@ const renderWithUserData = ( userData = mockUserSettings ) => {
 
 describe( 'PersonalDetailsSection', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
 		mockCreateSuccessNotice.mockClear();
 		mockCreateErrorNotice.mockClear();
-		nock.cleanAll();
 	} );
 
 	describe( 'Basic rendering', () => {

--- a/client/dashboard/me/profile-personal-details/update-email/test/email-verification-banner.test.tsx
+++ b/client/dashboard/me/profile-personal-details/update-email/test/email-verification-banner.test.tsx
@@ -47,18 +47,12 @@ const renderWithUserData = ( userData = mockUserSettings ) => {
 
 describe( 'EmailVerificationBanner', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
-		nock.cleanAll();
 		mockReplaceState.mockClear();
 
 		Object.defineProperty( window, 'location', {
 			value: { search: '', pathname: '/test' },
 			writable: true,
 		} );
-	} );
-
-	afterEach( () => {
-		nock.cleanAll();
 	} );
 
 	it( 'renders verification notice when email is pending', async () => {

--- a/client/dashboard/me/profile-personal-details/update-username/test/confirmation-modal.test.tsx
+++ b/client/dashboard/me/profile-personal-details/update-username/test/confirmation-modal.test.tsx
@@ -18,10 +18,6 @@ const defaultProps = {
 };
 
 describe( 'UsernameUpdateConfirmationModal', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'Modal content', () => {
 		it( 'displays warning message with current username', () => {
 			render(

--- a/client/dashboard/me/profile-personal-details/update-username/test/index.test.tsx
+++ b/client/dashboard/me/profile-personal-details/update-username/test/index.test.tsx
@@ -46,7 +46,6 @@ const defaultProps = {
 
 describe( 'UsernameUpdateForm', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
 		mockIsUsernameValid.mockReturnValue( false );
 		mockGetUsernameValidationMessage.mockReturnValue( null );
 		mockGetAllowedActions.mockReturnValue( {} );

--- a/client/dashboard/me/profile-personal-details/update-username/test/username-validation-utils.test.ts
+++ b/client/dashboard/me/profile-personal-details/update-username/test/username-validation-utils.test.ts
@@ -46,10 +46,6 @@ jest.mock( '@automattic/api-core', () => ( {
 const mockValidateUsername = validateUsername as jest.MockedFunction< typeof validateUsername >;
 
 describe( 'Username Validation Utils', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'validateUsernameDebounced', () => {
 		it( 'is a debounced function that delegates parameters correctly', () => {
 			const setValidationResult = jest.fn();

--- a/client/dashboard/sites/backups/test/index.test.tsx
+++ b/client/dashboard/sites/backups/test/index.test.tsx
@@ -189,18 +189,6 @@ function renderBackupsListPage( {
 	return render( <BackupsListPage /> );
 }
 
-afterEach( () => {
-	nock.cleanAll();
-	jest.clearAllMocks();
-} );
-
-beforeAll( () => {
-	nock.disableNetConnect();
-} );
-afterAll( () => {
-	nock.enableNetConnect();
-} );
-
 test.each( summaryTestCases )(
 	'renders the details section correctly for rewindId %s',
 	async ( rewindId, summary ) => {

--- a/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/test/index.test.tsx
@@ -167,19 +167,6 @@ function renderActivityLogsDataViews() {
 	);
 }
 
-afterEach( () => {
-	nock.cleanAll();
-	jest.clearAllMocks();
-} );
-
-beforeAll( () => {
-	nock.disableNetConnect();
-} );
-
-afterAll( () => {
-	nock.enableNetConnect();
-} );
-
 test( 'clicking backup action navigates to backup detail page', async () => {
 	const user = userEvent.setup();
 	renderActivityLogsDataViews();

--- a/client/dashboard/sites/logs/dataviews/test/index.test.tsx
+++ b/client/dashboard/sites/logs/dataviews/test/index.test.tsx
@@ -115,19 +115,6 @@ const fixedDateRange = {
 	end: new Date( Date.UTC( 2025, 0, 2, 0, 0, 0 ) ),
 };
 
-afterEach( () => {
-	nock.cleanAll();
-	jest.clearAllMocks();
-} );
-
-beforeAll( () => {
-	nock.disableNetConnect();
-} );
-
-afterAll( () => {
-	nock.enableNetConnect();
-} );
-
 describe( 'SiteLogsDataViews', () => {
 	test( 'renders PHP logs and syncs URL params', async () => {
 		const replaceSpy = jest.spyOn( window.history, 'replaceState' );

--- a/client/dashboard/sites/logs/test/downloader.test.tsx
+++ b/client/dashboard/sites/logs/test/downloader.test.tsx
@@ -80,10 +80,6 @@ beforeAll( () => {
 		.mockImplementation( () => {} );
 } );
 
-afterEach( () => {
-	jest.clearAllMocks();
-} );
-
 afterAll( () => {
 	anchorClickSpy.mockRestore();
 } );

--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -175,18 +175,6 @@ beforeEach( () => {
 	nockSiteAndSettings();
 } );
 
-afterEach( () => {
-	nock.cleanAll();
-	jest.clearAllMocks();
-} );
-
-beforeAll( () => {
-	nock.disableNetConnect();
-} );
-afterAll( () => {
-	nock.enableNetConnect();
-} );
-
 describe( 'SiteLogs page', () => {
 	test.each( Object.entries( LogType ) )(
 		'on selecting tab %s, navigates to /%s',

--- a/client/dashboard/sites/overview-backup-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-backup-card/test/index.test.tsx
@@ -36,10 +36,6 @@ jest.mock( '../../../app/locale', () => ( {
 	useLocale: () => 'en',
 } ) );
 
-afterEach( () => {
-	jest.clearAllMocks();
-} );
-
 describe( 'BackupCard', () => {
 	test( 'shows "No backups yet" when there are no backups', async () => {
 		mockFetchSiteActivityLog.mockResolvedValue( {

--- a/client/dashboard/sites/overview-scan-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-scan-card/test/index.test.tsx
@@ -44,10 +44,6 @@ jest.mock( '../../../app/locale', () => ( {
 	useLocale: () => 'en',
 } ) );
 
-afterEach( () => {
-	jest.clearAllMocks();
-} );
-
 describe( 'ScanCard', () => {
 	test( 'shows "No risks found" when there are no threats', async () => {
 		mockFetchSiteScan.mockResolvedValue( {

--- a/client/dashboard/sites/overview/test/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/test/storage-warning-banner.tsx
@@ -50,8 +50,6 @@ function renderTestBanner() {
 	return render( <StorageWarningBanner site={ testSite as any } /> ); // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
-afterEach( () => nock.cleanAll() );
-
 test( 'warning banner when storage is low, and no banner when storage is not low', async () => {
 	mockTestEndpoints( {
 		storage_used_bytes: 900,

--- a/client/dashboard/sites/scan/test/use-fix-threats.test.tsx
+++ b/client/dashboard/sites/scan/test/use-fix-threats.test.tsx
@@ -45,9 +45,6 @@ describe( 'useFixThreats', () => {
 	const mockThreatIds = [ 100001, 100002, 100003 ];
 
 	beforeEach( () => {
-		// Reset all mocks
-		jest.clearAllMocks();
-
 		// Setup default mock implementation
 		mockFetchFixThreatsStatus.mockResolvedValue( createFixThreatsStatusResponse( {} ) );
 	} );

--- a/client/dashboard/sites/site/test/environment-switcher.test.tsx
+++ b/client/dashboard/sites/site/test/environment-switcher.test.tsx
@@ -161,10 +161,6 @@ const clickDropdown = async ( user: ReturnType< typeof userEvent.setup > ) => {
 };
 
 describe( 'EnvironmentSwitcher', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'Environment Display', () => {
 		test( 'displays "Production" for production sites', () => {
 			render( <EnvironmentSwitcher site={ mockProductionSiteWithStaging } /> );

--- a/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
@@ -84,10 +84,6 @@ const renderModal = ( site: Site, onClose = jest.fn() ) =>
 	render( <StagingSiteDeleteModal site={ site } onClose={ onClose } /> );
 
 describe( 'StagingSiteDeleteModal', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	describe( 'Modal Display', () => {
 		test( 'renders modal with correct title and content', () => {
 			renderModal( mockStagingSite );

--- a/client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx
@@ -194,7 +194,6 @@ const setup = ( props = {} ) => {
 
 describe( 'StagingSiteSyncModal', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
 		mockUseMutation();
 	} );
 

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -1,11 +1,11 @@
 const path = require( 'path' );
 const base = require( '@automattic/calypso-jest' );
 
-module.exports = {
+const shared = {
 	...base,
-	rootDir: '../../client',
+	rootDir: path.join( __dirname, '../../client' ),
 	cacheDirectory: path.join( __dirname, '../../.cache/jest' ),
-	testPathIgnorePatterns: [ '<rootDir>/server/' ],
+	testPathIgnorePatterns: [ ...base.testPathIgnorePatterns, '<rootDir>/server/' ],
 
 	moduleNameMapper: {
 		'^@automattic/calypso-config$': '<rootDir>/server/config/index.js',
@@ -18,9 +18,32 @@ module.exports = {
 		url: 'https://example.com',
 	},
 	setupFiles: [ 'jest-canvas-mock' ],
-	setupFilesAfterEnv: [ '<rootDir>/../test/client/setup-test-framework.js' ],
 	globals: {
 		google: {},
 		__i18n_text_domain__: 'default',
 	},
+};
+
+module.exports = {
+	projects: [
+		{
+			...shared,
+			displayName: 'client',
+			testPathIgnorePatterns: [ ...shared.testPathIgnorePatterns, '<rootDir>/dashboard/' ],
+			setupFilesAfterEnv: [
+				...shared.setupFilesAfterEnv,
+				'<rootDir>/../test/client/setup-test-framework.js',
+			],
+		},
+		{
+			...shared,
+			displayName: 'dashboard',
+			// Override testMatch to only run dashboard tests
+			testMatch: [ '<rootDir>/dashboard/**/test/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+			setupFilesAfterEnv: [
+				...shared.setupFilesAfterEnv,
+				'<rootDir>/../test/client/setup-dashboard-test-framework.js',
+			],
+		},
+	],
 };

--- a/test/client/setup-dashboard-test-framework.js
+++ b/test/client/setup-dashboard-test-framework.js
@@ -1,0 +1,61 @@
+import '@testing-library/jest-dom';
+
+const { TextEncoder, TextDecoder } = require( 'util' );
+const nock = require( 'nock' );
+
+// Fail any network requests which aren't mocked.
+nock.disableNetConnect();
+
+afterEach( () => {
+	nock.cleanAll();
+	jest.clearAllMocks();
+} );
+
+// Define TextEncoder for ReactDOMServer
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+global.ResizeObserver = require( 'resize-observer-polyfill' );
+
+// Mock @automattic/agenttic-client to resolve dependency issues
+jest.mock(
+	'@automattic/agenttic-client',
+	() => ( {
+		__esModule: true,
+		getAgentManager: jest.fn( () => ( {
+			createAgent: jest.fn(),
+			getAgent: jest.fn(),
+		} ) ),
+		useAgentChat: jest.fn( () => ( {
+			messages: [],
+			isLoading: false,
+			sendMessage: jest.fn(),
+			clearMessages: jest.fn(),
+		} ) ),
+	} ),
+	{ virtual: true }
+);
+
+// Mock @automattic/agenttic-ui to resolve dependency issues
+jest.mock(
+	'@automattic/agenttic-ui',
+	() => ( {
+		__esModule: true,
+		ThinkingMessage: jest.fn( () => 'Thinking...' ),
+		AgentUI: jest.fn( () => null ),
+		createMessageRenderer: jest.fn(),
+		EmptyView: jest.fn( () => null ),
+	} ),
+	{ virtual: true }
+);
+
+global.matchMedia = jest.fn( ( query ) => ( {
+	matches: false,
+	media: query,
+	onchange: null,
+	addListener: jest.fn(), // deprecated
+	removeListener: jest.fn(), // deprecated
+	addEventListener: jest.fn(),
+	removeEventListener: jest.fn(),
+	dispatchEvent: jest.fn(),
+} ) );

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -8,14 +8,14 @@ const nock = require( 'nock' );
 // Disables all network requests for all tests.
 nock.disableNetConnect();
 
-beforeAll( () => {
+beforeEach( () => {
 	// reactivate nock on test start
 	if ( ! nock.isActive() ) {
 		nock.activate();
 	}
 } );
 
-afterAll( () => {
+afterEach( () => {
 	// helps clean up nock after each test run and avoid memory leaks
 	nock.restore();
 	nock.cleanAll();

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -8,14 +8,14 @@ const nock = require( 'nock' );
 // Disables all network requests for all tests.
 nock.disableNetConnect();
 
-beforeEach( () => {
+beforeAll( () => {
 	// reactivate nock on test start
 	if ( ! nock.isActive() ) {
 		nock.activate();
 	}
 } );
 
-afterEach( () => {
+afterAll( () => {
 	// helps clean up nock after each test run and avoid memory leaks
 	nock.restore();
 	nock.cleanAll();
@@ -24,12 +24,6 @@ afterEach( () => {
 // Define TextEncoder for ReactDOMServer
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
-
-// This is used by @wordpress/components in https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/ui/utils/space.ts#L33
-// JSDOM or CSSDOM don't provide an implementation for it, so for now we have to mock it.
-global.CSS = {
-	supports: jest.fn(),
-};
 
 global.ResizeObserver = require( 'resize-observer-polyfill' );
 


### PR DESCRIPTION
## Proposed Changes

* Create jest config specifically for the dashboard tests
* Switch nock `activate`/`restore`/`cleanAll` from `beforeAll`/`afterAll` to `beforeEach`/`afterEach` in the client test framework setup.

## Why are these changes being made?

Using `beforeAll`/`afterAll` means nock interceptors set up in one test can leak into subsequent tests within the same file, causing flaky failures and memory leaks. Running cleanup per-test ensures each test starts with a fresh nock state.

We want to tidy dashboard tests without breaking any existing tests, hence the split project config.

## Testing Instructions

* Run `yarn test-client` and verify tests pass as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?