### PR TITLE
CIAB: Early create sites

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -209,16 +209,15 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			};
 		}
 
-		// CIAB early site creation flow: The site was already created earlier during the AI chat session.
+		// Flow A: The site was early-created during the AI chat session.
+		// Flow B: If early_created_site is absent, the regular createSiteWithCart path below handles creation.
 		const earlyCreatedSite = urlQueryParams.get( 'early_created_site' );
 		if ( flow === AI_SITE_BUILDER_FLOW && gardenName && earlyCreatedSite ) {
-			if ( earlyCreatedSite === 'failed' ) {
-				throw new Error(
-					'We were unable to create your store. Please try again or contact support.'
-				);
-			}
-
 			const blogId = parseInt( earlyCreatedSite, 10 );
+
+			if ( isNaN( blogId ) ) {
+				throw new Error( 'Invalid early_created_site parameter.' );
+			}
 
 			// Trigger the AI site builder job. This queues an async job that waits
 			// for provisioning to complete, then runs the Site Builder Workflow Agent.
@@ -227,6 +226,9 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 					path: `/sites/${ blogId }/big-sky/trigger-backend-build`,
 					apiNamespace: 'wpcom/v2',
 					method: 'POST',
+					body: {
+						spec_id: urlQueryParams.get( 'spec_id' ),
+					},
 				} );
 			} catch ( error ) {
 				// eslint-disable-next-line no-console

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -54,9 +54,16 @@ function hasSourceSlug( data: unknown ): data is { sourceSlug: string } {
 	return false;
 }
 
-async function pollForGardenProvisioning( siteId: number, maxAttempts = 22, delayMs = 5000 ) {
-	// Sleep for 10 seconds to allow for site creation to settle
-	await new Promise( ( resolve ) => setTimeout( resolve, 10000 ) );
+async function pollForGardenProvisioning(
+	siteId: number,
+	maxAttempts = 22,
+	delayMs = 5000,
+	initialDelayMs = 10000
+) {
+	// Initial delay to allow for site creation to settle.
+	if ( initialDelayMs > 0 ) {
+		await new Promise( ( resolve ) => setTimeout( resolve, initialDelayMs ) );
+	}
 
 	for ( let attempt = 1; attempt <= maxAttempts; attempt++ ) {
 		try {
@@ -198,6 +205,45 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			return {
 				siteSlug: getSignupCompleteSlug(),
 				goToCheckout: shouldGoToCheckout,
+				siteCreated: true,
+			};
+		}
+
+		// CIAB early site creation flow: The site was already created earlier during the AI chat session.
+		const earlyCreatedSite = urlQueryParams.get( 'early_created_site' );
+		if ( flow === AI_SITE_BUILDER_FLOW && gardenName && earlyCreatedSite ) {
+			if ( earlyCreatedSite === 'failed' ) {
+				throw new Error(
+					'We were unable to create your store. Please try again or contact support.'
+				);
+			}
+
+			const blogId = parseInt( earlyCreatedSite, 10 );
+
+			// Trigger the AI site builder job. This queues an async job that waits
+			// for provisioning to complete, then runs the Site Builder Workflow Agent.
+			try {
+				await wpcomRequest( {
+					path: `/sites/${ blogId }/big-sky/trigger-backend-build`,
+					apiNamespace: 'wpcom/v2',
+					method: 'POST',
+				} );
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to trigger backend build:', error );
+				throw new Error(
+					'We were unable to build your store. Please try again or contact support.'
+				);
+			}
+
+			// Poll until the provisioning is considered complete.
+			// Skip the initial delay since the site may have been provisioning for minutes already.
+			await pollForGardenProvisioning( blogId, 22, 5000, 0 );
+
+			return {
+				siteId: blogId,
+				siteSlug: String( blogId ),
+				goToCheckout: false,
 				siteCreated: true,
 			};
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -1,4 +1,6 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
+import wpcomRequest from 'wpcom-proxy-request';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSpec } from 'calypso/lib/site-spec';
@@ -7,13 +9,63 @@ import type { Step as StepType } from '../../types';
 
 const SiteSpec: StepType = function SiteSpec() {
 	const translate = useTranslate();
-	// Use the SiteSpec hook to handle the loading and initialization of the SiteSpec widget
 	const queryParams = useQuery();
 	const source = queryParams.get( 'source' );
 
+	let siteCreationPromise: Promise< number | null > | null = null;
+	let isSubmitting = false;
+
+	const handleFirstMessage = async ( _message: string, sessionId: string ) => {
+		siteCreationPromise = ( async () => {
+			try {
+				const response = ( await wpcomRequest( {
+					path: '/sites/new',
+					apiVersion: '1.1',
+					method: 'POST',
+					body: {
+						client_id: config( 'wpcom_signup_id' ),
+						client_secret: config( 'wpcom_signup_key' ),
+						garden_name: 'commerce',
+						garden_partner_name: 'woo',
+						spec_id: sessionId,
+						options: {
+							site_creation_flow: 'ai-site-builder',
+							trigger_backend_build: false,
+						},
+					},
+				} ) ) as { blog_details: { blogid: number } };
+
+				return response?.blog_details?.blogid ?? null;
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to create garden site:', error );
+				return null;
+			}
+		} )();
+	};
+
+	const handleSpecConfirm = async ( specData: any ) => {
+		if ( isSubmitting ) {
+			return;
+		}
+		isSubmitting = true;
+
+		const specId = specData.spec_id || specData.session_id || '';
+		const blogId = siteCreationPromise ? await siteCreationPromise : null;
+		const earlyCreatedParam = blogId || 'failed';
+
+		window.location.href = `/setup/ai-site-builder/?create_garden_site=1&spec_id=${ encodeURIComponent(
+			specId
+		) }&early_created_site=${ earlyCreatedParam }`;
+	};
+
 	let siteSpecConfig: SiteSpecConfig | undefined;
 	if ( source && source.startsWith( 'ciab-' ) ) {
-		siteSpecConfig = getCiabSiteSpecConfig() as SiteSpecConfig;
+		siteSpecConfig = {
+			...getCiabSiteSpecConfig(),
+			onFirstMessage: handleFirstMessage,
+			onSpecConfirm: handleSpecConfirm,
+		} as SiteSpecConfig;
 	}
 
 	useSiteSpec( { siteSpecConfig } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -4,71 +4,79 @@ import wpcomRequest from 'wpcom-proxy-request';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSpec } from 'calypso/lib/site-spec';
-import { getCiabSiteSpecConfig, type SiteSpecConfig } from 'calypso/lib/site-spec/utils';
+import { getCiabSiteSpecConfig } from 'calypso/lib/site-spec/utils';
 import type { Step as StepType } from '../../types';
 
 const SiteSpec: StepType = function SiteSpec() {
 	const translate = useTranslate();
 	const queryParams = useQuery();
 	const source = queryParams.get( 'source' );
+	const isCiab = source && source.startsWith( 'ciab-' );
 
 	let siteCreationPromise: Promise< number | null > | null = null;
+	let messageCount = 0;
 	let isSubmitting = false;
 
-	const handleFirstMessage = async ( _message: string, sessionId: string ) => {
-		siteCreationPromise = ( async () => {
-			try {
-				const response = ( await wpcomRequest( {
-					path: '/sites/new',
-					apiVersion: '1.1',
-					method: 'POST',
-					body: {
-						client_id: config( 'wpcom_signup_id' ),
-						client_secret: config( 'wpcom_signup_key' ),
-						garden_name: 'commerce',
-						garden_partner_name: 'woo',
-						spec_id: sessionId,
-						options: {
-							site_creation_flow: 'ai-site-builder',
-							trigger_backend_build: false,
+	const handleMessage = () => {
+		messageCount++;
+		if ( messageCount === 1 ) {
+			siteCreationPromise = ( async () => {
+				try {
+					const response = ( await wpcomRequest( {
+						path: '/sites/new',
+						apiVersion: '1.1',
+						method: 'POST',
+						body: {
+							client_id: config( 'wpcom_signup_id' ),
+							client_secret: config( 'wpcom_signup_key' ),
+							garden_name: 'commerce',
+							garden_partner_name: 'woo',
+							blog_title: '',
+							blog_name: '',
+							options: {
+								site_creation_flow: 'ai-site-builder',
+								trigger_backend_build: false,
+							},
 						},
-					},
-				} ) ) as { blog_details: { blogid: number } };
+					} ) ) as { blog_details: { blogid: number } };
 
-				return response?.blog_details?.blogid ?? null;
-			} catch ( error ) {
-				// eslint-disable-next-line no-console
-				console.error( 'Failed to create garden site:', error );
-				return null;
-			}
-		} )();
+					return response?.blog_details?.blogid ?? null;
+				} catch ( error ) {
+					// eslint-disable-next-line no-console
+					console.error( 'Failed to create garden site:', error );
+					return null;
+				}
+			} )();
+		}
 	};
 
 	const handleSpecConfirm = async ( specData: any ) => {
 		if ( isSubmitting ) {
 			return;
 		}
+
 		isSubmitting = true;
 
-		const specId = specData.spec_id || specData.session_id || '';
+		const specId = specData.session_id || '';
 		const blogId = siteCreationPromise ? await siteCreationPromise : null;
-		const earlyCreatedParam = blogId || 'failed';
 
-		window.location.href = `/setup/ai-site-builder/?create_garden_site=1&spec_id=${ encodeURIComponent(
+		let url = `/setup/ai-site-builder/?create_garden_site=1&spec_id=${ encodeURIComponent(
 			specId
-		) }&early_created_site=${ earlyCreatedParam }`;
+		) }`;
+		if ( blogId ) {
+			url += `&early_created_site=${ encodeURIComponent( blogId ) }`;
+		}
+
+		window.location.href = url;
 	};
 
-	let siteSpecConfig: SiteSpecConfig | undefined;
-	if ( source && source.startsWith( 'ciab-' ) ) {
-		siteSpecConfig = {
-			...getCiabSiteSpecConfig(),
-			onFirstMessage: handleFirstMessage,
-			onSpecConfirm: handleSpecConfirm,
-		} as SiteSpecConfig;
-	}
+	const siteSpecConfig = isCiab ? getCiabSiteSpecConfig() : undefined;
 
-	useSiteSpec( { siteSpecConfig } );
+	useSiteSpec( {
+		siteSpecConfig,
+		onMessage: isCiab ? handleMessage : undefined,
+		onSpecConfirm: isCiab ? handleSpecConfirm : undefined,
+	} );
 
 	return (
 		<>

--- a/client/lib/site-spec/use-site-spec.ts
+++ b/client/lib/site-spec/use-site-spec.ts
@@ -13,6 +13,7 @@ declare global {
 				buildSiteUrl?: string;
 				locale?: string;
 				onMessage?: ( message: unknown ) => void;
+				onSpecConfirm?: ( specData: unknown ) => void | Promise< void >;
 				onError?: ( error: unknown ) => void;
 			} ) => void;
 		};
@@ -34,6 +35,7 @@ function resolveContainer( target: string | HTMLElement ): HTMLElement | null {
 type UseSiteSpecOptions = {
 	container?: string | HTMLElement;
 	onMessage?: ( message: unknown ) => void;
+	onSpecConfirm?: ( specData: unknown ) => void;
 	onError?: ( error: unknown ) => void;
 	siteSpecConfig?: SiteSpecConfig;
 };
@@ -43,7 +45,13 @@ type UseSiteSpecOptions = {
  * Cleans up global loader state on unmount.
  */
 export function useSiteSpec( options: UseSiteSpecOptions = {} ) {
-	const { container = '#site-spec-container', onMessage, onError, siteSpecConfig } = options;
+	const {
+		container = '#site-spec-container',
+		onMessage,
+		onSpecConfirm,
+		onError,
+		siteSpecConfig,
+	} = options;
 
 	const locale = useLocale();
 
@@ -83,6 +91,7 @@ export function useSiteSpec( options: UseSiteSpecOptions = {} ) {
 					...config,
 					locale,
 					onMessage,
+					onSpecConfirm,
 					onError,
 				} );
 
@@ -102,5 +111,5 @@ export function useSiteSpec( options: UseSiteSpecOptions = {} ) {
 			resetSiteSpecScriptState();
 		};
 		// Re-run only if the container target, handlers, locale, or config change.
-	}, [ container, onMessage, onError, locale, siteSpecConfig ] );
+	}, [ container, onMessage, onSpecConfirm, onError, locale, siteSpecConfig ] );
 }

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -31,6 +31,8 @@ export interface SiteSpecConfig {
 	agentUrl?: string;
 	agentId?: string;
 	buildSiteUrl?: string;
+	onFirstMessage?: ( message: string, sessionId: string ) => void;
+	onSpecConfirm?: ( specData: any ) => void;
 	theme?: {
 		// Branding
 		brandIcon?: SVGRectElement | string | null; // ReactElement or image URL; null hides

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -31,8 +31,6 @@ export interface SiteSpecConfig {
 	agentUrl?: string;
 	agentId?: string;
 	buildSiteUrl?: string;
-	onFirstMessage?: ( message: string, sessionId: string ) => void;
-	onSpecConfirm?: ( specData: any ) => void;
 	theme?: {
 		// Branding
 		brandIcon?: SVGRectElement | string | null; // ReactElement or image URL; null hides


### PR DESCRIPTION
1. When the user sends their first chat message, send a backend request to start creating the site.
2. After confirming the spec, call `/trigger-backend-build` to attach the spec ID to the early-created-site and trigger AI building.

If the early site creation fails, it will fallback to existing functionality where a new site creation request will be sent on the next step after the redirect.

## Testing

Go to `http://my.woo.localhost:3000/sites` and create a new store, spending about ~30 seconds between sending the first message and confirming the spec. After creating "create my store", you should be redirected and dropped into the site quite quickly (~10secs spent cold-loading wp-admin).

Note: The AI builder won't actually run unless you also sandbox the async job and run the sandbox jobs watcher