### PR TITLE
Update: No Jetpack Logo for deleted Commerce Garden sites

### DIFF
--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -9,7 +9,7 @@ import { getSiteDisplayName } from '../../utils/site-name';
 import { getSitePlanDisplayName } from '../../utils/site-plan';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
 import { getSiteBlockingStatus } from '../../utils/site-status';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { isCommerceGarden, isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { getSiteDisplayUrl } from '../../utils/site-url';
 import { getSiteVisibility, getVisibilityLabels } from '../../utils/site-visibility';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
@@ -74,6 +74,7 @@ function getDefaultFields( queries: AppConfig[ 'queries' ] ): Field< Site >[] {
 						nag={ item.plan?.expired ? { isExpired: true, site: item } : { isExpired: false } }
 						isSelfHostedJetpackConnected={ isSelfHostedJetpackConnected( item ) }
 						isJetpack={ item.jetpack }
+						isCommerceGarden={ isCommerceGarden( item ) }
 						isOwner={ item.site_owner === user.ID }
 						value={ getSitePlanDisplayName( item ) ?? '' }
 					/>

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -406,15 +406,37 @@ export function Plan( {
 	nag,
 	isSelfHostedJetpackConnected,
 	isJetpack,
+	isCommerceGarden,
 	isOwner,
 	value,
 }: {
 	nag: { isExpired: false } | { isExpired: true; site: Pick< Site, 'slug' | 'plan' > };
 	isSelfHostedJetpackConnected: boolean;
 	isJetpack: boolean;
+	isCommerceGarden: boolean;
 	isOwner?: boolean;
 	value: string;
 } ) {
+	// Commerce garden sites (e.g. CIAB) should never show the Jetpack logo, including when deleted
+	// (deleted sites may have reduced API data where is_garden is missing).
+	if ( isCommerceGarden ) {
+		if ( nag.isExpired ) {
+			return (
+				<VStack spacing={ 1 }>
+					<Text intent="error">
+						{ sprintf(
+							/* translators: %s: plan name */
+							__( '%s-expired' ),
+							value
+						) }
+					</Text>
+					{ isOwner && <PlanRenewNag site={ nag.site } source="plan" /> }
+				</VStack>
+			);
+		}
+		return <>{ value }</>;
+	}
+
 	if ( isSelfHostedJetpackConnected ) {
 		if ( ! isJetpack ) {
 			return <IneligibleIndicator />;

--- a/client/dashboard/sites/site-fields/test/plan.tsx
+++ b/client/dashboard/sites/site-fields/test/plan.tsx
@@ -22,7 +22,13 @@ function render( ui: React.ReactElement ) {
 describe( '<Plan>', () => {
 	test( 'for self-hosted, Jetpack-connected sites, active Jetpack plugin, it renders the Jetpack logo and plan name', () => {
 		const { container } = render(
-			<Plan isJetpack isSelfHostedJetpackConnected value="Free" nag={ { isExpired: false } } />
+			<Plan
+				isJetpack
+				isSelfHostedJetpackConnected
+				isCommerceGarden={ false }
+				value="Free"
+				nag={ { isExpired: false } }
+			/>
 		);
 		expect( container.querySelector( 'svg' ) ).toBeInTheDocument();
 		expect( container.textContent ).toBe( 'Free' );
@@ -33,6 +39,7 @@ describe( '<Plan>', () => {
 			<Plan
 				isJetpack={ false }
 				isSelfHostedJetpackConnected
+				isCommerceGarden={ false }
 				value="Free"
 				nag={ { isExpired: false } }
 			/>
@@ -45,6 +52,7 @@ describe( '<Plan>', () => {
 			<Plan
 				isJetpack={ false }
 				isSelfHostedJetpackConnected={ false }
+				isCommerceGarden={ false }
 				value="Premium"
 				nag={ { isExpired: false } }
 			/>
@@ -57,11 +65,26 @@ describe( '<Plan>', () => {
 			<Plan
 				isJetpack
 				isSelfHostedJetpackConnected={ false }
+				isCommerceGarden={ false }
 				value="Business"
 				nag={ { isExpired: false } }
 			/>
 		);
 		expect( container.textContent ).toBe( 'Business' );
+	} );
+
+	test( 'for commerce garden sites, it does not show the Jetpack logo even when Jetpack-connected', () => {
+		const { container } = render(
+			<Plan
+				isJetpack
+				isSelfHostedJetpackConnected
+				isCommerceGarden
+				value="Trial"
+				nag={ { isExpired: false } }
+			/>
+		);
+		expect( container.querySelector( 'svg' ) ).not.toBeInTheDocument();
+		expect( container.textContent ).toBe( 'Trial' );
 	} );
 
 	test( 'for sites with expired plan, it renders the plan name with "-expired" suffix', () => {
@@ -75,6 +98,7 @@ describe( '<Plan>', () => {
 			<Plan
 				isJetpack={ false }
 				isSelfHostedJetpackConnected={ false }
+				isCommerceGarden={ false }
 				value="Business"
 				nag={ { isExpired: true, site } }
 			/>
@@ -96,6 +120,7 @@ describe( '<Plan>', () => {
 			<Plan
 				isJetpack={ false }
 				isSelfHostedJetpackConnected={ false }
+				isCommerceGarden={ false }
 				isOwner
 				value="Business"
 				nag={ { isExpired: true, site } }
@@ -122,6 +147,7 @@ describe( '<Plan>', () => {
 			<Plan
 				isJetpack={ false }
 				isSelfHostedJetpackConnected={ false }
+				isCommerceGarden={ false }
 				isOwner
 				value="Trial"
 				nag={ { isExpired: true, site } }

--- a/client/dashboard/utils/site-types.ts
+++ b/client/dashboard/utils/site-types.ts
@@ -15,7 +15,13 @@ export function isSimple( site: Site ) {
 }
 
 export function isCommerceGarden( site: Site ) {
-	return site.is_garden && site.garden_name === 'commerce';
+	// Include garden_name check alone so deleted sites (which may omit is_garden) are still identified.
+	if ( ( site.is_garden && site.garden_name === 'commerce' ) || site.garden_name === 'commerce' ) {
+		return true;
+	}
+	// Deleted sites may omit is_garden and garden_name; use URL/slug as fallback (e.g. *.commerce-garden.com).
+	const urlOrSlug = site.URL || site.slug || '';
+	return urlOrSlug.includes( 'commerce-garden.com' );
 }
 
 export function isStagingSite( site: Site ) {


### PR DESCRIPTION
Fixes ARC-1494

When visiting the Stores listing page and showing deleted sites, deleted commerce garden sites show a Jetpack logo in the plan column when they shouldn't. This update fixes this issue.

## Proposed Changes

* Don't display the Jetpack logo in the plan column for deleted commerce garden sites when viewing the list of stores.

## Testing Instructions

* 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
