### PR TITLE
A4A: Remove 'a4a-partner-directory' feature flag and conditional flow.

### DIFF
--- a/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
+++ b/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
@@ -96,31 +95,22 @@ export default function useOnboardingTours() {
 				title: translate( 'Start earning commission on referrals' ),
 				useCalypsoPath: true,
 			},
-			...( config.isEnabled( 'a4a-partner-directory' )
-				? [
-						{
-							calypso_path: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
-							completed: checkTourCompletion( preferences, 'boostAgencyVisibility' ),
-							disabled: false,
-							actionDispatch: () => {
-								dispatch(
-									recordTracksEvent(
-										'calypso_a4a_overview_next_steps_boost_agency_visibility_click'
-									)
-								);
-								dispatch(
-									savePreference(
-										A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'boostAgencyVisibility' ],
-										true
-									)
-								);
-							},
-							id: 'boost_agency_visibility',
-							title: translate( "Boost your agency's visibilty across our partner directories" ),
-							useCalypsoPath: true,
-						},
-				  ]
-				: [] ),
+			{
+				calypso_path: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
+				completed: checkTourCompletion( preferences, 'boostAgencyVisibility' ),
+				disabled: false,
+				actionDispatch: () => {
+					dispatch(
+						recordTracksEvent( 'calypso_a4a_overview_next_steps_boost_agency_visibility_click' )
+					);
+					dispatch(
+						savePreference( A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'boostAgencyVisibility' ], true )
+					);
+				},
+				id: 'boost_agency_visibility',
+				title: translate( "Boost your agency's visibilty across our partner directories" ),
+				useCalypsoPath: true,
+			},
 			{
 				calypso_path: A4A_TEAM_LINK,
 				completed: checkTourCompletion( preferences, 'inviteTeam' ),

--- a/client/a8c-for-agencies/sections/overview/partner-directory-onboarding-card/hooks/use-partner-directory-onboard-card.ts
+++ b/client/a8c-for-agencies/sections/overview/partner-directory-onboarding-card/hooks/use-partner-directory-onboard-card.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { savePreference } from 'calypso/state/preferences/actions';
@@ -18,7 +17,7 @@ export function usePartnerDirectoryOnboardingCard() {
 	}, [ dispatch ] );
 
 	return {
-		isActive: ! hasPreference && config.isEnabled( 'a4a-partner-directory' ),
+		isActive: ! hasPreference,
 		hideCard,
 	};
 }

--- a/client/state/a8c-for-agencies/agency/actions.ts
+++ b/client/state/a8c-for-agencies/agency/actions.ts
@@ -79,11 +79,6 @@ export function receiveAgencies( agencies: Agency[] ): AgencyThunkAction {
 			) {
 				config.enable( 'a4a-bd-checkout' );
 			}
-
-			// Enable the Partner Directory section
-			if ( ! config.isEnabled( 'a4a-partner-directory' ) && newAgency.partner_directory.allowed ) {
-				config.enable( 'a4a-partner-directory' );
-			}
 		}
 	};
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -39,7 +39,6 @@
 		"oauth": true,
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
-		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -32,7 +32,6 @@
 		"oauth": false,
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
-		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -32,7 +32,6 @@
 		"a8c-for-agencies": true,
 		"cookie-banner": true,
 		"oauth": true,
-		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -34,7 +34,6 @@
 		"cookie-banner": false,
 		"oauth": true,
 		"a4a/site-migration": false,
-		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-pressable-referrals": true,
 		"a4a-pressable-premium-plans": true,


### PR DESCRIPTION
The partner directory feature is now always enabled, so remove the feature flag and its conditional checks from all config and source files.


## Proposed Changes
This pull request removes the use of the `a4a-partner-directory` feature flag, making the Partner Directory features always enabled in the application. The conditional logic and configuration for this flag have been removed from both the codebase and the environment configuration files.

The most important changes are:

**Feature flag removal and code cleanup:**

* Removed all imports and usage of the `a4a-partner-directory` feature flag from the codebase, so the Partner Directory features are now always active. (`client/a8c-for-agencies/hooks/use-onboarding-tours.ts`, `client/a8c-for-agencies/sections/overview/partner-directory-onboarding-card/hooks/use-partner-directory-onboard-card.ts`, `client/state/a8c-for-agencies/agency/actions.ts`) [[1]](diffhunk://#diff-7fecb72d317f1b7bc3768851a8dfef1cad8a3068088e80ca29f4ce4fad891e32L1) [[2]](diffhunk://#diff-7fecb72d317f1b7bc3768851a8dfef1cad8a3068088e80ca29f4ce4fad891e32L99-L123) [[3]](diffhunk://#diff-fc8fb7494e4549b0da1f30c79c3fac9a3573b67be5486494bcdf360aa77e96a4L1) [[4]](diffhunk://#diff-fc8fb7494e4549b0da1f30c79c3fac9a3573b67be5486494bcdf360aa77e96a4L21-R20) [[5]](diffhunk://#diff-17a1538e99710d428e8c1317482f709dd610608c70a13ddbea1680a7fc281447L66-L70)

**Configuration updates:**

* Removed the `a4a-partner-directory` flag from all environment configuration files, since it is no longer needed. (`config/a8c-for-agencies-development.json`, `config/a8c-for-agencies-horizon.json`, `config/a8c-for-agencies-production.json`, `config/a8c-for-agencies-stage.json`) [[1]](diffhunk://#diff-b7fdfbca27fe9c8150a2cb73e811d96b030fad1f6072494c8291f188cef9779aL42) [[2]](diffhunk://#diff-1c75c03fadc6b49d3df97ba7dd9ba5ad3304c19beebef3584ffad47314e4ac5fL35) [[3]](diffhunk://#diff-6cae595596e0ea2cf4edffd0083ea7fb071702d10e058839990765fb49f4aa36L35) [[4]](diffhunk://#diff-75d25521c97285a60bd86cedb61e8660ece2a553e9e420e2bba8c2aee89f3cb1L37)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
