### PR TITLE
A4A: Fix Pressable premium plans referral button visibility

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/premium-plan-section.tsx
@@ -51,9 +51,6 @@ export default function PremiumPlanSection( {
 		scheduleCall();
 	};
 
-	// Show refer button if premium plans are not enabled or if they are enabled and we are not in referral mode
-	const shouldShowReferButton = ! isPremiumPlansEnabled || marketplaceType !== 'referral';
-
 	return (
 		<HostingPlanSection className="pressable-plan-section" heading={ heading }>
 			{ banner }
@@ -73,20 +70,18 @@ export default function PremiumPlanSection( {
 					</div>
 
 					<div className="premium-plan-section__cta-buttons">
-						{ shouldShowReferButton && (
-							<Button
-								href={
-									isPremiumPlansEnabled
-										? A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK
-										: A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK
-								}
-								onClick={ onReferNowClick }
-								variant="primary"
-								__next40pxDefaultSize
-							>
-								{ translate( 'Refer now and get rewarded' ) }
-							</Button>
-						) }
+						<Button
+							href={
+								isPremiumPlansEnabled && marketplaceType !== 'referral'
+									? A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK
+									: A4A_MARKETPLACE_HOSTING_REFER_PRESSABLE_PREMIUM_PLAN_LINK
+							}
+							onClick={ onReferNowClick }
+							variant="primary"
+							__next40pxDefaultSize
+						>
+							{ translate( 'Refer now and get rewarded' ) }
+						</Button>
 
 						<Button
 							className="premium-plan-section__cta-button"


### PR DESCRIPTION



Context: pgjTho-1LU-p2#comment-1773

## Proposed Changes
Always show the "Refer now and get rewarded" button and adjust the href logic so it links to the correct destination based on marketplace type.

<img width="1608" height="908" alt="Screenshot 2026-02-19 at 5 00 30 PM" src="https://github.com/user-attachments/assets/b0a8d380-5a50-473b-88ed-cc0950402afa" />

## Why are these changes being made?

* We still need to show the Referral button for Agencies that seek more than we offer.

## Testing Instructions

* Use the A4A live link and navigate to `/marketplace/hosting/pressable`.
* Toggle Referral mode
* Go to Premium plans tab > Select 'More' option.
* Verify that you see the refer button.
* Verify that the button redirects to the form.`/marketplace/hosting/refer-pressable-premium-plan`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?