### PR TITLE
Revert "Domain Flow: Add items to cart if picking the free plan through the escape hatch"

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -326,8 +326,6 @@ const domain: FlowV2< typeof initialize > = {
 
 				case STEPS.SITE_PICKER.slug: {
 					if ( ! siteHasPaidPlan( providedDependencies.site ) ) {
-						setSiteUrl( providedDependencies.siteSlug );
-
 						return navigate(
 							`${ STEPS.UNIFIED_PLANS.slug }?siteSlug=${ providedDependencies.siteSlug }`
 						);
@@ -384,7 +382,21 @@ const domain: FlowV2< typeof initialize > = {
 					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.
 					setProductCartItems( addOns );
 
-					const addItemsToCartAndGoToCheckout = () => {
+					if ( ! pickedPlan ) {
+						// Since we're removing the paid domain, it means that the user chose to continue
+						// with a free domain. Because signupDomainOrigin should reflect the last domain
+						// selection status before they land on the checkout page, this value can be
+						// 'free' or 'choose-later'
+						if ( signupDomainOrigin === 'choose-later' ) {
+							setSignupDomainOrigin( signupDomainOrigin );
+						} else {
+							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
+						}
+
+						if ( siteSlug ) {
+							return goToCheckout( siteSlug );
+						}
+					} else if ( siteSlug ) {
 						setPendingAction( async () => {
 							const aggregatedCartItems = [
 								...( pickedPlan ? [ pickedPlan ] : [] ),
@@ -406,24 +418,6 @@ const domain: FlowV2< typeof initialize > = {
 						} );
 
 						return navigate( STEPS.PROCESSING.slug );
-					};
-
-					if ( ! pickedPlan ) {
-						// Since we're removing the paid domain, it means that the user chose to continue
-						// with a free domain. Because signupDomainOrigin should reflect the last domain
-						// selection status before they land on the checkout page, this value can be
-						// 'free' or 'choose-later'
-						if ( signupDomainOrigin === 'choose-later' ) {
-							setSignupDomainOrigin( signupDomainOrigin );
-						} else {
-							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
-						}
-
-						if ( siteSlug ) {
-							return addItemsToCartAndGoToCheckout();
-						}
-					} else if ( siteSlug ) {
-						return addItemsToCartAndGoToCheckout();
 					}
 
 					setSignupCompleteFlowName( this.name );

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -34,6 +34,12 @@ const selectors = {
 		}
 		return `button.is-${ name.toLowerCase() }-plan:visible`;
 	},
+	selectModalUpsellPlanButton: ( name: 'Free' | 'Personal' ) => {
+		if ( name === 'Free' ) {
+			return 'button.is-upsell-modal-free-plan:visible';
+		}
+		return `button.is-upsell-modal-${ name.toLowerCase() }-plan:visible`;
+	},
 
 	// Navigation
 	mobileNavTabsToggle: 'button.section-nav__mobile-header',
@@ -127,22 +133,13 @@ export class PlansPage {
 	 * @param {Plans} plan Plan to select.
 	 */
 	async selectModalUpsellPlan( plan: Plans ): Promise< void > {
-		if ( plan !== 'Free' && plan !== 'Personal' && plan !== 'Premium' ) {
+		if ( plan !== 'Free' && plan !== 'Personal' ) {
 			throw Error( `Unsupported plan to be selected in modal upsell: ${ plan }` );
 		}
 
-		const locator = this.page.getByText( 'start with a free plan' );
+		const locator = this.page.locator( selectors.selectModalUpsellPlanButton( plan ) );
 
 		await locator.first().click();
-
-		const continueWithPlanButton = this.page.getByRole( 'button', {
-			name: `Continue with ${ plan } plan`,
-		} );
-		if ( await continueWithPlanButton.isVisible() ) {
-			await continueWithPlanButton.click();
-		} else {
-			await this.page.getByRole( 'button', { name: `Get ${ plan } plan` } ).click();
-		}
 	}
 
 	/* Generic */

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -104,27 +104,4 @@ export class SignupPickPlanPage {
 
 		await Promise.all( actions );
 	}
-
-	/**
-	 * Selects the Free plan escape hatch on the modal upsell.
-	 *
-	 * @param {Plans} planName Name of the plan.
-	 * @param {RegExp} redirectUrl Optional redirect URL to wait for.
-	 * @returns {Promise<void>}
-	 */
-	async selectEscapeHatchWithoutSiteCreation(
-		planName: Plans,
-		redirectUrl?: RegExp
-	): Promise< void > {
-		await this.page.waitForURL( plansPageUrl );
-
-		redirectUrl ??= new RegExp( '.*checkout.*' );
-
-		const actions = [
-			this.page.waitForURL( redirectUrl, { timeout: 30 * 1000 } ),
-			this.plansPage.selectModalUpsellPlan( planName ),
-		];
-
-		await Promise.all( actions );
-	}
 }

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -6,7 +6,7 @@ import {
 	NewUserResponse,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
-import { tags, test, expect } from '../../lib/pw-base';
+import { tags, test } from '../../lib/pw-base';
 import { apiCloseAccount, apiDeleteSite } from '../shared';
 
 test.describe(
@@ -115,84 +115,7 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can create a free site and then add a domain WITHOUT a plan upgrade', async ( {
-			page,
-			componentDomainSearch,
-			componentSelectItems,
-			componentSiteSelect,
-			helperData,
-			pageCartCheckout,
-			pageSignupPickPlan,
-			pageUserSignUp,
-		} ) => {
-			const siteCreationPlan = 'Free';
-			const testUser = helperData.getNewTestUser();
-			let newUserDetails: NewUserResponse;
-			let newSiteDetails: NewSiteResponse;
-			let selectedDomain: string;
-
-			await test.step( 'When I enter the onboarding flow', async function () {
-				await page.goto( helperData.getCalypsoURL( '/setup' ) );
-			} );
-
-			await test.step( 'And I sign up as a new user', async function () {
-				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
-			} );
-
-			await test.step( 'And I skip the domains step', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( `And I select the ${ siteCreationPlan } plan`, async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan(
-					siteCreationPlan,
-					new RegExp( '.*/home/.*' )
-				);
-				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
-			} );
-
-			await test.step( 'And I enter the domain flow', async function () {
-				await page.goto( helperData.getCalypsoURL( '/setup/domain' ) );
-			} );
-
-			await test.step( 'And I search for a domain', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-			} );
-
-			await test.step( 'And I add the first suggestion to the cart', async function () {
-				selectedDomain = await componentDomainSearch.selectFirstSuggestion();
-			} );
-
-			await test.step( 'And I continue to the next step', async function () {
-				await componentDomainSearch.continue();
-			} );
-
-			await test.step( 'And I select existing site option', async function () {
-				await componentSelectItems.clickButton( 'Existing WordPress.com site', 'Select a site' );
-			} );
-
-			await test.step( 'And I select the site', async function () {
-				await componentSiteSelect.selectSite(
-					newSiteDetails.blog_details.site_slug as string,
-					false
-				);
-			} );
-
-			await test.step( 'And I select the Free plan', async function () {
-				await pageSignupPickPlan.selectEscapeHatchWithoutSiteCreation( 'Free' );
-			} );
-
-			await test.step( 'And I see the domain at checkout', async function () {
-				await pageCartCheckout.validateCartItem( selectedDomain );
-
-				await expect( page ).toHaveURL(
-					new RegExp( `/checkout/${ newSiteDetails.blog_details.site_slug }` )
-				);
-			} );
-		} );
-
-		test( 'As a new user, I can create a free site and then add a domain WITH a plan upgrade', async ( {
+		test( 'As a new user, I can create a free site and then add a domain with a plan upgrade', async ( {
 			page,
 			componentDomainSearch,
 			componentSelectItems,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#108749, it's causing intense e2e flakiness that is blocking the deploy pipeline.