### PR TITLE
ARC-1486: Update unauthenticated accept-invite for Woo Commerce Garden

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -100,6 +100,7 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		useConnectScreenActions: PropTypes.bool,
 		disableTosText: PropTypes.bool,
 		allowedSocialServices: PropTypes.arrayOf( PropTypes.string ),
 
@@ -786,6 +787,7 @@ class SignupForm extends Component {
 						onInputChange={ this.handleChangeEvent }
 						onCreateAccountError={ this.handleCreateAccountError }
 						onCreateAccountSuccess={ this.props.handleCreateAccountSuccess }
+						useConnectScreenActions={ this.props.useConnectScreenActions }
 						{ ...formProps }
 					>
 						{ emailErrorMessage && (
@@ -811,6 +813,7 @@ class SignupForm extends Component {
 							onInputChange={ this.handleChangeEvent }
 							onCreateAccountError={ this.handleCreateAccountError }
 							onCreateAccountSuccess={ this.props.handleCreateAccountSuccess }
+							useConnectScreenActions={ this.props.useConnectScreenActions }
 							{ ...formProps }
 						>
 							{ emailErrorMessage && (

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -8,6 +8,7 @@ import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
@@ -35,10 +36,12 @@ class PasswordlessSignupForm extends Component {
 		onCreateAccountError: PropTypes.func,
 		onCreateAccountSuccess: PropTypes.func,
 		disableTosText: PropTypes.bool,
+		useConnectScreenActions: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		locale: 'en',
+		useConnectScreenActions: false,
 	};
 
 	state = {
@@ -307,16 +310,30 @@ class PasswordlessSignupForm extends Component {
 
 	formFooter() {
 		const { isSubmitting } = this.state;
+		const isPrimaryDisabled =
+			isSubmitting || !! this.props.disabled || !! this.props.disableSubmitButton;
 		const submitButtonText = isSubmitting
 			? this.props.submitButtonLoadingLabel || this.props.translate( 'Creating Your Account…' )
 			: this.props.submitButtonLabel || this.props.translate( 'Create your account' );
 
+		if ( this.props.useConnectScreenActions ) {
+			return (
+				<>
+					<ActionButtons
+						className="signup-form__action-buttons"
+						primaryLabel={ submitButtonText }
+						primaryType="submit"
+						primaryLoading={ isSubmitting }
+						primaryDisabled={ isPrimaryDisabled }
+					/>
+					{ this.props.secondaryFooterButton }
+				</>
+			);
+		}
+
 		return (
 			<LoggedOutFormFooter>
-				<SignupSubmitButton
-					isBusy={ isSubmitting }
-					isDisabled={ isSubmitting || !! this.props.disabled || !! this.props.disableSubmitButton }
-				>
+				<SignupSubmitButton isBusy={ isSubmitting } isDisabled={ isPrimaryDisabled }>
 					{ submitButtonText }
 				</SignupSubmitButton>
 				{ this.props.secondaryFooterButton }

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -12,6 +12,19 @@ import PasswordlessSignupForm from '../passwordless';
 describe( 'createAccountError', () => {
 	const mockStore = configureStore( [ thunk ] );
 
+	it( 'renders connect-screen action buttons when enabled', () => {
+		const store = mockStore( {} );
+
+		render(
+			<Provider store={ store }>
+				<PasswordlessSignupForm useConnectScreenActions submitButtonLabel="Continue" />
+			</Provider>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Continue' } ) ).toBeInTheDocument();
+		expect( document.querySelector( '.connect-screen-action-buttons' ) ).toBeInTheDocument();
+	} );
+
 	const renderFormAndSubmit = async () => {
 		const onCreateAccountError = jest.fn();
 		const store = mockStore( {} );

--- a/client/components/connect-screen/action-buttons/index.tsx
+++ b/client/components/connect-screen/action-buttons/index.tsx
@@ -6,7 +6,8 @@ import './style.scss';
 
 export interface ActionButtonsProps {
 	primaryLabel: ReactNode;
-	primaryOnClick: () => void;
+	primaryOnClick?: () => void;
+	primaryType?: 'button' | 'submit';
 	primaryLoading?: boolean;
 	primaryDisabled?: boolean;
 	primaryClassName?: string;
@@ -37,6 +38,7 @@ export interface ActionButtonsProps {
 export function ActionButtons( {
 	primaryLabel,
 	primaryOnClick,
+	primaryType = 'button',
 	primaryLoading = false,
 	primaryDisabled = false,
 	primaryClassName,
@@ -63,6 +65,7 @@ export function ActionButtons( {
 				) }
 				<Button
 					variant="primary"
+					type={ primaryType }
 					onClick={ primaryOnClick }
 					disabled={ primaryDisabled || primaryLoading }
 					className={ clsx( 'connect-screen-action-buttons__primary', primaryClassName ) }

--- a/client/components/connect-screen/action-buttons/test/index.tsx
+++ b/client/components/connect-screen/action-buttons/test/index.tsx
@@ -53,6 +53,14 @@ describe( 'ActionButtons', () => {
 			expect( screen.getByRole( 'button', { name: 'Accept' } ) ).toBeInTheDocument();
 			expect( screen.queryByRole( 'button', { name: 'Switch Account' } ) ).not.toBeInTheDocument();
 		} );
+
+		it( 'supports submit type for primary button', () => {
+			render( <ActionButtons primaryLabel="Accept" primaryType="submit" /> );
+			expect( screen.getByRole( 'button', { name: 'Accept' } ) ).toHaveAttribute(
+				'type',
+				'submit'
+			);
+		} );
 	} );
 
 	describe( 'click handlers', () => {

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -12,7 +12,7 @@ import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
-import InviteFormHeader from 'calypso/my-sites/invites/invite-form-header';
+import InviteFormHeaderLoggedOut from 'calypso/my-sites/invites/invite-form-header-logged-out';
 import P2InviteAcceptLoggedOut from 'calypso/my-sites/invites/p2/invite-accept-logged-out';
 import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
 import { createAccount, acceptInvite } from 'calypso/state/invites/actions';
@@ -85,7 +85,7 @@ class InviteAcceptLoggedOut extends Component {
 	};
 
 	renderFormHeader = () => {
-		return <InviteFormHeader { ...this.props.invite } />;
+		return <InviteFormHeaderLoggedOut site={ this.props.invite?.site } />;
 	};
 
 	loginUser = () => {
@@ -204,6 +204,7 @@ class InviteAcceptLoggedOut extends Component {
 						) }
 						submitButtonLabel={ this.props.translate( 'Create an account' ) }
 						labelText={ this.props.translate( 'Your email address' ) }
+						useConnectScreenActions
 					/>
 					{ this.state.userData && this.loginUser() }
 				</div>

--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -1,8 +1,7 @@
-@import "@automattic/typography/styles/variables";
-@import "@wordpress/base-styles/breakpoints";
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
 
-$recoleta-font-family: "Recoleta", sans-serif;
-$font-sf-pro-text: "SF Pro Text", $sans;
+$font-sf-pro-text: 'SF Pro Text', $sans;
 body.is-section-accept-invite {
 	.logged-out-wp-logo {
 		position: absolute;
@@ -12,7 +11,7 @@ body.is-section-accept-invite {
 	background: #fdfdfd;
 	.invite-accept {
 		padding-top: 50px;
-		height: calc(100vh - 100px);
+		height: calc( 100vh - 100px );
 	}
 	.invite-accept__form {
 		height: 100%;
@@ -40,22 +39,14 @@ body.is-section-accept-invite {
 		max-height: 340px;
 	}
 
-	.invite-form-header__title {
-		color: var(--studio-gray-100, #2c3338);
-		text-align: center;
-		font-family: $recoleta-font-family;
-		font-size: 2rem;
-		line-height: 1.26;
-		a {
-			text-decoration: none;
-		}
-	}
-
-	.invite-form-header__explanation {
-		color: var(--studio-gray-50, #2c3338);
-		text-align: center;
-		margin-top: 6px;
-		font-size: 14px;
+	.invite-form-header--logged-out .connect-screen-brand-header__description a {
+		color: var( --studio-gray-70 );
+		text-decoration-line: underline;
+		text-decoration-style: solid;
+		text-decoration-skip-ink: none;
+		text-decoration-thickness: auto;
+		text-underline-offset: auto;
+		text-underline-position: from-font;
 	}
 
 	.card.logged-out-form {
@@ -66,27 +57,27 @@ body.is-section-accept-invite {
 
 		button.is-primary {
 			border-radius: 2px;
-			border: 1px solid var(--studio-wordpress-blue, #3858e9);
-			background: var(--studio-wordpress-blue, #3858e9);
+			border: 1px solid var( --studio-wordpress-blue, #3858e9 );
+			background: var( --studio-wordpress-blue, #3858e9 );
 			height: 48px;
 			font-weight: 500;
 			&:hover {
-				background: var(--studio-wordpress-blue-60);
+				background: var( --studio-wordpress-blue-60 );
 			}
 			&:focus {
-				background-color: var(--studio-wordpress-blue-60);
-				border-color: var(--studio-wordpress-blue-60);
-				color: var(--color-text-inverted);
+				background-color: var( --studio-wordpress-blue-60 );
+				border-color: var( --studio-wordpress-blue-60 );
+				color: var( --color-text-inverted );
 				box-shadow: none;
 			}
 			&:disabled {
-				background: var(--studio-gray-20);
-				border: 1px solid var(--studio-gray-20);
-				color: var(--color-surface);
+				background: var( --studio-gray-20 );
+				border: 1px solid var( --studio-gray-20 );
+				color: var( --color-surface );
 			}
 		}
 		label.form-label {
-			color: var(--studio-gray-60, #50575e);
+			color: var( --studio-gray-60, #50575e );
 			font-size: 0.875rem;
 			font-weight: 500;
 			line-height: 20px;
@@ -106,7 +97,7 @@ body.is-section-accept-invite {
 	.signup-form__passwordless-form-wrapper {
 		.signup-form__terms-of-service-link {
 			margin: 30px 0 16px;
-			color: var(--studio-gray-50, #2c3338);
+			color: var( --studio-gray-50, #2c3338 );
 			font-size: $font-body-small; // 14px
 			line-height: 20px;
 		}
@@ -117,7 +108,7 @@ body.is-section-accept-invite {
 		padding: 0;
 	}
 	.logged-out-form__link-item {
-		color: var(--color-link);
+		color: var( --color-link );
 		font-size: 12px;
 	}
 }

--- a/client/my-sites/invites/invite-form-header-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-form-header-logged-out/index.jsx
@@ -1,0 +1,47 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { createInterpolateElement } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
+import { BrandHeader } from 'calypso/components/connect-screen/brand-header';
+
+function InviteFormHeaderLoggedOut( { site } ) {
+	const translate = useTranslate();
+	const siteName = site?.title || site?.domain || translate( 'this site' );
+
+	const description = createInterpolateElement(
+		translate(
+			'Just a little reminder that by continuing with any of the options below, you agree to our <tosLink>Terms of Service</tosLink> and <privacyLink>Privacy Policy</privacyLink>.'
+		),
+		{
+			tosLink: (
+				<a
+					href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+					onClick={ () => recordTracksEvent( 'calypso_signup_tos_link_click' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+			privacyLink: (
+				<a
+					href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+					onClick={ () => recordTracksEvent( 'calypso_signup_privacy_link_click' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+		}
+	);
+
+	return (
+		<div className="invite-form-header invite-form-header--logged-out">
+			<BrandHeader
+				title={ translate( 'Create an account for %(siteName)s', {
+					args: { siteName },
+				} ) }
+				description={ description }
+			/>
+		</div>
+	);
+}
+
+export default InviteFormHeaderLoggedOut;


### PR DESCRIPTION
Part of ARC-1486

## Proposed Changes

* Replace the logged-out legacy invite header with the shared `BrandHeader` component via a new logged-out-only invite header component.
* Replace the logged-out invite signup primary action with shared `ActionButtons`, scoped to invite flow only.
* Keep shared changes minimal by adding an opt-in `useConnectScreenActions` path in `SignupForm/passwordless` and `primaryType` support in `connect-screen` `ActionButtons` for submit semantics.

## Why are these changes being made?

* Reduce PR scope to focus on migrating legacy logged-out invite UI to shared `connect-screen` components.
* Keep backward compatibility by limiting behavior changes to logged-out invite accept flow and avoiding broader invite/unified/controller refactors in this PR.

## Testing Instructions

* `yarn run eslint client/blocks/signup-form/index.jsx client/blocks/signup-form/passwordless.jsx client/blocks/signup-form/test/passwordless.jsx client/components/connect-screen/action-buttons/index.tsx client/components/connect-screen/action-buttons/test/index.tsx client/my-sites/invites/invite-accept-logged-out/index.jsx client/my-sites/invites/invite-form-header-logged-out/index.jsx`
* `yarn run stylelint client/my-sites/invites/invite-accept-logged-out/style.scss`
* `yarn run test-client client/components/connect-screen/action-buttons/test/index.tsx client/blocks/signup-form/test/passwordless.jsx`
* Manual check logged-out accept-invite route:
  * Header renders with `BrandHeader` copy and legal links.
  * Primary action uses `ActionButtons` and submits create-account flow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?