### PR TITLE
A4A: fix Pressable usage panel showing add-on instead of plan

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/index.tsx
@@ -20,6 +20,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import HostingAdditionalFeaturesSection from '../../../common/hosting-additional-features-section';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
 import { MarketplaceTypeContext, TermPricingContext } from '../../../context';
+import { isPressableAddonProduct } from '../../../lib/hosting';
 import useGetPressablePlanByProductId from '../../../pressable-overview/hooks/use-get-pressable-plan-by-product-id';
 import getPressablePlan from '../../../pressable-overview/lib/get-pressable-plan';
 import usePressableOwnershipType from '../../hooks/use-pressable-ownership-type';
@@ -61,9 +62,12 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 
 	const licenses = data?.items;
 
-	// Find the first occurrence for of Pressable license with its referral as null
+	// Find the first non-referral Pressable plan license (exclude Pressable add-ons).
 	const agencyPressableLicense = licenses?.find(
-		( license ) => license.licenseKey.startsWith( 'pressable' ) && ! license.referral
+		( license ) =>
+			license.licenseKey.startsWith( 'pressable' ) &&
+			! isPressableAddonProduct( license.licenseKey ) &&
+			! license.referral
 	);
 
 	const agencyPressablePlan = useGetPressablePlanByProductId( {


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/3402

Part of https://linear.app/a8c/issue/A4A-2134/the-pressable-usage-panel-in-the-marketplace-display-the-add-on-on

## Proposed Changes

* Update `PremierAgencyHosting` Pressable license selection to ignore Pressable add-on licenses.
* Keep selecting the first non-referral Pressable hosting license for usage panel plan derivation.

**Before**

<img width="1521" height="298" alt="image" src="https://github.com/user-attachments/assets/1a0327a8-447a-42f5-953e-948195f934d1" />

**After**

<img width="1076" height="445" alt="image" src="https://github.com/user-attachments/assets/d3ebbcc6-d7e8-4002-a433-b2ff657c3c25" />

## Why are these changes being made?

* The usage panel could select a `pressable-addon*` license when sorting by issuance date, causing the panel to display add-on info instead of the active Pressable plan.

## Testing Instructions

- Check the code.
- Open an A4A live link.
- Open A4A Marketplace Pressable hosting overview with an agency that has both Pressable plan and Pressable add-on licenses.
- Confirm the Pressable Usage panel header reflects the Pressable plan (not add-on).


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
