### PR TITLE
MSD Sites: Update the default fields to visibility and plan

### DIFF
--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -44,6 +44,7 @@ export default function CIABSites() {
 		user,
 		isAutomattician,
 		isRestoringAccount,
+		fields: [ 'visibility', 'plan' ],
 	} );
 
 	const { view, updateView, resetView } = usePersistentView( {

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -44,7 +44,6 @@ export default function CIABSites() {
 		user,
 		isAutomattician,
 		isRestoringAccount,
-		fields: [ 'visibility', 'plan' ],
 	} );
 
 	const { view, updateView, resetView } = usePersistentView( {

--- a/client/dashboard/sites/dataviews/views.ts
+++ b/client/dashboard/sites/dataviews/views.ts
@@ -48,17 +48,20 @@ export function getDefaultView( {
 	user,
 	isAutomattician,
 	isRestoringAccount,
+	fields,
 }: {
 	user: User;
 	isAutomattician: boolean;
 	isRestoringAccount: boolean;
+	fields?: string[];
 } ): View {
 	const type = isRestoringAccount || user.site_count > DEFAULT_PER_PAGE ? 'table' : 'grid';
 
 	const defaultView = {
-		type,
 		...DEFAULT_VIEW,
 		...DEFAULT_LAYOUTS[ type ],
+		type,
+		fields: fields ?? DEFAULT_VIEW.fields,
 	} as View;
 
 	if ( isAutomattician ) {

--- a/client/dashboard/sites/dataviews/views.ts
+++ b/client/dashboard/sites/dataviews/views.ts
@@ -37,7 +37,7 @@ export const DEFAULT_PER_PAGE = 12;
 
 const DEFAULT_VIEW: Partial< View > = {
 	perPage: DEFAULT_PER_PAGE,
-	fields: [ 'visibility', 'visitors', 'subscribers_count', 'plan' ],
+	fields: [ 'visibility', 'plan' ],
 	sort: {
 		field: 'name',
 		direction: 'asc' as SortDirection,
@@ -48,20 +48,17 @@ export function getDefaultView( {
 	user,
 	isAutomattician,
 	isRestoringAccount,
-	fields,
 }: {
 	user: User;
 	isAutomattician: boolean;
 	isRestoringAccount: boolean;
-	fields?: string[];
 } ): View {
 	const type = isRestoringAccount || user.site_count > DEFAULT_PER_PAGE ? 'table' : 'grid';
 
 	const defaultView = {
+		type,
 		...DEFAULT_VIEW,
 		...DEFAULT_LAYOUTS[ type ],
-		type,
-		fields: fields ?? DEFAULT_VIEW.fields,
 	} as View;
 
 	if ( isAutomattician ) {

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -16,7 +16,6 @@ const mockSites = [
 		URL: 'https://my-first-site.wordpress.com',
 		is_coming_soon: false,
 		is_private: false,
-		subscribers_count: 123,
 		site_migration: {},
 		plan: { product_slug: 'business-bundle', product_name_short: 'Business' },
 	} as Site,
@@ -27,7 +26,6 @@ const mockSites = [
 		URL: 'https://my-second-site.wordpress.com',
 		is_coming_soon: true,
 		is_private: false,
-		subscribers_count: 456,
 		site_migration: {},
 		plan: { product_slug: 'free_plan', product_name_short: 'Free' },
 	} as Site,
@@ -91,24 +89,18 @@ describe( '<Sites>', () => {
 		const header = within( rows[ 0 ] ).getAllByRole( 'columnheader' );
 		expect( header[ 0 ] ).toHaveTextContent( 'Site' );
 		expect( header[ 1 ] ).toHaveTextContent( 'Visibility' );
-		expect( header[ 2 ] ).toHaveTextContent( '7-day visitors' );
-		expect( header[ 3 ] ).toHaveTextContent( 'Subscribers' );
-		expect( header[ 4 ] ).toHaveTextContent( 'Plan' );
+		expect( header[ 2 ] ).toHaveTextContent( 'Plan' );
 
 		const row1 = within( rows[ 1 ] ).getAllByRole( 'cell' );
 		expect( row1[ 0 ] ).toHaveTextContent( 'My First Site' );
 		expect( row1[ 0 ] ).toHaveTextContent( 'my-first-site.wordpress.com' );
 		expect( row1[ 1 ] ).toHaveTextContent( 'Public' );
-		expect( row1[ 2 ] ).toHaveAccessibleName( '' ); // empty because it's async-loaded
-		expect( row1[ 3 ] ).toHaveTextContent( '123' );
-		expect( row1[ 4 ] ).toHaveTextContent( 'Business' );
+		expect( row1[ 2 ] ).toHaveTextContent( 'Business' );
 
 		const row2 = within( rows[ 2 ] ).getAllByRole( 'cell' );
 		expect( row2[ 0 ] ).toHaveTextContent( 'My Second Site' );
 		expect( row2[ 0 ] ).toHaveTextContent( 'my-second-site.wordpress.com' );
 		expect( row2[ 1 ] ).toHaveTextContent( 'Coming soon' );
-		expect( row2[ 2 ] ).toHaveAccessibleName( '' ); // empty because it's async-loaded
-		expect( row2[ 3 ] ).toHaveTextContent( '456' );
-		expect( row2[ 4 ] ).toHaveTextContent( 'Free' );
+		expect( row2[ 2 ] ).toHaveTextContent( 'Free' );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of p1770639664595919-slack-C09JEQLTH8R

## Proposed Changes

* Remove the 7-day visitors and subscriber count from the default fields of the view
* I noticed that we should not use the `user.site_count` to get the default view for CIAB dashboard as it's not the site count of the ciab sites. We can add local state to track total count of the ciab sites but it means the screen needs to wait for the sites information before rendering. Maybe we should add `garden_site_count` to the response of `/me` 🤔 Any thoughts?

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We don't want to show a lot of info by default

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /ciab
* If you have any customizations, click "Reset view"
* Ensure you can only see `Visibility` and `Plan` columns by default

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?