### PR TITLE
Dashboard: Fix domain name wrapping in domains table

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -3,10 +3,10 @@ import config from '@automattic/calypso-config';
 import { Link, useMatches } from '@tanstack/react-router';
 import { Tooltip, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
 import { domainOverviewRoute, domainTransferRoute } from '../../app/router/domains';
 import { siteDomainsRoute, siteOverviewRoute } from '../../app/router/sites';
 import { Text } from '../../components/text';
-import { textOverflowStyles } from './utils';
 import type { DomainSummary, Site } from '@automattic/api-core';
 
 export const DomainNameField = ( {
@@ -30,14 +30,25 @@ export const DomainNameField = ( {
 			? domainTransferRoute.fullPath
 			: domainOverviewRoute.fullPath;
 
+	const wrappableDomainName = useMemo( () => {
+		const [ domainName, ...tlds ] = value.split( '.' );
+		const tld = tlds.join( '.' );
+
+		return (
+			<span style={ { wordBreak: 'break-word', hyphens: 'none' } }>
+				{ domainName }
+				<span style={ { whiteSpace: 'nowrap' } }>.{ tld }</span>
+			</span>
+		);
+	}, [ value ] );
+
 	const content = (
 		<VStack spacing={ 1 }>
-			<span style={ textOverflowStyles }>{ value }</span>
+			{ wrappableDomainName }
 			{ showPrimaryDomainBadge && domain.primary_domain && (
 				<Tooltip text={ __( 'The address people see when visiting your site.' ) }>
 					<span
 						style={ {
-							...textOverflowStyles,
 							color: 'var(--dashboard__foreground-color-success)',
 							fontWeight: 'normal',
 							textDecoration: 'underline',
@@ -49,7 +60,7 @@ export const DomainNameField = ( {
 				</Tooltip>
 			) }
 			{ domain.subtype.id !== DomainSubtype.DOMAIN_REGISTRATION && (
-				<Text variant="muted" style={ { ...textOverflowStyles, fontWeight: 'normal' } }>
+				<Text variant="muted" style={ { fontWeight: 'normal' } }>
 					{ domain.subtype.label }
 				</Text>
 			) }

--- a/client/dashboard/domains/dataviews/utils.ts
+++ b/client/dashboard/domains/dataviews/utils.ts
@@ -1,5 +1,0 @@
-export const textOverflowStyles = {
-	overflowX: 'hidden',
-	textOverflow: 'ellipsis',
-	whiteSpace: 'nowrap',
-} as const;

--- a/client/dashboard/domains/dataviews/views.ts
+++ b/client/dashboard/domains/dataviews/views.ts
@@ -5,6 +5,13 @@ const BASE_VIEW_PROPS: View = {
 	type: 'table',
 	layout: {
 		density: 'balanced',
+		styles: {
+			domain: { minWidth: '200px' },
+			blog_name: { minWidth: '100px', maxWidth: '200px' },
+			ssl_status: { maxWidth: '80px' },
+			expiry: { minWidth: '150px', maxWidth: '200px' },
+			domain_status: { minWidth: '100px', maxWidth: '200px' },
+		},
 	},
 	sort: {
 		field: 'domain',


### PR DESCRIPTION
Part of DOMENG-225

## Proposed Changes

* Replace textOverflowStyles (nowrap + ellipsis) with smart domain name wrapping that splits the domain from its TLD
* Add layout.styles column width constraints to the DataViews table configuration to prevent columns from shrinking too small
* Remove now-unused utils.ts file

## Why are these changes being made?

Domain names in the Dashboard domains table wrap in a weird way. Long domain names either get truncated with ellipsis (losing important information) or cause the table columns to collapse in unexpected ways. This fix uses the same smart wrapping pattern already used in the domain overview page, ensuring the TLD always stays together with the last part of the domain name, while the rest of the domain can break naturally.

## Testing Instructions

* Navigate to the Dashboard domains list
* Verify that long domain names wrap properly - the TLD should stay on the same line as the preceding part
* Verify that the table columns maintain reasonable widths and do not collapse
* Check at different viewport widths to ensure wrapping behaves well at all sizes
* Verify Primary site address badge and domain subtype labels still display correctly

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the Status String Freeze label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the Status Needs Privacy Updates label?
