### PR TITLE
Fix READ-295: Reader back button returns to top of feed

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -465,8 +465,7 @@ export default class InfiniteList extends Component {
 	 * HTML5 history.
 	 */
 	_overrideHistoryScroll() {
-		// If we have a selected item, assume scroll is handled elsewhere.
-		if ( ! this._contextLoaded() || this.props.selectedItem ) {
+		if ( ! this._contextLoaded() ) {
 			return;
 		}
 		this._scrollContainer.addEventListener( 'scroll', this._resetScroll );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -188,7 +188,7 @@ class ReaderStream extends Component {
 	};
 
 	_popstate = () => {
-		if ( this.props.selectedPostKey && window.history.scrollRestoration !== 'manual' ) {
+		if ( this.props.selectedPostKey ) {
 			this.scrollToSelectedPost( false );
 		}
 	};


### PR DESCRIPTION
Fixes READ-295

## Proposed Changes

* Remove the `selectedItem` bail-out in `InfiniteList._overrideHistoryScroll()` so the scroll guard listener is always active during history navigation, preventing the browser from resetting scroll position to the top.
* Fix the dead condition in `ReaderStream._popstate()` that prevented `scrollToSelectedPost` from ever firing on popstate events.

## Why are these changes being made?

When viewing a post in Reader and clicking the "Back" link, the user is intermittently returned to the top of the feed instead of the position of the post that was just viewed.

Two issues contributed to this:

1. **`InfiniteList._overrideHistoryScroll()`** skipped adding a scroll guard listener when `selectedItem` was set, assuming scroll restoration was handled elsewhere. However, without this guard, any scroll-reset event (from the browser or layout shifts) after InfiniteList's initial scroll restore would go unchecked, resetting the feed to the top.

2. **`ReaderStream._popstate()`** had a condition `window.history.scrollRestoration !== 'manual'` that was always `false` because `scrollRestoration` is set to `'manual'` on mount (line 232). This made the popstate handler dead code, so the fallback scroll-to-selected-post never fired.

## Testing Instructions

1. Go to WordPress.com Reader
2. Open a regular feed
3. Scroll down the page
4. Click on a post
5. Click the "Back" link
6. Verify the feed scroll position is restored to the post that was just viewed
7. Repeat several times to confirm consistency (the bug was intermittent)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)