### PR TITLE
Hundred-Year Domain: Fix E2E test

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -48,7 +48,8 @@ const hundredYearProducts = [
 ] as const;
 
 interface Props {
-	siteSlug: string;
+	siteId?: number;
+	siteSlug?: string;
 	receiptId: number;
 	productSlug: ( typeof hundredYearProducts )[ number ];
 }
@@ -146,6 +147,7 @@ const CustomizedWordPressLogo = styled( WordPressLogo )`
 `;
 
 export default function HundredYearThankYou( {
+	siteId: siteIdFromProps,
 	siteSlug,
 	receiptId,
 	productSlug = PLAN_100_YEARS,
@@ -153,7 +155,8 @@ export default function HundredYearThankYou( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
+	const siteIdFromSiteSlug = useSelector( ( state ) => getSiteId( state, siteSlug ?? null ) );
+	const siteId = siteIdFromProps ?? siteIdFromSiteSlug;
 	const siteCreatedTimeStamp = useSelector(
 		( state ) => getSiteOptions( state, siteId ?? 0 )?.created_at
 	);
@@ -227,12 +230,12 @@ export default function HundredYearThankYou( {
 	const isMobile = useMobileBreakpoint();
 	const isPageLoading = isReceiptLoading;
 	const hundredYearPlanCta = (
-		<StyledLightButton onClick={ () => page( `/home/${ siteSlug }` ) }>
+		<StyledLightButton onClick={ () => page( `/home/${ siteSlug ?? siteId }` ) }>
 			{ translate( 'Manage your site' ) }
 		</StyledLightButton>
 	);
 	const hundredYearDomainCta = (
-		<StyledLightButton onClick={ () => page( `/domains/manage/${ siteSlug }` ) }>
+		<StyledLightButton onClick={ () => page( `/domains/manage/${ siteSlug ?? siteId }` ) }>
 			{ translate( 'Manage your domain' ) }
 		</StyledLightButton>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -21,7 +21,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import { getSiteId, getSiteOptions } from 'calypso/state/sites/selectors';
+import { getSiteId } from 'calypso/state/sites/selectors';
 import { hideMasterbar } from 'calypso/state/ui/actions';
 
 const VideoContainer = styled.div< { isMobile: boolean } >`
@@ -157,9 +157,6 @@ export default function HundredYearThankYou( {
 
 	const siteIdFromSiteSlug = useSelector( ( state ) => getSiteId( state, siteSlug ?? null ) );
 	const siteId = siteIdFromProps ?? siteIdFromSiteSlug;
-	const siteCreatedTimeStamp = useSelector(
-		( state ) => getSiteOptions( state, siteId ?? 0 )?.created_at
-	);
 
 	const receipt = useSelector( ( state ) => getReceiptById( state, receiptId ) );
 	const isReceiptLoading = ! receipt.hasLoadedFromServer || receipt.isRequesting;
@@ -227,24 +224,26 @@ export default function HundredYearThankYou( {
 		page( '/' );
 	}
 
-	const isMobile = useMobileBreakpoint();
-	const isPageLoading = isReceiptLoading;
-	const hundredYearPlanCta = (
-		<StyledLightButton onClick={ () => page( `/home/${ siteSlug ?? siteId }` ) }>
-			{ translate( 'Manage your site' ) }
-		</StyledLightButton>
-	);
-	const hundredYearDomainCta = (
-		<StyledLightButton onClick={ () => page( `/domains/manage/${ siteSlug ?? siteId }` ) }>
-			{ translate( 'Manage your domain' ) }
-		</StyledLightButton>
-	);
-	const cta = resolvedProductSlug === PLAN_100_YEARS ? hundredYearPlanCta : hundredYearDomainCta;
 	const primaryDomainFromState = siteDomains.find( ( domain ) => domain.isPrimary )?.domain;
 	const displayDomain =
 		resolvedProductSlug === PLAN_100_YEARS
 			? primaryDomainFromState || siteSlug
 			: purchasedDomainName || siteSlug;
+
+	const isMobile = useMobileBreakpoint();
+	const isPageLoading = isReceiptLoading;
+	const hundredYearPlanCta = (
+		<StyledLightButton onClick={ () => page( `/home/${ displayDomain }` ) }>
+			{ translate( 'Manage your site' ) }
+		</StyledLightButton>
+	);
+	const hundredYearDomainCta = (
+		<StyledLightButton onClick={ () => page( `/domains/manage/${ displayDomain }` ) }>
+			{ translate( 'Manage your domain' ) }
+		</StyledLightButton>
+	);
+	const cta = resolvedProductSlug === PLAN_100_YEARS ? hundredYearPlanCta : hundredYearDomainCta;
+
 	const domainSpecificDescription =
 		resolvedProductSlug === domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
 			? translate( 'Your 100-Year Domain %(domain)s has been registered.', {
@@ -319,7 +318,7 @@ export default function HundredYearThankYou( {
 								{ translate( 'Your century-long legacy begins now' ) }
 							</Header>
 							<Highlight isMobile={ isMobile }>{ description }</Highlight>
-							{ siteCreatedTimeStamp && <ButtonBar isMobile={ isMobile }>{ cta }</ButtonBar> }
+							<ButtonBar isMobile={ isMobile }>{ cta }</ButtonBar>
 						</div>
 						<VideoContainer isMobile={ isMobile }>
 							<video

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -527,18 +527,6 @@ export class CheckoutThankYou extends Component<
 		);
 	};
 
-	getSingleHundredYearDomainPurchase = () => {
-		const purchases = getPurchases( this.props ).filter( ( purchase ) => ! isCredits( purchase ) );
-		const domainPurchase = purchases[ 0 ];
-		const domain = this.props.siteDomains?.find(
-			( siteDomain ) => siteDomain.name === domainPurchase.meta
-		);
-
-		if ( domain?.isHundredYearDomain ) {
-			return domain;
-		}
-	};
-
 	renderLoading = () => {
 		return (
 			<>
@@ -565,6 +553,9 @@ export class CheckoutThankYou extends Component<
 			);
 		}
 
+		const [ , predicate ] = getDomainPurchaseTypeAndPredicate( purchases );
+		const domainPurchases = purchases.filter( predicate );
+
 		if ( ! this.isGenericReceipt() ) {
 			wasJetpackPlanPurchased = purchases.some( isJetpackPlan );
 			wasEcommercePlanPurchased = purchases.some( isEcommerce );
@@ -586,7 +577,9 @@ export class CheckoutThankYou extends Component<
 			);
 		}
 
-		const hundredYearDomainPurchase = this.getSingleHundredYearDomainPurchase();
+		const hundredYearDomainPurchase = domainPurchases.find(
+			( purchase ) => purchase.isHundredYearDomain
+		);
 
 		/** REFACTORED REDESIGN */
 		if ( isRefactoredForThankYouV2( this.props ) ) {
@@ -635,7 +628,7 @@ export class CheckoutThankYou extends Component<
 							` }
 						/>
 						<HundredYearThankYou
-							siteSlug={ hundredYearDomainPurchase.siteSlug }
+							siteId={ hundredYearDomainPurchase.blogId }
 							receiptId={ this.props.receiptId }
 							productSlug={ domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION }
 						/>
@@ -643,9 +636,6 @@ export class CheckoutThankYou extends Component<
 				);
 			} else if ( this.props.receipt.data && isOnlyDomainPurchases( purchases ) ) {
 				if ( shouldShowNewDomainThankYou() ) {
-					const [ , predicate ] = getDomainPurchaseTypeAndPredicate( purchases );
-					const domainPurchases = purchases.filter( predicate );
-
 					if ( domainPurchases.length > 1 ) {
 						const domainsUrl = this.props.hasDashboardOptIn
 							? dashboardLink( '/domains' )


### PR DESCRIPTION
Part of #108665.

## Proposed Changes

Relies on the blog ID from the purchase instead of waiting for the site ID from the back-end, which often produces a race condition. That race condition can either redirect the user to `/sites` or show the regular thank you page. None of which is the desired 100-year domain thank you page.

## Testing Instructions

You need to be running Calypso locally to reproduce these instructions.

Verify you can enter the thank you page for 100-year domain purchases after going through checkout. Open the dev tools and run `resetState()` which will refresh the page automatically. You should still be on the same page instead of being redirected to home or seeing the regular thank you page.