### PR TITLE
Checkout: Fix empty cart redirect to /setup/ routes

### DIFF
--- a/client/my-sites/checkout/src/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/src/lib/leave-checkout.ts
@@ -125,11 +125,14 @@ export const leaveCheckout = ( {
 			const cancelPath = searchParams.get( 'cancel_to' ) ?? '';
 
 			if ( isRelativeUrl( cancelPath ) ) {
-				navigate( cancelPath );
-			} else if ( dashboardOrigins().some( ( origin ) => cancelPath.startsWith( origin ) ) ) {
 				window.location.href = cancelPath;
+				return;
 			}
-			return;
+			if ( dashboardOrigins().some( ( origin ) => cancelPath.startsWith( origin ) ) ) {
+				window.location.href = cancelPath;
+				return;
+			}
+			// If cancel_to is invalid (e.g., external URL), fall through to default close URL.
 		}
 	} catch ( error ) {
 		// Silently ignore query string errors (eg: which may occur in IE since it doesn't support URLSearchParams).

--- a/client/my-sites/checkout/src/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/src/lib/leave-checkout.ts
@@ -125,6 +125,9 @@ export const leaveCheckout = ( {
 			const cancelPath = searchParams.get( 'cancel_to' ) ?? '';
 
 			if ( isRelativeUrl( cancelPath ) ) {
+				// We use window.location.href instead of navigate() because navigate() uses page.show()
+				// which silently fails for /setup/ Stepper routes. Since we're leaving checkout entirely,
+				// the SPA optimization from navigate() provides no meaningful benefit.
 				window.location.href = cancelPath;
 				return;
 			}

--- a/client/my-sites/checkout/src/test/leave-checkout.ts
+++ b/client/my-sites/checkout/src/test/leave-checkout.ts
@@ -36,12 +36,13 @@ describe( 'leaveCheckout', () => {
 	} );
 
 	describe( 'cancel_to parameter handling', () => {
-		it( 'should navigate to cancel_to path when it is a relative URL', () => {
+		it( 'should redirect to cancel_to path when it is a relative URL', () => {
 			window.location.search = '?cancel_to=/home';
 
 			leaveCheckout( { tracksEvent: 'checkout_cancel' } );
 
-			expect( navigate ).toHaveBeenCalledWith( '/home' );
+			expect( window.location.href ).toBe( '/home' );
+			expect( navigate ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should not navigate to cancel_to path when it is an absolute URL', () => {
@@ -66,6 +67,19 @@ describe( 'leaveCheckout', () => {
 			leaveCheckout( { tracksEvent: 'checkout_cancel' } );
 
 			expect( navigate ).not.toHaveBeenCalledWith( '/\\example.com' );
+		} );
+
+		it( 'should fall through to closeUrl when cancel_to is an invalid external URL', () => {
+			window.location.search = '?cancel_to=https://evil.com/malicious';
+
+			leaveCheckout( {
+				siteSlug: 'test.wordpress.com',
+				tracksEvent: 'checkout_cancel',
+				userHasClearedCart: true,
+			} );
+
+			expect( window.location.href ).not.toBe( 'https://evil.com/malicious' );
+			expect( navigate ).toHaveBeenCalledWith( '/plans/test.wordpress.com' );
 		} );
 	} );
 


### PR DESCRIPTION
Resolves [SHILL-1630](https://linear.app/a8c/issue/SHILL-1630)

## Proposed Changes

* Use `window.location.href` instead of `navigate()` for `cancel_to` redirects in `leaveCheckout()`.
* Restructure the `cancel_to` block so invalid values fall through to the default close URL instead of silently stranding the user.

## Why are these changes being made?

When a user removes the last item from their cart during a woo-hosted-plans checkout, `leaveCheckout()` redirects to the `cancel_to` path (`/setup/woo-hosted-plans/plans?...`). The redirect silently fails, leaving the user stuck on a "Hm… This is taking a while…" loading screen indefinitely.

### Root cause

`leaveCheckout()` calls `navigate(cancelPath)`, which uses `page.show()` — Calypso's page.js client-side router. But `/setup/` routes are handled by the Stepper framework, not page.js. `page.show('/setup/...')` silently does nothing: no route matches, no navigation occurs, no error is thrown.

The `navigate()` function decides between `page.show()` and `window.history.pushState()` based on `isCurrentPathOutOfScope(window.location.pathname)` — which checks the **current** path, not the **target**. Since `/checkout/` is "in scope" for page.js, it always falls through to `page.show()`, regardless of where the target path lives.

### Why `navigate()` was used originally

PR #96514 (Nov 2024) introduced `cancel_to` support and intentionally used `navigate()` for SPA speed — avoiding a full page reload for same-origin paths. At the time, all `cancel_to` values pointed to standard Calypso routes that `page.show()` handles correctly. The `/setup/` Stepper routes were not yet using `cancel_to`.

PR #107684 (Dec 2025) later added a `dashboardOrigins()` branch for cross-origin MSD redirects, correctly using `window.location.href` since `page.show()` can't handle cross-origin navigation. This created a split: same-origin paths used `navigate()` (SPA), cross-origin used `window.location.href` (full reload).

### Why `window.location.href` is the right fix

- We're **leaving checkout entirely** — the SPA speed optimization provides no meaningful UX benefit for an exit redirect.
- `window.location.href` works for **all** valid same-origin paths, including `/setup/` Stepper routes, making the redirect universally reliable.
- All other redirect paths in `leaveCheckout()` already use `window.location.href` — this makes `cancel_to` consistent.
- `isRelativeUrl()` security validation is preserved (same-origin check via `new URL().origin`).
- Confirmed working via live console test on the stuck checkout page.

### Secondary fix: invalid `cancel_to` fallthrough

The previous code had an unconditional `return` at the end of the `cancel_to` block. If `cancel_to` was present but failed both validation checks (not same-origin relative, not a dashboard origin), the function returned without navigating anywhere — silently stranding the user. Now, invalid `cancel_to` values fall through to the default close URL (`/plans/{siteSlug}` or `/start`).

## Testing Instructions

### Automated
27 unit tests pass, including updated assertions for `window.location.href` and a new test for invalid `cancel_to` fallthrough.

```bash
yarn test-client client/my-sites/checkout/src/test/leave-checkout.ts
```

### Manual reproduction (CIAB woo-hosted-plans)
1. Go to a CIAB site's WooCommerce onboarding: `https://{ciab-site}.commerce-garden.com/wp-admin/admin.php?page=next-admin&p=%2Fwoocommerce%2Fonboarding`
2. Select a plan to go to checkout
3. Remove the plan from the cart
4. **Before:** Stuck on "Hm… This is taking a while…" indefinitely
5. **After:** Immediately redirects back to the plan selection page

### Test scenarios

| # | Scenario | Expected Result |
|---|----------|-----------------|
| 1 | `cancel_to` with `/setup/` stepper path | Redirects via `window.location.href` (was broken, now fixed) |
| 2 | `cancel_to` with standard Calypso path (e.g., `/plans/mysite.com`) | Redirects via `window.location.href` (consistent with other paths) |
| 3 | `cancel_to` with dashboard origin (e.g., `https://my.wordpress.com/...`) | Redirects via `window.location.href` (unchanged) |
| 4 | No `cancel_to` parameter | Falls through to `navigate(closeUrl)` → `/plans/{siteSlug}` or `/start` (unchanged) |
| 5 | Invalid `cancel_to` (e.g., `https://evil.com`) | Falls through to safe default close URL (improved — was silently stuck) |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?