### PR TITLE
A4A: Disable Purchases and Dev site creation when agency is not yet approved.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v1.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v1.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
+import { Tooltip } from '@wordpress/components';
 import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -19,6 +20,7 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -55,6 +57,9 @@ function CheckoutV1( { isClient, referralBlogId }: Props ) {
 	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
 
 	const canIssueLicenses = agency?.can_issue_licenses ?? true;
+	const isAgencyPendingOrRejected =
+		agency?.approval_status === ApprovalStatus.PENDING ||
+		agency?.approval_status === ApprovalStatus.REJECTED;
 	const [ showPopover, setShowPopover ] = useState( false );
 	const wrapperRef = useRef< HTMLButtonElement | null >( null );
 
@@ -171,28 +176,43 @@ function CheckoutV1( { isClient, referralBlogId }: Props ) {
 			<NoticeSummary type="agency-purchase" />
 
 			<div className="checkout__aside-actions">
-				<span
-					role="button"
-					tabIndex={ 0 }
-					className="checkout__aside-actions-wrapper"
-					onMouseEnter={ handleShowPopover }
-					onClick={ handleShowPopover }
-					onKeyUp={ ( event ) => {
-						if ( event.key === 'Enter' || event.key === ' ' ) {
-							handleShowPopover;
-						}
-					} }
+				<Tooltip
+					text={
+						isAgencyPendingOrRejected
+							? translate(
+									'Your agency is not yet approved. Please wait for approval before making a purchase.'
+							  )
+							: undefined
+					}
 				>
-					<Button
-						primary
-						onClick={ onCheckout }
-						disabled={ ! checkoutItems.length || ! isReady || ! canIssueLicenses }
-						busy={ ! isReady }
-						ref={ wrapperRef }
+					<span
+						role="button"
+						tabIndex={ 0 }
+						className="checkout__aside-actions-wrapper"
+						onMouseEnter={ handleShowPopover }
+						onClick={ handleShowPopover }
+						onKeyUp={ ( event ) => {
+							if ( event.key === 'Enter' || event.key === ' ' ) {
+								handleShowPopover;
+							}
+						} }
 					>
-						{ translate( 'Purchase' ) }
-					</Button>
-				</span>
+						<Button
+							primary
+							onClick={ onCheckout }
+							disabled={
+								! checkoutItems.length ||
+								! isReady ||
+								! canIssueLicenses ||
+								isAgencyPendingOrRejected
+							}
+							busy={ ! isReady }
+							ref={ wrapperRef }
+						>
+							{ translate( 'Purchase' ) }
+						</Button>
+					</span>
+				</Tooltip>
 
 				{ siteId ? (
 					<Button onClick={ cancelPurchase }>{ translate( 'Cancel' ) }</Button>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v1.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/checkout-v1.tsx
@@ -19,8 +19,10 @@ import LayoutHeader, {
 	LayoutHeaderBreadcrumb as Breadcrumb,
 } from 'calypso/layout/hosting-dashboard/header';
 import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
+import {
+	getActiveAgency,
+	hasApprovedAgencyStatus,
+} from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
@@ -57,9 +59,8 @@ function CheckoutV1( { isClient, referralBlogId }: Props ) {
 	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
 
 	const canIssueLicenses = agency?.can_issue_licenses ?? true;
-	const isAgencyPendingOrRejected =
-		agency?.approval_status === ApprovalStatus.PENDING ||
-		agency?.approval_status === ApprovalStatus.REJECTED;
+	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
+
 	const [ showPopover, setShowPopover ] = useState( false );
 	const wrapperRef = useRef< HTMLButtonElement | null >( null );
 
@@ -178,7 +179,7 @@ function CheckoutV1( { isClient, referralBlogId }: Props ) {
 			<div className="checkout__aside-actions">
 				<Tooltip
 					text={
-						isAgencyPendingOrRejected
+						! isAgencyApproved
 							? translate(
 									'Your agency is not yet approved. Please wait for approval before making a purchase.'
 							  )
@@ -201,10 +202,7 @@ function CheckoutV1( { isClient, referralBlogId }: Props ) {
 							primary
 							onClick={ onCheckout }
 							disabled={
-								! checkoutItems.length ||
-								! isReady ||
-								! canIssueLicenses ||
-								isAgencyPendingOrRejected
+								! checkoutItems.length || ! isReady || ! canIssueLicenses || ! isAgencyApproved
 							}
 							busy={ ! isReady }
 							ref={ wrapperRef }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -1,5 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { useContext } from 'react';
+import page from '@automattic/calypso-router';
+import { useContext, useEffect } from 'react';
+import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
 import { MarketplaceTypeContext } from '../context';
 import withMarketplaceProviders from '../hoc/with-marketplace-providers';
 import { MARKETPLACE_TYPE_REFERRAL } from '../hoc/with-marketplace-type';
@@ -16,6 +21,21 @@ interface CheckoutProps {
 function Checkout( { referralBlogId, isClient, siteSlug, planSlug }: CheckoutProps ) {
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const isReferralMarketplace = marketplaceType === MARKETPLACE_TYPE_REFERRAL;
+
+	const currentAgency = useSelector( getActiveAgency );
+	const isAgencyPendingOrRejected =
+		currentAgency?.approval_status === ApprovalStatus.PENDING ||
+		currentAgency?.approval_status === ApprovalStatus.REJECTED;
+
+	useEffect( () => {
+		if ( isAgencyPendingOrRejected && ! isClient ) {
+			page.redirect( A4A_MARKETPLACE_LINK );
+		}
+	}, [ isAgencyPendingOrRejected, isClient ] );
+
+	if ( isAgencyPendingOrRejected && ! isClient ) {
+		return null;
+	}
 
 	// New Billing Dragon Checkout V2 page: check for BD feature flag and it's not in a referral context
 	if (

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -3,8 +3,7 @@ import page from '@automattic/calypso-router';
 import { useContext, useEffect } from 'react';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
+import { hasApprovedAgencyStatus } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { MarketplaceTypeContext } from '../context';
 import withMarketplaceProviders from '../hoc/with-marketplace-providers';
 import { MARKETPLACE_TYPE_REFERRAL } from '../hoc/with-marketplace-type';
@@ -22,18 +21,15 @@ function Checkout( { referralBlogId, isClient, siteSlug, planSlug }: CheckoutPro
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const isReferralMarketplace = marketplaceType === MARKETPLACE_TYPE_REFERRAL;
 
-	const currentAgency = useSelector( getActiveAgency );
-	const isAgencyPendingOrRejected =
-		currentAgency?.approval_status === ApprovalStatus.PENDING ||
-		currentAgency?.approval_status === ApprovalStatus.REJECTED;
+	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
 
 	useEffect( () => {
-		if ( isAgencyPendingOrRejected && ! isClient ) {
+		if ( ! isAgencyApproved && ! isClient ) {
 			page.redirect( A4A_MARKETPLACE_LINK );
 		}
-	}, [ isAgencyPendingOrRejected, isClient ] );
+	}, [ isAgencyApproved, isClient ] );
 
-	if ( isAgencyPendingOrRejected && ! isClient ) {
+	if ( ! isAgencyApproved && ! isClient ) {
 		return null;
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-plan-section/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import clsx from 'clsx';
 import { TranslateResult } from 'i18n-calypso';
 import { Children } from 'react';
@@ -21,6 +21,7 @@ type AsideProps = BaseProps & {
 		disabled?: boolean;
 		href?: string;
 		target?: string;
+		tooltip?: string;
 	};
 };
 
@@ -42,19 +43,23 @@ function Aside( { heading, cta, children }: AsideProps ) {
 
 			<footer className="hosting-plan-section__aside-footer">
 				{ cta && (
-					<Button
-						className="hosting-plan-section__aside-button"
-						variant={ cta.variant }
-						onClick={ cta.onClick }
-						disabled={ cta.disabled }
-						{ ...( cta.href && { href: cta.href, target: cta.target } ) }
-						icon={ cta.icon }
-						iconPosition="right"
-						iconSize={ 16 }
-						__next40pxDefaultSize
-					>
-						{ cta.label }
-					</Button>
+					<Tooltip text={ cta.tooltip }>
+						<span>
+							<Button
+								className="hosting-plan-section__aside-button"
+								variant={ cta.variant }
+								onClick={ cta.onClick }
+								disabled={ cta.disabled }
+								{ ...( cta.href && { href: cta.href, target: cta.target } ) }
+								icon={ cta.icon }
+								iconPosition="right"
+								iconSize={ 16 }
+								__next40pxDefaultSize
+							>
+								{ cta.label }
+							</Button>
+						</span>
+					</Tooltip>
 				) }
 			</footer>
 		</aside>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
@@ -14,8 +14,7 @@ import {
 import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
 import { getWPCOMCreatorPlan } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
+import { hasApprovedAgencyStatus } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import HostingPlanSection from '../../common/hosting-plan-section';
 import WPCOMPlanSlider from '../wpcom-plan-selector/slider';
@@ -36,10 +35,7 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 
 	const { data: devLicenses } = useFetchDevLicenses();
 
-	const currentAgency = useSelector( getActiveAgency );
-	const isAgencyPendingOrRejected =
-		currentAgency?.approval_status === ApprovalStatus.PENDING ||
-		currentAgency?.approval_status === ApprovalStatus.REJECTED;
+	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
 
 	const availableDevSites = devLicenses?.available;
 
@@ -161,9 +157,9 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 						label: translate( 'Create a development site' ),
 						variant: 'secondary',
 						icon: arrowRight,
-						disabled: ! availableDevSites || isAgencyPendingOrRejected,
+						disabled: ! availableDevSites || ! isAgencyApproved,
 						onClick: onClickCreateWPCOMDevSite,
-						tooltip: isAgencyPendingOrRejected
+						tooltip: ! isAgencyApproved
 							? translate(
 									'Your agency is not yet approved. Please wait for approval before creating a development site.'
 							  )

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
@@ -13,7 +13,9 @@ import {
 } from 'calypso/a8c-for-agencies/sections/marketplace/context';
 import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
 import { getWPCOMCreatorPlan } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import HostingPlanSection from '../../common/hosting-plan-section';
 import WPCOMPlanSlider from '../wpcom-plan-selector/slider';
@@ -33,6 +35,11 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 	const dispatch = useDispatch();
 
 	const { data: devLicenses } = useFetchDevLicenses();
+
+	const currentAgency = useSelector( getActiveAgency );
+	const isAgencyPendingOrRejected =
+		currentAgency?.approval_status === ApprovalStatus.PENDING ||
+		currentAgency?.approval_status === ApprovalStatus.REJECTED;
 
 	const availableDevSites = devLicenses?.available;
 
@@ -154,8 +161,13 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 						label: translate( 'Create a development site' ),
 						variant: 'secondary',
 						icon: arrowRight,
-						disabled: ! availableDevSites,
+						disabled: ! availableDevSites || isAgencyPendingOrRejected,
 						onClick: onClickCreateWPCOMDevSite,
+						tooltip: isAgencyPendingOrRejected
+							? translate(
+									'Your agency is not yet approved. Please wait for approval before creating a development site.'
+							  )
+							: undefined,
 					} }
 				>
 					<p>

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
@@ -1,9 +1,11 @@
 import { Button } from '@automattic/components';
-import { Popover } from '@wordpress/components';
+import { Popover, Tooltip } from '@wordpress/components';
 import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import CommissionsInfo from '../../commissions-info';
 import { MarketplaceTypeContext, TermPricingContext } from '../../context';
@@ -22,6 +24,11 @@ type Props = {
 
 export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, items }: Props ) {
 	const translate = useTranslate();
+
+	const currentAgency = useSelector( getActiveAgency );
+	const isAgencyPendingOrRejected =
+		currentAgency?.approval_status === ApprovalStatus.PENDING ||
+		currentAgency?.approval_status === ApprovalStatus.REJECTED;
 
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const { termPricing } = useContext( TermPricingContext );
@@ -81,14 +88,25 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 						<CommissionsInfo items={ items } termPricing={ termPricing } />
 					) }
 
-					<Button
-						className="shopping-cart__menu-checkout-button"
-						onClick={ onCheckout }
-						disabled={ ! items.length }
-						primary
+					<Tooltip
+						text={
+							isAgencyPendingOrRejected
+								? translate(
+										'Your agency is not yet approved. Please wait for approval before making a purchase.'
+								  )
+								: undefined
+						}
 					>
-						{ translate( 'Checkout' ) }
-					</Button>
+						<span className="shopping-cart__menu-checkout-button">
+							<Button
+								onClick={ onCheckout }
+								disabled={ ! items.length || isAgencyPendingOrRejected }
+								primary
+							>
+								{ translate( 'Checkout' ) }
+							</Button>
+						</span>
+					</Tooltip>
 				</div>
 			</div>
 		</Popover>

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
@@ -4,8 +4,7 @@ import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import { useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
+import { hasApprovedAgencyStatus } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import CommissionsInfo from '../../commissions-info';
 import { MarketplaceTypeContext, TermPricingContext } from '../../context';
@@ -25,10 +24,7 @@ type Props = {
 export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, items }: Props ) {
 	const translate = useTranslate();
 
-	const currentAgency = useSelector( getActiveAgency );
-	const isAgencyPendingOrRejected =
-		currentAgency?.approval_status === ApprovalStatus.PENDING ||
-		currentAgency?.approval_status === ApprovalStatus.REJECTED;
+	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
 
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const { termPricing } = useContext( TermPricingContext );
@@ -90,7 +86,7 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 
 					<Tooltip
 						text={
-							isAgencyPendingOrRejected
+							! isAgencyApproved
 								? translate(
 										'Your agency is not yet approved. Please wait for approval before making a purchase.'
 								  )
@@ -100,7 +96,7 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 						<span className="shopping-cart__menu-checkout-button">
 							<Button
 								onClick={ onCheckout }
-								disabled={ ! items.length || isAgencyPendingOrRejected }
+								disabled={ ! items.length || ! isAgencyApproved }
 								primary
 							>
 								{ translate( 'Checkout' ) }

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
@@ -92,9 +92,13 @@
 .shopping-cart__menu-checkout-button {
 	display: flex;
 	align-items: center;
-	justify-content: center;
-	min-height: 40px;
-	@include heading-medium;
-	border-radius: 4px;
-	margin-block-start: 20px;
+	justify-content: stretch;
+
+	.button {
+		@include heading-medium;
+		border-radius: 4px;
+		margin-block-start: 20px;
+		min-height: 40px;
+		width: 100%;
+	}
 }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/index.tsx
@@ -10,8 +10,7 @@ import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-crea
 import PressableBanner from 'calypso/assets/images/a8c-for-agencies/pressable-card-banner.svg';
 import WPCOMBanner from 'calypso/assets/images/a8c-for-agencies/wpcom-card-banner.svg';
 import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
+import { hasApprovedAgencyStatus } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
@@ -50,10 +49,7 @@ export default function MigrationsHostingOptions() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const currentAgency = useSelector( getActiveAgency );
-	const isAgencyPendingOrRejected =
-		currentAgency?.approval_status === ApprovalStatus.PENDING ||
-		currentAgency?.approval_status === ApprovalStatus.REJECTED;
+	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
 
 	const { data: devLicenses } = useFetchDevLicenses();
 
@@ -117,7 +113,7 @@ export default function MigrationsHostingOptions() {
 						<Tooltip
 							key="create-dev-site-cta-button"
 							text={
-								isAgencyPendingOrRejected
+								! isAgencyApproved
 									? translate(
 											'Your agency is not yet approved. Please wait for approval before creating a development site.'
 									  )
@@ -127,7 +123,7 @@ export default function MigrationsHostingOptions() {
 							<span>
 								<Button
 									variant="secondary"
-									disabled={ ! availableDevSites || isAgencyPendingOrRejected }
+									disabled={ ! availableDevSites || ! isAgencyApproved }
 									onClick={ onClickCreateWPCOMDevSite }
 								>
 									{ translate( 'Create a development site →' ) }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Card } from '@wordpress/components';
+import { Button, Card, Tooltip } from '@wordpress/components';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
@@ -9,7 +9,9 @@ import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fet
 import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
 import PressableBanner from 'calypso/assets/images/a8c-for-agencies/pressable-card-banner.svg';
 import WPCOMBanner from 'calypso/assets/images/a8c-for-agencies/wpcom-card-banner.svg';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
@@ -47,6 +49,11 @@ function HostingOptionCard( {
 export default function MigrationsHostingOptions() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const currentAgency = useSelector( getActiveAgency );
+	const isAgencyPendingOrRejected =
+		currentAgency?.approval_status === ApprovalStatus.PENDING ||
+		currentAgency?.approval_status === ApprovalStatus.REJECTED;
 
 	const { data: devLicenses } = useFetchDevLicenses();
 
@@ -107,14 +114,26 @@ export default function MigrationsHostingOptions() {
 						comment: '%(pendingSites)s is the number of free licenses available.',
 					} ) }
 					buttons={ [
-						<Button
-							variant="secondary"
+						<Tooltip
 							key="create-dev-site-cta-button"
-							disabled={ ! availableDevSites }
-							onClick={ onClickCreateWPCOMDevSite }
+							text={
+								isAgencyPendingOrRejected
+									? translate(
+											'Your agency is not yet approved. Please wait for approval before creating a development site.'
+									  )
+									: undefined
+							}
 						>
-							{ translate( 'Create a development site →' ) }
-						</Button>,
+							<span>
+								<Button
+									variant="secondary"
+									disabled={ ! availableDevSites || isAgencyPendingOrRejected }
+									onClick={ onClickCreateWPCOMDevSite }
+								>
+									{ translate( 'Create a development site →' ) }
+								</Button>
+							</span>
+						</Tooltip>,
 					] }
 				/>
 

--- a/client/components/add-new-site/menu-item.tsx
+++ b/client/components/add-new-site/menu-item.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { TranslateResult } from 'i18n-calypso';
@@ -14,6 +14,7 @@ type Props = {
 	heading: string;
 	icon: JSX.Element;
 	isBanner?: boolean;
+	tooltip?: string;
 };
 
 const AddNewSiteMenuItem: React.FC< Props > = ( {
@@ -24,24 +25,29 @@ const AddNewSiteMenuItem: React.FC< Props > = ( {
 	heading,
 	icon,
 	isBanner,
+	tooltip,
 } ) => {
 	return (
-		<Button
-			{ ...buttonProps }
-			className={ clsx( 'add-new-site__popover-button', {
-				'is-banner': isBanner,
-				'is-disabled': disabled,
-			} ) }
-		>
-			<div className="add-new-site__popover-button-icon">
-				<Icon className="sidebar__menu-icon" icon={ icon } size={ ICON_SIZE } />
-			</div>
-			<div className="add-new-site__popover-button-content">
-				<div className="add-new-site__popover-button-heading">{ heading }</div>
-				<div className="add-new-site__popover-button-description">{ description }</div>
-				{ children }
-			</div>
-		</Button>
+		<Tooltip text={ tooltip }>
+			<span>
+				<Button
+					{ ...buttonProps }
+					className={ clsx( 'add-new-site__popover-button', {
+						'is-banner': isBanner,
+						'is-disabled': disabled,
+					} ) }
+				>
+					<div className="add-new-site__popover-button-icon">
+						<Icon className="sidebar__menu-icon" icon={ icon } size={ ICON_SIZE } />
+					</div>
+					<div className="add-new-site__popover-button-content">
+						<div className="add-new-site__popover-button-heading">{ heading }</div>
+						<div className="add-new-site__popover-button-description">{ description }</div>
+						{ children }
+					</div>
+				</Button>
+			</span>
+		</Tooltip>
 	);
 };
 

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -22,6 +22,9 @@ import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import AddNewSiteContext from 'calypso/components/add-new-site/context';
 import AddNewSiteMenuItem from 'calypso/components/add-new-site/menu-item';
 import AddNewSitePopoverColumn from 'calypso/components/add-new-site/popover-column';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
 import type { AddNewSiteMenuItemsProps } from 'calypso/components/add-new-site/types';
 
 type PendingSite = { features: { wpcom_atomic: { state: string; license_key: string } } };
@@ -32,6 +35,8 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 	const { setVisibleModalType } = useContext( AddNewSiteContext );
 
 	const pressableOwnership = usePressableOwnershipType();
+
+	const currentAgency = useSelector( getActiveAgency );
 
 	const { data: pendingSites } = useFetchPendingSites();
 	const { data: devLicenses } = useFetchDevLicenses();
@@ -48,7 +53,11 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 	const availableDevSites = devLicenses?.available;
 	const hasAvailableDevSites = devLicenses?.available > 0;
 
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
+	const isAgencyPendingOrRejected =
+		currentAgency?.approval_status === ApprovalStatus.PENDING ||
+		currentAgency?.approval_status === ApprovalStatus.REJECTED;
+
+	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' ) && ! isAgencyPendingOrRejected;
 
 	const handleOnClick = useCallback(
 		( modalType: string ) => {

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -23,8 +23,7 @@ import AddNewSiteContext from 'calypso/components/add-new-site/context';
 import AddNewSiteMenuItem from 'calypso/components/add-new-site/menu-item';
 import AddNewSitePopoverColumn from 'calypso/components/add-new-site/popover-column';
 import { useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
+import { hasApprovedAgencyStatus } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import type { AddNewSiteMenuItemsProps } from 'calypso/components/add-new-site/types';
 
 type PendingSite = { features: { wpcom_atomic: { state: string; license_key: string } } };
@@ -35,8 +34,6 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 	const { setVisibleModalType } = useContext( AddNewSiteContext );
 
 	const pressableOwnership = usePressableOwnershipType();
-
-	const currentAgency = useSelector( getActiveAgency );
 
 	const { data: pendingSites } = useFetchPendingSites();
 	const { data: devLicenses } = useFetchDevLicenses();
@@ -53,9 +50,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 	const availableDevSites = devLicenses?.available;
 	const hasAvailableDevSites = devLicenses?.available > 0;
 
-	const isAgencyPendingOrRejected =
-		currentAgency?.approval_status === ApprovalStatus.PENDING ||
-		currentAgency?.approval_status === ApprovalStatus.REJECTED;
+	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
 
 	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
@@ -146,10 +141,10 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 						description={ translate(
 							'Develop WordPress.com sites for as long as you need, with free development sites. Only pay when you launch!'
 						) }
-						disabled={ ! hasAvailableDevSites || isAgencyPendingOrRejected }
+						disabled={ ! hasAvailableDevSites || ! isAgencyApproved }
 						buttonProps={ {
 							onClick: () => {
-								if ( ! hasAvailableDevSites || isAgencyPendingOrRejected ) {
+								if ( ! hasAvailableDevSites || ! isAgencyApproved ) {
 									return;
 								}
 								if ( paymentMethodRequired ) {
@@ -163,7 +158,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 							},
 						} }
 						tooltip={
-							isAgencyPendingOrRejected
+							! isAgencyApproved
 								? translate(
 										'Your agency is not yet approved. Please wait for approval before creating a development site.'
 								  )

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -57,7 +57,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 		currentAgency?.approval_status === ApprovalStatus.PENDING ||
 		currentAgency?.approval_status === ApprovalStatus.REJECTED;
 
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' ) && ! isAgencyPendingOrRejected;
+	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
 	const handleOnClick = useCallback(
 		( modalType: string ) => {
@@ -146,10 +146,10 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 						description={ translate(
 							'Develop WordPress.com sites for as long as you need, with free development sites. Only pay when you launch!'
 						) }
-						disabled={ ! hasAvailableDevSites }
+						disabled={ ! hasAvailableDevSites || isAgencyPendingOrRejected }
 						buttonProps={ {
 							onClick: () => {
-								if ( ! hasAvailableDevSites ) {
+								if ( ! hasAvailableDevSites || isAgencyPendingOrRejected ) {
 									return;
 								}
 								if ( paymentMethodRequired ) {
@@ -162,6 +162,13 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 								setMenuVisible( false );
 							},
 						} }
+						tooltip={
+							isAgencyPendingOrRejected
+								? translate(
+										'Your agency is not yet approved. Please wait for approval before creating a development site.'
+								  )
+								: undefined
+						}
 					>
 						<div>
 							<div className="add-new-site-popover__count">


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/A4A-1987/pending-and-deactivated-agencies-can-create-and-launch-dev-sites

## Proposed Changes
This pull request introduces agency approval status checks throughout the A8C for Agencies marketplace and site management UI. The main goal is to prevent users from performing key actions, such as making purchases or creating development sites, when their agency is pending approval or has been rejected. The changes also enhance user experience by providing clear tooltips explaining why certain actions are disabled.

The most important changes are:

**Agency Approval Enforcement Across UI:**

* Added checks for agency approval status (`PENDING` or `REJECTED`) in key components, disabling actions like checkout, creating dev sites, and adding new sites when the agency is not approved. This logic is now present in checkout flows, shopping cart, hosting plan sections, migration options, and site creation menus. [[1]](diffhunk://#diff-68d485b445f772aa04c09b1e1ac8c2af7843aa838fbd0f123cf81c92f1e0ef4eR60-R62) [[2]](diffhunk://#diff-be4c16d4d6bb07962c39f80ca952686713c80d06e4d3aa15105182cf35ea6f2fR25-R39) [[3]](diffhunk://#diff-b77cc4a79b1bea83aa7cda81a2b5b0d4c059cae4cef552e95c35d96997b2591aR39-R43) [[4]](diffhunk://#diff-c4168c2ee718d33864be6b7217879ac7ad5f6fff6c1e725c9b2578c68b78e401R53-R57) [[5]](diffhunk://#diff-53f5305c620a0fe0597259e73c8ec8cad7d99fe020687e857898cb2ba342e0abR28-R32) [[6]](diffhunk://#diff-f46e298bc8986dbeae1dc4c4aa0bf142e18560ba0d59b2672e4641290fd1f0b1R55-R58)

**User Feedback Enhancements:**

* Introduced contextual tooltips using the `Tooltip` component to inform users why actions are disabled due to agency status, improving clarity and user experience. This is applied to checkout buttons, dev site creation buttons, and site creation menu items. [[1]](diffhunk://#diff-68d485b445f772aa04c09b1e1ac8c2af7843aa838fbd0f123cf81c92f1e0ef4eR179-R187) [[2]](diffhunk://#diff-1704fba7639167b10e29a8dfa83d882a43c68dc412f36db5c71a4dfa83c9edf1R46-R47) [[3]](diffhunk://#diff-b77cc4a79b1bea83aa7cda81a2b5b0d4c059cae4cef552e95c35d96997b2591aL157-R170) [[4]](diffhunk://#diff-c4168c2ee718d33864be6b7217879ac7ad5f6fff6c1e725c9b2578c68b78e401R117-R136) [[5]](diffhunk://#diff-312211fc8958f684ec58a3057936a77b4808beb05a2dc69c7482d86d3c9f2753R28-R32)

**Redirects and UI Blocking:**

* Implemented an automatic redirect to the main marketplace page if a non-client user with a pending or rejected agency tries to access the checkout page, and ensured the UI does not render in such cases.

**Component and Type Updates:**

* Updated button components and their props to accept an optional `tooltip` field, and wrapped actionable buttons in `Tooltip` components for consistent messaging. [[1]](diffhunk://#diff-1704fba7639167b10e29a8dfa83d882a43c68dc412f36db5c71a4dfa83c9edf1R24) [[2]](diffhunk://#diff-312211fc8958f684ec58a3057936a77b4808beb05a2dc69c7482d86d3c9f2753R17)

**Styling Adjustments:**

* Adjusted styling for checkout buttons in the shopping cart to ensure full-width display and consistent alignment with the new tooltip wrappers.

These changes collectively ensure that agency approval status is consistently enforced across the product, with clear communication to users about restrictions and next steps.
<img width="690" height="380" alt="Screenshot 2026-02-17 at 8 46 44 PM" src="https://github.com/user-attachments/assets/bfa965bf-3c9b-4d3b-b1d2-a31648fb7a35" />
<img width="942" height="448" alt="Screenshot 2026-02-17 at 8 47 53 PM" src="https://github.com/user-attachments/assets/5ad6b45e-4076-4a83-b584-01590df6a3d1" />
<img width="628" height="364" alt="Screenshot 2026-02-17 at 8 52 54 PM" src="https://github.com/user-attachments/assets/3efdb062-cce4-4b73-9c40-55bd4809498d" />
<img width="663" height="181" alt="Screenshot 2026-02-17 at 8 56 16 PM" src="https://github.com/user-attachments/assets/b980e568-387b-48cb-ac59-651434a31e5d" />
<img width="542" height="275" alt="Screenshot 2026-02-17 at 9 04 00 PM" src="https://github.com/user-attachments/assets/dd769b80-6fa3-42af-80d5-1eb4f177c09d" />

## Why are these changes being made?
This is causing us problems with our stats and a broken flow for Agencies that are yet to be approved.

## Testing Instructions

* Set your agencies status to 'Pending' or 'Rejected' in the MC tool.
* Use the A4A live link and navigate to the marketplace.
* Confirm you are not able to do checkout.
* Navigate to the Overview page, Sites page, and Migrations page.
* Confirm you are not able to create sites for all access points.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
