### PR TITLE
Don't set first-domain-free for the Gravatar flow

### DIFF
--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -379,7 +379,13 @@ const DomainSearchUI = (
 	// For /start flows, we want to show the free domain for a year discount for all flows
 	// except if we're in a site context, in the free or monthly plan flows or in the domain-only flow
 	const isFirstDomainFreeForFirstYear = useMemo( () => {
-		if ( siteSlug || siteId || isMonthlyOrFreeFlow( flowName ) || isDomainOnlyFlow ) {
+		if (
+			siteSlug ||
+			siteId ||
+			isMonthlyOrFreeFlow( flowName ) ||
+			isDomainOnlyFlow ||
+			isDomainForGravatarFlow( flowName )
+		) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOMENG-426

## Proposed Changes

Previously, this returned true for Gravatar which was fine because the pricing display was still correct.

Now that we've fixed the coupon on the backend, we don't need this set for Gravatar. It will automatically display the correct pricing based on the backend data.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/start/domain-for-gravatar/domain-only?skippedCheckout=1 (or use the calypso.live url).
* Verify that the first-year pricing is $0
<img width="1212" height="1201" alt="CleanShot 2026-02-19 at 09 34 42" src="https://github.com/user-attachments/assets/58a4476b-cea6-4a49-a382-04215bab9081" />
* Add a domain to the cart and verify you get the discount.
<img width="1239" height="497" alt="CleanShot 2026-02-19 at 10 02 56" src="https://github.com/user-attachments/assets/01754009-8213-4a7f-bdbe-d8ddd3677e76" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
