### PR TITLE
Prevent domain TLD from wrapping separately in checkout

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -1,6 +1,8 @@
 import {
 	isBiennially,
 	isDIFMProduct,
+	isDomainProduct,
+	isDomainTransfer,
 	isMonthlyProduct,
 	isTriennially,
 	isWpComPlan,
@@ -22,6 +24,7 @@ import {
 	filterCostOverridesForLineItem,
 	getLabel,
 	isOverrideCodeIntroductoryOffer,
+	LineItemDomainLabel,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { getQueryArg } from '@wordpress/url';
@@ -425,7 +428,13 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 		<SimplifiedSingleProductAndCostOverridesListWrapper>
 			<WPCheckoutCheckIcon />
 			<ProductTitleAreaForCostOverridesList>
-				<span className="cost-overrides-list-product__title">{ label }</span>
+				<span className="cost-overrides-list-product__title">
+					{ isDomainProduct( product ) || isDomainTransfer( product ) ? (
+						<LineItemDomainLabel label={ label } />
+					) : (
+						label
+					) }
+				</span>
 				<SimplifiedLineItemPrice
 					actualAmount={ actualAmountDisplay }
 					crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1,6 +1,8 @@
 import {
 	isAddOn,
+	isDomainProduct,
 	isDomainRegistration,
+	isDomainTransfer,
 	isPlan,
 	isMonthlyProduct,
 	isYearly,
@@ -182,6 +184,22 @@ const LineItemTitle = styled.div< {
 	gap: 0.5em;
 	font-size: inherit;
 `;
+
+function LineItemDomainLabel( { label }: { label: string } ) {
+	const dotIndex = label.indexOf( '.' );
+	if ( dotIndex === -1 ) {
+		return <>{ label }</>;
+	}
+	const domain = label.slice( 0, dotIndex );
+	const tld = label.slice( dotIndex );
+	return (
+		<span style={ { wordBreak: 'break-all' } }>
+			{ domain }
+			<span style={ { whiteSpace: 'nowrap' } }>{ tld }</span>
+		</span>
+	);
+}
+
 const LineItemSublabelTitle = styled.div`
 	flex: 1;
 `;
@@ -1545,7 +1563,11 @@ function CheckoutLineItem( {
 				</MobileGiftWrapper>
 			) }
 			<LineItemTitle isSummary={ isSummary }>
-				{ label }
+				{ isDomainProduct( product ) || isDomainTransfer( product ) ? (
+					<LineItemDomainLabel label={ label } />
+				) : (
+					label
+				) }
 				{ responseCart.is_gift_purchase && (
 					<DesktopGiftWrapper>
 						<GiftBadgeWithText />

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -185,7 +185,7 @@ const LineItemTitle = styled.div< {
 	font-size: inherit;
 `;
 
-function LineItemDomainLabel( { label }: { label: string } ) {
+export function LineItemDomainLabel( { label }: { label: string } ) {
 	const dotIndex = label.indexOf( '.' );
 	if ( dotIndex === -1 ) {
 		return <>{ label }</>;


### PR DESCRIPTION
Part of DOMENG-225

## Proposed Changes

* Add a `LineItemDomainLabel` component that splits domain names at the first dot and renders the TLD portion with `white-space: nowrap`.
* Apply the component to domain product and domain transfer line items in the checkout cart.

## Why are these changes being made?

When a long domain name wraps in the checkout cart, the TLD can end up on a new line by itself. This applies the same fix already used in domain search results.

## Testing Instructions

* Add a long domain name to the shopping cart and go to checkout.
* Resize the browser to a narrow width.
* Verify the TLD stays together with the domain name and does not wrap independently.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
