### PR TITLE
Domain Flow: Add items to cart if picking the free plan through the escape hatch

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -324,6 +324,8 @@ const domain: FlowV2< typeof initialize > = {
 
 				case STEPS.SITE_PICKER.slug: {
 					if ( ! siteHasPaidPlan( providedDependencies.site ) ) {
+						setSiteUrl( providedDependencies.siteSlug );
+
 						return navigate(
 							`${ STEPS.UNIFIED_PLANS.slug }?siteSlug=${ providedDependencies.siteSlug }`
 						);
@@ -372,21 +374,7 @@ const domain: FlowV2< typeof initialize > = {
 					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.
 					setProductCartItems( addOns );
 
-					if ( ! pickedPlan ) {
-						// Since we're removing the paid domain, it means that the user chose to continue
-						// with a free domain. Because signupDomainOrigin should reflect the last domain
-						// selection status before they land on the checkout page, this value can be
-						// 'free' or 'choose-later'
-						if ( signupDomainOrigin === 'choose-later' ) {
-							setSignupDomainOrigin( signupDomainOrigin );
-						} else {
-							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
-						}
-
-						if ( siteSlug ) {
-							return goToCheckout( siteSlug );
-						}
-					} else if ( siteSlug ) {
+					const addItemsToCartAndGoToCheckout = () => {
 						setPendingAction( async () => {
 							if ( pickedPlan ) {
 								await addPlanToCart( siteSlug, this.name, true, '', pickedPlan );
@@ -408,6 +396,24 @@ const domain: FlowV2< typeof initialize > = {
 						} );
 
 						return navigate( STEPS.PROCESSING.slug );
+					};
+
+					if ( ! pickedPlan ) {
+						// Since we're removing the paid domain, it means that the user chose to continue
+						// with a free domain. Because signupDomainOrigin should reflect the last domain
+						// selection status before they land on the checkout page, this value can be
+						// 'free' or 'choose-later'
+						if ( signupDomainOrigin === 'choose-later' ) {
+							setSignupDomainOrigin( signupDomainOrigin );
+						} else {
+							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
+						}
+
+						if ( siteSlug ) {
+							return addItemsToCartAndGoToCheckout();
+						}
+					} else if ( siteSlug ) {
+						return addItemsToCartAndGoToCheckout();
 					}
 
 					setSignupCompleteFlowName( this.name );

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -34,12 +34,6 @@ const selectors = {
 		}
 		return `button.is-${ name.toLowerCase() }-plan:visible`;
 	},
-	selectModalUpsellPlanButton: ( name: 'Free' | 'Personal' ) => {
-		if ( name === 'Free' ) {
-			return 'button.is-upsell-modal-free-plan:visible';
-		}
-		return `button.is-upsell-modal-${ name.toLowerCase() }-plan:visible`;
-	},
 
 	// Navigation
 	mobileNavTabsToggle: 'button.section-nav__mobile-header',
@@ -133,13 +127,22 @@ export class PlansPage {
 	 * @param {Plans} plan Plan to select.
 	 */
 	async selectModalUpsellPlan( plan: Plans ): Promise< void > {
-		if ( plan !== 'Free' && plan !== 'Personal' ) {
+		if ( plan !== 'Free' && plan !== 'Personal' && plan !== 'Premium' ) {
 			throw Error( `Unsupported plan to be selected in modal upsell: ${ plan }` );
 		}
 
-		const locator = this.page.locator( selectors.selectModalUpsellPlanButton( plan ) );
+		const locator = this.page.getByText( 'start with a free plan' );
 
 		await locator.first().click();
+
+		const continueWithPlanButton = this.page.getByRole( 'button', {
+			name: `Continue with ${ plan } plan`,
+		} );
+		if ( await continueWithPlanButton.isVisible() ) {
+			await continueWithPlanButton.click();
+		} else {
+			await this.page.getByRole( 'button', { name: `Get ${ plan } plan` } ).click();
+		}
 	}
 
 	/* Generic */

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -104,4 +104,27 @@ export class SignupPickPlanPage {
 
 		await Promise.all( actions );
 	}
+
+	/**
+	 * Selects the Free plan escape hatch on the modal upsell.
+	 *
+	 * @param {Plans} planName Name of the plan.
+	 * @param {RegExp} redirectUrl Optional redirect URL to wait for.
+	 * @returns {Promise<void>}
+	 */
+	async selectEscapeHatchWithoutSiteCreation(
+		planName: Plans,
+		redirectUrl?: RegExp
+	): Promise< void > {
+		await this.page.waitForURL( plansPageUrl );
+
+		redirectUrl ??= new RegExp( '.*checkout.*' );
+
+		const actions = [
+			this.page.waitForURL( redirectUrl, { timeout: 30 * 1000 } ),
+			this.plansPage.selectModalUpsellPlan( planName ),
+		];
+
+		await Promise.all( actions );
+	}
 }


### PR DESCRIPTION
## Proposed Changes

While working on #108747, I noticed that if you click the "start with free plan" escape hatch within `/setup/domain` while on an existing site, the domains that you picked in the domain step wouldn't actually be in the cart.

This PR makes sure we won't have this problem anymore.

## Testing Instructions

Enter `/setup/domain`, pick a domain, pick an existing site in the site picker, then click the escape hatch at the subtitle of the plans step.

Continue with the free plan and verify you end up at the checkout step of the corresponding site with the domain items in the cart.