### PR TITLE
Dashboard: Fix domain transfer site search to also filter by URL

### DIFF
--- a/client/dashboard/domains/domain-transfer/select-site.tsx
+++ b/client/dashboard/domains/domain-transfer/select-site.tsx
@@ -95,7 +95,11 @@ export function SelectSite( { attachedSiteId, onSiteSelect }: Props ) {
 		// Apply search filter
 		if ( view.search ) {
 			const searchTerm = view.search.toLowerCase();
-			filteredSites = sites.filter( ( site ) => site.name?.toLowerCase().includes( searchTerm ) );
+			filteredSites = sites.filter(
+				( site ) =>
+					site.name?.toLowerCase().includes( searchTerm ) ||
+					getSiteDisplayUrl( site ).toLowerCase().includes( searchTerm )
+			);
 		}
 
 		// Apply pagination (infinite scroll)

--- a/client/dashboard/domains/domain-transfer/test/select-site.test.tsx
+++ b/client/dashboard/domains/domain-transfer/test/select-site.test.tsx
@@ -3,32 +3,18 @@
  */
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import { render } from '../../../test-utils';
 import { SelectSite } from '../select-site';
 import type { Site } from '@automattic/api-core';
-import type { DeepPartial } from 'utility-types';
 
-const mockSitesQuery = jest.fn();
-
-jest.mock( '../../../app/context', () => ( {
-	...jest.requireActual( '../../../app/context' ),
-	useAppContext: jest.fn( () => ( {
-		queries: {
-			sitesQuery: () => mockSitesQuery(),
-		},
-	} ) ),
-} ) );
-
-jest.mock( '../../../sites/features', () => ( {
-	canManageSite: () => true,
-} ) );
-
-const mockSites: DeepPartial< Site >[] = [
+const mockSites = [
 	{
 		ID: 1,
 		name: 'My Blog',
 		slug: 'myblog.wordpress.com',
 		URL: 'https://myblog.wordpress.com',
+		capabilities: { manage_options: true },
 		site_migration: { migration_status: '' },
 	},
 	{
@@ -36,6 +22,7 @@ const mockSites: DeepPartial< Site >[] = [
 		name: 'Online Store',
 		slug: 'casually-left-cherryblossom.commerce-garden.com',
 		URL: 'https://casually-left-cherryblossom.commerce-garden.com',
+		capabilities: { manage_options: true },
 		site_migration: { migration_status: '' },
 	},
 	{
@@ -43,55 +30,52 @@ const mockSites: DeepPartial< Site >[] = [
 		name: 'Portfolio Site',
 		slug: 'portfolio.wordpress.com',
 		URL: 'https://portfolio.wordpress.com',
+		capabilities: { manage_options: true },
 		site_migration: { migration_status: '' },
 	},
-];
+] as Site[];
 
-function renderSelectSite( onSiteSelect = jest.fn() ) {
-	mockSitesQuery.mockReturnValue( {
-		queryKey: [ 'sites' ],
-		queryFn: () => Promise.resolve( mockSites ),
+describe( '<SelectSite>', () => {
+	beforeEach( () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/sites' )
+			.query( true )
+			.reply( 200, { sites: mockSites } );
 	} );
 
-	return render( <SelectSite onSiteSelect={ onSiteSelect } /> );
-}
+	test( 'filters sites by name', async () => {
+		const user = userEvent.setup();
+		render( <SelectSite onSiteSelect={ jest.fn() } /> );
 
-afterEach( () => {
-	jest.clearAllMocks();
-} );
+		await waitFor( () => {
+			expect( screen.getByText( 'My Blog' ) ).toBeVisible();
+		} );
 
-test( 'filters sites by name', async () => {
-	const user = userEvent.setup();
-	renderSelectSite();
+		const searchInput = screen.getByRole( 'searchbox' );
+		await user.type( searchInput, 'Online Store' );
 
-	await waitFor( () => {
-		expect( screen.getByText( 'My Blog' ) ).toBeVisible();
+		await waitFor( () => {
+			expect( screen.getByText( 'Online Store' ) ).toBeVisible();
+			expect( screen.queryByText( 'My Blog' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Portfolio Site' ) ).not.toBeInTheDocument();
+		} );
 	} );
 
-	const searchInput = screen.getByRole( 'searchbox' );
-	await user.type( searchInput, 'Online Store' );
+	test( 'filters sites by URL', async () => {
+		const user = userEvent.setup();
+		render( <SelectSite onSiteSelect={ jest.fn() } /> );
 
-	await waitFor( () => {
-		expect( screen.getByText( 'Online Store' ) ).toBeVisible();
-		expect( screen.queryByText( 'My Blog' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Portfolio Site' ) ).not.toBeInTheDocument();
-	} );
-} );
+		await waitFor( () => {
+			expect( screen.getByText( 'My Blog' ) ).toBeVisible();
+		} );
 
-test( 'filters sites by URL', async () => {
-	const user = userEvent.setup();
-	renderSelectSite();
+		const searchInput = screen.getByRole( 'searchbox' );
+		await user.type( searchInput, 'casually-left-cherryblossom' );
 
-	await waitFor( () => {
-		expect( screen.getByText( 'My Blog' ) ).toBeVisible();
-	} );
-
-	const searchInput = screen.getByRole( 'searchbox' );
-	await user.type( searchInput, 'casually-left-cherryblossom' );
-
-	await waitFor( () => {
-		expect( screen.getByText( 'Online Store' ) ).toBeVisible();
-		expect( screen.queryByText( 'My Blog' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Portfolio Site' ) ).not.toBeInTheDocument();
+		await waitFor( () => {
+			expect( screen.getByText( 'Online Store' ) ).toBeVisible();
+			expect( screen.queryByText( 'My Blog' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Portfolio Site' ) ).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/dashboard/domains/domain-transfer/test/select-site.test.tsx
+++ b/client/dashboard/domains/domain-transfer/test/select-site.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import { SelectSite } from '../select-site';
+import type { Site } from '@automattic/api-core';
+import type { DeepPartial } from 'utility-types';
+
+const mockSitesQuery = jest.fn();
+
+jest.mock( '../../../app/context', () => ( {
+	...jest.requireActual( '../../../app/context' ),
+	useAppContext: jest.fn( () => ( {
+		queries: {
+			sitesQuery: () => mockSitesQuery(),
+		},
+	} ) ),
+} ) );
+
+jest.mock( '../../../sites/features', () => ( {
+	canManageSite: () => true,
+} ) );
+
+const mockSites: DeepPartial< Site >[] = [
+	{
+		ID: 1,
+		name: 'My Blog',
+		slug: 'myblog.wordpress.com',
+		URL: 'https://myblog.wordpress.com',
+		site_migration: { migration_status: '' },
+	},
+	{
+		ID: 2,
+		name: 'Online Store',
+		slug: 'casually-left-cherryblossom.commerce-garden.com',
+		URL: 'https://casually-left-cherryblossom.commerce-garden.com',
+		site_migration: { migration_status: '' },
+	},
+	{
+		ID: 3,
+		name: 'Portfolio Site',
+		slug: 'portfolio.wordpress.com',
+		URL: 'https://portfolio.wordpress.com',
+		site_migration: { migration_status: '' },
+	},
+];
+
+function renderSelectSite( onSiteSelect = jest.fn() ) {
+	mockSitesQuery.mockReturnValue( {
+		queryKey: [ 'sites' ],
+		queryFn: () => Promise.resolve( mockSites ),
+	} );
+
+	return render( <SelectSite onSiteSelect={ onSiteSelect } /> );
+}
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+test( 'filters sites by name', async () => {
+	const user = userEvent.setup();
+	renderSelectSite();
+
+	await waitFor( () => {
+		expect( screen.getByText( 'My Blog' ) ).toBeVisible();
+	} );
+
+	const searchInput = screen.getByRole( 'searchbox' );
+	await user.type( searchInput, 'Online Store' );
+
+	await waitFor( () => {
+		expect( screen.getByText( 'Online Store' ) ).toBeVisible();
+		expect( screen.queryByText( 'My Blog' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Portfolio Site' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+test( 'filters sites by URL', async () => {
+	const user = userEvent.setup();
+	renderSelectSite();
+
+	await waitFor( () => {
+		expect( screen.getByText( 'My Blog' ) ).toBeVisible();
+	} );
+
+	const searchInput = screen.getByRole( 'searchbox' );
+	await user.type( searchInput, 'casually-left-cherryblossom' );
+
+	await waitFor( () => {
+		expect( screen.getByText( 'Online Store' ) ).toBeVisible();
+		expect( screen.queryByText( 'My Blog' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Portfolio Site' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/domains/domain-transfer/test/select-site.test.tsx
+++ b/client/dashboard/domains/domain-transfer/test/select-site.test.tsx
@@ -47,9 +47,7 @@ describe( '<SelectSite>', () => {
 		const user = userEvent.setup();
 		render( <SelectSite onSiteSelect={ jest.fn() } /> );
 
-		await waitFor( () => {
-			expect( screen.getByText( 'My Blog' ) ).toBeVisible();
-		} );
+		await screen.findByText( 'My Blog' );
 
 		const searchInput = screen.getByRole( 'searchbox' );
 		await user.type( searchInput, 'Online Store' );
@@ -65,9 +63,7 @@ describe( '<SelectSite>', () => {
 		const user = userEvent.setup();
 		render( <SelectSite onSiteSelect={ jest.fn() } /> );
 
-		await waitFor( () => {
-			expect( screen.getByText( 'My Blog' ) ).toBeVisible();
-		} );
+		await screen.findByText( 'My Blog' );
 
 		const searchInput = screen.getByRole( 'searchbox' );
 		await user.type( searchInput, 'casually-left-cherryblossom' );


### PR DESCRIPTION
Fixes DOTMSD-817

## Proposed Changes

* Extended the site search filter on the "Attach Domain" / "Transfer to other site" page to also match against the site URL, not just the site name.

## Why are these changes being made?

The search field on the domain transfer page (`domains/{domain}/transfer/other-site`) only filtered sites by their name. Users who searched by a domain/URL (e.g., `casually-left-cherryblossom`) got no results, even though a matching site existed. This fix uses the already-imported `getSiteDisplayUrl` helper to also match against the displayed URL.

## Testing Instructions

1. Navigate to `domains/{domain}/transfer/other-site` in the Hosting Dashboard.
2. Search for a site by its URL/domain (e.g., part of the subdomain).
3. Verify the site appears in the results.
4. Search by site name and verify that still works as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)