### PR TITLE
Reader: Hide "Add new" and Reddit tab when  isDiscoverV3Enabled is enabled

### DIFF
--- a/client/reader/discover/components/navigation/index.tsx
+++ b/client/reader/discover/components/navigation/index.tsx
@@ -39,6 +39,7 @@ const DiscoverNavigation = ( { selectedTab }: Props ) => {
 	const currentLocale = useLocale();
 	const dispatch = useDispatch();
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const isNewSubscriptionEnabled = isDiscoverV3Enabled();
 
 	const recordTabClick = ( tab: string ) => {
 		recordAction( 'click_discover_tab' );
@@ -63,7 +64,7 @@ const DiscoverNavigation = ( { selectedTab }: Props ) => {
 				title: translate( 'Recommended' ),
 				path: '/discover/recommended',
 			},
-			...( ! isDiscoverV3Enabled()
+			...( ! isNewSubscriptionEnabled
 				? [
 						{
 							slug: ADD_NEW_TAB,
@@ -82,7 +83,7 @@ const DiscoverNavigation = ( { selectedTab }: Props ) => {
 				title: translate( 'Tags' ),
 				path: '/discover/tags?selectedTag=dailyprompt',
 			},
-			...( ! isDiscoverV3Enabled()
+			...( ! isNewSubscriptionEnabled
 				? [
 						{
 							slug: REDDIT_TAB,

--- a/client/reader/discover/components/navigation/index.tsx
+++ b/client/reader/discover/components/navigation/index.tsx
@@ -47,7 +47,7 @@ const DiscoverNavigation = ( { selectedTab }: Props ) => {
 		dispatch( recordReaderTracksEvent( 'calypso_reader_discover_tab_clicked', { tab } ) );
 	};
 
-	// Only show the "Add new" and "Reddit" tabs if the user is logged in.
+	// Only show the "Add new" and "Reddit" tabs when the user is logged in and Discover v3 is disabled.
 	const tabs = useMemo( () => {
 		const getLocalizedPath = ( path: string ) => {
 			return addLocaleToPathLocaleInFront( path, currentLocale );

--- a/client/reader/discover/components/navigation/index.tsx
+++ b/client/reader/discover/components/navigation/index.tsx
@@ -35,13 +35,6 @@ const byProtectedTab =
 		return ( tab.slug !== ADD_NEW_TAB && tab.slug !== REDDIT_TAB ) || isLoggedIn;
 	};
 
-const byFeatureFlag = ( tab: Tab ): boolean => {
-	if ( ! isDiscoverV3Enabled() ) {
-		return true;
-	}
-	return [ ADD_NEW_TAB, REDDIT_TAB ].includes( tab.slug ) ? false : true;
-};
-
 const DiscoverNavigation = ( { selectedTab }: Props ) => {
 	const currentLocale = useLocale();
 	const dispatch = useDispatch();
@@ -70,11 +63,15 @@ const DiscoverNavigation = ( { selectedTab }: Props ) => {
 				title: translate( 'Recommended' ),
 				path: '/discover/recommended',
 			},
-			{
-				slug: ADD_NEW_TAB,
-				title: translate( 'Add new' ),
-				path: '/discover/add-new',
-			},
+			...( ! isDiscoverV3Enabled()
+				? [
+						{
+							slug: ADD_NEW_TAB,
+							title: translate( 'Add new' ),
+							path: '/discover/add-new',
+						},
+				  ]
+				: [] ),
 			{
 				slug: FIRST_POSTS_TAB,
 				title: translate( 'First posts' ),
@@ -85,11 +82,15 @@ const DiscoverNavigation = ( { selectedTab }: Props ) => {
 				title: translate( 'Tags' ),
 				path: '/discover/tags?selectedTag=dailyprompt',
 			},
-			{
-				slug: REDDIT_TAB,
-				title: translate( 'Reddit' ),
-				path: '/discover/reddit',
-			},
+			...( ! isDiscoverV3Enabled()
+				? [
+						{
+							slug: REDDIT_TAB,
+							title: translate( 'Reddit' ),
+							path: '/discover/reddit',
+						},
+				  ]
+				: [] ),
 			{
 				slug: LATEST_TAB,
 				title: translate( 'Latest', {
@@ -99,13 +100,10 @@ const DiscoverNavigation = ( { selectedTab }: Props ) => {
 			},
 		];
 
-		return baseTabs
-			.filter( byProtectedTab( isLoggedIn ) )
-			.filter( byFeatureFlag )
-			.map( ( tab ) => ( {
-				...tab,
-				path: getLocalizedPath( tab.path ),
-			} ) );
+		return baseTabs.filter( byProtectedTab( isLoggedIn ) ).map( ( tab ) => ( {
+			...tab,
+			path: getLocalizedPath( tab.path ),
+		} ) );
 	}, [ isLoggedIn, currentLocale ] );
 
 	const selectedTabData = tabs.find( ( tab ) => tab.slug === selectedTab );

--- a/client/reader/discover/components/navigation/index.tsx
+++ b/client/reader/discover/components/navigation/index.tsx
@@ -1,5 +1,6 @@
 import { addLocaleToPathLocaleInFront, useLocale } from '@automattic/i18n-utils';
 import { translate, TranslateResult } from 'i18n-calypso';
+import { useMemo } from 'react';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -11,6 +12,7 @@ import {
 	RECOMMENDED_TAB,
 } from 'calypso/reader/discover/helper';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { isDiscoverV3Enabled } from 'calypso/reader/utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
@@ -27,6 +29,19 @@ interface Props {
 	selectedTab: string;
 }
 
+const byProtectedTab =
+	( isLoggedIn: boolean ) =>
+	( tab: Tab ): boolean => {
+		return ( tab.slug !== ADD_NEW_TAB && tab.slug !== REDDIT_TAB ) || isLoggedIn;
+	};
+
+const byFeatureFlag = ( tab: Tab ): boolean => {
+	if ( ! isDiscoverV3Enabled() ) {
+		return true;
+	}
+	return [ ADD_NEW_TAB, REDDIT_TAB ].includes( tab.slug ) ? false : true;
+};
+
 const DiscoverNavigation = ( { selectedTab }: Props ) => {
 	const currentLocale = useLocale();
 	const dispatch = useDispatch();
@@ -38,60 +53,60 @@ const DiscoverNavigation = ( { selectedTab }: Props ) => {
 		dispatch( recordReaderTracksEvent( 'calypso_reader_discover_tab_clicked', { tab } ) );
 	};
 
-	const getLocalizedPath = ( path: string ) => {
-		return addLocaleToPathLocaleInFront( path, currentLocale );
-	};
-
-	const baseTabs: Tab[] = [
-		{
-			slug: FRESHLY_PRESSED_TAB,
-			title: translate( 'Freshly Pressed' ),
-			path: '/discover',
-		},
-		{
-			slug: RECOMMENDED_TAB,
-			title: translate( 'Recommended' ),
-			path: '/discover/recommended',
-		},
-		{
-			slug: ADD_NEW_TAB,
-			title: translate( 'Add new' ),
-			path: '/discover/add-new',
-		},
-		{
-			slug: FIRST_POSTS_TAB,
-			title: translate( 'First posts' ),
-			path: '/discover/firstposts',
-		},
-		{
-			slug: 'tags',
-			title: translate( 'Tags' ),
-			path: '/discover/tags?selectedTag=dailyprompt',
-		},
-		{
-			slug: REDDIT_TAB,
-			title: translate( 'Reddit' ),
-			path: '/discover/reddit',
-		},
-		{
-			slug: LATEST_TAB,
-			title: translate( 'Latest', {
-				context: 'latest blog posts',
-			} ),
-			path: '/discover/latest',
-		},
-	];
-
 	// Only show the "Add new" and "Reddit" tabs if the user is logged in.
-	const filteredTabs = baseTabs.filter(
-		( tab ) => ( tab.slug !== ADD_NEW_TAB && tab.slug !== REDDIT_TAB ) || isLoggedIn
-	);
+	const tabs = useMemo( () => {
+		const getLocalizedPath = ( path: string ) => {
+			return addLocaleToPathLocaleInFront( path, currentLocale );
+		};
 
-	// Add localization to paths if needed.
-	const tabs = filteredTabs.map( ( tab ) => ( {
-		...tab,
-		path: getLocalizedPath( tab.path ),
-	} ) );
+		const baseTabs: Tab[] = [
+			{
+				slug: FRESHLY_PRESSED_TAB,
+				title: translate( 'Freshly Pressed' ),
+				path: '/discover',
+			},
+			{
+				slug: RECOMMENDED_TAB,
+				title: translate( 'Recommended' ),
+				path: '/discover/recommended',
+			},
+			{
+				slug: ADD_NEW_TAB,
+				title: translate( 'Add new' ),
+				path: '/discover/add-new',
+			},
+			{
+				slug: FIRST_POSTS_TAB,
+				title: translate( 'First posts' ),
+				path: '/discover/firstposts',
+			},
+			{
+				slug: 'tags',
+				title: translate( 'Tags' ),
+				path: '/discover/tags?selectedTag=dailyprompt',
+			},
+			{
+				slug: REDDIT_TAB,
+				title: translate( 'Reddit' ),
+				path: '/discover/reddit',
+			},
+			{
+				slug: LATEST_TAB,
+				title: translate( 'Latest', {
+					context: 'latest blog posts',
+				} ),
+				path: '/discover/latest',
+			},
+		];
+
+		return baseTabs
+			.filter( byProtectedTab( isLoggedIn ) )
+			.filter( byFeatureFlag )
+			.map( ( tab ) => ( {
+				...tab,
+				path: getLocalizedPath( tab.path ),
+			} ) );
+	}, [ isLoggedIn, currentLocale ] );
 
 	const selectedTabData = tabs.find( ( tab ) => tab.slug === selectedTab );
 

--- a/client/reader/discover/components/navigation/index.tsx
+++ b/client/reader/discover/components/navigation/index.tsx
@@ -105,7 +105,7 @@ const DiscoverNavigation = ( { selectedTab }: Props ) => {
 			...tab,
 			path: getLocalizedPath( tab.path ),
 		} ) );
-	}, [ isLoggedIn, currentLocale ] );
+	}, [ isLoggedIn, currentLocale, isNewSubscriptionEnabled ] );
 
 	const selectedTabData = tabs.find( ( tab ) => tab.slug === selectedTab );
 

--- a/client/reader/discover/components/navigation/test/index.test.tsx
+++ b/client/reader/discover/components/navigation/test/index.test.tsx
@@ -32,8 +32,8 @@ describe( 'DiscoverNavigation', () => {
 		expect( screen.getByRole( 'menuitem', { name: 'Tags' } ) ).toBeVisible();
 		expect( screen.getByRole( 'menuitem', { name: 'Latest' } ) ).toBeVisible();
 
-		expect( screen.getByRole( 'menuitem', { name: 'Add new' } ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'menuitem', { name: 'Reddit' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'menuitem', { name: 'Add new' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'menuitem', { name: 'Reddit' } ) ).not.toBeInTheDocument();
 	} );
 
 	describe( 'when the feature discover v3 is disabled', () => {

--- a/client/reader/discover/components/navigation/test/index.test.tsx
+++ b/client/reader/discover/components/navigation/test/index.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { isDiscoverV3Enabled } from 'calypso/reader/utils';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import DiscoverNavigation from '../index';
+
+jest.mock( 'calypso/reader/utils', () => ( {
+	...jest.requireActual( 'calypso/reader/utils' ),
+	isDiscoverV3Enabled: jest.fn().mockReturnValue( false ),
+} ) );
+
+describe( 'DiscoverNavigation', () => {
+	it( 'shows the navigation tabs', () => {
+		( isDiscoverV3Enabled as jest.Mock ).mockReturnValue( true );
+
+		renderWithProvider( <DiscoverNavigation selectedTab="freshly-pressed" />, {
+			initialState: {
+				currentUser: {
+					id: 1,
+				},
+			},
+		} );
+
+		const links = screen.getAllByRole( 'menuitem' );
+		expect( links ).toHaveLength( 5 );
+		expect( screen.getByRole( 'menuitem', { name: 'Freshly Pressed' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Recommended' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'First posts' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Tags' } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: 'Latest' } ) ).toBeVisible();
+	} );
+
+	describe( 'when the feature discover v3 is disabled', () => {
+		beforeEach( () => {
+			( isDiscoverV3Enabled as jest.Mock ).mockReturnValue( false );
+		} );
+
+		it( 'shows the navigation tabs', () => {
+			renderWithProvider( <DiscoverNavigation selectedTab="freshly-pressed" />, {
+				initialState: {
+					currentUser: {
+						id: 1,
+					},
+				},
+			} );
+
+			const links = screen.getAllByRole( 'menuitem' );
+			expect( links ).toHaveLength( 7 );
+			expect( screen.getByRole( 'menuitem', { name: 'Freshly Pressed' } ) ).toBeVisible();
+			expect( screen.getByRole( 'menuitem', { name: 'Recommended' } ) ).toBeVisible();
+			expect( screen.getByRole( 'menuitem', { name: 'First posts' } ) ).toBeVisible();
+			expect( screen.getByRole( 'menuitem', { name: 'Tags' } ) ).toBeVisible();
+			expect( screen.getByRole( 'menuitem', { name: 'Latest' } ) ).toBeVisible();
+			expect( screen.getByRole( 'menuitem', { name: 'Reddit' } ) ).toBeVisible();
+			expect( screen.getByRole( 'menuitem', { name: 'Add new' } ) ).toBeVisible();
+		} );
+	} );
+} );

--- a/client/reader/discover/components/navigation/test/index.test.tsx
+++ b/client/reader/discover/components/navigation/test/index.test.tsx
@@ -31,6 +31,9 @@ describe( 'DiscoverNavigation', () => {
 		expect( screen.getByRole( 'menuitem', { name: 'First posts' } ) ).toBeVisible();
 		expect( screen.getByRole( 'menuitem', { name: 'Tags' } ) ).toBeVisible();
 		expect( screen.getByRole( 'menuitem', { name: 'Latest' } ) ).toBeVisible();
+
+		expect( screen.getByRole( 'menuitem', { name: 'Add new' } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'menuitem', { name: 'Reddit' } ) ).not.toBeInTheDocument();
 	} );
 
 	describe( 'when the feature discover v3 is disabled', () => {

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -33,6 +33,28 @@ global.CSS = {
 
 global.ResizeObserver = require( 'resize-observer-polyfill' );
 
+// JSDOM doesn't implement IntersectionObserver, but various UI components rely on it
+// (e.g. `client/components/section-nav/tabs.jsx`). Provide a minimal mock for tests.
+if ( typeof global.IntersectionObserver !== 'function' ) {
+	class MockIntersectionObserver {
+		constructor( callback, options ) {
+			this.callback = callback;
+			this.options = options;
+		}
+
+		observe = jest.fn();
+		unobserve = jest.fn();
+		disconnect = jest.fn();
+		takeRecords = jest.fn( () => [] );
+	}
+
+	Object.defineProperty( global, 'IntersectionObserver', {
+		value: MockIntersectionObserver,
+		writable: true,
+		configurable: true,
+	} );
+}
+
 global.fetch = jest.fn( () =>
 	Promise.resolve( {
 		json: () => Promise.resolve(),


### PR DESCRIPTION
Closes READ-3

## Proposed Changes
* Hide "Add new" and "Reddit" tabs based on the feature flag state


## Testing Instructions
## Testing Instructions

### Feature OFF
* Go to`/discover?flags=-reader/discover-v3`
* Check if you can see the tabs "Add new" and "Reddit"


### Feature ON
* Go to`/discover?flags=reader/discover-v3`
* Check if you CAN NOT see the tabs "Add new" and "Reddit"


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
