### PR TITLE
Switch to DropdownMenu

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -7,7 +7,9 @@ import {
 	Button,
 	Flex,
 	__experimentalHStack as HStack,
-	privateApis as componentsPrivateApis,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -21,7 +23,6 @@ import {
 	bell,
 	backup,
 } from '@wordpress/icons';
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -30,12 +31,6 @@ import { HELP_CENTER_STORE } from '../stores';
 import { BackButton } from './back-button';
 import type { Header } from '../types';
 import type { HelpCenterSelect } from '@automattic/data-stores';
-export const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-	'@wordpress/edit-site'
-);
-
-const { Menu } = unlock( componentsPrivateApis );
 
 import './help-center-header.scss';
 
@@ -87,54 +82,62 @@ const EllipsisMenu = () => {
 	};
 
 	return (
-		<Menu>
-			<Menu.TriggerButton
-				title={ __( 'Help Center Options', __i18n_text_domain__ ) }
-				render={ <Button icon={ moreVertical } /> }
-			/>
-			<Menu.Popover>
-				<Menu.Item
-					prefix={ <Icon icon={ lineSolid } width={ 20 } height={ 20 } /> }
-					onClick={ () => setIsMinimized( true ) }
-				>
-					<Menu.ItemLabel>{ __( 'Minimize', __i18n_text_domain__ ) }</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu.Separator />
-				<Menu.Item
-					onClick={ clearChat }
-					prefix={ <Icon icon={ comment } width={ 24 } height={ 24 } /> }
-				>
-					<Menu.ItemLabel>{ __( 'New chat', __i18n_text_domain__ ) }</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu.Item
-					onClick={ handleViewChats }
-					prefix={ <Icon icon={ backup } width={ 24 } height={ 24 } /> }
-				>
-					<Menu.ItemLabel>{ __( 'Support history', __i18n_text_domain__ ) }</Menu.ItemLabel>
-				</Menu.Item>
-				{ isLoggedIn && (
-					<>
-						<Menu.Separator />
-						<Menu.Item
-							onClick={ toggleSoundNotifications }
-							prefix={
-								areSoundNotificationsEnabled ? (
-									<MutedBellIcon />
-								) : (
-									<Icon icon={ bell } width={ 24 } height={ 24 } />
-								)
-							}
+		<DropdownMenu icon={ moreVertical } label={ __( 'Help Center Options', __i18n_text_domain__ ) }>
+			{ ( { onClose } ) => (
+				<>
+					<MenuGroup>
+						<MenuItem
+							icon={ lineSolid }
+							iconPosition="left"
+							onClick={ () => {
+								setIsMinimized( true );
+								onClose();
+							} }
 						>
-							<Menu.ItemLabel>
+							{ __( 'Minimize', __i18n_text_domain__ ) }
+						</MenuItem>
+					</MenuGroup>
+					<MenuGroup>
+						<MenuItem
+							icon={ comment }
+							iconPosition="left"
+							onClick={ () => {
+								clearChat();
+								onClose();
+							} }
+						>
+							{ __( 'New chat', __i18n_text_domain__ ) }
+						</MenuItem>
+						<MenuItem
+							icon={ backup }
+							iconPosition="left"
+							onClick={ () => {
+								handleViewChats();
+								onClose();
+							} }
+						>
+							{ __( 'Support history', __i18n_text_domain__ ) }
+						</MenuItem>
+					</MenuGroup>
+					{ isLoggedIn && (
+						<MenuGroup>
+							<MenuItem
+								icon={ areSoundNotificationsEnabled ? <MutedBellIcon /> : bell }
+								iconPosition="left"
+								onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+									toggleSoundNotifications( e );
+									onClose();
+								} }
+							>
 								{ areSoundNotificationsEnabled
 									? __( 'Turn off sound notifications', __i18n_text_domain__ )
 									: __( 'Turn on sound notifications', __i18n_text_domain__ ) }
-							</Menu.ItemLabel>
-						</Menu.Item>
-					</>
-				) }
-			</Menu.Popover>
-		</Menu>
+							</MenuItem>
+						</MenuGroup>
+					) }
+				</>
+			) }
+		</DropdownMenu>
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-16050

| Before  | After |
| ------------- | ------------- |
| <img width="435" height="731" alt="Screenshot 2026-02-12 at 14 55 06" src="https://github.com/user-attachments/assets/5e42a8a2-78ed-4dd1-85d3-6e4ea367c7af" />  | <img width="459" height="721" alt="Screenshot 2026-02-12 at 14 54 11" src="https://github.com/user-attachments/assets/a1eb272a-127f-4e55-a94f-b2fe9f095c73" />  |

## Proposed Changes

* Replace the private WordPress `Menu` component (accessed via `__dangerousOptInToUnstableAPIsOnlyForCoreModules`) with the public `DropdownMenu`, `MenuGroup`, and `MenuItem` from `@wordpress/components` in the Help Center header.
* Use `iconPosition="left"` on all header menu items so icons remain on the left, matching previous behavior.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Help Center uses the private `Menu` API via `__dangerousOptInToUnstableAPIsOnlyForCoreModules`, which is intended only for JavaScript modules shipped with WordPress core. When the Help Center is loaded in non-core contexts (e.g. the logged-out help center or other entry points), WordPress throws: *"You tried to opt-in to unstable APIs without confirming you know the consequences..."*, breaking the UI.
* Switching to the public `DropdownMenu` / `MenuItem` API removes the dependency on unstable/private APIs so the Help Center works in all contexts (Calypso, logged-out, etc.) without runtime errors, while preserving the same options (Minimize, New chat, Support history, sound notifications) and left-aligned icons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch
- cd to apps/help-center
- run yarn dev --sync
- Test the help center menu. It should retain the same behaviour
- Test in forums and support site with: dotcom_support_enable_odie_answers=true
- Test for regressions: wp-admin and calypso


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
