### PR TITLE
MSD: Fix TypeError in getSiteFromCache() for paginated site queries

### DIFF
--- a/client/dashboard/app/analytics/super-props.ts
+++ b/client/dashboard/app/analytics/super-props.ts
@@ -65,10 +65,15 @@ export function getSiteFromCache( queryClient: QueryClient, siteSlug: string ): 
 		return site;
 	}
 
-	const sitesQueries = queryClient.getQueriesData< Site[] >( { queryKey: sitesQueryKey } );
+	const sitesQueries = queryClient.getQueriesData< Site[] | { sites: Site[] } >( {
+		queryKey: sitesQueryKey,
+	} );
 	const sitesBySlug = new Map(
 		sitesQueries
-			.map( ( [ , sites ] ) => ( sites || [] ).map( ( site ) => [ site.slug, site ] ) )
+			.map( ( [ , data ] ) => {
+				const sites = Array.isArray( data ) ? data : data?.sites;
+				return ( sites || [] ).map( ( site ) => [ site.slug, site ] as const );
+			} )
 			.flat() as [ string, Site ][]
 	);
 


### PR DESCRIPTION
Fixes DOTMSD-1095

## Proposed Changes

The sites query cache may contain paginated response objects (with a `sites` field) instead of plain arrays. Accessing `.map()` directly on these objects caused a "map is not a function" TypeError in Sentry.

The fix is to check whether the data is array, or an object with a `sites` array.

## Why are these changes being made?

Fixes a Sentry bug.

## Testing Instructions

Test no regression when clicking around the Dashboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
