### PR TITLE
Dashboard: keep delete button spinning after successful site deletion

### DIFF
--- a/client/dashboard/sites/site-delete-modal/index.tsx
+++ b/client/dashboard/sites/site-delete-modal/index.tsx
@@ -222,7 +222,7 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
-							disabled={ mutation.isPending }
+							disabled={ mutation.isPending || mutation.isSuccess }
 							onClick={ onClose }
 						>
 							{ __( 'Cancel' ) }
@@ -232,7 +232,7 @@ function SiteDeleteConfirmContent( { site, onClose }: { site: Site; onClose: () 
 							variant="primary"
 							type="submit"
 							isDestructive
-							isBusy={ mutation.isPending }
+							isBusy={ mutation.isPending || mutation.isSuccess }
 							disabled={ formData.domain !== site.slug }
 						>
 							{ __( 'Delete site' ) }


### PR DESCRIPTION
## Proposed Changes

* Keep the "Delete site" button in its busy/spinning state after the deletion mutation succeeds, until the modal is dismissed by navigation.
* Also keep the "Cancel" button disabled during this window.

## Why are these changes being made?

After clicking "Delete site", the button's `isBusy` state was driven solely by `mutation.isPending`. Once the mutation succeeded, `isPending` became `false` — causing the spinner to briefly disappear before `router.navigate` closed the modal. This created a jarring flash where the button appeared clickable again.

Adding `mutation.isSuccess` to the `isBusy` and `disabled` checks ensures smooth visual continuity through the entire delete-then-navigate flow.

## Testing Instructions

1. Go to Dashboard > Sites, open a (free, deletable) site's delete modal.
2. Type the domain to confirm and click "Delete site".
3. Verify the button stays in its spinning/busy state continuously until the modal closes — no brief flash of an idle button.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?