### PR TITLE
Processing Step: Remove text-center alignment so the animation from the start

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -5,7 +5,6 @@
 .processing-step {
 	--wp-components-color-foreground: #3858E9;
 	max-width: 540px;
-	text-align: center;
 
 	&__progress-step {
 		@include onboarding-font-recoleta;


### PR DESCRIPTION
Part of DOTOBRD-260.

## Proposed Changes

There was a `text-align: center` CSS rule that made the determinate progress bar start from the middle instead of the left. Removing that rule fixed this problem.

| Before | After |
| --- | --- |
| <img width="2024" height="1060" alt="image" src="https://github.com/user-attachments/assets/80860482-b476-47b8-9129-c2c0781b8d75" /> | <img width="811" height="673" alt="image" src="https://github.com/user-attachments/assets/1a90f27b-9d3e-4c2e-8c7a-ba26865aca11" /> |


## Testing Instructions

Enter `/setup/entrepreneur` and create a new Commerce trial site. Verify that, once the site is created and the progress bar becomes determinate, the progress indicator is aligned to the left rather than centered.