### PR TITLE
Clarify domain terminology consistency on "Use a domain name I own" page

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -373,7 +373,7 @@ function UseMyDomain( props ) {
 	const headerText = useMemo( () => {
 		switch ( mode ) {
 			case inputMode.domainInput:
-				return __( 'Use a domain I own' );
+				return __( 'Use a domain name I own' );
 			case inputMode.transferDomain:
 				return createInterpolateElement(
 					sprintf(
@@ -392,7 +392,7 @@ function UseMyDomain( props ) {
 				return createInterpolateElement(
 					sprintf(
 						/* translators: %(domainName)s - the name of the domain the user will add to their site */
-						__( 'Use a domain I own: <span>%(domainName)s</span>' ),
+						__( 'Use a domain name I own: <span>%(domainName)s</span>' ),
 						{
 							domainName,
 						}

--- a/client/components/domains/use-my-domain/utilities/option-info.js
+++ b/client/components/domains/use-my-domain/utilities/option-info.js
@@ -12,7 +12,7 @@ const optionTitleText = {
 		return __( 'Transfer your domain name' );
 	},
 	get connect() {
-		return __( 'Connect your site address' );
+		return __( 'Connect your domain name' );
 	},
 };
 
@@ -43,7 +43,7 @@ const transferNotSupported = {
 		return optionTitleText.transfer;
 	},
 	get topText() {
-		return __( 'This domain cannot be transfered.' );
+		return __( 'This domain name cannot be transferred.' );
 	},
 	learnMoreLink: INCOMING_DOMAIN_TRANSFER,
 };
@@ -75,7 +75,7 @@ const connectNotSupported = {
 		return optionTitleText.connect;
 	},
 	get topText() {
-		return __( 'This domain cannot be connected.' );
+		return __( 'This domain name cannot be connected.' );
 	},
 	learnMoreLink: MAP_EXISTING_DOMAIN,
 };

--- a/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/use-a-domain-i-own-page.ts
@@ -3,7 +3,7 @@ import { Locator, Page } from 'playwright';
 const selectors = {
 	ownedDomainInput: '.use-my-domain__domain-input-fieldset input',
 	continueButton: 'button:text("Continue")',
-	connectDomainButton: 'button span:text("Connect your site address")',
+	connectDomainButton: 'button span:text("Connect your domain name")',
 	transferDomainButton: 'button span:text("Transfer your domain name")',
 };
 


### PR DESCRIPTION
Part of DOMENG-301

## Proposed Changes

* Replace "Connect your site address" with "Connect your domain name" to be consistent with the transfer option ("Transfer your domain name")
* Replace "Use a domain I own" with "Use a domain name I own" to consistently use "domain name" instead of bare "domain"
* Replace "This domain cannot be transfered/connected" with "This domain name cannot be transferred/connected" (also fixing the "transfered" typo to "transferred")
* Update E2E test selectors to match the new copy

## Why are these changes being made?

The "Use a domain name I own" page inconsistently mixes "domain name," "site address," and "domain" terminology, which may confuse users. Per our vocabulary guidelines, "domain" should always appear as "domain name", and terminology should be consistent throughout the page.

## Testing Instructions

* Navigate to the "Use a domain name I own" page (during onboarding or via domain management)
* Verify the page header says "Use a domain name I own"
* Enter a valid domain and verify:
  * The transfer option says "Transfer your domain name"
  * The connect option says "Connect your domain name" (previously "Connect your site address")
  * If domain cannot be transferred, the message says "This domain name cannot be transferred."
  * If domain cannot be connected, the message says "This domain name cannot be connected."

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
