### PR TITLE
SummerSpecial cleanup: Remove unused type parameters

### DIFF
--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -434,7 +434,7 @@ export type Plan = BillingTerm & {
 	 * to determine what a given plan *may* be capable of doing
 	 * before verifying with an API.
 	 */
-	getIncludedFeatures?: ( hasSummerSpecialSticker?: boolean ) => Feature[];
+	getIncludedFeatures?: () => Feature[];
 
 	/**
 	 * Features that are superseded by another feature included in this plan.

--- a/packages/plans-grid-next/src/hooks/data-store/use-restructured-plan-features-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-restructured-plan-features-for-comparison-grid.ts
@@ -35,7 +35,6 @@ export type UseRestructuredPlanFeaturesForComparisonGrid = ( {
 	intent?: PlansIntent;
 	selectedFeature?: string | null;
 	showLegacyStorageFeature?: boolean;
-	isSummerSpecial?: boolean;
 	useLongSetFeatures?: boolean;
 	useLongSetStackedFeatures?: boolean;
 	useShortSetStackedFeatures?: boolean;


### PR DESCRIPTION
Part of CHE-412

## Proposed Changes

* Remove the unused `hasSummerSpecialSticker` parameter from the `getIncludedFeatures` type definition
* Remove the unused `isSummerSpecial` parameter from `UseRestructuredPlanFeaturesForComparisonGrid` type

## Why are these changes being made?

Continuing the SummerSpecial cleanup effort. These type parameters were no longer being used anywhere in the codebase and can be safely removed.

## Testing Instructions

* TypeScript compilation should pass without errors
* No runtime behavior changes expected

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?