### PR TITLE
Domains: show site name in detach domain action and modal

### DIFF
--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -228,7 +228,7 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 				<SectionHeader
 					title={ sprintf(
 						/* translators: %s is the domain name */
-						__( 'Detach domain %s' ),
+						__( 'Detach %s' ),
 						domainName
 					) }
 					description={ createInterpolateElement(

--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -165,7 +165,11 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 				{ availableActions.disconnect && (
 					<ActionList.ActionItem
 						title={ __( 'Detach' ) }
-						description={ __( 'Detach this domain from the site.' ) }
+						description={ sprintf(
+							/* translators: %s is the site slug, e.g. "mysite.wordpress.com" */
+							__( 'Detach this domain from %s.' ),
+							domain.site_slug
+						) }
 						actions={
 							<Button
 								size="compact"
@@ -228,7 +232,11 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 						domainName
 					) }
 					description={ createInterpolateElement(
-						__( 'Are you sure you want to detach this domain? <learnMoreLink />' ),
+						sprintf(
+							/* translators: %s is the site slug, e.g. "mysite.wordpress.com" */
+							__( 'Are you sure you want to detach this domain from %s? <learnMoreLink />' ),
+							domain.site_slug
+						),
 						{
 							learnMoreLink: (
 								<InlineSupportLink

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/disconnect/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/disconnect/index.tsx
@@ -122,7 +122,9 @@ const DisconnectDomainCard = ( { domain, selectedSite }: DomainInfoCardProps ) =
 							} ) }
 						</FormSectionHeading>
 						<p>
-							{ translate( 'Are you sure? This will detach the domain from its current site.' ) }
+							{ translate( 'Are you sure you want to detach this domain from %(siteName)s?', {
+								args: { siteName: selectedSite.slug },
+							} ) }
 						</p>
 					</div>
 				</div>
@@ -135,7 +137,9 @@ const DisconnectDomainCard = ( { domain, selectedSite }: DomainInfoCardProps ) =
 			<DomainInfoCard
 				type="click"
 				title={ translate( 'Detach' ) }
-				description={ translate( 'Detach this domain from the site' ) }
+				description={ translate( 'Detach this domain from %(siteName)s.', {
+					args: { siteName: selectedSite.slug },
+				} ) }
 				onClick={ () => setDialogVisible( true ) }
 				ctaText={ translate( 'Detach' ) }
 			/>


### PR DESCRIPTION
Part of [DOMENG-309](https://linear.app/a8c/issue/DOMENG-309/make-the-detach-domain-feature-more-clear#comment-72dd5b51)

## Proposed Changes

* Show the site slug in the "Detach" action row description (e.g. "Detach this domain from mysite.wordpress.com.")
* Show the site slug in the detach confirmation modal (e.g. "Are you sure you want to detach this domain from mysite.wordpress.com?")
* Applied to both the Dashboard client and legacy Calypso client

## Why are these changes being made?

When navigating from Global navigation, it's not clear which site a domain is being detached from. Adding the site name makes the action unambiguous and prevents accidental detachment from the wrong site.

## Testing Instructions

1. Navigate to a domain overview page for a domain connected to a site
2. Scroll down to the "Actions" section
3. Verify the "Detach" action description shows the site slug
4. Click "Detach" and verify the confirmation modal includes the site slug in the question

**MSD**

| Before | After |
|--------|--------|
| <img width="1545" height="961" alt="image" src="https://github.com/user-attachments/assets/7d8d93cb-1c1f-45dc-a52e-49642c5e38d0" /> | <img width="1508" height="913" alt="image" src="https://github.com/user-attachments/assets/97f91038-4788-4041-b0ba-63a5b183b722" /> |
| <img width="1183" height="714" alt="image" src="https://github.com/user-attachments/assets/8011d026-83dd-423a-b1a8-9cb7e909d79f" /> | <img width="1126" height="764" alt="image" src="https://github.com/user-attachments/assets/f6141ab3-91f3-49ac-aa45-f8385649908b" /> | 





## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)