### PR TITLE
Fix paid subscriptions column spacing and alignment

### DIFF
--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -169,19 +169,18 @@ body.is-section-earn.theme-default.color-scheme {
 
 .paid-subscriptions-list {
 	margin: 20px 0 0;
+	display: grid;
+	grid-template-columns: 2fr 2fr 1fr 1fr auto;
+	gap: 0 16px;
 
 	.row {
-		border-block-end: 1px solid $studio-gray-5;
-		display: flex;
+		display: grid;
+		grid-template-columns: subgrid;
+		grid-column: 1 / -1;
 		align-items: center;
-		flex-direction: row;
-		gap: 16px;
+		border-block-end: 1px solid $studio-gray-5;
 		padding-top: 20px;
 		padding-bottom: 20px;
-
-		> * {
-			flex: 1;
-		}
 
 		.paid-subscriptions-list__checkbox-column,
 		.paid-subscriptions-list__profile-column,
@@ -199,12 +198,10 @@ body.is-section-earn.theme-default.color-scheme {
 		.paid-subscriptions-list__profile-column {
 			display: flex;
 			align-items: center;
-			flex: 2;
 			min-width: 0;
 		}
 
 		.paid-subscriptions-list__offer-type-column {
-			flex: 2;
 			.paid-subscriptions-list__offer-type-title {
 				font-weight: 600;
 				/* stylelint-disable-next-line unit-allowed-list */
@@ -220,7 +217,7 @@ body.is-section-earn.theme-default.color-scheme {
 		}
 
 		.paid-subscriptions-list__menu-column {
-			flex: 0 0 80px;
+			text-align: end;
 
 			.gridicon {
 				fill: $studio-gray-50;
@@ -294,6 +291,7 @@ body.is-section-earn.theme-default.color-scheme {
 
 @media (max-width: $break-large) {
 	.paid-subscriptions-list {
+		grid-template-columns: 2fr 2fr 1fr auto;
 		padding-left: 16px;
 		padding-right: 16px;
 
@@ -305,6 +303,7 @@ body.is-section-earn.theme-default.color-scheme {
 
 @media (max-width: $break-medium) {
 	.paid-subscriptions-list {
+		grid-template-columns: 2fr 1fr auto;
 		padding-left: 16px;
 		padding-right: 16px;
 

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -175,6 +175,7 @@ body.is-section-earn.theme-default.color-scheme {
 		display: flex;
 		align-items: center;
 		flex-direction: row;
+		gap: 16px;
 		padding-top: 20px;
 		padding-bottom: 20px;
 
@@ -219,8 +220,7 @@ body.is-section-earn.theme-default.color-scheme {
 		}
 
 		.paid-subscriptions-list__menu-column {
-			flex-basis: 48px;
-			flex-grow: initial;
+			flex: 0 0 80px;
 
 			.gridicon {
 				fill: $studio-gray-50;


### PR DESCRIPTION
## Proposed Changes

Fixes https://linear.app/a8c/issue/CM-545/alignment-issues-on-monetize-active-paid-subscriptions

* Replace flexbox layout with CSS Grid + `subgrid` on the paid subscriptions table so header and data columns share the same track sizing
* Define `grid-template-columns: 2fr 2fr 1fr 1fr auto` on the list container, with responsive overrides at `$break-large` and `$break-medium`
* Add `gap: 0 16px` between columns so long subscriber names no longer run into the Offer Type column
* Right-align the menu column with `text-align: end` instead of a fixed flex-basis

Before | After
---- | ----
<img width="1134" height="256" alt="Screenshot 2026-02-17 at 4 27 48 PM" src="https://github.com/user-attachments/assets/f2232ec0-04ae-470b-b9b2-80ca3335f686" /> | <img width="1137" height="269" alt="Screenshot 2026-02-18 at 9 33 31 AM" src="https://github.com/user-attachments/assets/f9f2db46-01fa-423c-b900-6fb39a9f9c75" />


## Why are these changes being made?

On `/earn/paid-subscriptions/`, long subscriber names run directly into the Offer Type column with no spacing between them. Additionally, the "Offer Type" header is misaligned with its data because the Export button in the header's menu column overflows its flex-basis, causing the header row's flex distribution to differ from the data rows. Switching to CSS Grid with `subgrid` ensures every row shares the exact same column tracks, eliminating the misalignment entirely.

## Testing Instructions

* Navigate to `/earn/paid-subscriptions/` on a site with active paid subscribers
* Verify there is spacing between the Name and Offer Type columns, especially with long subscriber names
* Verify the "Offer Type" header aligns with the data below it
* Check that the Export button in the header row doesn't cause column misalignment
* Resize the browser to check responsive behavior at medium and large breakpoints
* Test with different locales and RTL

Note that there's a misalignment on the Payment settings tab in all dev environments. It doesn't seem to be related to this change.
<img width="1101" height="542" alt="Screenshot 2026-02-18 at 10 18 40 AM" src="https://github.com/user-attachments/assets/fd723cb4-9654-4e30-a307-ad45b09266e8" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)