### PR TITLE
Fix READ-313: Filter out subscribed blog from recommended blogs modal

### DIFF
--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -47,6 +47,7 @@ const ReaderSuggestedFollowsDialog = ( {
 			author,
 			siteId,
 			postId,
+			excludeSiteId: siteId,
 		} ),
 		[ author, siteId, postId ]
 	);

--- a/client/blocks/reader-suggested-follows/hooks/use-recommend-or-related-sites-query/index.ts
+++ b/client/blocks/reader-suggested-follows/hooks/use-recommend-or-related-sites-query/index.ts
@@ -14,6 +14,7 @@ interface QueryParams {
 	author?: Author;
 	siteId: number;
 	postId: number;
+	excludeSiteId?: number;
 }
 
 interface QueryOptions {
@@ -36,7 +37,7 @@ const getResourceType = (
 };
 
 export const useRecommendOrRelatedSitesQuery = ( query: QueryParams, options?: QueryOptions ) => {
-	const { author, siteId, postId } = query;
+	const { author, siteId, postId, excludeSiteId } = query;
 	const userLogin = author?.wpcom_login || author?.ID;
 	const enabled = options?.enabled ?? true;
 	const hasUserLogin = Boolean( userLogin );
@@ -61,7 +62,17 @@ export const useRecommendOrRelatedSitesQuery = ( query: QueryParams, options?: Q
 		enabled: shouldLoadRelatedSites && enabled,
 	} );
 
-	const data = recommendedFeeds?.length > 0 ? recommendedFeeds : relatedSites;
+	// Filter out the excluded site from both recommended feeds and related sites
+	const filteredRecommendedFeeds = excludeSiteId
+		? recommendedFeeds?.filter( ( feed ) => Number( feed.siteId ) !== excludeSiteId )
+		: recommendedFeeds;
+
+	const filteredRelatedSites = excludeSiteId
+		? relatedSites?.filter( ( site ) => site.site_ID !== excludeSiteId )
+		: relatedSites;
+
+	const data =
+		filteredRecommendedFeeds?.length > 0 ? filteredRecommendedFeeds : filteredRelatedSites;
 	const isLoading = isLoadingRecommendedFeeds || isLoadingRelatedSites;
 	const isFetched = isFetchedRecommendedFeeds || isFetchedRelatedSites;
 
@@ -69,6 +80,6 @@ export const useRecommendOrRelatedSitesQuery = ( query: QueryParams, options?: Q
 		data: isFetched ? data : [],
 		isLoading,
 		isFetched,
-		resourceType: getResourceType( recommendedFeeds, relatedSites ),
+		resourceType: getResourceType( filteredRecommendedFeeds, filteredRelatedSites ),
 	};
 };


### PR DESCRIPTION
Fixes READ-313

## Proposed Changes

* Pass `excludeSiteId` (set to the current `siteId`) from the suggested follows dialog to the `useRecommendOrRelatedSitesQuery` hook.
* Filter both recommended feeds and related sites to exclude the blog the user just subscribed to.
* Use filtered results for both the displayed data and the `resourceType` determination.

## Why are these changes being made?

When a user subscribes to a blog in Reader, the recommended blogs modal appears showing suggested blogs. Previously, the blog just subscribed to could appear in this list, which is confusing — the user already subscribed to it. This fix filters it out by matching on `siteId` for recommended feeds (with string→number conversion) and `site_ID` for related sites.

## Testing Instructions

1. Go to a blog feed page in Reader (e.g., `/reader/feeds/132345515`)
2. Subscribe to the blog
3. The recommended blogs modal should appear
4. Verify the blog you just subscribed to is **not** in the list of recommended/suggested blogs

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)