### PR TITLE
Fix gift subscription guard to reject non-numeric user IDs

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -426,7 +426,10 @@ export default function SubscriberDataViews( {
 						return;
 					}
 
-					if ( ! subscriber.user_id ) {
+					// TODO: Subscriber.user_id is typed as number but can be a string
+					// (e.g., email address) at runtime. The type should be widened to
+					// number | string and downstream consumers updated to validate.
+					if ( ! subscriber.user_id || isNaN( Number( subscriber.user_id ) ) ) {
 						dispatch(
 							errorNotice(
 								translate(


### PR DESCRIPTION
## Proposed Changes

* Add `isNaN( Number() )` check to the gift subscription action guard to properly reject non-numeric `user_id` values (e.g., email addresses)
* Related to https://linear.app/a8c/issue/NL-425/gift-a-subscription-modal-unresponsive-and-voucher-codes-failing-at

## Why are these changes being made?

The subscribers API can return non-numeric `user_id` values (such as email addresses) for email-only subscribers, particularly since the new helper library was enabled. The gift action guard only checked for falsy values (`! subscriber.user_id`), which missed truthy non-numeric values like email strings. This caused invalid requests to the `POST /sites/{siteId}/memberships/gifts/{user_id}/{plan_id}` endpoint. The guard now matches the defensive pattern already used in the subscriber remove mutation.

## Testing Instructions

* Navigate to the Subscribers page for a site with coupons/gifts enabled
* Find an email-only subscriber (no WordPress.com account)
* Click the "Gift a subscription" action
* Verify that an error notice appears: "This subscriber needs to create a WordPress.com account before they can receive a gift subscription."
* Verify that no invalid API request is sent

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)