### PR TITLE
Cancel: fix decision to display refund options for plan with bundled domain

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -42,7 +42,7 @@ const willShowDomainOptionsRadioButtons = (
 	return (
 		includedDomainPurchase.is_domain_registration &&
 		purchase.is_refundable &&
-		includedDomainPurchase.is_refundable
+		!! includedDomainPurchase.cost_to_unbundle_display
 	);
 };
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
@@ -236,7 +236,7 @@ const CancelPurchaseDomainOptions = ( {
 	if (
 		'domain_transfer' === includedDomainPurchase.product_slug ||
 		! purchase.is_refundable ||
-		! includedDomainPurchase.is_refundable
+		! includedDomainPurchase.cost_to_unbundle_display
 	) {
 		return (
 			<CancelPlanWithoutCancellingDomainMessage

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -96,7 +96,7 @@ const willShowDomainOptionsRadioButtons = (
 	return (
 		includedDomainPurchase.is_domain_registration &&
 		purchase.is_refundable &&
-		includedDomainPurchase.is_refundable
+		!! includedDomainPurchase.cost_to_unbundle_display
 	);
 };
 

--- a/client/me/purchases/cancel-purchase/domain-options.tsx
+++ b/client/me/purchases/cancel-purchase/domain-options.tsx
@@ -25,7 +25,7 @@ export const willShowDomainOptionsRadioButtons = (
 	return (
 		isDomainRegistration( includedDomainPurchase ) &&
 		isRefundable( purchase ) &&
-		isRefundable( includedDomainPurchase )
+		!! includedDomainPurchase.costToUnbundleText
 	);
 };
 
@@ -253,7 +253,7 @@ const CancelPurchaseDomainOptions = ( {
 	if (
 		isDomainTransfer( includedDomainPurchase ) ||
 		! isRefundable( purchase ) ||
-		! isRefundable( includedDomainPurchase )
+		! includedDomainPurchase.costToUnbundleText
 	) {
 		return (
 			<CancelPlanWithoutCancellingDomainMessage


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-396/cancelling-bundledomain-requires-two-steps

## Proposed Changes

This PR changes the cancel flow logic to check for the presence of `cost_to_unbundle_display` (aka `costToUnbundleText`) instead of `is_refundable` (aka `isRefundable`). This correctly identifies when a domain has value in the context of a bundle cancellation and will properly show the option to cancel the domain and plan together (rather than just the plan).

These changes are made for both the cancel flow in calypso as well as in the Multi Site Dashboard (MSD).

Environment | Before             |  After
:-------------------------:|:-------------------------:|:-------------------------:
MSD | <img width="695" height="440" alt="cancel-bundled-plan-msd-step-2" src="https://github.com/user-attachments/assets/00660d2f-3c14-44fa-8361-2f8e19352faf" /> | <img width="695" height="397" alt="cancel-bundled-plan-msd-step-2-fixed" src="https://github.com/user-attachments/assets/86a456be-56fd-4892-8e90-9759537bc07c" />
Calypso | <img width="628" height="449" alt="cancel-bundled-plan-calypso-step-2" src="https://github.com/user-attachments/assets/c14919e4-6409-4541-8345-1cd4092c4ec6" /> | <img width="1077" height="544" alt="cancel-bundled-plan-calypso-step-2-fixed" src="https://github.com/user-attachments/assets/97f7c1bc-064a-476e-b469-bf602ff7323e" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When a domain was purchased using the domain credit of a plan, beginning the cancel flow for the plan (when both are in their refund periods) should give the user the option to cancel both together for a full refund, or just the plan, withholding an amount to cover the cost of the domain.

However, the option is not being shown. This is because:

  - The domain's `is_refundable` (aka `isRefundable`) flag is false (because it wasn't purchased separately).
  - However, the domain has a `cost_to_unbundle_display` (aka `costToUnbundleText`) value that indicates how much would be deducted from the refund to keep the domain.
  - The cancel flow logic only checked `isRefundable(includedDomainPurchase)`, which prevented the domain refund option step from showing.

We instead need to rely on the value of the domain upgrade's `cost_to_unbundle_display`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can manually reproduce by purchasing a plan and a bundled domain, then starting the cancel flow for just the plan.

Click through the first confirmation step and make sure you are provided with a choice of cancelling both the domain and plan together (for a full plan refund) or just the plan (for a partial refund).

Try this both in the calypso cancel page (starting at `/me/purchases`, something like http://calypso.localhost:3000/wordpress.com/purchases/subscriptions/example.com/1211800/cancel) and the MSD cancel page (something like: http://my.localhost:3000/me/billing/purchases/1211800/cancel).
