### PR TITLE
Domain-Only Thank You Page Redesign: Enable feature flag globally

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domain-transfer-redesign": true,
-		"domains/new-thank-you-page": false,
+		"domains/new-thank-you-page": true,
 		"email-accounts/enabled": true,
 		"global-styles/on-personal-plan": true,
 		"google-drive": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,7 +35,7 @@
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"domain-transfer-redesign": true,
-		"domains/new-thank-you-page": false,
+		"domains/new-thank-you-page": true,
 		"global-styles/on-personal-plan": true,
 		"google-my-business": false,
 		"help": true,

--- a/config/production.json
+++ b/config/production.json
@@ -45,7 +45,7 @@
 		"dashboard/v2/paginated-site-list": true,
 		"dashboard/v2/backport/site-overview": true,
 		"domain-transfer-redesign": true,
-		"domains/new-thank-you-page": false,
+		"domains/new-thank-you-page": true,
 		"global-styles/on-personal-plan": true,
 		"google-my-business": true,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,7 +45,7 @@
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,
-		"domains/new-thank-you-page": false,
+		"domains/new-thank-you-page": true,
 		"global-styles/on-personal-plan": true,
 		"google-my-business": true,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,7 +50,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domain-transfer-redesign": true,
-		"domains/new-thank-you-page": false,
+		"domains/new-thank-you-page": true,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,


### PR DESCRIPTION
Blocked by #108755.

## Proposed Changes

Enables the redesigned domain-only thank you page globally.

## Testing Instructions

Verify the behavior observed in the linked PR is now the default and you don't need to do anything special to see the redesigned thank you page after purchasing a domain.