### PR TITLE
Fix untranslated "Have an account?" text on signup form

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -226,7 +226,9 @@ const SignupFormSocialFirst = ( {
 				/>
 				{ isSliderVariation && (
 					<p className="signup-form-social-first__login-link">
-						Have an account? <Step.LinkButton href={ logInUrl }>{ __( 'Log in' ) }</Step.LinkButton>
+						{ createInterpolateElement( __( 'Have an account? <link>Log in</link>' ), {
+							link: <Step.LinkButton href={ logInUrl } />,
+						} ) }
 					</p>
 				) }
 			</div>


### PR DESCRIPTION
## Proposed Changes

* Wrap the "Have an account?" string with `__()` and `createInterpolateElement` so it gets properly localized.

<img width="5480" height="2360" alt="image" src="https://github.com/user-attachments/assets/ab644044-cff6-45b2-9842-e6dddbbf1c3a" />


## Why are these changes being made?

* The "Have an account?" text on the social-first signup form was hardcoded in English. While the rest of the page (including the adjacent "Log in" link) was translated, this string was not wrapped in a translation function, causing it to appear in English for all locales.

## Testing Instructions

* Visit the signup page in a non-English locale (e.g., `https://wordpress.com/setup/onboarding/user/pt-br`) and verify that the "Have an account?" text is now translated.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?