### PR TITLE
Fixup connection event

### DIFF
--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -7,6 +7,10 @@ function fetchZendeskConfig() {
 	return fetch( 'https://wpcom.zendesk.com/embeddable/config' ).then( ( res ) => res.json() );
 }
 
+// Track which dataUpdatedAt timestamps we've already recorded events for
+// This persists across component mounts/unmounts
+const trackedExecutions = new Set< number >();
+
 /**
  * This hook verifies connectivity to Zendesk's messaging service by making a config request and manages automatic retries with error tracking.
  */
@@ -30,8 +34,18 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 	} );
 
 	useEffect( () => {
+		// Only track when query has completed (success or error)
+		const isSettled = query.status === 'success' || query.status === 'error';
+		const hasTracked = trackedExecutions.has( query.dataUpdatedAt );
+
+		if ( ! isSettled || hasTracked || query.dataUpdatedAt === 0 ) {
+			return;
+		}
+
+		trackedExecutions.add( query.dataUpdatedAt );
+
 		// Leaving for backwards compatibility. This event is no longer needed. The one below is more general.
-		if ( ! query.data && query.status !== 'pending' ) {
+		if ( ! query.data && query.status === 'error' ) {
 			recordTracksEvent( 'calypso_helpcenter_zendesk_config_error', {
 				status: query.status,
 				status_text: query.error?.message,
@@ -43,7 +57,7 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 			status_text: query.error?.message,
 			failure_count: query.failureCount,
 		} );
-	}, [ query.data, query.error?.message, query.status, query.failureCount ] );
+	}, [ query.status, query.dataUpdatedAt, query.data, query.error?.message, query.failureCount ] );
 
 	return query;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
