### PR TITLE
MCP: update tool categories

### DIFF
--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -33,6 +33,9 @@ interface McpAbility {
 	description: string;
 	enabled: boolean;
 	category?: string;
+	category_label?: string;
+	type?: string;
+	annotations?: Record< string, unknown >;
 }
 
 interface McpSite {
@@ -124,7 +127,7 @@ function McpComponent() {
 		const grouped: Record< string, Array< [ string, McpAbility ] > > = {};
 
 		tools.forEach( ( [ toolId, tool ] ) => {
-			const displayCategory = getDisplayCategory( toolId );
+			const displayCategory = getDisplayCategory( toolId, tool );
 			if ( ! grouped[ displayCategory ] ) {
 				grouped[ displayCategory ] = [];
 			}

--- a/packages/api-core/src/me-settings/types.ts
+++ b/packages/api-core/src/me-settings/types.ts
@@ -1,16 +1,38 @@
+export type McpAbilityAnnotations = {
+	readonly?: boolean;
+	destructive?: boolean;
+	openWorldHint?: boolean;
+	idempotent?: boolean;
+	placeholder_images?: boolean;
+	defaults?: Record< string, unknown >;
+	recommended_context?: Array< {
+		tool: string;
+		operation: string;
+		optional?: boolean;
+	} >;
+};
+
 export type McpAbility = {
 	name: string;
 	title: string;
 	description: string;
 	category: string;
+	category_label?: string;
 	type: string;
 	enabled: boolean;
+	annotations?: McpAbilityAnnotations;
+};
+
+export type McpSiteOverride = {
+	blog_id: number;
+	account_tools_enabled?: boolean;
+	abilities?: Record< string, unknown >;
 };
 
 export type McpAbilities = {
 	account?: Record< string, McpAbility >;
-	site?: Record< string, McpAbility >; // Default values for all sites
-	sites?: Record< string, Record< string, number > >; // Custom overrides per site (0/1 values only)
+	site?: Record< string, McpAbility >; // Site-scoped ability defaults
+	sites?: McpSiteOverride[]; // Array of site-specific overrides
 };
 
 export interface UserSettings {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/AIINT-244

Updates the Hosting Dashboard MCP settings page to support the new mcp_abilities payload. The page now groups abilities using the API category field instead of a large hardcoded map, and the types reflect the expanded structure.

## Proposed Changes

* `categories.ts` – Introduces `API_CATEGORY_TO_DISPLAY` (maps API categories to display labels) and a small `TOOL_DISPLAY_OVERRIDES` for tools that need different grouping. `getDisplayCategory` now uses API category first, with overrides, instead of a large hardcoded map.
* `index.tsx` – Extends McpAbility with `category_label`, `type`, and `annotations`. Passes tool into `getDisplayCategory(toolId, tool)` so API category is used.
* `me-settings/types.ts` – Adds `McpAbilityAnnotations` and `McpSiteOverride`, and updates `McpAbilities.sites` to `McpSiteOverride[]` to match the API.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 203746-ghe-Automattic/wpcom
* Go to calypso.localhost:3000/me/mcp confirm MCP tools are listed and behave as you expect
* Add your test account to allowlist-config.php and go to http://my.localhost:3000/me/mcp and confirm MCP tools are listed and behave as you expect

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?