### PR TITLE
MSD: Add overlay to site switcher to prevent click-through

### DIFF
--- a/client/dashboard/components/switcher/index.tsx
+++ b/client/dashboard/components/switcher/index.tsx
@@ -7,9 +7,12 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import { chevronDownSmall } from '@wordpress/icons';
 import { useState, type ComponentProps } from 'react';
+import { createPortal } from 'react-dom';
 import SwitcherContent from './switcher-content';
 import { RenderItemTitle, RenderItemMedia, RenderItemDescription } from './types';
 import type { Field, View } from '@wordpress/dataviews';
+
+import './style.scss';
 
 interface RenderCallbackProps {
 	onClose: () => void;
@@ -49,56 +52,84 @@ export default function Switcher< T >( {
 	defaultOpen,
 }: SwitcherProps< T > ) {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	// Track open state internally to render overlay. Uses controlled `open` if provided,
+	// otherwise falls back to internal state for uncontrolled usage.
+	const [ internalIsOpen, setInternalIsOpen ] = useState( defaultOpen ?? false );
+	const isOpen = open ?? internalIsOpen;
+
+	const handleToggle = ( willOpen: boolean ) => {
+		setInternalIsOpen( willOpen );
+		onToggle?.( willOpen );
+	};
+
+	const handleOverlayClick = ( event: React.MouseEvent ) => {
+		// Prevent click from propagating to elements beneath the overlay
+		event.stopPropagation();
+		handleToggle( false );
+	};
+
 	const isDesktop = useViewportMatch( 'medium' );
 	return (
-		<Dropdown
-			open={ open }
-			onToggle={ onToggle }
-			defaultOpen={ defaultOpen }
-			renderToggle={ ( { onToggle, isOpen } ) => (
-				<Button
-					className="dashboard-menu__item active"
-					icon={ chevronDownSmall }
-					iconPosition="right"
-					onClick={ () => onToggle() }
-					onKeyDown={ ( event: React.KeyboardEvent ) => {
-						if ( ! isOpen && event.code === 'ArrowDown' ) {
-							event.preventDefault();
-							onToggle();
-						}
-					} }
-					aria-haspopup="true"
-					aria-expanded={ isOpen }
-					style={ { width: '100%', justifyContent: 'flex-start' } }
-				>
-					<HStack
-						alignment="center"
-						style={ { overflow: 'hidden', maxWidth: isDesktop ? 'calc(30vw)' : '100%' } }
+		<>
+			{ isOpen &&
+				createPortal(
+					// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+					<div
+						className="dashboard-switcher-overlay"
+						data-testid="switcher-overlay"
+						onClick={ handleOverlayClick }
+					/>,
+					document.body
+				) }
+			<Dropdown
+				open={ open }
+				onToggle={ handleToggle }
+				defaultOpen={ defaultOpen }
+				renderToggle={ ( { onToggle, isOpen } ) => (
+					<Button
+						className="dashboard-menu__item active"
+						icon={ chevronDownSmall }
+						iconPosition="right"
+						onClick={ () => onToggle() }
+						onKeyDown={ ( event: React.KeyboardEvent ) => {
+							if ( ! isOpen && event.code === 'ArrowDown' ) {
+								event.preventDefault();
+								onToggle();
+							}
+						} }
+						aria-haspopup="true"
+						aria-expanded={ isOpen }
+						style={ { width: '100%', justifyContent: 'flex-start' } }
 					>
-						{ renderItemMedia( { item: value, context: 'dropdown', size: 16 } ) }
-						{ renderItemTitle( { item: value, context: 'dropdown' } ) }
-					</HStack>
-				</Button>
-			) }
-			renderContent={ ( { onClose } ) => (
-				<>
-					<ScrollLock />
-					<SwitcherContent
-						items={ items }
-						searchableFields={ searchableFields }
-						getItemUrl={ getItemUrl }
-						renderItemMedia={ renderItemMedia }
-						renderItemTitle={ renderItemTitle }
-						renderItemDescription={ renderItemDescription }
-						view={ view }
-						onChangeView={ setView }
-						onClose={ onClose }
-						onItemClick={ onItemClick }
-					>
-						{ children?.( { onClose } ) }
-					</SwitcherContent>
-				</>
-			) }
-		/>
+						<HStack
+							alignment="center"
+							style={ { overflow: 'hidden', maxWidth: isDesktop ? 'calc(30vw)' : '100%' } }
+						>
+							{ renderItemMedia( { item: value, context: 'dropdown', size: 16 } ) }
+							{ renderItemTitle( { item: value, context: 'dropdown' } ) }
+						</HStack>
+					</Button>
+				) }
+				renderContent={ ( { onClose } ) => (
+					<>
+						<ScrollLock />
+						<SwitcherContent
+							items={ items }
+							searchableFields={ searchableFields }
+							getItemUrl={ getItemUrl }
+							renderItemMedia={ renderItemMedia }
+							renderItemTitle={ renderItemTitle }
+							renderItemDescription={ renderItemDescription }
+							view={ view }
+							onChangeView={ setView }
+							onClose={ onClose }
+							onItemClick={ onItemClick }
+						>
+							{ children?.( { onClose } ) }
+						</SwitcherContent>
+					</>
+				) }
+			/>
+		</>
 	);
 }

--- a/client/dashboard/components/switcher/style.scss
+++ b/client/dashboard/components/switcher/style.scss
@@ -1,0 +1,8 @@
+.dashboard-switcher-overlay {
+	position: fixed;
+	inset: 0;
+	// WordPress Popover uses z-index around 1000000. Position overlay just below it
+	// so it captures clicks while the popover content remains interactive.
+	z-index: 999999;
+	background: transparent;
+}

--- a/client/dashboard/components/switcher/test/index.test.tsx
+++ b/client/dashboard/components/switcher/test/index.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import Switcher from '../index';
+
+type Item = { id: number; name: string };
+
+const mockItems: Item[] = [
+	{ id: 1, name: 'Site One' },
+	{ id: 2, name: 'Site Two' },
+	{ id: 3, name: 'Site Three' },
+];
+
+const searchableFields = [
+	{
+		id: 'name',
+		getValue: ( { item }: { item: Item } ) => item.name,
+	},
+];
+
+const defaultProps = {
+	items: mockItems,
+	value: mockItems[ 0 ],
+	searchableFields,
+	getItemUrl: ( item: Item ) => `/site/${ item.id }`,
+	renderItemMedia: () => <span data-testid="item-media">Icon</span>,
+	renderItemTitle: ( { item }: { item: Item } ) => <span>{ item.name }</span>,
+};
+
+describe( 'Switcher', () => {
+	describe( 'Click-outside overlay', () => {
+		test( 'renders overlay when dropdown is open', async () => {
+			const user = userEvent.setup();
+			render( <Switcher { ...defaultProps } /> );
+
+			// Overlay should not exist initially
+			expect( screen.queryByTestId( 'switcher-overlay' ) ).not.toBeInTheDocument();
+
+			// Open the dropdown
+			const toggleButton = screen.getByRole( 'button' );
+			await user.click( toggleButton );
+
+			// Overlay should now be present
+			await waitFor( () => {
+				expect( screen.getByTestId( 'switcher-overlay' ) ).toBeInTheDocument();
+			} );
+		} );
+
+		test( 'clicking overlay closes the dropdown', async () => {
+			const onToggle = jest.fn();
+			const user = userEvent.setup();
+			render( <Switcher { ...defaultProps } defaultOpen onToggle={ onToggle } /> );
+
+			// Find and click the overlay
+			const overlay = await screen.findByTestId( 'switcher-overlay' );
+			await user.click( overlay );
+
+			// onToggle should be called with false to close
+			expect( onToggle ).toHaveBeenCalledWith( false );
+		} );
+
+		test( 'clicking overlay does not propagate to elements beneath', async () => {
+			const onOuterClick = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+				<div onClick={ onOuterClick } data-testid="outer-container">
+					<Switcher { ...defaultProps } defaultOpen />
+				</div>
+			);
+
+			// Click the overlay
+			const overlay = await screen.findByTestId( 'switcher-overlay' );
+			await user.click( overlay );
+
+			// The outer container's click handler should not have been called
+			expect( onOuterClick ).not.toHaveBeenCalled();
+		} );
+
+		test( 'overlay is removed when dropdown closes', async () => {
+			const user = userEvent.setup();
+			render( <Switcher { ...defaultProps } /> );
+
+			// Open the dropdown
+			const toggleButton = screen.getByRole( 'button' );
+			await user.click( toggleButton );
+
+			// Overlay should be present
+			await waitFor( () => {
+				expect( screen.getByTestId( 'switcher-overlay' ) ).toBeInTheDocument();
+			} );
+
+			// Close by clicking toggle again
+			await user.click( toggleButton );
+
+			// Overlay should be removed
+			await waitFor( () => {
+				expect( screen.queryByTestId( 'switcher-overlay' ) ).not.toBeInTheDocument();
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
Part of DOTMSD-856

## Proposed Changes

- Add a transparent overlay that renders when the site switcher dropdown is open
- The overlay captures clicks and closes the dropdown without propagating to elements beneath
- Add unit tests for the overlay behavior

## Why are these changes being made?

On the Site Overview page (especially on small screens), clicking outside the site switcher dropdown to close it would also trigger clicks on elements beneath—typically tile cards that navigate the user away from the page. This creates a frustrating UX where users accidentally navigate away when they just wanted to close the dropdown.

The overlay intercepts these clicks, allowing the dropdown to close normally without triggering unintended navigation.

See: https://github.com/Automattic/wp-calypso/pull/107062#issuecomment-3524160058

## Testing Instructions

1. Go to the Dashboard Site Overview page
2. Open the site switcher dropdown
3. Click outside the dropdown (on a tile card area)
4. Verify the dropdown closes without navigating away
5. Test on mobile viewport sizes where this issue was most prominent

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?