### PR TITLE
A4A > Migrations: Add commission tagging improvements for migrations

### DIFF
--- a/client/a8c-for-agencies/components/agency-site-tags/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tags/index.tsx
@@ -2,7 +2,9 @@ import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { KeyboardEvent, useState } from 'react';
 import AgencySiteTag from 'calypso/a8c-for-agencies/components/agency-site-tag';
+import useCanTagSitesForCommission from 'calypso/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+
 import './style.scss';
 
 interface Props {
@@ -30,6 +32,12 @@ export default function AgencySiteTags( { tags, isLoading, onAddTags, onRemoveTa
 	};
 
 	const isTagsSubmitDisabled = tagsInput === '' || ! tagsInput;
+
+	const { migrationTags } = useCanTagSitesForCommission();
+
+	const isTagRemovable = ( tag: string ) => {
+		return ! migrationTags.includes( tag );
+	};
 
 	return (
 		<div className="agency-site-tags">
@@ -68,7 +76,7 @@ export default function AgencySiteTags( { tags, isLoading, onAddTags, onRemoveTa
 								key={ tag }
 								tag={ tag }
 								onRemoveTag={ onRemoveTag }
-								isRemovable={ tag !== 'a4a_self_migrated_site' }
+								isRemovable={ isTagRemovable( tag ) }
 							/>
 						</li>
 					) ) }

--- a/client/a8c-for-agencies/hooks/use-tag-sites-for-commission.ts
+++ b/client/a8c-for-agencies/hooks/use-tag-sites-for-commission.ts
@@ -1,0 +1,62 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import SiteTag from 'calypso/a8c-for-agencies/types/site-tag';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { APIError } from 'calypso/state/partner-portal/types';
+
+interface TagSitesForCommissionMutationOptions {
+	siteIds: number[];
+	tags: string[];
+	migrationSourceHost: string;
+}
+
+function mutationTagSitesForCommission( {
+	agencyId,
+	siteIds,
+	tags,
+	migrationSourceHost,
+}: TagSitesForCommissionMutationOptions & { agencyId: number | undefined } ): Promise<
+	Record< number, SiteTag[] | APIError >
+> {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to tag sites for commission' );
+	}
+
+	return wpcom.req.put( {
+		method: 'PUT',
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/sites/tag-for-commission`,
+		body: {
+			tags,
+			site_ids: siteIds,
+			migration_source_host: migrationSourceHost,
+		},
+	} );
+}
+
+export default function useTagSitesForCommissionMutation< TContext = unknown >(
+	options?: UseMutationOptions<
+		Record< number, SiteTag[] | APIError >,
+		APIError,
+		TagSitesForCommissionMutationOptions,
+		TContext
+	>
+): UseMutationResult<
+	Record< number, SiteTag[] | APIError >,
+	APIError,
+	TagSitesForCommissionMutationOptions,
+	TContext
+> {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation<
+		Record< number, SiteTag[] | APIError >,
+		APIError,
+		TagSitesForCommissionMutationOptions,
+		TContext
+	>( {
+		...options,
+		mutationFn: ( args ) => mutationTagSitesForCommission( { ...args, agencyId } ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
@@ -8,15 +8,15 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import useUpdateSiteTagsMutation from '../../sites/site-preview-pane/hooks/use-update-site-tags-mutation';
-import { A4A_MIGRATED_SITE_TAG } from '../lib/constants';
-import { TaggedSite } from '../types';
+import type { TaggedSite } from '../types';
 
 type Props = {
 	site: TaggedSite;
 	fetchMigratedSites: () => void;
+	migrationTags: string[];
 };
 
-const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
+const CommissionListActions = ( { fetchMigratedSites, site, migrationTags }: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -39,9 +39,9 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 
 	const onRemoveSite = useCallback( () => {
 		closeDropdown();
-		// Removing the A4A_MIGRATED_SITE_TAG tag only
+		// Removing the migration tags only
 		const newTags = site.tags.reduce( ( acc, tag ) => {
-			if ( tag.name === A4A_MIGRATED_SITE_TAG ) {
+			if ( migrationTags.includes( tag.name ) ) {
 				return acc;
 			}
 			acc.push( tag.name );
@@ -66,11 +66,13 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 			}
 		);
 	}, [
-		fetchMigratedSites,
-		mutate,
-		site,
 		closeDropdown,
-		setShowRemoveSiteDialog,
+		site.tags,
+		site.id,
+		site.url,
+		mutate,
+		migrationTags,
+		fetchMigratedSites,
 		dispatch,
 		translate,
 	] );

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -13,9 +13,11 @@ import type { Field } from '@wordpress/dataviews';
 export default function MigrationsCommissionsList( {
 	items,
 	fetchMigratedSites,
+	migrationTags,
 }: {
 	items: TaggedSite[];
 	fetchMigratedSites: () => void;
+	migrationTags: string[];
 } ) {
 	const translate = useTranslate();
 
@@ -66,12 +68,16 @@ export default function MigrationsCommissionsList( {
 				label: translate( 'Actions' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: TaggedSite } ) => (
-					<CommissionListActions fetchMigratedSites={ fetchMigratedSites } site={ item } />
+					<CommissionListActions
+						fetchMigratedSites={ fetchMigratedSites }
+						site={ item }
+						migrationTags={ migrationTags }
+					/>
 				),
 				enableSorting: false,
 			},
 		],
-		[ translate, fetchMigratedSites ]
+		[ translate, fetchMigratedSites, migrationTags ]
 	);
 
 	if ( ! isDesktop ) {

--- a/client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Run: yarn test-client client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+import {
+	A4A_MIGRATED_SITE_TAG,
+	A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
+} from '../../lib/constants';
+import useCanTagSitesForCommission from '../use-can-tag-sites-for-commission';
+
+jest.mock( 'react-redux', () => ( {
+	useSelector: jest.fn(),
+} ) );
+
+function mockActiveAgency( overrides: Record< string, unknown > = {} ) {
+	return {
+		id: 1,
+		name: 'Test Agency',
+		third_party: {
+			pressable: {
+				usage: {
+					start_date: undefined,
+					end_date: undefined,
+				},
+			},
+		},
+		...overrides,
+	};
+}
+
+function createState( activeAgency: ReturnType< typeof mockActiveAgency > | null ) {
+	return {
+		a8cForAgencies: {
+			agencies: {
+				activeAgency,
+			},
+		},
+	};
+}
+
+describe( 'useCanTagSitesForCommission', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns canTagSitesForCommission true and includes incentive tag when no start_date', () => {
+		const agency = mockActiveAgency();
+		jest
+			.mocked( useSelector )
+			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
+				selector( createState( agency ) )
+			);
+
+		const { result } = renderHook( () => useCanTagSitesForCommission() );
+
+		expect( result.current.canTagSitesForCommission ).toBe( true );
+		expect( result.current.migrationTags ).toEqual( [
+			A4A_MIGRATED_SITE_TAG,
+			A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
+		] );
+	} );
+
+	it( 'returns canTagSitesForCommission true when start_date is on or before cutoff (2025-08-11)', () => {
+		const agency = mockActiveAgency( {
+			third_party: {
+				pressable: {
+					usage: { start_date: '2025-08-11T00:00:00Z', end_date: null },
+				},
+			},
+		} );
+		jest
+			.mocked( useSelector )
+			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
+				selector( createState( agency ) )
+			);
+
+		const { result } = renderHook( () => useCanTagSitesForCommission() );
+
+		expect( result.current.canTagSitesForCommission ).toBe( true );
+		expect( result.current.migrationTags ).toContain(
+			A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026
+		);
+	} );
+
+	it( 'returns canTagSitesForCommission true when start_date is before cutoff', () => {
+		const agency = mockActiveAgency( {
+			third_party: {
+				pressable: {
+					usage: { start_date: '2025-08-10', end_date: null },
+				},
+			},
+		} );
+		jest
+			.mocked( useSelector )
+			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
+				selector( createState( agency ) )
+			);
+
+		const { result } = renderHook( () => useCanTagSitesForCommission() );
+
+		expect( result.current.canTagSitesForCommission ).toBe( true );
+		expect( result.current.migrationTags ).toEqual( [
+			A4A_MIGRATED_SITE_TAG,
+			A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
+		] );
+	} );
+
+	it( 'returns canTagSitesForCommission false when start_date is after cutoff', () => {
+		const agency = mockActiveAgency( {
+			third_party: {
+				pressable: {
+					usage: { start_date: '2025-08-12', end_date: null },
+				},
+			},
+		} );
+		jest
+			.mocked( useSelector )
+			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
+				selector( createState( agency ) )
+			);
+
+		const { result } = renderHook( () => useCanTagSitesForCommission() );
+
+		expect( result.current.canTagSitesForCommission ).toBe( false );
+		expect( result.current.migrationTags ).toEqual( [ A4A_MIGRATED_SITE_TAG ] );
+	} );
+
+	it( 'returns canTagSitesForCommission true when start_date is empty string', () => {
+		const agency = mockActiveAgency( {
+			third_party: {
+				pressable: {
+					usage: { start_date: '', end_date: null },
+				},
+			},
+		} );
+		jest
+			.mocked( useSelector )
+			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
+				selector( createState( agency ) )
+			);
+
+		const { result } = renderHook( () => useCanTagSitesForCommission() );
+
+		expect( result.current.canTagSitesForCommission ).toBe( true );
+		expect( result.current.migrationTags ).toContain(
+			A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026
+		);
+	} );
+} );

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
+import { A4A_MIGRATED_SITE_TAG, A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE } from '../lib/constants';
+
+export default function useCanTagSitesForCommission(): {
+	canTagSitesForCommission: boolean;
+	migrationTags: string[];
+} {
+	const pressableOwnership = usePressableOwnershipType();
+	const canTagPressableSitesForCommission = pressableOwnership !== 'agency';
+
+	return useMemo( () => {
+		const migrationTags = [
+			A4A_MIGRATED_SITE_TAG,
+			...( canTagPressableSitesForCommission ? [ A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE ] : [] ),
+		];
+		return {
+			canTagSitesForCommission: canTagPressableSitesForCommission,
+			migrationTags,
+		};
+	}, [ canTagPressableSitesForCommission ] );
+}

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
@@ -1,6 +1,9 @@
 import { useMemo } from 'react';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
-import { A4A_MIGRATED_SITE_TAG, A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE } from '../lib/constants';
+import {
+	A4A_MIGRATED_SITE_TAG,
+	A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
+} from '../lib/constants';
 
 export default function useCanTagSitesForCommission(): {
 	canTagSitesForCommission: boolean;
@@ -12,7 +15,9 @@ export default function useCanTagSitesForCommission(): {
 	return useMemo( () => {
 		const migrationTags = [
 			A4A_MIGRATED_SITE_TAG,
-			...( canTagPressableSitesForCommission ? [ A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE ] : [] ),
+			...( canTagPressableSitesForCommission
+				? [ A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026 ]
+				: [] ),
 		];
 		return {
 			canTagSitesForCommission: canTagPressableSitesForCommission,

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
@@ -1,27 +1,44 @@
 import { useMemo } from 'react';
-import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
+import { useSelector } from 'react-redux';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import {
 	A4A_MIGRATED_SITE_TAG,
 	A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
+	PRESSABLE_LAST_PURCHASE_CUTOFF_DATE,
 } from '../lib/constants';
+
+/**
+ * Returns true if the user is eligible to see migration tagging based on Pressable usage start_date.
+ * If start_date is not found, always allow (show). Otherwise allow only if start_date is on or before the cut-off.
+ * E.g. start_date '2025-12-17' (Dec) > cutoff '2025-08-11' (Aug) → false (do not show).
+ *      start_date '2025-08-10' (Aug 10) <= cutoff → true (show).
+ */
+function isWithinPressablePurchaseCutoff( startDate: string | undefined | null ): boolean {
+	if ( startDate == null || startDate === '' ) {
+		return true;
+	}
+	const datePart = startDate.slice( 0, 10 );
+	return datePart <= PRESSABLE_LAST_PURCHASE_CUTOFF_DATE;
+}
 
 export default function useCanTagSitesForCommission(): {
 	canTagSitesForCommission: boolean;
 	migrationTags: string[];
 } {
-	const pressableOwnership = usePressableOwnershipType();
-	const canTagPressableSitesForCommission = pressableOwnership !== 'agency';
+	const activeAgency = useSelector( getActiveAgency );
+
+	const pressableUsageStartDate = activeAgency?.third_party?.pressable?.usage?.start_date;
+	const withinPurchaseCutoff = isWithinPressablePurchaseCutoff( pressableUsageStartDate );
 
 	return useMemo( () => {
+		const canTagSitesForCommission = withinPurchaseCutoff;
 		const migrationTags = [
 			A4A_MIGRATED_SITE_TAG,
-			...( canTagPressableSitesForCommission
-				? [ A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026 ]
-				: [] ),
+			...( canTagSitesForCommission ? [ A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026 ] : [] ),
 		];
 		return {
-			canTagSitesForCommission: canTagPressableSitesForCommission,
+			canTagSitesForCommission,
 			migrationTags,
 		};
-	}, [ canTagPressableSitesForCommission ] );
+	}, [ withinPurchaseCutoff ] );
 }

--- a/client/a8c-for-agencies/sections/migrations/lib/constants.ts
+++ b/client/a8c-for-agencies/sections/migrations/lib/constants.ts
@@ -1,7 +1,3 @@
 export const A4A_MIGRATED_SITE_TAG = 'a4a_self_migrated_site';
-export const A4A_MIGRATED_SITE_VERIFIED = 'a4a_self_migrated_site_verified';
-export const A4A_MIGRATED_SITE_REJECTED = 'a4a_self_migrated_site_rejected';
-export const A4A_MIGRATED_TYPE_WPE = 'a4a_self_migrated_type_wpe';
-export const A4A_MIGRATED_TYPE_STANDARD = 'a4a_self_migrated_type_standard';
-export const A4A_MIGRATED_STATUS_PAID = 'a4a_self_migrated_status_paid';
-export const A4A_MIGRATED_STATUS_UNPAID = 'a4a_self_migrated_status_unpaid';
+export const A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE =
+	'a4a_self_migrated_site_pressable_incentive';

--- a/client/a8c-for-agencies/sections/migrations/lib/constants.ts
+++ b/client/a8c-for-agencies/sections/migrations/lib/constants.ts
@@ -1,3 +1,3 @@
 export const A4A_MIGRATED_SITE_TAG = 'a4a_self_migrated_site';
-export const A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE =
-	'a4a_self_migrated_site_pressable_incentive';
+export const A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026 =
+	'a4a_self_migrated_site_pressable_incentive_2026';

--- a/client/a8c-for-agencies/sections/migrations/lib/constants.ts
+++ b/client/a8c-for-agencies/sections/migrations/lib/constants.ts
@@ -1,3 +1,9 @@
 export const A4A_MIGRATED_SITE_TAG = 'a4a_self_migrated_site';
 export const A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026 =
 	'a4a_self_migrated_site_pressable_incentive_2026';
+
+/**
+ * Cut-off date for Pressable subscription start_date.
+ * Users with a Pressable purchase (subscription start) after this date do not see the migration tagging option.
+ */
+export const PRESSABLE_LAST_PURCHASE_CUTOFF_DATE = '2025-08-11';

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/empty-state.tsx
@@ -9,8 +9,10 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export default function MigrationsCommissionsEmptyState( {
 	setShowAddSitesModal,
+	canTagSitesForCommission,
 }: {
 	setShowAddSitesModal: ( show: boolean ) => void;
+	canTagSitesForCommission: boolean;
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -34,47 +36,49 @@ export default function MigrationsCommissionsEmptyState( {
 					)
 				) }
 			/>
-			<StepSectionItem
-				heading={ translate( 'Tag your transferred sites so we can pay you for them.' ) }
-				description={
-					<>
-						{ translate(
-							'If you transferred sites by yourself, follow these two steps to indicate which ones we should pay you for.'
-						) }
+			{ canTagSitesForCommission && (
+				<StepSectionItem
+					heading={ translate( 'Tag your transferred sites so we can pay you for them.' ) }
+					description={
+						<>
+							{ translate(
+								'If you transferred sites by yourself, follow these two steps to indicate which ones we should pay you for.'
+							) }
 
-						<ul>
-							<li>
-								{ translate(
-									'Ensure the {{a}}Automattic for Agencies plugin{{/a}} ↗ is installed and connected to each site.',
-									{
-										components: {
-											a: (
-												<a
-													target="_blank"
-													href={ a4aPluginUrl }
-													onClick={ () => {
-														dispatch(
-															recordTracksEvent(
-																'calypso_a8c_migrations_commissions_a4a_plugin_link_click'
-															)
-														);
-													} }
-													rel="noopener noreferrer"
-												/>
-											),
-										},
-									}
-								) }
-							</li>
-							<li>{ translate( 'Tag the connected sites using the button below.' ) }</li>
-						</ul>
+							<ul>
+								<li>
+									{ translate(
+										'Ensure the {{a}}Automattic for Agencies plugin{{/a}} ↗ is installed and connected to each site.',
+										{
+											components: {
+												a: (
+													<a
+														target="_blank"
+														href={ a4aPluginUrl }
+														onClick={ () => {
+															dispatch(
+																recordTracksEvent(
+																	'calypso_a8c_migrations_commissions_a4a_plugin_link_click'
+																)
+															);
+														} }
+														rel="noopener noreferrer"
+													/>
+												),
+											},
+										}
+									) }
+								</li>
+								<li>{ translate( 'Tag the connected sites using the button below.' ) }</li>
+							</ul>
 
-						<Button variant="primary" onClick={ onTagMySelfMigratedSitesClick }>
-							{ translate( 'Tag my self-migrated sites' ) }
-						</Button>
-					</>
-				}
-			/>
+							<Button variant="primary" onClick={ onTagMySelfMigratedSitesClick }>
+								{ translate( 'Tag my self-migrated sites' ) }
+							</Button>
+						</>
+					}
+				/>
+			) }
 		</StepSection>
 	);
 }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -17,6 +17,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MigrationsCommissionsList from '../../commissions-list';
 import MigrationsConsolidatedCommissions from '../../consolidated-commissions';
+import useCanTagSitesForCommission from '../../hooks/use-can-tag-sites-for-commission';
 import useFetchTaggedSitesForMigration from '../../hooks/use-fetch-tagged-sites-for-migration';
 import MigrationsTagSitesModal from '../../tag-sites-modal';
 import MigrationsCommissionsEmptyState from './empty-state';
@@ -28,6 +29,7 @@ export default function MigrationsCommissions() {
 	const dispatch = useDispatch();
 
 	const [ showAddSitesModal, setShowAddSitesModal ] = useState( false );
+	const { canTagSitesForCommission, migrationTags } = useCanTagSitesForCommission();
 
 	const title = translate( 'Migrations: Commissions' );
 
@@ -55,17 +57,28 @@ export default function MigrationsCommissions() {
 		}
 
 		return showEmptyState ? (
-			<MigrationsCommissionsEmptyState setShowAddSitesModal={ setShowAddSitesModal } />
+			<MigrationsCommissionsEmptyState
+				setShowAddSitesModal={ setShowAddSitesModal }
+				canTagSitesForCommission={ canTagSitesForCommission }
+			/>
 		) : (
 			<div className="migrations-commissions__content">
 				<MigrationsConsolidatedCommissions items={ taggedSites } />
 				<MigrationsCommissionsList
 					items={ taggedSites }
 					fetchMigratedSites={ fetchMigratedSites }
+					migrationTags={ migrationTags }
 				/>
 			</div>
 		);
-	}, [ isLoading, showEmptyState, taggedSites, setShowAddSitesModal, fetchMigratedSites ] );
+	}, [
+		isLoading,
+		showEmptyState,
+		canTagSitesForCommission,
+		taggedSites,
+		fetchMigratedSites,
+		migrationTags,
+	] );
 
 	return (
 		<Layout
@@ -92,9 +105,11 @@ export default function MigrationsCommissions() {
 					/>
 					<Actions useColumnAlignment>
 						<MobileSidebarNavigation />
-						<Button variant="primary" onClick={ onTagSitesClick }>
-							{ translate( 'Tag sites for commission' ) }
-						</Button>
+						{ canTagSitesForCommission && (
+							<Button variant="primary" onClick={ onTagSitesClick }>
+								{ translate( 'Tag sites for commission' ) }
+							</Button>
+						) }
 					</Actions>
 				</LayoutHeader>
 			</LayoutTop>
@@ -107,6 +122,7 @@ export default function MigrationsCommissions() {
 							onClose={ () => setShowAddSitesModal( false ) }
 							taggedSites={ taggedSites }
 							fetchMigratedSites={ fetchMigratedSites }
+							migrationTags={ migrationTags }
 						/>
 					) }
 				</>

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/add-sites-table.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/add-sites-table.tsx
@@ -1,5 +1,9 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
-import { CheckboxControl } from '@wordpress/components';
+import {
+	BaseControl,
+	CheckboxControl,
+	__experimentalSpacer as Spacer,
+} from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
@@ -19,10 +23,12 @@ export default function MigrationsAddSitesTable( {
 	selectedSites,
 	setSelectedSites,
 	taggedSites,
+	migrationSourceHost,
 }: {
 	selectedSites: SiteItem[];
 	setSelectedSites: ( sites: SiteItem[] ) => void;
 	taggedSites?: TaggedSite[];
+	migrationSourceHost: string;
 } ) {
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
@@ -137,23 +143,37 @@ export default function MigrationsAddSitesTable( {
 
 	return (
 		<div className="add-sites-table redesigned-a8c-table">
-			{ isLoading ? (
-				<A4ATablePlaceholder />
-			) : (
-				<ItemsDataViews
-					data={ {
-						items: allSites,
-						fields,
-						getItemId: ( item ) => `${ item.id }`,
-						pagination: paginationInfo,
-						enableSearch: false,
-						actions: [],
-						dataViewsState: dataViewsState,
-						setDataViewsState: setDataViewsState,
-						defaultLayouts: { table: {} },
-					} }
-				/>
-			) }
+			<BaseControl
+				label={ translate( 'Select sites to tag' ) }
+				className="migrations-tag-sites-modal__table-control"
+			>
+				{ migrationSourceHost && (
+					<Spacer margin={ 4 }>
+						<div className="migrations-tag-sites-modal__instruction">
+							{ translate( 'Make sure you only select sites previously hosted on %s', {
+								args: [ migrationSourceHost ],
+							} ) }
+						</div>
+					</Spacer>
+				) }
+				{ isLoading ? (
+					<A4ATablePlaceholder />
+				) : (
+					<ItemsDataViews
+						data={ {
+							items: allSites,
+							fields,
+							getItemId: ( item ) => `${ item.id }`,
+							pagination: paginationInfo,
+							enableSearch: false,
+							actions: [],
+							dataViewsState: dataViewsState,
+							setDataViewsState: setDataViewsState,
+							defaultLayouts: { table: {} },
+						} }
+					/>
+				) }
+			</BaseControl>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/add-sites-table.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/add-sites-table.tsx
@@ -148,7 +148,7 @@ export default function MigrationsAddSitesTable( {
 				className="migrations-tag-sites-modal__table-control"
 			>
 				{ migrationSourceHost && (
-					<Spacer margin={ 4 }>
+					<Spacer marginY={ 4 }>
 						<div className="migrations-tag-sites-modal__instruction">
 							{ translate( 'Make sure you only select sites previously hosted on %s', {
 								args: [ migrationSourceHost ],

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
@@ -35,10 +35,6 @@ export default function MigrationsTagSitesModal( {
 
 	const migrationSourceOptions = [
 		{ label: translate( 'Select a host' ), value: '' },
-		{ label: translate( 'WordPress.com Hosting' ), value: 'wpcom' },
-		{ label: translate( 'Automattic' ), value: 'automattic' },
-		{ label: translate( 'Pressable' ), value: 'pressable' },
-		{ label: translate( 'WP Cloud' ), value: 'wpcloud' },
 		{ label: translate( 'Kinsta' ), value: 'kinsta' },
 		{ label: translate( 'WP Engine' ), value: 'wpengine' },
 		{ label: translate( 'Pantheon' ), value: 'pantheon' },
@@ -106,6 +102,9 @@ export default function MigrationsTagSitesModal( {
 		dispatch( recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_close' ) );
 	};
 
+	const selectedMigrationSourceHost =
+		migrationSourceOptions.find( ( option ) => option.value === migrationSourceHost )?.label ?? '';
+
 	return (
 		<A4AModal
 			onClose={ handleOnClose }
@@ -152,7 +151,7 @@ export default function MigrationsTagSitesModal( {
 					taggedSites={ taggedSites }
 					selectedSites={ selectedSites }
 					setSelectedSites={ setSelectedSites }
-					migrationSourceHost={ migrationSourceHost }
+					migrationSourceHost={ selectedMigrationSourceHost }
 				/>
 			) }
 		</A4AModal>

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
@@ -1,4 +1,9 @@
-import { Button, SelectControl, __experimentalSpacer as Spacer } from '@wordpress/components';
+import {
+	Button,
+	SelectControl,
+	TextControl,
+	__experimentalSpacer as Spacer,
+} from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -32,25 +37,34 @@ export default function MigrationsTagSitesModal( {
 
 	const [ selectedSites, setSelectedSites ] = useState< SiteItem[] | [] >( [] );
 	const [ migrationSourceHost, setMigrationSourceHost ] = useState( '' );
+	const [ otherHostingProvider, setOtherHostingProvider ] = useState( '' );
+
+	const OTHER_OPTION_VALUE = 'other';
 
 	const migrationSourceOptions = [
 		{ label: translate( 'Select a host' ), value: '' },
-		{ label: translate( 'Kinsta' ), value: 'kinsta' },
 		{ label: translate( 'WP Engine' ), value: 'wpengine' },
+		{ label: translate( 'Kinsta' ), value: 'kinsta' },
 		{ label: translate( 'Pantheon' ), value: 'pantheon' },
-		{ label: translate( 'Nexcess' ), value: 'nexcess' },
-		{ label: translate( 'Pagely' ), value: 'pagely' },
-		{ label: translate( 'Wix' ), value: 'Wix' },
-		{ label: translate( 'Squarespace Hosted' ), value: 'squarespace' },
-		{ label: translate( 'Shopify Hosted' ), value: 'shopify' },
+		{ label: translate( 'Cloudways' ), value: 'cloudways' },
+		{ label: translate( 'SiteGround' ), value: 'siteground' },
+		{ label: translate( 'Bluehost' ), value: 'bluehost' },
+		{ label: translate( 'Liquid Web' ), value: 'liquidweb' },
+		{ label: translate( 'Other' ), value: OTHER_OPTION_VALUE },
 	];
+
+	const isOtherSelected = migrationSourceHost === OTHER_OPTION_VALUE;
+	const finalMigrationSourceHost = isOtherSelected ? otherHostingProvider : migrationSourceHost;
+	const isValidHostingProvider = isOtherSelected
+		? otherHostingProvider.trim().length > 0
+		: migrationSourceHost.length > 0;
 
 	const handleAddSites = () => {
 		tagSitesForMigration(
 			{
 				siteIds: selectedSites.map( ( site ) => site.id ),
 				tags: migrationTags,
-				migrationSourceHost,
+				migrationSourceHost: finalMigrationSourceHost,
 			},
 			{
 				onSuccess: () => {
@@ -59,7 +73,7 @@ export default function MigrationsTagSitesModal( {
 					dispatch(
 						recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_add_sites_success', {
 							count: selectedSites.length,
-							migration_source_host: migrationSourceHost,
+							migration_source_host: finalMigrationSourceHost,
 						} )
 					);
 					const hasSingleSite = selectedSites.length === 1;
@@ -92,7 +106,7 @@ export default function MigrationsTagSitesModal( {
 		dispatch(
 			recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_add_sites_click', {
 				count: selectedSites.length,
-				migration_source_host: migrationSourceHost,
+				migration_source_host: finalMigrationSourceHost,
 			} )
 		);
 	};
@@ -102,8 +116,17 @@ export default function MigrationsTagSitesModal( {
 		dispatch( recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_close' ) );
 	};
 
-	const selectedMigrationSourceHost =
-		migrationSourceOptions.find( ( option ) => option.value === migrationSourceHost )?.label ?? '';
+	const handleMigrationSourceHostChange = ( value: string ) => {
+		setMigrationSourceHost( value );
+		if ( value !== OTHER_OPTION_VALUE ) {
+			setOtherHostingProvider( '' );
+		}
+	};
+
+	const selectedMigrationSourceHost = isOtherSelected
+		? otherHostingProvider
+		: migrationSourceOptions.find( ( option ) => option.value === migrationSourceHost )?.label ??
+		  '';
 
 	return (
 		<A4AModal
@@ -112,7 +135,7 @@ export default function MigrationsTagSitesModal( {
 				<Button
 					variant="primary"
 					onClick={ handleAddSites }
-					disabled={ isPending || ! migrationSourceHost || selectedSites.length === 0 }
+					disabled={ isPending || ! isValidHostingProvider || selectedSites.length === 0 }
 					isBusy={ isPending }
 				>
 					{ selectedSites.length > 0
@@ -144,9 +167,20 @@ export default function MigrationsTagSitesModal( {
 				label={ translate( 'Hosting provider' ) }
 				value={ migrationSourceHost }
 				options={ migrationSourceOptions }
-				onChange={ ( value ) => setMigrationSourceHost( value ) }
+				onChange={ handleMigrationSourceHostChange }
 			/>
-			{ migrationSourceHost && (
+			{ isOtherSelected && (
+				<>
+					<Spacer marginBottom={ 4 } />
+					<TextControl
+						label={ translate( 'Other hosting provider' ) }
+						value={ otherHostingProvider }
+						onChange={ setOtherHostingProvider }
+						placeholder={ translate( 'Enter hosting provider name' ) }
+					/>
+				</>
+			) }
+			{ isValidHostingProvider && (
 				<MigrationsAddSitesTable
 					taggedSites={ taggedSites }
 					selectedSites={ selectedSites }

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, SelectControl, __experimentalSpacer as Spacer } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -7,8 +7,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import useUpdateTagsForSitesMutation from '../../../hooks/use-update-tags-for-sites';
-import { A4A_MIGRATED_SITE_TAG } from '../lib/constants';
+import useTagSitesForCommissionMutation from '../../../hooks/use-tag-sites-for-commission';
 import MigrationsAddSitesTable from './add-sites-table';
 import type { SiteItem } from '../hooks/use-fetch-all-managed-sites-for-commission';
 import type { TaggedSite } from '../types';
@@ -19,23 +18,43 @@ export default function MigrationsTagSitesModal( {
 	onClose,
 	taggedSites,
 	fetchMigratedSites,
+	migrationTags,
 }: {
 	onClose: () => void;
 	taggedSites?: TaggedSite[];
 	fetchMigratedSites: () => void;
+	migrationTags: string[];
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { mutate: tagSitesForMigration, isPending } = useUpdateTagsForSitesMutation();
+	const { mutate: tagSitesForMigration, isPending } = useTagSitesForCommissionMutation();
 
 	const [ selectedSites, setSelectedSites ] = useState< SiteItem[] | [] >( [] );
+	const [ migrationSourceHost, setMigrationSourceHost ] = useState( '' );
+
+	const migrationSourceOptions = [
+		{ label: translate( 'Select a host' ), value: '' },
+		{ label: translate( 'WordPress.com Hosting' ), value: 'wpcom' },
+		{ label: translate( 'Automattic' ), value: 'automattic' },
+		{ label: translate( 'Pressable' ), value: 'pressable' },
+		{ label: translate( 'WP Cloud' ), value: 'wpcloud' },
+		{ label: translate( 'Kinsta' ), value: 'kinsta' },
+		{ label: translate( 'WP Engine' ), value: 'wpengine' },
+		{ label: translate( 'Pantheon' ), value: 'pantheon' },
+		{ label: translate( 'Nexcess' ), value: 'nexcess' },
+		{ label: translate( 'Pagely' ), value: 'pagely' },
+		{ label: translate( 'Wix' ), value: 'Wix' },
+		{ label: translate( 'Squarespace Hosted' ), value: 'squarespace' },
+		{ label: translate( 'Shopify Hosted' ), value: 'shopify' },
+	];
 
 	const handleAddSites = () => {
 		tagSitesForMigration(
 			{
 				siteIds: selectedSites.map( ( site ) => site.id ),
-				tags: [ A4A_MIGRATED_SITE_TAG ],
+				tags: migrationTags,
+				migrationSourceHost,
 			},
 			{
 				onSuccess: () => {
@@ -44,6 +63,7 @@ export default function MigrationsTagSitesModal( {
 					dispatch(
 						recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_add_sites_success', {
 							count: selectedSites.length,
+							migration_source_host: migrationSourceHost,
 						} )
 					);
 					const hasSingleSite = selectedSites.length === 1;
@@ -76,6 +96,7 @@ export default function MigrationsTagSitesModal( {
 		dispatch(
 			recordTracksEvent( 'calypso_a8c_migrations_tag_sites_modal_add_sites_click', {
 				count: selectedSites.length,
+				migration_source_host: migrationSourceHost,
 			} )
 		);
 	};
@@ -92,7 +113,7 @@ export default function MigrationsTagSitesModal( {
 				<Button
 					variant="primary"
 					onClick={ handleAddSites }
-					disabled={ isPending }
+					disabled={ isPending || ! migrationSourceHost || selectedSites.length === 0 }
 					isBusy={ isPending }
 				>
 					{ selectedSites.length > 0
@@ -119,11 +140,21 @@ export default function MigrationsTagSitesModal( {
 					)
 				) }
 			</div>
-			<MigrationsAddSitesTable
-				taggedSites={ taggedSites }
-				selectedSites={ selectedSites }
-				setSelectedSites={ setSelectedSites }
+			<Spacer marginBottom={ 4 } />
+			<SelectControl
+				label={ translate( 'Hosting provider' ) }
+				value={ migrationSourceHost }
+				options={ migrationSourceOptions }
+				onChange={ ( value ) => setMigrationSourceHost( value ) }
 			/>
+			{ migrationSourceHost && (
+				<MigrationsAddSitesTable
+					taggedSites={ taggedSites }
+					selectedSites={ selectedSites }
+					setSelectedSites={ setSelectedSites }
+					migrationSourceHost={ migrationSourceHost }
+				/>
+			) }
 		</A4AModal>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

### Commission tagging API

- New hook use-tag-sites-for-commission.ts that calls PUT /agency/{id}/sites/tag-for-commission with siteIds, tags, and migrationSourceHost (replacing the previous tag-update flow for this flow).

### Tag sites modal (Migrations → Commission)

- Hosting provider dropdown: WP Engine, Kinsta, Pantheon, Cloudways, SiteGround, Bluehost, Liquid Web, and Other.

- “Other” shows a free-text field; value is sent as migrationSourceHost. Primary action is disabled if “Other” is selected and the text field is empty.

- Modal uses the new commission tagging hook and passes the selected hosting provider.

###  Pressable cutoff for migration tagging

- New hook use-can-tag-sites-for-commission.ts: reads activeAgency?.third_party?.pressable?.usage?.start_date and only allows migration tagging when there is no Pressable subscription start after the cutoff (i.e. start_date on or before PRESSABLE_LAST_PURCHASE_CUTOFF_DATE). Missing or empty start_date is treated as eligible.

- Constants in migrations/lib/constants.ts: PRESSABLE_LAST_PURCHASE_CUTOFF_DATE (e.g. '2026-08-11') and A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026. Commission list and tag-sites modal use migrationTags from the hook so the Pressable incentive tag is only applied when within the cutoff.

### Tests

- Tests for useCanTagSitesForCommission: no start_date, on/before cutoff, after cutoff, null agency, empty start_date. Run with:
yarn test-client client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts

### Other

- The commission list and migrations-commissions empty state use the new hook for eligibility and tag list. Agency site tags component uses migrationTags from the same hook.


## Testing Instructions

* Navigate to Migrations > Commissions section
* Verify that the "Tag sites for commission" button appears/disappears based on eligibility
* Test tagging sites and verify the correct migration tags are applied
* Test removing tags from sites and verify only migration tags are removed
* Verify empty state displays correctly when no sites are tagged

<img width="785" height="646" alt="Screenshot 2026-02-11 at 9 57 05 PM" src="https://github.com/user-attachments/assets/404fd8f9-e589-4ae0-8062-da884ecc4e50" />
<img width="785" height="646" alt="Screenshot 2026-02-11 at 9 57 13 PM" src="https://github.com/user-attachments/assets/4815e64a-354f-4853-a223-2162c15dbd9a" />
<img width="785" height="646" alt="Screenshot 2026-02-11 at 9 57 33 PM" src="https://github.com/user-attachments/assets/551be459-1a3a-47ab-97a7-aaa979f8bc2e" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
