### PR TITLE
100-year domain: show appropriate domain purchase thank you page

### DIFF
--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -138,6 +138,7 @@ export type ResponseDomain = {
 	registrationDate: string;
 	registryExpiryDate: string;
 	renewableUntil: string;
+	siteSlug: string;
 	sslStatus: 'active' | 'pending' | 'disabled' | 'newly_registered' | null;
 	subdomainPart?: string;
 	subscriptionId: string | null;

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -227,12 +227,12 @@ export default function HundredYearThankYou( {
 	const isMobile = useMobileBreakpoint();
 	const isPageLoading = isReceiptLoading;
 	const hundredYearPlanCta = (
-		<StyledLightButton onClick={ () => page( ` /home/${ siteSlug }` ) }>
+		<StyledLightButton onClick={ () => page( `/home/${ siteSlug }` ) }>
 			{ translate( 'Manage your site' ) }
 		</StyledLightButton>
 	);
 	const hundredYearDomainCta = (
-		<StyledLightButton onClick={ () => page( ` /domains/manage/${ siteSlug }` ) }>
+		<StyledLightButton onClick={ () => page( `/domains/manage/${ siteSlug }` ) }>
 			{ translate( 'Manage your domain' ) }
 		</StyledLightButton>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -518,7 +518,7 @@ export class CheckoutThankYou extends Component<
 		);
 	};
 
-	isSingleHundredYearDomainPurchase = () => {
+	getSingleHundredYearDomainPurchase = () => {
 		const purchases = getPurchases( this.props ).filter( ( purchase ) => ! isCredits( purchase ) );
 		const domainPurchase = purchases[ 0 ];
 		const domain = this.props.siteDomains?.find(
@@ -526,9 +526,8 @@ export class CheckoutThankYou extends Component<
 		);
 
 		if ( domain?.isHundredYearDomain ) {
-			return true;
+			return domain;
 		}
-		return false;
 	};
 
 	render() {
@@ -569,6 +568,8 @@ export class CheckoutThankYou extends Component<
 			);
 		}
 
+		const hundredYearDomainPurchase = this.getSingleHundredYearDomainPurchase();
+
 		/** REFACTORED REDESIGN */
 		if ( isRefactoredForThankYouV2( this.props ) ) {
 			let pageContent = null;
@@ -585,7 +586,7 @@ export class CheckoutThankYou extends Component<
 						currency={ this.props.receipt.data?.currency ?? 'USD' }
 					/>
 				);
-			} else if ( this.props.receipt.data && this.isSingleHundredYearDomainPurchase() ) {
+			} else if ( this.props.receipt.data && hundredYearDomainPurchase ) {
 				pageContent = (
 					<>
 						<Global
@@ -612,8 +613,8 @@ export class CheckoutThankYou extends Component<
 							` }
 						/>
 						<HundredYearThankYou
-							siteSlug={ String( domainPurchase?.blogId ) }
-							receiptId={ Number( this.props.receiptId ) }
+							siteSlug={ hundredYearDomainPurchase.siteSlug }
+							receiptId={ this.props.receiptId }
 							productSlug={ domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION }
 						/>
 					</>

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -123,6 +123,16 @@ export default function () {
 	);
 
 	page(
+		'/checkout/100-year/thank-you/no-site/:receiptId',
+		refreshUserSession, // Load user session into state in userless checkout
+		redirectLoggedOut,
+		noSite,
+		checkoutThankYou,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/checkout/100-year/thank-you/:site/:receiptId',
 		loggedInSiteSelection,
 		hundredYearCheckoutThankYou,

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -492,6 +492,7 @@ export function noSite( context, next ) {
 	const isDomainOnlyFlow = context.query?.isDomainOnly === '1' || ! siteFragment;
 	const isJetpackCheckoutFlow = context.pathname.includes( '/checkout/jetpack' );
 	const isAkismetCheckoutFlow = context.pathname.includes( '/checkout/akismet' );
+	const is100YearCheckoutFlow = context.pathname.includes( '/checkout/100-year' );
 
 	// /checkout/marketplace/ is for standard siteless checkout, while
 	// /checkout/passport/ allows to use customized URL for Passport as well as custom branding.
@@ -512,6 +513,7 @@ export function noSite( context, next ) {
 		! isUnifiedCheckoutFlow &&
 		! isGiftCheckoutFlow &&
 		! isDomainsManage &&
+		! is100YearCheckoutFlow &&
 		// We allow renewals without a site through because we want to show these
 		// users an error message on the checkout page.
 		! isRenewal &&

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -249,6 +249,7 @@ export class CartCheckoutPage {
 		await this.page.selectOption( selectors.countrySelect, registrarDetails.countryCode );
 		await this.page.fill( selectors.addressInput, registrarDetails.address );
 		await this.page.fill( selectors.cityInput, registrarDetails.city );
+		await this.page.waitForSelector( selectors.stateSelect );
 		await this.page.selectOption( selectors.stateSelect, registrarDetails.stateCode );
 		await this.page.fill( selectors.postalCodeInput, registrarDetails.postalCode );
 		await this.page.click( selectors.submitRegistrarInformationButton );
@@ -303,7 +304,9 @@ export class CartCheckoutPage {
 	async enterPaymentDetails( paymentDetails: PaymentDetails ): Promise< void > {
 		// Click on the Credit or debit card input in order
 		// to expand the fields.
-		const cardInputLocator = this.page.locator( 'span:has-text("Credit or debit card")' );
+		const cardInputLocator = await this.page.waitForSelector(
+			'span:has-text("Credit or debit card")'
+		);
 		await cardInputLocator.click();
 
 		// Begin filling in the card details from

--- a/test/e2e/specs/flows/setup-hundred-year-domain.spec.ts
+++ b/test/e2e/specs/flows/setup-hundred-year-domain.spec.ts
@@ -49,9 +49,12 @@ test.describe(
 			} );
 
 			await test.step( 'And I pay at checkout', async function () {
+				const registrarDetails = helperData.getTestDomainRegistrarDetails( testUser.email );
+				await pageCartCheckout.enterDomainRegistrarDetails( registrarDetails );
+
 				const paymentDetails = helperData.getTestPaymentDetails();
-				await pageCartCheckout.enterBillingDetails( paymentDetails );
 				await pageCartCheckout.enterPaymentDetails( paymentDetails );
+
 				await pageCartCheckout.purchase( { timeout: 90 * 1000 } );
 			} );
 

--- a/test/e2e/specs/flows/setup-hundred-year-domain.spec.ts
+++ b/test/e2e/specs/flows/setup-hundred-year-domain.spec.ts
@@ -1,0 +1,93 @@
+import {
+	BrowserManager,
+	NewTestUserDetails,
+	NewUserResponse,
+	RestAPIClient,
+} from '@automattic/calypso-e2e';
+import { tags, test, expect } from '../../lib/pw-base';
+import { apiCloseAccount } from '../shared';
+
+test.describe(
+	'Setup Hundred Year Domain Flow',
+	{
+		tag: [ tags.CALYPSO_RELEASE ],
+	},
+	() => {
+		const accountsToCleanup: {
+			testUser: NewTestUserDetails;
+			newUserDetails: NewUserResponse;
+		}[] = [];
+
+		test( 'As a new user I can purchase a 100-year domain and see the thank you page', async ( {
+			page,
+			componentDomainSearch,
+			helperData,
+			pageCartCheckout,
+			pageUserSignUp,
+		} ) => {
+			const testUser = helperData.getNewTestUser();
+			let newUserDetails: NewUserResponse;
+			let selectedDomain: string;
+
+			await test.step( 'When I enter the 100-year domain flow', async function () {
+				BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+				// Use the flow URL (marketing entry is wordpress.com/100-year-domain/#search)
+				await page.goto( helperData.getCalypsoURL( '/setup/hundred-year-domain' ) );
+			} );
+
+			await test.step( 'And I search for a domain', async function () {
+				await componentDomainSearch.search( `${ helperData.getBlogName() }.blog` );
+			} );
+
+			await test.step( 'And I pick the first .blog domain in the list', async function () {
+				selectedDomain = await componentDomainSearch.selectFirstSuggestion( false );
+			} );
+
+			await test.step( 'And I create the account', async function () {
+				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				accountsToCleanup.push( { testUser, newUserDetails } );
+			} );
+
+			await test.step( 'And I pay at checkout', async function () {
+				const paymentDetails = helperData.getTestPaymentDetails();
+				await pageCartCheckout.enterBillingDetails( paymentDetails );
+				await pageCartCheckout.enterPaymentDetails( paymentDetails );
+				await pageCartCheckout.purchase( { timeout: 90 * 1000 } );
+			} );
+
+			await test.step( 'Then I see the hundred year thank you page', async function () {
+				await expect(
+					page.getByText( `Your 100-Year Domain ${ selectedDomain } has been registered.` )
+				).toBeVisible( {
+					timeout: 60 * 1000,
+				} );
+			} );
+
+			await test.step( 'When I click "Manage your domain"', async function () {
+				await page.getByRole( 'button', { name: 'Manage your domain' } ).click();
+			} );
+
+			await test.step( 'Then I am on the domain management page', async function () {
+				await expect( page ).toHaveURL( new RegExp( `/domains/manage/${ selectedDomain }` ) );
+			} );
+		} );
+
+		test.afterAll( 'Close all user accounts generated', async function () {
+			for ( const account of accountsToCleanup ) {
+				const restAPIClient = new RestAPIClient(
+					{
+						username: account.testUser.username,
+						password: account.testUser.password,
+					},
+					account.newUserDetails.body.bearer_token
+				);
+
+				await apiCloseAccount( restAPIClient, {
+					userID: account.newUserDetails.body.user_id,
+					username: account.newUserDetails.body.username,
+					email: account.testUser.email,
+				} );
+			}
+		} );
+	}
+);


### PR DESCRIPTION
Closes DOTCOM-16045.

## Proposed Changes

As reported by @paulopmt1 [here](https://github.com/Automattic/wp-calypso/pull/108627#discussion_r2798372026), we were showing the wrong thank-you page for 100-year domain purchases.

This PR fixes it and adds an E2E test to assert the whole flow works moving forward.

## Testing Instructions

Enter `/setup/hundred-year-domain` and purchase a 100-year domain.

You should see this thank you page, and clicking the CTA should open the domain management page:

<img width="1833" height="1354" alt="image" src="https://github.com/user-attachments/assets/d3eb8859-13c5-4122-af78-4956a6b7d251" />
