### PR TITLE
Checkout: Use only TopBar for CIAB flows

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -50,7 +50,8 @@ import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
-import { masterbarIsVisible } from 'calypso/state/ui/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, masterbarIsVisible } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import { refreshColorScheme, getColorSchemeFromCurrentQuery } from './color-scheme';
 import HelpCenterLoader from './help-center-loader';
@@ -87,6 +88,7 @@ const LayoutLoggedOut = ( {
 	userAllowedToHelpCenter,
 	colorScheme,
 	isJetpackCloud,
+	isCIABSite,
 } ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const currentRoute = useSelector( getCurrentRoute );
@@ -260,6 +262,7 @@ const LayoutLoggedOut = ( {
 				isCheckoutPending={ isCheckoutPending }
 				isCheckoutFailed={ isCheckoutFailed }
 				redirectUri={ redirectUri }
+				isCIABSite={ isCIABSite }
 			/>
 		);
 	}
@@ -402,6 +405,10 @@ export default withCurrentRoute(
 			 */
 			const colorScheme = isWooJPC ? getColorSchemeFromCurrentQuery( currentQuery ) : null;
 
+			const siteId = getSelectedSiteId( state );
+			const site = getSite( state, siteId );
+			const isCIABSite = site?.is_garden && site.garden_name === 'commerce';
+
 			return {
 				isAkismet,
 				isPassport,
@@ -425,6 +432,7 @@ export default withCurrentRoute(
 				twoFactorEnabled,
 				colorScheme,
 				isJetpackCloud: isJetpackCloudOAuth2Client( oauth2Client ),
+				isCIABSite,
 			};
 		},
 		{ clearLastActionRequiresLogin }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -60,6 +60,7 @@ import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getMostRecentlySelectedSiteId, getSectionGroup } from 'calypso/state/ui/selectors';
+import EmptyMasterbar from './empty';
 import Item from './item';
 import Masterbar from './masterbar';
 import Notifications from './masterbar-notifications/notifications-button';
@@ -81,6 +82,7 @@ class MasterbarLoggedIn extends Component {
 		isGravatarDomain: PropTypes.bool,
 		dashboardOptIn: PropTypes.bool,
 		useUnifiedAgent: PropTypes.bool,
+		isCIABSite: PropTypes.bool,
 	};
 
 	handleLayoutFocus = ( currentSection ) => {
@@ -812,7 +814,13 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	render() {
-		const { isCheckout, isCheckoutPending, isCheckoutFailed, loadHelpCenterIcon } = this.props;
+		const { isCheckout, isCheckoutPending, isCheckoutFailed, loadHelpCenterIcon, isCIABSite } =
+			this.props;
+
+		// Hide the masterbar entirely during checkout CIAB flows; they will use TopBar instead
+		if ( ( isCheckout || isCheckoutPending ) && isCIABSite ) {
+			return <EmptyMasterbar />;
+		}
 
 		// Checkout flow uses it's own version of the masterbar
 		if ( isCheckout || isCheckoutPending || isCheckoutFailed ) {
@@ -898,6 +906,7 @@ export default connect(
 			isGravatarDomain: hasGravatarDomainQueryParam( state ),
 			dashboardOptIn: hasDashboardOptIn( state ),
 			useUnifiedAgent: getPreference( state, 'unified_ai_chat' ) ?? false,
+			isCIABSite: site?.is_garden && site.garden_name === 'commerce',
 		};
 	},
 	{

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -13,6 +13,7 @@ import { withCurrentRoute } from 'calypso/components/route';
 import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
+import EmptyMasterbar from './empty';
 import Item from './item';
 import Masterbar from './masterbar';
 
@@ -24,6 +25,7 @@ class MasterbarLoggedOut extends Component {
 		isCheckout: PropTypes.bool,
 		isCheckoutPending: PropTypes.bool,
 		isCheckoutFailed: PropTypes.bool,
+		isCIABSite: PropTypes.bool,
 
 		// Connected props
 		currentQuery: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
@@ -232,7 +234,13 @@ class MasterbarLoggedOut extends Component {
 	}
 
 	render() {
-		const { title, isCheckout, isCheckoutPending, isCheckoutFailed, sectionName } = this.props;
+		const { title, isCheckout, isCheckoutPending, isCheckoutFailed, sectionName, isCIABSite } =
+			this.props;
+
+		// Hide the masterbar entirely during checkout CIAB flows; they will use TopBar instead
+		if ( ( isCheckout || isCheckoutPending ) && isCIABSite ) {
+			return <EmptyMasterbar />;
+		}
 
 		if ( isCheckout || isCheckoutPending || isCheckoutFailed ) {
 			return (

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -530,7 +530,7 @@ export default function CheckoutMainContent( {
 			return (
 				<>
 					<PerformanceTrackerStop />
-					<Step.Loading />
+					<Step.Loading hideLogo={ isWooHostedCheckout } />
 				</>
 			);
 		}

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -512,6 +512,7 @@ export default function CheckoutMainContent( {
 
 	const isStepContainerV2 = useInitialIsInStepContainerV2FlowContext();
 	const isLargeViewport = useViewportMatch( 'large', '>=' );
+	const isUsingTopBar = isStepContainerV2 || isWooHostedCheckout;
 
 	const { helpCenterButtonCopy, helpCenterButtonLink, toggleHelpCenter } = useCheckoutHelpCenter();
 
@@ -526,7 +527,7 @@ export default function CheckoutMainContent( {
 	} = checkoutActions;
 
 	if ( transactionStatus === TransactionStatus.COMPLETE ) {
-		if ( isStepContainerV2 ) {
+		if ( isUsingTopBar ) {
 			return (
 				<>
 					<PerformanceTrackerStop />
@@ -605,7 +606,7 @@ export default function CheckoutMainContent( {
 						>
 							<CheckoutSummaryTitleContent className="checkout__summary-title">
 								<CheckoutSummaryTitle>
-									{ ! isStepContainerV2 && (
+									{ ! isUsingTopBar && (
 										<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
 									) }
 									{ translate( 'Purchase Details' ) }
@@ -645,7 +646,7 @@ export default function CheckoutMainContent( {
 		<RestorableProductsProvider>
 			<WPCheckoutMainContent className="checkout-main-content">
 				<CheckoutOrderBanner />
-				{ isStepContainerV2 ? (
+				{ isUsingTopBar ? (
 					<Step.Heading
 						text={ translate( 'Checkout' ) }
 						align="left"
@@ -855,7 +856,7 @@ export default function CheckoutMainContent( {
 		</RestorableProductsProvider>
 	);
 
-	if ( ! isStepContainerV2 ) {
+	if ( ! isUsingTopBar ) {
 		return (
 			<WPCheckoutWrapper className="checkout-wrapper" isLargeViewport={ isLargeViewport }>
 				{ checkoutSummary }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1634/wordpresscom-logo-displays-after-checkout

## Proposed Changes

In this PR the masterbar is updated to render nothing if checkout is for a CIAB garden site and it is replaced with the TopBar, which is a replacement developed for the signup stepper but never fully launched. This will cause the masterbar to be hidden while checkout is pending.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1512" height="527" alt="Screenshot 2026-02-12 at 9 59 52 AM" src="https://github.com/user-attachments/assets/781a3314-c35d-4496-9b3b-ea956c2158e8" /> | <img width="1503" height="548" alt="Screenshot 2026-02-12 at 10 05 47 AM" src="https://github.com/user-attachments/assets/a39470c6-d35c-47be-b8b9-6b06b9792c30" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The checkout masterbar is being rendered during the pending state for CIAB, which shows the WordPress.com logo and "Secure checkout" text briefly before redirecting. CIAB should not have its brand tied to WordPress.com so this is an issue.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Add a product to your cart and visit checkout for a CIAB site.
- Complete checkout.
- Make sure the top of the page never shows anything while the pending page is shown.
