### PR TITLE
Dashboard: Fix domain expiry sort crash when expiry is undefined

### DIFF
--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -11,7 +11,7 @@ import { DomainStatusField } from './field-domain-status';
 import { DomainExpiryField } from './field-expiry';
 import { DomainSslField } from './field-ssl';
 import { IneligibleIndicator } from './ineligible-indicator';
-import { sortByExpiry } from './sort-by-expiry';
+import { sortNullableStrings } from './sort-nullable-strings';
 import type { DomainSummary, Site } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
 
@@ -138,7 +138,7 @@ export const useFields = ( {
 				label: __( 'Paid until' ),
 				enableHiding: false,
 				enableSorting: true,
-				sort: sortByExpiry,
+				sort: sortNullableStrings,
 				elements: [
 					{ value: '2-next-90-days', label: __( '90 days' ) },
 					{ value: '1-expired', label: __( 'Expired' ) },

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -138,14 +138,14 @@ export const useFields = ( {
 				enableHiding: false,
 				enableSorting: true,
 				sort: ( a, b, direction ) => {
-					if ( a.expiry === null && b.expiry === null ) {
+					if ( a.expiry == null && b.expiry == null ) {
 						return 0;
 					}
-					if ( a.expiry === null ) {
+					if ( a.expiry == null ) {
 						return 1;
 					}
 
-					if ( b.expiry === null ) {
+					if ( b.expiry == null ) {
 						return -1;
 					}
 

--- a/client/dashboard/domains/dataviews/fields.tsx
+++ b/client/dashboard/domains/dataviews/fields.tsx
@@ -11,6 +11,7 @@ import { DomainStatusField } from './field-domain-status';
 import { DomainExpiryField } from './field-expiry';
 import { DomainSslField } from './field-ssl';
 import { IneligibleIndicator } from './ineligible-indicator';
+import { sortByExpiry } from './sort-by-expiry';
 import type { DomainSummary, Site } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
 
@@ -137,21 +138,7 @@ export const useFields = ( {
 				label: __( 'Paid until' ),
 				enableHiding: false,
 				enableSorting: true,
-				sort: ( a, b, direction ) => {
-					if ( a.expiry == null && b.expiry == null ) {
-						return 0;
-					}
-					if ( a.expiry == null ) {
-						return 1;
-					}
-
-					if ( b.expiry == null ) {
-						return -1;
-					}
-
-					const factor = direction === 'asc' ? 1 : -1;
-					return a.expiry.localeCompare( b.expiry ) * factor;
-				},
+				sort: sortByExpiry,
 				elements: [
 					{ value: '2-next-90-days', label: __( '90 days' ) },
 					{ value: '1-expired', label: __( 'Expired' ) },

--- a/client/dashboard/domains/dataviews/sort-by-expiry.ts
+++ b/client/dashboard/domains/dataviews/sort-by-expiry.ts
@@ -1,0 +1,20 @@
+import type { DomainSummary } from '@automattic/api-core';
+
+export function sortByExpiry(
+	a: Pick< DomainSummary, 'expiry' >,
+	b: Pick< DomainSummary, 'expiry' >,
+	direction: string
+) {
+	if ( a.expiry == null && b.expiry == null ) {
+		return 0;
+	}
+	if ( a.expiry == null ) {
+		return 1;
+	}
+	if ( b.expiry == null ) {
+		return -1;
+	}
+
+	const factor = direction === 'asc' ? 1 : -1;
+	return a.expiry.localeCompare( b.expiry ) * factor;
+}

--- a/client/dashboard/domains/dataviews/sort-by-expiry.ts
+++ b/client/dashboard/domains/dataviews/sort-by-expiry.ts
@@ -1,8 +1,14 @@
-export function sortByExpiry(
-	a: string | null | undefined,
-	b: string | null | undefined,
-	direction: string
-) {
+import type { SortDirection } from '@wordpress/dataviews';
+
+/**
+ * Sort comparator for the expiry field.
+ *
+ * Note: Despite the Field<Item> type declaring sort as (a: Item, b: Item, ...),
+ * the dataviews library's normalizeFields wraps it and actually passes getValue
+ * results (category strings like '1-expired', '2-next-90-days', etc.) at runtime.
+ * We use `any` to bridge this type mismatch.
+ */
+export function sortByExpiry( a: any, b: any, direction: SortDirection ) {
 	if ( a == null && b == null ) {
 		return 0;
 	}
@@ -14,5 +20,5 @@ export function sortByExpiry(
 	}
 
 	const factor = direction === 'asc' ? 1 : -1;
-	return a.localeCompare( b ) * factor;
+	return String( a ).localeCompare( String( b ) ) * factor;
 }

--- a/client/dashboard/domains/dataviews/sort-by-expiry.ts
+++ b/client/dashboard/domains/dataviews/sort-by-expiry.ts
@@ -1,20 +1,18 @@
-import type { DomainSummary } from '@automattic/api-core';
-
 export function sortByExpiry(
-	a: Pick< DomainSummary, 'expiry' >,
-	b: Pick< DomainSummary, 'expiry' >,
+	a: string | null | undefined,
+	b: string | null | undefined,
 	direction: string
 ) {
-	if ( a.expiry == null && b.expiry == null ) {
+	if ( a == null && b == null ) {
 		return 0;
 	}
-	if ( a.expiry == null ) {
+	if ( a == null ) {
 		return 1;
 	}
-	if ( b.expiry == null ) {
+	if ( b == null ) {
 		return -1;
 	}
 
 	const factor = direction === 'asc' ? 1 : -1;
-	return a.expiry.localeCompare( b.expiry ) * factor;
+	return a.localeCompare( b ) * factor;
 }

--- a/client/dashboard/domains/dataviews/sort-nullable-strings.ts
+++ b/client/dashboard/domains/dataviews/sort-nullable-strings.ts
@@ -1,14 +1,14 @@
 import type { SortDirection } from '@wordpress/dataviews';
 
 /**
- * Sort comparator for the expiry field.
+ * Sort comparator for nullable string field values. Null/undefined values sort
+ * to the end regardless of direction.
  *
  * Note: Despite the Field<Item> type declaring sort as (a: Item, b: Item, ...),
  * the dataviews library's normalizeFields wraps it and actually passes getValue
- * results (category strings like '1-expired', '2-next-90-days', etc.) at runtime.
- * We use `any` to bridge this type mismatch.
+ * results at runtime. We use `any` to bridge this type mismatch.
  */
-export function sortByExpiry( a: any, b: any, direction: SortDirection ) {
+export function sortNullableStrings( a: any, b: any, direction: SortDirection ) {
 	if ( a == null && b == null ) {
 		return 0;
 	}

--- a/client/dashboard/domains/dataviews/sort-nullable-strings.ts
+++ b/client/dashboard/domains/dataviews/sort-nullable-strings.ts
@@ -3,10 +3,6 @@ import type { SortDirection } from '@wordpress/dataviews';
 /**
  * Sort comparator for nullable string field values. Null/undefined values sort
  * to the end regardless of direction.
- *
- * Note: Despite the Field<Item> type declaring sort as (a: Item, b: Item, ...),
- * the dataviews library's normalizeFields wraps it and actually passes getValue
- * results at runtime. We use `any` to bridge this type mismatch.
  */
 export function sortNullableStrings( a: any, b: any, direction: SortDirection ) {
 	if ( a == null && b == null ) {

--- a/client/dashboard/domains/dataviews/test/fields.test.ts
+++ b/client/dashboard/domains/dataviews/test/fields.test.ts
@@ -1,45 +1,35 @@
 import { sortByExpiry } from '../sort-by-expiry';
 
 describe( 'sortByExpiry', () => {
-	it( 'returns 0 when both expiry values are null', () => {
-		expect( sortByExpiry( { expiry: null }, { expiry: null }, 'asc' ) ).toBe( 0 );
+	it( 'returns 0 when both values are null', () => {
+		expect( sortByExpiry( null, null, 'asc' ) ).toBe( 0 );
 	} );
 
-	it( 'returns 0 when both expiry values are undefined', () => {
-		expect(
-			sortByExpiry(
-				{ expiry: undefined as unknown as null },
-				{ expiry: undefined as unknown as null },
-				'asc'
-			)
-		).toBe( 0 );
+	it( 'returns 0 when both values are undefined', () => {
+		expect( sortByExpiry( undefined, undefined, 'asc' ) ).toBe( 0 );
 	} );
 
-	it( 'sorts items with null expiry to the end', () => {
-		expect( sortByExpiry( { expiry: null }, { expiry: '2025-01-01' }, 'asc' ) ).toBe( 1 );
-		expect( sortByExpiry( { expiry: '2025-01-01' }, { expiry: null }, 'asc' ) ).toBe( -1 );
+	it( 'sorts null values to the end', () => {
+		expect( sortByExpiry( null, '2-next-90-days', 'asc' ) ).toBe( 1 );
+		expect( sortByExpiry( '2-next-90-days', null, 'asc' ) ).toBe( -1 );
 	} );
 
-	it( 'sorts items with undefined expiry to the end', () => {
-		expect(
-			sortByExpiry( { expiry: undefined as unknown as null }, { expiry: '2025-01-01' }, 'asc' )
-		).toBe( 1 );
-		expect(
-			sortByExpiry( { expiry: '2025-01-01' }, { expiry: undefined as unknown as null }, 'asc' )
-		).toBe( -1 );
+	it( 'sorts undefined values to the end', () => {
+		expect( sortByExpiry( undefined, '2-next-90-days', 'asc' ) ).toBe( 1 );
+		expect( sortByExpiry( '2-next-90-days', undefined, 'asc' ) ).toBe( -1 );
 	} );
 
-	it( 'sorts dates ascending', () => {
-		const result = sortByExpiry( { expiry: '2025-01-01' }, { expiry: '2026-01-01' }, 'asc' );
-		expect( result ).toBeLessThan( 0 );
+	it( 'sorts expiry categories ascending', () => {
+		expect( sortByExpiry( '1-expired', '2-next-90-days', 'asc' ) ).toBeLessThan( 0 );
+		expect( sortByExpiry( '2-next-90-days', '3-more-than-90-days', 'asc' ) ).toBeLessThan( 0 );
 	} );
 
-	it( 'sorts dates descending', () => {
-		const result = sortByExpiry( { expiry: '2025-01-01' }, { expiry: '2026-01-01' }, 'desc' );
-		expect( result ).toBeGreaterThan( 0 );
+	it( 'sorts expiry categories descending', () => {
+		expect( sortByExpiry( '1-expired', '2-next-90-days', 'desc' ) ).toBeGreaterThan( 0 );
+		expect( sortByExpiry( '2-next-90-days', '3-more-than-90-days', 'desc' ) ).toBeGreaterThan( 0 );
 	} );
 
-	it( 'returns 0 for equal dates', () => {
-		expect( sortByExpiry( { expiry: '2025-06-15' }, { expiry: '2025-06-15' }, 'asc' ) ).toBe( 0 );
+	it( 'returns 0 for equal values', () => {
+		expect( sortByExpiry( '1-expired', '1-expired', 'asc' ) ).toBe( 0 );
 	} );
 } );

--- a/client/dashboard/domains/dataviews/test/fields.test.ts
+++ b/client/dashboard/domains/dataviews/test/fields.test.ts
@@ -1,0 +1,45 @@
+import { sortByExpiry } from '../sort-by-expiry';
+
+describe( 'sortByExpiry', () => {
+	it( 'returns 0 when both expiry values are null', () => {
+		expect( sortByExpiry( { expiry: null }, { expiry: null }, 'asc' ) ).toBe( 0 );
+	} );
+
+	it( 'returns 0 when both expiry values are undefined', () => {
+		expect(
+			sortByExpiry(
+				{ expiry: undefined as unknown as null },
+				{ expiry: undefined as unknown as null },
+				'asc'
+			)
+		).toBe( 0 );
+	} );
+
+	it( 'sorts items with null expiry to the end', () => {
+		expect( sortByExpiry( { expiry: null }, { expiry: '2025-01-01' }, 'asc' ) ).toBe( 1 );
+		expect( sortByExpiry( { expiry: '2025-01-01' }, { expiry: null }, 'asc' ) ).toBe( -1 );
+	} );
+
+	it( 'sorts items with undefined expiry to the end', () => {
+		expect(
+			sortByExpiry( { expiry: undefined as unknown as null }, { expiry: '2025-01-01' }, 'asc' )
+		).toBe( 1 );
+		expect(
+			sortByExpiry( { expiry: '2025-01-01' }, { expiry: undefined as unknown as null }, 'asc' )
+		).toBe( -1 );
+	} );
+
+	it( 'sorts dates ascending', () => {
+		const result = sortByExpiry( { expiry: '2025-01-01' }, { expiry: '2026-01-01' }, 'asc' );
+		expect( result ).toBeLessThan( 0 );
+	} );
+
+	it( 'sorts dates descending', () => {
+		const result = sortByExpiry( { expiry: '2025-01-01' }, { expiry: '2026-01-01' }, 'desc' );
+		expect( result ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'returns 0 for equal dates', () => {
+		expect( sortByExpiry( { expiry: '2025-06-15' }, { expiry: '2025-06-15' }, 'asc' ) ).toBe( 0 );
+	} );
+} );

--- a/client/dashboard/domains/dataviews/test/fields.test.ts
+++ b/client/dashboard/domains/dataviews/test/fields.test.ts
@@ -1,35 +1,39 @@
-import { sortByExpiry } from '../sort-by-expiry';
+import { sortNullableStrings } from '../sort-nullable-strings';
 
-describe( 'sortByExpiry', () => {
+describe( 'sortNullableStrings', () => {
 	it( 'returns 0 when both values are null', () => {
-		expect( sortByExpiry( null, null, 'asc' ) ).toBe( 0 );
+		expect( sortNullableStrings( null, null, 'asc' ) ).toBe( 0 );
 	} );
 
 	it( 'returns 0 when both values are undefined', () => {
-		expect( sortByExpiry( undefined, undefined, 'asc' ) ).toBe( 0 );
+		expect( sortNullableStrings( undefined, undefined, 'asc' ) ).toBe( 0 );
 	} );
 
 	it( 'sorts null values to the end', () => {
-		expect( sortByExpiry( null, '2-next-90-days', 'asc' ) ).toBe( 1 );
-		expect( sortByExpiry( '2-next-90-days', null, 'asc' ) ).toBe( -1 );
+		expect( sortNullableStrings( null, '2-next-90-days', 'asc' ) ).toBe( 1 );
+		expect( sortNullableStrings( '2-next-90-days', null, 'asc' ) ).toBe( -1 );
 	} );
 
 	it( 'sorts undefined values to the end', () => {
-		expect( sortByExpiry( undefined, '2-next-90-days', 'asc' ) ).toBe( 1 );
-		expect( sortByExpiry( '2-next-90-days', undefined, 'asc' ) ).toBe( -1 );
+		expect( sortNullableStrings( undefined, '2-next-90-days', 'asc' ) ).toBe( 1 );
+		expect( sortNullableStrings( '2-next-90-days', undefined, 'asc' ) ).toBe( -1 );
 	} );
 
-	it( 'sorts expiry categories ascending', () => {
-		expect( sortByExpiry( '1-expired', '2-next-90-days', 'asc' ) ).toBeLessThan( 0 );
-		expect( sortByExpiry( '2-next-90-days', '3-more-than-90-days', 'asc' ) ).toBeLessThan( 0 );
+	it( 'sorts strings ascending', () => {
+		expect( sortNullableStrings( '1-expired', '2-next-90-days', 'asc' ) ).toBeLessThan( 0 );
+		expect( sortNullableStrings( '2-next-90-days', '3-more-than-90-days', 'asc' ) ).toBeLessThan(
+			0
+		);
 	} );
 
-	it( 'sorts expiry categories descending', () => {
-		expect( sortByExpiry( '1-expired', '2-next-90-days', 'desc' ) ).toBeGreaterThan( 0 );
-		expect( sortByExpiry( '2-next-90-days', '3-more-than-90-days', 'desc' ) ).toBeGreaterThan( 0 );
+	it( 'sorts strings descending', () => {
+		expect( sortNullableStrings( '1-expired', '2-next-90-days', 'desc' ) ).toBeGreaterThan( 0 );
+		expect(
+			sortNullableStrings( '2-next-90-days', '3-more-than-90-days', 'desc' )
+		).toBeGreaterThan( 0 );
 	} );
 
 	it( 'returns 0 for equal values', () => {
-		expect( sortByExpiry( '1-expired', '1-expired', 'asc' ) ).toBe( 0 );
+		expect( sortNullableStrings( '1-expired', '1-expired', 'asc' ) ).toBe( 0 );
 	} );
 } );


### PR DESCRIPTION
Fixes CALYPSO-2HDV
Fixes DOTMSD-1092

## Proposed Changes

* Extract a generic `sortNullableStrings` comparator into its own module for reuse and testability.
* Fix the sort function to compare `getValue` results directly instead of accessing `.expiry` on them. The `@wordpress/dataviews` library calls `getValue` on each item first, then passes those results to `field.sort` — the original code incorrectly treated the sort arguments as full `DomainSummary` objects.
* Add unit tests covering null, undefined, ascending, descending, and equal value cases.

## Why are these changes being made?

The domain expiry sort in the Dashboard domains DataView was broken in two ways:
1. It only guarded against `null` expiry values, but some domains have `undefined` expiry at runtime, causing a `TypeError` crash (CALYPSO-2HDV — 4 occurrences, 3 users impacted).
2. Even without the crash, the sort never worked correctly because the `@wordpress/dataviews` library wraps `field.sort` — it calls `getValue` first and passes the category strings (`'1-expired'`, `'2-next-90-days'`, `'3-more-than-90-days'`) to `sort`, not full `DomainSummary` objects. The old code did `a.expiry.localeCompare(b.expiry)` on these strings, which silently failed.

## Testing Instructions

* Navigate to the Domains page in the Dashboard (`/domains`)
* Sort domains by the "Paid until" column (click the column header)
* Verify expired domains sort before expiring-soon domains, which sort before others
* Verify toggling the sort direction reverses the order
* Verify domains with no expiry date sort to the end

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?