### PR TITLE
e2e: Update SEO test to use document sidebar instead of Jetpack sidebar

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -708,13 +708,17 @@ export class EditorPage {
 	}
 
 	/**
-	 * Enters SEO details on the Editor sidebar.
+	 * Enters SEO details on the document sidebar.
+	 *
+	 * The SEO fields are located in the main document sidebar under the
+	 * Post/Page tab, not the Jetpack sidebar.
 	 *
 	 * @param param0 Keyed object parameter.
 	 * @param {string} param0.title SEO title.
 	 * @param {string} param0.description SEO description.
 	 */
 	async enterSEODetails( { title, description }: { title: string; description: string } ) {
+		await this.editorSettingsSidebarComponent.expandSection( 'SEO' );
 		await this.editorSettingsSidebarComponent.enterText( title, { label: 'SEO TITLE' } );
 		await this.editorSettingsSidebarComponent.enterText( description, {
 			label: 'SEO DESCRIPTION',

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -718,6 +718,10 @@ export class EditorPage {
 	 * @param {string} param0.description SEO description.
 	 */
 	async enterSEODetails( { title, description }: { title: string; description: string } ) {
+		await Promise.race( [
+			this.editorSettingsSidebarComponent.clickTab( 'Page' ),
+			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
+		] );
 		await this.editorSettingsSidebarComponent.expandSection( 'SEO' );
 		await this.editorSettingsSidebarComponent.enterText( title, { label: 'SEO TITLE' } );
 		await this.editorSettingsSidebarComponent.enterText( description, {

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -95,6 +95,18 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	describe( 'Jetpack features', function () {
+		skipItIf( envVariables.TEST_ON_ATOMIC !== true )(
+			'Enter SEO title and description',
+			async function () {
+				await editorPage.openSettings( 'Settings' );
+				await editorPage.enterSEODetails( {
+					title: seoTitle,
+					description: seoDescription,
+				} );
+				await editorPage.closeSettings();
+			}
+		);
+
 		it( 'Open Jetpack settings', async function () {
 			// @TODO https://github.com/Automattic/wp-calypso/pull/82301
 			// Works around the scenario where the Jetpack icon isn't pinned on the
@@ -104,16 +116,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 			await page.getByRole( 'menuitemcheckbox', { name: 'Jetpack' } ).click();
 		} );
-
-		skipItIf( envVariables.TEST_ON_ATOMIC !== true )(
-			'Enter SEO title and preview',
-			async function () {
-				await editorPage.enterSEODetails( {
-					title: seoTitle,
-					description: seoDescription,
-				} );
-			}
-		);
 
 		skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )( 'Link preview', function () {
 			it( 'Open link preview', async function () {


### PR DESCRIPTION
## Summary

The SEO title and description fields have moved from the Jetpack sidebar to the main document sidebar in the editor (see Automattic/jetpack#47045).

- Update `enterSEODetails` in `EditorPage` to expand the "SEO" section in the document sidebar
- Move SEO entry step in `editor__post-basic-flow` to open the document Settings sidebar before entering SEO details, since the fields are no longer in the Jetpack sidebar

## Test plan

- [ ] `editor__post-basic-flow` passes on Atomic