### PR TITLE
Stepper: Skip rendering Help Center in CIAB flows

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -3,6 +3,12 @@ import accessibleFocus from '@automattic/accessible-focus';
 import { initializeAnalytics } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { UserActions, User as UserStore } from '@automattic/data-stores';
+import {
+	AI_SITE_BUILDER_FLOW,
+	AI_SITE_BUILDER_SPEC_FLOW,
+	DOMAIN_FLOW,
+	WOO_HOSTED_PLANS_FLOW,
+} from '@automattic/onboarding';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { dispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
@@ -60,6 +66,19 @@ const getSiteIdFromURL = () => {
 	const siteId = new URLSearchParams( window.location.search ).get( 'siteId' );
 	return siteId ? Number( siteId ) : null;
 };
+
+/**
+ * Flows that should not render the Help Center. The stepper has no masterbar or help button, so
+ * the Help Center can only auto-open from persisted preferences in these flows, which is
+ * disruptive. Flows that programmatically open the Help Center (e.g., hundred-year-plan,
+ * do-it-for-me) should NOT be added to this set.
+ */
+const FLOWS_WITHOUT_HELP_CENTER = new Set< string >( [
+	AI_SITE_BUILDER_FLOW,
+	AI_SITE_BUILDER_SPEC_FLOW,
+	DOMAIN_FLOW,
+	WOO_HOSTED_PLANS_FLOW,
+] );
 
 async function main() {
 	const { pathname, search } = window.location;
@@ -176,7 +195,12 @@ async function main() {
 							id="notices"
 						/>
 					</BrowserRouter>
-					<AsyncHelpCenterApp currentUser={ user as UserStore.CurrentUser } sectionName="stepper" />
+					{ ! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) && (
+						<AsyncHelpCenterApp
+							currentUser={ user as UserStore.CurrentUser }
+							sectionName="stepper"
+						/>
+					) }
 					{ 'development' === process.env.NODE_ENV && (
 						<AsyncLoad require="calypso/components/webpack-build-monitor" placeholder={ null } />
 					) }


### PR DESCRIPTION
Part of WOOPRD-2254

## Proposed Changes

* Conditionally skip rendering `AsyncHelpCenterApp` for stepper flows that we are sure should not show the Help Center for now: `ai-site-builder`, `ai-site-builder-spec`, `domain`, and `woo-hosted-plans`.

## Why are these changes being made?

The Help Center persists its open/closed state via a `help_center_open` preference. Stepper flows have no masterbar or help button, so the Help Center can only appear through this auto-open mechanism. In the CIAB experience, this is disruptive and unwanted.

Rather than removing the Help Center from all stepper flows (which would break flows like `hundred-year-plan` and `do-it-for-me` that programmatically open it), or using the `hidden` prop (which still mounts the component tree and makes network requests), we skip rendering the component entirely for the affected flows.

## Testing Instructions

1. Set `help_center_open` to `true` in preferences (via browser console or API, or simply open a wordpres.com/sites tab and open the Help Center there).
2. Navigate to each affected URL and confirm the Help Center does **not** appear:
   - `/setup/ai-site-builder-spec/site-spec?source=ciab-sites-dashboard`
   - `/setup/ai-site-builder/processing?create_garden_site=1`
   - `/setup/woo-hosted-plans/plans?siteSlug=<any-site>`
   - `/setup/domain/domains?siteSlug=<any-site>`
3. Confirm the Help Center still works in flows that use it programmatically:
   - `/setup/hundred-year-plan/...` — "Contact us" link should still open Help Center
   - `/setup/do-it-for-me/...` — Help Center button should still work
4. Confirm no regression in other stepper flows (e.g., `onboarding`, `site-migration`).
