### PR TITLE
A4A: UX Improvement with Pressable Premium plan referral links.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -74,3 +74,6 @@ export const EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE =
 export const EXTERNAL_WPCOM_ACCOUNT_URL = 'https://wordpress.com/me';
 export const EXTERNAL_WPCOM_PAYMENT_METHODS_URL = `${ EXTERNAL_WPCOM_ACCOUNT_URL }/purchases/payment-methods`;
 export const EXTERNAL_WPCOM_BILLING_HISTORY_URL = `${ EXTERNAL_WPCOM_ACCOUNT_URL }/purchases/billing`;
+
+// Pressable External links
+export const EXTERNAL_PRESSABLE_AUTH_URL = 'https://my.pressable.com/agency/auth';

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -1,6 +1,7 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { EXTERNAL_PRESSABLE_AUTH_URL } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import CancelSubscriptionAction from '../../cancel-subscription-confirmation-dialog';
@@ -30,7 +31,7 @@ export function SubscriptionPurchase( {
 					className="manage-pressable-link"
 					target="_blank"
 					rel="norefferer nooppener"
-					href="https://my.pressable.com/agency/auth"
+					href={ EXTERNAL_PRESSABLE_AUTH_URL }
 					variant="link"
 				>
 					{ translate( 'Manage in Pressable ↗' ) }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
@@ -52,8 +52,7 @@ export default function PremiumPlanSection( {
 	};
 
 	// Show refer button if premium plans are not enabled or if they are enabled and we are not in referral mode
-	const shouldShowReferButton =
-		! isPremiumPlansEnabled || ( isPremiumPlansEnabled && marketplaceType !== 'referral' );
+	const shouldShowReferButton = ! isPremiumPlansEnabled || marketplaceType !== 'referral';
 
 	return (
 		<HostingPlanSection className="pressable-plan-section" heading={ heading }>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
@@ -1,10 +1,16 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useContext } from 'react';
+import {
+	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+	A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
 import useScheduleCall from 'calypso/a8c-for-agencies/hooks/use-schedule-call';
+import { MarketplaceTypeContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
 import { PRESSABLE_PREMIUM_PLAN_COMMISSION_PERCENTAGE } from 'calypso/a8c-for-agencies/sections/marketplace/lib/constants';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import { useDispatch } from 'calypso/state';
@@ -19,6 +25,10 @@ export default function PremiumPlanSection( {
 	banner: React.ReactNode;
 } ) {
 	const translate = useTranslate();
+	const isPremiumPlansEnabled = isEnabled( 'a4a-pressable-premium-plans' );
+
+	const { marketplaceType, toggleMarketplaceType } = useContext( MarketplaceTypeContext );
+
 	const dispatch = useDispatch();
 
 	const isDesktop = useBreakpoint( '>1280px' );
@@ -29,6 +39,9 @@ export default function PremiumPlanSection( {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_premium_refer_now_click' )
 		);
+		if ( isPremiumPlansEnabled && marketplaceType !== 'referral' ) {
+			toggleMarketplaceType();
+		}
 	};
 
 	const onTalkToUsClick = () => {
@@ -37,6 +50,10 @@ export default function PremiumPlanSection( {
 		);
 		scheduleCall();
 	};
+
+	// Show refer button if premium plans are not enabled or if they are enabled and we are not in referral mode
+	const shouldShowReferButton =
+		! isPremiumPlansEnabled || ( isPremiumPlansEnabled && marketplaceType !== 'referral' );
 
 	return (
 		<HostingPlanSection className="pressable-plan-section" heading={ heading }>
@@ -57,15 +74,20 @@ export default function PremiumPlanSection( {
 					</div>
 
 					<div className="premium-plan-section__cta-buttons">
-						<Button
-							className="premium-plan-section__cta-button"
-							href={ A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK }
-							onClick={ onReferNowClick }
-							variant="primary"
-							__next40pxDefaultSize
-						>
-							{ translate( 'Refer now and get rewarded' ) }
-						</Button>
+						{ shouldShowReferButton && (
+							<Button
+								href={
+									isPremiumPlansEnabled
+										? A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK
+										: A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK
+								}
+								onClick={ onReferNowClick }
+								variant="primary"
+								__next40pxDefaultSize
+							>
+								{ translate( 'Refer now and get rewarded' ) }
+							</Button>
+						) }
 
 						<Button
 							className="premium-plan-section__cta-button"

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/regular-plan-card-content.tsx
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { EXTERNAL_PRESSABLE_AUTH_URL } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useGetProductPricingInfo } from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-marketplace';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import { useSelector } from 'calypso/state';
@@ -122,7 +123,7 @@ export default function RegularPlanCardContent( {
 					variant="secondary"
 					target="_blank"
 					rel="norefferer nooppener"
-					href="https://my.pressable.com/agency/auth"
+					href={ EXTERNAL_PRESSABLE_AUTH_URL }
 					__next40pxDefaultSize
 				>
 					{ translate( 'Manage in Pressable ↗' ) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -3,6 +3,7 @@ import { formatCurrency, formatNumber, formatNumberCompact } from '@automattic/n
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
+import { EXTERNAL_PRESSABLE_AUTH_URL } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -179,7 +180,7 @@ export default function PlanSelectionDetails( {
 										<Button
 											target="_blank"
 											rel="norefferer nooppener"
-											href="https://my.pressable.com/agency/auth"
+											href={ EXTERNAL_PRESSABLE_AUTH_URL }
 											disabled={ ! isOwner }
 										>
 											{ isOwner

--- a/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offering.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offering.tsx
@@ -5,12 +5,13 @@ import { Badge } from '@automattic/ui';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
-import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+	EXTERNAL_PRESSABLE_AUTH_URL,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import { getActiveAgency, isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-
-const pressableUrl = 'https://my.pressable.com/agency/auth';
 
 const PressableOffering = () => {
 	const translate = useTranslate();
@@ -93,7 +94,7 @@ const PressableOffering = () => {
 						primary
 						target="_blank"
 						rel="norefferer nooppener"
-						href={ pressableUrl }
+						href={ EXTERNAL_PRESSABLE_AUTH_URL }
 					>
 						{ translate( 'View your dashboard ↗' ) }
 					</Button>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -8,6 +8,7 @@ import {
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
 	A4A_SITES_LINK_NEEDS_SETUP,
+	EXTERNAL_PRESSABLE_AUTH_URL,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
 	isPressableHostingProduct,
@@ -61,7 +62,6 @@ export default function LicenseDetailsActions( {
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
 	const isWPCOMHostingLicense = isWPCOMHostingProduct( licenseKey );
-	const pressableManageUrl = 'https://my.pressable.com/agency/auth';
 	const isAutoRenewDisabled =
 		subscription?.status === 'active' && ! subscription.isAutoRenewEnabled;
 
@@ -135,7 +135,7 @@ export default function LicenseDetailsActions( {
 				<Button
 					primary
 					compact
-					href={ pressableManageUrl }
+					href={ EXTERNAL_PRESSABLE_AUTH_URL }
 					target="_blank"
 					rel="noopener noreferrer"
 				>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -12,6 +12,7 @@ import {
 	A4A_SITES_LINK_NEEDS_SETUP,
 	A4A_FEEDBACK_LINK,
 	A4A_LICENSES_LINK,
+	EXTERNAL_PRESSABLE_AUTH_URL,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
 	isPressableHostingProduct,
@@ -66,7 +67,7 @@ export const ManageInPressable = ( { attachedAt }: { attachedAt: string | null }
 			className="license-preview__product-pressable-link"
 			target="_blank"
 			rel="norefferer noopener noreferrer"
-			href="https://my.pressable.com/agency/auth"
+			href={ EXTERNAL_PRESSABLE_AUTH_URL }
 			onClick={ () => {
 				if ( ! isFeedbackShown ) {
 					page.redirect(

--- a/client/a8c-for-agencies/sections/referrals/common/referral-details-table/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/referral-details-table/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 export default function ReferralDetailsTable( { items, fields }: Props ) {
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
-		fields: [ 'product-details', 'assigned-to', 'date', 'total' ],
+		fields: [ 'product-details', 'site-details', 'date', 'total' ],
 	} );
 
 	const { data, paginationInfo } = useMemo( () => {

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
@@ -1,8 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
+import { ExternalLink } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import { EXTERNAL_PRESSABLE_AUTH_URL } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { ReferralPurchase } from '../../types';
 import AssignedTo from '../components/assigned-to';
@@ -31,6 +33,8 @@ const PurchaseItem = ( { purchase, data, isFetching }: PurchaseItemProps ) => {
 		[ dispatch ]
 	);
 
+	const isPressablePlan = purchase.license?.license_key?.startsWith( 'pressable-' );
+
 	return (
 		<div className="referral-purchases-mobile">
 			<div className="referral-purchases-mobile__content">
@@ -48,13 +52,21 @@ const PurchaseItem = ( { purchase, data, isFetching }: PurchaseItemProps ) => {
 				</p>
 			</div>
 			<div className="referral-purchases-mobile__content">
-				<h3>{ translate( 'Assigned to' ).toUpperCase() }</h3>
-				<AssignedTo
-					purchase={ purchase }
-					data={ data }
-					handleAssignToSite={ handleAssignToSite }
-					isFetching={ isFetching }
-				/>
+				<h3>{ translate( 'Site Details' ).toUpperCase() }</h3>
+				{ isPressablePlan && (
+					<ExternalLink href={ EXTERNAL_PRESSABLE_AUTH_URL }>
+						{ translate( 'Manage in Pressable' ) }
+					</ExternalLink>
+				) }
+
+				{ ! isPressablePlan && (
+					<AssignedTo
+						purchase={ purchase }
+						data={ data }
+						handleAssignToSite={ handleAssignToSite }
+						isFetching={ isFetching }
+					/>
+				) }
 			</div>
 			<div className="referral-purchases-mobile__content">
 				<h3>{ translate( 'Total' ).toUpperCase() }</h3>

--- a/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
@@ -46,7 +46,7 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 				label: translate( 'Site details' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
-					if ( item.license.license_key.startsWith( 'pressable-' ) ) {
+					if ( item.license?.license_key?.startsWith( 'pressable-' ) ) {
 						return (
 							<ExternalLink href={ EXTERNAL_PRESSABLE_AUTH_URL }>
 								{ translate( 'Manage in Pressable' ) }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, ReactNode, useCallback } from 'react';
+import { EXTERNAL_PRESSABLE_AUTH_URL } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -47,7 +48,7 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
 					if ( item.license.license_key.startsWith( 'pressable-' ) ) {
 						return (
-							<ExternalLink href="https://my.pressable.com/agency/auth">
+							<ExternalLink href={ EXTERNAL_PRESSABLE_AUTH_URL }>
 								{ translate( 'Manage in Pressable' ) }
 							</ExternalLink>
 						);

--- a/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, ReactNode, useCallback } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
@@ -10,6 +11,7 @@ import DateAssigned from './components/date';
 import ProductDetails from './components/product-details';
 import TotalAmount from './components/total-amount';
 import type { ReferralPurchase } from '../types';
+
 import './style.scss';
 
 export default function ReferralPurchases( { purchases }: { purchases: ReferralPurchase[] } ) {
@@ -39,10 +41,18 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 				enableSorting: false,
 			},
 			{
-				id: 'assigned-to',
-				label: translate( 'Assigned to' ).toUpperCase(),
+				id: 'site-details',
+				label: translate( 'Site details' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
+					if ( item.license.license_key.startsWith( 'pressable-' ) ) {
+						return (
+							<ExternalLink href="https://my.pressable.com/agency/auth">
+								{ translate( 'Manage in Pressable' ) }
+							</ExternalLink>
+						);
+					}
+
 					return (
 						<AssignedTo
 							purchase={ item }

--- a/client/a8c-for-agencies/sections/sites/features/hosting/overview.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/hosting/overview.tsx
@@ -1,6 +1,7 @@
 import { WordPressLogo } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { EXTERNAL_PRESSABLE_AUTH_URL } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import { Site } from '../../types';
@@ -70,7 +71,7 @@ const HostingOverviewPreview = ( { site }: Props ) => {
 									<Button
 										target="_blank"
 										rel="norefferer nooppener"
-										href="https://my.pressable.com/agency/auth"
+										href={ EXTERNAL_PRESSABLE_AUTH_URL }
 										variant="link"
 									>
 										{ translate( 'Manage all Pressable sites ↗' ) }

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -11,6 +11,7 @@ import {
 	A4A_PAYMENT_METHODS_ADD_LINK,
 	A4A_SITES_LINK,
 	A4A_SITES_LINK_NEEDS_SETUP,
+	EXTERNAL_PRESSABLE_AUTH_URL,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
@@ -99,7 +100,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 					buttonProps={ {
 						href:
 							pressableOwnership === 'regular'
-								? 'https://my.pressable.com/agency/auth'
+								? EXTERNAL_PRESSABLE_AUTH_URL
 								: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 						target: pressableOwnership === 'regular' ? '_blank' : undefined,
 					} }


### PR DESCRIPTION
Context: pgjTho-1Le-p2#comment-1764

## Proposed Changes
eature flags, improved context usage, and more accurate labeling and linking in the referrals UI.

**Pressable Premium Plan Section improvements:**
- Added feature flag check (`a4a-pressable-premium-plans`) to control the behavior and visibility of the "Refer now" button. The button now conditionally links to either the main Pressable link or the referral link, and toggles marketplace type context as needed. [[1]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543R1-R13) [[2]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543R28-R31) [[3]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543R42-R44) [[4]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543R54-R57) [[5]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543R77-R90)
- Integrated `MarketplaceTypeContext` to manage and toggle the marketplace type state, enabling more dynamic UI behavior based on user actions and feature flags. [[1]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543R1-R13) [[2]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543R28-R31) [[3]](diffhunk://#diff-919839f2ca06011619277822cf98d5debcd77e5f046371cd5c39dacd46bfa543R42-R44)

<img width="1709" height="839" alt="Screenshot 2026-02-17 at 6 33 38 PM" src="https://github.com/user-attachments/assets/4aa65836-405f-4e64-a685-2c36b178264f" />


**Referrals Table and Details improvements:**
- Changed the referrals details table column from "Assigned to" to "Site details" for clarity, and updated the default fields to match. [[1]](diffhunk://#diff-c66d7aa6657bed17ad5371f374cdbd676b1b186aba52491c11ab6f888eec34e1L19-R19) [[2]](diffhunk://#diff-f7c42947c4ad52cd6acd56091021032301c59e20bc50619bcfe954fd035a7ba2L42-R55)
- For Pressable-related purchases, the "Site details" column now displays a direct "Manage in Pressable" external link instead of a static value, improving user navigation.
- Added the `ExternalLink` component to support external management links in the referrals details.

<img width="874" height="444" alt="Screenshot 2026-02-17 at 6 29 45 PM" src="https://github.com/user-attachments/assets/ac6a7e2e-f9a9-45a1-8d2a-acbae7be6d93" />


These changes collectively improve the usability and flexibility of the Pressable premium plan section and the referrals management experience.

## Why are these changes being made?

* Patches inconsistency with our UI.

## Testing Instructions
* Ensure you use the agency that is on the BD system.
* Use the A4A live link and navigate to http://agencies.localhost:3000/marketplace/hosting/pressable
* Click the '**Premium plan**' tab.
* Click the '**Refer now and get rewarded**' button.
* Confirm it toggles the Referral mode.
* Continue to refer a Pressable plan.
* Once checkout, go to the Referrals dashboard and find the new Referral. Click the **Purchases** tab.
* Confirm that for Pressable products. It now shows a '**Manage in Pressable**' link.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?