### PR TITLE
MSD: Hide opt-in survey for CIAB

### DIFF
--- a/client/dashboard/components/opt-in-survey/index.tsx
+++ b/client/dashboard/components/opt-in-survey/index.tsx
@@ -4,6 +4,7 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
+import { useAppContext } from '../../app/context';
 import { ButtonStack } from '../button-stack';
 import { Notice } from '../notice';
 
@@ -62,6 +63,7 @@ function checkEligible( welcomeNoticeDismissedAt: string | null ) {
 }
 
 export default function OptInSurvey() {
+	const { optIn } = useAppContext();
 	const { recordTracksEvent } = useAnalytics();
 	const [ isDismissed, setIsDismissed ] = useState( false );
 
@@ -80,7 +82,7 @@ export default function OptInSurvey() {
 		)
 	);
 
-	if ( ! isEligible || isDismissed ) {
+	if ( ! optIn || ! isEligible || isDismissed ) {
 		return null;
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Add `optIn` context check to `OptInSurvey` component so it does not render when `optIn` is `false` (e.g., in CIAB).

## Why are these changes being made?

* The `OptInWelcome` component already checks `optIn` from `useAppContext()` and hides itself when opt-in is disabled. However, `OptInSurvey` was missing this guard, causing the "How's your experience" survey banner to appear in CIAB where opt-in banners should not be shown.

## Testing Instructions

* Navigate to the CIAB dashboard (`/ciab`).
* Open a site overview page.
* Verify the opt-in survey banner does not appear.
* Navigate to the dotcom dashboard and verify the survey still appears when eligible.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?