### PR TITLE
Domain-only Thank You Page: Redirect to correct existing page instead of the generic outdated one

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
@@ -29,7 +29,7 @@ export default function DomainOnlyThankYou( {
 	const [ , predicate ] = getDomainPurchaseTypeAndPredicate( purchases );
 	const domainPurchases = purchases.filter( predicate );
 	const domainNames = domainPurchases.map( ( purchase ) => purchase?.meta );
-	const domainOnlySite = useSelector( ( state ) => getSite( state, domainPurchases[ 0 ]?.blogId ) );
+	const domainSite = useSelector( ( state ) => getSite( state, domainPurchases[ 0 ]?.blogId ) );
 	const siteDomains = useSelector( ( state ) =>
 		getDomainsBySiteId( state, domainPurchases[ 0 ]?.blogId )
 	);
@@ -89,8 +89,8 @@ export default function DomainOnlyThankYou( {
 			<ThankYouDomainProduct
 				purchase={ purchase }
 				key={ `domain-${ purchase.meta }` }
-				siteSlug={ domainOnlySite?.slug }
-				isDomainOnly
+				siteSlug={ domainSite?.slug }
+				isDomainOnly={ domainSite?.options?.is_domain_only ?? true }
 				isGravatarDomain={ isGravatarDomain }
 			/>
 		);

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -118,16 +118,16 @@ function getDomainSignupFlowDestination( { siteId, designType, siteSlug } ) {
 			return dashboardLink( `/sites/${ siteSlug }/domains` );
 		}
 
-		return `/checkout/thank-you/${ siteSlug }`;
+		// Redirection URL handled by the checkout controller
+		return '';
 	}
 
 	if ( dashboardType ) {
 		return dashboardLink( '/domains' );
 	}
 
-	// `getThankYouPageUrl` appends a receipt ID to this slug even if it doesn't contain the
-	// `:receipt_id` placeholder
-	return '/checkout/thank-you/no-site';
+	// Redirection URL handled by the checkout controller
+	return '';
 }
 
 function getEmailSignupFlowDestination( { siteId, siteSlug } ) {


### PR DESCRIPTION
Closes DOTCOM-16029.

## Proposed Changes

  * Updated `getDomainSignupFlowDestination` in signup flows to let the checkout controller handle the thank you page redirection for domain-only purchases
  * Removed hardcoded redirect paths that were sending users to incorrect thank you pages
  * Only mark purchases as domain-only if the destination is indeed a domain-only site

  ## Why are these changes being made?

  Domain-only purchases were being redirected to generic thank you pages that weren't appropriate for the checkout flow. By returning an empty string instead of hardcoded paths, we allow the checkout
  controller to determine the correct thank you page based on the purchase context, ensuring users see the right post-purchase experience.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1023" height="608" alt="image" src="https://github.com/user-attachments/assets/efa63b44-5614-42a1-8559-02a45a3a3d77" /> | <img width="1359" height="603" alt="image" src="https://github.com/user-attachments/assets/e177c3f5-c2d1-410e-9fb2-0452b666bed4" /> |

  ## Testing Instructions

  * Start a domain-only purchase flow (without selecting a plan or site)
  * Complete the checkout process
  * Verify you are redirected to the appropriate domain-specific thank you page (not the generic `/checkout/thank-you/no-site` page). Verify you see the "Create site" button in the domain row
  * Test with a new site: purchase a domain for a new site and verify you're directed to `/start/setup-site`
  * Test with an existing site: purchase a domain for an existing site and verify the redirect goes to the correct site-specific thank you page. Verify you don't see the "Create site" button in the domain row
