### PR TITLE
Fix CIAB social login redirecting to my.wordpress.com/wp-login.php

### DIFF
--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -1,18 +1,24 @@
 import config from '@automattic/calypso-config';
 import { useEffect, useRef } from 'react';
 
+// Calypso-only deployments that do not serve wp-login.php.
+const CALYPSO_ONLY_HOSTNAMES = [
+	'wpcalypso.wordpress.com',
+	'horizon.wordpress.com',
+	'my.wordpress.com',
+];
+
+// Subdomains of wordpress.com that do not serve wp-login.php.
+const EXCLUDED_SUBDOMAINS = [ 'public-api', 'my' ];
+
 function getFormAction( redirectTo ) {
 	const subdomainRegExp = /^https?:\/\/([a-z0-9-]+)\.wordpress\.com(?:$|\/)/;
 	const hostname = config( 'hostname' );
 	let subdomain = '';
 
-	if (
-		subdomainRegExp.test( redirectTo ) &&
-		hostname !== 'wpcalypso.wordpress.com' &&
-		hostname !== 'horizon.wordpress.com'
-	) {
+	if ( subdomainRegExp.test( redirectTo ) && ! CALYPSO_ONLY_HOSTNAMES.includes( hostname ) ) {
 		const subdomainMatch = redirectTo.match( subdomainRegExp );
-		if ( subdomainMatch && subdomainMatch[ 1 ] !== 'public-api' ) {
+		if ( subdomainMatch && ! EXCLUDED_SUBDOMAINS.includes( subdomainMatch[ 1 ] ) ) {
 			subdomain = subdomainMatch[ 1 ] + '.';
 		}
 	}

--- a/client/signup/wpcom-login-form/test/index.jsx
+++ b/client/signup/wpcom-login-form/test/index.jsx
@@ -111,4 +111,27 @@ describe( 'WpcomLoginForm', () => {
 			'https://wordpress.com/wp-login.php'
 		);
 	} );
+
+	test( 'its action should have no subdomain when `redirectTo` contains my.wordpress.com', () => {
+		const { container } = render(
+			<WpcomLoginForm { ...props } redirectTo="https://my.wordpress.com/ciab/sites" />
+		);
+
+		expect( container.firstChild ).toHaveAttribute(
+			'action',
+			'https://wordpress.com/wp-login.php'
+		);
+	} );
+
+	test( 'its action should have no subdomain when `hostname` is my.wordpress.com', () => {
+		config.mockReturnValueOnce( 'my.wordpress.com' );
+		const { container } = render(
+			<WpcomLoginForm { ...props } redirectTo="https://foo.wordpress.com" />
+		);
+
+		expect( container.firstChild ).toHaveAttribute(
+			'action',
+			'https://wordpress.com/wp-login.php'
+		);
+	} );
 } );


### PR DESCRIPTION
## Proposed Changes

* Exclude `my.wordpress.com` from `WpcomLoginForm`'s subdomain-based `wp-login.php` URL construction so the form always posts to `https://wordpress.com/wp-login.php`

Fixes https://linear.app/a8c/issue/ARC-1461/wpcom-account-creation-via-social-login-gmail-is-broken-from-the-msd

## Why are these changes being made?

When a user signs up via Google social login on the CIAB dashboard (`my.wordpress.com/ciab/sites`), the post-signup auto-login form (`WpcomLoginForm`) extracts the `my` subdomain from the `redirect_to` URL and constructs `https://my.wordpress.com/wp-login.php` as the form action. Since `my.wordpress.com` is a Calypso deployment (not WordPress), this URL returns a 404.

`getFormAction()` already excluded `wpcalypso.wordpress.com` and `horizon.wordpress.com` as Calypso-only hostnames, but `my.wordpress.com` was missing from the list.

The fix adds:
- `my.wordpress.com` to the Calypso-only hostname exclusion list (prevents using any subdomain when running on `my.wordpress.com`)
- `my` to the excluded subdomains list alongside `public-api` (prevents redirecting to `my.wordpress.com/wp-login.php` regardless of which host the signup runs on)

## Testing Instructions

* Run unit tests: `yarn test-client client/signup/wpcom-login-form/test/index.jsx`
* TBD

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?