### PR TITLE
Replace my.woo.com with my.woo.ai

### DIFF
--- a/client/dashboard/app-ciab/routing.ts
+++ b/client/dashboard/app-ciab/routing.ts
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 
-const CIAB_DASHBOARD_ALLOWED_HOSTNAMES = [ 'my.woo.localhost', 'my.woo.com' ];
+const CIAB_DASHBOARD_ALLOWED_HOSTNAMES = [ 'my.woo.localhost', 'my.woo.ai' ];
 
 export function isAllowedCiabDashboardHostname( hostname?: string ): boolean {
 	return CIAB_DASHBOARD_ALLOWED_HOSTNAMES.includes( hostname ?? '' );
@@ -11,10 +11,8 @@ export function getCiabDashboardBasePath( hostname: string ): string {
 }
 
 export function buildCiabDashboardLink( path: string = '' ) {
-	// TODO: replace the base URL with the new domain when it's ready.
-
 	if ( config( 'env' ) === 'development' ) {
 		return new URL( `/ciab${ path }`, 'http://my.localhost:3000' ).href;
 	}
-	return new URL( `/ciab${ path }`, 'https://my.wordpress.com' ).href;
+	return new URL( path, 'https://my.woo.ai' ).href;
 }

--- a/client/dashboard/app/command-palette/README.md
+++ b/client/dashboard/app/command-palette/README.md
@@ -60,7 +60,7 @@ export const navigationCommands: Command[] = [
 ];
 ```
 
-The command palette will only register commands for features that are enabled in the current dashboard configuration. This allows different dashboards (e.g., `my.wordpress.com` vs `/ciab`) to show different commands without code duplication.
+The command palette will only register commands for features that are enabled in the current dashboard configuration. This allows different dashboards (e.g., `my.wordpress.com` vs `my.woo.ai`) to show different commands without code duplication.
 
 ## Adding Custom Commands
 

--- a/client/dashboard/docs/entry-points.md
+++ b/client/dashboard/docs/entry-points.md
@@ -10,7 +10,7 @@ The dashboard architecture is designed to support multiple entry points, where e
 Currently, the dashboard supports two main entry points:
 
 - WordPress.com (dotcom) at `my.wordpress.com`
-- CIAB at `/ciab`
+- CIAB at `my.woo.ai`
 
 This multi-entry point approach allows us to reuse the same codebase while tailoring the user experience to specific products and user types.
 

--- a/client/dashboard/utils/link.ts
+++ b/client/dashboard/utils/link.ts
@@ -10,7 +10,7 @@ export function dashboardOrigins(): string[] {
 		'http://my.localhost:3000',
 		'https://my.wordpress.com',
 		'http://my.woo.localhost:3000',
-		'https://my.woo.com',
+		'https://my.woo.ai',
 	];
 }
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -73,7 +73,7 @@ type ReceiptIdOrPlaceholder = ReceiptIdPlaceholder | PurchaseId | ReceiptId;
 const allowedExternalSites = [
 	'my.wordpress.com',
 	'my.localhost',
-	'my.woo.com',
+	'my.woo.ai',
 	'my.woo.localhost',
 	'cloud.jetpack.com',
 	'jetpack.cloud.localhost',

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -267,7 +267,7 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
 		'wpcalypso.wordpress.com',
 		'horizon.wordpress.com',
 		'my.wordpress.com',
-		'my.woo.com',
+		'my.woo.ai',
 		'calypso.localhost',
 		'my.localhost',
 		'my.woo.localhost',

--- a/client/reauth-required/component.jsx
+++ b/client/reauth-required/component.jsx
@@ -8,7 +8,7 @@ import './style.scss';
 
 // Only allow redirects to production environments,
 // as two-step authentication is only available on production environments.
-const ALLOWED_ORIGINS = [ 'https://my.wordpress.com' ];
+const ALLOWED_ORIGINS = [ 'https://my.wordpress.com', 'https://my.woo.ai' ];
 
 export default function ReauthRequired() {
 	useEffect( () => {

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -6,6 +6,7 @@ const CALYPSO_ONLY_HOSTNAMES = [
 	'wpcalypso.wordpress.com',
 	'horizon.wordpress.com',
 	'my.wordpress.com',
+	'my.woo.ai',
 ];
 
 // Subdomains of wordpress.com that do not serve wp-login.php.

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -5,7 +5,7 @@
 	"client_slug": "browser",
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
-	"hostname_allowlist": [ "my.wordpress.com", "my.woo.com" ],
+	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -5,7 +5,7 @@
 	"client_slug": "browser",
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
-	"hostname_allowlist": [ "my.wordpress.com", "my.woo.com" ],
+	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -5,7 +5,7 @@
 	"client_slug": "browser",
 	"survicate_enabled": true,
 	"hostname": "my.wordpress.com",
-	"hostname_allowlist": [ "my.wordpress.com", "my.woo.com" ],
+	"hostname_allowlist": [ "my.wordpress.com", "my.woo.ai" ],
 	"i18n_default_locale_slug": "en",
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -547,6 +547,7 @@ const wpcomAllowedOrigins = [
 	'https://jetpack.com',
 	'https://agencies.automattic.com',
 	'https://my.wordpress.com',
+	'https://my.woo.ai',
 	'http://wpcalypso.wordpress.com', // for running docker on dev instances
 	'http://widgets.wp.com',
 	'https://widgets.wp.com',


### PR DESCRIPTION
Part of DOTMSD-1091

## Proposed Changes

* Replace all `my.woo.com` references with `my.woo.ai` across config and source files
* Resolve TODO in `buildCiabDashboardLink` — use `my.woo.ai` as prod base URL instead of `my.wordpress.com/ciab`
* Add `my.woo.ai` to reauth allowed origins, login form hostnames, and proxy request allowed origins

## Why are these changes being made?

CIAB MSD is moving from `my.woo.com` to `my.woo.ai`. The `my.woo.localhost` dev domain stays unchanged.

## Testing Instructions (some only actionable once DNS changes have been made)

* Verify no remaining references to `my.woo.com` in the codebase: `grep -r "my.woo.com" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" --include="*.json"`
* Verify CIAB dashboard loads correctly on `my.woo.ai` in production
* Verify checkout redirect allowlists accept `my.woo.ai` as a valid redirect target
* Verify reauth flow works when initiated from `my.woo.ai`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?