### PR TITLE
Fix siteless domain purchases showing wrong status and hidden payment method in Dashboard billing

### DIFF
--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -100,7 +100,12 @@ export function PurchaseExpiryStatus( {
 		return <span>{ __( 'Disconnected from WordPress.com' ) }</span>;
 	}
 
-	if ( isDisconnectedSite && ! isA4APurchase && ! isKnownTemporarySiteProductType ) {
+	if (
+		isDisconnectedSite &&
+		! isA4APurchase &&
+		! isKnownTemporarySiteProductType &&
+		! purchase.is_domain
+	) {
 		return (
 			<span>
 				{ createInterpolateElement(

--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -42,10 +42,10 @@ function FormattedExpiryDate( { locale, purchase }: { locale: string; purchase: 
 
 export function PurchaseExpiryStatus( {
 	purchase,
-	isDisconnectedSite,
+	isSiteMissing,
 }: {
 	purchase: Purchase;
-	isDisconnectedSite?: boolean;
+	isSiteMissing?: boolean;
 } ) {
 	const locale = useLocale();
 	const { setShowHelpCenter } = useHelpCenter();
@@ -74,7 +74,7 @@ export function PurchaseExpiryStatus( {
 	}
 
 	if (
-		isDisconnectedSite &&
+		isSiteMissing &&
 		isTemporarySitePurchase( purchase ) &&
 		purchase.product_type === 'jetpack'
 	) {
@@ -96,12 +96,12 @@ export function PurchaseExpiryStatus( {
 		temporarySitePurchaseProductTypes.includes( purchase.product_type );
 	const isJetpack = purchase.is_jetpack_plan_or_product;
 
-	if ( isDisconnectedSite && ! isA4APurchase && ! isKnownTemporarySiteProductType && isJetpack ) {
+	if ( isSiteMissing && ! isA4APurchase && ! isKnownTemporarySiteProductType && isJetpack ) {
 		return <span>{ __( 'Disconnected from WordPress.com' ) }</span>;
 	}
 
 	if (
-		isDisconnectedSite &&
+		isSiteMissing &&
 		! isA4APurchase &&
 		! isKnownTemporarySiteProductType &&
 		! purchase.is_domain

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -393,7 +393,7 @@ export function getFields( {
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
 					<div>
-						<PurchaseExpiryStatus purchase={ item } isDisconnectedSite={ ! site } />
+						<PurchaseExpiryStatus purchase={ item } isSiteMissing={ ! site } />
 					</div>
 				);
 			},
@@ -427,7 +427,7 @@ export function getFields( {
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
 					<HStack justify="flex-start" spacing={ 1 }>
-						<PurchasePaymentMethod purchase={ item } isDisconnectedSite={ ! site } />
+						<PurchasePaymentMethod purchase={ item } isSiteMissing={ ! site } />
 						{ isBackupMethodAvailable && isRenewing( item ) && <BackupPaymentMethodNotice /> }
 					</HStack>
 				);

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -10,11 +10,11 @@ import './style.scss';
 
 export function PurchasePaymentMethod( {
 	purchase,
-	isDisconnectedSite,
+	isSiteMissing,
 	showUpdateButton,
 }: {
 	purchase: Purchase;
-	isDisconnectedSite?: boolean;
+	isSiteMissing?: boolean;
 	showUpdateButton?: boolean;
 } ) {
 	const navigate = useNavigate();
@@ -34,7 +34,7 @@ export function PurchasePaymentMethod( {
 		isExpired( purchase ) ||
 		purchase.partner_name ||
 		isAkismetFreeProduct( purchase ) ||
-		( isDisconnectedSite && ! purchase.is_domain )
+		( isSiteMissing && ! purchase.is_domain )
 	) {
 		return null;
 	}

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -34,7 +34,7 @@ export function PurchasePaymentMethod( {
 		isExpired( purchase ) ||
 		purchase.partner_name ||
 		isAkismetFreeProduct( purchase ) ||
-		isDisconnectedSite
+		( isDisconnectedSite && ! purchase.is_domain )
 	) {
 		return null;
 	}


### PR DESCRIPTION
Resolves [SHILL-1660](https://linear.app/a8c/issue/SHILL-1660)

## Proposed Changes

* Rename `isDisconnectedSite` to `isSiteMissing` in Dashboard billing components — the old name implied a Jetpack disconnection state when it really just means no matching site was found in the user's sites list
* Add `! purchase.is_domain` guard to the `isSiteMissing` check in `PurchaseExpiryStatus` so domain purchases fall through to the actual expiry/renewal logic
* Add the same guard in `PurchasePaymentMethod` so domain purchases show their payment method and "Update" button

## Why are these changes being made?

Siteless domain purchases (domain registrations not attached to a site) display incorrectly in the Dashboard billing page. The `isSiteMissing` flag is computed as `! site` by matching `purchase.blog_id` against the user's sites list. Since siteless domains have no matching site, they hit early-return guards that:

1. Show "You no longer have access to this site and its purchases" instead of the actual renewal/expiry status
2. Hide the payment method column entirely — no card info, no "Update" button

The existing exemptions (Jetpack, Akismet, A4A, marketplace temporary-site purchases) don't cover domain products. Using `purchase.is_domain` (rather than `is_domain_registration`) covers registrations, mappings, and transfers.


| Scenario | Before | After |
|----------|--------|-------|
| Expiry status for siteless domain | "You no longer have access to this site and its purchases. Contact support" | Actual renewal/expiry status (e.g., "Renews yearly at $X on date") |
| Payment method for siteless domain | Blank | Shows card details and "Update" button |

Before:
 - <img width="1273" height="1103" alt="Screenshot 2026-02-16 at 12 08 10 PM" src="https://github.com/user-attachments/assets/80d03cfd-7914-4568-b45f-f43f7ef92fef" />

After:
 - <img width="1273" height="1103" alt="Screenshot 2026-02-16 at 12 07 35 PM" src="https://github.com/user-attachments/assets/eafe1c16-a19c-4607-882c-4b6f32a5f5bb" />



## Testing Instructions

**Environment:**
- Local: `calypso.localhost:3000` or staging

**Steps:**
1. Log in as a user that owns a domain registration **not** attached to any site (a siteless domain)
2. Navigate to Dashboard billing: `my.wordpress.com/me/billing/purchases/`
3. Find the domain purchase in the list

**Before this change:**
- Expiry status column shows "You no longer have access to this site and its purchases. Contact support"
- Payment method column is blank

**After this change:**
- Expiry status column shows the real renewal/expiry status (e.g., "Renews yearly at $X on [date]" or "Expires on [date]")
- Payment method column shows the card on file with an "Update" button (if auto-renewing)

### Test scenarios

| # | Scenario | Expected Result |
|---|----------|-----------------|
| 1 | Siteless domain, auto-renewing | Expiry: "Renews yearly at $X on [date]". Payment: card details + Update button |
| 2 | Siteless domain, auto-renew off | Expiry: "Expires on [date]" (with warning color if within 30 days). Payment: "Add payment method" link |
| 3 | Siteless domain, expired | Expiry: "Expired [X days ago]" in red. Payment: blank (correct — expired) |
| 4 | Non-domain disconnected site purchase | Unchanged — still shows "You no longer have access…" and blank payment method |
| 5 | Jetpack/Akismet/A4A temporary site purchase | Unchanged — existing exemptions still work |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
