### PR TITLE
Activity Log: Hide backup/scan events for sites without self-serve access

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -198,7 +198,10 @@ export const siteOverviewRoute = createRoute( {
 	loader: async ( { params: { siteSlug }, preload } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( preload ) {
-			queryClient.prefetchQuery( siteLastFiveActivityLogEntriesQuery( site.ID ) );
+			const hasBackupsSelfServe = hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
+			// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
+			const notGroup = hasBackupsSelfServe ? undefined : [ 'rewind', 'scan' ];
+			queryClient.prefetchQuery( siteLastFiveActivityLogEntriesQuery( site.ID, notGroup ) );
 			if ( hasHostingFeature( site, HostingFeatures.SCAN_SELF_SERVE ) ) {
 				queryClient.prefetchQuery( siteScanQuery( site.ID ) );
 			}

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -56,7 +56,11 @@ import {
 	canViewWordPressSettings,
 } from '../../sites/features';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
-import { hasHostingFeature, hasPlanFeature } from '../../utils/site-features';
+import {
+	getActivityLogHiddenGroups,
+	hasHostingFeature,
+	hasPlanFeature,
+} from '../../utils/site-features';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSiteMigrationInProgress, getSiteMigrationState } from '../../utils/site-status';
 import { hasSiteTrialEnded } from '../../utils/site-trial';
@@ -198,9 +202,7 @@ export const siteOverviewRoute = createRoute( {
 	loader: async ( { params: { siteSlug }, preload } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( preload ) {
-			const hasBackupsSelfServe = hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
-			// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
-			const notGroup = hasBackupsSelfServe ? undefined : [ 'rewind', 'scan' ];
+			const notGroup = getActivityLogHiddenGroups( site );
 			queryClient.prefetchQuery( siteLastFiveActivityLogEntriesQuery( site.ID, notGroup ) );
 			if ( hasHostingFeature( site, HostingFeatures.SCAN_SELF_SERVE ) ) {
 				queryClient.prefetchQuery( siteScanQuery( site.ID ) );

--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -1,4 +1,4 @@
-import { ActivityLogParams, LogType } from '@automattic/api-core';
+import { ActivityLogParams, HostingFeatures, LogType } from '@automattic/api-core';
 import { siteActivityLogQuery, siteActivityLogGroupCountsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalHStack as HStack } from '@wordpress/components';
@@ -10,6 +10,7 @@ import { useAnalytics } from '../../../app/analytics';
 import { usePersistentView } from '../../../app/hooks/use-persistent-view';
 import { siteLogsActivityRoute } from '../../../app/router/sites';
 import { DataViews } from '../../../components/dataviews';
+import { hasHostingFeature } from '../../../utils/site-features';
 import { buildTimeRangeInSeconds } from '../../logs/utils';
 import { ActivityLogsCallout } from '../activity-logs-callout';
 import { transformActivityLogEntry } from '../activity-transformer';
@@ -61,12 +62,17 @@ function SiteActivityLogsDataViews( {
 
 	const searchTerm = view.search?.trim() ?? '';
 
+	// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
+	const hasBackupsSelfServe = hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
+	const notGroup = hasBackupsSelfServe ? undefined : [ 'rewind', 'scan' ];
+
 	const activityLogQueryParams: ActivityLogParams = {
 		sort_order: view.sort?.direction,
 		number: view.perPage || ACTIVITY_LOGS_DEFAULT_PAGE_SIZE,
 		page: view.page,
 		after: afterIso,
 		before: beforeIso,
+		...( notGroup?.length && { not_group: notGroup } ),
 	};
 
 	if ( searchTerm ) {
@@ -97,6 +103,7 @@ function SiteActivityLogsDataViews( {
 			after: afterIso,
 			before: beforeIso,
 			number: 1000,
+			...( notGroup?.length && { not_group: notGroup } ),
 		} )
 	);
 	const isFetching = isFetchingData || isFetchingFilters;

--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -1,4 +1,4 @@
-import { ActivityLogParams, HostingFeatures, LogType } from '@automattic/api-core';
+import { ActivityLogParams, LogType } from '@automattic/api-core';
 import { siteActivityLogQuery, siteActivityLogGroupCountsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalHStack as HStack } from '@wordpress/components';
@@ -10,7 +10,7 @@ import { useAnalytics } from '../../../app/analytics';
 import { usePersistentView } from '../../../app/hooks/use-persistent-view';
 import { siteLogsActivityRoute } from '../../../app/router/sites';
 import { DataViews } from '../../../components/dataviews';
-import { hasHostingFeature } from '../../../utils/site-features';
+import { getActivityLogHiddenGroups } from '../../../utils/site-features';
 import { buildTimeRangeInSeconds } from '../../logs/utils';
 import { ActivityLogsCallout } from '../activity-logs-callout';
 import { transformActivityLogEntry } from '../activity-transformer';
@@ -62,9 +62,7 @@ function SiteActivityLogsDataViews( {
 
 	const searchTerm = view.search?.trim() ?? '';
 
-	// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
-	const hasBackupsSelfServe = hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
-	const notGroup = hasBackupsSelfServe ? undefined : [ 'rewind', 'scan' ];
+	const notGroup = getActivityLogHiddenGroups( site );
 
 	const activityLogQueryParams: ActivityLogParams = {
 		sort_order: view.sort?.direction,

--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -1,3 +1,4 @@
+import { HostingFeatures } from '@automattic/api-core';
 import { siteLastFiveActivityLogEntriesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
@@ -11,6 +12,7 @@ import { TextSkeleton } from '../../components/text-skeleton';
 import TimeSince from '../../components/time-since';
 import { gridiconToWordPressIcon } from '../../utils/gridicons';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
+import { hasHostingFeature } from '../../utils/site-features';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { ActivityLogEntry, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -63,7 +65,10 @@ export default function LatestActivityCard( {
 	site: Site;
 	isCompact?: boolean;
 } ) {
-	const { data } = useQuery( siteLastFiveActivityLogEntriesQuery( site.ID ) );
+	const hasBackupsSelfServe = hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
+	// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
+	const notGroup = hasBackupsSelfServe ? undefined : [ 'rewind', 'scan' ];
+	const { data } = useQuery( siteLastFiveActivityLogEntriesQuery( site.ID, notGroup ) );
 	const { recordTracksEvent } = useAnalytics();
 
 	const view = {

--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -1,4 +1,3 @@
-import { HostingFeatures } from '@automattic/api-core';
 import { siteLastFiveActivityLogEntriesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
@@ -12,7 +11,7 @@ import { TextSkeleton } from '../../components/text-skeleton';
 import TimeSince from '../../components/time-since';
 import { gridiconToWordPressIcon } from '../../utils/gridicons';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
-import { hasHostingFeature } from '../../utils/site-features';
+import { getActivityLogHiddenGroups } from '../../utils/site-features';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import type { ActivityLogEntry, Site } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
@@ -65,9 +64,7 @@ export default function LatestActivityCard( {
 	site: Site;
 	isCompact?: boolean;
 } ) {
-	const hasBackupsSelfServe = hasHostingFeature( site, HostingFeatures.BACKUPS_SELF_SERVE );
-	// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
-	const notGroup = hasBackupsSelfServe ? undefined : [ 'rewind', 'scan' ];
+	const notGroup = getActivityLogHiddenGroups( site );
 	const { data } = useQuery( siteLastFiveActivityLogEntriesQuery( site.ID, notGroup ) );
 	const { recordTracksEvent } = useAnalytics();
 

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -34,3 +34,10 @@ export function hasHostingFeature( site: Site, feature: HostingFeatureSlug ) {
 export function hasJetpackModule( site: Site, module: `${ JetpackModuleSlug }` ) {
 	return site.jetpack && site.jetpack_modules?.includes( module );
 }
+
+// Returns activity log groups that should be hidden for the given site.
+// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
+export function getActivityLogHiddenGroups( site: Site ): string[] | undefined {
+	const hasBackupsSelfServe = hasHostingFeature( site, DotcomFeatures.BACKUPS_SELF_SERVE );
+	return hasBackupsSelfServe ? undefined : [ 'rewind', 'scan' ];
+}

--- a/client/dashboard/utils/test/site-features.ts
+++ b/client/dashboard/utils/test/site-features.ts
@@ -1,5 +1,5 @@
 import { DotcomFeatures, HostingFeatures } from '@automattic/api-core';
-import { hasHostingFeature, hasPlanFeature } from '../site-features';
+import { getActivityLogHiddenGroups, hasHostingFeature, hasPlanFeature } from '../site-features';
 import type { Site } from '@automattic/api-core';
 
 describe( 'hasPlanFeature', () => {
@@ -82,5 +82,34 @@ describe( 'hasHostingFeature', () => {
 			},
 		} as Site;
 		expect( hasHostingFeature( site, HostingFeatures.BACKUPS ) ).toBe( true );
+	} );
+} );
+
+describe( 'getActivityLogHiddenGroups', () => {
+	it( 'should return hidden groups when site does not have backups self-serve feature', () => {
+		const site = {
+			plan: {
+				features: {
+					active: [],
+				},
+			},
+		} as unknown as Site;
+		expect( getActivityLogHiddenGroups( site ) ).toEqual( [ 'rewind', 'scan' ] );
+	} );
+
+	it( 'should return undefined when site has backups self-serve feature', () => {
+		const site = {
+			plan: {
+				features: {
+					active: [ HostingFeatures.BACKUPS_SELF_SERVE ],
+				},
+			},
+		} as unknown as Site;
+		expect( getActivityLogHiddenGroups( site ) ).toBeUndefined();
+	} );
+
+	it( 'should return hidden groups when site has no plan', () => {
+		const site = {} as unknown as Site;
+		expect( getActivityLogHiddenGroups( site ) ).toEqual( [ 'rewind', 'scan' ] );
 	} );
 } );

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -1,4 +1,7 @@
-import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
+import {
+	WPCOM_FEATURES_BACKUPS_SELF_SERVE,
+	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { Tooltip } from '@wordpress/components';
 import clsx from 'clsx';
@@ -40,7 +43,14 @@ const ActivityLogV2: FunctionComponent = () => {
 	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
 	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
-	const { data: logs } = useActivityLogQuery( siteId, filter );
+	const hasBackupsSelfServe = useSelector(
+		( state ) => siteId && siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_SELF_SERVE )
+	);
+	// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
+	const filterWithNotGroup = hasBackupsSelfServe
+		? filter
+		: { ...filter, notGroup: [ 'rewind', 'scan' ] };
+	const { data: logs } = useActivityLogQuery( siteId, filterWithNotGroup );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
 

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -1,7 +1,4 @@
-import {
-	WPCOM_FEATURES_BACKUPS_SELF_SERVE,
-	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
-} from '@automattic/calypso-products';
+import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { Tooltip } from '@wordpress/components';
 import clsx from 'clsx';
@@ -26,6 +23,7 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector } from 'calypso/state/partner-portal/partner/selectors';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
+import getActivityLogHiddenGroups from 'calypso/state/selectors/get-activity-log-hidden-groups';
 import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
@@ -43,13 +41,8 @@ const ActivityLogV2: FunctionComponent = () => {
 	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
 	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
-	const hasBackupsSelfServe = useSelector(
-		( state ) => siteId && siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_SELF_SERVE )
-	);
-	// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
-	const filterWithNotGroup = hasBackupsSelfServe
-		? filter
-		: { ...filter, notGroup: [ 'rewind', 'scan' ] };
+	const notGroup = useSelector( ( state ) => getActivityLogHiddenGroups( state, siteId ) );
+	const filterWithNotGroup = notGroup ? { ...filter, notGroup } : filter;
 	const { data: logs } = useActivityLogQuery( siteId, filterWithNotGroup );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -1,10 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { siteByIdQuery, stagingSiteSyncStateQuery } from '@automattic/api-queries';
-import {
-	WPCOM_FEATURES_BACKUPS_SELF_SERVE,
-	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
-} from '@automattic/calypso-products';
+import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
 import { isMobile } from '@automattic/viewport';
 import { useQuery } from '@tanstack/react-query';
 import { localize } from 'i18n-calypso';
@@ -55,6 +52,7 @@ import { getPreference } from 'calypso/state/preferences/selectors';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
 import getRewindPoliciesRequestStatus from 'calypso/state/rewind/selectors/get-rewind-policies-request-status';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
+import getActivityLogHiddenGroups from 'calypso/state/selectors/get-activity-log-hidden-groups';
 import getBackupProgress from 'calypso/state/selectors/get-backup-progress';
 import getRequestedRewind from 'calypso/state/selectors/get-requested-rewind';
 import getRestoreProgress from 'calypso/state/selectors/get-restore-progress';
@@ -650,13 +648,8 @@ function withActivityLog( Inner ) {
 	const WithActivityLog = ( props ) => {
 		const { siteId, filter, gmtOffset, timezone, rewindState } = props;
 		const visibleDays = useSelector( ( state ) => getActivityLogVisibleDays( state, siteId ) );
-		const hasBackupsSelfServe = useSelector(
-			( state ) => siteId && siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_SELF_SERVE )
-		);
-		// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
-		const filterWithNotGroup = hasBackupsSelfServe
-			? filter
-			: { ...filter, notGroup: [ 'rewind', 'scan' ] };
+		const notGroup = useSelector( ( state ) => getActivityLogHiddenGroups( state, siteId ) );
+		const filterWithNotGroup = notGroup ? { ...filter, notGroup } : filter;
 		const { data, isSuccess } = useActivityLogQuery( siteId, filterWithNotGroup );
 		const allLogEntries = data ?? emptyList;
 		const visibleLogEntries = filterLogEntries( allLogEntries, visibleDays, gmtOffset, timezone );

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -1,7 +1,10 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { siteByIdQuery, stagingSiteSyncStateQuery } from '@automattic/api-queries';
-import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
+import {
+	WPCOM_FEATURES_BACKUPS_SELF_SERVE,
+	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
+} from '@automattic/calypso-products';
 import { isMobile } from '@automattic/viewport';
 import { useQuery } from '@tanstack/react-query';
 import { localize } from 'i18n-calypso';
@@ -647,7 +650,14 @@ function withActivityLog( Inner ) {
 	const WithActivityLog = ( props ) => {
 		const { siteId, filter, gmtOffset, timezone, rewindState } = props;
 		const visibleDays = useSelector( ( state ) => getActivityLogVisibleDays( state, siteId ) );
-		const { data, isSuccess } = useActivityLogQuery( siteId, filter );
+		const hasBackupsSelfServe = useSelector(
+			( state ) => siteId && siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_SELF_SERVE )
+		);
+		// Sites without self-serve backup access shouldn't see backup/scan events in the activity list.
+		const filterWithNotGroup = hasBackupsSelfServe
+			? filter
+			: { ...filter, notGroup: [ 'rewind', 'scan' ] };
+		const { data, isSuccess } = useActivityLogQuery( siteId, filterWithNotGroup );
 		const allLogEntries = data ?? emptyList;
 		const visibleLogEntries = filterLogEntries( allLogEntries, visibleDays, gmtOffset, timezone );
 		const allLogsVisible = visibleLogEntries.length === allLogEntries.length;

--- a/client/state/selectors/get-activity-log-hidden-groups.ts
+++ b/client/state/selectors/get-activity-log-hidden-groups.ts
@@ -1,0 +1,22 @@
+import { WPCOM_FEATURES_BACKUPS_SELF_SERVE } from '@automattic/calypso-products';
+import { AppState } from 'calypso/types';
+import siteHasFeature from './site-has-feature';
+
+/**
+ * Returns activity log groups that should be hidden for the given site.
+ * Sites without self-serve backup access shouldn't see backup/scan events.
+ * @param state - Global state tree
+ * @param siteId - The site ID
+ * @returns Array of group names to hide, or undefined if none should be hidden
+ */
+export default function getActivityLogHiddenGroups(
+	state: AppState,
+	siteId: number | null
+): string[] | undefined {
+	if ( ! siteId ) {
+		return undefined;
+	}
+
+	const hasBackupsSelfServe = siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS_SELF_SERVE );
+	return hasBackupsSelfServe ? undefined : [ 'rewind', 'scan' ];
+}

--- a/client/state/selectors/test/get-activity-log-hidden-groups.ts
+++ b/client/state/selectors/test/get-activity-log-hidden-groups.ts
@@ -1,0 +1,49 @@
+import { WPCOM_FEATURES_BACKUPS_SELF_SERVE } from '@automattic/calypso-products';
+import getActivityLogHiddenGroups from 'calypso/state/selectors/get-activity-log-hidden-groups';
+import type { AppState } from 'calypso/types';
+
+describe( 'getActivityLogHiddenGroups()', () => {
+	test( 'should return undefined when siteId is null', () => {
+		const state = {} as AppState;
+		expect( getActivityLogHiddenGroups( state, null ) ).toBeUndefined();
+	} );
+
+	test( 'should return hidden groups when site does not have backups self-serve feature', () => {
+		const state = {
+			sites: {
+				features: {
+					123: {
+						data: {
+							active: [],
+						},
+					},
+				},
+			},
+		} as unknown as AppState;
+		expect( getActivityLogHiddenGroups( state, 123 ) ).toEqual( [ 'rewind', 'scan' ] );
+	} );
+
+	test( 'should return undefined when site has backups self-serve feature', () => {
+		const state = {
+			sites: {
+				features: {
+					123: {
+						data: {
+							active: [ WPCOM_FEATURES_BACKUPS_SELF_SERVE ],
+						},
+					},
+				},
+			},
+		} as unknown as AppState;
+		expect( getActivityLogHiddenGroups( state, 123 ) ).toBeUndefined();
+	} );
+
+	test( 'should return hidden groups when site features are not loaded', () => {
+		const state = {
+			sites: {
+				features: {},
+			},
+		} as unknown as AppState;
+		expect( getActivityLogHiddenGroups( state, 123 ) ).toEqual( [ 'rewind', 'scan' ] );
+	} );
+} );

--- a/packages/api-core/src/site-activity-log/types.ts
+++ b/packages/api-core/src/site-activity-log/types.ts
@@ -121,7 +121,7 @@ export interface ActivityLogParams {
 	by?: string;
 	date_range?: string;
 	number?: number;
-	not_group?: string;
+	not_group?: string[];
 	group?: string[];
 	name?: string[];
 	text_search?: string;

--- a/packages/api-queries/src/site-activity-log.ts
+++ b/packages/api-queries/src/site-activity-log.ts
@@ -5,10 +5,14 @@ import {
 } from '@automattic/api-core';
 import { queryOptions } from '@tanstack/react-query';
 
-export const siteLastFiveActivityLogEntriesQuery = ( siteId: number ) =>
+export const siteLastFiveActivityLogEntriesQuery = ( siteId: number, notGroup?: string[] ) =>
 	queryOptions( {
-		queryKey: [ 'site', siteId, 'activity-log', 'last-five' ],
-		queryFn: () => fetchSiteActivityLog( siteId, { number: 5 } ),
+		queryKey: [ 'site', siteId, 'activity-log', 'last-five', notGroup ],
+		queryFn: () =>
+			fetchSiteActivityLog( siteId, {
+				number: 5,
+				...( notGroup?.length && { not_group: notGroup } ),
+			} ),
 		select: ( data ) => data.activityLogs?.slice( 0, 5 ) ?? [],
 	} );
 


### PR DESCRIPTION
## Related Issues
Fixes CHE-395 - a summer special clean-up issue

## Summary
Sites on Personal and Premium plans no longer have self-serve access to backup and scan features, but backups are still made for HE convenience. This change hides backup and scan activity events from the activity log for sites without the `BACKUPS_SELF_SERVE` feature.

**Changes:**
- Updated `not_group` API parameter type from `string` to `string[]` to match API expectations
- Added feature check and filtering logic to hide `rewind` and `scan` activity groups for sites without `BACKUPS_SELF_SERVE` feature
- Applied filtering to:
  - Dashboard: Overview latest activity card
  - Dashboard: Full activity logs page
  - Old Calypso: Activity log v1 and v2

## Testing Instructions

### Testing Matrix

| Location | URL Pattern | Expected Behavior |
|----------|-------------|-------------------|
| Dashboard Overview | `/sites/:siteSlug` | Latest Activity card should not show backup/scan events for sites without BACKUPS_SELF_SERVE |
| Dashboard Activity Logs | `/sites/:siteSlug/logs/activity` | Full activity log should not show backup/scan events for sites without BACKUPS_SELF_SERVE |
| Old Calypso Activity Log | `/activity-log/:site` | Activity log should not show backup/scan events for sites without BACKUPS_SELF_SERVE |

### Test Cases

1. **Site WITHOUT `BACKUPS_SELF_SERVE` feature** (e.g., Personal or Premium plan):
   - [ ] Dashboard Overview (`/sites/:siteSlug`): Latest Activity card does NOT show "Backup complete" or "Scan complete" activities
   - [ ] Dashboard Activity Logs (`/sites/:siteSlug/logs/activity`): No backup/scan events visible
   - [ ] Old Calypso Activity Log (`/activity-log/:site`): No backup/scan events visible
   - [ ] API requests include `not_group[]=rewind&not_group[]=scan` parameters

2. **Site WITH `BACKUPS_SELF_SERVE` feature** (e.g., Business plan):
   - [ ] Dashboard Overview: Latest Activity card shows backup/scan activities normally
   - [ ] Dashboard Activity Logs: Backup/scan events are visible
   - [ ] Old Calypso Activity Log: Backup/scan events are visible
   - [ ] API requests do NOT include `not_group` parameters

### How to identify sites for testing
- Sites without BACKUPS_SELF_SERVE will show an upsell on `/backup/:site` page
- Sites with BACKUPS_SELF_SERVE will show the backup interface

What | Before | After
-------|------ |------
Activity log | <img width="1455" height="952" alt="Screenshot 2026-02-18 at 14 27 48" src="https://github.com/user-attachments/assets/2d97439c-1a7d-4ec1-9559-0ceb119d2e3f" /> | <img width="1455" height="952" alt="Screenshot 2026-02-18 at 14 28 29" src="https://github.com/user-attachments/assets/777ecb9c-e247-48ae-b56a-2170b0c5d438" />
Dash | <img width="488" height="382" alt="Screenshot 2026-02-18 at 14 48 15" src="https://github.com/user-attachments/assets/eba0843b-95ec-43fc-abb9-12873a1e7fdf" /> | <img width="488" height="382" alt="Screenshot 2026-02-18 at 14 48 29" src="https://github.com/user-attachments/assets/9880cba3-0966-4f96-b1b1-4e3ddeb05968" />
MSD | <img width="1358" height="693" alt="Screenshot 2026-02-18 at 14 49 59" src="https://github.com/user-attachments/assets/bc111aa6-a626-4965-8ab0-cf64341842a3" /> | <img width="1358" height="693" alt="Screenshot 2026-02-18 at 14 50 09" src="https://github.com/user-attachments/assets/04e673d2-5e31-4dd4-bc4f-1f10cd2f8a29" />

## Pre-merge Checklist

- [ ] Has the PR been tested on Calypso (Simple or Atomic)?
- [ ] Has the PR been tested on Jetpack self-hosted?
- [ ] Has the PR been tested on WoA?
- [ ] Has the PR been tested on A4A?
- [ ] Has the PR been tested in the Dashboard?