### PR TITLE
E2E: Fix block inserter selector in openBlockInserter

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -119,9 +119,7 @@ export class EditorToolbarComponent {
 		} );
 
 		if ( ! ( await this.targetIsOpen( blockInserterButton ) ) ) {
-			const editorParent = await this.editor.parent();
-			const locator = editorParent.locator( selectors.blockInserterButton );
-			await locator.click();
+			await blockInserterButton.click();
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Replace brittle CSS class selector (`button[class*="inserter-toggle"]`) with a role-based locator (`getByRole('button', { name: 'Block Inserter' })`) in `openBlockInserter()`.

## Why are these changes being made?

The `openBlockInserter` method in `EditorToolbarComponent` used a CSS selector targeting `button[class*="inserter-toggle"]` to click the block inserter. On Gutenberg Edge, the toolbar DOM structure changed and this class no longer matches, causing `editor__post-basic-flow.ts` (and likely other editor e2e tests) to fail with a timeout.

The method already used `getByRole('button', { name: 'Block Inserter' })` for the state check — this change simply reuses that same resilient locator for the click, matching how `closeBlockInserter()` already works.

**Target element (the blue "+" block inserter button in the toolbar):**

<!-- Drag and drop the annotated screenshot here -->

## Testing Instructions

* Run with Gutenberg Edge: `TEST_ON_ATOMIC=true GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test -- specs/editor/editor__post-basic-flow.ts`
* All 22 tests pass after the fix.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?