### PR TITLE
GitHub Deployments: Fix log viewer line wrapping

### DIFF
--- a/client/dashboard/sites/deployments-list/deployment-logs/deployment-logs-entry.tsx
+++ b/client/dashboard/sites/deployments-list/deployment-logs/deployment-logs-entry.tsx
@@ -86,7 +86,7 @@ export const DeploymentLogsEntry = ( {
 	return (
 		<HStack spacing={ 3 }>
 			<VStack spacing={ 2 }>
-				<Text style={ { color: '#FBFBFB' } } as="code">
+				<Text style={ { color: '#FBFBFB', whiteSpace: 'pre-wrap' } } as="code">
 					<Text style={ { color: '#B3AFAE' } }>
 						{ formatDate( new Date( entry.timestamp ), locale, { timeStyle: 'medium' } ) }
 					</Text>{ ' ' }
@@ -106,7 +106,7 @@ export const DeploymentLogsEntry = ( {
 					) }
 				</Text>
 				{ detailExpanded && (
-					<Text style={ { color: '#FBFBFB' } } as="code">
+					<Text style={ { color: '#FBFBFB', whiteSpace: 'pre-wrap' } } as="code">
 						{ getDetail() }
 					</Text>
 				) }


### PR DESCRIPTION
Fixes DOTDEV-345

## Proposed Changes

Update the log viewer styles so long log lines are wrapped.

## Why are these changes being made?

The Hosting Dashboard's GitHub Deployments log viewer outputs log details in one continous line, making these hard to read. The old dashboard handles this correctly with `whiteSpace: 'pre-wrap'` on the `<pre>` elements. This change restores that behavior.

## Testing Instructions

1. Run `yarn start-dashboard` or use the Calypso live link
2. Navigate to a site's GitHub Deployments page
3. Open a deployment and expand the logs where possible ("show more" link)
4. Check that the toggled log lines wrap cleanly with preserved indentation
5. Check that the log still scrolls vertically

| trunk | this branch |
|--------|--------|
| <img width="1698" height="1060" alt="CleanShot 2026-02-17 at 16 15 35@2x" src="https://github.com/user-attachments/assets/49b52cef-5903-4bb6-99df-6647544c3689" /> | <img width="1692" height="1058" alt="CleanShot 2026-02-17 at 16 14 36@2x" src="https://github.com/user-attachments/assets/ff5e515f-26bc-4db3-a140-056128043b6b" /> | 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?