### PR TITLE
A4A > Referrals: add referral logo picker and shared logo validation

### DIFF
--- a/client/a8c-for-agencies/components/logo-file-upload/index.tsx
+++ b/client/a8c-for-agencies/components/logo-file-upload/index.tsx
@@ -1,0 +1,151 @@
+import {
+	Button,
+	FormFileUpload,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { Icon, upload } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import {
+	A4A_LOGO_MAX_FILE_SIZE_BYTES,
+	A4A_LOGO_REQUIRED_HEIGHT,
+	A4A_LOGO_REQUIRED_WIDTH,
+	getAcceptMimeTypes,
+	REFERRAL_CHECKOUT_LOGO_ALLOWED_MIME_TYPES,
+	type LogoFileValidationError,
+	validateLogoDimensions,
+	validateLogoFile,
+} from 'calypso/a8c-for-agencies/lib/logo-file-validation';
+
+import './style.scss';
+
+export interface LogoFileUploadProps {
+	/** Current preview URL (e.g. object URL of selected file). */
+	displayUrl?: string | null;
+	/** Called when user selects a valid file. */
+	onFileSelect: ( file: File ) => void;
+}
+
+/**
+ * Reusable logo file upload using FormFileUpload.
+ * Validates format (JPG, PNG), dimensions (800x320), and size (max 5 MB) on the client.
+ */
+export function LogoFileUpload( { displayUrl, onFileSelect }: LogoFileUploadProps ) {
+	const translate = useTranslate();
+	const [ error, setError ] = useState< LogoFileValidationError | 'dimensions' | null >( null );
+	const maxLogoSizeMb = Math.floor( A4A_LOGO_MAX_FILE_SIZE_BYTES / ( 1024 * 1024 ) );
+
+	const handleFileSelect = useCallback(
+		async ( event: React.ChangeEvent< HTMLInputElement > ) => {
+			const file = event.target.files?.[ 0 ];
+			event.target.value = '';
+			setError( null );
+			if ( ! file ) {
+				return;
+			}
+			const validationError = validateLogoFile( file, {
+				allowedMimeTypes: REFERRAL_CHECKOUT_LOGO_ALLOWED_MIME_TYPES,
+				maxFileSizeBytes: A4A_LOGO_MAX_FILE_SIZE_BYTES,
+			} );
+			if ( validationError ) {
+				setError( validationError );
+				return;
+			}
+
+			const isValidDimensions = await validateLogoDimensions( file, {
+				requiredWidth: A4A_LOGO_REQUIRED_WIDTH,
+				requiredHeight: A4A_LOGO_REQUIRED_HEIGHT,
+			} );
+
+			if ( ! isValidDimensions ) {
+				setError( 'dimensions' );
+				return;
+			}
+
+			onFileSelect( file );
+		},
+		[ onFileSelect ]
+	);
+
+	let errorMessage: React.ReactNode | null = null;
+
+	if ( error === 'format' ) {
+		errorMessage = translate( 'Unsupported format. Please use JPG or PNG.' );
+	}
+
+	if ( error === 'size' ) {
+		errorMessage = translate( 'File is too large. Please upload a logo under %(maxSize)d MB.', {
+			args: { maxSize: maxLogoSizeMb },
+		} );
+	}
+
+	if ( error === 'dimensions' ) {
+		errorMessage = translate( 'Company logo must have %(width)dpx width and %(height)dpx height.', {
+			args: {
+				width: A4A_LOGO_REQUIRED_WIDTH,
+				height: A4A_LOGO_REQUIRED_HEIGHT,
+			},
+		} );
+	}
+
+	const uploadHelpText = translate(
+		'Upload your logo sized at %(width)dpx by %(height)dpx. JPG or PNG. Max %(maxSize)d MB.',
+		{
+			args: {
+				width: A4A_LOGO_REQUIRED_WIDTH,
+				height: A4A_LOGO_REQUIRED_HEIGHT,
+				maxSize: maxLogoSizeMb,
+			},
+		}
+	);
+
+	return (
+		<FormFileUpload
+			accept={ getAcceptMimeTypes( REFERRAL_CHECKOUT_LOGO_ALLOWED_MIME_TYPES ) }
+			onChange={ handleFileSelect }
+			render={ ( { openFileDialog } ) => (
+				<VStack className="logo-file-upload" spacing={ 0 }>
+					<HStack spacing={ 5 } alignment="top">
+						<Button
+							variant="tertiary"
+							className="logo-file-upload-placeholder"
+							onClick={ openFileDialog }
+							aria-label={ displayUrl ? translate( 'Replace logo' ) : translate( 'Select logo' ) }
+						>
+							{ displayUrl ? (
+								<img src={ displayUrl } alt="" className="logo-file-upload-preview" />
+							) : (
+								<Icon icon={ upload } className="logo-file-upload-icon" />
+							) }
+						</Button>
+						<VStack spacing={ 5 } style={ { flex: 1, minWidth: 0 } }>
+							<VStack spacing={ 2 }>
+								<Button
+									variant="secondary"
+									onClick={ openFileDialog }
+									style={ { width: 'fit-content' } }
+								>
+									{ displayUrl ? translate( 'Replace file' ) : translate( 'Select file' ) }
+								</Button>
+								{ errorMessage && (
+									<Text as="p" className="logo-file-upload-error" role="alert" size={ 12 }>
+										{ errorMessage }
+									</Text>
+								) }
+							</VStack>
+							<VStack spacing={ 0 }>
+								<Text as="p" variant="muted" size={ 12 }>
+									{ uploadHelpText }
+								</Text>
+							</VStack>
+						</VStack>
+					</HStack>
+				</VStack>
+			) }
+		/>
+	);
+}
+
+export default LogoFileUpload;

--- a/client/a8c-for-agencies/components/logo-file-upload/index.tsx
+++ b/client/a8c-for-agencies/components/logo-file-upload/index.tsx
@@ -32,7 +32,7 @@ export interface LogoFileUploadProps {
  * Reusable logo file upload using FormFileUpload.
  * Validates format (JPG, PNG), dimensions (800x320), and size (max 5 MB) on the client.
  */
-export function LogoFileUpload( { displayUrl, onFileSelect }: LogoFileUploadProps ) {
+function LogoFileUpload( { displayUrl, onFileSelect }: LogoFileUploadProps ) {
 	const translate = useTranslate();
 	const [ error, setError ] = useState< LogoFileValidationError | 'dimensions' | null >( null );
 	const maxLogoSizeMb = Math.floor( A4A_LOGO_MAX_FILE_SIZE_BYTES / ( 1024 * 1024 ) );
@@ -115,7 +115,11 @@ export function LogoFileUpload( { displayUrl, onFileSelect }: LogoFileUploadProp
 							aria-label={ displayUrl ? translate( 'Replace logo' ) : translate( 'Select logo' ) }
 						>
 							{ displayUrl ? (
-								<img src={ displayUrl } alt="" className="logo-file-upload-preview" />
+								<img
+									src={ displayUrl }
+									alt={ translate( 'Logo preview' ) }
+									className="logo-file-upload-preview"
+								/>
 							) : (
 								<Icon icon={ upload } className="logo-file-upload-icon" />
 							) }

--- a/client/a8c-for-agencies/components/logo-file-upload/style.scss
+++ b/client/a8c-for-agencies/components/logo-file-upload/style.scss
@@ -1,0 +1,47 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.logo-file-upload {
+	width: 100%;
+}
+
+.logo-file-upload-placeholder {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 134px;
+	height: 134px;
+	min-width: 134px;
+	min-height: 134px;
+	padding: 0;
+	border: 1px dashed var( --color-neutral-20 );
+	border-radius: 4px;
+	background: var( --color-neutral-0 );
+	cursor: pointer;
+	box-shadow: none;
+	transition: border-color 0.15s ease, background-color 0.15s ease;
+
+	&:hover {
+		border-color: var( --color-neutral-40 );
+		background: var( --color-neutral-5 );
+	}
+
+	&:focus-visible {
+		outline: 2px solid var( --color-primary );
+		outline-offset: 2px;
+	}
+}
+
+.logo-file-upload-preview {
+	max-width: 132px;
+	max-height: 132px;
+	object-fit: contain;
+}
+
+.logo-file-upload-icon {
+	color: var( --color-neutral-40 );
+}
+
+p.logo-file-upload-error {
+	color: var( --color-error );
+}

--- a/client/a8c-for-agencies/lib/logo-file-validation.ts
+++ b/client/a8c-for-agencies/lib/logo-file-validation.ts
@@ -1,0 +1,69 @@
+export const A4A_LOGO_MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+export const A4A_LOGO_REQUIRED_WIDTH = 800;
+export const A4A_LOGO_REQUIRED_HEIGHT = 320;
+export const A4A_LOGO_DIMENSIONS_TOLERANCE = 5;
+
+export const REFERRAL_CHECKOUT_LOGO_ALLOWED_MIME_TYPES = [ 'image/png', 'image/jpeg' ];
+
+export type LogoFileValidationError = 'format' | 'size';
+
+type ValidateLogoFileOptions = {
+	allowedMimeTypes: string[];
+	maxFileSizeBytes?: number;
+};
+
+export const getAcceptMimeTypes = ( mimeTypes: string[] ) => mimeTypes.join( ',' );
+
+export const validateLogoFile = (
+	file: File,
+	{ allowedMimeTypes, maxFileSizeBytes = A4A_LOGO_MAX_FILE_SIZE_BYTES }: ValidateLogoFileOptions
+): LogoFileValidationError | null => {
+	if ( ! allowedMimeTypes.includes( file.type ) ) {
+		return 'format';
+	}
+
+	if ( file.size > maxFileSizeBytes ) {
+		return 'size';
+	}
+
+	return null;
+};
+
+type ValidateLogoDimensionsOptions = {
+	requiredWidth: number;
+	requiredHeight: number;
+	tolerance?: number;
+};
+
+const getImageDimensions = ( file: File ): Promise< { width: number; height: number } > =>
+	new Promise( ( resolve, reject ) => {
+		const imageUrl = URL.createObjectURL( file );
+		const image = new Image();
+
+		image.onload = () => {
+			resolve( { width: image.width, height: image.height } );
+			URL.revokeObjectURL( imageUrl );
+		};
+
+		image.onerror = () => {
+			reject( new Error( 'Unable to read image dimensions.' ) );
+			URL.revokeObjectURL( imageUrl );
+		};
+
+		image.src = imageUrl;
+	} );
+
+export const validateLogoDimensions = async (
+	file: File,
+	{
+		requiredWidth,
+		requiredHeight,
+		tolerance = A4A_LOGO_DIMENSIONS_TOLERANCE,
+	}: ValidateLogoDimensionsOptions
+): Promise< boolean > => {
+	const { width, height } = await getImageDimensions( file );
+	return (
+		Math.abs( width - requiredWidth ) <= tolerance &&
+		Math.abs( height - requiredHeight ) <= tolerance
+	);
+};

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo.tsx
@@ -1,0 +1,88 @@
+import { FormLabel } from '@automattic/components';
+import {
+	RadioControl,
+	__experimentalSpacer as Spacer,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import LogoFileUpload from 'calypso/a8c-for-agencies/components/logo-file-upload';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export default function ReferralLogo() {
+	const translate = useTranslate();
+	const agency = useSelector( getActiveAgency );
+	const profileLogoUrl = agency?.profile?.company_details?.logo_url || null;
+	const hasProfileLogo = !! profileLogoUrl;
+
+	const [ logoOption, setLogoOption ] = useState< 'profile' | 'different' >(
+		hasProfileLogo ? 'profile' : 'different'
+	);
+	const [ selectedLogoFile, setSelectedLogoFile ] = useState< File | null >( null );
+	const [ logoPreviewUrl, setLogoPreviewUrl ] = useState< string | null >( null );
+
+	useEffect( () => {
+		if ( selectedLogoFile ) {
+			const url = URL.createObjectURL( selectedLogoFile );
+			setLogoPreviewUrl( url );
+			return () => URL.revokeObjectURL( url );
+		}
+		setLogoPreviewUrl( null );
+	}, [ selectedLogoFile ] );
+
+	useEffect( () => {
+		if ( ! hasProfileLogo ) {
+			setLogoOption( 'different' );
+		}
+	}, [ hasProfileLogo ] );
+
+	return (
+		<VStack spacing={ 2 } className="checkout__logo-section">
+			<FormLabel style={ { marginBottom: 0 } } htmlFor="logo">
+				{ translate( 'Your logo' ) }
+			</FormLabel>
+			<Text as="p" variant="muted">
+				{ translate( 'Builds trust and shows this referral comes from you.' ) }
+			</Text>
+			<VStack spacing={ 3 }>
+				{ hasProfileLogo && (
+					<VStack spacing={ 0 }>
+						<RadioControl
+							selected={ logoOption }
+							options={ [ { label: translate( 'Use profile logo' ), value: 'profile' } ] }
+							onChange={ () => setLogoOption( 'profile' ) }
+						/>
+						{ logoOption === 'profile' && (
+							<>
+								<Spacer marginTop={ 3 } />
+								<div className="checkout__profile-logo-preview">
+									<img src={ profileLogoUrl } alt={ translate( 'Profile logo preview' ) } />
+								</div>
+							</>
+						) }
+					</VStack>
+				) }
+				<VStack spacing={ 0 }>
+					<RadioControl
+						selected={ logoOption }
+						options={ [
+							{
+								label: translate( 'Use a different logo for this referral' ),
+								value: 'different',
+							},
+						] }
+						onChange={ () => setLogoOption( 'different' ) }
+					/>
+					{ logoOption === 'different' && (
+						<>
+							<Spacer marginBottom={ 3 } />
+							<LogoFileUpload displayUrl={ logoPreviewUrl } onFileSelect={ setSelectedLogoFile } />
+						</>
+					) }
+				</VStack>
+			</VStack>
+		</VStack>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button, FormLabel, Tooltip } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -37,6 +38,7 @@ import useShoppingCart from '../hooks/use-shopping-cart';
 import { isPressableAddonProduct } from '../lib/hosting';
 import hasActiveReferralPressablePlanForClient from './lib/has-active-referral-pressable-plan';
 import NoticeSummary from './notice-summary';
+import ReferralLogo from './referral-logo';
 import type { ShoppingCartItem, TermPricingType } from '../types';
 interface Props {
 	checkoutItems: ShoppingCartItem[];
@@ -59,6 +61,8 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const [ email, setEmail ] = useState( '' );
 	const [ message, setMessage ] = useState( '' );
 	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
+
+	const isCobrandedCheckoutEnabled = isEnabled( 'a4a-referral-cobranded-checkout' );
 
 	const ctaButtonRef = useRef< HTMLButtonElement >( null );
 
@@ -271,6 +275,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						}
 					/>
 				</FormFieldset>
+				{ isCobrandedCheckoutEnabled && <ReferralLogo /> }
 			</div>
 
 			<NoticeSummary type="request-client-payment" />

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
@@ -407,3 +407,27 @@
 		justify-content: center;
 	}
 }
+
+.checkout__logo-section {
+	.checkout__profile-logo-preview {
+		width: 134px;
+		height: 134px;
+		border: 1px solid var( --color-neutral-20 );
+		border-radius: 4px;
+		background: var( --color-neutral-0 );
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+	}
+
+	.checkout__profile-logo-preview img {
+		max-width: 132px;
+		max-height: 132px;
+		object-fit: contain;
+	}
+
+	.components-radio-control__input[type='radio']:checked {
+		background-color: var( --color-primary-50 );
+	}
+}

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/logo-picker.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/logo-picker.tsx
@@ -1,32 +1,15 @@
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import A4AImagePicker from 'calypso/a8c-for-agencies/components/a4a-image-picker';
-
-const LOGO_SIZE_WIDTH = 800;
-const LOGO_SIZE_HEIGHT = 320;
-const LOGO_SIZE_TOLERANCE = 5;
+import {
+	A4A_LOGO_REQUIRED_HEIGHT,
+	A4A_LOGO_REQUIRED_WIDTH,
+	validateLogoDimensions,
+} from 'calypso/a8c-for-agencies/lib/logo-file-validation';
 
 type Props = {
 	logo?: string | null;
 	onPick?: ( url: string ) => void;
-};
-
-const getImage = ( file: File ): Promise< HTMLImageElement > => {
-	return new Promise( ( resolve ) => {
-		const reader = new FileReader();
-
-		reader.onload = function () {
-			const img = new Image();
-
-			img.onload = function () {
-				resolve( img );
-			};
-
-			img.src = ( reader.result as string ) ?? '';
-		};
-
-		reader.readAsDataURL( file );
-	} );
 };
 
 const LogoPicker = ( { logo, onPick }: Props ) => {
@@ -34,21 +17,20 @@ const LogoPicker = ( { logo, onPick }: Props ) => {
 
 	const [ error, setError ] = useState< string | null >( null );
 
-	const onImagePick = ( file: File ) => {
+	const onImagePick = async ( file: File ) => {
 		setError( null );
 
-		getImage( file ).then( ( img ) => {
-			// Check against the allowed deviation in pixels from the required logo dimensions
-			const isWidthValid = Math.abs( img.width - LOGO_SIZE_WIDTH ) <= LOGO_SIZE_TOLERANCE;
-			const isHeightValid = Math.abs( img.height - LOGO_SIZE_HEIGHT ) <= LOGO_SIZE_TOLERANCE;
-
-			if ( ! isWidthValid || ! isHeightValid ) {
-				setError( translate( 'Company logo must have 800px width and 320px height.' ) );
-				return;
-			}
-
-			onPick?.( URL.createObjectURL( file ) );
+		const isValidDimensions = await validateLogoDimensions( file, {
+			requiredWidth: A4A_LOGO_REQUIRED_WIDTH,
+			requiredHeight: A4A_LOGO_REQUIRED_HEIGHT,
 		} );
+
+		if ( ! isValidDimensions ) {
+			setError( translate( 'Company logo must have 800px width and 320px height.' ) );
+			return;
+		}
+
+		onPick?.( URL.createObjectURL( file ) );
 	};
 
 	return (

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -43,6 +43,7 @@
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
+		"a4a-referral-cobranded-checkout": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -36,6 +36,7 @@
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
+		"a4a-referral-cobranded-checkout": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -36,6 +36,7 @@
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
+		"a4a-referral-cobranded-checkout": false,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -38,6 +38,7 @@
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
+		"a4a-referral-cobranded-checkout": false,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": false,


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-2092/frontend-logo-picker-and-co-branded-checkout-ui
Resolves https://linear.app/a8c/issue/A4A-2121/initial-implementation-of-logo-upload-for-referrals

## Proposed Changes

- Add a new feature-flagged referral logo section in checkout (`a4a-referral-cobranded-checkout`) and enable it in A4A development + horizon.
- Extract logo UI/behavior into a dedicated `ReferralLogo` checkout component and a reusable `LogoFileUpload` component.
- Add shared logo validation helpers (`logo-file-validation.ts`) and use them across referral checkout and partner-directory (consistent format + dimension checks; partner-directory keeps no size limit as requested).
- Update referral flow behavior so:
  - profile logo option is shown only when `agency.profile.company_details.logo_url` exists,
  - profile preview renders under “Use profile logo” only when selected,
  - uploader renders under “Use a different logo…” only when selected.

## Why are these changes being made?

These changes implement the frontend for the co-branded referrals checkout experience:

- let agencies choose branding for each referral (Use profile logo vs Use a different logo for this referral),
show the profile logo preview when selected,
- allow logo upload for referral branding,

## Testing Instructions

Note: This is not a full implementation. 

* Open the A4A live link > Go to Partner Directory > Edit Profile > Please don't save the changes if you haven't uploaded any logo till now. Try uploading a logo that is not 800px*320px > Verify that the error is shown as before. We refactored the logic a bit here. The intention is to see if it still works fine. 
* Go to Marketplace > Toggle the referral mode > Select some products > Go to checkout > Verify the Logo section is displayed as shown below:

When there is no profile logo

<img width="502" height="257" alt="Screenshot 2026-02-16 at 11 34 21 AM" src="https://github.com/user-attachments/assets/fcdbc8cb-6353-4082-91f0-719683c3ea3b" />

When there is a profile logo

<img width="475" height="302" alt="Screenshot 2026-02-16 at 11 28 33 AM" src="https://github.com/user-attachments/assets/f86715b4-8367-4b49-8076-d9e5d14f4586" />

* If you don't have a profile logo uploaded,> Go to Partner Directory and upload the profile logo > Come back to Referral checkout and verify you can see it here.
* Verify you can choose both the option > Select "Use a different logo for this referral" >  Play around with different scenarios mentioned below and verify it works as expected.

When no logo is uploaded:

<img width="494" height="289" alt="Screenshot 2026-02-16 at 11 28 45 AM" src="https://github.com/user-attachments/assets/5e280f16-b0ea-4d78-bf4a-fa8ca87b3117" />

When a logo is uploaded:

<img width="508" height="289" alt="Screenshot 2026-02-16 at 11 28 55 AM" src="https://github.com/user-attachments/assets/07f82959-87d8-4a6e-9728-39399556c04d" />

Error scenarios:

<img width="481" height="298" alt="Screenshot 2026-02-16 at 11 29 12 AM" src="https://github.com/user-attachments/assets/b7b46aa9-e056-4100-876c-ca21ca5eb480" />

<img width="497" height="289" alt="Screenshot 2026-02-16 at 11 30 07 AM" src="https://github.com/user-attachments/assets/8360b53a-afae-4578-969a-2fee7230c69b" />

* Append the URL with ?flags=-a4a-referral-cobranded-checkout and verify you are able to send a referral. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
