### PR TITLE
Domain Flow: Allow purchasing only one domain if coming from CIAB

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -3,7 +3,6 @@ import { isDomainMapping, isDomainTransfer } from '@automattic/calypso-products'
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import {
 	DOMAIN_FLOW,
-	addPlanToCart,
 	addProductsToCart,
 	clearStepPersistedState,
 	replaceProductsInCart,
@@ -387,20 +386,16 @@ const domain: FlowV2< typeof initialize > = {
 
 					const addItemsToCartAndGoToCheckout = () => {
 						setPendingAction( async () => {
+							const aggregatedCartItems = [
+								pickedPlan,
+								...( addOns.length > 0 ? addOns : [] ),
+								...( domainCartItems && domainCartItems.length > 0 ? domainCartItems : [] ),
+							];
+
 							if ( isCiab ) {
-								await replaceProductsInCart( siteSlug, [] );
-							}
-
-							if ( pickedPlan ) {
-								await addPlanToCart( siteSlug, this.name, true, '', pickedPlan );
-							}
-
-							if ( addOns.length > 0 ) {
-								await addProductsToCart( siteSlug, this.name, addOns );
-							}
-
-							if ( domainCartItems ) {
-								await addProductsToCart( siteSlug, this.name, domainCartItems );
+								await replaceProductsInCart( siteSlug, aggregatedCartItems );
+							} else {
+								await addProductsToCart( siteSlug, this.name, aggregatedCartItems );
 							}
 
 							return {

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -6,6 +6,7 @@ import {
 	addPlanToCart,
 	addProductsToCart,
 	clearStepPersistedState,
+	replaceProductsInCart,
 } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -94,6 +95,8 @@ const domain: FlowV2< typeof initialize > = {
 			} ),
 			[]
 		);
+
+		const isCiab = useQuery().get( 'dashboard' ) === 'ciab';
 
 		const redirectTo = useQuery().get( 'redirect_to' ) || undefined;
 		const defaultRedirect = dashboardLink( `/sites/${ siteSlug }/domains` );
@@ -351,7 +354,15 @@ const domain: FlowV2< typeof initialize > = {
 								};
 							}
 
-							await addProductsToCart( providedDependencies.siteSlug, this.name, domainCartItems );
+							if ( isCiab ) {
+								await replaceProductsInCart( providedDependencies.siteSlug, domainCartItems );
+							} else {
+								await addProductsToCart(
+									providedDependencies.siteSlug,
+									this.name,
+									domainCartItems
+								);
+							}
 						}
 
 						return {
@@ -376,6 +387,10 @@ const domain: FlowV2< typeof initialize > = {
 
 					const addItemsToCartAndGoToCheckout = () => {
 						setPendingAction( async () => {
+							if ( isCiab ) {
+								await replaceProductsInCart( siteSlug, [] );
+							}
+
 							if ( pickedPlan ) {
 								await addPlanToCart( siteSlug, this.name, true, '', pickedPlan );
 							}

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -387,7 +387,7 @@ const domain: FlowV2< typeof initialize > = {
 					const addItemsToCartAndGoToCheckout = () => {
 						setPendingAction( async () => {
 							const aggregatedCartItems = [
-								pickedPlan,
+								...( pickedPlan ? [ pickedPlan ] : [] ),
 								...( addOns.length > 0 ? addOns : [] ),
 								...( domainCartItems && domainCartItems.length > 0 ? domainCartItems : [] ),
 							];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -86,6 +86,8 @@ const DomainSearchStep: StepType< {
 	const dashboard = queryParams.get( 'dashboard' );
 	const { __ } = useI18n();
 
+	const isCiab = dashboard === 'ciab';
+
 	// eslint-disable-next-line no-nested-ternary
 	const currentSiteUrl = site?.URL ? site.URL : siteSlug ? `https://${ siteSlug }` : undefined;
 	// eslint-disable-next-line no-nested-ternary
@@ -310,7 +312,7 @@ const DomainSearchStep: StepType< {
 			events={ events }
 			flowAllowsMultipleDomainsInCart={
 				isOnboardingFlow( flow ) ||
-				isDomainFlow( flow ) ||
+				( isDomainFlow( flow ) && ! isCiab ) ||
 				isNewHostedSiteCreationFlow( flow ) ||
 				isDomainAndPlanFlow( flow )
 			}


### PR DESCRIPTION
Closes WOOPRD-2003.

## Proposed Changes

Adds flow modifiers so that it's possible to pick only one domain when browsing `/setup/domain` coming from the CIAB dashboard.

## Testing Instructions

Enter http://my.localhost:3000/ciab/domains, click `Add domain name > Search domain names`. Verify you're sent to `/setup/domain?dashboard=ciab`.

Verify you don't see the mini cart stuck at the bottom of the page. Pick a domain and verify that you're sent to the next step immediately.

Create a new site and see your new, single domain at checkout.

Go through the flow again and this time pick an existing website, preferably one that already has cart items. Verify you end up at checkout with the single domain (and potentially a plan) instead of whatever you had in the cart before.