### PR TITLE
Reader: While adding Reddit feed add .rss in the url

### DIFF
--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -19,6 +19,7 @@ export type AddSitesFormProps = {
 	source: string;
 	onChangeFeedPreview?: ( hasPreview: boolean ) => void;
 	onChangeSubscribe?: ( subscribed: boolean ) => void;
+	transformUrl?: ( url: string ) => string;
 };
 
 type SubscriptionError = {
@@ -33,6 +34,7 @@ const AddSitesForm = ( {
 	source,
 	onChangeFeedPreview,
 	onChangeSubscribe,
+	transformUrl,
 }: AddSitesFormProps ) => {
 	const translate = useTranslate();
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -81,26 +83,26 @@ const AddSitesForm = ( {
 		if ( isValidInput ) {
 			setIsSubmitting( true );
 			subscribe(
-				{ url: parseUrl( inputValue ).toString() },
+				{ url: parseUrl( getTransformedInputValue() ).toString() },
 				{
 					onSuccess: ( data ) => {
 						if ( data?.info === 'already_subscribed' ) {
-							showWarningNotice( inputValue );
+							showWarningNotice( getTransformedInputValue() );
 						} else {
 							if ( data?.subscription?.blog_ID ) {
 								recordSiteSubscribed( {
 									blog_id: data?.subscription?.blog_ID,
-									url: inputValue,
+									url: getTransformedInputValue(),
 									source,
 								} );
 							}
 
-							showSuccessNotice( inputValue );
+							showSuccessNotice( getTransformedInputValue() );
 							onSubscribeToggle( true );
 						}
 					},
 					onError: ( error: SubscriptionError ) => {
-						showErrorNotice( inputValue, error );
+						showErrorNotice( getTransformedInputValue(), error );
 						onChangeSubscribe?.( false );
 					},
 					onSettled: (): void => {
@@ -119,6 +121,10 @@ const AddSitesForm = ( {
 		onChangeSubscribe?.( subscribed );
 	}
 
+	function getTransformedInputValue(): string {
+		return transformUrl ? transformUrl( inputValue ) : inputValue;
+	}
+
 	return (
 		<>
 			<form onSubmit={ onSubmit } className="subscriptions-add-sites__form--container">
@@ -135,7 +141,6 @@ const AddSitesForm = ( {
 						help={ isValidInput ? <Icon icon={ check } data-testid="check-icon" /> : undefined }
 						onBlur={ () => validateInputValue( inputValue, true ) }
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
 					/>
 
 					{ inputFieldError ? <FormInputValidation isError text={ inputFieldError } /> : null }
@@ -154,7 +159,7 @@ const AddSitesForm = ( {
 			</form>
 
 			<FeedPreview
-				url={ isValidInput ? inputValue : '' } // Passing empty state to make sure that debounce works correctly else it was firing events 2 times.
+				url={ isValidInput ? getTransformedInputValue() : '' } // Passing empty state to make sure that debounce works correctly else it was firing events 2 times.
 				source={ source }
 				onChangeFeedPreview={ onChangeFeedPreview }
 				onChangeSubscribe={ onSubscribeToggle }

--- a/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
@@ -93,4 +93,29 @@ describe( 'AddSitesForm', () => {
 
 		expect( addButton ).toBeDisabled();
 	} );
+
+	describe( 'transformUrl prop', () => {
+		test( 'calls transformUrl with the input value', () => {
+			const transformUrl = jest.fn( ( url: string ) => `${ url }/transformed` );
+			renderWithContextProvider( <AddSitesForm { ...mockProps } transformUrl={ transformUrl } /> );
+
+			const input = screen.getByRole( 'textbox' );
+			fireEvent.change( input, { target: { value: 'https://www.example.com' } } );
+			fireEvent.blur( input );
+
+			expect( transformUrl ).toHaveBeenCalledWith( 'https://www.example.com' );
+			expect( transformUrl ).toHaveReturnedWith( 'https://www.example.com/transformed' );
+		} );
+
+		test( 'does not call transformUrl when input is empty', () => {
+			const transformUrl = jest.fn( ( url: string ) => `${ url }/transformed` );
+			renderWithContextProvider( <AddSitesForm { ...mockProps } transformUrl={ transformUrl } /> );
+
+			const input = screen.getByRole( 'textbox' );
+			fireEvent.change( input, { target: { value: '' } } );
+			fireEvent.blur( input );
+
+			expect( transformUrl ).not.toHaveBeenCalled();
+		} );
+	} );
 } );

--- a/client/reader/new-subscription/components/add-reddit/index.tsx
+++ b/client/reader/new-subscription/components/add-reddit/index.tsx
@@ -29,6 +29,41 @@ const AddReddit = () => {
 		dispatch( requestFollows() ); // In other places we show subscriptions table due to which list get refreshed automatically. Here we need to refresh the list manually.
 	}, [ dispatch ] );
 
+	/**
+	 * Transforms a Reddit URL to its RSS feed equivalent (/.rss at the end).
+	 * If the URL already contains .rss, it's returned unchanged.
+	 */
+	function transformRedditUrl( url: string ): string {
+		if ( url.includes( '.rss' ) ) {
+			return url;
+		}
+
+		let parsedUrl: URL;
+		try {
+			parsedUrl = new URL( url );
+		} catch {
+			return url;
+		}
+
+		if ( ! parsedUrl.hostname.includes( 'reddit.com' ) ) {
+			return url;
+		}
+
+		const pathname = parsedUrl.pathname;
+
+		// Handle search URLs: /search?q=query -> /search.rss?q=query
+		if ( pathname.startsWith( '/search' ) ) {
+			parsedUrl.pathname = '/search.rss';
+			return parsedUrl.toString();
+		}
+
+		// Handle all other paths by appending /.rss.
+		const cleanPath = pathname.endsWith( '/' ) ? pathname.slice( 0, -1 ) : pathname;
+		parsedUrl.pathname = cleanPath + '/.rss';
+
+		return parsedUrl.toString();
+	}
+
 	return (
 		<div className="reader-add-reddit">
 			<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Reader }>
@@ -51,6 +86,7 @@ const AddReddit = () => {
 						source={ isDiscoverV3Enabled() ? 'reader-add-reddit' : 'discover-reddit' }
 						onChangeFeedPreview={ onChangeFeedPreview }
 						onChangeSubscribe={ onSubscribeToggle }
+						transformUrl={ transformRedditUrl }
 					/>
 				</div>
 				{ ! hasFeedPreview ? (
@@ -64,27 +100,27 @@ const AddReddit = () => {
 						<ul className="reader-add-reddit__instructions-list">
 							<li>
 								<strong>{ translate( 'Front page:' ) }</strong>
-								{ ' https://www.reddit.com/.rss' }
+								{ ' https://www.reddit.com' }
 							</li>
 							<li>
 								<strong>{ translate( 'A subreddit:' ) }</strong>
-								{ ' https://www.reddit.com/r/{ SUBREDDIT }/.rss' }
+								{ ' https://www.reddit.com/r/{ SUBREDDIT }' }
 							</li>
 							<li>
 								<strong>{ translate( 'A user:' ) }</strong>
-								{ ' https://www.reddit.com/user/{ REDDITOR }/.rss' }
+								{ ' https://www.reddit.com/user/{ REDDITOR }' }
 							</li>
 							<li>
 								<strong>{ translate( 'User comments:' ) }</strong>
-								{ ' https://www.reddit.com/user/{ REDDITOR }/comments/.rss' }
+								{ ' https://www.reddit.com/user/{ REDDITOR }/comments' }
 							</li>
 							<li>
 								<strong>{ translate( 'User submissions:' ) }</strong>
-								{ ' https://www.reddit.com/user/{ REDDITOR }/submitted/.rss' }
+								{ ' https://www.reddit.com/user/{ REDDITOR }/submitted' }
 							</li>
 							<li>
 								<strong>{ translate( 'Search result:' ) }</strong>
-								{ ' https://www.reddit.com/search.rss?q={ QUERY }' }
+								{ ' https://www.reddit.com/search?q={ QUERY }' }
 							</li>
 						</ul>
 					</div>

--- a/client/reader/new-subscription/components/add-reddit/index.tsx
+++ b/client/reader/new-subscription/components/add-reddit/index.tsx
@@ -100,27 +100,27 @@ const AddReddit = () => {
 						<ul className="reader-add-reddit__instructions-list">
 							<li>
 								<strong>{ translate( 'Front page:' ) }</strong>
-								{ ' https://www.reddit.com' }
+								{ ' https://www.reddit.com/.rss' }
 							</li>
 							<li>
 								<strong>{ translate( 'A subreddit:' ) }</strong>
-								{ ' https://www.reddit.com/r/{ SUBREDDIT }' }
+								{ ' https://www.reddit.com/r/{ SUBREDDIT }/.rss' }
 							</li>
 							<li>
 								<strong>{ translate( 'A user:' ) }</strong>
-								{ ' https://www.reddit.com/user/{ REDDITOR }' }
+								{ ' https://www.reddit.com/user/{ REDDITOR }/.rss' }
 							</li>
 							<li>
 								<strong>{ translate( 'User comments:' ) }</strong>
-								{ ' https://www.reddit.com/user/{ REDDITOR }/comments' }
+								{ ' https://www.reddit.com/user/{ REDDITOR }/comments/.rss' }
 							</li>
 							<li>
 								<strong>{ translate( 'User submissions:' ) }</strong>
-								{ ' https://www.reddit.com/user/{ REDDITOR }/submitted' }
+								{ ' https://www.reddit.com/user/{ REDDITOR }/submitted/.rss' }
 							</li>
 							<li>
 								<strong>{ translate( 'Search result:' ) }</strong>
-								{ ' https://www.reddit.com/search?q={ QUERY }' }
+								{ ' https://www.reddit.com/search.rss?q={ QUERY }' }
 							</li>
 						</ul>
 					</div>

--- a/client/reader/new-subscription/components/add-reddit/test/index.test.ts
+++ b/client/reader/new-subscription/components/add-reddit/test/index.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import React from 'react';
+import { AddSitesFormProps } from 'calypso/landing/subscriptions/components/add-sites-form/add-sites-form';
+import AddReddit from '../index';
+
+let transformedUrl: ( ( url: string ) => string ) | undefined;
+
+jest.mock( '../style.scss', () => ( {} ) );
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: jest.fn( () => ( text: string ) => text ),
+} ) );
+jest.mock( 'react-redux', () => ( {
+	useDispatch: jest.fn( () => jest.fn() ),
+	useSelector: jest.fn( () => {} ),
+} ) );
+jest.mock( 'calypso/landing/subscriptions/components/add-sites-form', () => ( {
+	AddSitesForm: ( props: AddSitesFormProps ) => {
+		transformedUrl = props.transformUrl;
+		return null;
+	},
+} ) );
+jest.mock( 'calypso/landing/subscriptions/components/subscription-manager-context', () => ( {
+	SubscriptionManagerContextProvider: ( { children }: { children: React.ReactNode } ) => children,
+	SubscriptionsPortal: { Reader: 'reader' },
+} ) );
+jest.mock( 'calypso/reader/components/icons/reddit-icon', () => () => null );
+jest.mock( 'calypso/reader/utils', () => ( {
+	isDiscoverV3Enabled: jest.fn( () => true ),
+} ) );
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn( () => true ),
+} ) );
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	isCurrentUserEmailVerified: jest.fn( () => true ),
+} ) );
+jest.mock( 'calypso/state/reader/follows/actions', () => ( {
+	requestFollows: jest.fn(),
+} ) );
+jest.mock( 'calypso/components/notice', () => () => null );
+
+describe( 'AddReddit', () => {
+	describe( 'transformRedditUrl', () => {
+		beforeEach( () => {
+			transformedUrl = undefined;
+			render( React.createElement( AddReddit ) );
+		} );
+
+		test( 'passes transformUrl prop to AddSitesForm', () => {
+			expect( transformedUrl ).toBeDefined();
+		} );
+
+		describe( 'subreddit URLs', () => {
+			test( 'transforms subreddit URL to RSS feed', () => {
+				expect( transformedUrl!( 'https://www.reddit.com/r/javascript' ) ).toBe(
+					'https://www.reddit.com/r/javascript/.rss'
+				);
+			} );
+
+			test( 'transforms subreddit URL with trailing slash', () => {
+				expect( transformedUrl!( 'https://www.reddit.com/r/javascript/' ) ).toBe(
+					'https://www.reddit.com/r/javascript/.rss'
+				);
+			} );
+		} );
+
+		describe( 'user URLs', () => {
+			test( 'transforms user URL to RSS feed', () => {
+				expect( transformedUrl!( 'https://www.reddit.com/user/example' ) ).toBe(
+					'https://www.reddit.com/user/example/.rss'
+				);
+			} );
+
+			test( 'transforms user comments URL to RSS feed', () => {
+				expect( transformedUrl!( 'https://www.reddit.com/user/example/comments' ) ).toBe(
+					'https://www.reddit.com/user/example/comments/.rss'
+				);
+			} );
+
+			test( 'transforms user submitted URL to RSS feed', () => {
+				expect( transformedUrl!( 'https://www.reddit.com/user/example/submitted' ) ).toBe(
+					'https://www.reddit.com/user/example/submitted/.rss'
+				);
+			} );
+		} );
+
+		describe( 'front page URLs', () => {
+			test( 'transforms front page URL to RSS feed', () => {
+				expect( transformedUrl!( 'https://www.reddit.com' ) ).toBe( 'https://www.reddit.com/.rss' );
+			} );
+
+			test( 'transforms front page URL with trailing slash', () => {
+				expect( transformedUrl!( 'https://www.reddit.com/' ) ).toBe(
+					'https://www.reddit.com/.rss'
+				);
+			} );
+		} );
+
+		describe( 'search URLs', () => {
+			test( 'transforms search URL to RSS feed', () => {
+				expect( transformedUrl!( 'https://www.reddit.com/search?q=javascript' ) ).toBe(
+					'https://www.reddit.com/search.rss?q=javascript'
+				);
+			} );
+
+			test( 'transforms search URL with trailing slash', () => {
+				expect( transformedUrl!( 'https://www.reddit.com/search/?q=javascript' ) ).toBe(
+					'https://www.reddit.com/search.rss?q=javascript'
+				);
+			} );
+		} );
+
+		describe( 'URLs already containing .rss', () => {
+			test( 'returns URL unchanged if already has .rss', () => {
+				expect( transformedUrl!( 'https://www.reddit.com/r/javascript/.rss' ) ).toBe(
+					'https://www.reddit.com/r/javascript/.rss'
+				);
+			} );
+
+			test( 'returns search RSS URL unchanged', () => {
+				expect( transformedUrl!( 'https://www.reddit.com/search.rss?q=test' ) ).toBe(
+					'https://www.reddit.com/search.rss?q=test'
+				);
+			} );
+		} );
+
+		describe( 'non-Reddit URLs', () => {
+			test( 'returns non-Reddit URL unchanged', () => {
+				expect( transformedUrl!( 'https://www.example.com/page' ) ).toBe(
+					'https://www.example.com/page'
+				);
+			} );
+
+			test( 'returns WordPress URL unchanged', () => {
+				expect( transformedUrl!( 'https://wordpress.com/blog' ) ).toBe(
+					'https://wordpress.com/blog'
+				);
+			} );
+
+			test( 'returns invalid URL unchanged', () => {
+				expect( transformedUrl!( 'not-a-valid-url' ) ).toBe( 'not-a-valid-url' );
+			} );
+
+			test( 'returns empty string unchanged', () => {
+				expect( transformedUrl!( '' ) ).toBe( '' );
+			} );
+		} );
+	} );
+} );

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -3,7 +3,7 @@
 // Reader-specific tweaks to components
 
 // Overrides default 720px width
-.is-reader-page .following.main,
+.is-reader-page .main,
 .is-reader-page .tag-stream__main.main {
 	max-width: 768px;
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -3,7 +3,7 @@
 // Reader-specific tweaks to components
 
 // Overrides default 720px width
-.is-reader-page .main,
+.is-reader-page .following.main,
 .is-reader-page .tag-stream__main.main {
 	max-width: 768px;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/READ-8

## Proposed Changes

- Add `transformRedditUrl` in `AddReddit` component which handles adding `.rss` in the url if not present.
- Pass this function to `AddSites` component which takes input (now transform it) and then show feed preview to user.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To improve UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `discover/reddit`
- Verify that a feed can be added without `.rss` in the url.
- Verify that a feed can be added having `.rss` in the url.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
