### PR TITLE
Agents Manager: fix publish panel

### DIFF
--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/style.scss
@@ -313,6 +313,14 @@ body.post-php.agents-manager-sidebar-container {
 	&.agents-manager-sidebar-container--sidebar-open {
 		@include sidebar-open-base( '.edit-post-layout' );
 		@include editor-save-panel-open();
+
+		.editor-post-publish-panel {
+			top: $layout-spacing;
+			bottom: $layout-spacing;
+			right: $sidebar-width + $layout-spacing;
+			animation: none;
+			transform: translateX( 0 );
+		}
 	}
 }
 


### PR DESCRIPTION
Adjusts the post editor publish panel for the docked Agents Manager sidebar:

<img width="1352" height="1538" alt="image" src="https://github.com/user-attachments/assets/0c405b02-300f-490b-979d-2e66fa01f4a7" />

Fixes AI-859

Note this disables the slide-in animation. This seemed the best way of handling it without having to make too many CSS changes, and doesn't noticeably impact the editor.

## Why are these changes being made?

* The publish panel needs adjusting for the docked Agents Manager sidebar.

## Testing Instructions

* `cd apps/agents-manager`
* `yarn dev --sync`
* Edit an unpublished post with the docked Agents Manager
* Press the publish button
* Confirm the publish panel appears as in the screenshot and not on the top of the sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
