### PR TITLE
Agent Manager: Add currentScreen and selectedSiteId to client context

### DIFF
--- a/packages/agents-manager/src/utils/create-agent-config.ts
+++ b/packages/agents-manager/src/utils/create-agent-config.ts
@@ -82,6 +82,7 @@ function wrapToolProvider( toolProvider: ToolProvider ): UseAgentChatConfig[ 'to
  */
 async function createWrappedContextProvider(
 	contextProvider: ContextProvider,
+	siteId?: number,
 	version?: string
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
 	const canAccessZendesk = await canConnectToZendesk();
@@ -99,6 +100,10 @@ async function createWrappedContextProvider(
 			return {
 				...resolvedContext,
 				can_access_zendesk: canAccessZendesk,
+				currentScreen: resolvedContext.currentScreen || {
+					url: window.location.href,
+				},
+				...( siteId && ! resolvedContext.selectedSiteId && { selectedSiteId: siteId } ),
 				constructorArguments: {
 					...( resolvedContext.constructorArguments || {} ),
 					...( version && { version } ),
@@ -114,6 +119,7 @@ async function createWrappedContextProvider(
 async function createDefaultContextProvider(
 	currentRoute: string | undefined,
 	environment: string,
+	siteId?: number,
 	version?: string
 ): Promise< UseAgentChatConfig[ 'contextProvider' ] > {
 	const canAccessZendesk = await canConnectToZendesk();
@@ -124,6 +130,9 @@ async function createDefaultContextProvider(
 			search: window.location.search,
 			can_access_zendesk: canAccessZendesk,
 			environment,
+			// Match Odie's context shape so the server can read current_screen.url
+			currentScreen: { url: window.location.href },
+			...( siteId && { selectedSiteId: siteId } ),
 			// TODO: Remove once agenttic-client supports top-level constructorArguments
 			...( version && { constructorArguments: { version } } ),
 		} ),
@@ -164,11 +173,12 @@ export async function createAgentConfig(
 	}
 
 	if ( contextProvider ) {
-		config.contextProvider = await createWrappedContextProvider( contextProvider, version );
+		config.contextProvider = await createWrappedContextProvider( contextProvider, siteId, version );
 	} else {
 		config.contextProvider = await createDefaultContextProvider(
 			currentRoute,
 			environment,
+			siteId,
 			version
 		);
 	}


### PR DESCRIPTION
HAL-672

## Proposed Changes

* Add `currentScreen: { url }` to the client context sent by agents-manager, matching Odie's shape so the server can read `current_screen.url`.
* Thread `siteId` through to both context providers and include `selectedSiteId` in the client context.
* For the wrapped context provider (plugin-provided), inject these as fallbacks only if the plugin doesn't already provide them.

## Why are these changes being made?

The server expects `current_screen.url` and `selectedSiteId` in the client context, matching the shape that Odie sends. The agents-manager was only sending `url` as a flat top-level field and was not including the site ID in the context at all (it was only used for auth). This caused `client.current_screen.url` to be missing on the server side.

## Testing Instructions

* Open the unified chat in Calypso on a site with these qargs: `?agent=wpcom-workflow-support_chat&version=1.0.25`
* Start a conversation.
* Verify the client context `client.current_screen.url` is present in the chat context, available in the MC chat list.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
