### PR TITLE
Agents Manager: Add feedback buttons to agent messages

### DIFF
--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -68,8 +68,6 @@ interface AgentChatProps {
 	imageUpload?: UseImageUploadResult;
 	/** Whether to show the feedback text input (after thumbs down). */
 	showFeedbackInput?: boolean;
-	/** The message ID the feedback is for. */
-	feedbackMessageId?: string | null;
 	/** Called when the user submits feedback text. */
 	onSubmitFeedbackText?: ( feedbackText: string ) => Promise< void >;
 	/** Called when the user cancels the feedback input. */
@@ -100,9 +98,8 @@ export default function AgentChat( {
 	isCompactMode = false,
 	imageUpload,
 	showFeedbackInput = false,
-	feedbackMessageId,
-	onSubmitFeedbackText,
-	onCancelFeedback,
+	onSubmitFeedbackText = () => Promise.resolve(),
+	onCancelFeedback = () => {},
 }: AgentChatProps ) {
 	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
 	const { floatingPosition } = useSelect( ( select ) => {
@@ -165,7 +162,7 @@ export default function AgentChat( {
 			<AgentUI.ConversationView>
 				<ChatHeader isChatDocked={ isDocked } onClose={ onClose } options={ chatHeaderOptions } />
 				{ isLoadingConversation ? <ChatMessageSkeleton count={ 3 } /> : <AgentUI.Messages /> }
-				{ showFeedbackInput && feedbackMessageId && onSubmitFeedbackText && onCancelFeedback && (
+				{ showFeedbackInput && (
 					<FeedbackInput onSubmit={ onSubmitFeedbackText } onCancel={ onCancelFeedback } />
 				) }
 				<AgentUI.Footer>

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -16,6 +16,7 @@ import clsx from 'clsx';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import ChatMessageSkeleton from '../chat-message-skeleton';
+import FeedbackInput from '../feedback-input';
 import { AI } from '../icons';
 import SelectedBlock from '../selected-block';
 import type { UseImageUploadResult } from '../../utils/load-external-providers';
@@ -65,6 +66,14 @@ interface AgentChatProps {
 	isCompactMode?: boolean;
 	/** Image upload state from the parent component. When provided, enables the image uploader UI. */
 	imageUpload?: UseImageUploadResult;
+	/** Whether to show the feedback text input (after thumbs down). */
+	showFeedbackInput?: boolean;
+	/** The message ID the feedback is for. */
+	feedbackMessageId?: string | null;
+	/** Called when the user submits feedback text. */
+	onSubmitFeedbackText?: ( feedbackText: string ) => Promise< void >;
+	/** Called when the user cancels the feedback input. */
+	onCancelFeedback?: () => void;
 }
 
 export default function AgentChat( {
@@ -90,6 +99,10 @@ export default function AgentChat( {
 	onInputChange,
 	isCompactMode = false,
 	imageUpload,
+	showFeedbackInput = false,
+	feedbackMessageId,
+	onSubmitFeedbackText,
+	onCancelFeedback,
 }: AgentChatProps ) {
 	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
 	const { floatingPosition } = useSelect( ( select ) => {
@@ -152,6 +165,9 @@ export default function AgentChat( {
 			<AgentUI.ConversationView>
 				<ChatHeader isChatDocked={ isDocked } onClose={ onClose } options={ chatHeaderOptions } />
 				{ isLoadingConversation ? <ChatMessageSkeleton count={ 3 } /> : <AgentUI.Messages /> }
+				{ showFeedbackInput && feedbackMessageId && onSubmitFeedbackText && onCancelFeedback && (
+					<FeedbackInput onSubmit={ onSubmitFeedbackText } onCancel={ onCancelFeedback } />
+				) }
 				<AgentUI.Footer>
 					<AgentUI.Suggestions />
 					<AgentUI.Notice />

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -176,7 +176,7 @@ export default function AgentDock( {
 		messages,
 		agentId,
 		sessionId,
-		authProvider: agentConfig.authProvider,
+		authProvider: agentConfig.authProvider!,
 	} );
 
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -171,7 +171,7 @@ export default function AgentDock( {
 		[ onSubmit, pendingImages.length, uploadImagesToWordPress ]
 	);
 
-	const { showFeedbackInput, submitFeedbackText, cancelFeedback } = useFeedback( {
+	const { showFeedbackInput, submitFeedbackText, resetFeedback } = useFeedback( {
 		registerMessageActions,
 		messages,
 		agentId,
@@ -411,7 +411,7 @@ export default function AgentDock( {
 			imageUpload={ imageUpload }
 			showFeedbackInput={ showFeedbackInput }
 			onSubmitFeedbackText={ submitFeedbackText }
-			onCancelFeedback={ cancelFeedback }
+			onCancelFeedback={ resetFeedback }
 		/>
 	);
 

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -176,7 +176,7 @@ export default function AgentDock( {
 		messages,
 		agentId,
 		sessionId,
-		authProvider: agentConfig.authProvider!,
+		authProvider: agentConfig.authProvider,
 	} );
 
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -171,15 +171,13 @@ export default function AgentDock( {
 		[ onSubmit, pendingImages.length, uploadImagesToWordPress ]
 	);
 
-	const { showFeedbackInput, feedbackMessageId, submitFeedbackText, cancelFeedback } = useFeedback(
-		{
-			registerMessageActions,
-			messages,
-			agentId,
-			sessionId,
-			authProvider: agentConfig.authProvider,
-		}
-	);
+	const { showFeedbackInput, submitFeedbackText, cancelFeedback } = useFeedback( {
+		registerMessageActions,
+		messages,
+		agentId,
+		sessionId,
+		authProvider: agentConfig.authProvider,
+	} );
 
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
 	const dynamicSuggestions = useSuggestions?.();
@@ -412,7 +410,6 @@ export default function AgentDock( {
 			isCompactMode={ isCompactMode }
 			imageUpload={ imageUpload }
 			showFeedbackInput={ showFeedbackInput }
-			feedbackMessageId={ feedbackMessageId }
 			onSubmitFeedbackText={ submitFeedbackText }
 			onCancelFeedback={ cancelFeedback }
 		/>

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -18,6 +18,7 @@ import { useAgentsManagerContext } from '../../contexts';
 import useAdminBarIntegration from '../../hooks/use-admin-bar-integration';
 import useAgentLayoutManager from '../../hooks/use-agent-layout-manager';
 import useConversation from '../../hooks/use-conversation';
+import useFeedback from '../../hooks/use-feedback';
 import useSetupCustomActions from '../../hooks/use-setup-custom-actions';
 import { useShouldUseUnifiedAgent } from '../../hooks/use-should-use-unified-agent';
 import { AGENTS_MANAGER_STORE } from '../../stores';
@@ -124,6 +125,7 @@ export default function AgentDock( {
 		abortCurrentRequest,
 		clearSuggestions,
 		registerSuggestions,
+		registerMessageActions,
 	} = useAgentChat( agentConfig );
 
 	const imageUpload = useImageUpload?.();
@@ -167,6 +169,16 @@ export default function AgentDock( {
 			}
 		},
 		[ onSubmit, pendingImages.length, uploadImagesToWordPress ]
+	);
+
+	const { showFeedbackInput, feedbackMessageId, submitFeedbackText, cancelFeedback } = useFeedback(
+		{
+			registerMessageActions,
+			messages,
+			agentId,
+			siteId: site?.ID,
+			sessionId,
+		}
 	);
 
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
@@ -399,6 +411,10 @@ export default function AgentDock( {
 			onInputChange={ setInputValue }
 			isCompactMode={ isCompactMode }
 			imageUpload={ imageUpload }
+			showFeedbackInput={ showFeedbackInput }
+			feedbackMessageId={ feedbackMessageId }
+			onSubmitFeedbackText={ submitFeedbackText }
+			onCancelFeedback={ cancelFeedback }
 		/>
 	);
 

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -176,8 +176,8 @@ export default function AgentDock( {
 			registerMessageActions,
 			messages,
 			agentId,
-			siteId: site?.ID,
 			sessionId,
+			authProvider: agentConfig.authProvider,
 		}
 	);
 

--- a/packages/agents-manager/src/components/feedback-input/index.tsx
+++ b/packages/agents-manager/src/components/feedback-input/index.tsx
@@ -47,7 +47,7 @@ export default function FeedbackInput( { onSubmit, onCancel }: FeedbackInputProp
 			}, 2000 );
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
-			console.error( 'Error submitting feedback:', error );
+			console.error( '[FeedbackInput] Error submitting feedback:', error );
 			setSubmitError(
 				__( 'Failed to submit feedback. Please try again.', '__i18n_text_domain__' )
 			);

--- a/packages/agents-manager/src/components/feedback-input/index.tsx
+++ b/packages/agents-manager/src/components/feedback-input/index.tsx
@@ -19,8 +19,10 @@ export default function FeedbackInput( { onSubmit, onCancel }: FeedbackInputProp
 	const [ submitSuccess, setSubmitSuccess ] = useState( false );
 	const [ submitError, setSubmitError ] = useState< string | null >( null );
 	const timeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const containerRef = useRef< HTMLDivElement | null >( null );
 
 	useEffect( () => {
+		containerRef.current?.querySelector( 'textarea' )?.focus();
 		return () => {
 			if ( timeoutRef.current ) {
 				clearTimeout( timeoutRef.current );
@@ -92,7 +94,7 @@ export default function FeedbackInput( { onSubmit, onCancel }: FeedbackInputProp
 
 	return (
 		<div className="agents-manager-feedback-input-container">
-			<div className="agents-manager-feedback-input">
+			<div className="agents-manager-feedback-input" ref={ containerRef }>
 				<TextareaControl
 					label={ __( 'What could be improved?', '__i18n_text_domain__' ) }
 					value={ feedbackText }

--- a/packages/agents-manager/src/components/feedback-input/index.tsx
+++ b/packages/agents-manager/src/components/feedback-input/index.tsx
@@ -1,0 +1,127 @@
+import { Button } from '@wordpress/components';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import './style.scss';
+
+interface FeedbackInputProps {
+	onSubmit: ( feedbackText: string ) => Promise< void >;
+	onCancel: () => void;
+}
+
+export default function FeedbackInput( { onSubmit, onCancel }: FeedbackInputProps ) {
+	const [ feedbackText, setFeedbackText ] = useState( '' );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ submitSuccess, setSubmitSuccess ] = useState( false );
+	const [ submitError, setSubmitError ] = useState( false );
+	const timeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const textareaRef = useRef< HTMLTextAreaElement >( null );
+
+	useEffect( () => {
+		return () => {
+			if ( timeoutRef.current ) {
+				clearTimeout( timeoutRef.current );
+			}
+		};
+	}, [] );
+
+	// Focus textarea on mount
+	useEffect( () => {
+		textareaRef.current?.focus();
+	}, [] );
+
+	const handleSubmit = async () => {
+		if ( ! feedbackText.trim() || isSubmitting ) {
+			return;
+		}
+
+		setIsSubmitting( true );
+
+		try {
+			await onSubmit( feedbackText.trim() );
+			setFeedbackText( '' );
+			setSubmitSuccess( true );
+
+			timeoutRef.current = setTimeout( () => {
+				onCancel();
+			}, 2000 );
+		} catch {
+			setSubmitError( true );
+
+			timeoutRef.current = setTimeout( () => {
+				onCancel();
+			}, 2000 );
+		} finally {
+			setIsSubmitting( false );
+		}
+	};
+
+	const handleKeyDown = ( event: React.KeyboardEvent ) => {
+		if ( ( event.metaKey || event.ctrlKey ) && event.key === 'Enter' && ! event.shiftKey ) {
+			event.preventDefault();
+			handleSubmit();
+		}
+		if ( event.key === 'Escape' ) {
+			onCancel();
+		}
+	};
+
+	if ( submitSuccess ) {
+		return (
+			<div className="agents-manager-feedback-input">
+				<div className="agents-manager-feedback-input__status agents-manager-feedback-input__status--success">
+					{ __( 'Feedback submitted, thank you!', '__i18n_text_domain__' ) }
+				</div>
+			</div>
+		);
+	}
+
+	if ( submitError ) {
+		return (
+			<div className="agents-manager-feedback-input">
+				<div className="agents-manager-feedback-input__status agents-manager-feedback-input__status--error">
+					{ __( 'Failed to submit feedback. Please try again.', '__i18n_text_domain__' ) }
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="agents-manager-feedback-input">
+			<label
+				className="agents-manager-feedback-input__label"
+				htmlFor="agents-manager-feedback-textarea"
+			>
+				{ __( 'What could be improved?', '__i18n_text_domain__' ) }
+			</label>
+			<textarea
+				ref={ textareaRef }
+				id="agents-manager-feedback-textarea"
+				className="agents-manager-feedback-input__textarea"
+				value={ feedbackText }
+				onChange={ ( e ) => setFeedbackText( e.target.value ) }
+				onKeyDown={ handleKeyDown }
+				placeholder={ __(
+					'Help us understand what you expected or what went wrong.',
+					'__i18n_text_domain__'
+				) }
+				rows={ 3 }
+				disabled={ isSubmitting }
+			/>
+			<div className="agents-manager-feedback-input__actions">
+				<Button variant="tertiary" onClick={ onCancel } disabled={ isSubmitting }>
+					{ __( 'Cancel', '__i18n_text_domain__' ) }
+				</Button>
+				<Button
+					variant="primary"
+					onClick={ handleSubmit }
+					disabled={ ! feedbackText.trim() || isSubmitting }
+					isBusy={ isSubmitting }
+				>
+					{ isSubmitting
+						? __( 'Submitting\u2026', '__i18n_text_domain__' )
+						: __( 'Submit', '__i18n_text_domain__' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/packages/agents-manager/src/components/feedback-input/index.tsx
+++ b/packages/agents-manager/src/components/feedback-input/index.tsx
@@ -1,4 +1,9 @@
-import { Button } from '@wordpress/components';
+/**
+ * Feedback Input Component
+ * Allows users to submit text feedback after clicking thumbs down.
+ * Adapted from big-sky-plugin's FeedbackInput component.
+ */
+import { Button, Spinner, TextareaControl } from '@wordpress/components';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import './style.scss';
@@ -12,9 +17,8 @@ export default function FeedbackInput( { onSubmit, onCancel }: FeedbackInputProp
 	const [ feedbackText, setFeedbackText ] = useState( '' );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const [ submitSuccess, setSubmitSuccess ] = useState( false );
-	const [ submitError, setSubmitError ] = useState( false );
+	const [ submitError, setSubmitError ] = useState< string | null >( null );
 	const timeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
-	const textareaRef = useRef< HTMLTextAreaElement >( null );
 
 	useEffect( () => {
 		return () => {
@@ -24,13 +28,8 @@ export default function FeedbackInput( { onSubmit, onCancel }: FeedbackInputProp
 		};
 	}, [] );
 
-	// Focus textarea on mount
-	useEffect( () => {
-		textareaRef.current?.focus();
-	}, [] );
-
 	const handleSubmit = async () => {
-		if ( ! feedbackText.trim() || isSubmitting ) {
+		if ( ! feedbackText.trim() ) {
 			return;
 		}
 
@@ -44,8 +43,12 @@ export default function FeedbackInput( { onSubmit, onCancel }: FeedbackInputProp
 			timeoutRef.current = setTimeout( () => {
 				onCancel();
 			}, 2000 );
-		} catch {
-			setSubmitError( true );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Error submitting feedback:', error );
+			setSubmitError(
+				__( 'Failed to submit feedback. Please try again.', '__i18n_text_domain__' )
+			);
 
 			timeoutRef.current = setTimeout( () => {
 				onCancel();
@@ -67,9 +70,11 @@ export default function FeedbackInput( { onSubmit, onCancel }: FeedbackInputProp
 
 	if ( submitSuccess ) {
 		return (
-			<div className="agents-manager-feedback-input">
-				<div className="agents-manager-feedback-input__status agents-manager-feedback-input__status--success">
-					{ __( 'Feedback submitted, thank you!', '__i18n_text_domain__' ) }
+			<div className="agents-manager-feedback-input-container">
+				<div className="agents-manager-feedback-input">
+					<div className="agents-manager-feedback-input__success">
+						{ __( 'Feedback submitted, thank you!', '__i18n_text_domain__' ) }
+					</div>
 				</div>
 			</div>
 		);
@@ -77,50 +82,51 @@ export default function FeedbackInput( { onSubmit, onCancel }: FeedbackInputProp
 
 	if ( submitError ) {
 		return (
-			<div className="agents-manager-feedback-input">
-				<div className="agents-manager-feedback-input__status agents-manager-feedback-input__status--error">
-					{ __( 'Failed to submit feedback. Please try again.', '__i18n_text_domain__' ) }
+			<div className="agents-manager-feedback-input-container">
+				<div className="agents-manager-feedback-input">
+					<div className="agents-manager-feedback-input__error">{ submitError }</div>
 				</div>
 			</div>
 		);
 	}
 
 	return (
-		<div className="agents-manager-feedback-input">
-			<label
-				className="agents-manager-feedback-input__label"
-				htmlFor="agents-manager-feedback-textarea"
-			>
-				{ __( 'What could be improved?', '__i18n_text_domain__' ) }
-			</label>
-			<textarea
-				ref={ textareaRef }
-				id="agents-manager-feedback-textarea"
-				className="agents-manager-feedback-input__textarea"
-				value={ feedbackText }
-				onChange={ ( e ) => setFeedbackText( e.target.value ) }
-				onKeyDown={ handleKeyDown }
-				placeholder={ __(
-					'Help us understand what you expected or what went wrong.',
-					'__i18n_text_domain__'
-				) }
-				rows={ 3 }
-				disabled={ isSubmitting }
-			/>
-			<div className="agents-manager-feedback-input__actions">
-				<Button variant="tertiary" onClick={ onCancel } disabled={ isSubmitting }>
-					{ __( 'Cancel', '__i18n_text_domain__' ) }
-				</Button>
-				<Button
-					variant="primary"
-					onClick={ handleSubmit }
-					disabled={ ! feedbackText.trim() || isSubmitting }
-					isBusy={ isSubmitting }
-				>
-					{ isSubmitting
-						? __( 'Submitting\u2026', '__i18n_text_domain__' )
-						: __( 'Submit', '__i18n_text_domain__' ) }
-				</Button>
+		<div className="agents-manager-feedback-input-container">
+			<div className="agents-manager-feedback-input">
+				<TextareaControl
+					label={ __( 'What could be improved?', '__i18n_text_domain__' ) }
+					value={ feedbackText }
+					onChange={ ( value: string ) => setFeedbackText( value ) }
+					onKeyDown={ handleKeyDown }
+					placeholder={ __(
+						'Help us understand what you expected or what went wrong.',
+						'__i18n_text_domain__'
+					) }
+					rows={ 3 }
+					disabled={ isSubmitting }
+				/>
+				<div className="agents-manager-feedback-input__actions">
+					<Button variant="tertiary" onClick={ onCancel } disabled={ isSubmitting }>
+						{ __( 'Cancel', '__i18n_text_domain__' ) }
+					</Button>
+					<Button
+						variant="primary"
+						onClick={ handleSubmit }
+						disabled={ ! feedbackText.trim() || isSubmitting }
+					>
+						{ isSubmitting && (
+							<Spinner
+								style={ {
+									height: '16px',
+									width: '16px',
+								} }
+							/>
+						) }
+						{ isSubmitting
+							? __( 'Submitting\u2026', '__i18n_text_domain__' )
+							: __( 'Submit', '__i18n_text_domain__' ) }
+					</Button>
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/agents-manager/src/components/feedback-input/style.scss
+++ b/packages/agents-manager/src/components/feedback-input/style.scss
@@ -1,9 +1,3 @@
-// Adapted from big-sky-plugin's feedback-input.scss
-// Uses .dark & pattern for dark mode support in the unified experience.
-
-// Adapted from big-sky-plugin's feedback-input.scss
-// Uses .dark & pattern for dark mode support in the unified experience.
-
 .agents-manager-feedback-input {
 	margin-top: 12px;
 	padding: 12px;

--- a/packages/agents-manager/src/components/feedback-input/style.scss
+++ b/packages/agents-manager/src/components/feedback-input/style.scss
@@ -1,0 +1,116 @@
+@import "@wordpress/base-styles/colors";
+@import "@wordpress/base-styles/variables";
+
+.agents-manager-feedback-input {
+	padding: 8px 16px 12px;
+	border-top: 1px solid rgba($black, 0.08);
+
+	.dark & {
+		border-top-color: rgba($white, 0.12);
+	}
+
+	&__label {
+		display: block;
+		font-size: 12px;
+		font-weight: 500;
+		margin-bottom: 6px;
+		color: $gray-700;
+
+		.dark & {
+			color: rgba($white, 0.7);
+		}
+	}
+
+	&__textarea {
+		display: block;
+		width: 100%;
+		padding: 8px;
+		border: 1px solid rgba($black, 0.15);
+		border-radius: 4px;
+		font-size: 13px;
+		font-family: inherit;
+		line-height: 1.4;
+		resize: vertical;
+		background: $white;
+		color: $gray-900;
+
+		&::placeholder {
+			color: $gray-600;
+		}
+
+		&:focus {
+			border-color: var(--wp-components-color-accent, #3858e9);
+			box-shadow: 0 0 0 1px var(--wp-components-color-accent, #3858e9);
+			outline: none;
+		}
+
+		&:disabled {
+			opacity: 0.6;
+		}
+
+		.dark & {
+			background: rgba($white, 0.08);
+			border-color: rgba($white, 0.2);
+			color: $white;
+
+			&::placeholder {
+				color: rgba($white, 0.4);
+			}
+
+			&:focus {
+				border-color: #6b8aff;
+				box-shadow: 0 0 0 1px #6b8aff;
+			}
+		}
+	}
+
+	&__actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		margin-top: 8px;
+
+		.components-button {
+			font-size: 13px;
+
+			&.is-tertiary {
+				color: $gray-700;
+
+				.dark & {
+					color: rgba($white, 0.7);
+
+					&:hover {
+						color: $white;
+					}
+				}
+			}
+
+			&.is-primary {
+				font-size: 13px;
+				padding: 4px 12px;
+			}
+		}
+	}
+
+	&__status {
+		padding: 8px 0;
+		font-size: 13px;
+		text-align: center;
+
+		&--success {
+			color: #00a32a;
+
+			.dark & {
+				color: #68de7c;
+			}
+		}
+
+		&--error {
+			color: #cc1818;
+
+			.dark & {
+				color: #f86368;
+			}
+		}
+	}
+}

--- a/packages/agents-manager/src/components/feedback-input/style.scss
+++ b/packages/agents-manager/src/components/feedback-input/style.scss
@@ -1,115 +1,98 @@
-@import "@wordpress/base-styles/colors";
-@import "@wordpress/base-styles/variables";
+// Adapted from big-sky-plugin's feedback-input.scss
+// Uses .dark & pattern for dark mode support in the unified experience.
+
+// Adapted from big-sky-plugin's feedback-input.scss
+// Uses .dark & pattern for dark mode support in the unified experience.
 
 .agents-manager-feedback-input {
-	padding: 8px 16px 12px;
-	border-top: 1px solid rgba($black, 0.08);
+	margin-top: 12px;
+	padding: 12px;
+	background: #fff;
+	border: 1px solid rgba(0, 0, 0, 0.15);
+	border-radius: 4px;
 
 	.dark & {
-		border-top-color: rgba($white, 0.12);
+		background: #1e1e1e;
+		border-color: #545454;
 	}
 
-	&__label {
-		display: block;
-		font-size: 12px;
-		font-weight: 500;
-		margin-bottom: 6px;
-		color: $gray-700;
-
-		.dark & {
-			color: rgba($white, 0.7);
-		}
+	.components-textarea-control {
+		margin-bottom: 12px;
 	}
 
-	&__textarea {
-		display: block;
-		width: 100%;
-		padding: 8px;
-		border: 1px solid rgba($black, 0.15);
-		border-radius: 4px;
+	.components-base-control__label {
 		font-size: 13px;
-		font-family: inherit;
-		line-height: 1.4;
-		resize: vertical;
-		background: $white;
-		color: $gray-900;
-
-		&::placeholder {
-			color: $gray-600;
-		}
-
-		&:focus {
-			border-color: var(--wp-components-color-accent, #3858e9);
-			box-shadow: 0 0 0 1px var(--wp-components-color-accent, #3858e9);
-			outline: none;
-		}
-
-		&:disabled {
-			opacity: 0.6;
-		}
+		text-transform: none;
 
 		.dark & {
-			background: rgba($white, 0.08);
-			border-color: rgba($white, 0.2);
-			color: $white;
+			color: #ccc;
+		}
+	}
+
+	.components-textarea-control__input {
+		width: 100%;
+		resize: vertical;
+
+		.dark & {
+			background: #2c2c2c;
+			border-color: #545454;
+			color: #e0e0e0;
 
 			&::placeholder {
-				color: rgba($white, 0.4);
-			}
-
-			&:focus {
-				border-color: #6b8aff;
-				box-shadow: 0 0 0 1px #6b8aff;
+				color: #999;
 			}
 		}
+	}
+
+	&__success {
+		padding: 12px;
+		background: #d5f2e3;
+		color: #00450c;
+		border-radius: 4px;
+		text-align: center;
+		font-size: 14px;
+	}
+
+	&__error {
+		padding: 12px;
+		background: #fef0f0;
+		color: #cc1818;
+		border-radius: 4px;
+		text-align: center;
+		font-size: 14px;
 	}
 
 	&__actions {
 		display: flex;
-		justify-content: flex-end;
 		gap: 8px;
-		margin-top: 8px;
+		justify-content: flex-end;
 
 		.components-button {
-			font-size: 13px;
+			display: flex;
+			align-items: center;
+			gap: 4px;
 
-			&.is-tertiary {
-				color: $gray-700;
-
-				.dark & {
-					color: rgba($white, 0.7);
-
-					&:hover {
-						color: $white;
-					}
-				}
-			}
-
-			&.is-primary {
-				font-size: 13px;
-				padding: 4px 12px;
-			}
-		}
-	}
-
-	&__status {
-		padding: 8px 0;
-		font-size: 13px;
-		text-align: center;
-
-		&--success {
-			color: #00a32a;
-
-			.dark & {
-				color: #68de7c;
+			.components-spinner {
+				margin: 0;
+				vertical-align: middle;
 			}
 		}
 
-		&--error {
-			color: #cc1818;
+		.dark & .components-button.is-tertiary {
+			color: #ccc;
 
-			.dark & {
-				color: #f86368;
+			&:hover {
+				color: #fff;
+			}
+		}
+
+		.dark & .components-button.is-primary {
+			background: #3858e9;
+			color: #fff;
+
+			&:disabled {
+				background: #2c2c2c;
+				color: #666;
 			}
 		}
 	}

--- a/packages/agents-manager/src/components/feedback-input/test/index.test.tsx
+++ b/packages/agents-manager/src/components/feedback-input/test/index.test.tsx
@@ -1,0 +1,300 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FeedbackInput from '../index';
+
+describe( 'FeedbackInput', () => {
+	const mockOnSubmit = jest.fn();
+	const mockOnCancel = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockOnSubmit.mockResolvedValue( undefined );
+	} );
+
+	describe( 'rendering', () => {
+		it( 'renders textarea with label and buttons', () => {
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			expect( screen.getByLabelText( /what could be improved/i ) ).toBeInTheDocument();
+			expect( screen.getByPlaceholderText( /help us understand/i ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: /cancel/i } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: /^submit$/i } ) ).toBeInTheDocument();
+		} );
+
+		it( 'focuses textarea on mount', () => {
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			expect( textarea ).toHaveFocus();
+		} );
+
+		it( 'disables submit button when textarea is empty', () => {
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const submitButton = screen.getByRole( 'button', { name: /^submit$/i } );
+			expect( submitButton ).toBeDisabled();
+		} );
+
+		it( 'enables submit button when textarea has text', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'This is helpful feedback' );
+
+			const submitButton = screen.getByRole( 'button', { name: /^submit$/i } );
+			expect( submitButton ).toBeEnabled();
+		} );
+	} );
+
+	describe( 'text input', () => {
+		it( 'updates textarea value when user types', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Test feedback' );
+
+			expect( textarea ).toHaveValue( 'Test feedback' );
+		} );
+
+		it( 'allows multiline input', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Line 1{Enter}Line 2' );
+
+			expect( textarea ).toHaveValue( 'Line 1\nLine 2' );
+		} );
+	} );
+
+	describe( 'submission', () => {
+		it( 'calls onSubmit with trimmed text when submit button is clicked', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, '  Feedback with spaces  ' );
+
+			const submitButton = screen.getByRole( 'button', { name: /^submit$/i } );
+			await user.click( submitButton );
+
+			expect( mockOnSubmit ).toHaveBeenCalledWith( 'Feedback with spaces' );
+		} );
+
+		it( 'submits with Cmd+Enter keyboard shortcut', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Quick feedback' );
+			await user.keyboard( '{Meta>}{Enter}{/Meta}' );
+
+			expect( mockOnSubmit ).toHaveBeenCalledWith( 'Quick feedback' );
+		} );
+
+		it( 'submits with Ctrl+Enter keyboard shortcut', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Quick feedback' );
+			await user.keyboard( '{Control>}{Enter}{/Control}' );
+
+			expect( mockOnSubmit ).toHaveBeenCalledWith( 'Quick feedback' );
+		} );
+
+		it( 'does not submit with Shift+Enter', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Line 1{Shift>}{Enter}{/Shift}Line 2' );
+
+			expect( mockOnSubmit ).not.toHaveBeenCalled();
+			expect( textarea ).toHaveValue( 'Line 1\nLine 2' );
+		} );
+
+		it( 'shows loading state while submitting', async () => {
+			const user = userEvent.setup();
+			let resolveSubmit: () => void;
+			const submitPromise = new Promise< void >( ( resolve ) => {
+				resolveSubmit = resolve;
+			} );
+			mockOnSubmit.mockReturnValue( submitPromise );
+
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Test' );
+
+			const submitButton = screen.getByRole( 'button', { name: /^submit$/i } );
+			await user.click( submitButton );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'button', { name: /submitting/i } ) ).toBeInTheDocument();
+			} );
+
+			expect( textarea ).toBeDisabled();
+			expect( screen.getByRole( 'button', { name: /cancel/i } ) ).toBeDisabled();
+
+			resolveSubmit!();
+		} );
+
+		it( 'shows success message after successful submission', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Test' );
+
+			const submitButton = screen.getByRole( 'button', { name: /^submit$/i } );
+			await user.click( submitButton );
+
+			await waitFor( () => {
+				expect( screen.getByText( /feedback submitted, thank you/i ) ).toBeInTheDocument();
+			} );
+		} );
+
+		it( 'calls onCancel after successful submission delay', async () => {
+			jest.useFakeTimers();
+			const user = userEvent.setup( { delay: null } );
+
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Test' );
+
+			const submitButton = screen.getByRole( 'button', { name: /^submit$/i } );
+			await user.click( submitButton );
+
+			await waitFor( () => {
+				expect( screen.getByText( /feedback submitted/i ) ).toBeInTheDocument();
+			} );
+
+			expect( mockOnCancel ).not.toHaveBeenCalled();
+
+			jest.advanceTimersByTime( 2000 );
+
+			expect( mockOnCancel ).toHaveBeenCalled();
+
+			jest.useRealTimers();
+		} );
+
+		it( 'shows error message when submission fails', async () => {
+			const user = userEvent.setup();
+			mockOnSubmit.mockRejectedValue( new Error( 'Network error' ) );
+
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Test' );
+
+			const submitButton = screen.getByRole( 'button', { name: /^submit$/i } );
+			await user.click( submitButton );
+
+			await waitFor( () => {
+				expect( screen.getByText( /failed to submit feedback/i ) ).toBeInTheDocument();
+			} );
+		} );
+
+		it( 'calls onCancel after error message delay', async () => {
+			jest.useFakeTimers();
+			const user = userEvent.setup( { delay: null } );
+			mockOnSubmit.mockRejectedValue( new Error( 'Network error' ) );
+
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Test' );
+
+			const submitButton = screen.getByRole( 'button', { name: /^submit$/i } );
+			await user.click( submitButton );
+
+			await waitFor( () => {
+				expect( screen.getByText( /failed to submit/i ) ).toBeInTheDocument();
+			} );
+
+			expect( mockOnCancel ).not.toHaveBeenCalled();
+
+			jest.advanceTimersByTime( 2000 );
+
+			expect( mockOnCancel ).toHaveBeenCalled();
+
+			jest.useRealTimers();
+		} );
+
+		it( 'does not submit empty or whitespace-only feedback', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, '   ' );
+
+			const submitButton = screen.getByRole( 'button', { name: /^submit$/i } );
+			expect( submitButton ).toBeDisabled();
+		} );
+
+		it( 'clears textarea after successful submission', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Test feedback' );
+
+			const submitButton = screen.getByRole( 'button', { name: /^submit$/i } );
+			await user.click( submitButton );
+
+			await waitFor( () => {
+				expect( screen.getByText( /feedback submitted/i ) ).toBeInTheDocument();
+			} );
+
+			// Textarea should be cleared (though hidden by success message)
+			expect( textarea ).toHaveValue( '' );
+		} );
+	} );
+
+	describe( 'cancellation', () => {
+		it( 'calls onCancel when cancel button is clicked', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const cancelButton = screen.getByRole( 'button', { name: /cancel/i } );
+			await user.click( cancelButton );
+
+			expect( mockOnCancel ).toHaveBeenCalled();
+		} );
+
+		it( 'calls onCancel when Escape key is pressed', async () => {
+			const user = userEvent.setup();
+			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
+
+			const textarea = screen.getByRole( 'textbox' );
+			await user.type( textarea, 'Some text{Escape}' );
+
+			expect( mockOnCancel ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'cleanup', () => {
+		it( 'clears timeout on unmount', () => {
+			jest.useFakeTimers();
+			const { unmount } = render(
+				<FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } />
+			);
+
+			unmount();
+
+			// Should not throw or cause issues
+			jest.advanceTimersByTime( 3000 );
+
+			jest.useRealTimers();
+
+			expect( mockOnCancel ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/packages/agents-manager/src/components/feedback-input/test/index.test.tsx
+++ b/packages/agents-manager/src/components/feedback-input/test/index.test.tsx
@@ -239,7 +239,7 @@ describe( 'FeedbackInput', () => {
 			expect( submitButton ).toBeDisabled();
 		} );
 
-		it( 'clears textarea after successful submission', async () => {
+		it( 'removes textarea after successful submission', async () => {
 			const user = userEvent.setup();
 			render( <FeedbackInput onSubmit={ mockOnSubmit } onCancel={ mockOnCancel } /> );
 
@@ -253,8 +253,8 @@ describe( 'FeedbackInput', () => {
 				expect( screen.getByText( /feedback submitted/i ) ).toBeInTheDocument();
 			} );
 
-			// Textarea should be cleared (though hidden by success message)
-			expect( textarea ).toHaveValue( '' );
+			// Textarea is replaced by the success message
+			expect( screen.queryByRole( 'textbox' ) ).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/agents-manager/src/components/test/FeedbackInput.test.tsx
+++ b/packages/agents-manager/src/components/test/FeedbackInput.test.tsx
@@ -3,7 +3,7 @@
  */
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import FeedbackInput from '../index';
+import FeedbackInput from '../feedback-input';
 
 describe( 'FeedbackInput', () => {
 	const mockOnSubmit = jest.fn();

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -181,7 +181,8 @@ export default function useFeedback( {
 			return;
 		}
 
-		recordTracksEvent( `wpcom_agents_manager_response_action_thumbs_${ feedback }`, {
+		recordTracksEvent( 'calypso_agents_manager_response_feedback_action', {
+			type: feedback === 'up' ? 'thumb_up' : 'thumb_down',
 			message_id: messageId,
 		} );
 
@@ -263,7 +264,7 @@ export default function useFeedback( {
 				previousMessages
 			);
 
-			recordTracksEvent( 'wpcom_agents_manager_response_feedback_submitted', {
+			recordTracksEvent( 'calypso_agents_manager_response_feedback_submitted', {
 				message_id: currentMessageId,
 			} );
 		},

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -1,0 +1,286 @@
+import { createFeedbackActions, ThumbsUpIcon, ThumbsDownIcon } from '@automattic/agenttic-ui';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import apiFetch from '@wordpress/api-fetch';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
+import { createElement, useState } from 'react';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
+import { getSessionId as getStoredSessionId } from '../../utils/agent-session';
+import type { Message } from '@automattic/agenttic-ui/dist/types';
+
+interface UseFeedbackConfig {
+	registerMessageActions: ( registration: {
+		id: string;
+		actions: ( message: Message ) => Array< {
+			id: string;
+			label: string;
+			icon?: React.ReactNode;
+			onClick: ( message: Message ) => void | Promise< void >;
+			condition?: ( message: Message ) => boolean;
+			tooltip?: string;
+			disabled?: boolean;
+			pressed?: boolean;
+			showLabel?: boolean;
+		} >;
+	} ) => void;
+	messages: Message[];
+	agentId: string;
+	siteId?: number | string;
+	sessionId?: string;
+}
+
+interface UseFeedbackReturn {
+	showFeedbackInput: boolean;
+	feedbackMessageId: string | null;
+	submitFeedbackText: ( feedbackText: string ) => Promise< void >;
+	cancelFeedback: () => void;
+}
+
+function rateMessage(
+	siteId: number | string,
+	sessionId: string,
+	messageId: string,
+	rating: 'up' | 'down'
+): void {
+	const path = `big-sky/v1/wp-orchestrator/${ encodeURIComponent( sessionId ) }/rate`;
+
+	if ( canAccessWpcomApis() ) {
+		wpcomRequest( {
+			path: `/sites/${ siteId }/${ path }`,
+			apiNamespace: 'wpcom/v2',
+			method: 'POST',
+			body: { message_id: messageId, rating },
+		} ).catch( () => {} );
+	} else {
+		apiFetch( {
+			path: `/wpcom/v2/${ path }`,
+			method: 'POST',
+			data: { message_id: messageId, rating },
+		} ).catch( () => {} );
+	}
+}
+
+interface PreviousMessage {
+	role: 'user' | 'agent';
+	text: string;
+}
+
+async function submitFeedback(
+	siteId: number | string,
+	sessionId: string,
+	messageId: string,
+	feedback: string,
+	previousMessages?: PreviousMessage[]
+): Promise< void > {
+	const path = `big-sky/v1/wp-orchestrator/${ encodeURIComponent( sessionId ) }/feedback`;
+
+	const body: Record< string, string | PreviousMessage[] > = {
+		message_id: messageId,
+		feedback,
+	};
+	if ( previousMessages && previousMessages.length > 0 ) {
+		body.previous_messages = previousMessages;
+	}
+	try {
+		body.page_url = window.location.href;
+	} catch {
+		// SSR or restricted context — skip
+	}
+
+	if ( canAccessWpcomApis() ) {
+		await wpcomRequest( {
+			path: `/sites/${ siteId }/${ path }`,
+			apiNamespace: 'wpcom/v2',
+			method: 'POST',
+			body,
+		} );
+	} else {
+		await apiFetch( {
+			path: `/wpcom/v2/${ path }`,
+			method: 'POST',
+			data: body,
+		} );
+	}
+}
+
+const MAX_CONTEXT_MESSAGES = 4;
+const MAX_MESSAGE_TEXT_LENGTH = 300;
+
+/**
+ * Extract meaningful text content from a message.
+ * Returns null for tool-only messages and local_tool_running placeholders.
+ */
+function getMessageText( message: Message ): string | null {
+	if ( ! message.content ) {
+		return null;
+	}
+	const textPart = message.content.find( ( part: { type?: string } ) => part.type === 'text' );
+	if ( ! textPart || ! ( 'text' in textPart ) ) {
+		return null;
+	}
+	const text = ( textPart.text as string ).trim();
+	if ( ! text ) {
+		return null;
+	}
+	// Replace raw placeholder with a human-readable description
+	if ( text === LOCAL_TOOL_RUNNING_MESSAGE ) {
+		return '[Displayed an interactive tool in the chat]';
+	}
+	if ( text.length > MAX_MESSAGE_TEXT_LENGTH ) {
+		return text.substring( 0, MAX_MESSAGE_TEXT_LENGTH ) + '...';
+	}
+	return text;
+}
+
+/**
+ * Extracts conversation context: the last few messages with meaningful text
+ * up to and including the rated message.
+ * Walks backwards to skip tool-only and placeholder messages.
+ */
+function getPreviousMessages( messages: Message[], targetMessageId: string ): PreviousMessage[] {
+	const targetIndex = messages.findIndex( ( m ) => m.id === targetMessageId );
+	if ( targetIndex < 0 ) {
+		return [];
+	}
+
+	const result: PreviousMessage[] = [];
+
+	// Walk backwards from the target message (inclusive) collecting messages with text
+	for ( let i = targetIndex; i >= 0 && result.length < MAX_CONTEXT_MESSAGES; i-- ) {
+		const msg = messages[ i ];
+		const text = getMessageText( msg );
+		if ( text ) {
+			const role = msg.role === 'user' ? 'user' : 'agent';
+			result.unshift( { role, text } );
+		}
+	}
+
+	return result;
+}
+
+export default function useFeedback( {
+	registerMessageActions,
+	messages,
+	agentId,
+	siteId,
+	sessionId,
+}: UseFeedbackConfig ): UseFeedbackReturn {
+	const [ showFeedbackInput, setShowFeedbackInput ] = useState( false );
+	const [ feedbackMessageId, setFeedbackMessageId ] = useState< string | null >( null );
+
+	// Keep refs to avoid recreating the feedback manager on every render
+	const agentIdRef = useRef( agentId );
+	const siteIdRef = useRef( siteId );
+	const sessionIdRef = useRef( sessionId );
+	const messagesRef = useRef( messages );
+	agentIdRef.current = agentId;
+	siteIdRef.current = siteId;
+	sessionIdRef.current = sessionId;
+	messagesRef.current = messages;
+
+	const hasRegistered = useRef( false );
+
+	const handleFeedback = useCallback( ( messageId: string, feedback: 'up' | 'down' ) => {
+		const currentSiteId = siteIdRef.current;
+		// agentConfig.sessionId can be empty for new chats — the server-assigned
+		// session ID is saved to localStorage by agenttic-client, so read it as fallback.
+		const currentSessionId = sessionIdRef.current || getStoredSessionId( agentIdRef.current );
+
+		if ( ! currentSiteId || ! currentSessionId ) {
+			return;
+		}
+
+		recordTracksEvent( `wpcom_agents_manager_response_action_thumbs_${ feedback }`, {
+			message_id: messageId,
+		} );
+
+		rateMessage( currentSiteId, currentSessionId, messageId, feedback );
+
+		if ( feedback === 'down' ) {
+			setShowFeedbackInput( true );
+			setFeedbackMessageId( messageId );
+		} else {
+			setShowFeedbackInput( false );
+			setFeedbackMessageId( null );
+		}
+	}, [] );
+
+	useEffect( () => {
+		if ( hasRegistered.current ) {
+			return;
+		}
+
+		const feedbackManager = createFeedbackActions( {
+			onFeedback: handleFeedback,
+			condition: ( message: Message ) => message.role === 'agent',
+			icons: {
+				up: createElement( ThumbsUpIcon, { size: 16 } ),
+				down: createElement( ThumbsDownIcon, { size: 16 } ),
+			},
+		} );
+
+		const feedbackRegistration = {
+			id: 'agents-manager-feedback',
+			actions: ( message: Message ) => feedbackManager.getActionsForMessage( message ),
+		};
+
+		registerMessageActions( feedbackRegistration );
+
+		const handleFeedbackChange = () => {
+			registerMessageActions( { ...feedbackRegistration } );
+		};
+		feedbackManager.onChange( handleFeedbackChange );
+
+		hasRegistered.current = true;
+
+		return () => {
+			feedbackManager.offChange( handleFeedbackChange );
+		};
+	}, [ registerMessageActions, handleFeedback ] );
+
+	// Reset feedback input when session changes
+	useEffect( () => {
+		setShowFeedbackInput( false );
+		setFeedbackMessageId( null );
+		hasRegistered.current = false;
+	}, [ sessionId ] );
+
+	const handleSubmitFeedbackText = useCallback(
+		async ( feedbackText: string ) => {
+			const currentSiteId = siteIdRef.current;
+			const currentSessionId = sessionIdRef.current || getStoredSessionId( agentIdRef.current );
+			const currentMessageId = feedbackMessageId;
+
+			if ( ! feedbackText.trim() || ! currentSiteId || ! currentSessionId || ! currentMessageId ) {
+				return;
+			}
+
+			const previousMessages = getPreviousMessages( messagesRef.current, currentMessageId );
+
+			await submitFeedback(
+				currentSiteId,
+				currentSessionId,
+				currentMessageId,
+				feedbackText.trim(),
+				previousMessages
+			);
+
+			recordTracksEvent( 'wpcom_agents_manager_response_feedback_submitted', {
+				message_id: currentMessageId,
+			} );
+		},
+		[ feedbackMessageId ]
+	);
+
+	const cancelFeedback = useCallback( () => {
+		setShowFeedbackInput( false );
+		setFeedbackMessageId( null );
+	}, [] );
+
+	return {
+		showFeedbackInput,
+		feedbackMessageId,
+		submitFeedbackText: handleSubmitFeedbackText,
+		cancelFeedback,
+	};
+}

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -67,10 +67,8 @@ async function submitFeedback(
 	if ( previousMessages && previousMessages.length > 0 ) {
 		data.previous_messages = previousMessages;
 	}
-	try {
+	if ( typeof window !== 'undefined' ) {
 		data.page_url = window.location.href;
-	} catch {
-		// SSR or restricted context — skip
 	}
 
 	const response = await fetch( url, {

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -1,12 +1,14 @@
 import { createFeedbackActions, ThumbsUpIcon, ThumbsDownIcon } from '@automattic/agenttic-ui';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { createElement, useState } from 'react';
-import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
 import { getSessionId as getStoredSessionId } from '../../utils/agent-session';
 import type { Message } from '@automattic/agenttic-ui/dist/types';
+
+type AuthProvider = () => Promise< Record< string, string > >;
+
+const FEEDBACK_API_BASE = 'https://public-api.wordpress.com/wpcom/v2/ai/feedback';
 
 interface UseFeedbackConfig {
 	registerMessageActions: ( registration: {
@@ -25,8 +27,8 @@ interface UseFeedbackConfig {
 	} ) => void;
 	messages: Message[];
 	agentId: string;
-	siteId?: number | string;
 	sessionId?: string;
+	authProvider?: AuthProvider;
 }
 
 interface UseFeedbackReturn {
@@ -36,28 +38,20 @@ interface UseFeedbackReturn {
 	cancelFeedback: () => void;
 }
 
-function rateMessage(
-	siteId: number | string,
+async function rateMessage(
+	authProvider: AuthProvider,
 	sessionId: string,
 	messageId: string,
 	rating: 'up' | 'down'
-): void {
-	const path = `big-sky/v1/wp-orchestrator/${ encodeURIComponent( sessionId ) }/rate`;
+): Promise< void > {
+	const headers = await authProvider();
+	const url = `${ FEEDBACK_API_BASE }/${ encodeURIComponent( sessionId ) }/rate`;
 
-	if ( canAccessWpcomApis() ) {
-		wpcomRequest( {
-			path: `/sites/${ siteId }/${ path }`,
-			apiNamespace: 'wpcom/v2',
-			method: 'POST',
-			body: { message_id: messageId, rating },
-		} ).catch( () => {} );
-	} else {
-		apiFetch( {
-			path: `/wpcom/v2/${ path }`,
-			method: 'POST',
-			data: { message_id: messageId, rating },
-		} ).catch( () => {} );
-	}
+	fetch( url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', ...headers },
+		body: JSON.stringify( { message_id: messageId, rating } ),
+	} ).catch( () => {} );
 }
 
 interface PreviousMessage {
@@ -66,13 +60,14 @@ interface PreviousMessage {
 }
 
 async function submitFeedback(
-	siteId: number | string,
+	authProvider: AuthProvider,
 	sessionId: string,
 	messageId: string,
 	feedback: string,
 	previousMessages?: PreviousMessage[]
 ): Promise< void > {
-	const path = `big-sky/v1/wp-orchestrator/${ encodeURIComponent( sessionId ) }/feedback`;
+	const headers = await authProvider();
+	const url = `${ FEEDBACK_API_BASE }/${ encodeURIComponent( sessionId ) }/text`;
 
 	const body: Record< string, string | PreviousMessage[] > = {
 		message_id: messageId,
@@ -87,20 +82,11 @@ async function submitFeedback(
 		// SSR or restricted context — skip
 	}
 
-	if ( canAccessWpcomApis() ) {
-		await wpcomRequest( {
-			path: `/sites/${ siteId }/${ path }`,
-			apiNamespace: 'wpcom/v2',
-			method: 'POST',
-			body,
-		} );
-	} else {
-		await apiFetch( {
-			path: `/wpcom/v2/${ path }`,
-			method: 'POST',
-			data: body,
-		} );
-	}
+	await fetch( url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', ...headers },
+		body: JSON.stringify( body ),
+	} );
 }
 
 const MAX_CONTEXT_MESSAGES = 4;
@@ -171,29 +157,29 @@ export default function useFeedback( {
 	registerMessageActions,
 	messages,
 	agentId,
-	siteId,
 	sessionId,
+	authProvider,
 }: UseFeedbackConfig ): UseFeedbackReturn {
 	const [ showFeedbackInput, setShowFeedbackInput ] = useState( false );
 	const [ feedbackMessageId, setFeedbackMessageId ] = useState< string | null >( null );
 
 	// Keep refs to avoid recreating the feedback manager on every render
 	const agentIdRef = useRef( agentId );
-	const siteIdRef = useRef( siteId );
 	const sessionIdRef = useRef( sessionId );
 	const messagesRef = useRef( messages );
+	const authProviderRef = useRef( authProvider );
 	agentIdRef.current = agentId;
-	siteIdRef.current = siteId;
 	sessionIdRef.current = sessionId;
 	messagesRef.current = messages;
+	authProviderRef.current = authProvider;
 
 	const handleFeedback = useCallback( ( messageId: string, feedback: 'up' | 'down' ) => {
-		const currentSiteId = siteIdRef.current;
+		const currentAuthProvider = authProviderRef.current;
 		// agentConfig.sessionId can be empty for new chats — the server-assigned
 		// session ID is saved to localStorage by agenttic-client, so read it as fallback.
 		const currentSessionId = sessionIdRef.current || getStoredSessionId( agentIdRef.current );
 
-		if ( ! currentSiteId || ! currentSessionId ) {
+		if ( ! currentSessionId || ! currentAuthProvider ) {
 			return;
 		}
 
@@ -201,7 +187,7 @@ export default function useFeedback( {
 			message_id: messageId,
 		} );
 
-		rateMessage( currentSiteId, currentSessionId, messageId, feedback );
+		rateMessage( currentAuthProvider, currentSessionId, messageId, feedback );
 
 		if ( feedback === 'down' ) {
 			setShowFeedbackInput( true );
@@ -247,18 +233,23 @@ export default function useFeedback( {
 
 	const handleSubmitFeedbackText = useCallback(
 		async ( feedbackText: string ) => {
-			const currentSiteId = siteIdRef.current;
+			const currentAuthProvider = authProviderRef.current;
 			const currentSessionId = sessionIdRef.current || getStoredSessionId( agentIdRef.current );
 			const currentMessageId = feedbackMessageId;
 
-			if ( ! feedbackText.trim() || ! currentSiteId || ! currentSessionId || ! currentMessageId ) {
+			if (
+				! feedbackText.trim() ||
+				! currentSessionId ||
+				! currentMessageId ||
+				! currentAuthProvider
+			) {
 				return;
 			}
 
 			const previousMessages = getPreviousMessages( messagesRef.current, currentMessageId );
 
 			await submitFeedback(
-				currentSiteId,
+				currentAuthProvider,
 				currentSessionId,
 				currentMessageId,
 				feedbackText.trim(),

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -71,13 +71,19 @@ async function submitFeedback(
 		data.page_url = window.location.href;
 	}
 
-	const response = await fetch( url, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json', ...headers },
-		body: JSON.stringify( data ),
-	} );
-	if ( ! response.ok ) {
-		throw new Error( `Feedback submission failed: ${ response.status }` );
+	try {
+		const response = await fetch( url, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', ...headers },
+			body: JSON.stringify( data ),
+		} );
+
+		if ( ! response.ok ) {
+			throw new Error( `[useFeedback] Feedback submission failed: ${ response.status }` );
+		}
+	} catch ( error ) {
+		const message = error instanceof Error ? error.message : 'Unknown error';
+		throw new Error( `[useFeedback] Feedback submission failed: ${ message }` );
 	}
 }
 

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -19,7 +19,7 @@ interface UseFeedbackConfig {
 interface UseFeedbackReturn {
 	showFeedbackInput: boolean;
 	submitFeedbackText: ( feedbackText: string ) => Promise< void >;
-	cancelFeedback: () => void;
+	resetFeedback: () => void;
 }
 
 async function rateMessage(
@@ -232,11 +232,15 @@ export default function useFeedback( {
 		};
 	}, [ registerMessageActions, handleFeedback, sessionId ] );
 
-	// Reset feedback input when session changes
-	useEffect( () => {
+	const resetFeedback = useCallback( () => {
 		setShowFeedbackInput( false );
 		setFeedbackMessageId( null );
-	}, [ sessionId ] );
+	}, [] );
+
+	// Reset feedback input when session changes
+	useEffect( () => {
+		resetFeedback();
+	}, [ sessionId, resetFeedback ] );
 
 	const handleSubmitFeedbackText = useCallback(
 		async ( feedbackText: string ) => {
@@ -270,14 +274,9 @@ export default function useFeedback( {
 		[ feedbackMessageId ]
 	);
 
-	const cancelFeedback = useCallback( () => {
-		setShowFeedbackInput( false );
-		setFeedbackMessageId( null );
-	}, [] );
-
 	return {
 		showFeedbackInput,
 		submitFeedbackText: handleSubmitFeedbackText,
-		cancelFeedback,
+		resetFeedback,
 	};
 }

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -210,8 +210,8 @@ export default function useFeedback( {
 			onFeedback: handleFeedback,
 			condition: ( message: Message ) => message.role === 'agent',
 			icons: {
-				up: createElement( ThumbsUpIcon, { size: 16 } ),
-				down: createElement( ThumbsDownIcon, { size: 16 } ),
+				up: createElement( ThumbsUpIcon, { size: 24 } ),
+				down: createElement( ThumbsDownIcon, { size: 24 } ),
 			},
 		} );
 

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -33,7 +33,6 @@ interface UseFeedbackConfig {
 
 interface UseFeedbackReturn {
 	showFeedbackInput: boolean;
-	feedbackMessageId: string | null;
 	submitFeedbackText: ( feedbackText: string ) => Promise< void >;
 	cancelFeedback: () => void;
 }
@@ -270,7 +269,6 @@ export default function useFeedback( {
 
 	return {
 		showFeedbackInput,
-		feedbackMessageId,
 		submitFeedbackText: handleSubmitFeedbackText,
 		cancelFeedback,
 	};

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -1,5 +1,6 @@
 import { createFeedbackActions, ThumbsUpIcon, ThumbsDownIcon } from '@automattic/agenttic-ui';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { createElement, useState } from 'react';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
@@ -46,10 +47,11 @@ async function rateMessage(
 	const headers = await authProvider();
 	const url = `${ FEEDBACK_API_BASE }/${ encodeURIComponent( sessionId ) }/rate`;
 
-	fetch( url, {
+	apiFetch( {
+		url,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json', ...headers },
-		body: JSON.stringify( { message_id: messageId, rating } ),
+		data: { message_id: messageId, rating },
 	} ).catch( () => {} );
 }
 
@@ -68,23 +70,24 @@ async function submitFeedback(
 	const headers = await authProvider();
 	const url = `${ FEEDBACK_API_BASE }/${ encodeURIComponent( sessionId ) }/text`;
 
-	const body: Record< string, string | PreviousMessage[] > = {
+	const data: Record< string, string | PreviousMessage[] > = {
 		message_id: messageId,
 		feedback,
 	};
 	if ( previousMessages && previousMessages.length > 0 ) {
-		body.previous_messages = previousMessages;
+		data.previous_messages = previousMessages;
 	}
 	try {
-		body.page_url = window.location.href;
+		data.page_url = window.location.href;
 	} catch {
 		// SSR or restricted context — skip
 	}
 
-	await fetch( url, {
+	await apiFetch( {
+		url,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json', ...headers },
-		body: JSON.stringify( body ),
+		data,
 	} );
 }
 

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -41,15 +41,21 @@ async function rateMessage(
 	authProvider: AuthProvider,
 	sessionId: string,
 	messageId: string,
-	rating: 'up' | 'down'
+	rating: 'up' | 'down',
+	messageText?: string
 ): Promise< void > {
 	const headers = await authProvider();
 	const url = `${ FEEDBACK_API_BASE }/${ encodeURIComponent( sessionId ) }/rate`;
 
+	const body: Record< string, string > = { message_id: messageId, rating };
+	if ( messageText ) {
+		body.message_text = messageText;
+	}
+
 	fetch( url, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json', ...headers },
-		body: JSON.stringify( { message_id: messageId, rating } ),
+		body: JSON.stringify( body ),
 	} ).catch( () => {} );
 }
 
@@ -189,7 +195,16 @@ export default function useFeedback( {
 			message_id: messageId,
 		} );
 
-		rateMessage( currentAuthProvider, currentSessionId, messageId, feedback );
+		const message = messagesRef.current.find( ( m ) => m.id === messageId );
+		const messageText = message ? getMessageText( message ) : undefined;
+
+		rateMessage(
+			currentAuthProvider,
+			currentSessionId,
+			messageId,
+			feedback,
+			messageText ?? undefined
+		);
 
 		if ( feedback === 'down' ) {
 			setShowFeedbackInput( true );

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -1,7 +1,6 @@
 import { createFeedbackActions, ThumbsUpIcon, ThumbsDownIcon } from '@automattic/agenttic-ui';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useCallback, useEffect, useRef } from '@wordpress/element';
-import { createElement, useState } from 'react';
+import { createElement, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
 import { getSessionId as getStoredSessionId } from '../../utils/agent-session';
 import type { AuthProvider, UseAgentChatReturn } from '@automattic/agenttic-client';

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -122,9 +122,17 @@ function getMessageText( message: Message ): string | null {
 	if ( ! text ) {
 		return null;
 	}
-	// Replace raw placeholder with a human-readable description
+	// Replace tool placeholders/JSON with a human-readable description
 	if ( text === LOCAL_TOOL_RUNNING_MESSAGE ) {
 		return '[Displayed an interactive tool in the chat]';
+	}
+	try {
+		const parsed = JSON.parse( text );
+		if ( parsed?.tool_id === 'big_sky__show_component' ) {
+			return '[Displayed an interactive tool in the chat]';
+		}
+	} catch {
+		// Not JSON, continue with normal text handling
 	}
 	if ( text.length > MAX_MESSAGE_TEXT_LENGTH ) {
 		return text.substring( 0, MAX_MESSAGE_TEXT_LENGTH ) + '...';

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -4,26 +4,13 @@ import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { createElement, useState } from 'react';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
 import { getSessionId as getStoredSessionId } from '../../utils/agent-session';
-import type { AuthProvider } from '@automattic/agenttic-client';
+import type { AuthProvider, UseAgentChatReturn } from '@automattic/agenttic-client';
 import type { Message } from '@automattic/agenttic-ui/dist/types';
 
 const FEEDBACK_API_BASE = 'https://public-api.wordpress.com/wpcom/v2/ai/feedback';
 
 interface UseFeedbackConfig {
-	registerMessageActions: ( registration: {
-		id: string;
-		actions: ( message: Message ) => Array< {
-			id: string;
-			label: string;
-			icon?: React.ReactNode;
-			onClick: ( message: Message ) => void | Promise< void >;
-			condition?: ( message: Message ) => boolean;
-			tooltip?: string;
-			disabled?: boolean;
-			pressed?: boolean;
-			showLabel?: boolean;
-		} >;
-	} ) => void;
+	registerMessageActions: UseAgentChatReturn[ 'registerMessageActions' ];
 	messages: Message[];
 	agentId: string;
 	sessionId?: string;

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -124,12 +124,13 @@ function getMessageText( message: Message ): string | null {
 	}
 	// Replace tool placeholders/JSON with a human-readable description
 	if ( text === LOCAL_TOOL_RUNNING_MESSAGE ) {
-		return '[Displayed an interactive tool in the chat]';
+		return '🔨 Tool';
 	}
 	try {
 		const parsed = JSON.parse( text );
-		if ( parsed?.tool_id === 'big_sky__show_component' ) {
-			return '[Displayed an interactive tool in the chat]';
+		if ( parsed?.tool_id ) {
+			const suffix = parsed.data?.type ? ` (${ parsed.data.type })` : '';
+			return `🔨 Tool: \`${ parsed.tool_id }\`${ suffix }`;
 		}
 	} catch {
 		// Not JSON, continue with normal text handling
@@ -186,8 +187,6 @@ export default function useFeedback( {
 	sessionIdRef.current = sessionId;
 	messagesRef.current = messages;
 
-	const hasRegistered = useRef( false );
-
 	const handleFeedback = useCallback( ( messageId: string, feedback: 'up' | 'down' ) => {
 		const currentSiteId = siteIdRef.current;
 		// agentConfig.sessionId can be empty for new chats — the server-assigned
@@ -214,10 +213,6 @@ export default function useFeedback( {
 	}, [] );
 
 	useEffect( () => {
-		if ( hasRegistered.current ) {
-			return;
-		}
-
 		const feedbackManager = createFeedbackActions( {
 			onFeedback: handleFeedback,
 			condition: ( message: Message ) => message.role === 'agent',
@@ -239,18 +234,15 @@ export default function useFeedback( {
 		};
 		feedbackManager.onChange( handleFeedbackChange );
 
-		hasRegistered.current = true;
-
 		return () => {
 			feedbackManager.offChange( handleFeedbackChange );
 		};
-	}, [ registerMessageActions, handleFeedback ] );
+	}, [ registerMessageActions, handleFeedback, sessionId ] );
 
 	// Reset feedback input when session changes
 	useEffect( () => {
 		setShowFeedbackInput( false );
 		setFeedbackMessageId( null );
-		hasRegistered.current = false;
 	}, [ sessionId ] );
 
 	const handleSubmitFeedbackText = useCallback(

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -1,6 +1,5 @@
 import { createFeedbackActions, ThumbsUpIcon, ThumbsDownIcon } from '@automattic/agenttic-ui';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { createElement, useState } from 'react';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
@@ -47,11 +46,10 @@ async function rateMessage(
 	const headers = await authProvider();
 	const url = `${ FEEDBACK_API_BASE }/${ encodeURIComponent( sessionId ) }/rate`;
 
-	apiFetch( {
-		url,
+	fetch( url, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json', ...headers },
-		data: { message_id: messageId, rating },
+		body: JSON.stringify( { message_id: messageId, rating } ),
 	} ).catch( () => {} );
 }
 
@@ -83,12 +81,14 @@ async function submitFeedback(
 		// SSR or restricted context — skip
 	}
 
-	await apiFetch( {
-		url,
+	const response = await fetch( url, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json', ...headers },
-		data,
+		body: JSON.stringify( data ),
 	} );
+	if ( ! response.ok ) {
+		throw new Error( `Feedback submission failed: ${ response.status }` );
+	}
 }
 
 const MAX_CONTEXT_MESSAGES = 4;

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -13,7 +13,7 @@ interface UseFeedbackConfig {
 	messages: Message[];
 	agentId: string;
 	sessionId?: string;
-	authProvider: AuthProvider;
+	authProvider?: AuthProvider;
 }
 
 interface UseFeedbackReturn {

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -4,9 +4,8 @@ import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { createElement, useState } from 'react';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
 import { getSessionId as getStoredSessionId } from '../../utils/agent-session';
+import type { AuthProvider } from '@automattic/agenttic-client';
 import type { Message } from '@automattic/agenttic-ui/dist/types';
-
-type AuthProvider = () => Promise< Record< string, string > >;
 
 const FEEDBACK_API_BASE = 'https://public-api.wordpress.com/wpcom/v2/ai/feedback';
 
@@ -28,7 +27,7 @@ interface UseFeedbackConfig {
 	messages: Message[];
 	agentId: string;
 	sessionId?: string;
-	authProvider?: AuthProvider;
+	authProvider: AuthProvider;
 }
 
 interface UseFeedbackReturn {

--- a/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
@@ -1,0 +1,412 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { renderHook, act } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { getSessionId as getStoredSessionId } from '../../../utils/agent-session';
+import useFeedback from '../index';
+import type { Message } from '@automattic/agenttic-ui/dist/types';
+
+jest.mock( '@automattic/calypso-analytics' );
+jest.mock( '@wordpress/api-fetch' );
+jest.mock( 'wpcom-proxy-request' );
+jest.mock( '../../../utils/agent-session' );
+
+const mockRegisterMessageActions = jest.fn();
+const mockRecordTracksEvent = recordTracksEvent as jest.MockedFunction< typeof recordTracksEvent >;
+const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+const mockWpcomRequest = wpcomRequest as jest.MockedFunction< typeof wpcomRequest >;
+const mockCanAccessWpcomApis = canAccessWpcomApis as jest.MockedFunction<
+	typeof canAccessWpcomApis
+>;
+const mockGetStoredSessionId = getStoredSessionId as jest.MockedFunction<
+	typeof getStoredSessionId
+>;
+
+const createMessage = ( id: string, role: 'user' | 'agent', text: string ): Message => ( {
+	id,
+	role,
+	content: [ { type: 'text', text } ],
+} );
+
+describe( 'useFeedback', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockCanAccessWpcomApis.mockReturnValue( true );
+		mockWpcomRequest.mockResolvedValue( {} );
+		mockApiFetch.mockResolvedValue( {} );
+		mockGetStoredSessionId.mockReturnValue( 'stored-session-123' );
+	} );
+
+	const defaultConfig = {
+		registerMessageActions: mockRegisterMessageActions,
+		messages: [],
+		agentId: 'test-agent',
+		siteId: 12345,
+		sessionId: 'session-abc',
+	};
+
+	describe( 'initialization', () => {
+		it( 'registers feedback actions on mount', () => {
+			renderHook( () => useFeedback( defaultConfig ) );
+
+			expect( mockRegisterMessageActions ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 'agents-manager-feedback',
+					actions: expect.any( Function ),
+				} )
+			);
+		} );
+
+		it( 'only registers once', () => {
+			const { rerender } = renderHook( () => useFeedback( defaultConfig ) );
+
+			expect( mockRegisterMessageActions ).toHaveBeenCalledTimes( 1 );
+
+			rerender();
+
+			expect( mockRegisterMessageActions ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'resets registration when session changes', () => {
+			const { rerender } = renderHook( ( props ) => useFeedback( props ), {
+				initialProps: defaultConfig,
+			} );
+
+			expect( mockRegisterMessageActions ).toHaveBeenCalledTimes( 1 );
+
+			rerender( { ...defaultConfig, sessionId: 'new-session' } );
+
+			// Should trigger re-registration on next effect cycle
+			expect( mockRegisterMessageActions ).toHaveBeenCalledTimes( 2 );
+		} );
+	} );
+
+	describe( 'thumbs up feedback', () => {
+		it( 'sends rating to wpcom when thumbs up is clicked', async () => {
+			renderHook( () => useFeedback( defaultConfig ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsUpAction = actions.find( ( a ) => a.id.includes( 'up' ) );
+
+			await act( async () => {
+				await thumbsUpAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			expect( mockWpcomRequest ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: '/sites/12345/big-sky/v1/wp-orchestrator/session-abc/rate',
+					method: 'POST',
+					body: { message_id: 'msg-1', rating: 'up' },
+				} )
+			);
+		} );
+
+		it( 'records tracks event for thumbs up', async () => {
+			renderHook( () => useFeedback( defaultConfig ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsUpAction = actions.find( ( a ) => a.id.includes( 'up' ) );
+
+			await act( async () => {
+				await thumbsUpAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'wpcom_agents_manager_response_action_thumbs_up',
+				{ message_id: 'msg-1' }
+			);
+		} );
+
+		it( 'does not show feedback input after thumbs up', async () => {
+			const { result } = renderHook( () => useFeedback( defaultConfig ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsUpAction = actions.find( ( a ) => a.id.includes( 'up' ) );
+
+			await act( async () => {
+				await thumbsUpAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			expect( result.current.showFeedbackInput ).toBe( false );
+			expect( result.current.feedbackMessageId ).toBeNull();
+		} );
+	} );
+
+	describe( 'thumbs down feedback', () => {
+		it( 'sends rating to wpcom when thumbs down is clicked', async () => {
+			renderHook( () => useFeedback( defaultConfig ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+
+			await act( async () => {
+				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			expect( mockWpcomRequest ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: '/sites/12345/big-sky/v1/wp-orchestrator/session-abc/rate',
+					method: 'POST',
+					body: { message_id: 'msg-1', rating: 'down' },
+				} )
+			);
+		} );
+
+		it( 'records tracks event for thumbs down', async () => {
+			renderHook( () => useFeedback( defaultConfig ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+
+			await act( async () => {
+				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'wpcom_agents_manager_response_action_thumbs_down',
+				{ message_id: 'msg-1' }
+			);
+		} );
+
+		it( 'shows feedback input after thumbs down', async () => {
+			const { result } = renderHook( () => useFeedback( defaultConfig ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+
+			await act( async () => {
+				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			expect( result.current.showFeedbackInput ).toBe( true );
+			expect( result.current.feedbackMessageId ).toBe( 'msg-1' );
+		} );
+	} );
+
+	describe( 'feedback text submission', () => {
+		it( 'submits feedback with conversation context to wpcom', async () => {
+			const messages = [
+				createMessage( 'msg-1', 'user', 'How do I set up my site?' ),
+				createMessage( 'msg-2', 'agent', 'Here are the steps...' ),
+				createMessage( 'msg-3', 'user', 'That did not work' ),
+				createMessage( 'msg-4', 'agent', 'Let me try a different approach...' ),
+			];
+
+			const { result } = renderHook( () => useFeedback( { ...defaultConfig, messages } ) );
+
+			// Simulate thumbs down first
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-4', 'agent', 'Test' ) );
+			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+
+			await act( async () => {
+				await thumbsDownAction?.onClick( createMessage( 'msg-4', 'agent', 'Test' ) );
+			} );
+
+			// Submit feedback text
+			await act( async () => {
+				await result.current.submitFeedbackText( 'The solution was unclear' );
+			} );
+
+			expect( mockWpcomRequest ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: '/sites/12345/big-sky/v1/wp-orchestrator/session-abc/feedback',
+					method: 'POST',
+					body: expect.objectContaining( {
+						message_id: 'msg-4',
+						feedback: 'The solution was unclear',
+						previous_messages: [
+							{ role: 'user', text: 'How do I set up my site?' },
+							{ role: 'agent', text: 'Here are the steps...' },
+							{ role: 'user', text: 'That did not work' },
+							{ role: 'agent', text: 'Let me try a different approach...' },
+						],
+					} ),
+				} )
+			);
+		} );
+
+		it( 'limits conversation context to last 4 messages', async () => {
+			const messages = [
+				createMessage( 'msg-1', 'user', 'Message 1' ),
+				createMessage( 'msg-2', 'agent', 'Message 2' ),
+				createMessage( 'msg-3', 'user', 'Message 3' ),
+				createMessage( 'msg-4', 'agent', 'Message 4' ),
+				createMessage( 'msg-5', 'user', 'Message 5' ),
+				createMessage( 'msg-6', 'agent', 'Message 6' ),
+			];
+
+			const { result } = renderHook( () => useFeedback( { ...defaultConfig, messages } ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-6', 'agent', 'Test' ) );
+			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+
+			await act( async () => {
+				await thumbsDownAction?.onClick( createMessage( 'msg-6', 'agent', 'Test' ) );
+			} );
+
+			await act( async () => {
+				await result.current.submitFeedbackText( 'Test feedback' );
+			} );
+
+			const callBody = mockWpcomRequest.mock.calls[ 1 ][ 0 ].body;
+			expect( callBody.previous_messages ).toHaveLength( 4 );
+			expect( callBody.previous_messages[ 0 ].text ).toBe( 'Message 3' );
+		} );
+
+		it( 'records tracks event when feedback text is submitted', async () => {
+			const { result } = renderHook( () => useFeedback( defaultConfig ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+
+			await act( async () => {
+				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			await act( async () => {
+				await result.current.submitFeedbackText( 'Helpful feedback' );
+			} );
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'wpcom_agents_manager_response_feedback_submitted',
+				{ message_id: 'msg-1' }
+			);
+		} );
+
+		it( 'uses stored session ID when sessionId prop is empty', async () => {
+			const { result } = renderHook( () =>
+				useFeedback( { ...defaultConfig, sessionId: undefined } )
+			);
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+
+			await act( async () => {
+				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			await act( async () => {
+				await result.current.submitFeedbackText( 'Test' );
+			} );
+
+			expect( mockWpcomRequest ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: '/sites/12345/big-sky/v1/wp-orchestrator/stored-session-123/feedback',
+				} )
+			);
+		} );
+
+		it( 'does not submit if feedback text is empty', async () => {
+			const { result } = renderHook( () => useFeedback( defaultConfig ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+
+			await act( async () => {
+				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			// Clear mocks from rating call
+			mockWpcomRequest.mockClear();
+
+			await act( async () => {
+				await result.current.submitFeedbackText( '   ' );
+			} );
+
+			expect( mockWpcomRequest ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'feedback cancellation', () => {
+		it( 'hides feedback input when cancelled', async () => {
+			const { result } = renderHook( () => useFeedback( defaultConfig ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+
+			await act( async () => {
+				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			expect( result.current.showFeedbackInput ).toBe( true );
+
+			act( () => {
+				result.current.cancelFeedback();
+			} );
+
+			expect( result.current.showFeedbackInput ).toBe( false );
+			expect( result.current.feedbackMessageId ).toBeNull();
+		} );
+	} );
+
+	describe( 'API routing', () => {
+		it( 'uses apiFetch when canAccessWpcomApis returns false', async () => {
+			mockCanAccessWpcomApis.mockReturnValue( false );
+
+			renderHook( () => useFeedback( defaultConfig ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const thumbsUpAction = actions.find( ( a ) => a.id.includes( 'up' ) );
+
+			await act( async () => {
+				await thumbsUpAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+			} );
+
+			expect( mockWpcomRequest ).not.toHaveBeenCalled();
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: '/wpcom/v2/big-sky/v1/wp-orchestrator/session-abc/rate',
+					method: 'POST',
+				} )
+			);
+		} );
+	} );
+
+	describe( 'conversation context extraction', () => {
+		it( 'skips tool messages in conversation context', async () => {
+			const messages = [
+				createMessage( 'msg-1', 'user', 'Show me analytics' ),
+				createMessage( 'msg-2', 'agent', '{"tool_id": "big_sky__show_component"}' ),
+				createMessage( 'msg-3', 'agent', 'Here are your analytics' ),
+			];
+
+			const { result } = renderHook( () => useFeedback( { ...defaultConfig, messages } ) );
+
+			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
+			const actions = registrationCall.actions( createMessage( 'msg-3', 'agent', 'Test' ) );
+			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+
+			await act( async () => {
+				await thumbsDownAction?.onClick( createMessage( 'msg-3', 'agent', 'Test' ) );
+			} );
+
+			await act( async () => {
+				await result.current.submitFeedbackText( 'Test' );
+			} );
+
+			const callBody = mockWpcomRequest.mock.calls[ 1 ][ 0 ].body;
+			expect( callBody.previous_messages ).toHaveLength( 2 );
+			expect( callBody.previous_messages[ 1 ].text ).toBe( 'Here are your analytics' );
+			// Tool message replaced with placeholder
+			expect( callBody.previous_messages ).not.toContainEqual(
+				expect.objectContaining( { text: expect.stringContaining( 'tool_id' ) } )
+			);
+		} );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
@@ -178,7 +178,6 @@ describe( 'useFeedback', () => {
 			} );
 
 			expect( result.current.showFeedbackInput ).toBe( false );
-			expect( result.current.feedbackMessageId ).toBeNull();
 		} );
 	} );
 
@@ -232,7 +231,6 @@ describe( 'useFeedback', () => {
 			} );
 
 			expect( result.current.showFeedbackInput ).toBe( true );
-			expect( result.current.feedbackMessageId ).toBe( 'msg-1' );
 		} );
 	} );
 
@@ -394,7 +392,6 @@ describe( 'useFeedback', () => {
 			} );
 
 			expect( result.current.showFeedbackInput ).toBe( false );
-			expect( result.current.feedbackMessageId ).toBeNull();
 		} );
 	} );
 

--- a/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
@@ -3,7 +3,6 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { renderHook, act } from '@testing-library/react';
-import apiFetch from '@wordpress/api-fetch';
 import { getSessionId as getStoredSessionId } from '../../../utils/agent-session';
 import useFeedback from '../index';
 import type { Message } from '@automattic/agenttic-ui/dist/types';
@@ -53,12 +52,13 @@ jest.mock(
 	{ virtual: true }
 );
 jest.mock( '@automattic/calypso-analytics' );
-jest.mock( '@wordpress/api-fetch' );
 jest.mock( '../../../utils/agent-session' );
+
+const mockFetch = jest.fn().mockResolvedValue( { ok: true } );
+global.fetch = mockFetch;
 
 const mockRegisterMessageActions = jest.fn();
 const mockRecordTracksEvent = recordTracksEvent as jest.MockedFunction< typeof recordTracksEvent >;
-const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
 const mockGetStoredSessionId = getStoredSessionId as jest.MockedFunction<
 	typeof getStoredSessionId
 >;
@@ -74,7 +74,7 @@ const createMessage = ( id: string, role: 'user' | 'agent', text: string ): Mess
 describe( 'useFeedback', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockApiFetch.mockResolvedValue( {} );
+		mockFetch.mockResolvedValue( { ok: true } );
 		mockGetStoredSessionId.mockReturnValue( 'stored-session-123' );
 	} );
 
@@ -123,7 +123,7 @@ describe( 'useFeedback', () => {
 	} );
 
 	describe( 'thumbs up feedback', () => {
-		it( 'sends rating via apiFetch when thumbs up is clicked', async () => {
+		it( 'sends rating via fetch when thumbs up is clicked', async () => {
 			renderHook( () => useFeedback( defaultConfig ) );
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
@@ -135,14 +135,14 @@ describe( 'useFeedback', () => {
 			} );
 
 			expect( mockAuthProvider ).toHaveBeenCalled();
-			expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect( mockFetch ).toHaveBeenCalledWith(
+				'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/rate',
 				expect.objectContaining( {
-					url: 'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/rate',
 					method: 'POST',
 					headers: expect.objectContaining( {
 						Authorization: 'Bearer test-token',
 					} ),
-					data: { message_id: 'msg-1', rating: 'up' },
+					body: JSON.stringify( { message_id: 'msg-1', rating: 'up' } ),
 				} )
 			);
 		} );
@@ -180,7 +180,7 @@ describe( 'useFeedback', () => {
 	} );
 
 	describe( 'thumbs down feedback', () => {
-		it( 'sends rating via apiFetch when thumbs down is clicked', async () => {
+		it( 'sends rating via fetch when thumbs down is clicked', async () => {
 			renderHook( () => useFeedback( defaultConfig ) );
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
@@ -191,11 +191,11 @@ describe( 'useFeedback', () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
 			} );
 
-			expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect( mockFetch ).toHaveBeenCalledWith(
+				'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/rate',
 				expect.objectContaining( {
-					url: 'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/rate',
 					method: 'POST',
-					data: { message_id: 'msg-1', rating: 'down' },
+					body: JSON.stringify( { message_id: 'msg-1', rating: 'down' } ),
 				} )
 			);
 		} );
@@ -233,7 +233,7 @@ describe( 'useFeedback', () => {
 	} );
 
 	describe( 'feedback text submission', () => {
-		it( 'submits feedback with conversation context via apiFetch', async () => {
+		it( 'submits feedback with conversation context via fetch', async () => {
 			const messages = [
 				createMessage( 'msg-1', 'user', 'How do I set up my site?' ),
 				createMessage( 'msg-2', 'agent', 'Here are the steps...' ),
@@ -257,20 +257,24 @@ describe( 'useFeedback', () => {
 				await result.current.submitFeedbackText( 'The solution was unclear' );
 			} );
 
-			expect( mockApiFetch ).toHaveBeenCalledWith(
+			const textCall = mockFetch.mock.calls.find(
+				( call: string[] ) => typeof call[ 0 ] === 'string' && call[ 0 ].includes( '/text' )
+			);
+			expect( textCall ).toBeDefined();
+			expect( textCall[ 0 ] ).toBe(
+				'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/text'
+			);
+			const body = JSON.parse( textCall[ 1 ].body );
+			expect( body ).toEqual(
 				expect.objectContaining( {
-					url: 'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/text',
-					method: 'POST',
-					data: expect.objectContaining( {
-						message_id: 'msg-4',
-						feedback: 'The solution was unclear',
-						previous_messages: [
-							{ role: 'user', text: 'How do I set up my site?' },
-							{ role: 'agent', text: 'Here are the steps...' },
-							{ role: 'user', text: 'That did not work' },
-							{ role: 'agent', text: 'Let me try a different approach...' },
-						],
-					} ),
+					message_id: 'msg-4',
+					feedback: 'The solution was unclear',
+					previous_messages: [
+						{ role: 'user', text: 'How do I set up my site?' },
+						{ role: 'agent', text: 'Here are the steps...' },
+						{ role: 'user', text: 'That did not work' },
+						{ role: 'agent', text: 'Let me try a different approach...' },
+					],
 				} )
 			);
 		} );
@@ -300,12 +304,11 @@ describe( 'useFeedback', () => {
 			} );
 
 			// Find the feedback text submission call (the /text URL)
-			const feedbackCall = mockApiFetch.mock.calls.find(
-				( call ) => ( call[ 0 ] as { url: string } ).url?.includes( '/text' )
+			const feedbackCall = mockFetch.mock.calls.find(
+				( call: string[] ) => typeof call[ 0 ] === 'string' && call[ 0 ].includes( '/text' )
 			);
 			expect( feedbackCall ).toBeDefined();
-			const callData = ( feedbackCall![ 0 ] as { data: { previous_messages: { text: string }[] } } )
-				.data;
+			const callData = JSON.parse( feedbackCall[ 1 ].body );
 			expect( callData.previous_messages ).toHaveLength( 4 );
 			expect( callData.previous_messages[ 0 ].text ).toBe( 'Message 3' );
 		} );
@@ -348,10 +351,12 @@ describe( 'useFeedback', () => {
 				await result.current.submitFeedbackText( 'Test' );
 			} );
 
-			expect( mockApiFetch ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					url: 'https://public-api.wordpress.com/wpcom/v2/ai/feedback/stored-session-123/text',
-				} )
+			const textCall = mockFetch.mock.calls.find(
+				( call: string[] ) => typeof call[ 0 ] === 'string' && call[ 0 ].includes( '/text' )
+			);
+			expect( textCall ).toBeDefined();
+			expect( textCall[ 0 ] ).toBe(
+				'https://public-api.wordpress.com/wpcom/v2/ai/feedback/stored-session-123/text'
 			);
 		} );
 
@@ -367,13 +372,13 @@ describe( 'useFeedback', () => {
 			} );
 
 			// Clear mocks from rating call
-			mockApiFetch.mockClear();
+			mockFetch.mockClear();
 
 			await act( async () => {
 				await result.current.submitFeedbackText( '   ' );
 			} );
 
-			expect( mockApiFetch ).not.toHaveBeenCalled();
+			expect( mockFetch ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -411,7 +416,7 @@ describe( 'useFeedback', () => {
 				await thumbsUpAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
 			} );
 
-			expect( mockApiFetch ).not.toHaveBeenCalled();
+			expect( mockFetch ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -442,12 +447,11 @@ describe( 'useFeedback', () => {
 			} );
 
 			// Find the feedback text submission call (the /text URL)
-			const feedbackCall = mockApiFetch.mock.calls.find(
-				( call ) => ( call[ 0 ] as { url: string } ).url?.includes( '/text' )
+			const feedbackCall = mockFetch.mock.calls.find(
+				( call: string[] ) => typeof call[ 0 ] === 'string' && call[ 0 ].includes( '/text' )
 			);
 			expect( feedbackCall ).toBeDefined();
-			const callData = ( feedbackCall![ 0 ] as { data: { previous_messages: { text: string }[] } } )
-				.data;
+			const callData = JSON.parse( feedbackCall[ 1 ].body );
 			expect( callData.previous_messages ).toHaveLength( 3 );
 			expect( callData.previous_messages[ 2 ].text ).toBe( 'Here are your analytics' );
 			// Tool JSON is replaced with a human-readable placeholder

--- a/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
@@ -123,15 +123,16 @@ describe( 'useFeedback', () => {
 	} );
 
 	describe( 'thumbs up feedback', () => {
-		it( 'sends rating via fetch when thumbs up is clicked', async () => {
-			renderHook( () => useFeedback( defaultConfig ) );
+		it( 'sends rating with message_text via fetch when thumbs up is clicked', async () => {
+			const messages = [ createMessage( 'msg-1', 'agent', 'Here is the answer' ) ];
+			renderHook( () => useFeedback( { ...defaultConfig, messages } ) );
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
-			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const actions = registrationCall.actions( messages[ 0 ] );
 			const thumbsUpAction = actions.find( ( a: { id: string } ) => a.id.includes( 'up' ) );
 
 			await act( async () => {
-				await thumbsUpAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+				await thumbsUpAction?.onClick( messages[ 0 ] );
 			} );
 
 			expect( mockAuthProvider ).toHaveBeenCalled();
@@ -142,7 +143,11 @@ describe( 'useFeedback', () => {
 					headers: expect.objectContaining( {
 						Authorization: 'Bearer test-token',
 					} ),
-					body: JSON.stringify( { message_id: 'msg-1', rating: 'up' } ),
+					body: JSON.stringify( {
+						message_id: 'msg-1',
+						rating: 'up',
+						message_text: 'Here is the answer',
+					} ),
 				} )
 			);
 		} );
@@ -180,22 +185,27 @@ describe( 'useFeedback', () => {
 	} );
 
 	describe( 'thumbs down feedback', () => {
-		it( 'sends rating via fetch when thumbs down is clicked', async () => {
-			renderHook( () => useFeedback( defaultConfig ) );
+		it( 'sends rating with message_text via fetch when thumbs down is clicked', async () => {
+			const messages = [ createMessage( 'msg-1', 'agent', 'Bad answer' ) ];
+			renderHook( () => useFeedback( { ...defaultConfig, messages } ) );
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
-			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
+			const actions = registrationCall.actions( messages[ 0 ] );
 			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
-				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
+				await thumbsDownAction?.onClick( messages[ 0 ] );
 			} );
 
 			expect( mockFetch ).toHaveBeenCalledWith(
 				'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/rate',
 				expect.objectContaining( {
 					method: 'POST',
-					body: JSON.stringify( { message_id: 'msg-1', rating: 'down' } ),
+					body: JSON.stringify( {
+						message_id: 'msg-1',
+						rating: 'down',
+						message_text: 'Bad answer',
+					} ),
 				} )
 			);
 		} );

--- a/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
@@ -9,6 +9,50 @@ import { getSessionId as getStoredSessionId } from '../../../utils/agent-session
 import useFeedback from '../index';
 import type { Message } from '@automattic/agenttic-ui/dist/types';
 
+jest.mock(
+	'@automattic/agenttic-ui',
+	() => {
+		let onFeedbackCb: ( messageId: string, feedback: 'up' | 'down' ) => void;
+
+		return {
+			createFeedbackActions: jest.fn(
+				( {
+					onFeedback,
+					condition,
+				}: {
+					onFeedback: ( messageId: string, feedback: 'up' | 'down' ) => void;
+					condition?: ( message: Message ) => boolean;
+				} ) => {
+					onFeedbackCb = onFeedback;
+					return {
+						getActionsForMessage: ( message: Message ) => {
+							if ( condition && ! condition( message ) ) {
+								return [];
+							}
+							return [
+								{
+									id: 'feedback-up',
+									label: 'Thumbs Up',
+									onClick: ( msg: Message ) => onFeedbackCb( msg.id, 'up' ),
+								},
+								{
+									id: 'feedback-down',
+									label: 'Thumbs Down',
+									onClick: ( msg: Message ) => onFeedbackCb( msg.id, 'down' ),
+								},
+							];
+						},
+						onChange: jest.fn(),
+						offChange: jest.fn(),
+					};
+				}
+			),
+			ThumbsUpIcon: () => null,
+			ThumbsDownIcon: () => null,
+		};
+	},
+	{ virtual: true }
+);
 jest.mock( '@automattic/calypso-analytics' );
 jest.mock( '@wordpress/api-fetch' );
 jest.mock( 'wpcom-proxy-request' );
@@ -379,10 +423,14 @@ describe( 'useFeedback', () => {
 	} );
 
 	describe( 'conversation context extraction', () => {
-		it( 'skips tool messages in conversation context', async () => {
+		it( 'replaces tool messages with placeholder in conversation context', async () => {
+			const toolJson = JSON.stringify( {
+				tool_id: 'big_sky__show_component',
+				data: { type: 'site-analytics' },
+			} );
 			const messages = [
 				createMessage( 'msg-1', 'user', 'Show me analytics' ),
-				createMessage( 'msg-2', 'agent', '{"tool_id": "big_sky__show_component"}' ),
+				createMessage( 'msg-2', 'agent', toolJson ),
 				createMessage( 'msg-3', 'agent', 'Here are your analytics' ),
 			];
 
@@ -401,11 +449,14 @@ describe( 'useFeedback', () => {
 			} );
 
 			const callBody = mockWpcomRequest.mock.calls[ 1 ][ 0 ].body;
-			expect( callBody.previous_messages ).toHaveLength( 2 );
-			expect( callBody.previous_messages[ 1 ].text ).toBe( 'Here are your analytics' );
-			// Tool message replaced with placeholder
+			expect( callBody.previous_messages ).toHaveLength( 3 );
+			expect( callBody.previous_messages[ 2 ].text ).toBe( 'Here are your analytics' );
+			// Tool JSON is replaced with a human-readable placeholder
 			expect( callBody.previous_messages ).not.toContainEqual(
 				expect.objectContaining( { text: expect.stringContaining( 'tool_id' ) } )
+			);
+			expect( callBody.previous_messages[ 1 ].text ).toBe(
+				'🔨 Tool: `big_sky__show_component` (site-analytics)'
 			);
 		} );
 	} );

--- a/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
@@ -4,7 +4,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { renderHook, act } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
-import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { getSessionId as getStoredSessionId } from '../../../utils/agent-session';
 import useFeedback from '../index';
 import type { Message } from '@automattic/agenttic-ui/dist/types';
@@ -55,19 +54,16 @@ jest.mock(
 );
 jest.mock( '@automattic/calypso-analytics' );
 jest.mock( '@wordpress/api-fetch' );
-jest.mock( 'wpcom-proxy-request' );
 jest.mock( '../../../utils/agent-session' );
 
 const mockRegisterMessageActions = jest.fn();
 const mockRecordTracksEvent = recordTracksEvent as jest.MockedFunction< typeof recordTracksEvent >;
 const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
-const mockWpcomRequest = wpcomRequest as jest.MockedFunction< typeof wpcomRequest >;
-const mockCanAccessWpcomApis = canAccessWpcomApis as jest.MockedFunction<
-	typeof canAccessWpcomApis
->;
 const mockGetStoredSessionId = getStoredSessionId as jest.MockedFunction<
 	typeof getStoredSessionId
 >;
+
+const mockAuthProvider = jest.fn().mockResolvedValue( { Authorization: 'Bearer test-token' } );
 
 const createMessage = ( id: string, role: 'user' | 'agent', text: string ): Message => ( {
 	id,
@@ -78,8 +74,6 @@ const createMessage = ( id: string, role: 'user' | 'agent', text: string ): Mess
 describe( 'useFeedback', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockCanAccessWpcomApis.mockReturnValue( true );
-		mockWpcomRequest.mockResolvedValue( {} );
 		mockApiFetch.mockResolvedValue( {} );
 		mockGetStoredSessionId.mockReturnValue( 'stored-session-123' );
 	} );
@@ -88,8 +82,8 @@ describe( 'useFeedback', () => {
 		registerMessageActions: mockRegisterMessageActions,
 		messages: [],
 		agentId: 'test-agent',
-		siteId: 12345,
 		sessionId: 'session-abc',
+		authProvider: mockAuthProvider,
 	};
 
 	describe( 'initialization', () => {
@@ -129,22 +123,26 @@ describe( 'useFeedback', () => {
 	} );
 
 	describe( 'thumbs up feedback', () => {
-		it( 'sends rating to wpcom when thumbs up is clicked', async () => {
+		it( 'sends rating via apiFetch when thumbs up is clicked', async () => {
 			renderHook( () => useFeedback( defaultConfig ) );
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsUpAction = actions.find( ( a ) => a.id.includes( 'up' ) );
+			const thumbsUpAction = actions.find( ( a: { id: string } ) => a.id.includes( 'up' ) );
 
 			await act( async () => {
 				await thumbsUpAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
 			} );
 
-			expect( mockWpcomRequest ).toHaveBeenCalledWith(
+			expect( mockAuthProvider ).toHaveBeenCalled();
+			expect( mockApiFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					path: '/sites/12345/big-sky/v1/wp-orchestrator/session-abc/rate',
+					url: 'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/rate',
 					method: 'POST',
-					body: { message_id: 'msg-1', rating: 'up' },
+					headers: expect.objectContaining( {
+						Authorization: 'Bearer test-token',
+					} ),
+					data: { message_id: 'msg-1', rating: 'up' },
 				} )
 			);
 		} );
@@ -154,7 +152,7 @@ describe( 'useFeedback', () => {
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsUpAction = actions.find( ( a ) => a.id.includes( 'up' ) );
+			const thumbsUpAction = actions.find( ( a: { id: string } ) => a.id.includes( 'up' ) );
 
 			await act( async () => {
 				await thumbsUpAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
@@ -171,7 +169,7 @@ describe( 'useFeedback', () => {
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsUpAction = actions.find( ( a ) => a.id.includes( 'up' ) );
+			const thumbsUpAction = actions.find( ( a: { id: string } ) => a.id.includes( 'up' ) );
 
 			await act( async () => {
 				await thumbsUpAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
@@ -182,22 +180,22 @@ describe( 'useFeedback', () => {
 	} );
 
 	describe( 'thumbs down feedback', () => {
-		it( 'sends rating to wpcom when thumbs down is clicked', async () => {
+		it( 'sends rating via apiFetch when thumbs down is clicked', async () => {
 			renderHook( () => useFeedback( defaultConfig ) );
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
 			} );
 
-			expect( mockWpcomRequest ).toHaveBeenCalledWith(
+			expect( mockApiFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					path: '/sites/12345/big-sky/v1/wp-orchestrator/session-abc/rate',
+					url: 'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/rate',
 					method: 'POST',
-					body: { message_id: 'msg-1', rating: 'down' },
+					data: { message_id: 'msg-1', rating: 'down' },
 				} )
 			);
 		} );
@@ -207,7 +205,7 @@ describe( 'useFeedback', () => {
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
@@ -224,7 +222,7 @@ describe( 'useFeedback', () => {
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
@@ -235,7 +233,7 @@ describe( 'useFeedback', () => {
 	} );
 
 	describe( 'feedback text submission', () => {
-		it( 'submits feedback with conversation context to wpcom', async () => {
+		it( 'submits feedback with conversation context via apiFetch', async () => {
 			const messages = [
 				createMessage( 'msg-1', 'user', 'How do I set up my site?' ),
 				createMessage( 'msg-2', 'agent', 'Here are the steps...' ),
@@ -248,7 +246,7 @@ describe( 'useFeedback', () => {
 			// Simulate thumbs down first
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-4', 'agent', 'Test' ) );
-			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-4', 'agent', 'Test' ) );
@@ -259,11 +257,11 @@ describe( 'useFeedback', () => {
 				await result.current.submitFeedbackText( 'The solution was unclear' );
 			} );
 
-			expect( mockWpcomRequest ).toHaveBeenCalledWith(
+			expect( mockApiFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					path: '/sites/12345/big-sky/v1/wp-orchestrator/session-abc/feedback',
+					url: 'https://public-api.wordpress.com/wpcom/v2/ai/feedback/session-abc/text',
 					method: 'POST',
-					body: expect.objectContaining( {
+					data: expect.objectContaining( {
 						message_id: 'msg-4',
 						feedback: 'The solution was unclear',
 						previous_messages: [
@@ -291,7 +289,7 @@ describe( 'useFeedback', () => {
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-6', 'agent', 'Test' ) );
-			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-6', 'agent', 'Test' ) );
@@ -301,9 +299,15 @@ describe( 'useFeedback', () => {
 				await result.current.submitFeedbackText( 'Test feedback' );
 			} );
 
-			const callBody = mockWpcomRequest.mock.calls[ 1 ][ 0 ].body;
-			expect( callBody.previous_messages ).toHaveLength( 4 );
-			expect( callBody.previous_messages[ 0 ].text ).toBe( 'Message 3' );
+			// Find the feedback text submission call (the /text URL)
+			const feedbackCall = mockApiFetch.mock.calls.find(
+				( call ) => ( call[ 0 ] as { url: string } ).url?.includes( '/text' )
+			);
+			expect( feedbackCall ).toBeDefined();
+			const callData = ( feedbackCall![ 0 ] as { data: { previous_messages: { text: string }[] } } )
+				.data;
+			expect( callData.previous_messages ).toHaveLength( 4 );
+			expect( callData.previous_messages[ 0 ].text ).toBe( 'Message 3' );
 		} );
 
 		it( 'records tracks event when feedback text is submitted', async () => {
@@ -311,7 +315,7 @@ describe( 'useFeedback', () => {
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
@@ -334,7 +338,7 @@ describe( 'useFeedback', () => {
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
@@ -344,9 +348,9 @@ describe( 'useFeedback', () => {
 				await result.current.submitFeedbackText( 'Test' );
 			} );
 
-			expect( mockWpcomRequest ).toHaveBeenCalledWith(
+			expect( mockApiFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					path: '/sites/12345/big-sky/v1/wp-orchestrator/stored-session-123/feedback',
+					url: 'https://public-api.wordpress.com/wpcom/v2/ai/feedback/stored-session-123/text',
 				} )
 			);
 		} );
@@ -356,20 +360,20 @@ describe( 'useFeedback', () => {
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
 			} );
 
 			// Clear mocks from rating call
-			mockWpcomRequest.mockClear();
+			mockApiFetch.mockClear();
 
 			await act( async () => {
 				await result.current.submitFeedbackText( '   ' );
 			} );
 
-			expect( mockWpcomRequest ).not.toHaveBeenCalled();
+			expect( mockApiFetch ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -379,7 +383,7 @@ describe( 'useFeedback', () => {
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
@@ -395,27 +399,19 @@ describe( 'useFeedback', () => {
 		} );
 	} );
 
-	describe( 'API routing', () => {
-		it( 'uses apiFetch when canAccessWpcomApis returns false', async () => {
-			mockCanAccessWpcomApis.mockReturnValue( false );
-
-			renderHook( () => useFeedback( defaultConfig ) );
+	describe( 'no authProvider', () => {
+		it( 'does not send rating when authProvider is not provided', async () => {
+			renderHook( () => useFeedback( { ...defaultConfig, authProvider: undefined } ) );
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-1', 'agent', 'Test' ) );
-			const thumbsUpAction = actions.find( ( a ) => a.id.includes( 'up' ) );
+			const thumbsUpAction = actions.find( ( a: { id: string } ) => a.id.includes( 'up' ) );
 
 			await act( async () => {
 				await thumbsUpAction?.onClick( createMessage( 'msg-1', 'agent', 'Test' ) );
 			} );
 
-			expect( mockWpcomRequest ).not.toHaveBeenCalled();
-			expect( mockApiFetch ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					path: '/wpcom/v2/big-sky/v1/wp-orchestrator/session-abc/rate',
-					method: 'POST',
-				} )
-			);
+			expect( mockApiFetch ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -435,7 +431,7 @@ describe( 'useFeedback', () => {
 
 			const registrationCall = mockRegisterMessageActions.mock.calls[ 0 ][ 0 ];
 			const actions = registrationCall.actions( createMessage( 'msg-3', 'agent', 'Test' ) );
-			const thumbsDownAction = actions.find( ( a ) => a.id.includes( 'down' ) );
+			const thumbsDownAction = actions.find( ( a: { id: string } ) => a.id.includes( 'down' ) );
 
 			await act( async () => {
 				await thumbsDownAction?.onClick( createMessage( 'msg-3', 'agent', 'Test' ) );
@@ -445,14 +441,20 @@ describe( 'useFeedback', () => {
 				await result.current.submitFeedbackText( 'Test' );
 			} );
 
-			const callBody = mockWpcomRequest.mock.calls[ 1 ][ 0 ].body;
-			expect( callBody.previous_messages ).toHaveLength( 3 );
-			expect( callBody.previous_messages[ 2 ].text ).toBe( 'Here are your analytics' );
+			// Find the feedback text submission call (the /text URL)
+			const feedbackCall = mockApiFetch.mock.calls.find(
+				( call ) => ( call[ 0 ] as { url: string } ).url?.includes( '/text' )
+			);
+			expect( feedbackCall ).toBeDefined();
+			const callData = ( feedbackCall![ 0 ] as { data: { previous_messages: { text: string }[] } } )
+				.data;
+			expect( callData.previous_messages ).toHaveLength( 3 );
+			expect( callData.previous_messages[ 2 ].text ).toBe( 'Here are your analytics' );
 			// Tool JSON is replaced with a human-readable placeholder
-			expect( callBody.previous_messages ).not.toContainEqual(
+			expect( callData.previous_messages ).not.toContainEqual(
 				expect.objectContaining( { text: expect.stringContaining( 'tool_id' ) } )
 			);
-			expect( callBody.previous_messages[ 1 ].text ).toBe(
+			expect( callData.previous_messages[ 1 ].text ).toBe(
 				'🔨 Tool: `big_sky__show_component` (site-analytics)'
 			);
 		} );

--- a/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
@@ -164,8 +164,8 @@ describe( 'useFeedback', () => {
 			} );
 
 			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
-				'wpcom_agents_manager_response_action_thumbs_up',
-				{ message_id: 'msg-1' }
+				'calypso_agents_manager_response_feedback_action',
+				{ type: 'thumb_up', message_id: 'msg-1' }
 			);
 		} );
 
@@ -222,8 +222,8 @@ describe( 'useFeedback', () => {
 			} );
 
 			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
-				'wpcom_agents_manager_response_action_thumbs_down',
-				{ message_id: 'msg-1' }
+				'calypso_agents_manager_response_feedback_action',
+				{ type: 'thumb_down', message_id: 'msg-1' }
 			);
 		} );
 
@@ -339,7 +339,7 @@ describe( 'useFeedback', () => {
 			} );
 
 			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
-				'wpcom_agents_manager_response_feedback_submitted',
+				'calypso_agents_manager_response_feedback_submitted',
 				{ message_id: 'msg-1' }
 			);
 		} );

--- a/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/test/index.test.ts
@@ -407,7 +407,7 @@ describe( 'useFeedback', () => {
 			expect( result.current.showFeedbackInput ).toBe( true );
 
 			act( () => {
-				result.current.cancelFeedback();
+				result.current.resetFeedback();
 			} );
 
 			expect( result.current.showFeedbackInput ).toBe( false );


### PR DESCRIPTION
Part of BSKY-1568

## Proposed Changes

* Add thumbs up/down feedback buttons on agent messages using agenttic-ui's `createFeedbackActions` + `registerMessageActions`
* New `useFeedback` hook based on the existing one in `big-sky-plugin`.
* New `FeedbackInput` component based on the existing one in `big-sky-plugin` shown on thumbs down for submitting text feedback with conversation context
* Detect show-component JSON messages in conversation context extraction and replace with human-readable placeholder

## Why are these changes being made?

The Unified AI chat experience had no mechanism for users to provide feedback on AI responses. The legacy Big Sky chat UI has thumbs up/down buttons, but these were never ported to Agents Manager. This adds feedback collection to improve signal on response quality.

## Testing Instructions

See instructions on https://github.com/Automattic/big-sky-plugin/pull/5658

**Edge cases:**
   - Feedback buttons should NOT appear on user messages
   - After clicking one thumb, the other should be disabled
   - Network error on feedback submit → error message, auto-dismiss
   - Multiple thumbs down on different messages → only one feedback input at a time

## Companion PR

- big-sky-plugin: https://github.com/Automattic/big-sky-plugin/pull/5658
- wpcom endpoints: 204016-ghe-Automattic/wpcom

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?