### PR TITLE
Fix ValidateTaxContactInfoParams in MSD

### DIFF
--- a/packages/api-core/src/me-tax-contact-information.ts
+++ b/packages/api-core/src/me-tax-contact-information.ts
@@ -1,7 +1,7 @@
 import { wpcom } from './wpcom-fetcher';
 
 export interface ValidateTaxContactInfoParams {
-	contactInformation: {
+	contact_information: {
 		country_code?: string;
 		postal_code?: string;
 		address_1?: string;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1668/fix-validatetaxcontactinfoparams-in-msd

## Proposed Changes

This PR fixes the TypeScript type, `ValidateTaxContactInfoParams` which incorrectly had a camelCase param. This type is not currently used anywhere but will be eventually and its types need to be correct.

Discovered while working on https://github.com/Automattic/wp-calypso/pull/108732
