### PR TITLE
Domain-Only Thank You Page: Redirect to domain management if purchasing more than one domain

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -24,11 +24,13 @@ import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import PlanThankYouCard from 'calypso/blocks/plan-thank-you-card';
+import QueryPreferences from 'calypso/components/data/query-preferences';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HappinessSupport from 'calypso/components/happiness-support';
 import Loading from 'calypso/components/loading';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { debug, TRACKING_IDS } from 'calypso/lib/analytics/ad-tracking/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { mayWeTrackByTracker } from 'calypso/lib/analytics/tracker-buckets';
@@ -36,6 +38,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isExternal } from 'calypso/lib/url';
 import {
 	domainManagementList,
+	domainManagementRoot,
 	domainManagementTransferInPrecheck,
 } from 'calypso/my-sites/domains/paths';
 import { GoogleWorkspaceSetUpThankYou } from 'calypso/my-sites/email/google-workspace-set-up-thank-you';
@@ -48,12 +51,14 @@ import {
 	getCurrentUserDate,
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import {
 	isRequesting as isRequestingSitePlugins,
 	getPlugins as getInstalledPlugins,
 } from 'calypso/state/plugins/installed/selectors';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { isProductsListFetching } from 'calypso/state/products-list/selectors';
 import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
@@ -86,6 +91,7 @@ import TransferPending from './transfer-pending';
 import './style.scss';
 import {
 	getDomainPurchase,
+	hasMultipleDomainPurchases,
 	isOnlyDomainTransfers,
 	isOnlyDomainPurchases,
 	isSearch,
@@ -137,6 +143,8 @@ export interface CheckoutThankYouConnectedProps {
 	site: SiteDetails | null | undefined;
 	siteDomains: ResponseDomain[] | null | undefined;
 	isGravatarDomain: boolean;
+	hasReceivedRemotePreferences: boolean;
+	hasDashboardOptIn: boolean;
 	fetchAtomicTransfer: ( siteId: number ) => void;
 	fetchSitePlugins: ( siteId: number ) => void;
 	fetchReceipt: ( receiptId: number ) => void;
@@ -376,6 +384,7 @@ export class CheckoutThankYou extends Component<
 		}
 
 		return (
+			this.props.hasReceivedRemotePreferences &&
 			( ! this.props.selectedSite || this.props.sitePlans.hasLoadedFromServer ) &&
 			this.props.receipt.hasLoadedFromServer &&
 			( ! this.props.gsuiteReceipt || this.props.gsuiteReceipt.hasLoadedFromServer ) &&
@@ -541,6 +550,7 @@ export class CheckoutThankYou extends Component<
 		if ( ! this.isDataLoaded() ) {
 			return (
 				<>
+					<QueryPreferences />
 					{ this.getMasterBar() }
 					<Loading />
 				</>
@@ -625,6 +635,16 @@ export class CheckoutThankYou extends Component<
 				);
 			} else if ( this.props.receipt.data && isOnlyDomainPurchases( purchases ) ) {
 				if ( shouldShowNewDomainThankYou() ) {
+					if ( hasMultipleDomainPurchases( purchases ) ) {
+						const domainsUrl = this.props.hasDashboardOptIn
+							? dashboardLink( '/domains' )
+							: domainManagementRoot();
+
+						window.location.replace( domainsUrl );
+
+						return null;
+					}
+
 					return (
 						<>
 							<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
@@ -803,6 +823,8 @@ export default connect(
 			site: siteId ? getSite( state, siteId ) : null,
 			siteDomains: siteId ? getDomainsBySiteId( state, siteId ) : null,
 			isGravatarDomain: hasGravatarDomainQueryParam( state ),
+			hasReceivedRemotePreferences: hasReceivedRemotePreferences( state ),
+			hasDashboardOptIn: hasDashboardOptIn( state ),
 		};
 	},
 	{

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -91,7 +91,7 @@ import TransferPending from './transfer-pending';
 import './style.scss';
 import {
 	getDomainPurchase,
-	hasMultipleDomainPurchases,
+	hasMultiplePurchases,
 	isOnlyDomainTransfers,
 	isOnlyDomainPurchases,
 	isSearch,
@@ -643,7 +643,7 @@ export class CheckoutThankYou extends Component<
 				);
 			} else if ( this.props.receipt.data && isOnlyDomainPurchases( purchases ) ) {
 				if ( shouldShowNewDomainThankYou() ) {
-					if ( hasMultipleDomainPurchases( purchases ) ) {
+					if ( hasMultiplePurchases( purchases ) ) {
 						const domainsUrl = this.props.hasDashboardOptIn
 							? dashboardLink( '/domains' )
 							: domainManagementRoot();

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -539,6 +539,15 @@ export class CheckoutThankYou extends Component<
 		}
 	};
 
+	renderLoading = () => {
+		return (
+			<>
+				{ this.getMasterBar() }
+				<Loading />
+			</>
+		);
+	};
+
 	render() {
 		const { translate, email, selectedFeature } = this.props;
 		const purchases = getPurchases( this.props ).filter( ( purchase ) => ! isCredits( purchase ) );
@@ -551,8 +560,7 @@ export class CheckoutThankYou extends Component<
 			return (
 				<>
 					<QueryPreferences />
-					{ this.getMasterBar() }
-					<Loading />
+					{ this.renderLoading() }
 				</>
 			);
 		}
@@ -642,7 +650,7 @@ export class CheckoutThankYou extends Component<
 
 						window.location.replace( domainsUrl );
 
-						return null;
+						return this.renderLoading();
 					}
 
 					return (

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -6,6 +6,7 @@ import { PLAN_PREMIUM, PLAN_PERSONAL } from '@automattic/calypso-products';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
 import CheckoutThankYouHeader from '../header';
 import { CheckoutThankYou } from '../index';
 
@@ -55,11 +56,16 @@ const defaultProps = {
 	fetchReceipt: () => {},
 	siteHomeUrl: '',
 	domainOnlySiteFlow: false,
+	hasReceivedRemotePreferences: true,
 };
 
 const initialState = {
 	purchases: {
 		isFetchingSitePurchases: true,
+	},
+	preferences: {
+		fetching: false,
+		remoteValues: {},
 	},
 };
 
@@ -73,7 +79,7 @@ describe( 'CheckoutThankYou', () => {
 	} );
 
 	beforeEach( () => {
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		store = mockStore( initialState );
 		CheckoutThankYouHeader.mockClear();
 	} );

--- a/client/my-sites/checkout/checkout-thank-you/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/utils.ts
@@ -102,6 +102,10 @@ export function isOnlyDomainPurchases( purchases: ReceiptPurchase[] ): boolean {
 	);
 }
 
+export function hasMultipleDomainPurchases( purchases: ReceiptPurchase[] ): boolean {
+	return purchases.length > 1;
+}
+
 export type FindPredicate = (
 	product: ( WithSnakeCaseSlug | WithCamelCaseSlug ) & {
 		is_domain_registration?: boolean;

--- a/client/my-sites/checkout/checkout-thank-you/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/utils.ts
@@ -102,7 +102,7 @@ export function isOnlyDomainPurchases( purchases: ReceiptPurchase[] ): boolean {
 	);
 }
 
-export function hasMultipleDomainPurchases( purchases: ReceiptPurchase[] ): boolean {
+export function hasMultiplePurchases( purchases: ReceiptPurchase[] ): boolean {
 	return purchases.length > 1;
 }
 


### PR DESCRIPTION
Closes DOTCOM-16071.

## Proposed Changes

As confirmed in this Slack message (p1770826964692149-slack-C04H4NY6STW), we want to send the user to the dashboard if they're purchasing more than one domain. This is because the new actions are supposed to be taken on a single domain.

## Testing Instructions

Purchase more than one domain within `/start/domain` and you should be redirected to `/domains/manage` if the current user doesn't have the dashboard opt-in, or `/domains` in the MSD if they do have it.

Purchase just one and you should see the new domain-only thank you page.

Remember to turn on the feature flag ;)