### PR TITLE
Upgrade i18n lint warnings to errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -586,7 +586,5 @@ module.exports = {
 		// @TODO remove these lines once we fixed the warnings so
 		// they'll become errors for new code added to the codebase
 		'@tanstack/query/exhaustive-deps': 'warn',
-		'@wordpress/i18n-no-flanking-whitespace': 'warn',
-		'@wordpress/i18n-hyphenated-range': 'warn',
 	},
 };


### PR DESCRIPTION
## Proposed Changes

* Remove `warn` overrides for `@wordpress/i18n-no-flanking-whitespace` and `@wordpress/i18n-hyphenated-range` in [`.eslintrc.js` L586](https://github.com/Automattic/wp-calypso/blob/trunk/.eslintrc.js#L586), upgrading them to default error severity.

## Why are these changes being made?

These rules were temporarily downgraded to warnings while existing violations were fixed. The codebase is now clean, so we can upgrade them to errors to prevent regressions.

## Testing Instructions

1. Run `yarn eslint . > all-errors.txt`
2. Verify no violations for:
   - [`@wordpress/i18n-no-flanking-whitespace`](https://github.com/WordPress/gutenberg/blob/trunk/packages/eslint-plugin/docs/rules/i18n-no-flanking-whitespace.md)
   - [`@wordpress/i18n-hyphenated-range`](https://github.com/WordPress/gutenberg/blob/trunk/packages/eslint-plugin/docs/rules/i18n-hyphenated-range.md)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?