### PR TITLE
A4A: Remove 'a4a-dev-sites' feature flag and conditional flows.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Popover, Gridicon, Button, WordPressLogo, JetpackLogo } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
@@ -63,8 +62,6 @@ export default function AddNewSiteButton( {
 	};
 
 	const popoverMenuContext = useRef( null );
-
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
 	const menuItem = ( {
 		icon,
@@ -203,58 +200,56 @@ export default function AddNewSiteButton( {
 					},
 				} ) }
 			</div>
-			{ devSitesEnabled && (
-				<div className="site-selector-and-importer__popover-column">
-					{ menuItem( {
-						icon: <img src={ devSiteBanner } alt="Start Building for Free" />,
-						heading: translate( 'Start Building for Free' ),
-						description: translate(
-							'Develop up to 5 WordPress.com sites at{{nbsp/}}once with free development licenses.{{br/}}Only pay when you launch!',
-							{
-								components: { br: <br />, nbsp: <>&nbsp;</> },
-								comment: 'br is a line break, nbsp is a non-breaking space character',
+			<div className="site-selector-and-importer__popover-column">
+				{ menuItem( {
+					icon: <img src={ devSiteBanner } alt="Start Building for Free" />,
+					heading: translate( 'Start Building for Free' ),
+					description: translate(
+						'Develop up to 5 WordPress.com sites at{{nbsp/}}once with free development licenses.{{br/}}Only pay when you launch!',
+						{
+							components: { br: <br />, nbsp: <>&nbsp;</> },
+							comment: 'br is a line break, nbsp is a non-breaking space character',
+						}
+					),
+					disabled: ! hasAvailableDevSites,
+					isBanner: true,
+					buttonProps: {
+						onClick: () => {
+							if ( ! hasAvailableDevSites ) {
+								return;
 							}
-						),
-						disabled: ! hasAvailableDevSites,
-						isBanner: true,
-						buttonProps: {
-							onClick: () => {
-								if ( ! hasAvailableDevSites ) {
-									return;
-								}
 
-								if ( paymentMethodRequired ) {
-									page(
-										`${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_SITES_LINK }?add_new_dev_site=true`
-									);
-								} else {
-									toggleDevSiteConfigurationsModal?.();
-								}
-								setMenuVisible( false );
-							},
+							if ( paymentMethodRequired ) {
+								page(
+									`${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_SITES_LINK }?add_new_dev_site=true`
+								);
+							} else {
+								toggleDevSiteConfigurationsModal?.();
+							}
+							setMenuVisible( false );
 						},
-						extraContent: (
-							<div>
-								<div className="site-selector-and-importer__popover-site-count">
-									{ translate( '%(pendingSites)d of 5 free licenses available', {
-										args: {
-											pendingSites: availableDevSites,
-										},
-										comment: '%(pendingSites)s is the number of free licenses available.',
-									} ) }
-								</div>
-								<div
-									className={ clsx( 'site-selector-and-importer__popover-development-site-cta', {
-										disabled: ! hasAvailableDevSites,
-									} ) }
-								>
-									{ translate( 'Create a site now →' ) }
-								</div>
+					},
+					extraContent: (
+						<div>
+							<div className="site-selector-and-importer__popover-site-count">
+								{ translate( '%(pendingSites)d of 5 free licenses available', {
+									args: {
+										pendingSites: availableDevSites,
+									},
+									comment: '%(pendingSites)s is the number of free licenses available.',
+								} ) }
 							</div>
-						),
-					} ) }
-				</div>
-			) }
+							<div
+								className={ clsx( 'site-selector-and-importer__popover-development-site-cta', {
+									disabled: ! hasAvailableDevSites,
+								} ) }
+							>
+								{ translate( 'Create a site now →' ) }
+							</div>
+						</div>
+					),
+				} ) }
+			</div>
 		</div>
 	);
 
@@ -275,9 +270,7 @@ export default function AddNewSiteButton( {
 				/>
 			</Button>
 			<Popover
-				className={ clsx( 'site-selector-and-importer__popover', {
-					'dev-sites-enabled': devSitesEnabled,
-				} ) }
+				className="site-selector-and-importer__popover dev-sites-enabled"
 				context={ popoverMenuContext?.current }
 				isVisible={ isMenuVisible }
 				closeOnEsc

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { category, code, starEmpty, tool, warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -23,8 +22,6 @@ const useSitesMenuItems = ( path: string ) => {
 				features.wpcom_atomic.state === 'pending' && !! features.wpcom_atomic.license_key
 		).length || 0;
 	const shouldAddNeedsSetup = totalAvailableSites > 0;
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
-
 	return useMemo( () => {
 		const items = [
 			{
@@ -65,18 +62,16 @@ const useSitesMenuItems = ( path: string ) => {
 				} );
 			}
 
-			if ( devSitesEnabled ) {
-				items.push( {
-					id: 'sites-development-menu-item',
-					icon: code,
-					path: A4A_SITES_LINK,
-					link: A4A_SITES_LINK_DEVELOPMENT,
-					title: translate( 'Development' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Sites / Development',
-					},
-				} );
-			}
+			items.push( {
+				id: 'sites-development-menu-item',
+				icon: code,
+				path: A4A_SITES_LINK,
+				link: A4A_SITES_LINK_DEVELOPMENT,
+				title: translate( 'Development' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Sites / Development',
+				},
+			} );
 
 			items.push( {
 				id: 'sites-favorites-menu-item',
@@ -91,6 +86,6 @@ const useSitesMenuItems = ( path: string ) => {
 		}
 
 		return items.map( ( item ) => createItem( item, path ) );
-	}, [ noActiveSite, path, translate, shouldAddNeedsSetup, devSitesEnabled ] );
+	}, [ noActiveSite, path, translate, shouldAddNeedsSetup ] );
 };
 export default useSitesMenuItems;

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -162,22 +162,13 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 					}
 				>
 					<div>
-						<div>
-							<div className="add-new-site-popover__count">
-								{ translate( '%(pendingSites)d of 5 free licenses available', {
-									args: {
-										pendingSites: availableDevSites,
-									},
-									comment: '%(pendingSites)s is the number of free licenses available.',
-								} ) }
-							</div>
-							<div
-								className={ clsx( 'add-new-site-popover__cta', {
-									disabled: ! hasAvailableDevSites,
-								} ) }
-							>
-								{ translate( 'Create a site now →' ) }
-							</div>
+						<div className="add-new-site-popover__count">
+							{ translate( '%(pendingSites)d of 5 free licenses available', {
+								args: {
+									pendingSites: availableDevSites,
+								},
+								comment: '%(pendingSites)s is the number of free licenses available.',
+							} ) }
 						</div>
 						<div
 							className={ clsx( 'add-new-site-popover__cta', {

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { WordPressLogo, JetpackLogo } from '@automattic/components';
 import clsx from 'clsx';
@@ -51,8 +50,6 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 	const hasAvailableDevSites = devLicenses?.available > 0;
 
 	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
-
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
 	const handleOnClick = useCallback(
 		( modalType: string ) => {
@@ -132,39 +129,39 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 					) : undefined }
 				</AddNewSiteMenuItem>
 			</AddNewSitePopoverColumn>
-			{ devSitesEnabled && (
-				<AddNewSitePopoverColumn>
-					<AddNewSiteMenuItem
-						isBanner
-						icon={ <img src={ devSiteBanner } alt="Start building for free" /> }
-						heading={ translate( 'Start building for free' ) }
-						description={ translate(
-							'Develop WordPress.com sites for as long as you need, with free development sites. Only pay when you launch!'
-						) }
-						disabled={ ! hasAvailableDevSites || ! isAgencyApproved }
-						buttonProps={ {
-							onClick: () => {
-								if ( ! hasAvailableDevSites || ! isAgencyApproved ) {
-									return;
-								}
-								if ( paymentMethodRequired ) {
-									page(
-										`${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_SITES_LINK }?add_new_dev_site=true`
-									);
-								} else {
-									setVisibleModalType( 'dev-site-configurations' );
-								}
-								setMenuVisible( false );
-							},
-						} }
-						tooltip={
-							! isAgencyApproved
-								? translate(
-										'Your agency is not yet approved. Please wait for approval before creating a development site.'
-								  )
-								: undefined
-						}
-					>
+			<AddNewSitePopoverColumn>
+				<AddNewSiteMenuItem
+					isBanner
+					icon={ <img src={ devSiteBanner } alt="Start building for free" /> }
+					heading={ translate( 'Start building for free' ) }
+					description={ translate(
+						'Develop WordPress.com sites for as long as you need, with free development sites. Only pay when you launch!'
+					) }
+					disabled={ ! hasAvailableDevSites || ! isAgencyApproved }
+					buttonProps={ {
+						onClick: () => {
+							if ( ! hasAvailableDevSites || ! isAgencyApproved ) {
+								return;
+							}
+							if ( paymentMethodRequired ) {
+								page(
+									`${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_SITES_LINK }?add_new_dev_site=true`
+								);
+							} else {
+								setVisibleModalType( 'dev-site-configurations' );
+							}
+							setMenuVisible( false );
+						},
+					} }
+					tooltip={
+						! isAgencyApproved
+							? translate(
+									'Your agency is not yet approved. Please wait for approval before creating a development site.'
+							  )
+							: undefined
+					}
+				>
+					<div>
 						<div>
 							<div className="add-new-site-popover__count">
 								{ translate( '%(pendingSites)d of 5 free licenses available', {
@@ -182,9 +179,16 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 								{ translate( 'Create a site now →' ) }
 							</div>
 						</div>
-					</AddNewSiteMenuItem>
-				</AddNewSitePopoverColumn>
-			) }
+						<div
+							className={ clsx( 'add-new-site-popover__cta', {
+								disabled: ! hasAvailableDevSites,
+							} ) }
+						>
+							{ translate( 'Create a site now →' ) }
+						</div>
+					</div>
+				</AddNewSiteMenuItem>
+			</AddNewSitePopoverColumn>
 		</>
 	);
 };

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -40,7 +40,6 @@
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
 		"a4a-partner-directory": false,
-		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
 		"a4a-referral-cobranded-checkout": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -33,7 +33,6 @@
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
 		"a4a-partner-directory": false,
-		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
 		"a4a-referral-cobranded-checkout": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -33,7 +33,6 @@
 		"cookie-banner": true,
 		"oauth": true,
 		"a4a-partner-directory": false,
-		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
 		"a4a-referral-cobranded-checkout": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -35,7 +35,6 @@
 		"oauth": true,
 		"a4a/site-migration": false,
 		"a4a-partner-directory": false,
-		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,
 		"a4a-referral-cobranded-checkout": true,

--- a/config/development.json
+++ b/config/development.json
@@ -42,7 +42,6 @@
 	"features": {
 		"100-year-domain": true,
 		"100-year-plan/vip": true,
-		"a4a-dev-sites": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"calypso/ai-blogging-prompts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -11,7 +11,6 @@
 	"facebook_api_key": "249643311490",
 	"features": {
 		"100-year-plan/vip": true,
-		"a4a-dev-sites": true,
 		"ad-tracking": false,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,

--- a/config/production.json
+++ b/config/production.json
@@ -20,7 +20,6 @@
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
 	"features": {
 		"100-year-plan/vip": true,
-		"a4a-dev-sites": true,
 		"ad-tracking": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"bilmur-script": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,7 +19,6 @@
 	"features": {
 		"100-year-domain": true,
 		"100-year-plan/vip": true,
-		"a4a-dev-sites": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/test.json
+++ b/config/test.json
@@ -22,7 +22,6 @@
 	"facebook_api_key": "249643311490",
 	"features": {
 		"100-year-plan/vip": true,
-		"a4a-dev-sites": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"calypso/all-domain-management": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -20,7 +20,6 @@
 		"100-year-plan/vip": true,
 		"100-year-domain": true,
 		"ad-tracking": false,
-		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-site-builder-flow": true,


### PR DESCRIPTION


## Proposed Changes

This pull request removes the use of the `a4a-dev-sites` feature flag from the codebase and configuration files. As a result, development site-related UI elements are now always enabled where previously they were gated behind this feature flag. The code is simplified by removing related conditional checks and configuration imports.

Key changes include:

**Feature flag and configuration cleanup:**

* Removed the `a4a-dev-sites` feature flag from all relevant configuration files, including environment-specific configs such as `development.json`, `production.json`, and others. [[1]](diffhunk://#diff-b7fdfbca27fe9c8150a2cb73e811d96b030fad1f6072494c8291f188cef9779aL43) [[2]](diffhunk://#diff-1c75c03fadc6b49d3df97ba7dd9ba5ad3304c19beebef3584ffad47314e4ac5fL36) [[3]](diffhunk://#diff-6cae595596e0ea2cf4edffd0083ea7fb071702d10e058839990765fb49f4aa36L36) [[4]](diffhunk://#diff-75d25521c97285a60bd86cedb61e8660ece2a553e9e420e2bba8c2aee89f3cb1L38) [[5]](diffhunk://#diff-811c6e3fd087924c069c3a6a662ecf053f21649dabd23857e6d6c431e0d7a17fL37) [[6]](diffhunk://#diff-1749fc93a69fa137def5ac9d4d1504e58e970ec69b60dcaac86936874e7e6241L14) [[7]](diffhunk://#diff-07e0c2ac42cdc22639d12b2282f02825cda2dcf94c741cad1f57706e93b62d2fL23) [[8]](diffhunk://#diff-0aa598dd5cdb70ad95f3df1be442ca2da1b220df5fde02f89a4ea90905bc0c72L22) [[9]](diffhunk://#diff-d89be8d1fbbb3d53093396ae19e980d20ef78af8b3bdb2fc8f8151086dea07e5L25) [[10]](diffhunk://#diff-18bd9c14117dc4d7b2d23214a1305c2e74d56b4f69db72fa0a5d633fce1d2be1L23)

**Codebase simplification:**

* Removed all imports and usage of `config.isEnabled('a4a-dev-sites')` from components and hooks, including `AddNewSiteButton`, `AddNewSiteA4AMenuItems`, and `useSitesMenuItems`. [[1]](diffhunk://#diff-03dc7d647b2e00fb6c00a8d427a3021109d89b9e87ad1f879aa4464142d686b3L1) [[2]](diffhunk://#diff-03dc7d647b2e00fb6c00a8d427a3021109d89b9e87ad1f879aa4464142d686b3L67-L68) [[3]](diffhunk://#diff-9401d5d56c0c6d7929f24b30f08ed2e8ef6cb71a58de1eba109b912952c21b58L1) [[4]](diffhunk://#diff-9401d5d56c0c6d7929f24b30f08ed2e8ef6cb71a58de1eba109b912952c21b58L26-L27) [[5]](diffhunk://#diff-f46e298bc8986dbeae1dc4c4aa0bf142e18560ba0d59b2672e4641290fd1f0b1L1) [[6]](diffhunk://#diff-f46e298bc8986dbeae1dc4c4aa0bf142e18560ba0d59b2672e4641290fd1f0b1L51-L52)
* Removed conditional rendering of development site-related UI elements, making them always visible. This affects components such as `AddNewSiteButton` and `AddNewSiteA4AMenuItems`. [[1]](diffhunk://#diff-03dc7d647b2e00fb6c00a8d427a3021109d89b9e87ad1f879aa4464142d686b3L206) [[2]](diffhunk://#diff-03dc7d647b2e00fb6c00a8d427a3021109d89b9e87ad1f879aa4464142d686b3L257) [[3]](diffhunk://#diff-f46e298bc8986dbeae1dc4c4aa0bf142e18560ba0d59b2672e4641290fd1f0b1L131) [[4]](diffhunk://#diff-f46e298bc8986dbeae1dc4c4aa0bf142e18560ba0d59b2672e4641290fd1f0b1L176) [[5]](diffhunk://#diff-9401d5d56c0c6d7929f24b30f08ed2e8ef6cb71a58de1eba109b912952c21b58L68) [[6]](diffhunk://#diff-9401d5d56c0c6d7929f24b30f08ed2e8ef6cb71a58de1eba109b912952c21b58L79) [[7]](diffhunk://#diff-9401d5d56c0c6d7929f24b30f08ed2e8ef6cb71a58de1eba109b912952c21b58L94-R89)
* Updated className logic for popovers to reflect the removal of the feature flag, ensuring consistent UI.

## Why are these changes being made?

* Simply remove outdated codes and ensure our codebase is clean and well-organized.

## Testing Instructions

* Use the A4A live link and navigate to the `/overview` page.
* Verify that you can still add the Dev site and no regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
