### PR TITLE
E2E: merge dashboard pre-release tests into main pre-release job

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -27,7 +27,6 @@ object WebApp : Project({
 	buildType(PlaywrightTestPRMatrix)
 	buildType(PlaywrightTestPreReleaseMatrix)
 	buildType(PlaywrightTestDashboardPRMatrix)
-	buildType(PlaywrightTestDashboardPreReleaseMatrix)
 	buildType(JestPreReleaseE2ETests)
 	buildType(PreReleaseE2ETests)
 	buildType(AuthenticationE2ETests)
@@ -1089,53 +1088,6 @@ object PlaywrightTestDashboardPRMatrix : BuildType({
 	}
 })
 
-object PlaywrightTestDashboardPreReleaseMatrix : BuildType({
-	templates(CalypsoE2ETestsBuildTemplate)
-	id("calypso_WebApp_Dashboard_E2E_Playwright_Pre_Release_Matrix")
-	uuid = "80904868-c163-4fec-817b-907611985c33"
-	name = "Dashboard Pre-Release E2E Tests"
-	description = "Runs Dashboard pre-release e2e tests using Playwright Test runner with build matrix"
-
-	params {
-		param("TEST_GROUP", "@dashboard-release")
-		param("CALYPSO_BASE_URL", "https://wordpress.com")
-		param("DASHBOARD_BASE_URL", "https://my.wordpress.com")
-	}
-
-	features {
-		matrix {
-			param("PROJECT", listOf(
-				value("desktop", label = "Desktop"),
-				value("mobile", label = "Mobile"),
-			))
-		}
-		notifications {
-			notifierSettings = slackNotifier {
-				connection = "PROJECT_EXT_11"
-				sendTo = "#e2eflowtesting-notif"
-				messageFormat = verboseMessageFormat {
-					addStatusText = true
-				}
-			}
-			branchFilter = "+:<default>"
-			buildFailedToStart = true
-			buildFailed = true
-			buildFinishedSuccessfully = false
-			buildProbablyHanging = true
-		}
-	}
-
-	triggers {
-		vcs {
-			branchFilter = """
-				+:<default>
-			""".trimIndent()
-			triggerRules = """
-				-:**.md
-			""".trimIndent()
-		}
-	}
-})
 
 object JestPreReleaseE2ETests : BuildType({
 	id("calypso_WebApp_Calypso_E2E_Jest_Pre_Release")

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -637,7 +637,6 @@ export const tags = {
 	CALYPSO_PR: '@calypso-pr',
 	CALYPSO_RELEASE: '@calypso-release',
 	DASHBOARD_PR: '@dashboard-pr',
-	DASHBOARD_RELEASE: '@dashboard-release',
 	DESKTOP_ONLY: '@desktop-only',
 	EXAMPLE_BLOCKS: '@example-blocks',
 	GUTENBERG: '@gutenberg',

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -32,7 +32,6 @@
 		"test:pw:a8c-for-agencies": "yarn playwright test --project=chrome --grep @a8c-for-agencies",
 		"test:pw:i18n": "yarn playwright test --project=chrome --grep @i18n",
 		"test:pw:dashboard-pr": "yarn playwright test --project=chrome --grep @dashboard-pr",
-		"test:pw:dashboard-release": "yarn playwright test --project=chrome --grep @dashboard-release",
 		"test:pw:p2": "yarn playwright test --project=chrome --grep @p2"
 	},
 	"devDependencies": {

--- a/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
@@ -2,7 +2,7 @@ import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	'Dashboard: Basic & Routing',
-	{ tag: [ tags.DASHBOARD_PR, tags.DASHBOARD_RELEASE ] },
+	{ tag: [ tags.DASHBOARD_PR, tags.CALYPSO_RELEASE ] },
 	() => {
 		test( 'As a WordPress.com user, I can see the new Multi-site Dashboard page as a list of my sites', async ( {
 			accountGivenByEnvironment,

--- a/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
@@ -10,7 +10,8 @@ test.describe(
 			pageDashboard,
 		} ) => {
 			await test.step( `Given I am authenticated as '${ accountGivenByEnvironment.accountName }'`, async function () {
-				await accountGivenByEnvironment.authenticate( page );
+				// Skip waiting for Calypso sidebar — we navigate to the dashboard immediately after.
+				await accountGivenByEnvironment.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'When I visit the dashboard page', async function () {
@@ -29,7 +30,8 @@ test.describe(
 			pageDashboard,
 		} ) => {
 			await test.step( `Given I am authenticated as '${ accountGivenByEnvironment.accountName }'`, async function () {
-				await accountGivenByEnvironment.authenticate( page );
+				// Skip waiting for Calypso sidebar — we navigate to the dashboard immediately after.
+				await accountGivenByEnvironment.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'When I visit the dashboard page', async function () {


### PR DESCRIPTION
## Proposed Changes

- Replace `@dashboard-release` tag with `@calypso-release` in dashboard test spec
- Remove `DASHBOARD_RELEASE` tag constant from `pw-base.ts`
- Remove `test:pw:dashboard-release` script from `test/e2e/package.json`
- Delete `PlaywrightTestDashboardPreReleaseMatrix` build type from TeamCity config

## Why are these changes being made?

This was discussed here: p4TIVU-b4I-p2#comment-12144

Dashboard pre-release E2E tests currently run in a separate TeamCity build (`PlaywrightTestDashboardPreReleaseMatrix`) from the main Calypso pre-release tests (`PlaywrightTestPreReleaseMatrix`). The aggregator (`PreReleaseE2ETests`) doesn't include the dashboard build, so dashboard failures are silently missed.

Re-tagging dashboard tests as `@calypso-release` lets them run inside the existing `PlaywrightTestPreReleaseMatrix` job — no config changes needed there since it already uses `TEST_GROUP=@calypso-release`. Both builds set `DASHBOARD_BASE_URL=https://my.wordpress.com` identically, so behavior is unchanged.

## Testing Instructions

1. Verify no orphan references: search repo for `@dashboard-release`, `DASHBOARD_RELEASE`, and `PlaywrightTestDashboardPreReleaseMatrix` — should return zero results
2. From `test/e2e/`, run `yarn playwright test --project=chrome --grep @calypso-release --list` and confirm the dashboard spec appears
3. Trigger `PlaywrightTestPreReleaseMatrix` in TeamCity from this branch and verify dashboard specs run and pass

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?