### PR TITLE
Fix duplicate launchpad on My Home for new-hosted-site flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -253,7 +253,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		// eslint-disable-next-line no-nested-ternary
 		const siteIntent = isNewSiteMigrationFlow( flow )
 			? 'migration'
-			: isSimplifiedOnboarding
+			: isSimplifiedOnboarding && ! isNewHostedSiteCreationFlow( flow )
 			? // For the simplified onboarding flow, we'll use the build intent since user can't choose the intent.
 			  Onboard.SiteIntent.Build
 			: '';


### PR DESCRIPTION
Related to 204313-ghe-Automattic/wpcom
Related to STU-1252

## Proposed Changes

* Exclude the `new-hosted-site` flow from the simplified onboarding `site_intent` override in the `create-site` step, preventing it from incorrectly setting `site_intent: 'build'`.

## Why are these changes being made?

After the simplified onboarding experiment was merged as the default treatment (f398bb8e15f), all flows sharing the `create-site` step started setting `site_intent: 'build'` — including the `new-hosted-site` flow.

This causes the backend home layout API to receive conflicting signals (`site_creation_flow: 'new-hosted-site'` + `site_intent: 'build'`) and return duplicate launchpad cards in the My Home page layout, rendering the "Next steps for your site" section twice.

This change restores the previous behavior for the `new-hosted-site` flow by falling back to an empty `site_intent`, letting the backend infer the correct layout from the `site_creation_flow` value alone.

## Testing Instructions

* Create a new site via `https://wordpress.com/setup/new-hosted-site/plans`
* Complete the flow and land on the My Home page (`/home/{siteSlug}`)
* Verify the "Next steps for your site" launchpad section appears only once

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?