### PR TITLE
Fix the playground mounts

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -178,6 +178,13 @@ async function getBlueprintFromUrl( recommendedPhpVersion: string ): Promise< Bl
 		} as BlueprintV1Declaration;
 	}
 
+	// If no blueprint URL or ID is provided, use default
+	const blueprintId = getBlueprintID( url.searchParams );
+	const blueprintUrl = url.searchParams.get( 'blueprint-url' );
+	if ( ! blueprintId && ! blueprintUrl ) {
+		return getDefaultBlueprint( recommendedPhpVersion );
+	}
+
 	const resolvedBlueprint = await resolveBlueprintFromURL( url );
 
 	// ZIP bundles pass through unchanged


### PR DESCRIPTION
This PR fixes https://linear.app/a8c/issue/ARC-1484/playground-without-blueprint-doesnt-work-sqlite-error-again

Because we were replacing the url in browser state, that caused the React to re-render and not running the following code with expected conditions. This resulted into:
- this was preventing playground from loading without a blueprint provided in url
- this was also intermittently causing SQLite error since it would figure it has WP already installed when it wasn't and try confirming the database connection when there is no database

## Proposed Changes

* 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
