### PR TITLE
Reduce redundant site API requests during Atomic wait

### DIFF
--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -1,7 +1,7 @@
 import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useDispatch } from 'calypso/state';
-import { requestSite } from 'calypso/state/sites/actions';
+import { receiveSite, requestSite } from 'calypso/state/sites/actions';
 import { getSite, isRequestingSite } from 'calypso/state/sites/selectors';
 import { useFlowState } from '../declarative-flow/internals/state-manager/store';
 import { SITE_STORE } from '../stores';
@@ -16,27 +16,48 @@ export function useSite( siteFragment?: number | string ) {
 	const createdSiteID = useFlowState().get( 'site' )?.siteId;
 	const siteIdOrSlug = siteFragment || siteIdParam || siteSlug || createdSiteID;
 
-	const site = useSelect(
+	const { site, siteStoreHasResolved } = useSelect(
 		( select ) => {
 			const siteStore = select( SITE_STORE ) as SiteSelect;
 
-			return siteIdOrSlug ? siteStore.getSite( siteIdOrSlug ) : null;
+			return {
+				site: siteIdOrSlug ? siteStore.getSite( siteIdOrSlug ) : null,
+				siteStoreHasResolved: siteIdOrSlug
+					? (
+							select( SITE_STORE ) as SiteSelect & {
+								hasFinishedResolution: ( selector: string, args: unknown[] ) => boolean;
+							}
+					   ).hasFinishedResolution( 'getSite', [ siteIdOrSlug ] )
+					: false,
+			};
 		},
 		[ siteIdOrSlug ]
 	);
 
-	// Request the site for the redux store
+	// Sync site data to the Redux store. We let the SITE_STORE resolver be the
+	// primary fetch to avoid a redundant network request. Once it resolves, we
+	// either sync the data into Redux or fall back to requestSite if the
+	// resolver failed.
 	useEffect( () => {
-		if ( siteIdOrSlug ) {
-			dispatch( ( d, getState ) => {
-				const state = getState();
-				if ( getSite( state, siteIdOrSlug ) || isRequestingSite( state, siteIdOrSlug ) ) {
-					return;
-				}
-				d( requestSite( siteIdOrSlug ) );
-			} );
+		if ( ! siteIdOrSlug || ! siteStoreHasResolved ) {
+			return;
 		}
-	}, [ dispatch, siteIdOrSlug ] );
+
+		dispatch( ( d, getState ) => {
+			const state = getState();
+			if ( getSite( state, siteIdOrSlug ) || isRequestingSite( state, siteIdOrSlug ) ) {
+				return;
+			}
+
+			if ( site ) {
+				// SITE_STORE resolved successfully — sync to Redux without a network request.
+				d( receiveSite( site ) );
+			} else {
+				// SITE_STORE resolver failed — fall back to fetching via Redux.
+				d( requestSite( siteIdOrSlug ) );
+			}
+		} );
+	}, [ dispatch, siteIdOrSlug, siteStoreHasResolved, site ] );
 
 	if ( siteIdOrSlug && site ) {
 		return site;

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -127,6 +127,9 @@ export const useWaitForAtomic = ( {
 	};
 
 	const waitForLatestSiteData = async () => {
+		let backoffTime = 3000;
+		const maxBackoff = 15000;
+
 		while ( true ) {
 			const requestedSite = await reduxDispatch< SiteDetails >( requestSite( siteId ) );
 			if (
@@ -136,7 +139,8 @@ export const useWaitForAtomic = ( {
 				break;
 			}
 
-			await wait( 1000 );
+			await wait( backoffTime );
+			backoffTime = Math.min( backoffTime * 2, maxBackoff );
 		}
 	};
 


### PR DESCRIPTION
## Summary

During the entrepreneur setup flow's loading screen (waitForAtomic step), the app aggressively polls `GET /rest/v1.2/sites/{id}` every **1 second** while waiting for the site to become Atomic. This generates **25+ identical requests over ~60 seconds**, each returning ~62KB of data — all just to check a single boolean (`is_wpcom_atomic`).

Additionally, when the processing step mounts, two independent code paths in `useSite()` fire simultaneous requests for the same site data:
- **SITE_STORE resolver** → `GET /rest/v1.1/sites/{id}?force=wpcom` 
- **Redux requestSite** → `GET /rest/v1.2/sites/{id}`

This PR addresses both issues:

### 1. Exponential backoff for `waitForLatestSiteData`
**File:** `client/landing/stepper/hooks/use-wait-for-atomic.ts`

Changed from a fixed 1s polling interval to exponential backoff starting at 3s, doubling each iteration, capped at 15s (3s → 6s → 12s → 15s → 15s...). This reduces requests from ~25 to ~6 with negligible UX impact since the user is on a loading screen anyway. This matches the pattern already used by `waitForPluginInstall`.

### 2. Deduplicate dual-fetch in `useSite()`
**File:** `client/landing/stepper/hooks/use-site.ts`

Previously, `useSite()` triggered two independent fetch paths on mount:
1. `useSelect` → SITE_STORE `getSite()` resolver → v1.1 API request
2. `useEffect` → Redux `requestSite()` → v1.2 API request

Now, the hook waits for the SITE_STORE resolver to complete first. If it succeeds, the site data is synced to the Redux store via `receiveSite()` — no second network request. If the resolver fails, it falls back to `requestSite()` as before.

## Test plan

- [ ] Go through the entrepreneur setup flow end-to-end
- [ ] Verify the waitForAtomic loading screen completes successfully
- [ ] Monitor network requests — should see ~6 site data requests instead of 25+
- [ ] Verify no duplicate simultaneous site requests on processing step mount
- [ ] Verify site data is available in Redux store after SITE_STORE resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)