### PR TITLE
Fix READ-301: Posts without titles doesn't look good in Reader sidebar

### DIFF
--- a/client/reader/recent/recent-post-field.tsx
+++ b/client/reader/recent/recent-post-field.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from 'react';
+import { translate } from 'i18n-calypso';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import AutoDirection from 'calypso/components/auto-direction';
 import type { PostItem } from './types';
@@ -16,7 +17,9 @@ const RecentPostField = forwardRef< HTMLDivElement, RecentPostFieldProps >( ( { 
 		<div className="recent-post-field" ref={ ref } role="button" tabIndex={ 0 }>
 			<AutoDirection>
 				<div className="recent-post-field__title">
-					<div className="recent-post-field__title-text">{ post?.title }</div>
+					<div className="recent-post-field__title-text">
+						{ post?.title || `(${ translate( 'no title' ) })` }
+					</div>
 					<div className="recent-post-field__site-name">{ post?.site_name }</div>
 				</div>
 			</AutoDirection>


### PR DESCRIPTION
Fixes READ-301

## Proposed Changes

* Display a "(no title)" fallback text in the Reader sidebar when a post has no title, consistent with how untitled posts are handled elsewhere in the Reader codebase (e.g., x-posts).

## Why are these changes being made?

* Posts published without a title (via Quick Post or the Gutenberg editor) appear with an empty/blank title in the Reader full post view sidebar list, which looks broken. This adds a translatable "(no title)" placeholder so users can still identify and interact with these posts.

## Testing Instructions

* Go to https://wordpress.com/reader in the Recent section
* Click on `.following__view-toggle` to open the DataViews version of the recent feed
* Find or create a post without a title
* Verify that "(no title)" is displayed instead of a blank space in the sidebar list

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?