### PR TITLE
Agents Manager: use shouldLoadInlineHelp to exclude certain routes

### DIFF
--- a/client/layout/agents-manager-loader.tsx
+++ b/client/layout/agents-manager-loader.tsx
@@ -5,15 +5,22 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { shouldLoadInlineHelp } from './utils';
 
-export default function AgentsManagerLoader( { sectionName }: { sectionName: string } ) {
+export default function AgentsManagerLoader( {
+	sectionName,
+	currentRoute,
+}: {
+	sectionName: string;
+	currentRoute: string;
+} ) {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 	const user = useSelector( getCurrentUser );
 	const selectedSite = useSelector( getSelectedSite );
 	const primarySiteSlug = useSelector( getPrimarySiteSlug );
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
 
-	if ( ! shouldUseUnifiedAgent ) {
+	if ( ! shouldUseUnifiedAgent || ! shouldLoadInlineHelp( sectionName, currentRoute ) ) {
 		return null;
 	}
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -269,7 +269,10 @@ class Layout extends Component {
 					currentRoute={ this.props.currentRoute }
 					source={ isA8CForAgencies() ? 'a4a' : 'wpcom' }
 				/>
-				<AgentsManagerLoader sectionName={ this.props.sectionName } />
+				<AgentsManagerLoader
+					sectionName={ this.props.sectionName }
+					currentRoute={ this.props.currentRoute }
+				/>
 				{ ! shouldDisableSidebarScrollSynchronizer && (
 					<SidebarScrollSynchronizer layoutFocus={ this.props.currentLayoutFocus } />
 				) }


### PR DESCRIPTION
Help Center uses the `shouldLoadInlineHelp` function to avoid showing on some routes, and we should do the same for Agents Manager. This will then mean we no longer load on places like the Jetpack connect pages, which is an awkward place for Agents Manager to appear.

<img width="2606" height="1816" alt="image" src="https://github.com/user-attachments/assets/04c64b32-fec0-45c7-bfaf-12c0b62f0df4" />

Fixes AI-866

## Why are these changes being made?

* Use the same page exclusion code as Help Center

## Testing Instructions

* `yarn start` in Calypso
* Go through the Jetpack connection process so you end up on `wordpress.com/jetpack/connect/`. If you follow the Big Sky local setup process then this will happen as part of that
* Copy the relative path from the connection page and load it in your local Calypso: httpp://calypso.localhost:3000/jetpack/connect/authorize...
* Confirm that Agents Manager does not appear and is not loaded (there will be an async-load-automattic-agents-manager resource loaded, but nothing more)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
