### PR TITLE
Domain Search: Prepend domain when adding it to the cart

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -64,7 +64,7 @@ export const useWPCOMDomainSearchCart = ( {
 	onContinue,
 	beforeAddDomainToCart = ( domain ) => domain,
 }: UseWPCOMDomainSearchCartOptions ) => {
-	const { responseCart, addProductsToCart, removeProductFromCart } = useShoppingCart( cartKey );
+	const { responseCart, replaceProductsInCart, removeProductFromCart } = useShoppingCart( cartKey );
 
 	return useMemo( () => {
 		const domainItems = flowAllowsMultipleDomainsInCart
@@ -118,7 +118,7 @@ export const useWPCOMDomainSearchCart = ( {
 			total,
 			hasItem: ( domain ) => !! domainItems.find( ( item ) => item.meta === domain ),
 			onAddItem: async ( { domain_name, product_slug, supports_privacy } ) => {
-				const cartItems = await addProductsToCart( [
+				const cartItems = await replaceProductsInCart( [
 					beforeAddDomainToCart( {
 						product_slug,
 						meta: domain_name,
@@ -130,6 +130,7 @@ export const useWPCOMDomainSearchCart = ( {
 							...( flowName && { flow_name: flowName } ),
 						},
 					} ),
+					...responseCart.products,
 				] );
 
 				if ( ! flowAllowsMultipleDomainsInCart ) {
@@ -151,7 +152,7 @@ export const useWPCOMDomainSearchCart = ( {
 	}, [
 		responseCart,
 		removeProductFromCart,
-		addProductsToCart,
+		replaceProductsInCart,
 		flowName,
 		isFirstDomainFreeForFirstYear,
 		flowAllowsMultipleDomainsInCart,


### PR DESCRIPTION
Closes DOTOBRD-397.

## Proposed Changes

Fixes the new site flow showing the wrong domain by prepending the newly selected domain to the cart search, rather than just adding it, so the newly chosen domain is first and displayed correctly within the plans step and checkout.

## Testing Instructions

Follow the video included in the issue description:

1. Enter `/setup`
2. Add a domain to the cart
3. Click "Continue" and click "start with a free plan" in the plans step
4. Verify the domain that shows up in the modal is the selected one
5. Click "Back" at the top-left
6. Add a different domain to the cart (keep the existing one)
7. Click "Continue" and click "start with a free plan" in the plans step

This time, verify the newly selected domain shows up in the modal instead of the first one that you selected.