### PR TITLE
HC: fix typography

### DIFF
--- a/packages/help-center/src/components/_mixins.scss
+++ b/packages/help-center/src/components/_mixins.scss
@@ -1,4 +1,3 @@
-@import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/variables";
 @import "variables";
 

--- a/packages/help-center/src/components/_variables.scss
+++ b/packages/help-center/src/components/_variables.scss
@@ -1,3 +1,15 @@
+@import "@automattic/typography/styles/variables";
+
+/**
+ * Typography overrides: em-based so sizes are independent of host page html font-size.
+ * Container sets font-size: 16px; same variable names as base typography.
+ */
+$font-body-extra-small: 0.75em;
+$font-body-small: 0.875em;
+$font-body: 1em;
+$font-title-small: 1.25em;
+$root-font-size: 1em;
+
 $head-foot-height: 56px;
 $help-center-z-index: 500000;
 $help-center-blue: #3858e9;

--- a/packages/help-center/src/components/back-button.scss
+++ b/packages/help-center/src/components/back-button.scss
@@ -1,4 +1,4 @@
-@import "@automattic/typography/styles/variables";
+@import "variables";
 
 .help-center .help-center__container {
 	.back-button__help-center {

--- a/packages/help-center/src/components/help-center-closure-notice.scss
+++ b/packages/help-center/src/components/help-center-closure-notice.scss
@@ -1,4 +1,4 @@
-@import "@automattic/typography/styles/variables";
+@import "variables";
 
 .help-center-closure-notice {
 	margin-bottom: 1em;

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -1,4 +1,4 @@
-@import "@automattic/typography/styles/variables";
+@import "variables";
 
 .help-center__container-content .help-center-contact-form__wrapper {
 	padding: 0 16px 80px;

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -1,5 +1,4 @@
 @import '@wordpress/base-styles/variables';
-@import "@automattic/typography/styles/variables";
 @import "variables";
 
 /**
@@ -119,7 +118,7 @@
 
 		div {
 			margin-bottom: 2px;
-			font-size: 0.875rem;
+			font-size: $font-body-small;
 		}
 
 		&:not( :disabled) {

--- a/packages/help-center/src/components/help-center-launchpad.scss
+++ b/packages/help-center/src/components/help-center-launchpad.scss
@@ -1,3 +1,5 @@
+@import "variables";
+
 .help-center .inline-help__launchpad-container {
 
 	display: block;
@@ -20,7 +22,7 @@
 		padding: 16px;
 
 		.inline-help-launchpad-link-text {
-			font-size: 0.875rem;
+			font-size: $font-body-small;
 		}
 	}
 }

--- a/packages/help-center/src/components/help-center-notice.scss
+++ b/packages/help-center/src/components/help-center-notice.scss
@@ -1,4 +1,4 @@
-@import "@automattic/typography/styles/variables";
+@import "variables";
 
 .help-center {
 	.help-center-notice__container {

--- a/packages/help-center/src/components/help-center-search-results.scss
+++ b/packages/help-center/src/components/help-center-search-results.scss
@@ -1,6 +1,5 @@
-@import "@automattic/typography/styles/variables";
-@import "mixins";
 @import "variables";
+@import "mixins";
 
 // Search results section
 .help-center-search-results {
@@ -13,7 +12,7 @@
 		padding-left: 19px;
 		text-transform: uppercase;
 		font-weight: 500;
-		font-size: 0.75rem;
+		font-size: $font-body-extra-small;
 	}
 
 	.help-center-search-results__title {

--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -3,7 +3,7 @@
 .help-center-support-chat__conversation-sub-information {
 	color: var( --studio-gray-50, #646970 );
 	display: flex;
-	font-size: 0.75rem;
+	font-size: $font-body-extra-small;
 	align-items: center;
 	gap: 4px;
 
@@ -86,7 +86,7 @@
 			box-sizing: border-box;
 			min-width: 26px;
 			height: 20px;
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			background-color: $help-center-blue;
 			color: #fff;
 		}
@@ -102,7 +102,7 @@
 			display: -webkit-box;
 			color: #000;
 			font-weight: 500;
-			font-size: 0.875rem;
+			font-size: $font-body-small;
 			line-height: 20px;
 			letter-spacing: -0.15px;
 			text-overflow: ellipsis;

--- a/packages/help-center/src/components/help-center-third-party-cookies-notice.scss
+++ b/packages/help-center/src/components/help-center-third-party-cookies-notice.scss
@@ -1,4 +1,4 @@
-@import "@automattic/typography/styles/variables";
+@import "variables";
 
 .help-center-third-party-cookies-notice {
 	h1 {

--- a/packages/help-center/src/components/notices.scss
+++ b/packages/help-center/src/components/notices.scss
@@ -32,6 +32,6 @@
 	}
 
 	button.help-center__notice-link {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }

--- a/packages/help-center/src/components/ticket-success-screen.scss
+++ b/packages/help-center/src/components/ticket-success-screen.scss
@@ -1,4 +1,4 @@
-@import "@automattic/typography/styles/variables";
+@import "variables";
 
 .help-center {
 	.ticket-success-screen__help-center {

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -1,5 +1,4 @@
 @import '@wordpress/base-styles/variables';
-@import '@automattic/typography/styles/variables';
 @import 'components/variables';
 
 /**
@@ -19,9 +18,10 @@
 	position: fixed;
 
 	/**
-	 * Generic Stylings
+	 * Typographic root: 16px so the help center has consistent sizing
+	 * regardless of host page html font-size. Use em for child font-sizes.
 	 */
-	font-size: $font-body-small;
+	font-size: 16px;
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
 		'Helvetica Neue', sans-serif;
 	font-weight: inherit;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #WOOPRD-2097

| Before  | After |
| ------------- | ------------- |
| <img width="963" height="938" alt="Screenshot 2026-02-13 at 18 16 07" src="https://github.com/user-attachments/assets/c7a2ba12-56e6-4786-b1b4-b9f650ed5ae4" />  | <img width="963" height="915" alt="Screenshot 2026-02-13 at 18 15 40" src="https://github.com/user-attachments/assets/7f1a74e6-38d3-4372-9f01-6b8a344fb811" /> |

## Proposed Changes

* Fixup typography

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To unify the typography.
* If consumer of the hc package has a font-size defined for `html` could result in differences in typography

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Run `yarn dev --sync`
* Run `yarn start`
* Compare this branch with trunk for font-size differences
* Test on wp-admin, calypso and garden site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
