### PR TITLE
Split cancel from refund in MSD

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
@@ -43,7 +43,7 @@ export default function CancelButton( {
 			! state.atomicRevertConfirmed &&
 			purchase.is_plan ) ||
 		( isDomainRegistrationPurchase && ! state.domainConfirmationConfirmed ) ||
-		! ( state?.customerConfirmedUnderstanding || false );
+		( ! state.showDomainOptionsStep && ! state.customerConfirmedUnderstanding );
 
 	const cancelButtonText = ( () => {
 		if ( includedDomainPurchase ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-full-text.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-full-text.tsx
@@ -1,6 +1,7 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { intlFormat } from 'date-fns';
+import { hasAmountAvailableToRefund, isDotcomPlan } from '../../../utils/purchase';
 import RefundAmountString from './refund-amount-string';
 import type { Purchase } from '@automattic/api-core';
 
@@ -24,7 +25,11 @@ export default function CancellationFullText( {
 		includedDomainPurchase,
 	} );
 
-	if ( refundAmountString ) {
+	// Skip refund text for refundable dotcom plans since refund is offered via the notice
+	if (
+		refundAmountString &&
+		! ( isDotcomPlan( purchase ) && hasAmountAvailableToRefund( purchase ) )
+	) {
 		return createInterpolateElement(
 			sprintf(
 				/* translators: $(refundText)s is of the form "[currency-symbol][amount]" i.e. "$20" */

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-full-text.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-full-text.tsx
@@ -1,7 +1,7 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { intlFormat } from 'date-fns';
-import { hasAmountAvailableToRefund, isDotcomPlan } from '../../../utils/purchase';
+import { shouldShowRefundEligibilityNotice } from '../../../utils/purchase';
 import RefundAmountString from './refund-amount-string';
 import type { Purchase } from '@automattic/api-core';
 
@@ -26,10 +26,7 @@ export default function CancellationFullText( {
 	} );
 
 	// Skip refund text for refundable dotcom plans since refund is offered via the notice
-	if (
-		refundAmountString &&
-		! ( isDotcomPlan( purchase ) && hasAmountAvailableToRefund( purchase ) )
-	) {
+	if ( refundAmountString && ! shouldShowRefundEligibilityNotice( purchase ) ) {
 		return createInterpolateElement(
 			sprintf(
 				/* translators: $(refundText)s is of the form "[currency-symbol][amount]" i.e. "$20" */

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -48,13 +48,13 @@ import {
 	hasMarketplaceProduct,
 	isAgencyPartnerType,
 	isAkismetTemporarySitePurchase,
-	isDotcomPlan,
 	isExpired,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 	isJetpackTemporarySitePurchase,
 	isAkismetProduct,
 	isPartnerPurchase,
 	isOneTimePurchase,
+	shouldShowRefundEligibilityNotice,
 } from '../../../utils/purchase';
 import CancelHeaderTitle from './cancel-header-title';
 import CancelPurchaseForm from './cancel-purchase-form';
@@ -1045,8 +1045,7 @@ export default function CancelPurchase() {
 		// If default Cancel button on refundable wpcom plan, use auto-renew flow
 		else if (
 			flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND &&
-			isDotcomPlan( purchase ) &&
-			hasAmountAvailableToRefund( purchase )
+			shouldShowRefundEligibilityNotice( purchase )
 		) {
 			effectiveFlowType = CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
 		}
@@ -1301,7 +1300,7 @@ export default function CancelPurchase() {
 			notices={
 				! state.surveyShown &&
 				! state.showDomainOptionsStep &&
-				( hasAmountAvailableToRefund( purchase ) && isDotcomPlan( purchase ) ? (
+				( shouldShowRefundEligibilityNotice( purchase ) ? (
 					<RefundEligibilityNotice
 						purchase={ purchase }
 						onClaimRefund={ onCancellationStartForRefund }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1300,8 +1300,8 @@ export default function CancelPurchase() {
 			}
 			notices={
 				! state.surveyShown &&
-				( hasAmountAvailableToRefund( purchase ) &&
-				getPurchaseCancellationFlowType( purchase ) === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND ? (
+				! state.showDomainOptionsStep &&
+				( hasAmountAvailableToRefund( purchase ) && isDotcomPlan( purchase ) ? (
 					<RefundEligibilityNotice
 						purchase={ purchase }
 						onClaimRefund={ onCancellationStartForRefund }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1222,12 +1222,13 @@ export default function CancelPurchase() {
 				/>
 			}
 			notices={
-				! state.surveyShown && (
-					<>
-						<RefundEligibilityNotice purchase={ purchase } onClaimRefund={ onCancellationStart } />
-						<TimeRemainingNotice purchase={ purchase } />
-					</>
-				)
+				! state.surveyShown &&
+				( hasAmountAvailableToRefund( purchase ) &&
+				getPurchaseCancellationFlowType( purchase ) === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND ? (
+					<RefundEligibilityNotice purchase={ purchase } onClaimRefund={ onCancellationStart } />
+				) : (
+					<TimeRemainingNotice purchase={ purchase } />
+				) )
 			}
 		>
 			<Card>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -647,11 +647,18 @@ export default function CancelPurchase() {
 		cancelIntent: CancelPurchaseState[ 'cancelIntent' ] = null,
 		customerConfirmedUnderstanding = false
 	) => {
-		// Only show domain options as a separate step if radio buttons will be displayed
-		if (
+		// When the eligibility notice is active and the user clicks the default cancel button
+		// (not the refund link), they're opting for an auto-renew cancellation — no refund, so
+		// no need to ask about the domain. Skip straight to the survey.
+		const skippingDomainOptionsForAutoRenew =
+			shouldShowRefundEligibilityNotice( purchase ) && cancelIntent !== 'refund';
+
+		const needsDomainOptions =
+			! skippingDomainOptionsForAutoRenew &&
 			includedDomainPurchase &&
-			willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase )
-		) {
+			willShowDomainOptionsRadioButtons( includedDomainPurchase, purchase );
+
+		if ( needsDomainOptions ) {
 			setState( ( state ) => ( {
 				...state,
 				cancelIntent,
@@ -660,7 +667,6 @@ export default function CancelPurchase() {
 				showDomainOptionsStep: true,
 			} ) );
 		} else {
-			// For direct cancellations (no domain options step), show survey directly
 			setState( ( state ) => ( {
 				...state,
 				cancelIntent,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -78,6 +78,7 @@ import { getUpsellType } from './get-upsell-type';
 import initialSurveyState from './initial-survey-state';
 import MarketPlaceSubscriptionsDialog from './marketplace-subscriptions-dialog';
 import nextStep from './next-step';
+import RefundEligibilityNotice from './refund-eligibility-notice';
 import TimeRemainingNotice from './time-remaining-notice';
 import type { CancelPurchaseState } from './types';
 import type {
@@ -1220,7 +1221,14 @@ export default function CancelPurchase() {
 					prefix={ <Breadcrumbs length={ 4 } /> }
 				/>
 			}
-			notices={ ! state.surveyShown && <TimeRemainingNotice purchase={ purchase } /> }
+			notices={
+				! state.surveyShown && (
+					<>
+						<RefundEligibilityNotice purchase={ purchase } onClaimRefund={ onCancellationStart } />
+						<TimeRemainingNotice purchase={ purchase } />
+					</>
+				)
+			}
 		>
 			<Card>
 				<CardBody>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -48,6 +48,7 @@ import {
 	hasMarketplaceProduct,
 	isAgencyPartnerType,
 	isAkismetTemporarySitePurchase,
+	isDotcomPlan,
 	isExpired,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 	isJetpackTemporarySitePurchase,
@@ -650,13 +651,25 @@ export default function CancelPurchase() {
 		) {
 			setState( ( state ) => ( {
 				...state,
+				cancelIntent: null,
 				siteId: purchase.blog_id,
 				showDomainOptionsStep: true,
 			} ) );
 		} else {
 			// For direct cancellations (no domain options step), show survey directly
-			setState( ( state ) => ( { ...state, siteId: purchase.blog_id, surveyShown: true } ) );
+			setState( ( state ) => ( {
+				...state,
+				cancelIntent: null,
+				siteId: purchase.blog_id,
+				surveyShown: true,
+			} ) );
 		}
+	};
+
+	const onCancellationStartForRefund = () => {
+		// Set intent to refund before starting cancellation
+		setState( ( state ) => ( { ...state, cancelIntent: 'refund' } ) );
+		onCancellationStart();
 	};
 
 	const clickNext = () => {
@@ -973,14 +986,80 @@ export default function CancelPurchase() {
 		} );
 	};
 
+	const submitTurnOffAutoRenew = ( purchase: Purchase ) => {
+		setPurchaseAutoRenewMutation.mutate(
+			{ purchaseId: purchase.ID, autoRenew: false },
+			{
+				onSuccess: () => {
+					const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
+					const subscriptionEndDate = intlFormat(
+						purchase.expiry_date,
+						{ dateStyle: 'medium' },
+						{ locale: 'en-US' }
+					);
+					createSuccessNotice(
+						sprintf(
+							/* translators: %(purchaseName)s is the name of the product that was purchased, %(subscriptionEndDate)s is the date the product will no longer be available because the subscription has ended */
+							__(
+								'%(purchaseName)s was successfully cancelled. It will be available for use until it expires on %(subscriptionEndDate)s.'
+							),
+							{
+								purchaseName,
+								subscriptionEndDate,
+							}
+						),
+						{ type: 'snackbar' }
+					);
+					navigate( {
+						to: purchaseSettingsRoute.fullPath,
+						params: { purchaseId: purchase.ID },
+					} );
+				},
+				onError: () => {
+					const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
+					createErrorNotice(
+						sprintf(
+							/* translators: %(purchaseName)s is the name of the product that was purchased. */
+							__(
+								'There was a problem canceling %(purchaseName)s. Please try again later or contact support.'
+							),
+							{ purchaseName }
+						),
+						{ type: 'snackbar' }
+					);
+					setState( ( state ) => ( { ...state, surveyShown: false, isLoading: false } ) );
+				},
+			}
+		);
+	};
+
 	const onSurveyComplete = () => {
 		// Set loading state to show busy button
 		setState( ( state ) => ( { ...state, isLoading: true } ) );
-		switch ( flowType ) {
+
+		// Determine effective flow type based on cancel intent
+		let effectiveFlowType = flowType;
+
+		// If user clicked refund button, use refund flow
+		if ( state.cancelIntent === 'refund' ) {
+			effectiveFlowType = CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND;
+		}
+		// If default Cancel button on refundable wpcom plan, use auto-renew flow
+		else if (
+			flowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND &&
+			isDotcomPlan( purchase ) &&
+			hasAmountAvailableToRefund( purchase )
+		) {
+			effectiveFlowType = CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
+		}
+
+		switch ( effectiveFlowType ) {
 			case CANCEL_FLOW_TYPE.REMOVE:
 				submitRemovePurchase( purchase );
 				break;
 			case CANCEL_FLOW_TYPE.CANCEL_AUTORENEW:
+				submitTurnOffAutoRenew( purchase );
+				break;
 			case CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND:
 				submitCancelAndRefundPurchase( purchase );
 				break;
@@ -1225,7 +1304,10 @@ export default function CancelPurchase() {
 				! state.surveyShown &&
 				( hasAmountAvailableToRefund( purchase ) &&
 				getPurchaseCancellationFlowType( purchase ) === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND ? (
-					<RefundEligibilityNotice purchase={ purchase } onClaimRefund={ onCancellationStart } />
+					<RefundEligibilityNotice
+						purchase={ purchase }
+						onClaimRefund={ onCancellationStartForRefund }
+					/>
 				) : (
 					<TimeRemainingNotice purchase={ purchase } />
 				) )

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -643,7 +643,10 @@ export default function CancelPurchase() {
 		} ) );
 	};
 
-	const onCancellationStart = ( cancelIntent: CancelPurchaseState[ 'cancelIntent' ] = null ) => {
+	const onCancellationStart = (
+		cancelIntent: CancelPurchaseState[ 'cancelIntent' ] = null,
+		customerConfirmedUnderstanding = false
+	) => {
 		// Only show domain options as a separate step if radio buttons will be displayed
 		if (
 			includedDomainPurchase &&
@@ -652,6 +655,7 @@ export default function CancelPurchase() {
 			setState( ( state ) => ( {
 				...state,
 				cancelIntent,
+				customerConfirmedUnderstanding,
 				siteId: purchase.blog_id,
 				showDomainOptionsStep: true,
 			} ) );
@@ -660,6 +664,7 @@ export default function CancelPurchase() {
 			setState( ( state ) => ( {
 				...state,
 				cancelIntent,
+				customerConfirmedUnderstanding,
 				siteId: purchase.blog_id,
 				surveyShown: true,
 			} ) );
@@ -667,7 +672,9 @@ export default function CancelPurchase() {
 	};
 
 	const onCancellationStartForRefund = () => {
-		onCancellationStart( 'refund' );
+		// Explicitly clicking the refund notice button is the user's confirmation — skip the
+		// confirmation checkbox that would otherwise be required on the pre-survey screen.
+		onCancellationStart( 'refund', true );
 	};
 
 	const clickNext = () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -643,7 +643,7 @@ export default function CancelPurchase() {
 		} ) );
 	};
 
-	const onCancellationStart = () => {
+	const onCancellationStart = ( cancelIntent: CancelPurchaseState[ 'cancelIntent' ] = null ) => {
 		// Only show domain options as a separate step if radio buttons will be displayed
 		if (
 			includedDomainPurchase &&
@@ -651,7 +651,7 @@ export default function CancelPurchase() {
 		) {
 			setState( ( state ) => ( {
 				...state,
-				cancelIntent: null,
+				cancelIntent,
 				siteId: purchase.blog_id,
 				showDomainOptionsStep: true,
 			} ) );
@@ -659,7 +659,7 @@ export default function CancelPurchase() {
 			// For direct cancellations (no domain options step), show survey directly
 			setState( ( state ) => ( {
 				...state,
-				cancelIntent: null,
+				cancelIntent,
 				siteId: purchase.blog_id,
 				surveyShown: true,
 			} ) );
@@ -667,9 +667,7 @@ export default function CancelPurchase() {
 	};
 
 	const onCancellationStartForRefund = () => {
-		// Set intent to refund before starting cancellation
-		setState( ( state ) => ( { ...state, cancelIntent: 'refund' } ) );
-		onCancellationStart();
+		onCancellationStart( 'refund' );
 	};
 
 	const clickNext = () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -631,7 +631,7 @@ export default function CancelPurchase() {
 	const onCancelConfirmationStateChange = ( newState: Partial< CancelPurchaseState > ) => {
 		setState( ( state ) => ( {
 			...state,
-			newState,
+			...newState,
 		} ) );
 	};
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -1,0 +1,56 @@
+import { Button } from '@wordpress/components';
+import { sprintf, __ } from '@wordpress/i18n';
+import Notice from '../../../components/notice';
+import { hasAmountAvailableToRefund, isDotcomPlan } from '../../../utils/purchase';
+import RefundAmountString from './refund-amount-string';
+import type { Purchase } from '@automattic/api-core';
+
+interface RefundEligibilityNoticeProps {
+	purchase: Purchase;
+	onClaimRefund: () => void;
+}
+
+export default function RefundEligibilityNotice( {
+	purchase,
+	onClaimRefund,
+}: RefundEligibilityNoticeProps ) {
+	// Only show for refundable WordPress.com plans
+	if (
+		! hasAmountAvailableToRefund( purchase ) ||
+		! isDotcomPlan( purchase ) ||
+		! purchase.is_plan
+	) {
+		return null;
+	}
+
+	const refundAmount = RefundAmountString( {
+		purchase,
+		cancelBundledDomain: false,
+		includedDomainPurchase: undefined,
+	} );
+
+	if ( ! refundAmount ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			variant="info"
+			actions={
+				<Button variant="link" isDestructive onClick={ onClaimRefund }>
+					{ __( 'Remove plan and claim refund' ) }
+				</Button>
+			}
+		>
+			{ sprintf(
+				/* translators: %(refundAmount)s is a monetary amount in the form "[currency-symbol][amount]" */
+				__(
+					"You're eligible for a %(refundAmount)s refund if you remove your plan now. Your features will be unavailable right away."
+				),
+				{
+					refundAmount,
+				}
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import Notice from '../../../components/notice';
-import { hasAmountAvailableToRefund, isDotcomPlan } from '../../../utils/purchase';
+import { shouldShowRefundEligibilityNotice } from '../../../utils/purchase';
 import RefundAmountString from './refund-amount-string';
 import type { Purchase } from '@automattic/api-core';
 
@@ -14,12 +14,7 @@ export default function RefundEligibilityNotice( {
 	purchase,
 	onClaimRefund,
 }: RefundEligibilityNoticeProps ) {
-	// Only show for refundable WordPress.com plans
-	if (
-		! hasAmountAvailableToRefund( purchase ) ||
-		! isDotcomPlan( purchase ) ||
-		! purchase.is_plan
-	) {
+	if ( ! shouldShowRefundEligibilityNotice( purchase ) ) {
 		return null;
 	}
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -1,7 +1,11 @@
 import { Button } from '@wordpress/components';
-import { sprintf, __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import Notice from '../../../components/notice';
-import { shouldShowRefundEligibilityNotice } from '../../../utils/purchase';
+import {
+	hasAmountAvailableToRefund,
+	shouldShowRefundEligibilityNotice,
+} from '../../../utils/purchase';
 import RefundAmountString from './refund-amount-string';
 import type { Purchase } from '@automattic/api-core';
 
@@ -14,29 +18,22 @@ export default function RefundEligibilityNotice( {
 	purchase,
 	onClaimRefund,
 }: RefundEligibilityNoticeProps ) {
-	if ( ! shouldShowRefundEligibilityNotice( purchase ) ) {
-		return null;
-	}
-
-	const refundAmount = RefundAmountString( {
-		purchase,
-		cancelBundledDomain: false,
-		includedDomainPurchase: undefined,
-	} );
-
-	if ( ! refundAmount ) {
+	if (
+		! shouldShowRefundEligibilityNotice( purchase ) ||
+		! hasAmountAvailableToRefund( purchase )
+	) {
 		return null;
 	}
 
 	return (
 		<Notice variant="info">
-			{ sprintf(
-				/* translators: %(refundAmount)s is a monetary amount in the form "[currency-symbol][amount]" */
+			{ createInterpolateElement(
+				/* translators: <refundAmount /> is a monetary amount in the form "[currency-symbol][amount]" */
 				__(
-					"You're eligible for a %(refundAmount)s refund if you remove your plan now. Your features will be unavailable right away."
+					"You're eligible for a <refundAmount /> refund if you remove your plan now. Your features will be unavailable right away."
 				),
 				{
-					refundAmount,
+					refundAmount: <RefundAmountString purchase={ purchase } cancelBundledDomain={ false } />,
 				}
 			) }{ ' ' }
 			<Button variant="link" isDestructive onClick={ onClaimRefund }>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -34,14 +34,7 @@ export default function RefundEligibilityNotice( {
 	}
 
 	return (
-		<Notice
-			variant="info"
-			actions={
-				<Button variant="link" isDestructive onClick={ onClaimRefund }>
-					{ __( 'Remove plan and claim refund' ) }
-				</Button>
-			}
-		>
+		<Notice variant="info">
 			{ sprintf(
 				/* translators: %(refundAmount)s is a monetary amount in the form "[currency-symbol][amount]" */
 				__(
@@ -50,7 +43,10 @@ export default function RefundEligibilityNotice( {
 				{
 					refundAmount,
 				}
-			) }
+			) }{ ' ' }
+			<Button variant="link" isDestructive onClick={ onClaimRefund }>
+				{ __( 'Remove plan and claim refund' ) }
+			</Button>
 		</Notice>
 	);
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
@@ -2,7 +2,11 @@ import config from '@automattic/calypso-config';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Text } from '../../../components/text';
-import { hasAmountAvailableToRefund, isOneTimePurchase } from '../../../utils/purchase';
+import {
+	hasAmountAvailableToRefund,
+	isOneTimePurchase,
+	isDotcomPlan,
+} from '../../../utils/purchase';
 import type { Purchase, Domain } from '@automattic/api-core';
 
 interface CancelPurchaseRefundInformationProps {
@@ -20,7 +24,10 @@ const CancelPurchaseRefundInformation = ( {
 	const { refund_period_in_days: refundPeriodInDays } = purchase;
 	let text;
 
-	if ( purchase.is_refundable ) {
+	// Treat refundable dotcom plans as non-refundable since refund is offered via the notice
+	const treatAsNonRefundable = isDotcomPlan( purchase ) && hasAmountAvailableToRefund( purchase );
+
+	if ( purchase.is_refundable && ! treatAsNonRefundable ) {
 		if ( purchase.is_domain_registration ) {
 			// Domain bought with domain credits, so there's no refund
 			if ( ! hasAmountAvailableToRefund( purchase ) ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-information.tsx
@@ -5,7 +5,7 @@ import { Text } from '../../../components/text';
 import {
 	hasAmountAvailableToRefund,
 	isOneTimePurchase,
-	isDotcomPlan,
+	shouldShowRefundEligibilityNotice,
 } from '../../../utils/purchase';
 import type { Purchase, Domain } from '@automattic/api-core';
 
@@ -25,7 +25,7 @@ const CancelPurchaseRefundInformation = ( {
 	let text;
 
 	// Treat refundable dotcom plans as non-refundable since refund is offered via the notice
-	const treatAsNonRefundable = isDotcomPlan( purchase ) && hasAmountAvailableToRefund( purchase );
+	const treatAsNonRefundable = shouldShowRefundEligibilityNotice( purchase );
 
 	if ( purchase.is_refundable && ! treatAsNonRefundable ) {
 		if ( purchase.is_domain_registration ) {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/types.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/types.ts
@@ -3,6 +3,7 @@ export interface CancelPurchaseState {
 	atomicRevertCheckTwo?: boolean;
 	atomicRevertConfirmed?: boolean;
 	cancelBundledDomain?: boolean;
+	cancelIntent?: 'refund' | null;
 	confirmCancelBundledDomain?: boolean;
 	customerConfirmedUnderstanding?: boolean;
 	domainConfirmationConfirmed?: boolean;

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -8,6 +8,7 @@ import {
 	TitanMailSlugs,
 	WPCOM_DIFM_LITE,
 } from '@automattic/api-core';
+import config from '@automattic/calypso-config';
 import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -650,6 +651,21 @@ export const getIncludedDomainPurchase = (
 
 export function hasAmountAvailableToRefund( purchase: Purchase ) {
 	return purchase.refund_amount > 0;
+}
+
+/**
+ * Returns true if the refund eligibility notice should be shown for the given purchase.
+ *
+ * The notice is shown for refundable WordPress.com plans when the feature flag is enabled.
+ * When shown, the notice replaces the standard refund flow with an auto-renew cancellation
+ * flow, offering the refund as an explicit opt-in action instead.
+ */
+export function shouldShowRefundEligibilityNotice( purchase: Purchase ): boolean {
+	return (
+		config.isEnabled( 'calypso/refund-eligibility-notice' ) &&
+		hasAmountAvailableToRefund( purchase ) &&
+		isDotcomPlan( purchase )
+	);
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-15962

## Proposed Changes

* Separate cancellations from refunds in MSD


<img width="708" height="703" alt="Screenshot 2026-02-17 at 18 09 39" src="https://github.com/user-attachments/assets/75bfac1b-04f6-4f1c-b054-4e932406d2bb" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get a plan using calypso.localhost and the store sandbox
* Using http://my.localhost:3000/
* Cancel the plan. Confirm that:
- You can get a refund using the new eligibility notice
- You don't get a refund using the Cancel plan button
- When the domain is purchased together with the plan, the new eligibility notice disappears in the domain options step

Non-wpcom plan upgrades, for example standalone domains, should be unaffected.

<img width="731" height="465" alt="Screenshot 2026-02-18 at 17 59 34" src="https://github.com/user-attachments/assets/e3b4f1dd-22a7-4313-9722-93d55b27473b" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
