### PR TITLE
A4A: Update Pressable incentives banners.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -26,6 +27,8 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 
 	const pressableOwnership = usePressableOwnershipType();
 
+	const { showSupportGuide } = useHelpCenter();
+
 	// Make sure we only show the offer if the agency is a Billing Dragon agency and does not have a Pressable license through A4A, unless we are in referral mode
 	const shouldShowOffer =
 		agency?.billing_system === 'billingdragon' &&
@@ -47,9 +50,42 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 		);
 	}, [ dispatch ] );
 
-	const onSeeFullTermClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_pressable_promo_offer_2026_see_full_terms_click' ) );
-	}, [ dispatch ] );
+	const onSeeFullTermClick = useCallback(
+		( e: React.MouseEvent< HTMLButtonElement > ) => {
+			e.stopPropagation();
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_pressable_promo_offer_2026_see_full_terms_click' )
+			);
+		},
+		[ dispatch ]
+	);
+
+	const onSeeMigrationBonusTermsClick = useCallback(
+		( e: React.MouseEvent< HTMLButtonElement > ) => {
+			e.stopPropagation();
+			dispatch(
+				recordTracksEvent(
+					'calypso_a4a_pressable_promo_offer_2026_see_migration_bonus_terms_click'
+				)
+			);
+		},
+		[ dispatch ]
+	);
+
+	const onSeeMigrationIncentivesTrackingGuideClick = useCallback(
+		( e: React.MouseEvent< HTMLButtonElement > ) => {
+			e.stopPropagation();
+			dispatch(
+				recordTracksEvent(
+					'calypso_a4a_pressable_promo_offer_2026_see_migration_incentives_tracking_guide_click'
+				)
+			);
+			showSupportGuide(
+				'https://agencieshelp.automattic.com/knowledge-base/migration-incentive-tracking/'
+			);
+		},
+		[ dispatch, showSupportGuide ]
+	);
 
 	if ( ! shouldShowOffer ) {
 		return null;
@@ -71,12 +107,7 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 				<h3 className="a4a-pressable-offer__title">
 					<span>
 						{ translate(
-							'{{b}}Limited time offer:{{/b}} Get up to 6 months of free Pressable hosting on new plans!',
-							{
-								components: {
-									b: <b />,
-								},
-							}
+							'Your Exclusive Automattic for Agencies Limited-Time Pressable Offer Just Got Better 🎉'
 						) }
 					</span>
 
@@ -90,7 +121,7 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 						<SimpleList
 							items={ [
 								translate(
-									'{{b}}6 Months Free on Annual Plans:{{/b}} Purchase a 12-month plan and receive a 50% discount on the upfront cost.',
+									'{{b}}6 months of free hosting on annual Premium or Signature plans:{{/b}} Purchase a 12-month plan and receive a 50% discount on your first year.',
 									{
 										components: {
 											b: <b />,
@@ -98,7 +129,7 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 									}
 								),
 								translate(
-									'{{b}}3 Months Free on Monthly Plans:{{/b}} Choose a monthly billing cycle and receive savings equal to 3 free months (applied as a discount evenly across the first 12 invoices).',
+									'{{b}}3 months of free hosting on monthly plans:{{/b}} Choose a monthly billing cycle and receive savings equal to 3 free months (applied as a discount evenly across the first 12 invoices).',
 									{
 										components: {
 											b: <b />,
@@ -106,10 +137,15 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 									}
 								),
 								translate(
-									'{{b}}Automattic for Agencies Exclusive:{{/b}} As a partner, you can unlock these savings on Pressable’s full Signature Plan suite in addition to Premium plans.',
+									'PLUS earn up to $200 for each Signature site and up to $1,000 for each Premium site successfully migrated and {{a}}tagged{{/a}} by the deadline.',
 									{
 										components: {
-											b: <b />,
+											a: (
+												<Button
+													variant="link"
+													onClick={ onSeeMigrationIncentivesTrackingGuideClick }
+												/>
+											),
 										},
 									}
 								),
@@ -130,18 +166,30 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 								</Button>
 							) }
 
-							<Button
-								variant="secondary"
-								href="https://pressable.com/legal/hosting-promotion-terms/"
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={ onSeeFullTermClick }
-							>
-								{ translate( 'See full terms ↗' ) }
-							</Button>
-
 							<span className="a4a-pressable-offer__body-actions-footnote">
-								{ translate( '*Offer valid January 27 - April 30, 2026' ) }
+								{ translate(
+									'See terms of Hosting Promotion {{TermLink}}here{{/TermLink}} and the Migration Bonus {{MigrationBonusLink}}here{{/MigrationBonusLink}}',
+									{
+										components: {
+											TermLink: (
+												<Button
+													variant="link"
+													onClick={ onSeeFullTermClick }
+													href="https://pressable.com/legal/hosting-promotion-terms/"
+													target="_blank"
+												/>
+											),
+											MigrationBonusLink: (
+												<Button
+													variant="link"
+													onClick={ onSeeMigrationBonusTermsClick }
+													href="https://pressable.com/legal/migration-bonus-2026/"
+													target="_blank"
+												/>
+											),
+										},
+									}
+								) }
 							</span>
 						</div>
 					</div>

--- a/client/a8c-for-agencies/components/upcoming-event/index.tsx
+++ b/client/a8c-for-agencies/components/upcoming-event/index.tsx
@@ -63,7 +63,7 @@ const UpcomingEvent = ( {
 			<div className="a4a-event__content">
 				<div className="a4a-event__header">
 					<div className="a4a-event__logo">
-						{ logoElement ?? <img src={ logoUrl } alt={ title } /> }
+						{ logoElement ?? <img src={ logoUrl } alt={ title as string } /> }
 					</div>
 					<div className="a4a-event__date-and-title">
 						<div className={ clsx( 'a4a-event__date', dateClassName ) }>

--- a/client/a8c-for-agencies/components/upcoming-event/index.tsx
+++ b/client/a8c-for-agencies/components/upcoming-event/index.tsx
@@ -62,9 +62,7 @@ const UpcomingEvent = ( {
 		<div className="a4a-event">
 			<div className="a4a-event__content">
 				<div className="a4a-event__header">
-					<div className="a4a-event__logo">
-						{ logoElement ?? <img src={ logoUrl } alt={ title as string } /> }
-					</div>
+					<div className="a4a-event__logo">{ logoElement ?? <img src={ logoUrl } alt="" /> }</div>
 					<div className="a4a-event__date-and-title">
 						<div className={ clsx( 'a4a-event__date', dateClassName ) }>
 							<time dateTime={ dateTimeString }>{ displayDate }</time>

--- a/client/a8c-for-agencies/components/upcoming-event/index.tsx
+++ b/client/a8c-for-agencies/components/upcoming-event/index.tsx
@@ -97,7 +97,7 @@ const UpcomingEvent = ( {
 						);
 					} ) }
 
-					{ extraContent }
+					<div className="a4a-event__extra-content">{ extraContent }</div>
 				</div>
 			</div>
 			<div

--- a/client/a8c-for-agencies/components/upcoming-event/style.scss
+++ b/client/a8c-for-agencies/components/upcoming-event/style.scss
@@ -119,6 +119,10 @@
 		width: 100%;
 	}
 
+	.a4a-event__extra-content {
+		@include body-small;
+	}
+
 	@include break-large {
 		flex-direction: row;
 		justify-content: flex-start;

--- a/client/a8c-for-agencies/components/upcoming-event/types.ts
+++ b/client/a8c-for-agencies/components/upcoming-event/types.ts
@@ -5,7 +5,7 @@ export type UpcomingEventProps = {
 	id: string;
 	date: { from: Moment; to: Moment };
 	displayDate?: string;
-	title: string;
+	title: TranslateResult;
 	subtitle: string;
 	descriptions: TranslateResult[];
 	logoUrl?: string;

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -67,7 +67,7 @@ export const useUpcomingEvents = () => {
 								from: moment( '2026-02-12' ),
 								to: moment( '2026-04-30' ),
 							},
-							displayDate: '',
+							displayDate: ' ', // Empty string to hide the date
 							title: translate(
 								'Your Exclusive Automattic for Agencies Limited-Time Pressable Offer Just Got Better 🎉'
 							),

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -59,7 +59,7 @@ export const useUpcomingEvents = () => {
 
 	return useMemo( () => {
 		const eventsData: UpcomingEventProps[] = [
-			...( shouldShowPressablePromoOffer
+			...( ! shouldShowPressablePromoOffer
 				? [
 						{
 							id: 'a4a-pressable-promo-offer-2026-01-29',
@@ -69,7 +69,12 @@ export const useUpcomingEvents = () => {
 							},
 							displayDate: ' ', // Empty string to hide the date
 							title: translate(
-								'Your Exclusive Automattic for Agencies Limited-Time Pressable Offer Just Got Better 🎉'
+								'Your Exclusive Automattic for Agencies Limited-Time Pressable Offer {{br/}}Just Got Better 🎉',
+								{
+									components: {
+										br: <br />,
+									},
+								}
 							),
 							subtitle: translate( 'Automattic for Agencies & Pressable' ),
 							descriptions: [

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -59,7 +59,7 @@ export const useUpcomingEvents = () => {
 
 	return useMemo( () => {
 		const eventsData: UpcomingEventProps[] = [
-			...( ! shouldShowPressablePromoOffer
+			...( shouldShowPressablePromoOffer
 				? [
 						{
 							id: 'a4a-pressable-promo-offer-2026-01-29',

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -69,10 +69,10 @@ export const useUpcomingEvents = () => {
 							},
 							displayDate: ' ', // Empty string to hide the date
 							title: translate(
-								'Your Exclusive Automattic for Agencies Limited-Time Pressable Offer {{br/}}Just Got Better 🎉',
+								'Your Exclusive Automattic for Agencies Limited-Time Pressable Offer Just{{nbsp/}}Got{{nbsp/}}Better 🎉',
 								{
 									components: {
-										br: <br />,
+										nbsp: <>&nbsp;</>,
 									},
 								}
 							),

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -1,13 +1,16 @@
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { UpcomingEventProps } from 'calypso/a8c-for-agencies/components/upcoming-event/types';
+import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/events/pressable-logo.svg';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export const useUpcomingEvents = () => {
 	const translate = useTranslate();
@@ -20,6 +23,40 @@ export const useUpcomingEvents = () => {
 	const shouldShowPressablePromoOffer =
 		agency?.billing_system === 'billingdragon' && pressableOwnership !== 'agency';
 
+	const dispatch = useDispatch();
+	const { showSupportGuide } = useHelpCenter();
+
+	const onSeeMigrationIncentivesTrackingGuideClick = useCallback(
+		( e: React.MouseEvent< HTMLButtonElement > ) => {
+			e.stopPropagation();
+			dispatch(
+				recordTracksEvent(
+					'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_see_migration_incentives_tracking_guide_click'
+				)
+			);
+			showSupportGuide(
+				'https://agencieshelp.automattic.com/knowledge-base/migration-incentive-tracking/'
+			);
+		},
+		[ dispatch, showSupportGuide ]
+	);
+
+	const onSeeFullTermClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent(
+				'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_see_full_terms_click'
+			)
+		);
+	}, [ dispatch ] );
+
+	const onSeeMigrationBonusTermsClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent(
+				'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_see_migration_bonus_terms_click'
+			)
+		);
+	}, [ dispatch ] );
+
 	return useMemo( () => {
 		const eventsData: UpcomingEventProps[] = [
 			...( shouldShowPressablePromoOffer
@@ -27,17 +64,31 @@ export const useUpcomingEvents = () => {
 						{
 							id: 'a4a-pressable-promo-offer-2026-01-29',
 							date: {
-								from: moment( '2026-01-27' ),
+								from: moment( '2026-02-12' ),
 								to: moment( '2026-04-30' ),
 							},
-							displayDate: translate( 'Jan 27—April 30, 2026' ),
+							displayDate: '',
 							title: translate(
-								'Limited time offer: Get up to 6 months of free Pressable hosting on new plans!'
+								'Your Exclusive Automattic for Agencies Limited-Time Pressable Offer Just Got Better 🎉'
 							),
 							subtitle: translate( 'Automattic for Agencies & Pressable' ),
 							descriptions: [
 								translate(
 									'Enjoy up to 6 months free on Pressable Signature and Premium Plans with Automattic for Agencies. Choose annual billing for 6 months free or monthly billing for 3 months free, while still earning revenue share and reseller incentives.'
+								),
+
+								translate(
+									'PLUS earn up to $200 for each Signature site and up to $1,000 for each Premium site successfully migrated and {{a}}tagged{{/a}} by the deadline.',
+									{
+										components: {
+											a: (
+												<Button
+													variant="link"
+													onClick={ onSeeMigrationIncentivesTrackingGuideClick }
+												/>
+											),
+										},
+									}
 								),
 							],
 							ctas: [
@@ -48,15 +99,34 @@ export const useUpcomingEvents = () => {
 									trackEventName:
 										'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_view_click',
 								},
-								{
-									variant: 'secondary',
-									label: translate( 'See full terms' ),
-									url: 'https://pressable.com/legal/hosting-promotion-terms',
-									isExternal: true,
-									trackEventName:
-										'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_view_terms_click',
-								},
 							],
+							extraContent: (
+								<>
+									{ translate(
+										'See terms of Hosting Promotion {{TermLink}}here{{/TermLink}} and the Migration Bonus {{MigrationBonusLink}}here{{/MigrationBonusLink}}',
+										{
+											components: {
+												TermLink: (
+													<Button
+														variant="link"
+														onClick={ onSeeFullTermClick }
+														href="https://pressable.com/legal/hosting-promotion-terms/"
+														target="_blank"
+													/>
+												),
+												MigrationBonusLink: (
+													<Button
+														variant="link"
+														onClick={ onSeeMigrationBonusTermsClick }
+														href="https://pressable.com/legal/migration-bonus-2026/"
+														target="_blank"
+													/>
+												),
+											},
+										}
+									) }
+								</>
+							),
 							logoUrl: PressableLogo,
 							dateClassName: 'a4a-event__date--pressable',
 						},
@@ -69,5 +139,12 @@ export const useUpcomingEvents = () => {
 			const today = localizedMoment().startOf( 'day' );
 			return eventDate.isSameOrAfter( today );
 		} );
-	}, [ localizedMoment, shouldShowPressablePromoOffer, translate ] );
+	}, [
+		localizedMoment,
+		onSeeFullTermClick,
+		onSeeMigrationBonusTermsClick,
+		onSeeMigrationIncentivesTrackingGuideClick,
+		shouldShowPressablePromoOffer,
+		translate,
+	] );
 };


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-2096/a4a-pressable-incentive-update-banner-copy-2x

## Proposed Changes

**Pressable Offer UI and Messaging Updates:**

- Updated the Pressable offer title and descriptions to emphasize exclusivity and clarify the details of the promotion, including new copy for annual/monthly plans and migration incentives. The offer now highlights the ability to earn up to $200 for Signature sites and $1,000 for Premium sites migrated and tagged by the deadline. [[1]](diffhunk://#diff-c74a0ede5e68a0fdc20394ab3ae89bb4b09937ef2f73ebd1734793a2af2264ccL74-R110) [[2]](diffhunk://#diff-c74a0ede5e68a0fdc20394ab3ae89bb4b09937ef2f73ebd1734793a2af2264ccL93-R148)


- The terms and migration bonus links are now presented as inline buttons within the offer's footnote, providing a clearer and more accessible way for users to view legal terms.

<img width="1543" height="369" alt="Screenshot 2026-02-12 at 10 41 09 PM" src="https://github.com/user-attachments/assets/5ad9ebde-51e1-4fb8-8597-fda03ffb6346" />

<img width="1020" height="307" alt="Screenshot 2026-02-13 at 12 42 01 AM" src="https://github.com/user-attachments/assets/3863a0e7-4660-4367-8d85-841d528fc550" />


## Why are these changes being made?

* Our banners need to be updated to include the 2nd migration that launched this week. 

## Testing Instructions
* Log in using an Agency that has not previously purchased a Pressable plan and ensure the Agency is on the BD system.
* Use the A4A live link and navigate to `/overview` and the `/marketplace/hosting` pages.
* Confirm you see the banners and links are working correctly.
* Ensure tracking events are firing as well.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
