### PR TITLE
Update: Change error messages on commerce garden sites

### DIFF
--- a/client/dashboard/sites/site/error.tsx
+++ b/client/dashboard/sites/site/error.tsx
@@ -1,12 +1,15 @@
 import { isInaccessibleJetpackError } from '@automattic/api-core';
+import { useQueryClient } from '@tanstack/react-query';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import UnknownError from '../../app/500';
+import { getSiteFromCache } from '../../app/analytics/super-props';
 import { siteRoute } from '../../app/router/sites';
 import { Notice } from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkButton from '../../components/router-link-button';
+import { isCommerceGarden } from '../../utils/site-types';
 
 export default function Error( { error }: { error: Error } ) {
 	if ( isInaccessibleJetpackError( error ) ) {
@@ -17,6 +20,14 @@ export default function Error( { error }: { error: Error } ) {
 
 function InaccessibleJetpackError( { error }: { error: Error } ) {
 	const { siteSlug } = siteRoute.useParams();
+	const queryClient = useQueryClient();
+	const site = getSiteFromCache( queryClient, siteSlug );
+	const isCommerceGardenSite = site ? isCommerceGarden( site ) : false;
+
+	// For commerce garden sites, remove "Jetpack" from the API error message
+	const displayMessage = isCommerceGardenSite
+		? error.message.replace( /^The Jetpack site /, 'The site ' )
+		: error.message;
 
 	return (
 		<PageLayout
@@ -33,14 +44,20 @@ function InaccessibleJetpackError( { error }: { error: Error } ) {
 			notices={
 				<Notice
 					variant="error"
-					title={ __( 'Your Jetpack site can not be reached at this time.' ) }
+					title={
+						isCommerceGardenSite
+							? __( 'Your site can not be reached at this time.' )
+							: __( 'Your Jetpack site can not be reached at this time.' )
+					}
 					actions={
-						<ExternalLink href="https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/">
-							{ __( 'Troubleshoot your Jetpack site' ) }
-						</ExternalLink>
+						! isCommerceGardenSite && (
+							<ExternalLink href="https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/">
+								{ __( 'Troubleshoot your Jetpack site' ) }
+							</ExternalLink>
+						)
 					}
 				>
-					{ error.message }
+					{ displayMessage }
 				</Notice>
 			}
 		></PageLayout>


### PR DESCRIPTION
Fixes ARC-1334

Updates error messages when there is an issue pulling information from a commerce garden site to make the messages more generic.

## Testing Instructions

* Run Calypso locally with the latest trunk.
* Modify a commerce garden site to fatal error on load, such as breaking the site's `wp-config.php` file.
* Visit http://my.localhost:3000/ciab/sites/TEST_SITE_URL where `TEST_SITE_URL` is your broken test site's hostname. Confirm that you get an error message stating the site cannot be reached.
* Switch this this branch and confirm that webpack rebuilds the files.
* Visit http://my.localhost:3000/ciab/sites/TEST_SITE_URL again and confirm that the error messages are now generic as described in ARC-1334.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
