### PR TITLE
Update domain registration display in purchase lists

### DIFF
--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -17,7 +17,7 @@ import {
 	isTransferredOwnership,
 	isAkismetTemporarySitePurchase,
 	isMarketplaceTemporarySitePurchase,
-	getTitleForDisplay,
+	getTitleForListDisplay,
 } from '../../utils/purchase';
 import { PurchasePaymentMethod } from './purchase-payment-method';
 import { PurchaseProduct } from './purchase-product';
@@ -252,7 +252,7 @@ export function getFields( {
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				// Render a bunch of things to make this easily searchable.
 				return (
-					getTitleForDisplay( item ) +
+					getTitleForListDisplay( item ) +
 					' ' +
 					item.blogname +
 					' ' +
@@ -266,7 +266,7 @@ export function getFields( {
 				return (
 					<HStack justify="flex-start" spacing={ 1 }>
 						<PurchaseSettingLink purchase={ item } disabled={ isTransferred }>
-							{ getTitleForDisplay( item ) }
+							{ getTitleForListDisplay( item ) }
 						</PurchaseSettingLink>
 						<OwnerInfo purchase={ item } isTransferredOwnership={ isTransferred } />
 					</HStack>

--- a/client/dashboard/me/billing-purchases/purchase-product.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-product.tsx
@@ -11,7 +11,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 		return null;
 	}
 
-	const productType = getSubtitleForDisplay( purchase );
+	const productType = purchase.is_domain_registration ? null : getSubtitleForDisplay( purchase );
 
 	if ( site ) {
 		if ( productType && site.name && site.slug ) {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -333,6 +333,15 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 	return purchase.product_name;
 }
 
+export function getTitleForListDisplay( purchase: Purchase ): string {
+	const title = getTitleForDisplay( purchase );
+	if ( purchase.is_domain_registration ) {
+		// translators: %s is the domain name, e.g. "Domain Registration: example.com"
+		return sprintf( __( 'Domain Registration: %s' ), title );
+	}
+	return title;
+}
+
 /**
  * Return a short description of a purchase, usually used as a subtitle for that
  * purchase's product name (as defined by `getTitleForDisplay`).

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -334,12 +334,15 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 }
 
 export function getTitleForListDisplay( purchase: Purchase ): string {
-	const title = getTitleForDisplay( purchase );
-	if ( purchase.is_domain_registration ) {
+	if ( purchase.is_domain_registration && purchase.meta ) {
+		if ( purchase.is_hundred_year_domain ) {
+			// translators: %s is the domain name, e.g. "100-Year Domain Registration: example.com"
+			return sprintf( __( '100-Year Domain Registration: %s' ), purchase.meta );
+		}
 		// translators: %s is the domain name, e.g. "Domain Registration: example.com"
-		return sprintf( __( 'Domain Registration: %s' ), title );
+		return sprintf( __( 'Domain Registration: %s' ), purchase.meta );
 	}
-	return title;
+	return getTitleForDisplay( purchase );
 }
 
 /**

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -1,5 +1,6 @@
 import {
 	isDomainTransfer,
+	isDomainRegistration,
 	isConciergeSession,
 	isAkismetFreeProduct,
 	PLAN_MONTHLY_PERIOD,
@@ -175,7 +176,7 @@ export function PurchaseItemProduct( {
 		return null;
 	}
 
-	const productType = purchaseType( purchase );
+	const productType = isDomainRegistration( purchase ) ? null : purchaseType( purchase );
 
 	if ( showSite && site ) {
 		if ( productType && site.name && slug ) {

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -75,6 +75,16 @@ export function getPurchasesFieldDefinitions( {
 	fieldIds?: string[];
 	transferredOwnershipPurchases?: Purchases.Purchase[];
 } ): Fields< Purchases.Purchase > {
+	const getListTitle = ( item: Purchases.Purchase ) => {
+		if ( item.isDomainRegistration ) {
+			// translators: %(domain)s is the domain name, e.g. "Domain Registration: example.com"
+			return translate( 'Domain Registration: %(domain)s', {
+				args: { domain: String( getDisplayName( item ) ) },
+			} );
+		}
+		return getDisplayName( item );
+	};
+
 	const backupPaymentMethods = paymentMethods.filter(
 		( paymentMethod ) => paymentMethod.is_backup === true
 	);
@@ -141,7 +151,7 @@ export function getPurchasesFieldDefinitions( {
 				// Render a bunch of things to make this easily searchable.
 				const site = sites.find( ( site ) => site.ID === item.siteId );
 				return (
-					getDisplayName( item ) +
+					getListTitle( item ) +
 					' ' +
 					( purchaseType( item ) || '' ) +
 					' ' +
@@ -162,7 +172,7 @@ export function getPurchasesFieldDefinitions( {
 						<div className="purchase-item__title">
 							{ hasTransferredOwnership ? (
 								<div>
-									{ getDisplayName( item ) }
+									{ getListTitle( item ) }
 									&nbsp;
 									<OwnerInfo purchase={ item } isTransferredOwnership={ hasTransferredOwnership } />
 								</div>
@@ -173,7 +183,7 @@ export function getPurchasesFieldDefinitions( {
 										title={ translate( 'Manage purchase', { textOnly: true } ) }
 										href={ getPurchaseUrl( item ) }
 									>
-										{ getDisplayName( item ) }
+										{ getListTitle( item ) }
 									</a>
 									<OwnerInfo purchase={ item } />
 								</>

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -76,10 +76,16 @@ export function getPurchasesFieldDefinitions( {
 	transferredOwnershipPurchases?: Purchases.Purchase[];
 } ): Fields< Purchases.Purchase > {
 	const getListTitle = ( item: Purchases.Purchase ) => {
-		if ( item.isDomainRegistration ) {
+		if ( item.isDomainRegistration && item.meta ) {
+			if ( item.isHundredYearDomain ) {
+				// translators: %(domain)s is the domain name, e.g. "100-Year Domain Registration: example.com"
+				return translate( '100-Year Domain Registration: %(domain)s', {
+					args: { domain: item.meta },
+				} );
+			}
 			// translators: %(domain)s is the domain name, e.g. "Domain Registration: example.com"
 			return translate( 'Domain Registration: %(domain)s', {
-				args: { domain: String( getDisplayName( item ) ) },
+				args: { domain: item.meta },
 			} );
 		}
 		return getDisplayName( item );


### PR DESCRIPTION
Resolves [CHE-263](https://linear.app/a8c/issue/CHE-263)

## Proposed Changes

* **Dashboard**: New `getTitleForListDisplay()` helper in `purchase.ts` wraps `getTitleForDisplay()` to prefix "Domain Registration:" for domain registrations, using `purchase.meta` (the actual domain name) rather than the display title
* **Dashboard**: Nulls out `productType` for domain registrations in `purchase-product.tsx` so the subtitle shows only site context
* **Classic**: New `getListTitle()` helper in `purchases-data-field.tsx` wraps `getDisplayName()` with the same prefix, also using `item.meta` directly
* **Classic**: Nulls out `purchaseType()` for domain registrations in `PurchaseItemProduct` so only site context is shown
* **Both**: 100-Year Domain registrations get a distinct "100-Year Domain Registration:" prefix so they aren't confused with regular domains

Note Dashboard list view does not have `site` context for siteless domain purchases but classic does. The API Dashboard uses doesn't provide site.


## Why are these changes being made?

Users reported confusion when domain registration purchases displayed as:

> **nopayexptest.blog**
> .blog Domain Registration for Site Title (tx2pnw-yxkov.wordpress.com)

The domain name alone as the title wasn't descriptive enough, and the TLD-prefixed product name (e.g., ".blog Domain Registration") in the subtitle was redundant. This follows the pattern suggested in the Linear discussion — similar to how Jetpack Search displays its product type in the title.

The list title uses `purchase.meta` directly instead of the display title to ensure the actual domain name always appears — this matters for products like 100-Year Domain Registration where `getTitleForDisplay()` returns the product name rather than the domain.

| View | Regular Domain | 100-Year Domain |
|------|---------------|-----------------|
| Before | `nopayexptest.blog`<br>`.blog Domain Registration for Site Title (site.com)` | `100-Year Domain Registration`<br>`<product_name> for Site Title (site.com)` |
| After | `Domain Registration: nopayexptest.blog`<br>`for Site Title (site.com)` | `100-Year Domain Registration: example.com`<br>`for Site Title (site.com)` |
| Detail/cancel/renewals | No change | No change |

## Screenshots
 - <img width="2542" height="1136" alt="Screenshot 2026-02-16 at 11 02 52 AM" src="https://github.com/user-attachments/assets/9da0bc96-a37a-49b9-9caa-ef7da024bf06" />
 -  <img width="2542" height="1136" alt="Screenshot 2026-02-16 at 11 03 01 AM" src="https://github.com/user-attachments/assets/dd6a9144-0028-4258-8fb4-29b94061e9d1" />


## Testing Instructions

**Environment:**
- [ ] Local: `calypso.localhost:3000` or `my.localhost:3000`

**Prerequisites:**
- A WordPress.com account with at least one domain registration purchase
- Ideally also a 100-Year Domain registration to verify the distinct prefix

**Dashboard UI (`/me/billing/purchases`):**

1. Navigate to: `my.localhost:3000/me/billing/purchases`
2. Locate a domain registration purchase in the list
3. Verify: title shows "Domain Registration: example.com", subtitle shows "for Site Title (site.com)"
4. Click through to the detail view — verify it still shows the domain name as title with ".blog Domain Registration" as subtitle (unchanged)

**Classic UI (`/me/purchases`):**

1. Navigate to: `calypso.localhost:3000/me/purchases`
2. Verify same list display as Dashboard above
3. Click "Manage purchase" — verify detail view is unchanged

**Verify other purchase types are unchanged:**

1. Plans still show: "Site plan for Site Title (site.com)"
2. Domain mappings still show product name + site context

### Test scenarios

| # | Scenario | Expected Result |
|---|----------|-----------------|
| 1 | Domain registration in list view | Title: "Domain Registration: example.com", Subtitle: "for Site Title (site.com)" |
| 2 | Domain registration in detail view | Unchanged — domain as title, product name as subtitle |
| 3 | 100-Year domain in list view | Title: "100-Year Domain Registration: example.com", Subtitle: "for Site Title (site.com)" |
| 4 | 100-Year domain in detail view | Unchanged |
| 5 | Plan purchase in list view | Unchanged — "Site plan for Site Title (site.com)" |
| 6 | Domain mapping in list view | Unchanged — product name + site context |
| 7 | Siteless domain in Dashboard list | Title: "Domain Registration: example.com", Subtitle: none |
| 8 | Siteless domain in Classic list | Title: "Domain Registration: example.com", Subtitle: "for Site Title (site.com)" |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
