### PR TITLE
Co-branded logo picker

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.scss
@@ -1,0 +1,110 @@
+.referral-email-preview-modal {
+	.referral-email-preview-modal__content {
+		padding: 24px;
+		max-width: 700px;
+	}
+
+	.referral-email-preview-modal__title {
+		margin-block-start: 0;
+		margin-block-end: 8px;
+		font-size: 24px;
+		font-weight: 600;
+		color: var(--color-text-primary);
+	}
+
+	.referral-email-preview-modal__subtitle {
+		margin-block-start: 0;
+		margin-block-end: 24px;
+		color: var(--color-text-secondary);
+		font-size: 14px;
+	}
+
+	.referral-email-preview-modal__email {
+		border: 1px solid var(--color-neutral-10);
+		border-radius: 4px;
+		background-color: var(--color-surface);
+		overflow: hidden;
+	}
+
+	.referral-email-preview-modal__email-header {
+		padding: 16px;
+		background-color: var(--color-neutral-5);
+		border-bottom: 1px solid var(--color-neutral-10);
+		font-size: 13px;
+		line-height: 1.8;
+
+		strong {
+			font-weight: 600;
+		}
+	}
+
+	.referral-email-preview-modal__email-body {
+		padding: 32px 24px;
+	}
+
+	.referral-email-preview-modal__email-logo {
+		margin-block-end: 24px;
+		text-align: center;
+
+		img {
+			max-width: 300px;
+			max-height: 100px;
+			height: auto;
+		}
+	}
+
+	.referral-email-preview-modal__email-greeting {
+		margin-block-end: 16px;
+		font-size: 15px;
+	}
+
+	.referral-email-preview-modal__email-intro {
+		margin-block-end: 16px;
+		font-size: 15px;
+		line-height: 1.6;
+	}
+
+	.referral-email-preview-modal__email-products {
+		margin-block-start: 12px;
+		margin-block-end: 24px;
+		padding-inline-start: 24px;
+
+		li {
+			margin-block-end: 8px;
+			font-size: 15px;
+		}
+	}
+
+	.referral-email-preview-modal__email-message {
+		margin-block-end: 24px;
+		padding: 16px;
+		background-color: var(--color-neutral-5);
+		border-left: 3px solid var(--color-accent);
+		border-radius: 4px;
+	}
+
+	.referral-email-preview-modal__email-message-label {
+		margin-block-end: 8px;
+		font-size: 14px;
+	}
+
+	.referral-email-preview-modal__email-message-content {
+		font-size: 15px;
+		line-height: 1.6;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
+	.referral-email-preview-modal__email-cta {
+		margin-block-end: 24px;
+		text-align: center;
+	}
+
+	.referral-email-preview-modal__email-footer {
+		padding-block-start: 24px;
+		border-top: 1px solid var(--color-neutral-10);
+		font-size: 12px;
+		color: var(--color-text-secondary);
+		line-height: 1.6;
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.scss
@@ -1,20 +1,13 @@
 .referral-email-preview-modal {
-	.referral-email-preview-modal__content {
-		padding: 24px;
-		max-width: 700px;
-	}
+	max-width: 700px;
 
-	.referral-email-preview-modal__title {
-		margin-block-start: 0;
-		margin-block-end: 8px;
-		font-size: 24px;
-		font-weight: 600;
-		color: var(--color-text-primary);
+	.referral-email-preview-modal__content {
+		padding: 16px 0;
 	}
 
 	.referral-email-preview-modal__subtitle {
 		margin-block-start: 0;
-		margin-block-end: 24px;
+		margin-block-end: 20px;
 		color: var(--color-text-secondary);
 		font-size: 14px;
 	}
@@ -24,6 +17,7 @@
 		border-radius: 4px;
 		background-color: var(--color-surface);
 		overflow: hidden;
+		margin-block-end: 20px;
 	}
 
 	.referral-email-preview-modal__email-header {
@@ -106,5 +100,12 @@
 		font-size: 12px;
 		color: var(--color-text-secondary);
 		line-height: 1.6;
+	}
+
+	.referral-email-preview-modal__actions {
+		display: flex;
+		justify-content: flex-end;
+		padding-block-start: 16px;
+		border-top: 1px solid var(--color-neutral-10);
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.tsx
@@ -1,0 +1,122 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import Dialog from 'calypso/components/dialog';
+
+interface ReferralEmailPreviewModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+	logoUrl: string | null;
+	clientEmail: string;
+	customMessage: string;
+	productNames: string[];
+}
+
+function ReferralEmailPreviewModal( {
+	isOpen,
+	onClose,
+	logoUrl,
+	clientEmail,
+	customMessage,
+	productNames,
+}: ReferralEmailPreviewModalProps ) {
+	const translate = useTranslate();
+	const agency = useSelector( getActiveAgency );
+
+	const agencyName = agency?.name || 'Your Agency';
+
+	const handleClose = useCallback( () => {
+		onClose();
+	}, [ onClose ] );
+
+	return (
+		<Dialog
+			isVisible={ isOpen }
+			onClose={ handleClose }
+			className="referral-email-preview-modal"
+			buttons={ [
+				<Button key="close" variant="primary" onClick={ handleClose }>
+					{ translate( 'Close' ) }
+				</Button>,
+			] }
+		>
+			<div className="referral-email-preview-modal__content">
+				<h2 className="referral-email-preview-modal__title">
+					{ translate( 'Email Preview' ) }
+				</h2>
+				<p className="referral-email-preview-modal__subtitle">
+					{ translate( 'This is what your client will receive:' ) }
+				</p>
+
+				<div className="referral-email-preview-modal__email">
+					<div className="referral-email-preview-modal__email-header">
+						<div className="referral-email-preview-modal__email-from">
+							<strong>{ translate( 'From:' ) }</strong> { agencyName } via Automattic for Agencies
+						</div>
+						<div className="referral-email-preview-modal__email-to">
+							<strong>{ translate( 'To:' ) }</strong> { clientEmail }
+						</div>
+						<div className="referral-email-preview-modal__email-subject">
+							<strong>{ translate( 'Subject:' ) }</strong> { agencyName }{ ' ' }
+							{ translate( 'sent you a referral' ) }
+						</div>
+					</div>
+
+					<div className="referral-email-preview-modal__email-body">
+						{ logoUrl && (
+							<div className="referral-email-preview-modal__email-logo">
+								<img src={ logoUrl } alt={ agencyName } />
+							</div>
+						) }
+
+						<div className="referral-email-preview-modal__email-greeting">
+							{ translate( 'Hi,' ) }
+						</div>
+
+						<div className="referral-email-preview-modal__email-intro">
+							<strong>{ agencyName }</strong> { translate( 'has referred you to' ) }{ ' ' }
+							<strong>Automattic for Agencies</strong>{ ' ' }
+							{ translate( 'for the following products:' ) }
+						</div>
+
+						<ul className="referral-email-preview-modal__email-products">
+							{ productNames.map( ( productName, index ) => (
+								<li key={ index }>{ productName }</li>
+							) ) }
+						</ul>
+
+						{ customMessage && (
+							<div className="referral-email-preview-modal__email-message">
+								<div className="referral-email-preview-modal__email-message-label">
+									<strong>{ translate( 'Personal message from' ) } { agencyName }:</strong>
+								</div>
+								<div className="referral-email-preview-modal__email-message-content">
+									{ customMessage }
+								</div>
+							</div>
+						) }
+
+						<div className="referral-email-preview-modal__email-cta">
+							<Button variant="primary">{ translate( 'View referral and complete payment' ) }</Button>
+						</div>
+
+						<div className="referral-email-preview-modal__email-footer">
+							{ translate(
+								'This email was sent by {{agency}} through Automattic for Agencies. If you have questions, please contact {{agency}} directly.',
+								{
+									args: {
+										agency: agencyName,
+									},
+								}
+							) }
+						</div>
+					</div>
+				</div>
+			</div>
+		</Dialog>
+	);
+}
+
+export default ReferralEmailPreviewModal;

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.tsx
@@ -1,9 +1,7 @@
-import { Button } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import Dialog from 'calypso/components/dialog';
 
 interface ReferralEmailPreviewModalProps {
 	isOpen: boolean;
@@ -27,25 +25,17 @@ function ReferralEmailPreviewModal( {
 
 	const agencyName = agency?.name || 'Your Agency';
 
-	const handleClose = useCallback( () => {
-		onClose();
-	}, [ onClose ] );
+	if ( ! isOpen ) {
+		return null;
+	}
 
 	return (
-		<Dialog
-			isVisible={ isOpen }
-			onClose={ handleClose }
+		<Modal
+			title={ translate( 'Email Preview' ) }
+			onRequestClose={ onClose }
 			className="referral-email-preview-modal"
-			buttons={ [
-				<Button key="close" variant="primary" onClick={ handleClose }>
-					{ translate( 'Close' ) }
-				</Button>,
-			] }
 		>
 			<div className="referral-email-preview-modal__content">
-				<h2 className="referral-email-preview-modal__title">
-					{ translate( 'Email Preview' ) }
-				</h2>
 				<p className="referral-email-preview-modal__subtitle">
 					{ translate( 'This is what your client will receive:' ) }
 				</p>
@@ -53,7 +43,8 @@ function ReferralEmailPreviewModal( {
 				<div className="referral-email-preview-modal__email">
 					<div className="referral-email-preview-modal__email-header">
 						<div className="referral-email-preview-modal__email-from">
-							<strong>{ translate( 'From:' ) }</strong> { agencyName } via Automattic for Agencies
+							<strong>{ translate( 'From:' ) }</strong> { agencyName } via Automattic for
+							Agencies
 						</div>
 						<div className="referral-email-preview-modal__email-to">
 							<strong>{ translate( 'To:' ) }</strong> { clientEmail }
@@ -77,8 +68,7 @@ function ReferralEmailPreviewModal( {
 
 						<div className="referral-email-preview-modal__email-intro">
 							<strong>{ agencyName }</strong> { translate( 'has referred you to' ) }{ ' ' }
-							<strong>Automattic for Agencies</strong>{ ' ' }
-							{ translate( 'for the following products:' ) }
+							<strong>Automattic for Agencies</strong> { translate( 'for the following products:' ) }
 						</div>
 
 						<ul className="referral-email-preview-modal__email-products">
@@ -99,7 +89,9 @@ function ReferralEmailPreviewModal( {
 						) }
 
 						<div className="referral-email-preview-modal__email-cta">
-							<Button variant="primary">{ translate( 'View referral and complete payment' ) }</Button>
+							<Button variant="primary">
+								{ translate( 'View referral and complete payment' ) }
+							</Button>
 						</div>
 
 						<div className="referral-email-preview-modal__email-footer">
@@ -114,8 +106,14 @@ function ReferralEmailPreviewModal( {
 						</div>
 					</div>
 				</div>
+
+				<div className="referral-email-preview-modal__actions">
+					<Button variant="primary" onClick={ onClose }>
+						{ translate( 'Close' ) }
+					</Button>
+				</div>
 			</div>
-		</Dialog>
+		</Modal>
 	);
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.scss
@@ -1,6 +1,13 @@
 .referral-logo-picker {
 	margin-block-end: 24px;
 
+	.referral-logo-picker__description {
+		margin-block-start: 4px;
+		margin-block-end: 16px;
+		color: var(--color-text-secondary);
+		font-size: 13px;
+	}
+
 	.referral-logo-picker__options {
 		display: flex;
 		flex-direction: column;
@@ -10,87 +17,72 @@
 	.referral-logo-picker__option {
 		display: flex;
 		flex-direction: column;
-		gap: 12px;
 	}
 
-	.referral-logo-picker__preview {
+	.referral-logo-picker__logo-display {
+		margin-block-start: 12px;
 		margin-inline-start: 28px;
-		padding: 12px;
+		padding: 16px;
 		border: 1px solid var(--color-neutral-10);
 		border-radius: 4px;
 		background-color: var(--color-surface);
-		max-width: 300px;
+		max-width: 200px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 
 		img {
 			max-width: 100%;
+			max-height: 60px;
 			height: auto;
 			display: block;
 		}
 	}
 
-	.referral-logo-picker__upload-area {
+	.referral-logo-picker__upload-section {
+		margin-block-start: 12px;
 		margin-inline-start: 28px;
-		margin-block-start: 8px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		align-items: flex-start;
 	}
 
 	.referral-logo-picker__file-input {
 		display: none;
 	}
 
-	.referral-logo-picker__dropzone {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		padding: 32px 24px;
+	.referral-logo-picker__upload-placeholder {
+		padding: 24px;
 		border: 2px dashed var(--color-neutral-20);
 		border-radius: 4px;
-		background-color: var(--color-surface);
-		text-align: center;
-		gap: 12px;
-		cursor: pointer;
-		transition: border-color 0.2s ease;
-
-		&:hover {
-			border-color: var(--color-accent);
-		}
+		background-color: var(--color-neutral-0);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 200px;
+		min-height: 100px;
 	}
 
-	.referral-logo-picker__dropzone-text {
-		margin: 0;
-		color: var(--color-text-primary);
-		font-size: 14px;
+	.referral-logo-picker__upload-icon {
+		color: var(--color-neutral-40);
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 
-	.referral-logo-picker__dropzone-hint {
+	.referral-logo-picker__upload-hint {
 		margin: 0;
 		color: var(--color-text-secondary);
 		font-size: 12px;
-	}
-
-	.referral-logo-picker__preview-container {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-		align-items: flex-start;
+		line-height: 1.5;
 	}
 
 	.referral-logo-picker__error {
-		margin-block-start: 8px;
 		padding: 8px 12px;
 		background-color: var(--color-error-5);
 		color: var(--color-error-50);
 		border-radius: 4px;
-		font-size: 13px;
-	}
-
-	.referral-logo-picker__info-text {
-		margin-block-start: 12px;
-		margin-block-end: 0;
-		padding: 12px;
-		background-color: var(--color-neutral-5);
-		border-radius: 4px;
-		color: var(--color-text-secondary);
 		font-size: 13px;
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.scss
@@ -1,106 +1,86 @@
-.referral-logo-picker {
+.logo-upload-section {
 	margin-block-end: 24px;
 
-	.components-base-control__help {
-		margin-block-start: 4px;
-		margin-block-end: 16px;
-	}
-
-	.referral-logo-picker__options {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-		margin-block-start: 8px;
-	}
-
-	.referral-logo-picker__option {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.referral-logo-picker__radio-label {
-		display: flex;
-		align-items: center;
-		cursor: pointer;
-		gap: 8px;
-		margin: 0;
-	}
-
-	.referral-logo-picker__radio-input {
-		margin: 0;
-		cursor: pointer;
-	}
-
-	.referral-logo-picker__radio-text {
+	h3 {
+		margin-block-start: 0;
+		margin-block-end: 8px;
 		font-size: 14px;
-		line-height: 1.4;
+		font-weight: 600;
+		color: var(--color-text-primary);
 	}
 
-	.referral-logo-picker__logo-display {
-		margin-block-start: 12px;
-		margin-inline-start: 28px;
-		padding: 16px;
-		border: 1px solid var(--color-neutral-10);
-		border-radius: 4px;
-		background-color: var(--color-surface);
-		max-width: 200px;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-
-		img {
-			max-width: 100%;
-			max-height: 60px;
-			height: auto;
-			display: block;
-		}
+	.logo-upload-description {
+		margin-block-start: 0;
+		margin-block-end: 16px;
+		font-size: 13px;
+		color: var(--color-text-secondary);
 	}
 
-	.referral-logo-picker__upload-section {
-		margin-block-start: 12px;
-		margin-inline-start: 28px;
+	.logo-upload-row {
 		display: flex;
-		flex-direction: column;
-		gap: 8px;
+		gap: 16px;
 		align-items: flex-start;
 	}
 
-	.referral-logo-picker__file-input {
-		display: none;
-	}
-
-	.referral-logo-picker__upload-placeholder {
-		padding: 24px;
+	.logo-placeholder {
+		flex-shrink: 0;
+		width: 120px;
+		height: 120px;
 		border: 2px dashed var(--color-neutral-20);
 		border-radius: 4px;
 		background-color: var(--color-neutral-0);
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		min-width: 200px;
-		min-height: 100px;
+		cursor: pointer;
+		transition: border-color 0.2s ease, background-color 0.2s ease;
+		padding: 8px;
+
+		&:hover {
+			border-color: var(--color-accent);
+			background-color: var(--color-neutral-5);
+		}
+
+		&:focus {
+			outline: 2px solid var(--color-accent);
+			outline-offset: 2px;
+		}
+
+		img {
+			max-width: 100%;
+			max-height: 100%;
+			object-fit: contain;
+		}
+
+		svg {
+			width: 32px;
+			height: 32px;
+			color: var(--color-neutral-40);
+		}
 	}
 
-	.referral-logo-picker__upload-icon {
-		color: var(--color-neutral-40);
+	.logo-upload-details {
+		flex: 1;
 		display: flex;
-		align-items: center;
-		justify-content: center;
+		flex-direction: column;
+		gap: 8px;
+		align-items: flex-start;
 	}
 
-	.referral-logo-picker__upload-hint {
+	.help-text {
 		margin: 0;
-		color: var(--color-text-secondary);
 		font-size: 12px;
 		line-height: 1.5;
+		color: var(--color-text-secondary);
 	}
 
-	.referral-logo-picker__error {
+	.logo-upload-error {
 		padding: 8px 12px;
 		background-color: var(--color-error-5);
 		color: var(--color-error-50);
 		border-radius: 4px;
 		font-size: 13px;
+		margin-block-start: 4px;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.scss
@@ -1,0 +1,102 @@
+.referral-logo-picker {
+	margin-block-end: 24px;
+
+	.referral-logo-picker__options {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	.referral-logo-picker__option {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.referral-logo-picker__preview {
+		margin-inline-start: 28px;
+		padding: 12px;
+		border: 1px solid var(--color-neutral-10);
+		border-radius: 4px;
+		background-color: var(--color-surface);
+		max-width: 300px;
+
+		img {
+			max-width: 100%;
+			height: auto;
+			display: block;
+		}
+	}
+
+	.referral-logo-picker__upload-area {
+		margin-inline-start: 28px;
+		margin-block-start: 8px;
+	}
+
+	.referral-logo-picker__file-input {
+		display: none;
+	}
+
+	.referral-logo-picker__dropzone {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 32px 24px;
+		border: 2px dashed var(--color-neutral-20);
+		border-radius: 4px;
+		background-color: var(--color-surface);
+		text-align: center;
+		gap: 12px;
+		cursor: pointer;
+		transition: border-color 0.2s ease;
+
+		&:hover {
+			border-color: var(--color-accent);
+		}
+	}
+
+	.referral-logo-picker__dropzone-text {
+		margin: 0;
+		color: var(--color-text-primary);
+		font-size: 14px;
+	}
+
+	.referral-logo-picker__dropzone-hint {
+		margin: 0;
+		color: var(--color-text-secondary);
+		font-size: 12px;
+	}
+
+	.referral-logo-picker__preview-container {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		align-items: flex-start;
+	}
+
+	.referral-logo-picker__error {
+		margin-block-start: 8px;
+		padding: 8px 12px;
+		background-color: var(--color-error-5);
+		color: var(--color-error-50);
+		border-radius: 4px;
+		font-size: 13px;
+	}
+
+	.referral-logo-picker__info-text {
+		margin-block-start: 12px;
+		margin-block-end: 0;
+		padding: 12px;
+		background-color: var(--color-neutral-5);
+		border-radius: 4px;
+		color: var(--color-text-secondary);
+		font-size: 13px;
+	}
+}
+
+.checkout__client-referral-preview {
+	margin-block-start: 16px;
+	margin-block-end: 24px;
+	text-align: center;
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.scss
@@ -1,22 +1,39 @@
 .referral-logo-picker {
 	margin-block-end: 24px;
 
-	.referral-logo-picker__description {
+	.components-base-control__help {
 		margin-block-start: 4px;
 		margin-block-end: 16px;
-		color: var(--color-text-secondary);
-		font-size: 13px;
 	}
 
 	.referral-logo-picker__options {
 		display: flex;
 		flex-direction: column;
 		gap: 16px;
+		margin-block-start: 8px;
 	}
 
 	.referral-logo-picker__option {
 		display: flex;
 		flex-direction: column;
+	}
+
+	.referral-logo-picker__radio-label {
+		display: flex;
+		align-items: center;
+		cursor: pointer;
+		gap: 8px;
+		margin: 0;
+	}
+
+	.referral-logo-picker__radio-input {
+		margin: 0;
+		cursor: pointer;
+	}
+
+	.referral-logo-picker__radio-text {
+		font-size: 14px;
+		line-height: 1.4;
 	}
 
 	.referral-logo-picker__logo-display {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
@@ -1,0 +1,233 @@
+import { Button, FormLabel } from '@automattic/components';
+import { upload } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { ChangeEvent, useCallback, useRef, useState } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormRadio from 'calypso/components/forms/form-radio';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+interface ReferralLogoPickerProps {
+	onLogoChange: ( logoUrl: string | null, logoFile: File | null ) => void;
+	selectedLogoUrl: string | null;
+	selectedLogoFile: File | null;
+}
+
+type LogoSelectionType = 'profile' | 'custom';
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_FILE_TYPES = [ 'image/jpeg', 'image/jpg', 'image/png', 'image/svg+xml' ];
+
+function ReferralLogoPicker( {
+	onLogoChange,
+	selectedLogoUrl,
+	selectedLogoFile,
+}: ReferralLogoPickerProps ) {
+	const translate = useTranslate();
+	const agency = useSelector( getActiveAgency );
+	const fileInputRef = useRef< HTMLInputElement >( null );
+
+	const profileLogoUrl = agency?.profile?.company_details?.logo_url || '';
+	const hasProfileLogo = !! profileLogoUrl;
+
+	const [ selectionType, setSelectionType ] = useState< LogoSelectionType >(
+		hasProfileLogo ? 'profile' : 'custom'
+	);
+	const [ validationError, setValidationError ] = useState< string | null >( null );
+	const [ previewUrl, setPreviewUrl ] = useState< string | null >( null );
+
+	const handleSelectionChange = useCallback(
+		( type: LogoSelectionType ) => {
+			setSelectionType( type );
+			setValidationError( null );
+
+			if ( type === 'profile' && hasProfileLogo ) {
+				// Use profile logo
+				setPreviewUrl( null );
+				onLogoChange( profileLogoUrl, null );
+			} else {
+				// Custom logo selected but no file yet
+				if ( ! selectedLogoFile ) {
+					onLogoChange( null, null );
+				}
+			}
+		},
+		[ hasProfileLogo, profileLogoUrl, onLogoChange, selectedLogoFile ]
+	);
+
+	const validateFile = useCallback(
+		( file: File ): string | null => {
+			if ( ! ALLOWED_FILE_TYPES.includes( file.type ) ) {
+				return translate(
+					'Invalid file format. Please upload a JPG, PNG, or SVG file.'
+				);
+			}
+
+			if ( file.size > MAX_FILE_SIZE ) {
+				return translate( 'File size exceeds 5MB. Please upload a smaller file.' );
+			}
+
+			return null;
+		},
+		[ translate ]
+	);
+
+	const handleFileChange = useCallback(
+		( event: ChangeEvent< HTMLInputElement > ) => {
+			const file = event.target.files?.[ 0 ];
+			if ( ! file ) {
+				return;
+			}
+
+			const error = validateFile( file );
+			if ( error ) {
+				setValidationError( error );
+				return;
+			}
+
+			setValidationError( null );
+
+			// Create preview URL
+			const objectUrl = URL.createObjectURL( file );
+			setPreviewUrl( objectUrl );
+
+			// Notify parent component
+			onLogoChange( objectUrl, file );
+		},
+		[ validateFile, onLogoChange ]
+	);
+
+	const handleUploadClick = useCallback( () => {
+		fileInputRef.current?.click();
+	}, [] );
+
+	const handleDrop = useCallback(
+		( event: React.DragEvent< HTMLDivElement > ) => {
+			event.preventDefault();
+			event.stopPropagation();
+
+			const file = event.dataTransfer.files?.[ 0 ];
+			if ( ! file ) {
+				return;
+			}
+
+			const error = validateFile( file );
+			if ( error ) {
+				setValidationError( error );
+				return;
+			}
+
+			setValidationError( null );
+
+			// Create preview URL
+			const objectUrl = URL.createObjectURL( file );
+			setPreviewUrl( objectUrl );
+
+			// Notify parent component
+			onLogoChange( objectUrl, file );
+		},
+		[ validateFile, onLogoChange ]
+	);
+
+	const handleDragOver = useCallback( ( event: React.DragEvent< HTMLDivElement > ) => {
+		event.preventDefault();
+		event.stopPropagation();
+	}, [] );
+
+	const displayLogoUrl = previewUrl || selectedLogoUrl;
+
+	return (
+		<div className="referral-logo-picker">
+			<FormFieldset>
+				<FormLabel>{ translate( 'Your logo' ) }</FormLabel>
+
+				<div className="referral-logo-picker__options">
+					{ hasProfileLogo && (
+						<div className="referral-logo-picker__option">
+							<FormRadio
+								id="logo-profile"
+								name="logo-selection"
+								value="profile"
+								checked={ selectionType === 'profile' }
+								onChange={ () => handleSelectionChange( 'profile' ) }
+								label={ translate( 'Use profile logo' ) }
+							/>
+							{ selectionType === 'profile' && (
+								<div className="referral-logo-picker__preview">
+									<img src={ profileLogoUrl } alt={ translate( 'Profile logo' ) } />
+								</div>
+							) }
+						</div>
+					) }
+
+					<div className="referral-logo-picker__option">
+						<FormRadio
+							id="logo-custom"
+							name="logo-selection"
+							value="custom"
+							checked={ selectionType === 'custom' }
+							onChange={ () => handleSelectionChange( 'custom' ) }
+							label={ translate( 'Use a different logo for this referral' ) }
+						/>
+
+						{ selectionType === 'custom' && (
+							<div className="referral-logo-picker__upload-area">
+								<input
+									ref={ fileInputRef }
+									type="file"
+									accept={ ALLOWED_FILE_TYPES.join( ',' ) }
+									onChange={ handleFileChange }
+									className="referral-logo-picker__file-input"
+								/>
+
+								{ ! displayLogoUrl ? (
+									<div
+										className="referral-logo-picker__dropzone"
+										onDrop={ handleDrop }
+										onDragOver={ handleDragOver }
+									>
+										<p className="referral-logo-picker__dropzone-text">
+											{ translate( 'Drag and drop your logo here, or' ) }
+										</p>
+										<Button onClick={ handleUploadClick } icon={ upload }>
+											{ translate( 'Select file' ) }
+										</Button>
+										<p className="referral-logo-picker__dropzone-hint">
+											{ translate( 'JPG, PNG, or SVG (max 5MB)' ) }
+										</p>
+									</div>
+								) : (
+									<div className="referral-logo-picker__preview-container">
+										<div className="referral-logo-picker__preview">
+											<img src={ displayLogoUrl } alt={ translate( 'Selected logo' ) } />
+										</div>
+										<Button onClick={ handleUploadClick } compact>
+											{ translate( 'Change logo' ) }
+										</Button>
+									</div>
+								) }
+
+								{ validationError && (
+									<div className="referral-logo-picker__error" role="alert">
+										{ validationError }
+									</div>
+								) }
+							</div>
+						) }
+					</div>
+				</div>
+
+				{ ! hasProfileLogo && (
+					<p className="referral-logo-picker__info-text">
+						{ translate(
+							'This logo will be saved to your profile and used for future referrals.'
+						) }
+					</p>
+				) }
+			</FormFieldset>
+		</div>
+	);
+}
+
+export default ReferralLogoPicker;

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
@@ -1,10 +1,6 @@
-import { FormLabel } from '@automattic/components';
-import { Button } from '@wordpress/components';
-import { upload } from '@wordpress/icons';
+import { Button, BaseControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useRef, useState } from 'react';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormRadio from 'calypso/components/forms/form-radio';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
@@ -104,23 +100,27 @@ function ReferralLogoPicker( {
 
 	return (
 		<div className="referral-logo-picker">
-			<FormFieldset>
-				<FormLabel>{ translate( 'Your logo' ) }</FormLabel>
-				<p className="referral-logo-picker__description">
-					{ translate( 'Build trust and show this referral comes from you.' ) }
-				</p>
-
+			<BaseControl
+				label={ translate( 'Your logo' ) }
+				id="referral-logo-picker"
+				help={ translate( 'Build trust and show this referral comes from you.' ) }
+			>
 				<div className="referral-logo-picker__options">
 					{ hasProfileLogo && (
 						<div className="referral-logo-picker__option">
-							<FormRadio
-								id="logo-profile"
-								name="logo-selection"
-								value="profile"
-								checked={ selectionType === 'profile' }
-								onChange={ () => handleSelectionChange( 'profile' ) }
-								label={ translate( 'Use profile logo' ) }
-							/>
+							<label className="referral-logo-picker__radio-label">
+								<input
+									type="radio"
+									name="logo-selection"
+									value="profile"
+									checked={ selectionType === 'profile' }
+									onChange={ () => handleSelectionChange( 'profile' ) }
+									className="referral-logo-picker__radio-input"
+								/>
+								<span className="referral-logo-picker__radio-text">
+									{ translate( 'Use profile logo' ) }
+								</span>
+							</label>
 							{ selectionType === 'profile' && displayLogoUrl && (
 								<div className="referral-logo-picker__logo-display">
 									<img src={ displayLogoUrl } alt={ translate( 'Profile logo' ) } />
@@ -130,14 +130,19 @@ function ReferralLogoPicker( {
 					) }
 
 					<div className="referral-logo-picker__option">
-						<FormRadio
-							id="logo-custom"
-							name="logo-selection"
-							value="custom"
-							checked={ selectionType === 'custom' }
-							onChange={ () => handleSelectionChange( 'custom' ) }
-							label={ translate( 'Use a different logo for this referral' ) }
-						/>
+						<label className="referral-logo-picker__radio-label">
+							<input
+								type="radio"
+								name="logo-selection"
+								value="custom"
+								checked={ selectionType === 'custom' }
+								onChange={ () => handleSelectionChange( 'custom' ) }
+								className="referral-logo-picker__radio-input"
+							/>
+							<span className="referral-logo-picker__radio-text">
+								{ translate( 'Use a different logo for this referral' ) }
+							</span>
+						</label>
 
 						{ selectionType === 'custom' && (
 							<div className="referral-logo-picker__upload-section">
@@ -186,7 +191,9 @@ function ReferralLogoPicker( {
 								</Button>
 
 								<p className="referral-logo-picker__upload-hint">
-									{ translate( 'Upload your logo: PNG or SVG. Max 5 MB. Transparent background works best.' ) }
+									{ translate(
+										'Upload your logo: PNG or SVG. Max 5 MB. Transparent background works best.'
+									) }
 								</p>
 
 								{ validationError && (
@@ -198,7 +205,7 @@ function ReferralLogoPicker( {
 						) }
 					</div>
 				</div>
-			</FormFieldset>
+			</BaseControl>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
@@ -1,9 +1,9 @@
-import { Button, FormLabel } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { upload } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useRef, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -17,7 +17,7 @@ interface ReferralLogoPickerProps {
 type LogoSelectionType = 'profile' | 'custom';
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
-const ALLOWED_FILE_TYPES = [ 'image/jpeg', 'image/jpg', 'image/png', 'image/svg+xml' ];
+const ALLOWED_FILE_TYPES = [ 'image/png', 'image/svg+xml' ];
 
 function ReferralLogoPicker( {
 	onLogoChange,
@@ -59,9 +59,7 @@ function ReferralLogoPicker( {
 	const validateFile = useCallback(
 		( file: File ): string | null => {
 			if ( ! ALLOWED_FILE_TYPES.includes( file.type ) ) {
-				return translate(
-					'Invalid file format. Please upload a JPG, PNG, or SVG file.'
-				);
+				return translate( 'Invalid file format. Please upload a PNG or SVG file.' );
 			}
 
 			if ( file.size > MAX_FILE_SIZE ) {
@@ -98,49 +96,19 @@ function ReferralLogoPicker( {
 		[ validateFile, onLogoChange ]
 	);
 
-	const handleUploadClick = useCallback( () => {
+	const handleSelectFileClick = useCallback( () => {
 		fileInputRef.current?.click();
 	}, [] );
 
-	const handleDrop = useCallback(
-		( event: React.DragEvent< HTMLDivElement > ) => {
-			event.preventDefault();
-			event.stopPropagation();
-
-			const file = event.dataTransfer.files?.[ 0 ];
-			if ( ! file ) {
-				return;
-			}
-
-			const error = validateFile( file );
-			if ( error ) {
-				setValidationError( error );
-				return;
-			}
-
-			setValidationError( null );
-
-			// Create preview URL
-			const objectUrl = URL.createObjectURL( file );
-			setPreviewUrl( objectUrl );
-
-			// Notify parent component
-			onLogoChange( objectUrl, file );
-		},
-		[ validateFile, onLogoChange ]
-	);
-
-	const handleDragOver = useCallback( ( event: React.DragEvent< HTMLDivElement > ) => {
-		event.preventDefault();
-		event.stopPropagation();
-	}, [] );
-
-	const displayLogoUrl = previewUrl || selectedLogoUrl;
+	const displayLogoUrl = selectionType === 'profile' ? profileLogoUrl : previewUrl || selectedLogoUrl;
 
 	return (
 		<div className="referral-logo-picker">
 			<FormFieldset>
 				<FormLabel>{ translate( 'Your logo' ) }</FormLabel>
+				<p className="referral-logo-picker__description">
+					{ translate( 'Build trust and show this referral comes from you.' ) }
+				</p>
 
 				<div className="referral-logo-picker__options">
 					{ hasProfileLogo && (
@@ -153,9 +121,9 @@ function ReferralLogoPicker( {
 								onChange={ () => handleSelectionChange( 'profile' ) }
 								label={ translate( 'Use profile logo' ) }
 							/>
-							{ selectionType === 'profile' && (
-								<div className="referral-logo-picker__preview">
-									<img src={ profileLogoUrl } alt={ translate( 'Profile logo' ) } />
+							{ selectionType === 'profile' && displayLogoUrl && (
+								<div className="referral-logo-picker__logo-display">
+									<img src={ displayLogoUrl } alt={ translate( 'Profile logo' ) } />
 								</div>
 							) }
 						</div>
@@ -172,7 +140,7 @@ function ReferralLogoPicker( {
 						/>
 
 						{ selectionType === 'custom' && (
-							<div className="referral-logo-picker__upload-area">
+							<div className="referral-logo-picker__upload-section">
 								<input
 									ref={ fileInputRef }
 									type="file"
@@ -181,32 +149,45 @@ function ReferralLogoPicker( {
 									className="referral-logo-picker__file-input"
 								/>
 
-								{ ! displayLogoUrl ? (
-									<div
-										className="referral-logo-picker__dropzone"
-										onDrop={ handleDrop }
-										onDragOver={ handleDragOver }
-									>
-										<p className="referral-logo-picker__dropzone-text">
-											{ translate( 'Drag and drop your logo here, or' ) }
-										</p>
-										<Button onClick={ handleUploadClick } icon={ upload }>
-											{ translate( 'Select file' ) }
-										</Button>
-										<p className="referral-logo-picker__dropzone-hint">
-											{ translate( 'JPG, PNG, or SVG (max 5MB)' ) }
-										</p>
+								{ displayLogoUrl ? (
+									<div className="referral-logo-picker__logo-display">
+										<img src={ displayLogoUrl } alt={ translate( 'Selected logo' ) } />
 									</div>
 								) : (
-									<div className="referral-logo-picker__preview-container">
-										<div className="referral-logo-picker__preview">
-											<img src={ displayLogoUrl } alt={ translate( 'Selected logo' ) } />
-										</div>
-										<Button onClick={ handleUploadClick } compact>
-											{ translate( 'Change logo' ) }
-										</Button>
+									<div className="referral-logo-picker__upload-placeholder">
+										<span className="referral-logo-picker__upload-icon">
+											<svg
+												width="24"
+												height="24"
+												viewBox="0 0 24 24"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<path
+													d="M12 4L12 16M12 4L8 8M12 4L16 8"
+													stroke="currentColor"
+													strokeWidth="2"
+													strokeLinecap="round"
+													strokeLinejoin="round"
+												/>
+												<path
+													d="M4 17V19C4 20.1046 4.89543 21 6 21H18C19.1046 21 20 20.1046 20 19V17"
+													stroke="currentColor"
+													strokeWidth="2"
+													strokeLinecap="round"
+												/>
+											</svg>
+										</span>
 									</div>
 								) }
+
+								<Button variant="secondary" onClick={ handleSelectFileClick }>
+									{ translate( 'Select file' ) }
+								</Button>
+
+								<p className="referral-logo-picker__upload-hint">
+									{ translate( 'Upload your logo: PNG or SVG. Max 5 MB. Transparent background works best.' ) }
+								</p>
 
 								{ validationError && (
 									<div className="referral-logo-picker__error" role="alert">
@@ -217,14 +198,6 @@ function ReferralLogoPicker( {
 						) }
 					</div>
 				</div>
-
-				{ ! hasProfileLogo && (
-					<p className="referral-logo-picker__info-text">
-						{ translate(
-							'This logo will be saved to your profile and used for future referrals.'
-						) }
-					</p>
-				) }
 			</FormFieldset>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
@@ -1,6 +1,8 @@
-import { Button, BaseControl } from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { upload, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
+import FormFileUpload from 'calypso/components/forms/form-file-upload';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
@@ -9,8 +11,6 @@ interface ReferralLogoPickerProps {
 	selectedLogoUrl: string | null;
 	selectedLogoFile: File | null;
 }
-
-type LogoSelectionType = 'profile' | 'custom';
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_FILE_TYPES = [ 'image/png', 'image/svg+xml' ];
@@ -22,35 +22,13 @@ function ReferralLogoPicker( {
 }: ReferralLogoPickerProps ) {
 	const translate = useTranslate();
 	const agency = useSelector( getActiveAgency );
-	const fileInputRef = useRef< HTMLInputElement >( null );
 
 	const profileLogoUrl = agency?.profile?.company_details?.logo_url || '';
-	const hasProfileLogo = !! profileLogoUrl;
-
-	const [ selectionType, setSelectionType ] = useState< LogoSelectionType >(
-		hasProfileLogo ? 'profile' : 'custom'
-	);
 	const [ validationError, setValidationError ] = useState< string | null >( null );
 	const [ previewUrl, setPreviewUrl ] = useState< string | null >( null );
 
-	const handleSelectionChange = useCallback(
-		( type: LogoSelectionType ) => {
-			setSelectionType( type );
-			setValidationError( null );
-
-			if ( type === 'profile' && hasProfileLogo ) {
-				// Use profile logo
-				setPreviewUrl( null );
-				onLogoChange( profileLogoUrl, null );
-			} else {
-				// Custom logo selected but no file yet
-				if ( ! selectedLogoFile ) {
-					onLogoChange( null, null );
-				}
-			}
-		},
-		[ hasProfileLogo, profileLogoUrl, onLogoChange, selectedLogoFile ]
-	);
+	const displayUrl = previewUrl || selectedLogoUrl || profileLogoUrl;
+	const hasCustomLogo = !! ( previewUrl || selectedLogoUrl );
 
 	const validateFile = useCallback(
 		( file: File ): string | null => {
@@ -67,8 +45,8 @@ function ReferralLogoPicker( {
 		[ translate ]
 	);
 
-	const handleFileChange = useCallback(
-		( event: ChangeEvent< HTMLInputElement > ) => {
+	const handleFileSelect = useCallback(
+		( event: React.ChangeEvent< HTMLInputElement > ) => {
 			const file = event.target.files?.[ 0 ];
 			if ( ! file ) {
 				return;
@@ -92,121 +70,69 @@ function ReferralLogoPicker( {
 		[ validateFile, onLogoChange ]
 	);
 
-	const handleSelectFileClick = useCallback( () => {
-		fileInputRef.current?.click();
-	}, [] );
-
-	const displayLogoUrl = selectionType === 'profile' ? profileLogoUrl : previewUrl || selectedLogoUrl;
+	const handleRevert = useCallback( () => {
+		setPreviewUrl( null );
+		setValidationError( null );
+		onLogoChange( profileLogoUrl || null, null );
+	}, [ onLogoChange, profileLogoUrl ] );
 
 	return (
-		<div className="referral-logo-picker">
-			<BaseControl
-				label={ translate( 'Your logo' ) }
-				id="referral-logo-picker"
-				help={ translate( 'Build trust and show this referral comes from you.' ) }
-			>
-				<div className="referral-logo-picker__options">
-					{ hasProfileLogo && (
-						<div className="referral-logo-picker__option">
-							<label className="referral-logo-picker__radio-label">
-								<input
-									type="radio"
-									name="logo-selection"
-									value="profile"
-									checked={ selectionType === 'profile' }
-									onChange={ () => handleSelectionChange( 'profile' ) }
-									className="referral-logo-picker__radio-input"
-								/>
-								<span className="referral-logo-picker__radio-text">
-									{ translate( 'Use profile logo' ) }
-								</span>
-							</label>
-							{ selectionType === 'profile' && displayLogoUrl && (
-								<div className="referral-logo-picker__logo-display">
-									<img src={ displayLogoUrl } alt={ translate( 'Profile logo' ) } />
+		<FormFileUpload
+			accept={ ALLOWED_FILE_TYPES.join( ',' ) }
+			onChange={ handleFileSelect }
+			render={ ( { openFileDialog } ) => (
+				<div className="logo-upload-section">
+					<h3>{ translate( 'Your logo' ) }</h3>
+					<p className="logo-upload-description">
+						{ translate( 'Builds trust and shows this referral comes from you.' ) }
+					</p>
+
+					<div className="logo-upload-row">
+						<button
+							type="button"
+							className="logo-placeholder"
+							onClick={ openFileDialog }
+							aria-label={ translate( 'Upload logo' ) }
+						>
+							{ displayUrl ? (
+								<img src={ displayUrl } alt={ translate( 'Logo preview' ) } />
+							) : (
+								<Icon icon={ upload } />
+							) }
+						</button>
+
+						<div className="logo-upload-details">
+							<Button variant="secondary" onClick={ openFileDialog }>
+								{ displayUrl ? translate( 'Replace file' ) : translate( 'Select file' ) }
+							</Button>
+
+							<p className="help-text">
+								{ translate( 'Upload your logo. PNG or SVG. Max 5 MB.' ) }
+								<br />
+								{ translate( 'Transparent background works best.' ) }
+							</p>
+
+							{ hasCustomLogo && (
+								<>
+									<p className="help-text">
+										{ translate( 'Replacing the logo only affects this referral.' ) }
+									</p>
+									<Button variant="link" onClick={ handleRevert }>
+										{ translate( 'Revert to profile logo' ) }
+									</Button>
+								</>
+							) }
+
+							{ validationError && (
+								<div className="logo-upload-error" role="alert">
+									{ validationError }
 								</div>
 							) }
 						</div>
-					) }
-
-					<div className="referral-logo-picker__option">
-						<label className="referral-logo-picker__radio-label">
-							<input
-								type="radio"
-								name="logo-selection"
-								value="custom"
-								checked={ selectionType === 'custom' }
-								onChange={ () => handleSelectionChange( 'custom' ) }
-								className="referral-logo-picker__radio-input"
-							/>
-							<span className="referral-logo-picker__radio-text">
-								{ translate( 'Use a different logo for this referral' ) }
-							</span>
-						</label>
-
-						{ selectionType === 'custom' && (
-							<div className="referral-logo-picker__upload-section">
-								<input
-									ref={ fileInputRef }
-									type="file"
-									accept={ ALLOWED_FILE_TYPES.join( ',' ) }
-									onChange={ handleFileChange }
-									className="referral-logo-picker__file-input"
-								/>
-
-								{ displayLogoUrl ? (
-									<div className="referral-logo-picker__logo-display">
-										<img src={ displayLogoUrl } alt={ translate( 'Selected logo' ) } />
-									</div>
-								) : (
-									<div className="referral-logo-picker__upload-placeholder">
-										<span className="referral-logo-picker__upload-icon">
-											<svg
-												width="24"
-												height="24"
-												viewBox="0 0 24 24"
-												fill="none"
-												xmlns="http://www.w3.org/2000/svg"
-											>
-												<path
-													d="M12 4L12 16M12 4L8 8M12 4L16 8"
-													stroke="currentColor"
-													strokeWidth="2"
-													strokeLinecap="round"
-													strokeLinejoin="round"
-												/>
-												<path
-													d="M4 17V19C4 20.1046 4.89543 21 6 21H18C19.1046 21 20 20.1046 20 19V17"
-													stroke="currentColor"
-													strokeWidth="2"
-													strokeLinecap="round"
-												/>
-											</svg>
-										</span>
-									</div>
-								) }
-
-								<Button variant="secondary" onClick={ handleSelectFileClick }>
-									{ translate( 'Select file' ) }
-								</Button>
-
-								<p className="referral-logo-picker__upload-hint">
-									{ translate(
-										'Upload your logo: PNG or SVG. Max 5 MB. Transparent background works best.'
-									) }
-								</p>
-
-								{ validationError && (
-									<div className="referral-logo-picker__error" role="alert">
-										{ validationError }
-									</div>
-								) }
-							</div>
-						) }
 					</div>
 				</div>
-			</BaseControl>
-		</div>
+			) }
+		/>
 	);
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
@@ -1,9 +1,9 @@
+import { FormLabel } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useRef, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo-picker.tsx
@@ -1,8 +1,7 @@
-import { Button } from '@wordpress/components';
-import { upload, Icon } from '@wordpress/icons';
+import { Button, FormFileUpload } from '@wordpress/components';
+import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
-import FormFileUpload from 'calypso/components/forms/form-file-upload';
+import { useCallback, useRef, useState } from 'react';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
@@ -22,6 +21,7 @@ function ReferralLogoPicker( {
 }: ReferralLogoPickerProps ) {
 	const translate = useTranslate();
 	const agency = useSelector( getActiveAgency );
+	const fileInputRef = useRef< HTMLInputElement >( null );
 
 	const profileLogoUrl = agency?.profile?.company_details?.logo_url || '';
 	const [ validationError, setValidationError ] = useState< string | null >( null );
@@ -66,6 +66,9 @@ function ReferralLogoPicker( {
 
 			// Notify parent component
 			onLogoChange( objectUrl, file );
+
+			// Clear input so same file can be selected again
+			event.target.value = '';
 		},
 		[ validateFile, onLogoChange ]
 	);
@@ -76,63 +79,67 @@ function ReferralLogoPicker( {
 		onLogoChange( profileLogoUrl || null, null );
 	}, [ onLogoChange, profileLogoUrl ] );
 
+	const handlePlaceholderClick = useCallback( () => {
+		fileInputRef.current?.click();
+	}, [] );
+
 	return (
-		<FormFileUpload
-			accept={ ALLOWED_FILE_TYPES.join( ',' ) }
-			onChange={ handleFileSelect }
-			render={ ( { openFileDialog } ) => (
-				<div className="logo-upload-section">
-					<h3>{ translate( 'Your logo' ) }</h3>
-					<p className="logo-upload-description">
-						{ translate( 'Builds trust and shows this referral comes from you.' ) }
+		<div className="logo-upload-section">
+			<h3>{ translate( 'Your logo' ) }</h3>
+			<p className="logo-upload-description">
+				{ translate( 'Builds trust and shows this referral comes from you.' ) }
+			</p>
+
+			<div className="logo-upload-row">
+				<button
+					type="button"
+					className="logo-placeholder"
+					onClick={ handlePlaceholderClick }
+					aria-label={ translate( 'Upload logo' ) }
+				>
+					{ displayUrl ? (
+						<img src={ displayUrl } alt={ translate( 'Logo preview' ) } />
+					) : (
+						<Icon icon={ upload } />
+					) }
+				</button>
+
+				<div className="logo-upload-details">
+					<FormFileUpload
+						accept={ ALLOWED_FILE_TYPES.join( ',' ) }
+						onChange={ handleFileSelect }
+						ref={ fileInputRef }
+					>
+						<Button variant="secondary">
+							{ displayUrl ? translate( 'Replace file' ) : translate( 'Select file' ) }
+						</Button>
+					</FormFileUpload>
+
+					<p className="help-text">
+						{ translate( 'Upload your logo. PNG or SVG. Max 5 MB.' ) }
+						<br />
+						{ translate( 'Transparent background works best.' ) }
 					</p>
 
-					<div className="logo-upload-row">
-						<button
-							type="button"
-							className="logo-placeholder"
-							onClick={ openFileDialog }
-							aria-label={ translate( 'Upload logo' ) }
-						>
-							{ displayUrl ? (
-								<img src={ displayUrl } alt={ translate( 'Logo preview' ) } />
-							) : (
-								<Icon icon={ upload } />
-							) }
-						</button>
-
-						<div className="logo-upload-details">
-							<Button variant="secondary" onClick={ openFileDialog }>
-								{ displayUrl ? translate( 'Replace file' ) : translate( 'Select file' ) }
-							</Button>
-
+					{ hasCustomLogo && (
+						<>
 							<p className="help-text">
-								{ translate( 'Upload your logo. PNG or SVG. Max 5 MB.' ) }
-								<br />
-								{ translate( 'Transparent background works best.' ) }
+								{ translate( 'Replacing the logo only affects this referral.' ) }
 							</p>
+							<Button variant="link" onClick={ handleRevert }>
+								{ translate( 'Revert to profile logo' ) }
+							</Button>
+						</>
+					) }
 
-							{ hasCustomLogo && (
-								<>
-									<p className="help-text">
-										{ translate( 'Replacing the logo only affects this referral.' ) }
-									</p>
-									<Button variant="link" onClick={ handleRevert }>
-										{ translate( 'Revert to profile logo' ) }
-									</Button>
-								</>
-							) }
-
-							{ validationError && (
-								<div className="logo-upload-error" role="alert">
-									{ validationError }
-								</div>
-							) }
+					{ validationError && (
+						<div className="logo-upload-error" role="alert">
+							{ validationError }
 						</div>
-					</div>
+					) }
 				</div>
-			) }
-		/>
+			</div>
+		</div>
 	);
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -22,9 +22,11 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { useUploadLogo } from '../../partner-directory/agency-details/hooks/use-upload-logo';
 import withMarketplaceProviders from '../hoc/with-marketplace-providers';
 import {
 	MARKETPLACE_TYPE_SESSION_STORAGE_KEY,
@@ -33,7 +35,12 @@ import {
 import useRequestClientPaymentMutation from '../hooks/use-request-client-payment-mutation';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import NoticeSummary from './notice-summary';
+import ReferralLogoPicker from './referral-logo-picker';
+import ReferralEmailPreviewModal from './referral-email-preview-modal';
 import type { ShoppingCartItem, TermPricingType } from '../types';
+
+import './referral-logo-picker.scss';
+import './referral-email-preview-modal.scss';
 interface Props {
 	checkoutItems: ShoppingCartItem[];
 	termPricing: TermPricingType;
@@ -54,12 +61,17 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const [ email, setEmail ] = useState( '' );
 	const [ message, setMessage ] = useState( '' );
 	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
+	const [ selectedLogoUrl, setSelectedLogoUrl ] = useState< string | null >( null );
+	const [ selectedLogoFile, setSelectedLogoFile ] = useState< File | null >( null );
 
 	const ctaButtonRef = useRef< HTMLButtonElement >( null );
 
 	const [ showVerifyAccountToolip, setShowVerifyAccountToolip ] = useState( false );
+	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
 
 	const { onClearCart } = useShoppingCart();
+	const agencyId = useSelector( getActiveAgencyId );
+	const uploadLogo = useUploadLogo();
 
 	const onEmailChange = ( event: ChangeEvent< HTMLInputElement > ) => {
 		setEmail( event.currentTarget.value );
@@ -72,9 +84,28 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 		setMessage( event.currentTarget.value );
 	}, [] );
 
+	const onLogoChange = useCallback( ( logoUrl: string | null, logoFile: File | null ) => {
+		setSelectedLogoUrl( logoUrl );
+		setSelectedLogoFile( logoFile );
+	}, [] );
+
+	const handlePreviewEmail = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_client_referral_preview_email_click' ) );
+		setIsPreviewModalOpen( true );
+	}, [ dispatch ] );
+
+	const handleClosePreview = useCallback( () => {
+		setIsPreviewModalOpen( false );
+	}, [] );
+
 	const { mutate: requestPayment, isPending } = useRequestClientPaymentMutation();
 
 	const hasCompletedForm = !! email && !! message;
+
+	const productNames = useMemo(
+		() => checkoutItems.map( ( item ) => item.name || item.slug ),
+		[ checkoutItems ]
+	);
 
 	const productIds = checkoutItems.map( ( item ) => item.product_id ).join( ',' );
 
@@ -92,7 +123,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const { isFeedbackShown } = useShowFeedback( FeedbackType.ReferralCompleted );
 
 	const handleRequestPayment = useCallback(
-		( flowType: ReferralOrderFlowType ) => {
+		async ( flowType: ReferralOrderFlowType ) => {
 			if ( flowType === 'send' && ! hasCompletedForm ) {
 				return;
 			}
@@ -112,9 +143,25 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						: 'calypso_a4a_marketplace_referral_checkout_request_payment_copy_click',
 					{
 						term_pricing: termPricing,
+						has_custom_logo: !! selectedLogoFile,
 					}
 				)
 			);
+			let logoUrl = selectedLogoUrl;
+
+			// Upload custom logo if a file was selected
+			if ( selectedLogoFile && agencyId ) {
+				try {
+					const uploadResult = await uploadLogo( agencyId, selectedLogoFile );
+					logoUrl = uploadResult?.logo_url || selectedLogoUrl;
+				} catch ( error ) {
+					dispatch(
+						errorNotice( translate( 'Failed to upload logo. Please try again.' ) )
+					);
+					return;
+				}
+			}
+
 			requestPayment(
 				{
 					client_email: email,
@@ -122,6 +169,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 					product_ids: productIds,
 					licenses: licenses,
 					flow_type: flowType,
+					logo_url: logoUrl || undefined,
 				},
 				{
 					onSuccess: ( referral ) => {
@@ -145,6 +193,8 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						);
 						setEmail( '' );
 						setMessage( '' );
+						setSelectedLogoUrl( null );
+						setSelectedLogoFile( null );
 						onClearCart();
 					},
 					onError: ( error ) => {
@@ -183,12 +233,23 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 			productIds,
 			requestPayment,
 			translate,
+			termPricing,
+			selectedLogoFile,
+			selectedLogoUrl,
+			agencyId,
+			uploadLogo,
 		]
 	);
 
 	return (
 		<>
 			<div className="checkout__client-referral-form">
+				<ReferralLogoPicker
+					onLogoChange={ onLogoChange }
+					selectedLogoUrl={ selectedLogoUrl }
+					selectedLogoFile={ selectedLogoFile }
+				/>
+
 				<FormFieldset>
 					<FormLabel htmlFor="email">{ translate( 'Client’s email address' ) }</FormLabel>
 					<FormTextInput
@@ -223,6 +284,25 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 					/>
 				</FormFieldset>
 			</div>
+
+			<div className="checkout__client-referral-preview">
+				<Button
+					variant="link"
+					onClick={ handlePreviewEmail }
+					disabled={ ! email || ! message }
+				>
+					{ translate( 'Preview referral email' ) }
+				</Button>
+			</div>
+
+			<ReferralEmailPreviewModal
+				isOpen={ isPreviewModalOpen }
+				onClose={ handleClosePreview }
+				logoUrl={ selectedLogoUrl }
+				clientEmail={ email }
+				customMessage={ message }
+				productNames={ productNames }
+			/>
 
 			<NoticeSummary type="request-client-payment" />
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -244,12 +244,6 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	return (
 		<>
 			<div className="checkout__client-referral-form">
-				<ReferralLogoPicker
-					onLogoChange={ onLogoChange }
-					selectedLogoUrl={ selectedLogoUrl }
-					selectedLogoFile={ selectedLogoFile }
-				/>
-
 				<FormFieldset>
 					<FormLabel htmlFor="email">{ translate( 'Client’s email address' ) }</FormLabel>
 					<FormTextInput
@@ -283,6 +277,12 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						}
 					/>
 				</FormFieldset>
+
+				<ReferralLogoPicker
+					onLogoChange={ onLogoChange }
+					selectedLogoUrl={ selectedLogoUrl }
+					selectedLogoFile={ selectedLogoFile }
+				/>
 			</div>
 
 			<div className="checkout__client-referral-preview">

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-request-client-payment-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-request-client-payment-mutation.ts
@@ -13,6 +13,7 @@ export interface MutationRequestClientPaymentVariables {
 		license_id: number;
 	}[];
 	flow_type: ReferralOrderFlowType;
+	logo_url?: string;
 }
 
 interface APIError {
@@ -28,6 +29,7 @@ function mutationRequestClientPayment( {
 	agencyId,
 	licenses,
 	flow_type,
+	logo_url,
 }: MutationRequestClientPaymentVariables & { agencyId?: number } ): Promise< ReferralAPIResponse > {
 	if ( ! agencyId ) {
 		throw new Error( 'Agency ID is required request a client payment' );
@@ -35,7 +37,7 @@ function mutationRequestClientPayment( {
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: `/agency/${ agencyId }/referrals`,
-		body: { client_email, client_message, product_ids, licenses, flow_type },
+		body: { client_email, client_message, product_ids, licenses, flow_type, logo_url },
 	} );
 }
 


### PR DESCRIPTION
Part of #A4A-2092

## Proposed Changes

*   Introduces a `ReferralLogoPicker` component allowing agencies to choose between their profile logo or upload a custom logo for a specific referral.
*   Implements client-side validation for uploaded logos (format, size) and displays error states.
*   Adds a `ReferralEmailPreviewModal` component to display a preview of the co-branded referral email, including the chosen logo and custom message.
*   Integrates the logo selection and email preview into the `RequestClientPayment` component.
*   Updates the `useRequestClientPaymentMutation` to send the selected `logo_url` with the referral request and handles uploading custom logos to the agency profile.

## Why are these changes being made?
*   To increase referral conversions by enabling agencies to co-brand referral emails and checkout flows with their logo, building trust with clients.
*   To address client concerns about referral emails appearing as spam and provide better context in the referral process.
*   To allow agencies to customize the referral experience, making it feel more personal and professional.

## Testing Instructions

1.  Navigate to the referral checkout flow (e.g., via A8C for Agencies Marketplace).
2.  **Test Logo Picker:**
    *   If your agency has a profile logo, verify "Use profile logo" is selected by default and displays the logo.
    *   Select "Use a different logo for this referral".
    *   **Upload valid files:** Drag and drop or select a JPG, PNG, or SVG file (under 5MB). Verify the logo preview appears.
    *   **Upload invalid files:**
        *   Try uploading a file with an unsupported format (e.g., `.gif`, `.txt`). Verify the "Invalid file format" error.
        *   Try uploading a file larger than 5MB. Verify the "File size exceeds 5MB" error.
    *   After uploading a custom logo, switch back to "Use profile logo" (if available) and then back to "Use a different logo". Ensure the custom logo is remembered.
    *   If no profile logo exists, verify "Use a different logo" is the default and the info message about saving the logo to the profile is displayed.
3.  **Test Email Preview:**
    *   Enter a client email address and a custom message in the respective fields.
    *   Click the "Preview referral email" link/button.
    *   Verify that the modal opens and displays the correct agency name, client email, selected logo (profile or custom), product names, and custom message.
    *   Close the modal.
4.  **Test Referral Actions:**
    *   With a logo selected (profile or custom), click "Send to client" or "Copy link instead".
    *   Verify that the referral process completes successfully and the selected logo is associated with the referral (this might require backend verification or checking the generated link/email content if possible).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

---
Linear Issue: [A4A-2092](https://linear.app/a8c/issue/A4A-2092/frontend-logo-picker-and-co-branded-checkout-ui)

<p><a href="https://cursor.com/background-agent?bcId=bc-92047bb3-0f29-4c15-be1b-511b1ec5e01c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92047bb3-0f29-4c15-be1b-511b1ec5e01c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

