### PR TITLE
Dashboard: fix Jetpack domain collision in the site list

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,4 +1,9 @@
-import { isAutomatticianQuery, siteBySlugQuery, siteByIdQuery } from '@automattic/api-queries';
+import {
+	isAutomatticianQuery,
+	jetpackSiteUrlsQuery,
+	siteBySlugQuery,
+	siteByIdQuery,
+} from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	useQuery,
@@ -23,6 +28,8 @@ import OptInSurvey from '../components/opt-in-survey';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
+import { getEffectiveSiteSlug } from '../utils/site-collisions';
+import { withoutHttp } from '../utils/url';
 import AddNewSite from './add-new-site';
 import {
 	SitesDataViews,
@@ -127,6 +134,12 @@ const getFetchPaginatedSitesOptions = (
 export function useSiteListQuery( view: View, options: SiteListQueryOptions ) {
 	const { queries } = useAppContext();
 
+	// Fetch Jetpack site URLs to detect domain collisions with wpcom sites.
+	const { data: jetpackSiteUrls } = useQuery( {
+		...jetpackSiteUrlsQuery(),
+		select: ( data ) => new Set( data.map( withoutHttp ) ),
+	} );
+
 	const { data: siteFilters } = useQuery( {
 		...queries.dashboardSiteFiltersQuery( [ 'plan' ] ),
 		staleTime: 5 * 60 * 1000, // Consider valid for 5 minutes
@@ -139,12 +152,29 @@ export function useSiteListQuery( view: View, options: SiteListQueryOptions ) {
 		...queries.sitesQuery( getFetchSitesOptions( view, options ) ),
 		placeholderData: keepPreviousData,
 		enabled: ! isEnabled( 'dashboard/v2/paginated-site-list' ),
+		select: ( data ) =>
+			! jetpackSiteUrls
+				? data
+				: data.map( ( s ) => ( {
+						...s,
+						slug: getEffectiveSiteSlug( s, jetpackSiteUrls ),
+				  } ) ),
 	} );
 
 	const paginatedSitesQueryResult = useQuery( {
 		...queries.paginatedSitesQuery( getFetchPaginatedSitesOptions( view, options, siteFilters ) ),
 		placeholderData: keepPreviousData,
 		enabled: isEnabled( 'dashboard/v2/paginated-site-list' ),
+		select: ( data ) =>
+			! jetpackSiteUrls
+				? data
+				: {
+						...data,
+						sites: data.sites.map( ( s ) => ( {
+							...s,
+							slug: getEffectiveSiteSlug( s, jetpackSiteUrls ),
+						} ) ),
+				  },
 		meta: {
 			fullPageLoader: true,
 		},

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -46,7 +46,12 @@ describe( '<Sites>', () => {
 
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/me/sites' )
-			.query( true )
+			.query( ( params ) => params.filters === 'jetpack' )
+			.reply( 200, { sites: [] } );
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/sites' )
+			.query( ( params ) => params.filters !== 'jetpack' )
 			.reply( 200, { sites: mockSites } );
 	} );
 
@@ -72,6 +77,60 @@ describe( '<Sites>', () => {
 		).toBeVisible();
 		expect( screen.getByRole( 'link', { name: 'Create a site' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'uses unmapped_url slug when a wpcom site URL collides with a Jetpack site', async () => {
+		nock.cleanAll();
+
+		const conflictingSite = {
+			ID: 3,
+			name: 'Conflicting Site',
+			slug: 'example.com',
+			URL: 'https://example.com',
+			jetpack: false,
+			is_coming_soon: false,
+			is_private: false,
+			site_migration: {},
+			capabilities: { manage_options: true },
+			options: { unmapped_url: 'https://conflicting-site.wordpress.com' },
+			plan: { product_slug: 'business-bundle', product_name_short: 'Business' },
+		} as Site;
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/read/teams' )
+			.query( true )
+			.reply( 200, { teams: [] } );
+
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.1/me/preferences' )
+			.query( true )
+			.reply( 200, { calypso_preferences: {} } );
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/sites' )
+			.query( ( params ) => params.filters === 'jetpack' )
+			.reply( 200, { sites: [ { URL: 'https://example.com', jetpack: true } ] } );
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/sites' )
+			.query( ( params ) => params.filters !== 'jetpack' )
+			.reply( 200, { sites: [ conflictingSite ] } );
+
+		render( <Sites />, {
+			user: { site_count: 13 } as User,
+		} );
+
+		const table = await screen.findByRole( 'table' );
+		await waitFor( () => expect( within( table ).getAllByRole( 'row' ) ).toHaveLength( 2 ) );
+
+		// Wait for the jetpack URL query to resolve and the slug override to take effect.
+		await waitFor( () => {
+			const row = within( table ).getAllByRole( 'row' )[ 1 ];
+			const links = within( row ).getAllByRole( 'link' );
+			const hrefs = links.map( ( l ) => l.getAttribute( 'href' ) );
+			expect( hrefs ).toContain( '/sites/conflicting-site.wordpress.com' );
+		} );
 	} );
 
 	test( 'renders DataViews when the user has sites', async () => {

--- a/client/dashboard/utils/site-collisions.ts
+++ b/client/dashboard/utils/site-collisions.ts
@@ -1,0 +1,20 @@
+import { urlToSlug, withoutHttp } from './url';
+import type { Site } from '@automattic/api-core';
+
+/**
+ * Returns effective slug for a site. When a wpcom site's URL collides with a Jetpack site's URL
+ * (or is a redirect), returns the unmapped_url to avoid API resolution to the wrong blog ID.
+ * Otherwise returns the original slug.
+ */
+export function getEffectiveSiteSlug( site: Site, jetpackUrls: Set< string > ): string {
+	const isConflicting = ! site.jetpack && jetpackUrls.has( withoutHttp( site.URL ) );
+
+	if ( isConflicting || site.options?.is_redirect ) {
+		const unmappedUrl = site.options?.unmapped_url;
+		if ( unmappedUrl ) {
+			return urlToSlug( unmappedUrl );
+		}
+	}
+
+	return site.slug;
+}

--- a/client/dashboard/utils/url.ts
+++ b/client/dashboard/utils/url.ts
@@ -13,8 +13,12 @@ export function isOnboardingUrl( url: string ) {
 	return [ '/setup', '/start' ].some( ( path ) => url.startsWith( wpcomLink( path ) ) );
 }
 
+export function withoutHttp( url: string ) {
+	return url.replace( /^https?:\/\//, '' );
+}
+
 export function urlToSlug( url: string ) {
-	return url.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+	return withoutHttp( url ).replace( /\//g, '::' );
 }
 
 export function queryParamToArray( param: unknown ): string[] {

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -54,6 +54,24 @@ export async function fetchSites(
 	return sites;
 }
 
+export async function fetchJetpackSiteUrls(): Promise< string[] > {
+	const { sites } = await wpcom.req.get(
+		{
+			path: '/me/sites',
+			apiVersion: '1.2',
+		},
+		{
+			fields: [ 'jetpack', 'URL' ],
+			site_visibility: 'all',
+			include_domain_only: false,
+			filters: 'jetpack',
+		}
+	);
+	return ( sites as Pick< Site, 'jetpack' | 'URL' >[] )
+		.filter( ( site ) => site.jetpack )
+		.map( ( site ) => site.URL );
+}
+
 export async function fetchPaginatedSites(
 	site_types: FetchSiteTypes,
 	{

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -28,6 +28,7 @@ export * from './emails';
 export * from './geo';
 export * from './github';
 export * from './hosting-update-schedules';
+export * from './jetpack-site-collisions';
 export * from './jetpack-user-license';
 export * from './marketplace-search';
 export * from './marketing-survey';

--- a/packages/api-queries/src/jetpack-site-collisions.ts
+++ b/packages/api-queries/src/jetpack-site-collisions.ts
@@ -1,0 +1,44 @@
+import { fetchJetpackSiteUrls } from '@automattic/api-core';
+import { queryOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+import type { Site } from '@automattic/api-core';
+
+function isSite( value: unknown ): value is Site {
+	return (
+		!! value &&
+		typeof value === 'object' &&
+		'jetpack' in value &&
+		typeof value.jetpack === 'boolean' &&
+		'URL' in value &&
+		typeof value.URL === 'string'
+	);
+}
+
+/**
+ * Scans the query cache for any cached Site objects (from sites lists or individual site queries)
+ * and returns URLs of Jetpack-connected sites. Used as placeholder data so collision detection
+ * can start immediately while the authoritative fetch runs in the background.
+ */
+function getJetpackUrlsFromCache(): string[] | undefined {
+	const urls = queryClient
+		.getQueriesData< unknown >( {
+			predicate: ( query ) =>
+				query.state.status === 'success' &&
+				( query.queryKey[ 0 ] === 'sites' ||
+					query.queryKey[ 0 ] === 'site-by-id' ||
+					query.queryKey[ 0 ] === 'site-by-slug' ),
+		} )
+		.flatMap( ( [ , data ] ) => {
+			const items = Array.isArray( data ) ? data : [ data ];
+			return items.flatMap( ( item ) => ( isSite( item ) && item.jetpack ? [ item.URL ] : [] ) );
+		} );
+
+	return urls.length > 0 ? [ ...new Set( urls ) ] : undefined;
+}
+
+export const jetpackSiteUrlsQuery = () =>
+	queryOptions( {
+		queryKey: [ 'jetpack-site-urls' ],
+		queryFn: fetchJetpackSiteUrls,
+		placeholderData: getJetpackUrlsFromCache,
+	} );


### PR DESCRIPTION
Part of DOTMSD-1043

## Proposed Changes

* Add `fetchJetpackSiteUrls` lightweight fetcher (only requests `URL` + `jetpack` fields) and `jetpackSiteUrlsQuery` with cache-based placeholder data
* Detect URL collisions between wpcom and Jetpack sites in `useSiteListQuery` via `select`, overriding `site.slug` to `unmapped_url` for conflicting sites
* Extract shared `withoutHttp` helper and `getEffectiveSiteSlug` collision resolver into `client/dashboard/utils/`

## Why are these changes being made?

When a domain was previously Jetpack-connected to a self-hosted site and later reused on a WordPress.com site, MSD resolves the domain to the old Jetpack blog ID via `/sites/{slug}`, causing "API calls to this blog have been disabled" errors. HD v1 solved this client-side by using `unmapped_url` for conflicting sites. This ports that fix to MSD.

## Testing Instructions

1. Find or simulate a user who has both a Jetpack site and a wpcom site sharing the same domain (e.g. `example.com` Jetpack-connected, then mapped to a wpcom site).
2. Open the MSD site list — the conflicting site's link should navigate to `/sites/{unmapped_url}` (e.g. `/sites/example.wordpress.com`) instead of `/sites/example.com`.
3. Verify the site overview page loads without "API calls disabled" errors.
4. Verify non-colliding sites are unaffected.
5. Run `yarn test-client client/dashboard/sites/test/index.test.tsx` — all 4 tests pass, including the new collision test.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?