### PR TITLE
Fix duplicate cancellation survey in Dashboard billing

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -17,7 +17,7 @@ import {
 	purchaseQuery,
 	siteByIdQuery,
 	sitePurchasesQuery,
-	userPreferencesMutation,
+	userPreferenceMutation,
 	hasPurchaseBeenExtendedQuery,
 	siteLatestAtomicTransferQuery,
 	siteFeaturesQuery,
@@ -329,7 +329,9 @@ export default function CancelPurchase() {
 	const cancelAndRefundMutation = useMutation( cancelAndRefundPurchaseMutation() );
 	const removePurchaseMutator = useMutation( removePurchaseMutation() );
 	const extendWithFreeMonthMutation = useMutation( extendPurchaseWithFreeMonthMutation() );
-	const userPreferencesMutator = useMutation( userPreferencesMutation() );
+	const surveyCompletedMutator = useMutation(
+		userPreferenceMutation( getCancelPurchaseSurveyCompletedPreferenceKey( purchase.ID ) )
+	);
 	const {
 		mutate: applyCancellationOffer,
 		isPending: isApplyingOffer,
@@ -365,13 +367,8 @@ export default function CancelPurchase() {
 			} );
 		}
 	}, [ productSlug, recordTracksEvent ] );
-	const savePreference = ( key: string | number, value: unknown ) => () => {
-		const payload = {
-			[ 'calypso_preferences' ]: {
-				[ key ]: value,
-			},
-		};
-		userPreferencesMutator.mutate( payload );
+	const cancelPurchaseSurveyCompleted = () => {
+		surveyCompletedMutator.mutate( 'true' );
 	};
 	const flowType = getPurchaseCancellationFlowType( purchase );
 
@@ -470,9 +467,6 @@ export default function CancelPurchase() {
 		setState( ( state ) => ( { ...state, isShowingMarketplaceSubscriptionsDialog: true } ) );
 	};
 
-	const cancelPurchaseSurveyCompleted = ( purchaseId: number ) => () => {
-		savePreference( getCancelPurchaseSurveyCompletedPreferenceKey( purchaseId ), true )();
-	};
 	const atomicRevertOnClickCheckOne = ( isChecked: boolean ) =>
 		setState( ( state ) => ( { ...state, atomicRevertCheckOne: isChecked } ) );
 
@@ -1023,7 +1017,7 @@ export default function CancelPurchase() {
 		} );
 
 		if ( flowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW ) {
-			cancelPurchaseSurveyCompleted( purchase.ID )();
+			cancelPurchaseSurveyCompleted();
 		}
 
 		if ( onSurveyComplete ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1023,7 +1023,7 @@ export default function CancelPurchase() {
 		} );
 
 		if ( flowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW ) {
-			cancelPurchaseSurveyCompleted( purchase.ID );
+			cancelPurchaseSurveyCompleted( purchase.ID )();
 		}
 
 		if ( onSurveyComplete ) {


### PR DESCRIPTION
Resolves [CHE-343](https://linear.app/a8c/issue/CHE-343)

## Proposed Changes

* Fix missing `()` invocation on curried `cancelPurchaseSurveyCompleted()` so the preference save actually executes
* Fix double-wrapped `calypso_preferences` in `savePreference` payload — `updatePreferences()` in `@automattic/api-core` already wraps in `calypso_preferences`, so the preference was being saved under the wrong path
* Refactor to use typed `userPreferenceMutation()` (single-key) instead of untyped `userPreferencesMutation()` (bulk), matching the pattern used by all other Dashboard components
* Remove unnecessary `savePreference` helper and curried `cancelPurchaseSurveyCompleted` wrapper

## Why are these changes being made?

When a user cancels a plan subscription and then later removes it, they are shown the same cancellation survey twice. The survey should only be shown once.

**Two bugs were preventing the survey-completed preference from being saved:**

1. **Missing invocation (line 1026):** `cancelPurchaseSurveyCompleted` is a curried function `(purchaseId) => () => { ... }`, but the call site only called `cancelPurchaseSurveyCompleted(purchase.ID)` — creating the inner thunk without invoking it.

2. **Double-wrapped payload (line 369-373):** `savePreference` wrapped the key under `calypso_preferences`, but `updatePreferences()` in `@automattic/api-core` already wraps the payload in `calypso_preferences` before sending to the API. This caused the preference to be saved under `calypso_preferences.calypso_preferences.{key}` instead of `calypso_preferences.{key}`, so `userPreferenceQuery` never found it.

Both bugs have existed since the Dashboard cancel-purchase flow was first implemented — the preference was never actually saved.

| Scenario | Before | After |
|----------|--------|-------|
| Cancel plan → Complete survey → Remove plan | Survey shown twice (during cancel AND remove) | Survey shown once (only during cancel) |

## Testing Instructions

**Environment:**
- [ ] Local: `my.localhost:3000`
- [ ] `public-api.wordpress.com` sandboxed
- [ ] Test on: Simple sites with active plan subscriptions

**Common test routes:**
- Dashboard purchases: `my.localhost:3000/me/billing/purchases/{purchaseId}`

**Prerequisites:**
- A site with an active plan subscription (e.g., Personal, Premium, Business)
- The plan must be **non-refundable** (past the 14-day refund window) so the cancel flow goes through `CANCEL_AUTORENEW` instead of `CANCEL_WITH_REFUND`. A refundable plan gets fully cancelled in one step, skipping the two-step cancel → remove flow entirely.

<details>
<summary><strong>Sandbox hack to bypass refund window</strong></summary>

If you don't have a plan past the refund window, you can force `is_refundable` to return `false` on your sandbox:

**File:** `wp-content/admin-plugins/wpcom-billing/store-subscription.php` (~line 1865)

```php
public function is_refundable(): bool {
    return false; // HACK: force non-refundable for testing
    if ( [] === $this->get_receipts_to_refund() ) {
        return false;
    }
    return true;
}
```

Sync to sandbox:
```bash
rsync -zar wpcom/public_html/wp-content/admin-plugins/wpcom-billing/store-subscription.php \
    wp_sandbox:/home/wpcom/public_html/wp-content/admin-plugins/wpcom-billing/store-subscription.php
```

**Remember to revert this after testing.**
</details>

**Steps:**

**Test 1: Cancel then remove (main fix verification)**

1. Navigate to `my.localhost:3000/me/billing/purchases/{purchaseId}` for an active plan
2. Click "Cancel plan"
3. Complete the cancellation survey (or click "Skip") → Submit
4. Plan is now cancelled (auto-renew off, set to expire)
5. Back on the purchase page, click "Remove"

**Before this change:**
- Survey is shown again during the Remove step
- User must answer the same questions a second time

**After this change:**
- Only the "Remove plan" confirmation is shown (features list, checkbox, Remove/Keep buttons)
- No duplicate survey

**Test 2: Fresh purchase still shows survey**

1. Start with a plan that has no prior cancellation
2. Initiate cancellation
3. **Expected:** Full survey is shown as normal (no regression)

**Test 3: Skip button also saves preference**

1. Cancel a plan, hit "Skip" instead of answering the survey
2. Back on the purchase page, click "Remove"
3. **Expected:** No survey on the Remove step

### Test scenarios

| # | Scenario | Expected Result |
|---|----------|-----------------|
| 1 | Cancel plan → Complete survey → Remove plan | Survey shown once (during cancel), skipped during remove |
| 2 | Cancel plan → Skip survey → Remove plan | Survey shown once (during cancel), skipped during remove |
| 3 | Fresh plan cancellation (no prior cancel) | Survey shown normally |
| 4 | Different plan on same site | Each plan has separate preference (scoped by purchaseId) |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
