### PR TITLE
WIP: support wpcom siteless checkout

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -80,6 +80,10 @@ export function checkoutAkismetSiteless( context, next ) {
 	sitelessCheckout( context, next, { sitelessCheckoutType: 'akismet' } );
 }
 
+export function checkoutWpcomSiteless( context, next ) {
+	sitelessCheckout( context, next, { sitelessCheckoutType: 'wpcom' } );
+}
+
 export function checkoutMarketplaceSiteless( context, next ) {
 	sitelessCheckout( context, next, { sitelessCheckoutType: 'marketplace' } );
 }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -17,6 +17,7 @@ import {
 	checkoutMarketplaceSiteless,
 	checkoutUnifiedSiteless,
 	checkoutA4ASiteless,
+	checkoutWpcomSiteless,
 	checkoutThankYou,
 	licensingPendingAsyncActivation,
 	licensingThankYouManualActivationInstructions,
@@ -215,6 +216,26 @@ export default function () {
 		setLocaleMiddleware(),
 		noSite,
 		checkoutUnifiedSiteless,
+		makeLayout,
+		clientRender
+	);
+
+	// wpcom siteless checkout — works logged-out, so no redirectLoggedOut.
+	page(
+		'/checkout/siteless/:productSlug',
+		setLocaleMiddleware(),
+		noSite,
+		checkoutWpcomSiteless,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/checkout/siteless/:productSlug/renew/:purchaseId',
+		setLocaleMiddleware(),
+		redirectLoggedOut,
+		noSite,
+		checkoutWpcomSiteless,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -472,6 +472,9 @@ export default function CheckoutMain( {
 	const isAkismetSitelessCheckout = responseCart.products.some(
 		( product ) => product.extra.isAkismetSitelessCheckout
 	);
+	const isWpcomSitelessCheckout = responseCart.products.some(
+		( product ) => product.extra.isWpcomSitelessCheckout
+	);
 	const includeDomainDetails = contactDetailsType === 'domain';
 	const includeGSuiteDetails = contactDetailsType === 'gsuite';
 	const dataForProcessor: PaymentProcessorOptions = useMemo(
@@ -492,6 +495,7 @@ export default function CheckoutMain( {
 			fromSiteSlug,
 			isJetpackNotAtomic,
 			isAkismetSitelessCheckout,
+			isWpcomSitelessCheckout,
 		} ),
 		[
 			contactDetails,
@@ -510,6 +514,7 @@ export default function CheckoutMain( {
 			fromSiteSlug,
 			isJetpackNotAtomic,
 			isAkismetSitelessCheckout,
+			isWpcomSitelessCheckout,
 		]
 	);
 

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -144,6 +144,7 @@ export default function usePrepareProductsForCart( {
 			sitelessCheckoutType === 'marketplace' ||
 			sitelessCheckoutType === 'a4a' ||
 			sitelessCheckoutType === 'unified' ||
+			sitelessCheckoutType === 'wpcom' ||
 			isGiftPurchase
 	);
 	useStripProductsFromUrl( siteSlug, doNotStripProducts );
@@ -623,6 +624,7 @@ function createRenewalItemToAddToCart( {
 		purchaseId: String( purchaseId ),
 		isAkismetSitelessCheckout: sitelessCheckoutType === 'akismet',
 		isMarketplaceSitelessCheckout: sitelessCheckoutType === 'marketplace',
+		isWpcomSitelessCheckout: sitelessCheckoutType === 'wpcom',
 		purchaseType: 'renewal',
 		isGiftPurchase,
 	};
@@ -678,6 +680,7 @@ function createItemToAddToCart( {
 		extra: {
 			isAkismetSitelessCheckout: sitelessCheckoutType === 'akismet',
 			isJetpackCheckout: sitelessCheckoutType === 'jetpack',
+			isWpcomSitelessCheckout: sitelessCheckoutType === 'wpcom',
 			jetpackSiteSlug,
 			jetpackPurchaseToken,
 			context: 'calypstore',

--- a/client/my-sites/checkout/src/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/src/lib/create-wpcom-account-before-transaction.ts
@@ -16,6 +16,9 @@ export async function createWpcomAccountBeforeTransaction(
 	const isA4AUserLessCheckout = transactionCart.products.some(
 		( product ) => product.extra.isA4ASitelessCheckout
 	);
+	const isWpcomUserLessCheckout = transactionCart.products.some(
+		( product ) => product.extra.isWpcomSitelessCheckout
+	);
 	const isGiftingCheckout = transactionCart.products.some(
 		( product ) => product.extra.isGiftPurchase
 	);
@@ -29,6 +32,9 @@ export async function createWpcomAccountBeforeTransaction(
 		}
 		if ( isA4AUserLessCheckout ) {
 			return 'a4a-userless-checkout';
+		}
+		if ( isWpcomUserLessCheckout ) {
+			return 'wpcom-userless-checkout';
 		}
 		if ( isGiftingCheckout ) {
 			return 'gifting-userless-checkout';

--- a/client/my-sites/checkout/src/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/src/lib/paypal-express-processor.ts
@@ -96,7 +96,10 @@ async function wpcomPayPalExpress(
 ) {
 	const isUserLessCheckout =
 		payload.cart.products.some(
-			( product ) => product.extra.isJetpackCheckout || product.extra.isAkismetSitelessCheckout
+			( product ) =>
+				product.extra.isJetpackCheckout ||
+				product.extra.isAkismetSitelessCheckout ||
+				product.extra.isWpcomSitelessCheckout
 		) && payload.cart.cart_key === 'no-user';
 
 	if ( transactionOptions.createUserAndSiteBeforeTransaction || isUserLessCheckout ) {

--- a/client/my-sites/checkout/src/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/src/lib/submit-wpcom-transaction.ts
@@ -30,7 +30,8 @@ export default async function submitWpcomTransaction(
 			return (
 				product.extra.isJetpackCheckout ||
 				product.extra.isAkismetSitelessCheckout ||
-				product.extra.isA4ASitelessCheckout
+				product.extra.isA4ASitelessCheckout ||
+				product.extra.isWpcomSitelessCheckout
 			);
 		} ) && payload.cart.cart_key === 'no-user';
 

--- a/client/my-sites/checkout/src/lib/translate-cart.ts
+++ b/client/my-sites/checkout/src/lib/translate-cart.ts
@@ -59,7 +59,8 @@ export function createTransactionEndpointCartFromResponseCart( {
 			return (
 				product.extra.isJetpackCheckout ||
 				product.extra.isAkismetSitelessCheckout ||
-				product.extra.isA4ASitelessCheckout
+				product.extra.isA4ASitelessCheckout ||
+				product.extra.isWpcomSitelessCheckout
 			);
 		} )
 	) {

--- a/client/my-sites/checkout/src/types/payment-processors.ts
+++ b/client/my-sites/checkout/src/types/payment-processors.ts
@@ -10,6 +10,7 @@ export interface PaymentProcessorOptions {
 	includeDomainDetails: boolean;
 	includeGSuiteDetails: boolean;
 	isAkismetSitelessCheckout: boolean;
+	isWpcomSitelessCheckout: boolean;
 	isJetpackNotAtomic: boolean;
 	createUserAndSiteBeforeTransaction: boolean;
 	stripe: Stripe | null;

--- a/client/my-sites/checkout/use-cart-key.ts
+++ b/client/my-sites/checkout/use-cart-key.ts
@@ -22,6 +22,8 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 		currentUrlPath.includes( '/checkout/marketplace' ) && isLoggedOutCart;
 	const isUnifiedSitelessCheckout =
 		currentUrlPath.includes( '/checkout/unified' ) && isLoggedOutCart;
+	const isWpcomSitelessCheckout =
+		currentUrlPath.includes( '/checkout/siteless' ) && isLoggedOutCart;
 	const isA4ASitelessCheckout =
 		isA8CForAgencies() &&
 		! selectedSite &&
@@ -32,6 +34,7 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 		isAkismetSitelessCheckout ||
 		isMarketplaceSitelessCheckout ||
 		isUnifiedSitelessCheckout ||
+		isWpcomSitelessCheckout ||
 		( ! isLoggedOutCart &&
 			currentUrlPath.includes( '/checkout/no-site' ) &&
 			'no-user' === searchParams.get( 'cart' ) );

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -886,6 +886,7 @@ export interface ResponseCartProductExtra {
 	isMarketplaceSitelessCheckout?: boolean;
 	isA4ASitelessCheckout?: boolean;
 	isA4ADevSiteCheckout?: boolean;
+	isWpcomSitelessCheckout?: boolean;
 	referral_id?: number;
 	agency_id?: number;
 
@@ -936,6 +937,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	isJetpackCheckout?: boolean;
 	isMarketplaceSitelessCheckout?: boolean;
 	isA4ASitelessCheckout?: boolean;
+	isWpcomSitelessCheckout?: boolean;
 	referral_id?: number;
 	agency_id?: number;
 	intentId?: number;

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -666,6 +666,7 @@ export type SitelessCheckoutType =
 	| 'marketplace'
 	| 'a4a'
 	| 'unified'
+	| 'wpcom'
 	| undefined;
 
 /**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

##  Proposed Changes

  - Add a new wpcom siteless checkout type, accessible at /checkout/siteless/:productSlug (and /checkout/siteless/:productSlug/renew/:purchaseId for renewals)
  - Register the new routes in the checkout router, with the base route accessible while logged out
  - Propagate the isWpcomSitelessCheckout flag through cart product extras, payment processors (Stripe, PayPal), and transaction submission so the backend can identify these purchases correctly
  - Use wpcom-userless-checkout as the signup flow name when account creation is needed during checkout

##  Why are these changes being made?

Akismet, Jetpack, Marketplace, and A4A all have dedicated siteless checkout flows, but there is no general-purpose siteless checkout for standard WordPress.com products. This adds one so that products can be sold without requiring the buyer to have a site in context first.

Unlike Akismet, users will be logged in after purchase and can manage their subscription through standard WordPress.com purchase management. No custom thank-you page is needed — the existing /checkout/thank-you/no-site/:receiptId route handles post-purchase correctly.

##  Testing Instructions

  1. Navigate to /checkout/siteless/<product-slug> while logged out → checkout should load with cart key no-user and the product in the cart
  2. Navigate to /checkout/siteless/<product-slug> while logged in → checkout should load with cart key no-site
  3. Inspect the cart API request — the product's extra field should include isWpcomSitelessCheckout: true
  4. Complete a purchase → should redirect to /checkout/thank-you/no-site/:receiptId
  5. Navigate to /checkout/siteless/<product-slug>/renew/<purchase-id> while logged out → should redirect to login (route requires auth)
