### PR TITLE
Help Center in Gutenberg: Wrong CIAB variable name

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -202,7 +202,7 @@ function HelpCenterContentWithProvider() {
 	);
 }
 
-if ( helpCenterData.isNextAdmin ) {
+if ( helpCenterData.isCommerceGarden ) {
 	const unsubscribe = subscribe( () => {
 		// Make sure the wp-logo menu item is registered before unregistering its default items.
 		// Use optional chaining since 'next-admin' store only exists in next-admin context


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/WOOPRD-2093/fix-help-in-editor

## Proposed Changes

* `isNextAdmin` variable is not used anymore, from Jetpack it is returned `isCommerceGarden` instead, so I updated it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We were no detecting anymore that we are in CIAB editor, and so the code was not called anymore.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a CIAB site using the MC tool
* Go to the editor
* `yarn dev --sync` from `apps/help-center`
* Sandbox widgets
* Help Center in CIAB editor should work
