### PR TITLE
CIAB: Use garden_site_count for default ciab sites view

### DIFF
--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -41,7 +41,7 @@ export default function CIABSites() {
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
 
 	const defaultView = getDefaultView( {
-		user,
+		siteCount: user.garden_site_count,
 		isAutomattician,
 		isRestoringAccount,
 	} );

--- a/client/dashboard/sites/dataviews/views.ts
+++ b/client/dashboard/sites/dataviews/views.ts
@@ -1,5 +1,4 @@
 import type { AnalyticsClient } from '../../app/analytics';
-import type { User } from '@automattic/api-core';
 import type { Operator, SortDirection, SupportedLayouts, View } from '@wordpress/dataviews';
 
 export const DEFAULT_LAYOUTS: SupportedLayouts = {
@@ -45,15 +44,15 @@ const DEFAULT_VIEW: Partial< View > = {
 };
 
 export function getDefaultView( {
-	user,
+	siteCount,
 	isAutomattician,
 	isRestoringAccount,
 }: {
-	user: User;
+	siteCount: number;
 	isAutomattician: boolean;
 	isRestoringAccount: boolean;
 } ): View {
-	const type = isRestoringAccount || user.site_count > DEFAULT_PER_PAGE ? 'table' : 'grid';
+	const type = isRestoringAccount || siteCount > DEFAULT_PER_PAGE ? 'table' : 'grid';
 
 	const defaultView = {
 		type,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -189,7 +189,7 @@ export default function Sites() {
 	const { data: isAutomattician } = useSuspenseQuery( isAutomatticianQuery() );
 
 	const defaultView = getDefaultView( {
-		user,
+		siteCount: user.site_count,
 		isAutomattician,
 		isRestoringAccount,
 	} );

--- a/packages/api-core/src/me/types.ts
+++ b/packages/api-core/src/me/types.ts
@@ -47,6 +47,7 @@ export interface User {
 	primary_blog_url: string;
 	profile_URL: string;
 	site_count: number;
+	garden_site_count: number;
 	social_login_connections: SocialLoginConnection[];
 	use_fallback_for_incomplete_languages: boolean;
 	user_ip_country_code: string;

--- a/packages/api-core/src/me/types.ts
+++ b/packages/api-core/src/me/types.ts
@@ -25,6 +25,7 @@ export interface User {
 	display_name: string;
 	email: string;
 	email_verified: boolean;
+	garden_site_count: number;
 	had_hosting_trial: boolean;
 	has_jetpack_partner_access?: boolean;
 	has_unseen_notes: boolean;
@@ -47,7 +48,6 @@ export interface User {
 	primary_blog_url: string;
 	profile_URL: string;
 	site_count: number;
-	garden_site_count: number;
 	social_login_connections: SocialLoginConnection[];
 	use_fallback_for_incomplete_languages: boolean;
 	user_ip_country_code: string;

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -39,6 +39,7 @@ const defaultContext: HelpCenterRequiredInformation = {
 		display_name: '',
 		email: '',
 		email_verified: false,
+		garden_site_count: 0,
 		had_hosting_trial: false,
 		has_unseen_notes: false,
 		i18n_empathy_mode: false,


### PR DESCRIPTION
## Proposed Changes

* Update `getDefaultView()` to accept a `siteCount` parameter instead of the full `user` object.
* CIAB sites view now passes `user.garden_site_count` to determine the default view (grid vs table).
* Regular sites view continues to use `user.site_count`.
* Add `garden_site_count` to the `User` type definition.

## Why are these changes being made?

The CIAB sites dashboard was using `user.site_count` (total sites across all platforms) to determine whether to show the grid or table view by default. This meant users with many non-garden sites would see a table view even with few or no garden stores. By using `garden_site_count`, the default view is now based on the actual number of garden sites, providing a better default experience.

## Testing Instructions

1. Navigate to the CIAB sites view at `my.woo.localhost:3000/sites`.
2. Verify the default view is **grid** when `garden_site_count` <= 12.
3. Navigate to the regular sites view at `calypso.localhost:3000/sites`.
4. Verify the default view behavior is unchanged (uses `site_count`).

### Before / After

| Before | After |
|--------|-------|
| ![Before - table view](https://github.com/user-attachments/assets/4ec6d299-a84e-479c-8b0c-fb4403f0923b) | ![After - grid view](https://github.com/user-attachments/assets/a3088ba0-f1b8-4b5a-ba02-f9cd25f45ccd) |
| ![Before - table view with store](https://github.com/user-attachments/assets/2070a889-ec1b-4263-8cde-d5274d2491b4) | ![After - grid view with store](https://github.com/user-attachments/assets/7a2eed0a-aaa4-41df-8254-0fd6f3576c4e) |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)