### PR TITLE
A4A > Checkout: Mobile CTA labels and scroll fix

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Button, FormLabel, Tooltip } from '@automattic/components';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { customLink, Icon, send, warning } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
@@ -49,6 +50,7 @@ type ValidationState = {
 function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const isMobile = useBreakpoint( '<660px' );
 
 	const user = useSelector( getCurrentUser );
 
@@ -289,7 +291,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 					busy={ isPending }
 				>
 					<Icon icon={ send } />
-					{ translate( 'Send to Client' ) }
+					{ isMobile ? translate( 'Send' ) : translate( 'Send to Client' ) }
 					{ isUserUnverified && <Icon icon={ warning } /> }
 				</Button>
 
@@ -302,7 +304,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 					busy={ isPending }
 				>
 					<Icon icon={ customLink } />
-					{ translate( 'Copy referral link' ) }
+					{ isMobile ? translate( 'Copy link' ) : translate( 'Copy referral link' ) }
 				</Button>
 
 				<Tooltip

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
@@ -7,13 +7,22 @@
 	background: var( --color-sidebar-menu-selected-background );
 }
 
+.checkout.hosting-dashboard-layout {
+	display: flex;
+	flex-direction: column;
+	height: calc(100vh - 32px);
+	overflow: hidden;
+}
+
 .checkout .hosting-dashboard-layout__body,
 .checkout .hosting-dashboard-layout__body-wrapper {
 	border-radius: 8px;
 }
 
 .checkout .hosting-dashboard-layout__container {
-	height: 100%;
+	height: auto;
+	flex: 1;
+	min-height: 0;
 }
 
 .checkout .hosting-dashboard-layout__body {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-2125/a4a-checkout-mobile-cta-labels-and-scroll-fix

## Proposed Changes

- **Mobile CTA labels:** On viewport <660px, shorten referral checkout buttons: `Send to Client` → `Send`, `Copy referral link` → `Copy link`. Desktop labels unchanged.
- **Mobile scroll fix:** Constrain checkout layout to viewport and allow body to flex so content scrolls properly on mobile (no stuck layout).

## Why are these changes being made?

Shorter labels improve fit and readability on small screens. The scroll fix ensures the referral checkout flow is usable on mobile when content exceeds the viewport.

## Testing Instructions

1. **Desktop:** Open referral checkout (request client payment). Confirm CTAs show `Send to Client` and `Copy referral link`.
2. **Mobile/narrow (<660px):** Same page; confirm CTAs show `Send` and `Copy link`. Verify send and copy flows still work.
3. **Mobile:** Resize or use device emulation so checkout content is tall; confirm the page scrolls and no content is stuck off-screen.

| Before | After |
|--------|--------|
| <img width="365" height="673" alt="Screenshot 2026-02-17 at 12 41 00 PM" src="https://github.com/user-attachments/assets/233938d8-cd18-4e93-8566-7d7eb06d584b" /> | <img width="365" height="673" alt="Screenshot 2026-02-17 at 12 43 11 PM" src="https://github.com/user-attachments/assets/6853674a-9c65-4548-b3b5-4d7b14553338" /> | 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?