### PR TITLE
Fix cancel purchase flow type for expired/grace-period purchases

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -644,6 +644,11 @@ export function hasAmountAvailableToRefund( purchase: Purchase ) {
  * Returns the purchase cancellation flow.
  */
 export function getPurchaseCancellationFlowType( purchase: Purchase ): CancelFlowType {
+	// Expired or grace-period purchases use the removal flow, matching the "Remove" button on the details page.
+	if ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
+		return CANCEL_FLOW_TYPE.REMOVE;
+	}
+
 	const isPlanRefundable = purchase.is_refundable;
 	const isPlanAutoRenewing = purchase.is_auto_renew_enabled;
 


### PR DESCRIPTION
Resolves [CHE-341](https://linear.app/a8c/issue/CHE-341)

## Proposed Changes

* Add an early return in `getPurchaseCancellationFlowType()` for expired or grace-period purchases, returning `REMOVE` instead of falling through to `CANCEL_AUTORENEW`.

## Why are these changes being made?

When a purchase is past its expiry date but still in its grace period (active subscription with auto-renew on), the purchase details page correctly shows a "Remove" button via `is_removable`. However, clicking it navigates to the cancel purchase page where `getPurchaseCancellationFlowType()` returns `CANCEL_AUTORENEW` (because auto-renew is still enabled), causing the heading and survey to say "Cancel" instead of "Remove".

| Scenario | Before | After |
|----------|--------|-------|
| Grace-period purchase with auto-renew on | Shows "Cancel product" heading | Shows "Remove product" heading |
| Expired purchase | Shows "Cancel product" heading | Shows "Remove product" heading |
| Refundable purchase | Cancel with refund (unchanged) | Cancel with refund (unchanged) |
| Non-refundable, auto-renewing | Cancel auto-renew (unchanged) | Cancel auto-renew (unchanged) |

## Testing Instructions

**Environment:**
- [ ] Enable Store Sandbox mode
- [ ] `public-api.wordpress.com` sandboxed



<details>
<summary><strong>Sandbox hack to simulate an expired/grace-period purchase</strong></summary>

Apply this hack to wp-content/admin-plugins/wpcom-billing/store-subscription.php on your sandbox:



**Sandbox hack required** — expired/grace-period domains are rare in dev. Apply this hack to `wp-content/admin-plugins/wpcom-billing/store-subscription.php` on your sandbox:

In `to_billing_upgrade()`, after the `$purchase` object is built (~line 4772), add:
```php
// HACK: Force domains into expiration grace period for testing.
if ( $this->is_domain() ) {
    $purchase->expiry_date = '2025-01-01T00:00:00+00:00';
}
```

And after the `is_cancelable`/`is_removable` assignments (~line 4835), add:
```php
// HACK: Force domains into grace-period removal state for testing.
if ( $this->is_domain() ) {
    $purchase->is_cancelable = false;
    $purchase->is_removable = true;
}
```

</details>


**Steps:**
1. Find a site with a domain that has **auto-renew enabled**
2. Navigate to `https://my.wordpress.com/me/billing/purchases/` (Dashboard billing)
3. Click on the domain purchase
4. Verify the details page shows a "Remove" button (not "Cancel")
5. Click "Remove"
6. Verify the cancel purchase page heading says **"Remove domain"** (not "Cancel domain")
7. Verify the survey heading says "Remove" language

**Before this change:**
- Step 6 shows "Cancel domain" heading despite arriving via "Remove" button

**After this change:**
- Step 6 correctly shows "Remove domain" heading

### Test scenarios
| # | Scenario | Expected Result |
|---|----------|-----------------|
| 1 | Grace-period domain, auto-renew ON | Heading: "Remove domain" |
| 2 | Grace-period plan, auto-renew ON | Heading: "Remove plan" |
| 3 | Refundable purchase | Heading: "Cancel plan" (unchanged) |
| 4 | Non-refundable, auto-renew ON, not expired | Heading: "Cancel plan" (unchanged) |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
