### PR TITLE
Reader: Fix focus & scroll on Quick Post editor

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -193,6 +193,7 @@ export default function QuickPost(): JSX.Element | null {
 			<div className="verbum-editor-wrapper">
 				<Editor
 					key={ editorKey }
+					focusOnMount={ false }
 					initialContent={ postContent }
 					onChange={ setPostContent }
 					isRTL={ isLocaleRtl( locale ) ?? false }

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"search:storybook:start": "echo 'Deprecated, run `yarn workspace @automattic/search run storybook:start` instead'",
 		"site-admin:storybook:start": "yarn workspace @automattic/site-admin run storybook:start",
 		"start": "npx check-node-version --package && node bin/welcome.js && yarn run build && yarn run start-build",
-		"start:debug": "NODE_OPTIONS='--max-old-space-size=6144' SOURCEMAP='eval-source-map' yarn start",
+		"start:debug": "NODE_OPTIONS='--max-old-space-size=8192' SOURCEMAP='eval-source-map' yarn start",
 		"start-mock-wordpress-com": "MOCK_WORDPRESSDOTCOM=1 yarn run start",
 		"start-build": "BROWSERSLIST_ENV=evergreen node build/server.js | bunyan -o short",
 		"start-jetpack-cloud": "CALYPSO_ENV=jetpack-cloud-development yarn run start",

--- a/packages/verbum-block-editor/src/editor/components/InitialBlockSelector.tsx
+++ b/packages/verbum-block-editor/src/editor/components/InitialBlockSelector.tsx
@@ -1,0 +1,102 @@
+import {
+	store as blockEditorStore,
+	// @ts-expect-error - Typings missing
+} from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useCallback, useRef } from '@wordpress/element';
+
+interface InitialBlockSelectorProps {
+	editorClass: string;
+	focusOnMount: boolean;
+	onBlockSelect: () => void;
+}
+
+/**
+ * Component to select the last block on initial load.
+ *
+ * NOTE: Must be rendered inside BlockEditorProvider to access the correct store context.
+ */
+export default function InitialBlockSelector( {
+	editorClass,
+	focusOnMount,
+	onBlockSelect,
+}: InitialBlockSelectorProps ): null {
+	const { selectBlock } = useDispatch( blockEditorStore );
+	const storeBlocks = useSelect( ( select ) => select( blockEditorStore ).getBlocks(), [] );
+	const hasInitialized = useRef( false );
+
+	/**
+	 * Waits for the selected block to be available in the DOM and then overrides the "scrollIntoView" function to prevent scrolling on initial load.
+	 *
+	 * As of v15.12 Gutenberg is using "useScrollIntoView" hook to scroll the selected block into view even when `initialPosition` of the block is set to "null" (no focus).
+	 * This is bringing the block into the view when the user doesn't want it.
+	 */
+	const waitForSelectedElementAndOverrideScroll = useCallback( () => {
+		// If we are focusing on mount then keep the default behavior of scrolling.
+		if ( focusOnMount ) {
+			return;
+		}
+
+		const blockSelector = '.wp-block.is-selected';
+		const editorIframe = document.querySelector(
+			`.${ editorClass } iframe`
+		) as HTMLIFrameElement | null;
+
+		if ( ! editorIframe?.contentDocument ) {
+			return;
+		}
+
+		let selectedElement: HTMLElement | null | undefined;
+		let originalScrollIntoView: ( arg?: boolean | ScrollIntoViewOptions ) => void;
+
+		const interval = setInterval( () => {
+			selectedElement = editorIframe?.contentDocument?.querySelector( blockSelector );
+
+			if ( ! selectedElement ) {
+				return;
+			}
+
+			// Store original and replace with empty function.
+			originalScrollIntoView = selectedElement.scrollIntoView;
+			selectedElement.scrollIntoView = () => {};
+			clearInterval( interval );
+		}, 50 );
+
+		// Clear interval and restore the original scrollIntoView to prevent breaking any future calls.
+		setTimeout( () => {
+			clearInterval( interval );
+
+			// Restore original scrollIntoView if it was replaced
+			if ( selectedElement && originalScrollIntoView ) {
+				selectedElement.scrollIntoView = originalScrollIntoView;
+			}
+		}, 5000 );
+	}, [ editorClass, focusOnMount ] );
+
+	useEffect( () => {
+		// To ensure we only run this useEffect once.
+		if ( hasInitialized.current ) {
+			return;
+		}
+
+		const lastBlock = storeBlocks[ storeBlocks.length - 1 ];
+		if ( ! lastBlock ) {
+			return;
+		}
+
+		hasInitialized.current = true;
+
+		selectBlock( lastBlock.clientId, focusOnMount ? 0 : null ).then( () => {
+			waitForSelectedElementAndOverrideScroll();
+			onBlockSelect();
+		} );
+	}, [
+		selectBlock,
+		storeBlocks,
+		onBlockSelect,
+		focusOnMount,
+		waitForSelectedElementAndOverrideScroll,
+	] );
+
+	return null;
+}

