### PR TITLE
CIAB: Enumerate valid options for allowedSocialServices

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -16,6 +16,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import PasswordlessSignupForm from './passwordless';
 import SocialSignupForm from './social';
+import type { AllowedSocialService } from 'calypso/components/social-buttons/utils';
 import './style.scss';
 
 interface QueryArgs {
@@ -51,7 +52,7 @@ interface SignupFormSocialFirst {
 	isEmailVariation?: boolean;
 	isMessagingVariation?: boolean;
 	isSliderVariation?: boolean;
-	allowedSocialServices?: string[];
+	allowedSocialServices?: AllowedSocialService[];
 	customTosElement?: JSX.Element;
 }
 

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -16,7 +16,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import PasswordlessSignupForm from './passwordless';
 import SocialSignupForm from './social';
-import type { AllowedSocialService } from 'calypso/components/social-buttons/utils';
+import type { SignupAllowedService } from 'calypso/components/social-buttons/utils';
 import './style.scss';
 
 interface QueryArgs {
@@ -52,7 +52,7 @@ interface SignupFormSocialFirst {
 	isEmailVariation?: boolean;
 	isMessagingVariation?: boolean;
 	isSliderVariation?: boolean;
-	allowedSocialServices?: AllowedSocialService[];
+	allowedSocialServices?: SignupAllowedService[];
 	customTosElement?: JSX.Element;
 }
 

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -94,7 +94,7 @@ describe( 'SignupFormSocialFirst', () => {
 
 	describe( 'allowedSocialServices', () => {
 		test( 'passes allowedSocialServices to SocialSignupForm', () => {
-			const allowedServices = [ 'google', 'paypal' ];
+			const allowedServices: Array< 'google' | 'paypal' > = [ 'google', 'paypal' ];
 
 			render(
 				<SignupFormSocialFirst { ...defaultProps } allowedSocialServices={ allowedServices } />

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -6,6 +6,7 @@ import SignupFormSocialFirst from 'calypso/blocks/signup-form/signup-form-social
 import loginReducer from 'calypso/state/login/reducer';
 import routeReducer from 'calypso/state/route/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import type { SignupAllowedService } from 'calypso/components/social-buttons/utils';
 
 // Mock the analytics module
 jest.mock( '@automattic/calypso-analytics', () => ( {
@@ -94,7 +95,7 @@ describe( 'SignupFormSocialFirst', () => {
 
 	describe( 'allowedSocialServices', () => {
 		test( 'passes allowedSocialServices to SocialSignupForm', () => {
-			const allowedServices: Array< 'google' | 'paypal' > = [ 'google', 'paypal' ];
+			const allowedServices: SignupAllowedService[] = [ 'google', 'paypal' ];
 
 			render(
 				<SignupFormSocialFirst { ...defaultProps } allowedSocialServices={ allowedServices } />

--- a/client/components/social-buttons/utils.ts
+++ b/client/components/social-buttons/utils.ts
@@ -7,8 +7,14 @@ import type { AppState } from 'calypso/types';
 
 export type SocialService = 'google' | 'apple' | 'github' | 'paypal';
 
+/** Service identifiers valid in signup context. */
+export type SignupAllowedService = SocialService | 'magic-login' | 'email';
+
+/** Service identifiers valid in login context. */
+export type LoginAllowedService = SocialService | 'magic-login' | 'qr-code' | 'email';
+
 /** All service identifiers that can appear in allowedSocialServices lists. */
-export type AllowedSocialService = SocialService | 'magic-login' | 'qr-code' | 'email';
+export type AllowedSocialService = SignupAllowedService | LoginAllowedService;
 
 export const getUxMode = ( state: AppState ) => {
 	const currentRoute = getCurrentRoute( state );

--- a/client/components/social-buttons/utils.ts
+++ b/client/components/social-buttons/utils.ts
@@ -7,6 +7,9 @@ import type { AppState } from 'calypso/types';
 
 export type SocialService = 'google' | 'apple' | 'github' | 'paypal';
 
+/** All service identifiers that can appear in allowedSocialServices lists. */
+export type AllowedSocialService = SocialService | 'magic-login' | 'qr-code' | 'email';
+
 export const getUxMode = ( state: AppState ) => {
 	const currentRoute = getCurrentRoute( state );
 	const oauth2Client = getCurrentOAuth2Client( state );

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -9,7 +9,10 @@ import wooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
 import { useSelector } from 'calypso/state';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
-import type { AllowedSocialService } from 'calypso/components/social-buttons/utils';
+import type {
+	AllowedSocialService,
+	SignupAllowedService,
+} from 'calypso/components/social-buttons/utils';
 
 /**
  * Logo configuration
@@ -37,7 +40,7 @@ export interface CiabPartnerConfig {
 	/** Compact logo for TopBar (falls back to logo if not provided) */
 	compactLogo?: LogoConfig;
 	/** SSO providers to show (in order). Others will be hidden. */
-	ssoProviders: AllowedSocialService[];
+	ssoProviders: SignupAllowedService[];
 	/** Font style identifier for login/signup headings */
 	fontStyle?: 'system';
 }

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -9,6 +9,7 @@ import wooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
 import { useSelector } from 'calypso/state';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import type { AllowedSocialService } from 'calypso/components/social-buttons/utils';
 
 /**
  * Logo configuration
@@ -36,7 +37,7 @@ export interface CiabPartnerConfig {
 	/** Compact logo for TopBar (falls back to logo if not provided) */
 	compactLogo?: LogoConfig;
 	/** SSO providers to show (in order). Others will be hidden. */
-	ssoProviders: string[];
+	ssoProviders: AllowedSocialService[];
 	/** Font style identifier for login/signup headings */
 	fontStyle?: 'system';
 }
@@ -119,7 +120,7 @@ export function getCiabConfig( from: string | string[] | undefined ): CiabPartne
  */
 export function getPartnerAllowedSocialServices(
 	from: string | string[] | undefined
-): string[] | null {
+): AllowedSocialService[] | null {
 	const ciabConfig = getCiabConfig( from );
 	return ciabConfig?.ssoProviders ?? null;
 }


### PR DESCRIPTION
Part of ARC-1425

## Proposed Changes

* Adds an `AllowedSocialService` type that enumerates all valid service identifiers (`google`, `apple`, `github`, `paypal`, `magic-login`, `qr-code`, `email`) instead of using plain `string[]`.
* Updates `ssoProviders` in `CiabPartnerConfig` and the `allowedSocialServices` prop in `SignupFormSocialFirst` to use the new type, so invalid service names are caught at compile time.

## Why are these changes being made?

* Addresses review feedback from #108320 to replace `string[]` with a typed union for the `allowedSocialServices` property, improving type safety and developer experience.

## Testing Instructions

* Run `yarn test-client client/blocks/signup-form/test/signup-form-social-first.tsx` — all tests should pass.
* Run `yarn test-client client/lib/test/partner-branding.tsx` — all tests should pass.
* You can also use Calypso Live on an incognito window to test the sign-in and the sign-up page to ensure it works.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?