### PR TITLE
MCP: add claude code config

### DIFF
--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -318,22 +318,93 @@ function McpSetupComponent() {
 										<ol style={ { color: '#757575', paddingInlineStart: '20px', margin: '0' } }>
 											<li>
 												<Text as="p" variant="muted">
-													{ __(
-														'Run this command in your terminal: claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1'
+													{ createInterpolateElement(
+														/* translators: %s is the CLI command to add the MCP server */
+														__( 'Run this command in your terminal: <code>%s</code>' ).replace(
+															'%s',
+															'claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1'
+														),
+														{
+															code: (
+																<code
+																	key="claude-code-cmd"
+																	style={ {
+																		backgroundColor: '#f0f0f1',
+																		padding: '2px 6px',
+																		borderRadius: '3px',
+																		fontFamily: 'monospace',
+																		fontSize: '13px',
+																	} }
+																>
+																	claude mcp add --transport http wpcom-mcp
+																	https://public-api.wordpress.com/wpcom/v2/mcp/v1
+																</code>
+															),
+														}
 													) }
 												</Text>
 											</li>
 											<li>
 												<Text as="p" variant="muted">
-													{ __(
-														'Or copy the configuration below and add it to your .mcp.json or ~/.claude.json file.'
+													{ createInterpolateElement(
+														__(
+															'Or copy the configuration below and add it to your <mcpJson/> or <claudeJson/> file.'
+														),
+														{
+															mcpJson: (
+																<code
+																	key="mcp-json"
+																	style={ {
+																		backgroundColor: '#f0f0f1',
+																		padding: '2px 6px',
+																		borderRadius: '3px',
+																		fontFamily: 'monospace',
+																		fontSize: '13px',
+																	} }
+																>
+																	.mcp.json
+																</code>
+															),
+															claudeJson: (
+																<code
+																	key="claude-json"
+																	style={ {
+																		backgroundColor: '#f0f0f1',
+																		padding: '2px 6px',
+																		borderRadius: '3px',
+																		fontFamily: 'monospace',
+																		fontSize: '13px',
+																	} }
+																>
+																	~/.claude.json
+																</code>
+															),
+														}
 													) }
 												</Text>
 											</li>
 											<li>
 												<Text as="p" variant="muted">
-													{ __(
-														'In Claude Code, run /mcp to authenticate with your WordPress.com account.'
+													{ createInterpolateElement(
+														__(
+															'In Claude Code, run <code/> to authenticate with your WordPress.com account.'
+														),
+														{
+															code: (
+																<code
+																	key="mcp-cmd"
+																	style={ {
+																		backgroundColor: '#f0f0f1',
+																		padding: '2px 6px',
+																		borderRadius: '3px',
+																		fontFamily: 'monospace',
+																		fontSize: '13px',
+																	} }
+																>
+																	/mcp
+																</code>
+															),
+														}
 													) }
 												</Text>
 											</li>

--- a/client/dashboard/me/mcp/setup/index.tsx
+++ b/client/dashboard/me/mcp/setup/index.tsx
@@ -31,11 +31,12 @@ function McpSetupComponent() {
 	// Copy button state
 	const [ copyStatus, setCopyStatus ] = useState( 'idle' );
 
-	type McpClient = 'claude' | 'cursor' | 'vscode' | 'continue' | 'default';
+	type McpClient = 'claude' | 'claude-code' | 'cursor' | 'vscode' | 'continue' | 'default';
 
 	// MCP client options
 	const mcpClientOptions: Array< { label: string; value: McpClient } > = [
 		{ label: 'Claude', value: 'claude' },
+		{ label: 'Claude Code', value: 'claude-code' },
 		{ label: 'Cursor', value: 'cursor' },
 		{ label: 'VS Code', value: 'vscode' },
 		{ label: 'Continue', value: 'continue' },
@@ -45,6 +46,7 @@ function McpSetupComponent() {
 	// Documentation links for each client
 	const clientDocumentation: Record< McpClient, string > = {
 		claude: 'https://docs.claude.com/en/docs/mcp',
+		'claude-code': 'https://code.claude.com/docs/en/mcp',
 		vscode: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
 		cursor: 'https://docs.cursor.com/en/context/mcp',
 		continue: 'https://docs.continue.dev/customize/deep-dives/mcp',
@@ -64,6 +66,15 @@ function McpSetupComponent() {
 				return {
 					mcpServers: {
 						[ serverName ]: baseConfig,
+					},
+				};
+			case 'claude-code':
+				return {
+					mcpServers: {
+						[ serverName ]: {
+							type: 'http',
+							url: baseConfig.url,
+						},
 					},
 				};
 			case 'vscode':
@@ -242,7 +253,9 @@ function McpSetupComponent() {
 					</CardBody>
 				</Card>
 
-				{ ( selectedMcpClient === 'claude' || selectedMcpClient === 'cursor' ) && (
+				{ ( selectedMcpClient === 'claude' ||
+					selectedMcpClient === 'claude-code' ||
+					selectedMcpClient === 'cursor' ) && (
 					<Card>
 						<CardBody>
 							<VStack spacing={ 4 }>
@@ -285,6 +298,43 @@ function McpSetupComponent() {
 											<li>
 												<Text as="p" variant="muted">
 													{ __( 'Select WordPress.com and follow the prompts to connect.' ) }
+												</Text>
+											</li>
+										</ol>
+									</VStack>
+								) }
+
+								{ /* Quick Setup for Claude Code */ }
+								{ selectedMcpClient === 'claude-code' && (
+									<VStack spacing={ 4 }>
+										<Text as="p" variant="muted">
+											{ __(
+												'Claude Code uses a different config format with type: "http". Use the CLI or copy the configuration below.'
+											) }
+										</Text>
+										<Text as="p" variant="muted">
+											{ __( 'Installation steps:' ) }
+										</Text>
+										<ol style={ { color: '#757575', paddingInlineStart: '20px', margin: '0' } }>
+											<li>
+												<Text as="p" variant="muted">
+													{ __(
+														'Run this command in your terminal: claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1'
+													) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" variant="muted">
+													{ __(
+														'Or copy the configuration below and add it to your .mcp.json or ~/.claude.json file.'
+													) }
+												</Text>
+											</li>
+											<li>
+												<Text as="p" variant="muted">
+													{ __(
+														'In Claude Code, run /mcp to authenticate with your WordPress.com account.'
+													) }
 												</Text>
 											</li>
 										</ol>

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -59,6 +59,7 @@ function McpSetupComponent( { path } ) {
 	// MCP client options
 	const mcpClientOptions = [
 		{ label: 'Claude', value: 'claude' },
+		{ label: 'Claude Code', value: 'claude-code' },
 		{ label: 'Cursor', value: 'cursor' },
 		{ label: 'VS Code', value: 'vscode' },
 		{ label: 'Continue', value: 'continue' },
@@ -68,6 +69,7 @@ function McpSetupComponent( { path } ) {
 	// Documentation links for each client
 	const clientDocumentation = {
 		claude: 'https://docs.claude.com/en/docs/mcp',
+		'claude-code': 'https://code.claude.com/docs/en/mcp',
 		vscode: 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers',
 		cursor: 'https://docs.cursor.com/en/context/mcp',
 		continue: 'https://docs.continue.dev/customize/deep-dives/mcp',
@@ -87,6 +89,15 @@ function McpSetupComponent( { path } ) {
 				return {
 					mcpServers: {
 						[ serverName ]: baseConfig,
+					},
+				};
+			case 'claude-code':
+				return {
+					mcpServers: {
+						[ serverName ]: {
+							type: 'http',
+							url: baseConfig.url,
+						},
 					},
 				};
 			case 'vscode':
@@ -287,6 +298,49 @@ function McpSetupComponent( { path } ) {
 										<li>
 											<Text as="p" size="medium">
 												{ translate( 'Select WordPress.com and follow the prompts to connect.' ) }
+											</Text>
+										</li>
+									</ol>
+								</VStack>
+							) }
+
+							{ /* Quick Setup for Claude Code */ }
+							{ selectedMcpClient === 'claude-code' && (
+								<VStack
+									spacing={ 4 }
+									style={ { borderBottom: '1px solid #e0e0e0', paddingBottom: '24px' } }
+								>
+									<CardHeading tagName="h1" size={ 16 } isBold>
+										{ translate( 'Quick Setup' ) }
+									</CardHeading>
+									<Text as="p" size="medium">
+										{ translate(
+											'Claude Code uses a different config format with type: "http". Use the CLI or copy the configuration below.'
+										) }
+									</Text>
+									<Text as="p" size="medium">
+										{ translate( 'Installation steps:' ) }
+									</Text>
+									<ol>
+										<li>
+											<Text as="p" size="medium">
+												{ translate(
+													'Run this command in your terminal: claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1'
+												) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" size="medium">
+												{ translate(
+													'Or copy the configuration below and add it to your .mcp.json or ~/.claude.json file.'
+												) }
+											</Text>
+										</li>
+										<li>
+											<Text as="p" size="medium">
+												{ translate(
+													'In Claude Code, run /mcp to authenticate with your WordPress.com account.'
+												) }
 											</Text>
 										</li>
 									</ol>

--- a/client/me/mcp/setup.jsx
+++ b/client/me/mcp/setup.jsx
@@ -324,22 +324,92 @@ function McpSetupComponent( { path } ) {
 									<ol>
 										<li>
 											<Text as="p" size="medium">
-												{ translate(
-													'Run this command in your terminal: claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1'
+												{ createInterpolateElement(
+													translate( 'Run this command in your terminal: <code>%s</code>' ).replace(
+														'%s',
+														'claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1'
+													),
+													{
+														code: (
+															<code
+																key="claude-code-cmd"
+																style={ {
+																	backgroundColor: '#f0f0f1',
+																	padding: '2px 6px',
+																	borderRadius: '3px',
+																	fontFamily: 'monospace',
+																	fontSize: '13px',
+																} }
+															>
+																claude mcp add --transport http wpcom-mcp
+																https://public-api.wordpress.com/wpcom/v2/mcp/v1
+															</code>
+														),
+													}
 												) }
 											</Text>
 										</li>
 										<li>
 											<Text as="p" size="medium">
-												{ translate(
-													'Or copy the configuration below and add it to your .mcp.json or ~/.claude.json file.'
+												{ createInterpolateElement(
+													translate(
+														'Or copy the configuration below and add it to your <mcpJson/> or <claudeJson/> file.'
+													),
+													{
+														mcpJson: (
+															<code
+																key="mcp-json"
+																style={ {
+																	backgroundColor: '#f0f0f1',
+																	padding: '2px 6px',
+																	borderRadius: '3px',
+																	fontFamily: 'monospace',
+																	fontSize: '13px',
+																} }
+															>
+																.mcp.json
+															</code>
+														),
+														claudeJson: (
+															<code
+																key="claude-json"
+																style={ {
+																	backgroundColor: '#f0f0f1',
+																	padding: '2px 6px',
+																	borderRadius: '3px',
+																	fontFamily: 'monospace',
+																	fontSize: '13px',
+																} }
+															>
+																~/.claude.json
+															</code>
+														),
+													}
 												) }
 											</Text>
 										</li>
 										<li>
 											<Text as="p" size="medium">
-												{ translate(
-													'In Claude Code, run /mcp to authenticate with your WordPress.com account.'
+												{ createInterpolateElement(
+													translate(
+														'In Claude Code, run <code/> to authenticate with your WordPress.com account.'
+													),
+													{
+														code: (
+															<code
+																key="mcp-cmd"
+																style={ {
+																	backgroundColor: '#f0f0f1',
+																	padding: '2px 6px',
+																	borderRadius: '3px',
+																	fontFamily: 'monospace',
+																	fontSize: '13px',
+																} }
+															>
+																/mcp
+															</code>
+														),
+													}
 												) }
 											</Text>
 										</li>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTCOM-16057/add-claude-code-to-list-of-mcp-clients-at-the-mcp-setup-page

Support for **Claude Code** as its own MCP client, with `type: "http"` config and specific install steps.

## Proposed Changes

1. **"Claude Code" dropdown option** – New client choice in both files.

2. **Config format** – For Claude Code only, config uses `type: "http"`:
   ```json
   { "type": "http", "url": "https://public-api.wordpress.com/wpcom/v2/mcp/v1" }
   ```

3. **Documentation link** – `https://code.claude.com/docs/en/mcp` for Claude Code.

4. **Quick Setup** – Install steps for Claude Code:
   - `claude mcp add --transport http wpcom-mcp https://public-api.wordpress.com/wpcom/v2/mcp/v1`
   - Or copy the config into `.mcp.json` / `~/.claude.json`
   - Run `/mcp` in Claude Code to authenticate

## Examples

<img width="702" height="782" alt="Screenshot 2026-02-16 at 14 41 35" src="https://github.com/user-attachments/assets/4a1a0b6f-9610-4c2c-9b1e-2405af09096d" />
<img width="1019" height="793" alt="Screenshot 2026-02-16 at 14 40 46" src="https://github.com/user-attachments/assets/38e94564-2d21-43b6-abdb-2eac8be366f2" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