--- a/packages/verbum-block-editor/src/editor/editor-style.scss
+++ b/packages/verbum-block-editor/src/editor/editor-style.scss
@@ -31,15 +31,8 @@
 			overflow: hidden;
 			justify-content: space-between;
 			align-items: center;
+			min-height: 52px;
 			border-bottom: solid 1px #dcdcde;
-			height: 10px;
-			opacity: 0;
-			transition: height 0.2s ease, border-bottom 0.15s ease, opacity 0.2s ease;
-			&:has(.block-editor-block-contextual-toolbar) {
-				border-bottom: solid 1px #dcdcde;
-				height: 52px;
-				opacity: 1;
-			}
 
 			button {
 				box-shadow: none;

--- a/packages/verbum-block-editor/src/editor/editor-types.ts
+++ b/packages/verbum-block-editor/src/editor/editor-types.ts
@@ -2,6 +2,7 @@ import { type BlockInstance } from '@wordpress/blocks';
 
 export interface EditorProps {
 	initialContent: string;
+	focusOnMount: boolean;
 	onChange: ( content: string ) => void;
 	isRTL: boolean;
 	isDarkMode: boolean;

--- a/packages/verbum-block-editor/src/editor/editor-types.ts
+++ b/packages/verbum-block-editor/src/editor/editor-types.ts
@@ -2,7 +2,7 @@ import { type BlockInstance } from '@wordpress/blocks';
 
 export interface EditorProps {
 	initialContent: string;
-	focusOnMount: boolean;
+	focusOnMount?: boolean;
 	onChange: ( content: string ) => void;
 	isRTL: boolean;
 	isDarkMode: boolean;

--- a/packages/verbum-block-editor/src/editor/index.tsx
+++ b/packages/verbum-block-editor/src/editor/index.tsx
@@ -10,8 +10,9 @@ import { getCompatibilityStyles } from '@wordpress/block-editor/build-module/com
 import { createBlock, serialize, type BlockInstance } from '@wordpress/blocks';
 import { Popover, SlotFillProvider, KeyboardShortcuts } from '@wordpress/components';
 import { useStateWithHistory, useResizeObserver } from '@wordpress/compose';
-import React, { useCallback } from '@wordpress/element';
+import React, { useState, useCallback } from '@wordpress/element';
 import { rawShortcut } from '@wordpress/keycodes';
+import clsx from 'clsx';
 import { safeParse } from '../utils';
 import { editorSettings } from './editor-settings';
 import { EditorProps, StateWithUndoManager } from './editor-types';
@@ -43,6 +44,8 @@ export const Editor: FC< EditorProps > = ( {
 	} = useStateWithHistory(
 		initialContent !== '' ? safeParse( initialContent ) : [ createBlock( 'core/paragraph' ) ]
 	) as unknown as StateWithUndoManager;
+	const [ isEditing, setIsEditing ] = useState( false );
+
 	/**
 	 * This prevents the editor from copying the theme styles inside the iframe. We don't want to copy the styles inside.
 	 * See: https://github.com/WordPress/gutenberg/blob/4c319590947b5f7853411e3c076861193942c6d2/packages/block-editor/src/components/iframe/index.js#L160
@@ -102,7 +105,7 @@ export const Editor: FC< EditorProps > = ( {
 						},
 					] }
 				>
-					<div className="editor__header">
+					<div className={ clsx( 'editor__header', { 'is-editing': isEditing } ) }>
 						<div className="editor__header-wrapper">
 							<div className="editor__header-toolbar">
 								<BlockToolbar hideDragHandle />

--- a/packages/verbum-block-editor/src/editor/index.tsx
+++ b/packages/verbum-block-editor/src/editor/index.tsx
@@ -4,18 +4,17 @@ import {
 	BlockTools,
 	BlockList,
 	BlockCanvas,
-	store as blockEditorStore,
 	// @ts-expect-error - Typings missing
 } from '@wordpress/block-editor';
 import { getCompatibilityStyles } from '@wordpress/block-editor/build-module/components/iframe/get-compatibility-styles';
 import { createBlock, serialize, type BlockInstance } from '@wordpress/blocks';
 import { Popover, SlotFillProvider, KeyboardShortcuts } from '@wordpress/components';
 import { useStateWithHistory, useResizeObserver } from '@wordpress/compose';
-import { useDispatch, useSelect } from '@wordpress/data';
+import React, { useState, useCallback } from '@wordpress/element';
 import { rawShortcut } from '@wordpress/keycodes';
 import clsx from 'clsx';
-import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { safeParse } from '../utils';
+import InitialBlockSelector from './components/InitialBlockSelector';
 import { editorSettings } from './editor-settings';
 import { EditorProps, StateWithUndoManager } from './editor-types';
 import type { FC, MouseEvent } from 'react';
@@ -110,6 +109,7 @@ export const Editor: FC< EditorProps > = ( {
 					] }
 				>
 					<InitialBlockSelector
+						editorClass={ EDITOR_MAIN_CLASS }
 						focusOnMount={ focusOnMount }
 						onBlockSelect={ () => setIsEditing( true ) }
 					/>
@@ -153,95 +153,3 @@ export const Editor: FC< EditorProps > = ( {
 		</SlotFillProvider>
 	);
 };
-
-/**
- * Component to select the last block on initial load.
- *
- * NOTE: Must be rendered inside BlockEditorProvider to access the correct store context.
- */
-function InitialBlockSelector( {
-	focusOnMount,
-	onBlockSelect,
-}: {
-	focusOnMount: boolean;
-	onBlockSelect: () => void;
-} ): null {
-	const { selectBlock } = useDispatch( blockEditorStore );
-	const storeBlocks = useSelect( ( select ) => select( blockEditorStore ).getBlocks(), [] );
-	const hasInitialized = useRef( false );
-
-	/**
-	 * Waits for the selected block to be available in the DOM and then overrides the "scrollIntoView" function to prevent scrolling on initial load.
-	 *
-	 * As of v15.12 Gutenberg is using "useScrollIntoView" hook to scroll the selected block into view even when `initialPosition` of the block is set to "null" (no focus).
-	 * This is bringing the block into the view when the user doesn't want it.
-	 */
-	const waitForSelectedElementAndOverrideScroll = useCallback( () => {
-		// If we are focusing on mount then keep the default behavior of scrolling.
-		if ( focusOnMount ) {
-			return;
-		}
-
-		const blockSelector = '.wp-block.is-selected';
-		const editorIframe = document.querySelector(
-			`.${ EDITOR_MAIN_CLASS } iframe`
-		) as HTMLIFrameElement | null;
-
-		if ( ! editorIframe?.contentDocument ) {
-			return;
-		}
-
-		let selectedElement: HTMLElement | null | undefined;
-		let originalScrollIntoView: ( arg?: boolean | ScrollIntoViewOptions ) => void;
-
-		const interval = setInterval( () => {
-			selectedElement = editorIframe?.contentDocument?.querySelector( blockSelector );
-
-			if ( ! selectedElement ) {
-				return;
-			}
-
-			// Store original and replace with empty function.
-			originalScrollIntoView = selectedElement.scrollIntoView;
-			selectedElement.scrollIntoView = () => {};
-			clearInterval( interval );
-		}, 50 );
-
-		// Clear interval and restore the original scrollIntoView to prevent breaking any future calls.
-		setTimeout( () => {
-			clearInterval( interval );
-
-			// Restore original scrollIntoView if it was replaced
-			if ( selectedElement && originalScrollIntoView ) {
-				selectedElement.scrollIntoView = originalScrollIntoView;
-			}
-		}, 5000 );
-	}, [ focusOnMount ] );
-
-	useEffect( () => {
-		// To ensure we only run this useEffect once.
-		if ( hasInitialized.current ) {
-			return;
-		}
-
-		const lastBlock = storeBlocks[ storeBlocks.length - 1 ];
-		if ( ! lastBlock ) {
-			return;
-		}
-
-		hasInitialized.current = true;
-
-		selectBlock( lastBlock.clientId, focusOnMount ? 0 : null ).then( () => {
-			waitForSelectedElementAndOverrideScroll();
-			onBlockSelect();
-		} );
-	}, [
-		selectBlock,
-		storeBlocks,
-		onBlockSelect,
-		focusOnMount,
-		waitForSelectedElementAndOverrideScroll,
-	] );
-
-	return null;
-}

--- a/packages/verbum-block-editor/src/editor/index.tsx
+++ b/packages/verbum-block-editor/src/editor/index.tsx
@@ -4,15 +4,17 @@ import {
 	BlockTools,
 	BlockList,
 	BlockCanvas,
+	store as blockEditorStore,
 	// @ts-expect-error - Typings missing
 } from '@wordpress/block-editor';
 import { getCompatibilityStyles } from '@wordpress/block-editor/build-module/components/iframe/get-compatibility-styles';
 import { createBlock, serialize, type BlockInstance } from '@wordpress/blocks';
 import { Popover, SlotFillProvider, KeyboardShortcuts } from '@wordpress/components';
 import { useStateWithHistory, useResizeObserver } from '@wordpress/compose';
-import React, { useState, useCallback } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { rawShortcut } from '@wordpress/keycodes';
 import clsx from 'clsx';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { safeParse } from '../utils';
 import { editorSettings } from './editor-settings';
 import { EditorProps, StateWithUndoManager } from './editor-types';
@@ -21,6 +23,7 @@ import darkModeCss from '!!css-loader!sass-loader!./inline-iframe-style-dark-mod
 import css from '!!css-loader!sass-loader!./inline-iframe-style.scss';
 import './editor-style.scss';
 
+const EDITOR_MAIN_CLASS: string = 'editor__main';
 const iframedCSS = css.reduce( ( css: string, [ , item ]: [ string, string ] ) => {
 	return css + '\n' + item;
 }, '' );
@@ -30,6 +33,7 @@ const iframedCSS = css.reduce( ( css: string, [ , item ]: [ string, string ] ) =
  */
 export const Editor: FC< EditorProps > = ( {
 	initialContent = '',
+	focusOnMount = true,
 	onChange,
 	isRTL,
 	isDarkMode,
@@ -105,6 +109,10 @@ export const Editor: FC< EditorProps > = ( {
 						},
 					] }
 				>
+					<InitialBlockSelector
+						focusOnMount={ focusOnMount }
+						onBlockSelect={ () => setIsEditing( true ) }
+					/>
 					<div className={ clsx( 'editor__header', { 'is-editing': isEditing } ) }>
 						<div className="editor__header-wrapper">
 							<div className="editor__header-toolbar">
@@ -113,7 +121,7 @@ export const Editor: FC< EditorProps > = ( {
 							<Popover.Slot />
 						</div>
 					</div>
-					<div className="editor__main">
+					<div className={ EDITOR_MAIN_CLASS }>
 						<Popover.Slot />
 						<BlockTools>
 							<BlockCanvas
@@ -145,3 +153,95 @@ export const Editor: FC< EditorProps > = ( {
 		</SlotFillProvider>
 	);
 };
+
+/**
+ * Component to select the last block on initial load.
+ *
+ * NOTE: Must be rendered inside BlockEditorProvider to access the correct store context.
+ */
+function InitialBlockSelector( {
+	focusOnMount,
+	onBlockSelect,
+}: {
+	focusOnMount: boolean;
+	onBlockSelect: () => void;
+} ): null {
+	const { selectBlock } = useDispatch( blockEditorStore );
+	const storeBlocks = useSelect( ( select ) => select( blockEditorStore ).getBlocks(), [] );
+	const hasInitialized = useRef( false );
+
+	/**
+	 * Waits for the selected block to be available in the DOM and then overrides the "scrollIntoView" function to prevent scrolling on initial load.
+	 *
+	 * As of v15.12 Gutenberg is using "useScrollIntoView" hook to scroll the selected block into view even when `initialPosition` of the block is set to "null" (no focus).
+	 * This is bringing the block into the view when the user doesn't want it.
+	 */
+	const waitForSelectedElementAndOverrideScroll = useCallback( () => {
+		// If we are focusing on mount then keep the default behavior of scrolling.
+		if ( focusOnMount ) {
+			return;
+		}
+
+		const blockSelector = '.wp-block.is-selected';
+		const editorIframe = document.querySelector(
+			`.${ EDITOR_MAIN_CLASS } iframe`
+		) as HTMLIFrameElement | null;
+
+		if ( ! editorIframe?.contentDocument ) {
+			return;
+		}
+
+		let selectedElement: HTMLElement | null | undefined;
+		let originalScrollIntoView: ( arg?: boolean | ScrollIntoViewOptions ) => void;
+
+		const interval = setInterval( () => {
+			selectedElement = editorIframe?.contentDocument?.querySelector( blockSelector );
+
+			if ( ! selectedElement ) {
+				return;
+			}
+
+			// Store original and replace with empty function.
+			originalScrollIntoView = selectedElement.scrollIntoView;
+			selectedElement.scrollIntoView = () => {};
+			clearInterval( interval );
+		}, 50 );
+
+		// Clear interval and restore the original scrollIntoView to prevent breaking any future calls.
+		setTimeout( () => {
+			clearInterval( interval );
+
+			// Restore original scrollIntoView if it was replaced
+			if ( selectedElement && originalScrollIntoView ) {
+				selectedElement.scrollIntoView = originalScrollIntoView;
+			}
+		}, 5000 );
+	}, [ focusOnMount ] );
+
+	useEffect( () => {
+		// To ensure we only run this useEffect once.
+		if ( hasInitialized.current ) {
+			return;
+		}
+
+		const lastBlock = storeBlocks[ storeBlocks.length - 1 ];
+		if ( ! lastBlock ) {
+			return;
+		}
+
+		hasInitialized.current = true;
+
+		selectBlock( lastBlock.clientId, focusOnMount ? 0 : null ).then( () => {
+			waitForSelectedElementAndOverrideScroll();
+			onBlockSelect();
+		} );
+	}, [
+		selectBlock,
+		storeBlocks,
+		onBlockSelect,
+		focusOnMount,
+		waitForSelectedElementAndOverrideScroll,
+	] );
+
+	return null;
+}

--- a/packages/verbum-block-editor/src/text-area-injector.tsx
+++ b/packages/verbum-block-editor/src/text-area-injector.tsx
@@ -11,13 +11,16 @@ import { loadTextFormatting } from './load-text-formatting';
  *                   It receives the serialized content as a parameter.
  * @param isRTL      Whether the editor should be RTL.
  * @param requestParamsGenerator Function that generates request params for embeds. It receives the embed URL as a parameter.
+ * @param isDarkMode Whether the editor should be in dark mode.
+ * @param focusOnMount Whether the editor should be focused on mount.
  */
 export const attachGutenberg = (
 	textarea: HTMLTextAreaElement,
 	setComment: ( newValue: string ) => void,
 	isRTL = false,
 	requestParamsGenerator: ( embedURL: string ) => EmbedRequestParams,
-	isDarkMode = false
+	isDarkMode = false,
+	focusOnMount = true
 ) => {
 	const editor = document.createElement( 'div' );
 	editor.className = 'verbum-editor-wrapper';
@@ -36,6 +39,7 @@ export const attachGutenberg = (
 			isRTL={ isRTL }
 			onChange={ ( content ) => setComment( content ) }
 			isDarkMode={ isDarkMode }
+			focusOnMount={ focusOnMount }
 		/>
 	);
 };


### PR DESCRIPTION
Related: [READ-295](https://linear.app/a8c/issue/READ-295)

## Proposed Changes

- Revert https://github.com/Automattic/wp-calypso/pull/108600
- Pass `null` to the second argument of `selectBlock` which doesn't focus the block on selection.
- Even after the above fix the block is scrolled into view and the root cause of this is the usage of [useScrollIntoView](https://github.com/WordPress/gutenberg/blob/1d37246491971d83607566be2aed711b3fe3f0e9/packages/block-editor/src/components/block-list/use-block-props/index.js#L129) hook in the "block-editor" package which is most likely a bug (it shouldn't scrolled the block into view when `initialPosition` is `null`). For this a workaround is implemented in "waitForSelectedElementAndOverrideScroll" function.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- To make sure that Toolbar appears on QuickPost.
- To make sure there will be no focus or scrolling issue when QuickPost editor is used.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /reader.
- Scroll and select any post.
- Go back to list view.
- Verify that the scroll is not shifted to Quick Post editor.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
