### PR TITLE
Update calypso-client rules with complete lint/test commands

### DIFF
--- a/.claude/rules/calypso-client.md
+++ b/.claude/rules/calypso-client.md
@@ -21,7 +21,7 @@ You are an expert React + TypeScript programming assistant focused on producing 
 - Keep components small and focused.
 - Use `import clsx from 'clsx'` instead of `classnames`.
 - There should be 1 empty line between `import './style.scss'` and other imports.
-- Adhere strictly to line rules.
+- Adhere strictly to lint rules.
   - Lint JS/TS/TSX: `yarn eslint <file>`
   - Lint + fix JS/TS/TSX: `yarn eslint --fix <file>`
   - Lint CSS/SCSS: `yarn stylelint <file>`

--- a/.claude/rules/calypso-client.md
+++ b/.claude/rules/calypso-client.md
@@ -17,10 +17,15 @@ You are an expert React + TypeScript programming assistant focused on producing 
 ## Code Style
 
 - Use TypeScript strictly; no `any` unless justified.
+  - Type-check with `yarn typecheck-client` (note: this is slow)
 - Keep components small and focused.
 - Use `import clsx from 'clsx'` instead of `classnames`.
 - There should be 1 empty line between `import './style.scss'` and other imports.
-- Follow ESLint-compatible patterns. Run `yarn eslint --fix` on that specific file individually for large changes.
+- Adhere strictly to line rules.
+  - Lint JS/TS/TSX: `yarn eslint <file>`
+  - Lint + fix JS/TS/TSX: `yarn eslint --fix <file>`
+  - Lint CSS/SCSS: `yarn stylelint <file>`
+- Format any file with `yarn prettier --write <file>` or only with `yarn prettier --check <file>`.
 
 ## Naming
 
@@ -59,7 +64,9 @@ You are an expert React + TypeScript programming assistant focused on producing 
 
 ## Testing
 
-- To run tests for individual files, use the command `yarn test-client <filename>`.
 - Use React Testing Library.
 - Prefer `userEvent` over `fireEvent`.
 - Use `toBeVisible` for user-visible assertions instead of `toBeInTheDocument`.
+- Run tests to verify changes:
+  - Run specific test file: `yarn test-client <test-file>`
+  - Find + run tests for a source file: `yarn test-client --findRelatedTests <file>`


### PR DESCRIPTION
Part of pgz0xU-xz-p2#comment-655

## Proposed Changes

* Move all linting and testing commands into the calypso-client Claude rules file so they're discoverable in one place
* Add `typecheck-client`, `stylelint`, and `prettier` commands
* Restructure lint section with separate entries for JS/TS/TSX, CSS/SCSS, and formatting
* Add `--findRelatedTests` option for running tests related to a source file

## Why are these changes being made?

Originally I had created a command cheatsheet just for the `client/dashboard/` code, but I've realised that the same commands work across all of the Calypso code, so we can load it into every context window.

The calypso-client rules file was missing several commonly-used commands (typecheck, stylelint, prettier) and the testing section lacked the `--findRelatedTests` flag. This consolidates all verification commands in one place so Claude agents can find and use them reliably.

## Testing Instructions

* Verify the `.claude/rules/calypso-client.md` file reads correctly and all commands are valid
* Confirm no existing instructions were lost

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?