### PR TITLE
Image Studio: Add frontend `wp-abilities` for self-hosted sites

### DIFF
--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -65,6 +65,8 @@ function getIndividualConfig( options = {} ) {
 					if ( request === '@wordpress/react-i18n' ) {
 						return null;
 					}
+					// TODO: Remove this override when @wordpress/abilities ships with
+					// WordPress core (expected in WP 7.0).
 					// Bundle @wordpress/abilities into image-studio so it works on
 					// self-hosted sites where the package isn't registered as a script.
 					if ( name === 'image-studio' && request === '@wordpress/abilities' ) {

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -61,8 +61,13 @@ function getIndividualConfig( options = {} ) {
 				requestToExternal( request ) {
 					// The extraction logic will only extract a package if requestToExternal
 					// explicitly returns undefined for the given request. Null
-					// shortcuts the logic such that react-i18n will be bundled.
+					// shortcuts the logic such that the package will be bundled.
 					if ( request === '@wordpress/react-i18n' ) {
+						return null;
+					}
+					// Bundle @wordpress/abilities into image-studio so it works on
+					// self-hosted sites where the package isn't registered as a script.
+					if ( name === 'image-studio' && request === '@wordpress/abilities' ) {
 						return null;
 					}
 				},


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

- Bundle @wordpress/abilities into the image-studio webpack entry point instead of externalizing it
- Only affects the image-studio build; agents-manager-gutenberg and agents-manager-wp-admin continue to
  externalize it as before

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The @wordpress/abilities JavaScript client is not yet shipped with WordPress core (expected in 7.0). WordPress 6.9 only includes the server-side PHP Abilities API. On self-hosted Jetpack sites running WP 6.9, the `wp-abilities` script handle doesn't exist, causing `image-studio.min.js` to silently fail to enqueue because WordPress can't resolve the dependency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install these PRs in you sandbox
```
bin/jetpack-downloader test jetpack forno-167/image-studio-jetpack-plugin
install-plugin.sh am forno-184/headless-agent-to-jetpack-plugin
```
* Deploy BigSky PR (prevent loading of Image Studio when Unified Chat is enabled)
* Enable Unified Chat, see pgatNH-1CI-p2
* Check Network Tab and verify `image-studio.min.js` is loading and search for `core/abilities`
<img width="985" height="487" alt="image" src="https://github.com/user-attachments/assets/9e6d8183-5eb9-4f0f-b44e-249e898a979f" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
