### PR TITLE
Update the copy for free to paid modal

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
@@ -25,10 +25,10 @@ export default function PaidDomainSuggestedPlanSection( props: {
 	const hasEnTranslation = useHasEnTranslation();
 	const { paidDomainName, onPlanSelected, isBusy } = props;
 
-	const previousCopy = translate( 'Free for one year. Includes Premium themes.' );
-	const updatedCopy = translate( 'Free for one year, includes Premium themes' );
+	const previousCopy = translate( 'Free for one year, includes Premium themes' );
+	const updatedCopy = translate( 'Free for one year, includes all Premium themes' );
 	const hasTranslationForUpdatedCopy = hasEnTranslation(
-		'Free for one year, includes Premium themes'
+		'Free for one year, includes all Premium themes'
 	);
 
 	return (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1647

## Proposed Changes

* Given that Personal also has a handful of Premium themes, the copy as is needs updating

## Why are these changes being made?

* Requested by @isatuncman-auto 

## Testing Instructions

* Go to /setup/onboarding
* Select a domain and then continue with free
* Observe updated copy with all

<img width="832" height="557" alt="Screenshot 2026-02-19 at 11 18 52" src="https://github.com/user-attachments/assets/5afb2b2e-3a1f-407e-b220-be54ee0132df" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
