### PR TITLE
Sidebar: Add support for inline icons to the Calypso sidebar

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -19,7 +19,7 @@ export default function SidebarItem( props ) {
 		'tooltip tooltip-right': !! props.tooltip,
 	} );
 	const sidebarIsCollapsed = useSelector( getSidebarIsCollapsed );
-	const { icon, customIcon, count, badge } = props;
+	const { icon, customIcon, count, badge, inlineIcon } = props;
 
 	let _preloaded = false;
 
@@ -84,6 +84,9 @@ export default function SidebarItem( props ) {
 						</Badge>
 					) }
 				</span>
+				{ inlineIcon && (
+					<span className={ 'sidebar__inline-icon dashicons-before ' + inlineIcon } aria-hidden />
+				) }
 				{ ( showAsExternal || props.forceShowExternalIcon ) &&
 					! ( sidebarIsCollapsed || props.sidebarIsCollapsed ) && (
 						<Icon icon={ external } size={ 18 } />
@@ -114,4 +117,5 @@ SidebarItem.propTypes = {
 	count: PropTypes.number,
 	badge: PropTypes.string,
 	sidebarIsCollapsed: PropTypes.bool,
+	inlineIcon: PropTypes.string,
 };

--- a/client/my-sites/sidebar/item.jsx
+++ b/client/my-sites/sidebar/item.jsx
@@ -19,6 +19,7 @@ export const MySitesSidebarUnifiedItem = ( {
 	badge,
 	count,
 	icon,
+	inlineIcon,
 	isSubItem = false,
 	selected = false,
 	slug,
@@ -53,6 +54,7 @@ export const MySitesSidebarUnifiedItem = ( {
 			onNavigate={ onNavigate }
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
+			inlineIcon={ inlineIcon }
 			forceInternalLink={ shouldOpenExternalLinksInCurrentTab }
 			forceExternalLink={ forceExternalLink }
 			forceShowExternalIcon={ forceShowExternalIcon }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -295,6 +295,15 @@ $font-size: rem(14px);
 			opacity: 0.8;
 		}
 
+		.sidebar__inline-icon {
+			opacity: 0.8;
+			position: absolute;
+			right: 16px;
+			&::before {
+				font-size: 16px;
+			}
+		}
+
 		img.sidebar__menu-icon {
 			opacity: 0.6;
 		}
@@ -684,6 +693,10 @@ $font-size: rem(14px);
 				}
 			}
 		}
+
+		.sidebar__inline-icon {
+			right: 8px;
+		}
 	}
 
 	&.is-classic-bright,
@@ -817,6 +830,9 @@ $font-size: rem(14px);
 		}
 
 		.sidebar__inline-text {
+			display: none;
+		}
+		.sidebar__inline-icon {
 			display: none;
 		}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13317

## Proposed Changes

* Add support for `inlineIcon` from the nav unification endpoint to the Sidebar. This icon is a Dashicon that will be output on the right of the sidebar (same location as count or plan badges).

<img width="277" height="216" alt="Screenshot 2026-02-17 at 14 15 22" src="https://github.com/user-attachments/assets/b7111b47-ac2d-4850-986d-573248a74a40" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `inlineIcon` property has been introduced in https://github.com/Automattic/jetpack/pull/47146 for the new standalone top-level Hosting menu item opening the MSD site overview panel, which is technically external to the site dashboard.

## Deployment considerations

This change is complementary to the Jetpack change, but the two don't technically depend on each others and can be merged indipendently without particular concerns.

Ideally, the Calypso change should be merged first, but if the Jetpack change is merged first instead, then the Hosting menu item will simply appear without external icon when viewing Calypso screens.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions for https://github.com/Automattic/jetpack/pull/47146.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
