### PR TITLE
Agents Manager: fix sidebar on new posts

### DIFF
--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -303,7 +303,8 @@ body.site-editor-php.agents-manager-sidebar-container {
 }
 
 /* Page editor */
-body.post-php.agents-manager-sidebar-container {
+body.post-php.agents-manager-sidebar-container,
+body.post-new-php.agents-manager-sidebar-container {
 	@include sidebar-base( '.edit-post-layout' );
 
 	.edit-post-layout {


### PR DESCRIPTION
The Agents Manager has an invalid sidebar style when creating a new post:

<img width="800" height="1112" alt="image" src="https://github.com/user-attachments/assets/d0f95b7f-ade3-424d-b621-677949fa6d06" />

This is caused by a missing body class check.

Fixes AI-893


## Why are these changes being made?
* Fix body class so docked agents manager displays correctly on new posts

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `cd apps/agents-manager`
* `yarn dev --sync`
* Open new post/page editor with a docked agents manager and confirm the display is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
