### PR TITLE
Domain-only Thank You Redesign: Add feature flag and placeholder page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only-new.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only-new.tsx
@@ -1,0 +1,12 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function DomainOnlyNew() {
+	const translate = useTranslate();
+
+	return (
+		<div className="domain-only-new">
+			<h1>{ translate( 'Thank you for your purchase!' ) }</h1>
+			<p>{ translate( 'Your domain is being set up.' ) }</p>
+		</div>
+	);
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
@@ -1,10 +1,7 @@
-import { domainProductSlugs } from '@automattic/calypso-products';
-import { css, Global } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QuerySites from 'calypso/components/data/query-sites';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
-import HundredYearThankYou from 'calypso/my-sites/checkout/checkout-thank-you/hundred-year-thank-you';
 import { PlaceholderThankYou } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/pages/placeholder';
 import { useSelector } from 'calypso/state';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -12,17 +9,15 @@ import { getSite } from 'calypso/state/sites/selectors';
 import { getDomainPurchaseTypeAndPredicate } from '../../utils';
 import ThankYouDomainProduct from '../products/domain-product';
 import getDomainFooterDetails from './content/get-domain-footer-details';
-import type { ReceiptData, ReceiptPurchase } from 'calypso/state/receipts/types';
+import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 interface DomainOnlyThankYouProps {
 	purchases: ReceiptPurchase[];
-	receipt: ReceiptData;
 	isGravatarDomain: boolean;
 }
 
 export default function DomainOnlyThankYou( {
 	purchases,
-	receipt,
 	isGravatarDomain,
 }: DomainOnlyThankYouProps ) {
 	const translate = useTranslate();
@@ -42,46 +37,6 @@ export default function DomainOnlyThankYou( {
 				<PlaceholderThankYou />
 			</>
 		);
-	}
-
-	if ( domainPurchases.length === 1 ) {
-		const purchasedDomain = domainPurchases[ 0 ];
-		const domain = siteDomains.find( ( siteDomain ) => siteDomain.name === purchasedDomain.meta );
-
-		if ( domain?.isHundredYearDomain ) {
-			return (
-				<>
-					<Global
-						styles={ css`
-							main.checkout-thank-you {
-								&.is-redesign-v2 {
-									&.main {
-										max-width: unset;
-									}
-								}
-							}
-
-							body.is-section-checkout,
-							body.is-section-checkout .layout__content,
-							body.is-section-checkout-thank-you,
-							body.is-section-checkout-thank-you .layout__content {
-								background: linear-gradient(
-									233deg,
-									#06101c 2.17%,
-									#050c16 41.26%,
-									#02080f 88.44%
-								);
-							}
-						` }
-					/>
-					<HundredYearThankYou
-						siteSlug={ String( purchasedDomain.blogId ) }
-						receiptId={ Number( receipt.receiptId ) }
-						productSlug={ domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION }
-					/>
-				</>
-			);
-		}
 	}
 
 	const products = domainPurchases.map( ( purchase ) => {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils/domain-thank-you-feature-flag.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils/domain-thank-you-feature-flag.ts
@@ -1,0 +1,9 @@
+import config from '@automattic/calypso-config';
+
+/**
+ * Check if the new domain thank you page should be shown.
+ * Feature flag: domains/new-thank-you-page
+ */
+export function shouldShowNewDomainThankYou(): boolean {
+	return config.isEnabled( 'domains/new-thank-you-page' );
+}

--- a/config/development.json
+++ b/config/development.json
@@ -68,6 +68,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domain-transfer-redesign": true,
+		"domains/new-thank-you-page": false,
 		"email-accounts/enabled": true,
 		"global-styles/on-personal-plan": true,
 		"google-drive": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,6 +35,7 @@
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"domain-transfer-redesign": true,
+		"domains/new-thank-you-page": false,
 		"global-styles/on-personal-plan": true,
 		"google-my-business": false,
 		"help": true,

--- a/config/production.json
+++ b/config/production.json
@@ -45,6 +45,7 @@
 		"dashboard/v2/paginated-site-list": true,
 		"dashboard/v2/backport/site-overview": true,
 		"domain-transfer-redesign": true,
+		"domains/new-thank-you-page": false,
 		"global-styles/on-personal-plan": true,
 		"google-my-business": true,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,6 +45,7 @@
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,
+		"domains/new-thank-you-page": false,
 		"global-styles/on-personal-plan": true,
 		"google-my-business": true,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,6 +50,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domain-transfer-redesign": true,
+		"domains/new-thank-you-page": false,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,


### PR DESCRIPTION
Closes DOTCOM-16013.

## Proposed Changes

- Add feature flag infrastructure for domain thank you page
- Create new simplified `DomainOnlyNew` placeholder component
- Extract hundred-year domain routing logic to parent component
- Add feature flag routing after hundred-year domain check
- Simplify `domain-only.tsx` by removing hundred-year domain handling
- Add `domains/new-thank-you-page` feature flag (disabled by default in all environments)

## Why are these changes being made?

This PR implements the infrastructure needed to A/B test a new simplified domain-only thank you page. By adding a feature flag, we can:

1. Safely test the new experience without affecting existing users
2. Gradually roll out the new thank you page to specific user segments
3. Quickly revert if any issues are discovered
4. Maintain the existing special handling for hundred-year domain purchases

The hundred-year domain routing logic has been extracted to the parent router to follow existing patterns (similar to TitanSetUpThankYou and GoogleWorkspaceSetUpThankYou).

## Testing Instructions

### Feature Flag Disabled (Default - Verify Existing Behavior)

1. Set `"domains/new-thank-you-page": false` in `config/development.json`
2. Start the dev server: `yarn start`
3. Complete a domain-only purchase in checkout
4. **Expected**: See the existing `DomainOnlyThankYou` page with domain products and footer
5. Purchase a hundred-year domain
6. **Expected**: See the `HundredYearThankYou` special page with century-long legacy messaging

### Feature Flag Enabled (New Behavior)

1. Set `"domains/new-thank-you-page": true` in `config/development.json`
2. Restart the dev server
3. Complete a domain-only purchase in checkout
4. **Expected**: See the new simplified placeholder page with "Thank you for your purchase!" message
5. Purchase a hundred-year domain
6. **Expected**: Still see the `HundredYearThankYou` special page (not affected by feature flag)

### Additional Test Scenarios

- Single domain purchase (regular domain)
- Multiple domain purchases
- Domain transfer purchases
- Domain purchase with Gravatar domain flag
- Verify loading states work correctly
- Verify query parameters are preserved

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?