### PR TITLE
Domain search: default to site title instead of site slug

### DIFF
--- a/client/components/domains/wpcom-domain-search/test/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-query-handler.ts
@@ -70,6 +70,37 @@ describe( 'useQueryHandler', () => {
 		expect( result.current.query ).toBe( 'stored-domain' );
 	} );
 
+	it( 'should initialize with query from sessionStorage when available even if currentSiteTitle is present', () => {
+		sessionStorage.setItem( 'domain-search-query', 'stored-domain' );
+		const { result } = renderHook( () =>
+			useQueryHandler( {
+				currentSiteUrl: 'https://test-site.wordpress.com',
+				currentSiteTitle: 'My Amazing Site',
+			} )
+		);
+		expect( result.current.query ).toBe( 'stored-domain' );
+	} );
+
+	it( 'should fall back to URL slug when currentSiteTitle is empty', () => {
+		const { result } = renderHook( () =>
+			useQueryHandler( {
+				currentSiteUrl: 'https://test-site.wordpress.com',
+				currentSiteTitle: '',
+			} )
+		);
+		expect( result.current.query ).toBe( 'test-site' );
+	} );
+
+	it( 'should fall back to URL slug when currentSiteTitle is whitespace only', () => {
+		const { result } = renderHook( () =>
+			useQueryHandler( {
+				currentSiteUrl: 'https://test-site.wordpress.com',
+				currentSiteTitle: '   ',
+			} )
+		);
+		expect( result.current.query ).toBe( 'test-site' );
+	} );
+
 	it( 'should update query and sessionStorage when setQuery is called', () => {
 		const { result } = renderHook( () => useQueryHandler( {} ) );
 

--- a/client/components/domains/wpcom-domain-search/test/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-query-handler.ts
@@ -25,6 +25,16 @@ describe( 'useQueryHandler', () => {
 		expect( result.current.query ).toBe( 'test-domain' );
 	} );
 
+	it( 'should initialize with currentSiteTitle when provided', () => {
+		const { result } = renderHook( () =>
+			useQueryHandler( {
+				currentSiteUrl: 'https://test-site.wordpress.com',
+				currentSiteTitle: 'My Amazing Site',
+			} )
+		);
+		expect( result.current.query ).toBe( 'my amazing site' );
+	} );
+
 	it( 'should initialize with domain from currentSiteUrl when provided', () => {
 		const { result } = renderHook( () =>
 			useQueryHandler( { currentSiteUrl: 'https://test-site.wordpress.com' } )

--- a/client/components/domains/wpcom-domain-search/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/use-query-handler.ts
@@ -38,7 +38,7 @@ export const useQueryHandler = ( {
 		}
 
 		// Prefer the site title over the site URL slug, as it's more meaningful for domain suggestions.
-		if ( currentSiteTitle ) {
+		if ( currentSiteTitle?.trim() ) {
 			return currentSiteTitle;
 		}
 

--- a/client/components/domains/wpcom-domain-search/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/use-query-handler.ts
@@ -39,7 +39,7 @@ export const useQueryHandler = ( {
 
 		// Prefer the site title over the site URL slug, as it's more meaningful for domain suggestions.
 		if ( currentSiteTitle?.trim() ) {
-			return currentSiteTitle;
+			return currentSiteTitle.trim();
 		}
 
 		if ( currentSiteUrl ) {

--- a/client/components/domains/wpcom-domain-search/use-query-handler.ts
+++ b/client/components/domains/wpcom-domain-search/use-query-handler.ts
@@ -21,9 +21,11 @@ const clearSessionStorageQuery = () => {
 export const useQueryHandler = ( {
 	initialQuery: externalInitialQuery,
 	currentSiteUrl,
+	currentSiteTitle,
 }: {
 	initialQuery?: string;
 	currentSiteUrl?: string;
+	currentSiteTitle?: string;
 } ) => {
 	const [ localQuery, setLocalQuery ] = useState< string | undefined >( () => {
 		if ( externalInitialQuery ) {
@@ -33,6 +35,11 @@ export const useQueryHandler = ( {
 		const storedQuery = getSessionStorageQuery();
 		if ( storedQuery ) {
 			return storedQuery;
+		}
+
+		// Prefer the site title over the site URL slug, as it's more meaningful for domain suggestions.
+		if ( currentSiteTitle ) {
+			return currentSiteTitle;
 		}
 
 		if ( currentSiteUrl ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -96,6 +96,7 @@ const DomainSearchStep: StepType< {
 	const { query, setQuery, clearQuery } = useQueryHandler( {
 		initialQuery,
 		currentSiteUrl,
+		currentSiteTitle: site?.name,
 	} );
 
 	const config = useMemo( () => {

--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -70,6 +70,7 @@ export default function DomainSearch() {
 	const { query, setQuery, clearQuery } = useQueryHandler( {
 		initialQuery,
 		currentSiteUrl,
+		currentSiteTitle: selectedSite?.name,
 	} );
 
 	const events = useMemo( () => {

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -86,6 +86,7 @@ const DomainSearchUI = (
 	const { query, setQuery, clearQuery } = useQueryHandler( {
 		initialQuery: queryObject.new,
 		currentSiteUrl,
+		currentSiteTitle: site?.name,
 	} );
 
 	const events = useMemo( () => {


### PR DESCRIPTION
Fixes DOMENG-417

## Proposed Changes

* Add `currentSiteTitle` parameter to the `useQueryHandler` hook
* Pass the site title (`site.name`) from all three domain search entry points
* When a site title is available, use it as the default domain search query instead of extracting the slug from the site URL

## Why are these changes being made?

When adding a domain to an existing site, the search input currently defaults to the site slug/subdomain, which is often randomly generated (e.g., `site-d7f3a2b`). This produces irrelevant domain suggestions. Using the site title instead provides more meaningful default suggestions.

## Testing Instructions

* Go to the MSD, CIAB, or old sites list and select a site that has a meaningful title but a randomly generated subdomain
* In the domains list, click "Add domain name" and "Search for a domain"
* Verify the search input defaults to the site title, not the subdomain
* Verify that if the site has no title, it still falls back to the subdomain

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?