### PR TITLE
Purchase Management: Support existing PayPal payment methods

### DIFF
--- a/client/dashboard/me/billing-purchases/change-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/change-payment-method.tsx
@@ -36,11 +36,20 @@ function ChangePaymentMethod() {
 	}
 	const { data: purchase } = useSuspenseQuery( purchaseQuery( numericId ) );
 
-	const { isLoading: isLoadingStoredCards } = useQuery( userPaymentMethodsQuery( {} ) );
+	const { isLoading: isLoadingStoredCards } = useQuery(
+		userPaymentMethodsQuery( {
+			type: 'card',
+		} )
+	);
+	const { isLoading: isLoadingPayPal } = useQuery(
+		userPaymentMethodsQuery( {
+			type: 'vault-token',
+		} )
+	);
 	const { isStripeLoading } = useStripe();
 
 	const paymentMethods = useCreateAssignablePaymentMethods( purchase );
-	const isDataLoading = isLoadingStoredCards || isStripeLoading;
+	const isDataLoading = isLoadingStoredCards || isLoadingPayPal || isStripeLoading;
 
 	useEffect( () => {
 		if ( ! isDataLoading && ! purchase ) {

--- a/client/dashboard/me/billing-purchases/change-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/change-payment-method.tsx
@@ -36,9 +36,7 @@ function ChangePaymentMethod() {
 	}
 	const { data: purchase } = useSuspenseQuery( purchaseQuery( numericId ) );
 
-	const { isLoading: isLoadingStoredCards } = useQuery(
-		userPaymentMethodsQuery( { type: 'card' } )
-	);
+	const { isLoading: isLoadingStoredCards } = useQuery( userPaymentMethodsQuery( {} ) );
 	const { isStripeLoading } = useStripe();
 
 	const paymentMethods = useCreateAssignablePaymentMethods( purchase );

--- a/client/dashboard/me/billing-purchases/payment-method-selector/get-payment-method-id-from-payment.ts
+++ b/client/dashboard/me/billing-purchases/payment-method-selector/get-payment-method-id-from-payment.ts
@@ -17,6 +17,11 @@ export default function getPaymentMethodIdFromPayment( purchase: Purchase | unde
 		// created; if we return 'paypal', then the PayPal option will be selected
 		// in the payment method list when PayPal is enabled and in that case we
 		// want the PayPal option to mean "add a new PayPal billing agreement".
+		// If there's a stored_details_id, return a specific ID for this PayPal method
+		// so it can be pre-selected in the list (similar to credit cards).
+		if ( purchase.stored_details_id ) {
+			return 'existingPayPalPPCP-' + purchase.stored_details_id;
+		}
 		return 'paypal-existing';
 	}
 

--- a/client/dashboard/me/billing-purchases/payment-method-selector/index.tsx
+++ b/client/dashboard/me/billing-purchases/payment-method-selector/index.tsx
@@ -26,6 +26,7 @@ import { creditCardHasAlreadyExpired, isAkismetProduct } from '../../../utils/pu
 import {
 	assignExistingCardProcessor,
 	assignPayPalProcessor,
+	assignExistingPayPalPPCPProcessor,
 	assignNewCardProcessor,
 } from '../payment-methods';
 import getPaymentMethodIdFromPayment from './get-payment-method-id-from-payment';
@@ -107,6 +108,8 @@ export function PaymentMethodSelector( {
 					assignExistingCardProcessor( purchase, data, assignPaymentMethod ),
 				'existing-card-ebanx': ( data: unknown ) =>
 					assignExistingCardProcessor( purchase, data, assignPaymentMethod ),
+				'existing-paypal-ppcp': ( data: unknown ) =>
+					assignExistingPayPalPPCPProcessor( purchase, data, assignPaymentMethod ),
 				card: ( data: unknown ) =>
 					assignNewCardProcessor(
 						{

--- a/client/dashboard/me/billing-purchases/payment-methods/assignment-processor-functions.ts
+++ b/client/dashboard/me/billing-purchases/payment-methods/assignment-processor-functions.ts
@@ -89,3 +89,38 @@ function isValidPayPalData( data: unknown ): data is PayPalSubmitData {
 	const payPalData = data as PayPalSubmitData;
 	return payPalData.countryCode !== undefined;
 }
+
+export async function assignExistingPayPalPPCPProcessor(
+	purchase: Purchase | undefined,
+	submitData: unknown,
+	assignPaymentMethod: AssignPaymentMethodMutation
+): Promise< PaymentProcessorResponse > {
+	try {
+		if ( ! isValidExistingPayPalPPCPData( submitData ) ) {
+			throw new Error( 'PayPal data is missing stored details id' );
+		}
+		const { storedDetailsId } = submitData;
+		if ( ! purchase ) {
+			throw new Error( 'Cannot assign existing PayPal payment method without a purchase' );
+		}
+		const data = await assignPaymentMethod( {
+			subscriptionId: String( purchase.ID ),
+			storedDetailsId,
+		} );
+		return makeSuccessResponse( data );
+	} catch ( error ) {
+		return makeErrorResponse( ( error as Error ).message );
+	}
+}
+
+function isValidExistingPayPalPPCPData( data: unknown ): data is ExistingPayPalPPCPSubmitData {
+	const existingPayPalData = data as ExistingPayPalPPCPSubmitData;
+	return !! existingPayPalData.storedDetailsId;
+}
+
+interface ExistingPayPalPPCPSubmitData {
+	storedDetailsId: string;
+	email: string;
+	paymentMethodToken: string;
+	paymentPartnerProcessorId: string;
+}

--- a/client/dashboard/me/billing-purchases/payment-methods/existing-paypal-ppcp-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/existing-paypal-ppcp-payment-method.tsx
@@ -1,0 +1,109 @@
+import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { PayPalLogo } from '../../../components/paypal-logo';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
+import type { ReactNode } from 'react';
+
+export function createExistingPayPalPPCPMethod( {
+	id,
+	email,
+	storedDetailsId,
+	paymentMethodToken,
+	paymentPartnerProcessorId,
+	submitButtonContent,
+}: {
+	id: string;
+	email: string;
+	storedDetailsId: string;
+	paymentMethodToken: string;
+	paymentPartnerProcessorId: string;
+	submitButtonContent: ReactNode;
+} ): PaymentMethod {
+	return {
+		id,
+		paymentProcessorId: 'existing-paypal-ppcp',
+		label: <ExistingPayPalPPCPLabel email={ email } />,
+		submitButton: (
+			<ExistingPayPalPPCPPayButton
+				email={ email }
+				storedDetailsId={ storedDetailsId }
+				paymentMethodToken={ paymentMethodToken }
+				paymentPartnerProcessorId={ paymentPartnerProcessorId }
+				submitButtonContent={ submitButtonContent }
+			/>
+		),
+		inactiveContent: <ExistingPayPalPPCPSummary email={ email } />,
+		getAriaLabel: () => `PayPal ${ email }`,
+	};
+}
+
+function ExistingPayPalPPCPLabel( { email }: { email: string } ) {
+	return (
+		<>
+			<div>
+				<span>PayPal { email }</span>
+			</div>
+			<div className="payment-logos">
+				<PayPalLogo />
+			</div>
+		</>
+	);
+}
+
+function ExistingPayPalPPCPPayButton( {
+	disabled,
+	onClick,
+	email,
+	storedDetailsId,
+	paymentMethodToken,
+	paymentPartnerProcessorId,
+	submitButtonContent,
+}: {
+	disabled?: boolean;
+	onClick?: ProcessPayment;
+	email: string;
+	storedDetailsId: string;
+	paymentMethodToken: string;
+	paymentPartnerProcessorId: string;
+	submitButtonContent: ReactNode;
+} ) {
+	const { formStatus } = useFormStatus();
+
+	// This must be typed as optional because it's injected by cloning the
+	// element in CheckoutSubmitButton, but the uncloned element does not have
+	// this prop yet.
+	if ( ! onClick ) {
+		throw new Error(
+			'Missing onClick prop; ExistingPayPalPPCPPayButton must be used as a payment button in CheckoutSubmitButton'
+		);
+	}
+
+	return (
+		<Button
+			disabled={ disabled }
+			onClick={ () => {
+				onClick( {
+					email,
+					storedDetailsId,
+					paymentMethodToken,
+					paymentPartnerProcessorId,
+				} );
+			} }
+			buttonType="primary"
+			isBusy={ FormStatus.SUBMITTING === formStatus }
+			fullWidth
+		>
+			{ submitButtonContent }
+		</Button>
+	);
+}
+
+function ExistingPayPalPPCPSummary( { email }: { email: string } ) {
+	return (
+		<div>
+			<div>
+				<PayPalLogo />
+			</div>
+			<div>{ email }</div>
+		</div>
+	);
+}

--- a/client/dashboard/me/billing-purchases/payment-methods/index.ts
+++ b/client/dashboard/me/billing-purchases/payment-methods/index.ts
@@ -9,12 +9,14 @@ export {
 export { useCreateExistingCards } from './use-create-payment-methods';
 export { useCreatePayPalExpress } from './use-create-paypal-express';
 export { useCreateCreditCard } from './use-create-credit-card';
+export { useCreateExistingPayPalPPCP } from './use-create-existing-paypal-ppcp';
 export { useMemoCompare } from './use-memo-compare';
 export { createExistingCardMethod } from './existing-card-payment-method';
 export { createCreditCardMethod } from './credit-card-payment-method';
 export {
 	assignExistingCardProcessor,
 	assignPayPalProcessor,
+	assignExistingPayPalPPCPProcessor,
 } from './assignment-processor-functions';
 export { assignNewCardProcessor } from './assign-new-card-processor';
 export { saveCreditCard, updateCreditCard } from './stored-payment-method-api';

--- a/client/dashboard/me/billing-purchases/payment-methods/translate-payment-method-names.ts
+++ b/client/dashboard/me/billing-purchases/payment-methods/translate-payment-method-names.ts
@@ -56,8 +56,13 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 	if ( paymentMethod.startsWith( 'existingCard' ) ) {
 		paymentMethod = 'existingCard';
 	}
+	// existing PayPal PPCP methods have unique paymentMethodIds
+	if ( paymentMethod.startsWith( 'existingPayPalPPCP' ) ) {
+		paymentMethod = 'existingPayPalPPCP';
+	}
 	switch ( paymentMethod ) {
 		case 'existingCard':
+		case 'existingPayPalPPCP':
 			return 'WPCOM_Billing_MoneyPress_Stored';
 		case 'pix':
 			return 'WPCOM_Billing_Ebanx_Redirect_Brazil_Pix';
@@ -125,6 +130,9 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 	if ( slug.startsWith( 'existingCard' ) ) {
 		slug = 'existingCard';
 	}
+	if ( slug.startsWith( 'existingPayPalPPCP' ) ) {
+		slug = 'existingPayPalPPCP';
+	}
 	switch ( slug ) {
 		case 'ebanx':
 		case 'pix':
@@ -135,6 +143,7 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 		case 'card':
 		case 'stripe':
 		case 'existingCard':
+		case 'existingPayPalPPCP':
 		case 'alipay':
 		case 'bancontact':
 		case 'ideal':

--- a/client/dashboard/me/billing-purchases/payment-methods/types.ts
+++ b/client/dashboard/me/billing-purchases/payment-methods/types.ts
@@ -2,6 +2,7 @@
 export type CheckoutPaymentMethodSlug =
 	| 'card'
 	| 'existingCard'
+	| 'existingPayPalPPCP'
 	| 'paypal-express'
 	| 'paypal-js'
 	| 'free-purchase'

--- a/client/dashboard/me/billing-purchases/payment-methods/use-create-existing-paypal-ppcp.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/use-create-existing-paypal-ppcp.tsx
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import { createExistingPayPalPPCPMethod } from './existing-paypal-ppcp-payment-method';
+import { useMemoCompare } from './use-memo-compare';
+import type { StoredPaymentMethod, StoredPaymentMethodPayPal } from '@automattic/api-core';
+import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { ReactNode } from 'react';
+
+export const existingPayPalPPCPPrefix = 'existingPayPalPPCP-';
+
+export function useCreateExistingPayPalPPCP( {
+	storedPaymentMethods,
+	submitButtonContent,
+}: {
+	storedPaymentMethods: StoredPaymentMethod[];
+	submitButtonContent: ReactNode;
+} ): PaymentMethod[] {
+	const onlyStoredPayPalPPCP = storedPaymentMethods.filter( isPaymentMethodPayPalPPCP );
+
+	// Memoize the PayPal payment methods by comparing their stored_details_id values, in case the
+	// objects themselves are recreated on each render.
+	const memoizedStoredPayPalPPCP = useMemoCompare( onlyStoredPayPalPPCP, ( prev, next ) => {
+		const prevIds = prev.map( ( method ) => method.stored_details_id ) ?? [];
+		const nextIds = next.map( ( method ) => method.stored_details_id ) ?? [];
+		return (
+			prevIds.length === nextIds.length && prevIds.every( ( id, index ) => id === nextIds[ index ] )
+		);
+	} );
+
+	const existingPayPalPPCPMethods = useMemo( () => {
+		return (
+			memoizedStoredPayPalPPCP.map( ( storedDetails ) =>
+				createExistingPayPalPPCPMethod( {
+					id: `${ existingPayPalPPCPPrefix }${ storedDetails.stored_details_id }`,
+					email: storedDetails.email,
+					storedDetailsId: storedDetails.stored_details_id,
+					paymentMethodToken: storedDetails.mp_ref,
+					paymentPartnerProcessorId: storedDetails.payment_partner,
+					submitButtonContent,
+				} )
+			) ?? []
+		);
+	}, [ memoizedStoredPayPalPPCP, submitButtonContent ] );
+
+	return existingPayPalPPCPMethods;
+}
+
+function isPaymentMethodPayPalPPCP(
+	method: StoredPaymentMethod
+): method is StoredPaymentMethodPayPal {
+	return method.payment_partner === 'paypal_ppcp';
+}

--- a/client/me/purchases/manage-purchase/payment-method-selector/get-payment-method-id-from-payment.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/get-payment-method-id-from-payment.ts
@@ -14,6 +14,11 @@ export default function getPaymentMethodIdFromPayment(
 		// created; if we return 'paypal', then the PayPal option will be selected
 		// in the payment method list when PayPal is enabled and in that case we
 		// want the PayPal option to mean "add a new PayPal billing agreement".
+		// If there's a storedDetailsId, return a specific ID for this PayPal method
+		// so it can be pre-selected in the list (similar to credit cards).
+		if ( payment.storedDetailsId ) {
+			return 'existingPayPalPPCP-' + payment.storedDetailsId;
+		}
 		return 'paypal-existing';
 	}
 	if ( payment?.type === 'credit_card' && payment.creditCard ) {

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -28,6 +28,7 @@ import {
 	assignPayPalProcessor,
 	assignNewCardProcessor,
 	assignExistingCardProcessor,
+	assignExistingPayPalPPCPProcessor,
 } from './assignment-processor-functions';
 import getPaymentMethodIdFromPayment from './get-payment-method-id-from-payment';
 import TosText from './tos-text';
@@ -206,6 +207,8 @@ export default function PaymentMethodSelector( {
 					assignExistingCardProcessor( purchase, reduxDispatch, data ),
 				'existing-card-ebanx': ( data: unknown ) =>
 					assignExistingCardProcessor( purchase, reduxDispatch, data ),
+				'existing-paypal-ppcp': ( data: unknown ) =>
+					assignExistingPayPalPPCPProcessor( purchase, reduxDispatch, data ),
 				card: ( data: unknown ) =>
 					assignNewCardProcessor(
 						{
@@ -295,6 +298,7 @@ function onPaymentSelectComplete( {
 function CurrentPaymentMethodNotAvailableNotice( { purchase }: { purchase: Purchase } ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
+	// @todo does this need to change to also include vault-token?
 	const { paymentMethods: storedPaymentAgreements } = useStoredPaymentMethods( {
 		type: 'agreement',
 	} );

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -298,7 +298,6 @@ function onPaymentSelectComplete( {
 function CurrentPaymentMethodNotAvailableNotice( { purchase }: { purchase: Purchase } ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
-	// @todo does this need to change to also include vault-token?
 	const { paymentMethods: storedPaymentAgreements } = useStoredPaymentMethods( {
 		type: 'agreement',
 	} );

--- a/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
@@ -7,7 +7,7 @@ import type { ComponentType } from 'react';
 
 export const storedPaymentMethodsQueryKey = 'use-stored-payment-methods';
 
-export type PaymentMethodRequestType = 'card' | 'agreement' | 'all';
+export type PaymentMethodRequestType = 'card' | 'agreement' | 'vault-token' | 'all';
 
 const fetchPaymentMethods = (
 	type: PaymentMethodRequestType,

--- a/packages/api-core/src/me-payment-methods/types.ts
+++ b/packages/api-core/src/me-payment-methods/types.ts
@@ -80,4 +80,4 @@ export interface StoredPaymentMethodTaxLocation {
 	is_for_business?: boolean | undefined;
 }
 
-export type PaymentMethodRequestType = 'card' | 'agreement' | 'all';
+export type PaymentMethodRequestType = 'card' | 'agreement' | 'vault-token' | 'all';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1631/allow-assigning-saved-paypal-payment-method-using-change-payment

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/108571 we modified checkout to support using existing PayPal payment methods. In this PR we modify both calypso and the Multi Site Dashboard purchase management pages to support assigning existing PayPal payment methods to active subscriptions.

Calypso             |  Dashboard
:-------------------------:|:-------------------------:
<img width="1076" height="587" alt="Screenshot 2026-02-16 at 1 22 56 PM" src="https://github.com/user-attachments/assets/6a5bfd31-210c-4c90-98e4-ad0845cd415e" /> | <img width="715" height="683" alt="Screenshot 2026-02-16 at 1 42 34 PM" src="https://github.com/user-attachments/assets/c5efb7b1-47e2-428f-b45a-cfbd4827bd4d" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We should be able to assign existing PayPal vault tokens to active subscriptions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use an account with an existing PayPal purchase or create one.
- Visit http://calypso.localhost:3000/me/purchases and click on an active subscription.
- Click "Change payment method".
- Make sure you see your existing PayPal payment methods as options. Select one and submit the form.
- Verify that the payment method attached to the subscription changes.
- Repeat the above steps with http://my.localhost:3000/me/billing/purchases.
