### PR TITLE
Fix console message typos in getCountryTaxRequirements

### DIFF
--- a/packages/wpcom-checkout/src/get-country-tax-requirements.ts
+++ b/packages/wpcom-checkout/src/get-country-tax-requirements.ts
@@ -24,7 +24,7 @@ export function getCountryTaxRequirements(
 	if ( ! countries?.length ) {
 		// eslint-disable-next-line no-console
 		console.error(
-			'Error: getCountryVatRequirements was called without a countries list. This will result in incorrect data!'
+			'Error: getCountryTaxRequirements was called without a countries list. This will result in incorrect data!'
 		);
 		return {};
 	}
@@ -36,7 +36,7 @@ export function getCountryTaxRequirements(
 	if ( ! countryListItem ) {
 		// eslint-disable-next-line no-console
 		console.warn(
-			`Warning: getCountryVatRequirements could not find the country "${ countryCode }"!`
+			`Warning: getCountryTaxRequirements could not find the country "${ countryCode }"!`
 		);
 		return {};
 	}


### PR DESCRIPTION
Resolves [SHILL-330](https://linear.app/a8c/issue/SHILL-330)

## Proposed Changes

* Fixed two console message strings in `packages/wpcom-checkout/src/get-country-tax-requirements.ts` that incorrectly referenced `getCountryVatRequirements` instead of the correct function name `getCountryTaxRequirements`

## Why are these changes being made?

The function has always been named `getCountryTaxRequirements` since its introduction in commit `438f50d6961` (Feb 2023), but the console error and warning messages on lines 27 and 39 contained a typo that referenced a non-existent function name `getCountryVatRequirements`. This was a copy/paste or naming confusion typo from the original implementation that has been present for 2+ years.

While this is purely cosmetic (no logic changes), correcting these strings improves debugging clarity for developers who encounter these console messages.

## Testing Instructions

**Environment:**
- [ ] Store Sandbox mode disabled (not relevant for this change)
- [ ] Local: `calypso.localhost:3000`

**Steps:**
1. Check out this branch locally
2. Run the build command to verify TypeScript compilation:
   ```bash
   cd /Users/Strahan/Desktop/CODE/payments/wp-calypso
   yarn workspace @automattic/wpcom-checkout build
   ```
3. Verify no references to `getCountryVatRequirements` remain in source:
   ```bash
   grep -r "getCountryVatRequirements" packages/wpcom-checkout/src/
   # Should return no results
   ```

### Automated validation
```bash
# ESLint
./node_modules/.bin/eslint packages/wpcom-checkout/src/get-country-tax-requirements.ts

# Prettier
./node_modules/.bin/prettier --check packages/wpcom-checkout/src/get-country-tax-requirements.ts
```

**Before this change:**
- Console messages would display `getCountryVatRequirements` (incorrect function name)
- Example: `Error: getCountryVatRequirements was called without a countries list. This will result in incorrect data!`

**After this change:**
- Console messages correctly display `getCountryTaxRequirements` (actual function name)
- Example: `Error: getCountryTaxRequirements was called without a countries list. This will result in incorrect data!`

### Manual verification (optional)
To trigger these console messages and verify the fix:
1. Start Calypso dev server: `yarn start`
2. Navigate to checkout flow: `http://calypso.localhost:3000/checkout/`
3. Open browser console
4. The error messages should now reference the correct function name if triggered (though these are edge cases that rarely occur in normal flow)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
