### PR TITLE
A4A: Improve signup URL error message and add contact mailto link

### DIFF
--- a/client/a8c-for-agencies/components/form/field/index.tsx
+++ b/client/a8c-for-agencies/components/form/field/index.tsx
@@ -13,7 +13,7 @@ type Props = {
 	showOptionalLabel?: boolean;
 	children: ReactNode;
 	isRequired?: boolean;
-	error?: string;
+	error?: string | ReactNode;
 };
 
 function FormField( {

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { createElement, ReactNode, useCallback, useState } from 'react';
 import { isSiteActive } from 'calypso/a8c-for-agencies/components/form/utils';
 import { preventWidows } from 'calypso/lib/formatting';
 import { AgencyDetailsPayload } from '../types';
@@ -13,7 +13,7 @@ type ValidationState = {
 	firstName?: string;
 	lastName?: string;
 	agencyName?: string;
-	agencyUrl?: string;
+	agencyUrl?: string | ReactNode;
 	line1?: string;
 	city?: string;
 	country?: string;
@@ -51,7 +51,14 @@ const useSignupFormValidation = () => {
 			) {
 				newValidationError.agencyUrl = preventWidows(
 					translate(
-						"Please enter a valid site URL for your business. If you're experiencing issues contact us at partnerships@automattic.com"
+						'No website was found at that URL, please check it and try again. If the issue persists, {{contactLink}}contact us{{/contactLink}}.',
+						{
+							components: {
+								contactLink: createElement( 'a', {
+									href: 'mailto:partnerships@automattic.com',
+								} ),
+							},
+						}
 					)
 				);
 			}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/hooks/use-contact-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/hooks/use-contact-form-validation.ts
@@ -1,6 +1,6 @@
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { createElement, ReactNode, useCallback, useState } from 'react';
 import { isSiteActive } from 'calypso/a8c-for-agencies/components/form/utils';
 import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
@@ -13,7 +13,7 @@ type ValidationState = {
 	firstName?: string;
 	lastName?: string;
 	agencyName?: string;
-	agencyUrl?: string;
+	agencyUrl?: string | ReactNode;
 	email?: string;
 };
 
@@ -65,7 +65,14 @@ const useContactFormValidation = ( { withEmail }: Props ) => {
 			) {
 				newValidationError.agencyUrl = preventWidows(
 					translate(
-						"Please enter a valid site URL for your business. If you're experiencing issues contact us at partnerships@automattic.com"
+						'No website was found at that URL, please check it and try again. If the issue persists, {{contactLink}}contact us{{/contactLink}}.',
+						{
+							components: {
+								contactLink: createElement( 'a', {
+									href: 'mailto:partnerships@automattic.com',
+								} ),
+							},
+						}
 					)
 				);
 			}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/A4A-1964/a4a-sign-up-form-url-error-verbiage-enhancements

## Proposed Changes

  - Updated the URL validation error message in the A4A signup form from "Please enter a valid site URL for your business. If you're experiencing issues contact us at partnerships@automattic.com" to "No website was found at that URL, please check
  it and try again. If the issue persists, contact us."
  - Made "contact us" a clickable mailto:partnerships@automattic.com link
  - Widened the FormField error prop type from string to string | ReactNode to support the link element

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When an agency enters a non-resolving URL in the signup form, the error message displays the email address as plain text. Per A4A-1964, the copy should be improved and "contact us" should be a clickable mailto link instead. 

## Testing Instructions

- Visit the Automattic for Agencies live link
- Go to /signup on A4A
- Fill in the required fields with valid data, but enter a non-existent URL (e.g., productmanagergrowth123.com) in the Business URL field
- Submit the form
- Verify the error message reads: "No website was found at that URL, please check it and try again. If the issue persists, contact us."
- Verify "contact us" is a clickable link that opens a mailto to partnerships@automattic.com

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
