### PR TITLE
Dashboard: Fix untranslated strings in domain and account settings

### DIFF
--- a/client/dashboard/domains/domain-forwarding/form.tsx
+++ b/client/dashboard/domains/domain-forwarding/form.tsx
@@ -115,11 +115,11 @@ export default function DomainForwardingForm( {
 				Edit: 'select',
 				elements: [
 					{
-						label: 'Subdomain',
+						label: __( 'Subdomain' ),
 						value: '',
 					},
 					{
-						label: 'Domain',
+						label: __( 'Domain' ),
 						value: 'root',
 					},
 				],

--- a/client/dashboard/domains/domain-security/dnssec.tsx
+++ b/client/dashboard/domains/domain-security/dnssec.tsx
@@ -97,14 +97,14 @@ export default function DnsSec( { domainName, domain }: DnsSecProps ) {
 										<DnsSecRecordTextarea
 											key={ `dnskey-${ index }` }
 											value={ dnskey }
-											label="DNSKEY Record"
+											label={ __( 'DNSKEY record' ) }
 										/>
 									) ) }
 									{ domain.dnssec_records?.ds_data?.map( ( dsRecord, index ) => (
 										<DnsSecRecordTextarea
 											key={ `ds-${ index }` }
 											value={ dsRecord }
-											label="Delegation Signer (DS) record"
+											label={ __( 'Delegation Signer (DS) record' ) }
 										/>
 									) ) }
 								</VStack>

--- a/client/dashboard/domains/domain-transfer/select-ips-tag.tsx
+++ b/client/dashboard/domains/domain-transfer/select-ips-tag.tsx
@@ -107,7 +107,7 @@ export default function SelectIpsTag( { domain, isDomainLocked }: SelectIpsTagPr
 				<FormTokenField
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
-					label="IPS tag"
+					label={ __( 'IPS tag' ) }
 					placeholder={ __( 'Start typing an IPS tag…' ) }
 					onChange={ ( tokens ) => {
 						setIpsTag( tokens.length > 0 ? ( tokens[ tokens.length - 1 ] as string ) : null );

--- a/client/dashboard/domains/domain-transfer/select-site.tsx
+++ b/client/dashboard/domains/domain-transfer/select-site.tsx
@@ -67,7 +67,7 @@ export function SelectSite( { attachedSiteId, onSiteSelect }: Props ) {
 		},
 		{
 			id: 'name',
-			label: 'Site Name',
+			label: __( 'Site name' ),
 			render: ( { item }: { item: Site } ) => item.name,
 		},
 		{

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -577,7 +577,7 @@ export default function CancelPurchase() {
 	const downgradeClick = () => {
 		if ( ! state.isSubmitting ) {
 			if ( ! downgradePlan ) {
-				createErrorNotice( 'Cannot find a plan to downgrade to', { type: 'snackbar' } );
+				createErrorNotice( __( 'Cannot find a plan to downgrade to.' ), { type: 'snackbar' } );
 				return;
 			}
 

--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -221,7 +221,7 @@ export const SubscriptionSettingsForm = ( { data, isAutomattician, onChange }: F
 			{
 				children: [ 'subscription_delivery_day', 'subscription_delivery_hour' ],
 				id: 'subscription_delivery_window',
-				label: 'Email delivery window',
+				label: __( 'Email delivery window' ),
 				layout: {
 					type: 'row' as const,
 					alignment: 'start' as const,


### PR DESCRIPTION
## Proposed Changes

* Wrap hardcoded English strings with `__()` for internationalization in several dashboard components:
  - Domain forwarding form: "Subdomain" and "Domain" labels
<img width="725" height="620" alt="SCR-20260211-kgdd" src="https://github.com/user-attachments/assets/a1708a5d-6ca5-4942-8147-a361c841f21f" />

  - DNSSEC: "DNSKEY record" and "Delegation Signer (DS) record" labels
<img width="707" height="813" alt="SCR-20260211-kqqn" src="https://github.com/user-attachments/assets/8f6a9707-be50-45b4-8966-86de6d3fa554" />


  - Domain transfer: "IPS tag" label and "Site name" column header
  - Cancel purchase: error notice message
  - Subscription settings: "Email delivery window" label
<img width="775" height="831" alt="Screenshot 2026-02-11 at 10 55 03 AM" src="https://github.com/user-attachments/assets/590a585b-9b7b-4223-9f46-6ca17a260c1e" />


## Why are these changes being made?

These strings were missing i18n wrappers, meaning they would not be translated for non-English users. This ensures the dashboard is fully translatable.

## Testing Instructions

* Switch the interface language to a non-English locale
* Verify the affected strings appear translated in:
  - Domain forwarding settings
  - DNSSEC settings
  - Domain transfer (IPS tag and site selection)
  - Purchase cancellation flow
  - Email subscription delivery window settings

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?