### PR TITLE
MSD: move canManageSite() check from beforeLoad to component itself

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -40,9 +40,16 @@ import {
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
-import { createLazyRoute, createRoute, lazyRouteComponent, redirect } from '@tanstack/react-router';
+import {
+	createLazyRoute,
+	createRoute,
+	lazyRouteComponent,
+	notFound,
+	redirect,
+} from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import {
+	canManageSite,
 	canTransferSite,
 	canViewHundredYearPlanSettings,
 	canViewSiteVisibilitySettings,
@@ -120,6 +127,10 @@ export const siteRoute = createRoute( {
 		} catch ( e ) {
 			// Do nothing and propagate the error through the loader function.
 			return;
+		}
+
+		if ( ! canManageSite( site ) ) {
+			throw notFound();
 		}
 
 		const overviewUrl = `/sites/${ siteSlug }`;

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -40,16 +40,9 @@ import {
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
-import {
-	createLazyRoute,
-	createRoute,
-	lazyRouteComponent,
-	notFound,
-	redirect,
-} from '@tanstack/react-router';
+import { createLazyRoute, createRoute, lazyRouteComponent, redirect } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import {
-	canManageSite,
 	canTransferSite,
 	canViewHundredYearPlanSettings,
 	canViewSiteVisibilitySettings,
@@ -127,10 +120,6 @@ export const siteRoute = createRoute( {
 		} catch ( e ) {
 			// Do nothing and propagate the error through the loader function.
 			return;
-		}
-
-		if ( ! canManageSite( site ) ) {
-			throw notFound();
 		}
 
 		const overviewUrl = `/sites/${ siteSlug }`;

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -1,6 +1,6 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Outlet } from '@tanstack/react-router';
+import { notFound, Outlet } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Suspense, useMemo, lazy } from 'react';
@@ -12,7 +12,7 @@ import HeaderBar from '../../components/header-bar';
 import MenuDivider from '../../components/menu-divider';
 import { hasStagingSite } from '../../utils/site-staging-site';
 import { isSiteMigrationInProgress } from '../../utils/site-status';
-import { canSwitchEnvironment } from '../features';
+import { canManageSite, canSwitchEnvironment } from '../features';
 import SiteMenu from '../site-menu';
 import EnvironmentSwitcher from './environment-switcher';
 
@@ -24,6 +24,10 @@ function Site() {
 
 	if ( isError ) {
 		throw error;
+	}
+
+	if ( ! canManageSite( site ) ) {
+		throw notFound();
 	}
 
 	return (


### PR DESCRIPTION
Fixes DOTMSD-1029

## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/108438 (please read it first before reviewing). I believe this should fix the issue once and for all 🥹 

Previously, the fixed `canManageSite()` check is called in `beforeLoad`. My suspicion of what's happening is that, the site's user get the permission revoked, and when the user gets back to the browser tab, the query cache is updated but the `beforeLoad` is not called again (because the route is still active). So, the `/sites/:slug/*` route gets re-rendered with a site with now-missing slug.

With this PR, the check is moved to the root Site component, making it impossible for downstream components to ever receive a `site` object with missing slug.

## Testing Instructions

1. Go to site list, click a site, verify no regression.
2. Go to `/sites/<bogus slug>`, verify you see 404 page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
