### PR TITLE
Add Blackbox JS to WordPress.com login

### DIFF
--- a/client/blocks/login/utils/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/get-blackbox-session-id.js
@@ -1,0 +1,26 @@
+/**
+ * Retrieve a Blackbox bot-detection session ID, if the library is loaded.
+ *
+ * Blackbox returns `BlackboxError` instead of throwing, so the `typeof`
+ * check filters those out. The try/catch is defense-in-depth in case the
+ * third-party script misbehaves — Blackbox must never block login.
+ * @returns {Promise<string|undefined>} Session ID, or undefined on failure.
+ */
+export async function getBlackboxSessionId() {
+	if ( ! window.Blackbox?.getSessionId ) {
+		return undefined;
+	}
+
+	try {
+		const result = await Promise.race( [
+			window.Blackbox.getSessionId(),
+			new Promise( ( resolve ) => setTimeout( resolve, 2000 ) ),
+		] );
+		if ( typeof result === 'string' ) {
+			return result;
+		}
+	} catch {
+		// Intentionally ignored — Blackbox must never block login.
+	}
+	return undefined;
+}

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -248,6 +248,18 @@ class Document extends Component {
 						/>
 					) }
 
+					{ sectionName === 'login' &&
+						config.isEnabled( 'blackbox-login' ) &&
+						config( 'blackbox_api_key' ) && (
+							<script
+								nonce={ inlineScriptNonce }
+								async
+								defer
+								src={ config( 'blackbox_url' ) }
+								data-apikey={ config( 'blackbox_api_key' ) }
+							/>
+						) }
+
 					{ entrypoint?.language?.manifest && (
 						<script nonce={ inlineScriptNonce } src={ entrypoint.language.manifest } />
 					) }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -253,7 +253,6 @@ class Document extends Component {
 						config( 'blackbox_api_key' ) && (
 							<script
 								nonce={ inlineScriptNonce }
-								async
 								defer
 								src={ config( 'blackbox_url' ) }
 								data-apikey={ config( 'blackbox_api_key' ) }

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -557,6 +557,7 @@ function setUpCSP( req, res, next ) {
 			'www.googletagmanager.com',
 			'https://accounts.google.com',
 			'https://bat.bing.com', // Bing Ads JS
+			'https://blackbox-api.wp.com', // Blackbox bot detection
 		],
 		'base-uri': [ "'none'" ],
 		'style-src': [
@@ -639,6 +640,7 @@ function setUpCSP( req, res, next ) {
 			'*.verygoodsecurity.com', // VGS Collect secure iframes
 			'www.paypal.com', // PayPal checkout flow
 			'*.paypal.com', // PayPal additional flows
+			'https://blackbox-api.wp.com', // Blackbox iframe transport
 		],
 		'font-src': [
 			"'self'",

--- a/client/state/login/actions/login-user-with-two-factor-verification-code.js
+++ b/client/state/login/actions/login-user-with-two-factor-verification-code.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { get } from 'lodash';
+import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
 import {
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE,
@@ -19,8 +20,10 @@ import 'calypso/state/login/init';
  * @returns {Function}                   A thunk that can be dispatched
  */
 export const loginUserWithTwoFactorVerificationCode =
-	( twoStepCode, twoFactorAuthType ) => ( dispatch, getState ) => {
+	( twoStepCode, twoFactorAuthType ) => async ( dispatch, getState ) => {
 		dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
+
+		const blackboxSessionId = await getBlackboxSessionId();
 
 		return postLoginRequest( 'two-step-authentication-endpoint', {
 			user_id: getTwoFactorUserId( getState() ),
@@ -30,6 +33,7 @@ export const loginUserWithTwoFactorVerificationCode =
 			remember_me: true,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
+			...( blackboxSessionId && { blackbox_session_id: blackboxSessionId } ),
 		} )
 			.then( ( response ) => {
 				return remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {

--- a/client/state/login/actions/login-user-with-two-factor-verification-code.js
+++ b/client/state/login/actions/login-user-with-two-factor-verification-code.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { get } from 'lodash';
-import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
 import {
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE,
@@ -20,10 +19,8 @@ import 'calypso/state/login/init';
  * @returns {Function}                   A thunk that can be dispatched
  */
 export const loginUserWithTwoFactorVerificationCode =
-	( twoStepCode, twoFactorAuthType ) => async ( dispatch, getState ) => {
+	( twoStepCode, twoFactorAuthType ) => ( dispatch, getState ) => {
 		dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
-
-		const blackboxSessionId = await getBlackboxSessionId();
 
 		return postLoginRequest( 'two-step-authentication-endpoint', {
 			user_id: getTwoFactorUserId( getState() ),
@@ -33,7 +30,6 @@ export const loginUserWithTwoFactorVerificationCode =
 			remember_me: true,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
-			...( blackboxSessionId && { blackbox_session_id: blackboxSessionId } ),
 		} )
 			.then( ( response ) => {
 				return remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {

--- a/client/state/login/actions/login-user.js
+++ b/client/state/login/actions/login-user.js
@@ -1,6 +1,7 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { get } from 'lodash';
+import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import {
 	LOGIN_REQUEST,
@@ -24,57 +25,61 @@ import 'calypso/state/login/init';
  * @param  {string}   domain          A domain to reverse login to
  * @returns {Function}                 A thunk that can be dispatched
  */
-export const loginUser = ( usernameOrEmail, password, redirectTo, domain ) => ( dispatch ) => {
-	dispatch( {
-		type: LOGIN_REQUEST,
-	} );
-
-	return postLoginRequest( 'login-endpoint', {
-		username: usernameOrEmail,
-		password,
-		remember_me: true,
-		redirect_to: redirectTo,
-		client_id: config( 'wpcom_signup_id' ),
-		client_secret: config( 'wpcom_signup_key' ),
-		domain: domain,
-		tos: JSON.stringify( getToSAcceptancePayload() ),
-		anon_id: getTracksAnonymousUserId(),
-	} )
-		.then( ( response ) => {
-			if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {
-				dispatch( {
-					type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
-					notice: {
-						message: getSMSMessageFromResponse( response ),
-						status: 'is-success',
-					},
-					twoStepNonce: get( response, 'body.data.two_step_nonce_sms' ),
-				} );
-			}
-
-			// if the user has 2FA, in this stage he's not yet logged in.
-			if ( ! get( response, 'body.data.two_step_notification_sent' ) ) {
-				return remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
-					dispatch( {
-						type: LOGIN_REQUEST_SUCCESS,
-						data: response.body && response.body.data,
-					} );
-				} );
-			}
-
-			return dispatch( {
-				type: LOGIN_REQUEST_SUCCESS,
-				data: response.body && response.body.data,
-			} );
-		} )
-		.catch( ( httpError ) => {
-			const error = getErrorFromHTTPError( httpError );
-
-			dispatch( {
-				type: LOGIN_REQUEST_FAILURE,
-				error,
-			} );
-
-			return Promise.reject( error );
+export const loginUser =
+	( usernameOrEmail, password, redirectTo, domain ) => async ( dispatch ) => {
+		dispatch( {
+			type: LOGIN_REQUEST,
 		} );
-};
+
+		const blackboxSessionId = await getBlackboxSessionId();
+
+		return postLoginRequest( 'login-endpoint', {
+			username: usernameOrEmail,
+			password,
+			remember_me: true,
+			redirect_to: redirectTo,
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+			domain: domain,
+			tos: JSON.stringify( getToSAcceptancePayload() ),
+			anon_id: getTracksAnonymousUserId(),
+			...( blackboxSessionId && { blackbox_session_id: blackboxSessionId } ),
+		} )
+			.then( ( response ) => {
+				if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {
+					dispatch( {
+						type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
+						notice: {
+							message: getSMSMessageFromResponse( response ),
+							status: 'is-success',
+						},
+						twoStepNonce: get( response, 'body.data.two_step_nonce_sms' ),
+					} );
+				}
+
+				// if the user has 2FA, in this stage he's not yet logged in.
+				if ( ! get( response, 'body.data.two_step_notification_sent' ) ) {
+					return remoteLoginUser( get( response, 'body.data.token_links', [] ) ).then( () => {
+						dispatch( {
+							type: LOGIN_REQUEST_SUCCESS,
+							data: response.body && response.body.data,
+						} );
+					} );
+				}
+
+				return dispatch( {
+					type: LOGIN_REQUEST_SUCCESS,
+					data: response.body && response.body.data,
+				} );
+			} )
+			.catch( ( httpError ) => {
+				const error = getErrorFromHTTPError( httpError );
+
+				dispatch( {
+					type: LOGIN_REQUEST_FAILURE,
+					error,
+				} );
+
+				return Promise.reject( error );
+			} );
+	};

--- a/client/state/login/actions/login-user.js
+++ b/client/state/login/actions/login-user.js
@@ -81,8 +81,10 @@ export const loginUser =
 				} );
 
 				// Reset Blackbox so the next login attempt gets a fresh session.
-				if ( window.Blackbox?.reset ) {
-					window.Blackbox.reset();
+				try {
+					window.Blackbox?.reset();
+				} catch {
+					// Intentionally ignored — Blackbox must never interfere with login.
 				}
 
 				return Promise.reject( error );

--- a/client/state/login/actions/login-user.js
+++ b/client/state/login/actions/login-user.js
@@ -80,6 +80,11 @@ export const loginUser =
 					error,
 				} );
 
+				// Reset Blackbox so the next login attempt gets a fresh session.
+				if ( window.Blackbox?.reset ) {
+					window.Blackbox.reset();
+				}
+
 				return Promise.reject( error );
 			} );
 	};

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -216,6 +216,8 @@
 	"theme_color_admin_color_scheme_override": true,
 	"100_year_plan_calendly_id": "wpcom-100-years/30min",
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
+	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
+	"blackbox_api_key": "",
 	"site_spec": {
 		"script_url": "https://widgets.wp.com/site-spec/v1.4.8/index.js",
 		"css_url": "https://widgets.wp.com/site-spec/v1.4.8/style.css"

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -217,7 +217,7 @@
 	"100_year_plan_calendly_id": "wpcom-100-years/30min",
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
-	"blackbox_api_key": "",
+	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"site_spec": {
 		"script_url": "https://widgets.wp.com/site-spec/v1.4.8/index.js",
 		"css_url": "https://widgets.wp.com/site-spec/v1.4.8/style.css"

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -217,7 +217,7 @@
 	"100_year_plan_calendly_id": "wpcom-100-years/30min",
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js",
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
-	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
+	"blackbox_api_key": "e16ecd5d7848b169d97088e4c69065d8",
 	"site_spec": {
 		"script_url": "https://widgets.wp.com/site-spec/v1.4.8/index.js",
 		"css_url": "https://widgets.wp.com/site-spec/v1.4.8/style.css"

--- a/config/development.json
+++ b/config/development.json
@@ -39,7 +39,6 @@
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
-	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"features": {
 		"100-year-domain": true,
 		"blackbox-login": true,

--- a/config/development.json
+++ b/config/development.json
@@ -39,8 +39,10 @@
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
+	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"features": {
 		"100-year-domain": true,
+		"blackbox-login": true,
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -9,9 +9,11 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
+	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"features": {
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
+		"blackbox-login": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -9,7 +9,6 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
-	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"features": {
 		"100-year-plan/vip": true,
 		"ad-tracking": false,

--- a/config/production.json
+++ b/config/production.json
@@ -18,11 +18,13 @@
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
+	"blackbox_api_key": "y68bUI0fqjJQF79C",
 	"features": {
 		"100-year-plan/vip": true,
 		"ad-tracking": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"bilmur-script": true,
+		"blackbox-login": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,

--- a/config/production.json
+++ b/config/production.json
@@ -18,7 +18,7 @@
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "cec07bc9-4da6-4dd2-afa7-c7e01ae73584",
-	"blackbox_api_key": "y68bUI0fqjJQF79C",
+	"blackbox_api_key": "1b4f123e7dae4d83bbd18170c4358f8e",
 	"features": {
 		"100-year-plan/vip": true,
 		"ad-tracking": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,7 +16,6 @@
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
-	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"features": {
 		"100-year-domain": true,
 		"100-year-plan/vip": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,11 +16,13 @@
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
+	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"features": {
 		"100-year-domain": true,
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
+		"blackbox-login": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,

--- a/config/test.json
+++ b/config/test.json
@@ -20,10 +20,12 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
+	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"features": {
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
+		"blackbox-login": true,
 		"calypso/all-domain-management": true,
 		"calypso/domains-dataviews": true,
 		"catch-js-errors": false,

--- a/config/test.json
+++ b/config/test.json
@@ -20,7 +20,6 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
-	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"features": {
 		"100-year-plan/vip": true,
 		"ad-tracking": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,7 +16,6 @@
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
-	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"features": {
 		"100-year-plan/vip": true,
 		"100-year-domain": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,11 +16,13 @@
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
+	"blackbox_api_key": "1f3Ze6VdnMmKdWGi",
 	"features": {
 		"100-year-plan/vip": true,
 		"100-year-domain": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
+		"blackbox-login": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,

--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -22,6 +22,7 @@ const features = {
 	'signup/social-first': false,
 	'login/magic-login': false,
 	'bilmur-script': false,
+	'blackbox-login': false,
 };
 
 export default ( data: ConfigData ): ConfigData => {


### PR DESCRIPTION
**Summary**

Integrates Blackbox into the WordPress.com password flow (If you'd like to know more about Blackbox, look us up on A8c Slack).

**What it does:**                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                          
1. Calypso's server-rendered HTML conditionally injects the blackbox <script> tag on the login page, gated by the blackbox-login feature flag and the presence of a configured API key.                                                                                                 
2. The script tag includes defer and a data-apikey attribute, so it loads without blocking the page.                                                                                                                                                                              
3. CSP rules in Calypso's server config whitelist blackbox-api.wp.com for both script-src (the JS bundles) and frame-src (the iframe transport).                                                                                                                                        
4. On load, the blackbox IIFE reads the API key from the script tag, exposes a frozen window.Blackbox API, and waits for DOMContentLoaded.
5. Once the DOM is ready, init() starts the Blackbox session
6. A fire-and-forget collect() kicks off immediately after init
7. When the user submits the login form, the loginUser Redux action calls getBlackboxSessionId(), a Calypso utility that wraps window.Blackbox.getSessionId() with a 2-second timeout.
8. If a session ID was already cached from the background collect, it returns immediately; otherwise it awaits the in-flight collect or fires a new one.
9. The session ID is included as blackbox_session_id in the login POST request body if Blackbox was able to successfully create a session.
10. If login fails, Calypso calls window.Blackbox.reset() to start a fresh session, again as a fire-and-forget collect() 
11. Every Blackbox call in Calypso is wrapped in try/catch — if the script fails to load, is blocked, or errors out, the login flow proceeds normally without it.
