### PR TITLE
Fix auto-renew survey modal option order and support link styling

### DIFF
--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -1,7 +1,6 @@
 import { isDomainRegistration, isPlan } from '@automattic/calypso-products';
 import { Button, RadioControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
-import { shuffle } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -49,15 +48,7 @@ class CancelAutoRenewalForm extends Component {
 		const { translate } = props;
 		const productType = this.getProductTypeString();
 
-		this.radioButtons = shuffle( [
-			{
-				value: 'let-it-expire',
-				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
-				label: translate( "I'm going to let this %(productType)s expire.", {
-					args: { productType },
-				} ),
-			},
-
+		this.radioButtons = [
 			{
 				value: 'manual-renew',
 				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
@@ -66,10 +57,17 @@ class CancelAutoRenewalForm extends Component {
 				} ),
 			},
 			{
+				value: 'let-it-expire',
+				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+				label: translate( "I'm going to let this %(productType)s expire.", {
+					args: { productType },
+				} ),
+			},
+			{
 				value: 'not-sure',
 				label: translate( "I'm not sure." ),
 			},
-		] );
+		];
 	}
 
 	onSubmit = () => {
@@ -93,37 +91,6 @@ class CancelAutoRenewalForm extends Component {
 		this.setState( {
 			response: value,
 		} );
-	};
-
-	renderButtons = () => {
-		const { translate, purchase, onClose } = this.props;
-		const { response } = this.state;
-		const disableSubmit = ! response;
-
-		const skip = {
-			action: 'skip',
-			disabled: false,
-			label: translate( 'Skip' ),
-			onClick: onClose,
-		};
-
-		const submit = {
-			action: 'submit',
-			isPrimary: true,
-			disabled: disableSubmit,
-			label: translate( 'Submit' ),
-			onClick: this.onSubmit,
-		};
-
-		const chat = (
-			<PrecancellationChatButton
-				purchase={ purchase }
-				onClick={ onClose }
-				className="cancel-auto-renewal-form__chat-button"
-			/>
-		);
-
-		return [ skip, submit, chat ];
 	};
 
 	render() {

--- a/client/components/marketing-survey/cancel-auto-renewal-form/style.scss
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/style.scss
@@ -12,4 +12,5 @@
 	transform: none;
 	display: inline-block;
 	margin-right: auto;
+	color: var(--studio-gray-100);
 }


### PR DESCRIPTION
Resolves [CHE-165](https://linear.app/a8c/issue/CHE-165)

## Proposed Changes

* Fixed survey options to display in a consistent order (manual-renew → let-it-expire → not-sure) instead of being shuffled randomly
* Updated support chat button styling to appear active/clickable (dark text) instead of disabled (gray)
* Removed unused `renderButtons()` method (30 lines of dead code)
* Removed unused `shuffle` import from lodash

## Why are these changes being made?

The auto-renew survey modal had two UX issues:

1. **Random option order**: The radio button options were shuffled on every render, making the survey unpredictable and harder to use. Design specs show a specific fixed order.
2. **Disabled appearance**: The "Need help?" support link appeared visually disabled (gray text) due to missing color styling, even though it was functional.

These changes improve UX consistency and accessibility by providing a predictable interface with clearly visible interactive elements.

| Scenario | Before | After |
|----------|--------|-------|
| Survey options | Random order on each render | Fixed order: manual-renew → let-it-expire → not-sure |
| Support link | Gray text, appears disabled | Dark text, clearly clickable |
| Code quality | 30 lines of unused `renderButtons()` method | Dead code removed |

## Testing Instructions

**Environment:**
- [ ] Local: `calypso.localhost:3000` or production `wordpress.com`
- [ ] Test on: Simple sites with active subscriptions/plans

**Prerequisites:**
- A WordPress.com account with an active subscription/plan that has auto-renew enabled
- Examples: Business plan, domain registration, premium plan

**Steps:**

1. Navigate to purchases screen:
   - Classic UI: https://wordpress.com/me/purchases
   - Dashboard UI: https://my.wordpress.com/me/billing/purchases/

2. Select an active subscription with auto-renew enabled

3. Click the "Auto-renew" toggle to turn it OFF

4. In the confirmation dialog, click "Turn off auto-renew"

5. **Verify the survey modal displays correctly:**
   - Title: "Help us improve" (no punctuation) ✓
   - Options in fixed order:
     1. "I'm going to renew the [product], but will do it manually."
     2. "I'm going to let this [product] expire."
     3. "I'm not sure."
   - "Need help?" link has dark text (not grayed out)
   - Skip and Submit buttons function correctly

6. **Repeat the process** (toggle auto-renew on, then off again):
   - Verify options remain in the SAME order (not shuffled)

7. **Test the support link:**
   - Click "Need help?" → should open chat support
   - Visual appearance: text should be dark/readable (matching "Skip" button color)

### Test scenarios

| # | Scenario | Expected Result |
|---|----------|-----------------|
| 1 | Toggle auto-renew off for Business plan | Survey shows with fixed option order |
| 2 | Toggle auto-renew off for domain registration | Survey shows with fixed option order |
| 3 | Repeat toggle multiple times | Options NEVER shuffle, always same order |
| 4 | Click "Need help?" | Chat opens, link text is visible (dark gray) |
| 5 | Mobile viewport (< 600px) | Chat button remains visible and clickable |

**Before this change:**
- Survey options appeared in random order each time
- Support link text was gray/faded, looked disabled

**After this change:**
- Survey options always display in the same predictable order
- Support link text is dark and clearly visible

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
