### PR TITLE
FORNO-202: Agents Manager - Include post content in Image Studio context

### DIFF
--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -22,12 +22,147 @@ export interface ImageStudioData {
 	metadata: ImageStudioMetadata;
 }
 
+export interface PageContentBlock {
+	name: string;
+	type?: 'header' | 'content' | 'footer';
+	clientId: string;
+	attributes?: Record< string, unknown >;
+	innerBlocks?: PageContentBlock[];
+}
+
 export interface ImageStudioClientContext extends Record< string, unknown > {
 	url: string;
 	pathname: string;
 	search: string;
 	environment: 'wp-admin';
 	imageStudio?: ImageStudioData;
+	currentPageContent?: PageContentBlock[];
+}
+
+const TEMPLATE_PART_SLUGS = [ 'header', 'header-hero', 'footer' ];
+
+/**
+ * Recursively process blocks to resolve template part inner blocks.
+ * Template part blocks don't include their innerBlocks by default;
+ * they must be fetched separately from the block editor store.
+ */
+function processTemplatePartBlocks(
+	blocks: any[],
+	getBlocks: ( clientId?: string ) => any[]
+): any[] {
+	return blocks.map( ( block: any ) => {
+		const processed = { ...block };
+
+		if ( block.name === 'core/template-part' ) {
+			processed.innerBlocks = getBlocks( block.clientId );
+		}
+
+		if ( processed.innerBlocks?.length ) {
+			processed.innerBlocks = processTemplatePartBlocks( processed.innerBlocks, getBlocks );
+		}
+
+		return processed;
+	} );
+}
+
+/**
+ * Get the current page content from the block editor.
+ * Returns an array of blocks structured with header/content/footer types,
+ * matching the format expected by the backend page context processor.
+ *
+ * Uses raw WordPress client IDs (no compression).
+ */
+function getCurrentPageContent(): PageContentBlock[] | null {
+	try {
+		const blockEditorSelect = select( 'core/block-editor' ) as any;
+		if ( ! blockEditorSelect ) {
+			return null;
+		}
+
+		const { getBlocks, getBlocksByName, getBlock } = blockEditorSelect;
+
+		// Try to get section root client ID (may not be available via public API)
+		let sectionRootClientId: string | null = null;
+		try {
+			sectionRootClientId = blockEditorSelect.getSectionRootClientId?.() ?? null;
+		} catch {
+			sectionRootClientId = null;
+		}
+
+		// Get blocks from section root or all root-level blocks
+		const sectionRootBlocks = sectionRootClientId ? getBlocks( sectionRootClientId ) : getBlocks();
+
+		// Find header and footer template parts
+		const templatePartBlockIds: string[] = getBlocksByName?.( 'core/template-part' ) || [];
+
+		let headerBlockId = templatePartBlockIds.find(
+			( blockId: string ) => getBlock( blockId )?.attributes?.slug === 'header-hero'
+		);
+		if ( ! headerBlockId ) {
+			headerBlockId = templatePartBlockIds.find(
+				( blockId: string ) => getBlock( blockId )?.attributes?.slug === 'header'
+			);
+		}
+		const footerBlockId = templatePartBlockIds.find(
+			( blockId: string ) => getBlock( blockId )?.attributes?.slug === 'footer'
+		);
+
+		// Filter content blocks (exclude known template parts)
+		const contentBlocks = sectionRootBlocks.filter(
+			( b: any ) =>
+				b.name !== 'core/template-part' || ! TEMPLATE_PART_SLUGS.includes( b.attributes?.slug )
+		);
+
+		// Get inner blocks of header and footer
+		const headerBlocks = headerBlockId ? getBlocks( headerBlockId ) : [];
+		const footerBlocks = footerBlockId ? getBlocks( footerBlockId ) : [];
+
+		// Process all block collections to resolve template part inner blocks
+		const processedHeaderBlocks = processTemplatePartBlocks( headerBlocks, getBlocks );
+		const processedFooterBlocks = processTemplatePartBlocks( footerBlocks, getBlocks );
+		const processedContentBlocks = processTemplatePartBlocks( contentBlocks, getBlocks );
+
+		const allBlocks: PageContentBlock[] = [];
+
+		// Add header
+		if ( processedHeaderBlocks.length && headerBlockId ) {
+			allBlocks.push( {
+				name: 'core/template-part',
+				type: 'header',
+				clientId: headerBlockId,
+				attributes: { ...getBlock( headerBlockId )?.attributes },
+				innerBlocks: processedHeaderBlocks,
+			} );
+		}
+
+		// Add content
+		if ( sectionRootClientId ) {
+			allBlocks.push( {
+				name: getBlock( sectionRootClientId )?.name,
+				type: 'content',
+				clientId: sectionRootClientId,
+				innerBlocks: processedContentBlocks,
+			} );
+		} else if ( processedContentBlocks.length ) {
+			allBlocks.push( ...processedContentBlocks );
+		}
+
+		// Add footer
+		if ( processedFooterBlocks.length && footerBlockId ) {
+			allBlocks.push( {
+				name: 'core/template-part',
+				type: 'footer',
+				clientId: footerBlockId,
+				attributes: { ...getBlock( footerBlockId )?.attributes },
+				innerBlocks: processedFooterBlocks,
+			} );
+		}
+
+		return allBlocks.length ? allBlocks : null;
+	} catch ( error ) {
+		window.console?.warn?.( '[Image Studio] Error getting page content:', error );
+		return null;
+	}
 }
 
 /**
@@ -99,6 +234,11 @@ export function getClientContext(): ImageStudioClientContext {
 
 	if ( imageStudio ) {
 		context.imageStudio = imageStudio;
+	}
+
+	const currentPageContent = getCurrentPageContent();
+	if ( currentPageContent ) {
+		context.currentPageContent = currentPageContent;
 	}
 
 	window.console?.log?.( '[Image Studio] Client context:', context );

--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -54,7 +54,7 @@ function processTemplatePartBlocks(
 	return blocks.map( ( block: any ) => {
 		const processed = { ...block };
 
-		if ( block.name === 'core/template-part' ) {
+		if ( block.name === 'core/template-part' || block.name === 'core/post-content' ) {
 			processed.innerBlocks = getBlocks( block.clientId );
 		}
 

--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -3,6 +3,7 @@
  *
  * Provides context about the current Image Studio state to the AI agent.
  */
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { select } from '@wordpress/data';
 import { store as imageStudioStore } from '../store';
 
