### PR TITLE
Redirect domain-only users with no visible sites to domains management page

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -1,12 +1,16 @@
 import config from '@automattic/calypso-config';
 import globalPageInstance from '@automattic/calypso-router';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import {
+	getCurrentUserVisibleSiteCount,
+	isUserLoggedIn,
+} from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getIsSubscriptionOnly from 'calypso/state/selectors/get-is-subscription-only';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import hasDomainOnlySites from 'calypso/state/selectors/has-domain-only-sites';
 import { requestSite } from 'calypso/state/sites/actions';
 import {
 	canCurrentUserUseCustomerHome,
@@ -114,6 +118,14 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 
 	if ( useReaderAsLandingPage ) {
 		return '/reader';
+	}
+
+	// Domain-only users (no visible sites but have a domain-only site) get a blank page if we
+	// send them to /home or /stats. Redirect only those to domains management.
+	const visibleSiteCount = getCurrentUserVisibleSiteCount( getState() ) ?? 0;
+
+	if ( visibleSiteCount === 0 && hasDomainOnlySites( getState() ) ) {
+		return '/domains/manage';
 	}
 
 	// determine the primary site ID (it's a property of "current user" object) and then

--- a/client/root.js
+++ b/client/root.js
@@ -105,6 +105,13 @@ const getSitesLink = ( isDashboardOptIn ) => {
 	return '/sites';
 };
 
+const getDomainsLink = ( isDashboardOptIn ) => {
+	if ( isDashboardOptIn && ! [ 'development', 'wpcalypso' ].includes( config( 'env_id' ) ) ) {
+		return dashboardLink( '/domains' );
+	}
+	return '/domains/manage';
+};
+
 async function getLoggedInLandingPage( { dispatch, getState } ) {
 	await dispatch( waitForPrefs() );
 	const useSitesAsLandingPage = hasSitesAsLandingPage( getState() );
@@ -125,7 +132,7 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 	const visibleSiteCount = getCurrentUserVisibleSiteCount( getState() ) ?? 0;
 
 	if ( visibleSiteCount === 0 && hasDomainOnlySites( getState() ) ) {
-		return '/domains/manage';
+		return getDomainsLink( dashboardOptIn );
 	}
 
 	// determine the primary site ID (it's a property of "current user" object) and then

--- a/client/state/selectors/has-domain-only-sites.ts
+++ b/client/state/selectors/has-domain-only-sites.ts
@@ -1,0 +1,12 @@
+import { createSelector } from '@automattic/state-utils';
+import getSites from 'calypso/state/selectors/get-sites';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns true if the user has at least one domain-only site (registered domain without a full site).
+ */
+export default createSelector(
+	( state: AppState ): boolean =>
+		getSites( state ).some( ( site ) => site && ( site.options?.is_domain_only ?? false ) ),
+	( state ) => [ state.sites.items ]
+);

--- a/client/state/selectors/test/has-domain-only-sites.js
+++ b/client/state/selectors/test/has-domain-only-sites.js
@@ -1,0 +1,48 @@
+import hasDomainOnlySites from 'calypso/state/selectors/has-domain-only-sites';
+
+const currentUser = { capabilities: {} };
+
+describe( 'hasDomainOnlySites()', () => {
+	test( 'returns false when user has no sites', () => {
+		const state = { currentUser, sites: { items: {} } };
+		expect( hasDomainOnlySites( state ) ).toBe( false );
+	} );
+
+	test( 'returns false when user has only regular sites', () => {
+		const state = {
+			currentUser,
+			sites: {
+				items: {
+					1: { ID: 1, options: { is_domain_only: false } },
+					2: { ID: 2, options: {} },
+				},
+			},
+		};
+		expect( hasDomainOnlySites( state ) ).toBe( false );
+	} );
+
+	test( 'returns true when user has at least one domain-only site', () => {
+		const state = {
+			currentUser,
+			sites: {
+				items: {
+					1: { ID: 1, options: { is_domain_only: false } },
+					2: { ID: 2, options: { is_domain_only: true } },
+				},
+			},
+		};
+		expect( hasDomainOnlySites( state ) ).toBe( true );
+	} );
+
+	test( 'returns true when user has only domain-only sites', () => {
+		const state = {
+			currentUser,
+			sites: {
+				items: {
+					1: { ID: 1, options: { is_domain_only: true } },
+				},
+			},
+		};
+		expect( hasDomainOnlySites( state ) ).toBe( true );
+	} );
+} );

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -36,7 +36,7 @@ describe( 'Logged Out Landing Page', () => {
 } );
 
 describe( 'Logged In Landing Page', () => {
-	test( 'user with no sites goes to Sites Dashboard', async () => {
+	test( 'user with no sites and no domain-only sites goes to Sites Dashboard', async () => {
 		const state = { currentUser: { id: 1 }, sites: { items: {} }, ui: {} };
 		const { page } = initRouter( { state } );
 
@@ -45,9 +45,37 @@ describe( 'Logged In Landing Page', () => {
 		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
 	} );
 
+	test( 'domain-only user with no visible sites goes to domains manage', async () => {
+		const state = {
+			currentUser: {
+				id: 1,
+				user: { primary_blog: 1, site_count: 1, visible_site_count: 0 },
+			},
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://domain-only.wordpress.com',
+						options: { is_domain_only: true },
+					},
+				},
+			},
+			ui: {},
+		};
+		const { page } = initRouter( { state } );
+
+		page( '/' );
+
+		await waitFor( () => expect( page.current ).toBe( '/domains/manage' ) );
+	} );
+
 	test( 'user with a primary site but no permissions goes to day stats', async () => {
 		const state = {
-			currentUser: { id: 1, capabilities: { 1: {} }, user: { primary_blog: 1 } },
+			currentUser: {
+				id: 1,
+				capabilities: { 1: {} },
+				user: { primary_blog: 1, visible_site_count: 1 },
+			},
 			ui: {},
 			sites: {
 				items: {
@@ -67,7 +95,11 @@ describe( 'Logged In Landing Page', () => {
 
 	test( 'user with a primary site and edit permissions goes to My Home', async () => {
 		const state = {
-			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
+			currentUser: {
+				id: 1,
+				capabilities: { 1: { edit_posts: true } },
+				user: { primary_blog: 1, visible_site_count: 1 },
+			},
 			ui: {},
 			sites: {
 				items: {
@@ -87,7 +119,11 @@ describe( 'Logged In Landing Page', () => {
 
 	test( 'user with a Jetpack site set as their primary site goes to day stats', async () => {
 		const state = {
-			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
+			currentUser: {
+				id: 1,
+				capabilities: { 1: { edit_posts: true } },
+				user: { primary_blog: 1, visible_site_count: 1 },
+			},
 			ui: {},
 			sites: {
 				items: {
@@ -181,7 +217,7 @@ describe( 'Logged In Landing Page', () => {
 			currentUser: {
 				id: 1,
 				capabilities: { 1: { edit_posts: true }, 2: { edit_posts: true } },
-				user: { primary_blog: 1 },
+				user: { primary_blog: 1, visible_site_count: 2 },
 			},
 			ui: { selectedSiteId: 2 },
 			sites: {
@@ -210,7 +246,7 @@ describe( 'Logged In Landing Page', () => {
 			currentUser: {
 				id: 1,
 				capabilities: { 1: { edit_posts: true } },
-				user: { primary_blog: 1 },
+				user: { primary_blog: 1, visible_site_count: 1 },
 			},
 			ui: { selectedSiteId: 1 },
 			sites: {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOMENG-250

## Proposed Changes

- Add `hasDomainOnlySites` selector (memoized) that returns true when the user has at least one domain-only site (registered domain without a full site).
- In the root section (`client/root.js`), when resolving the logged-in landing page: if the user has zero visible sites and has domain-only sites, redirect to `/domains/manage` instead of `/home` or `/stats`.
- Add unit tests for the selector and for the root section landing page (including the new domain-only user case).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Domain-only users (users who have only a registered domain and no full site) with zero visible sites were hitting a blank page when logging in: they were being sent to `/home` or `/stats`, which are not appropriate for users with no sites. Redirecting them to `/domains/manage` gives them a useful landing page where they can manage their domain(s).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Manually: log in as a user who has only a domain-only site (no visible sites) and visit `/`. You should be redirected to `/domains/manage` instead of seeing a blank page. (these are the instructions from the Linear issue)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
