### PR TITLE
CIAB: Apply partner font style to signup page

### DIFF
--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -1,3 +1,13 @@
+@import "@wordpress/base-styles/variables";
+
+/* Start: CIAB partner branding font styles for signup page */
+.layout.is-section-signup.is-ciab-font-system {
+	.wp-login__one-login-layout-heading-text {
+		font-family: $default-font;
+	}
+}
+/* End: CIAB partner branding font styles for signup page */
+
 body.is-section-signup .signup {
 	.signup-form.is-horizontal {
 		.signup-form__terms-of-service-link,


### PR DESCRIPTION
Part of ARC-1388

## Proposed Changes

* Extends the CIAB partner branding font override (added for the login page in #108509) to the signup page.
* When a partner configures `fontStyle: 'system'`, the signup heading now uses the system font stack (`$default-font`) instead of Recoleta.
* Covers both the `StepContainerV2` path (`.wp-brand-font`) and the legacy `StepContainer` path (`.formatted-header__title`).

## Why are these changes being made?

* PR #108509 added configurable font styles for partner branding but only applied it to the login page. The signup page should match the login page for a consistent branded experience across all CIAB touchpoints.

## Testing Instructions

* On an incognito window, open `/start/account/user-social?from=woo`.
* You should see the heading text using the system font (SF Pro on macOS, Segoe UI on Windows) instead of Recoleta.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?