### PR TITLE
A4A: Use isPressableAddonLicense to render the correct CTAs

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -11,6 +11,7 @@ import {
 	EXTERNAL_PRESSABLE_AUTH_URL,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
+	isPressableAddonProduct,
 	isPressableHostingProduct,
 	isWPCOMHostingProduct,
 } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
@@ -61,6 +62,8 @@ export default function LicenseDetailsActions( {
 
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
+	const isPressableAddonLicense =
+		isPressableAddonProduct( licenseKey ) || isPressableAddonProduct( product );
 	const isWPCOMHostingLicense = isWPCOMHostingProduct( licenseKey );
 	const isAutoRenewDisabled =
 		subscription?.status === 'active' && ! subscription.isAutoRenewEnabled;
@@ -131,22 +134,25 @@ export default function LicenseDetailsActions( {
 				</Button>
 			) }
 
-			{ isPressableLicense && licenseState === LicenseState.Attached && (
-				<Button
-					primary
-					compact
-					href={ EXTERNAL_PRESSABLE_AUTH_URL }
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					{ translate( 'Manage in Pressable ↗' ) }
-				</Button>
-			) }
+			{ isPressableLicense &&
+				( licenseState === LicenseState.Attached ||
+					( isPressableAddonLicense && licenseState !== LicenseState.Revoked ) ) && (
+					<Button
+						primary
+						compact
+						href={ EXTERNAL_PRESSABLE_AUTH_URL }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ translate( 'Manage in Pressable ↗' ) }
+					</Button>
+				) }
 
 			{ ( isPressableLicense || isWPCOMHostingLicense ) &&
 				licenseState !== LicenseState.Revoked &&
 				! isDevSite &&
 				! isClientLicense &&
+				! isPressableAddonLicense &&
 				! isAutoRenewDisabled && (
 					<Button
 						compact
@@ -172,11 +178,13 @@ export default function LicenseDetailsActions( {
 					</Button>
 				) }
 
-			{ licenseState === LicenseState.Detached && licenseType === LicenseType.Partner && (
-				<Button compact primary className="license-details__assign-button" href={ redirectUrl }>
-					{ isWPCOMHostingLicense ? translate( 'Create site' ) : translate( 'Assign license' ) }
-				</Button>
-			) }
+			{ ! isPressableAddonLicense &&
+				licenseState === LicenseState.Detached &&
+				licenseType === LicenseType.Partner && (
+					<Button compact primary className="license-details__assign-button" href={ redirectUrl }>
+						{ isWPCOMHostingLicense ? translate( 'Create site' ) : translate( 'Assign license' ) }
+					</Button>
+				) }
 
 			{ revokeDialog && (
 				<CancelLicenseFeedbackModal

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -124,39 +124,6 @@ export default function LicenseDetails( {
 								<Gridicon icon="clipboard" />
 							</ClipboardButton>
 						</div>
-
-						{ shouldShowSubscription && (
-							<>
-								<div className="license-details__subscription-row">
-									{ subscriptionBadgeLabel && (
-										<Badge
-											type={ subscription?.status === 'inactive' ? 'info-green' : 'info' }
-											className="license-details__subscription-badge"
-										>
-											{ subscriptionBadgeLabel }
-										</Badge>
-									) }
-									<span className="license-details__subscription-label">
-										{ subscriptionDateLabel }
-									</span>
-									<span className="license-details__subscription-date">
-										{ subscription?.expiry ? (
-											<FormattedDate
-												date={ subscription.expiry }
-												format={ DETAILS_DATE_FORMAT_SHORT }
-											/>
-										) : (
-											'-'
-										) }
-										{ subscriptionIntervalLabel && (
-											<span className="license-details__subscription-interval">
-												{ ` ${ subscriptionIntervalLabel }` }
-											</span>
-										) }
-									</span>
-								</div>
-							</>
-						) }
 					</li>
 				) }
 				{ isPressableLicense && licenseState !== LicenseState.Revoked && (
@@ -217,6 +184,32 @@ export default function LicenseDetails( {
 				productId={ productId }
 				subscription={ subscription }
 			/>
+
+			{ shouldShowSubscription ? (
+				<div className="license-details__subscription-row">
+					{ subscriptionBadgeLabel && (
+						<Badge
+							type={ subscription?.status === 'inactive' ? 'info-green' : 'info' }
+							className="license-details__subscription-badge"
+						>
+							{ subscriptionBadgeLabel }
+						</Badge>
+					) }
+					<span className="license-details__subscription-label">{ subscriptionDateLabel }</span>
+					<span className="license-details__subscription-date">
+						{ subscription?.expiry ? (
+							<FormattedDate date={ subscription.expiry } format={ DETAILS_DATE_FORMAT_SHORT } />
+						) : (
+							'-'
+						) }
+						{ subscriptionIntervalLabel && (
+							<span className="license-details__subscription-interval">
+								{ ` ${ subscriptionIntervalLabel }` }
+							</span>
+						) }
+					</span>
+				</div>
+			) : null }
 		</Card>
 	);
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
@@ -118,6 +118,7 @@
 
 	.license-details__subscription-row {
 		display: inline-flex;
+		margin-top: 16px;
 		align-items: center;
 		gap: 8px;
 	}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
@@ -125,6 +125,7 @@
 
 	.license-details__subscription-badge {
 		margin: 0;
+		font-size: $font-size-x-small;
 	}
 
 	.license-details__subscription-label {

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -16,6 +16,7 @@ import {
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import {
+	isPressableAddonProduct,
 	isPressableHostingProduct,
 	isWPCOMHostingProduct,
 } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
@@ -114,6 +115,8 @@ export default function LicensePreview( {
 
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
+	const isPressableAddonLicense =
+		isPressableAddonProduct( licenseKey ) || isPressableAddonProduct( license.product );
 	const isWPCOMLicense = isWPCOMHostingProduct( licenseKey );
 
 	const isOwner = useSelector( isAgencyOwner );
@@ -316,10 +319,10 @@ export default function LicensePreview( {
 							{ isPressableLicense && ! revokedAt && (
 								<ManageInPressable attachedAt={ attachedAt } />
 							) }
-							{ ! domain && licenseState === LicenseState.Detached && (
+							{ ! domain && licenseState === LicenseState.Detached && ! isPressableAddonLicense && (
 								<span className="license-preview__unassigned">
 									<Badge type="warning">{ translate( 'Unassigned' ) }</Badge>
-									{ licenseType === LicenseType.Partner && (
+									{ licenseType === LicenseType.Partner && ! isPressableAddonLicense && (
 										<Button
 											className="license-preview__assign-button"
 											borderless


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/3337
**Part of Linear:** A4A-2068


## Proposed Changes

It sets the correct Pressable Add-ons CTAs (Manage in Pressable). Also, it adds the subscription information below the CTAs buttons.

<img width="894" height="670" alt="image" src="https://github.com/user-attachments/assets/7fd5a7af-0552-4f31-a369-248ea1897a9e" />


**Follow-up**

- The usage information (from backend) doesn't include the Add-on information, so the usage data is not accurate. [WIP]
- 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Apply this change
- Activate the feature by activating the feature toggle = `?flags=a4a-pressable-addons`
- You will need an active Pressable Hosting plan. Then, purchased a Pressable Add-on.  
- Check the Purchase Add-on item and check the CTA buttons:

**Production. Bad:**

<img width="532" height="198" alt="image" src="https://github.com/user-attachments/assets/b6ad348e-ea9a-478b-bb9a-9bd74b329de3" />

**Expected** With the subscription information below the CTA button:

<img width="753" height="244" alt="image" src="https://github.com/user-attachments/assets/4c1111a1-1b21-4e69-bb10-2a94b0973213" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
