### PR TITLE
Fix blank Settings content when entering from legacy `/sites/settings/site/:site` URL

### DIFF
--- a/client/sites/index.tsx
+++ b/client/sites/index.tsx
@@ -21,6 +21,10 @@ export default function () {
 	/**
 	 * Backport Multi-site Dashboard
 	 */
+	page( '/sites/settings/site/:site', ( context ) => {
+		return page.redirect( `/sites/${ context.params.site }/settings` );
+	} );
+
 	page(
 		'/sites/:site/settings/:feature?',
 		siteSelection,


### PR DESCRIPTION
## Human Description

Calypso bug: When I go from wp-admin/options-general.php directly to calypso settings, the panel appears blank. But there are contents if I switch tabs to it or refresh on the url. 

<img width="842" height="81" alt="Screenshot 2026-02-16 at 6 09 15 PM" src="https://github.com/user-attachments/assets/4ec03e1a-1d72-489d-a676-06e3299b2bb8" />
The above on simple site `/wp-admin/options-general.php` goes to `https://wordpress.com/sites/settings/site/<site-slug>`.


---

Shortly after arriving in Firefox:

<img width="1087" height="501" alt="Screenshot 2026-02-16 at 6 05 51 PM" src="https://github.com/user-attachments/assets/bfb45af8-a996-4720-83fa-3912cbc5f784" />
(Url appears as `https://wordpress.com/sites/<site-slug>/settings` in the address bar, but I got here by visiting `/sites/settings/site/<site-slug>`).

This looks to be from a legacy url like `/sites/settings/site/<site-slug>` that's not working properly. Fix via redirecting that url.

Note: I have a video of the bug occuring here:
p1771284332707759/1771284297.147589-slack-C4GAQ900P


## AI Description

Codex helped me write the following. It has more details about the XHR that happens differently on the failed url and what it looks like:

## Summary
When users navigate from wp-admin (`/wp-admin/options-general.php`) via the **WordPress.com Site Settings** link, they land on a legacy Calypso URL:

- `/sites/settings/site/:site`

In this flow, Settings content can render briefly and then blank out.

This change adds an early canonical redirect:

- `/sites/settings/site/:site` -> `/sites/:site/settings`

so the Multi-site Dashboard settings route is used consistently.

## Problem
Directly loading:

- `/sites/:site/settings`

works as expected.

Loading the legacy URL:

- `/sites/settings/site/:site`

can trigger a site lookup for slug `settings` (`/rest/v1.1/sites/settings?...`), which returns `unknown_blog`. After that failed fetch resolves, the settings content area may blank.

## Root Cause
The app had mixed routing paths for site settings (legacy + canonical). Entering through the legacy URL could bootstrap the dashboard/backport path in a way that allowed `settings` to be treated like a site slug.

## Fix
In `client/sites/index.tsx`, add a high-priority redirect route:

- `page( '/sites/settings/site/:site', ... )`
- Redirect immediately to `/sites/${ context.params.site }/settings`

This avoids intermediate legacy-path behavior and ensures one canonical route for dashboard settings.

## Verification
Reproduced locally before fix:

1. Visit `/sites/settings/site/<site-slug>`
2. Observe XHR to `/rest/v1.1/sites/settings?...` returning `unknown_blog`
3. Settings content blanks after initial render

After fix:

1. Visit `/sites/settings/site/<site-slug>`
2. Immediate redirect to `/sites/<site-slug>/settings`
3. No blanking; settings content remains rendered

## Notes
- This is intentionally a routing-level guard to normalize entry from legacy links.
- Behavior for canonical settings URLs is unchanged.
- Follow-up (outside this PR): update wp-admin link generation to point directly to `/sites/:site/settings`.