@@ -74,23 +75,19 @@ function processTemplatePartBlocks(
  */
 function getCurrentPageContent(): PageContentBlock[] | null {
 	try {
-		const blockEditorSelect = select( 'core/block-editor' ) as any;
+		const blockEditorSelect = select( blockEditorStore ) as any;
 		if ( ! blockEditorSelect ) {
 			return null;
 		}
 
 		const { getBlocks, getBlocksByName, getBlock } = blockEditorSelect;
 
-		// Try to get section root client ID (may not be available via public API)
-		let sectionRootClientId: string | null = null;
-		try {
-			sectionRootClientId = blockEditorSelect.getSectionRootClientId?.() ?? null;
-		} catch {
-			sectionRootClientId = null;
+		// Bail early if not in a block editor context (e.g. uploads.php).
+		// The store is registered globally but has no blocks outside the editor.
+		const rootBlocks = getBlocks();
+		if ( ! rootBlocks?.length ) {
+			return null;
 		}
-
-		// Get blocks from section root or all root-level blocks
-		const sectionRootBlocks = sectionRootClientId ? getBlocks( sectionRootClientId ) : getBlocks();
 
 		// Find header and footer template parts
 		const templatePartBlockIds: string[] = getBlocksByName?.( 'core/template-part' ) || [];
@@ -108,7 +105,7 @@ function getCurrentPageContent(): PageContentBlock[] | null {
 		);
 
 		// Filter content blocks (exclude known template parts)
-		const contentBlocks = sectionRootBlocks.filter(
+		const contentBlocks = rootBlocks.filter(
 			( b: any ) =>
 				b.name !== 'core/template-part' || ! TEMPLATE_PART_SLUGS.includes( b.attributes?.slug )
 		);
@@ -136,14 +133,7 @@ function getCurrentPageContent(): PageContentBlock[] | null {
 		}
 
 		// Add content
-		if ( sectionRootClientId ) {
-			allBlocks.push( {
-				name: getBlock( sectionRootClientId )?.name,
-				type: 'content',
-				clientId: sectionRootClientId,
-				innerBlocks: processedContentBlocks,
-			} );
-		} else if ( processedContentBlocks.length ) {
+		if ( processedContentBlocks.length ) {
 			allBlocks.push( ...processedContentBlocks );
 		}
 


### PR DESCRIPTION
## Proposed Changes

* Passes current page content via context. Page structure is prepared the same way we do in Big Sky since we're using the same context variable.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is needed to generate image suggestions based on post content.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow testing steps from Big Sky PR 5597 but replace the Calypso branch with this one: `install-plugin.sh am try/fix-page-content-context`
* Create a post and add some text content
* Add an image block and choose `Generate Image`
* When Image Studio opens, verify that the suggestions relate to your post content

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
