### PR TITLE
A4A-2136: add Pressable add-on descriptions for Storage and Visits

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hocs/with-product-lightbox.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hocs/with-product-lightbox.tsx
@@ -104,7 +104,7 @@ function withProductLightbox< T >(
 		}, [ asReferral, isSelected, quantity, translate ] );
 
 		const customDescription = useMemo( () => {
-			if ( currentProduct.slug.startsWith( 'pressable-addon-sites-' ) ) {
+			if ( currentProduct.slug.startsWith( 'pressable-addon-' ) ) {
 				return (
 					<PressableAddonsCustomDescription
 						productName={ currentProduct.name }
@@ -118,7 +118,7 @@ function withProductLightbox< T >(
 			}
 
 			return undefined;
-		}, [ currentProduct.slug ] );
+		}, [ currentProduct.name, currentProduct.slug ] );
 
 		const customFooter = useMemo( () => {
 			if ( currentProduct.slug.startsWith( 'woocommerce-' ) ) {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/index.tsx
@@ -10,18 +10,75 @@ type Props = {
 	productSlug: string;
 };
 
-const getAddonCount = ( productSlug: string ): number | null => {
+type PressableAddonType = 'sites' | 'storage' | 'visits' | 'unknown';
+
+const getAddonType = ( productSlug: string ): PressableAddonType => {
+	if ( productSlug.startsWith( 'pressable-addon-sites-' ) ) {
+		return 'sites';
+	}
+
+	if ( productSlug.startsWith( 'pressable-addon-storage-' ) ) {
+		return 'storage';
+	}
+
+	if ( productSlug.startsWith( 'pressable-addon-visits-' ) ) {
+		return 'visits';
+	}
+
+	return 'unknown';
+};
+
+const getAddonValue = ( productSlug: string ): string | null => {
 	const parts = productSlug.split( '-' );
 	const lastPart = parts[ parts.length - 1 ];
-	const count = Number( lastPart );
-
-	return Number.isFinite( count ) ? count : null;
+	return lastPart || null;
 };
 
 export default function PressableAddonsCustomDescription( { productName, productSlug }: Props ) {
 	const translate = useTranslate();
 	const { description } = useProductDescription( productSlug );
-	const count = getAddonCount( productSlug );
+	const addOnType = getAddonType( productSlug );
+	const count = getAddonValue( productSlug );
+
+	const getCalloutCopy = () => {
+		if ( addOnType === 'sites' ) {
+			return translate( 'Site limit will be increased by %(count)s on your Signature plan', {
+				args: { count },
+			} );
+		}
+
+		if ( addOnType === 'storage' ) {
+			return translate( 'Storage limit will be increased by %(count)s on your Signature plan', {
+				args: { count },
+			} );
+		}
+
+		if ( addOnType === 'visits' ) {
+			return translate( 'Visits limit will be increased by %(count)s on your Signature plan', {
+				args: { count },
+			} );
+		}
+
+		return translate( 'Plan limit will be increased by %(count)s on your Signature plan', {
+			args: { count },
+		} );
+	};
+
+	const getDetailLimitCopy = () => {
+		if ( addOnType === 'sites' ) {
+			return translate( "Site add-ons raise your plan's limits while your plan is active." );
+		}
+
+		if ( addOnType === 'storage' ) {
+			return translate( "Storage add-ons raise your plan's limits while your plan is active." );
+		}
+
+		if ( addOnType === 'visits' ) {
+			return translate( "Visits add-ons raise your plan's limits while your plan is active." );
+		}
+
+		return translate( "Add-ons raise your plan's limits while your plan is active." );
+	};
 
 	return (
 		<div className="pressable-addons-custom-description">
@@ -37,11 +94,7 @@ export default function PressableAddonsCustomDescription( { productName, product
 			{ count !== null && (
 				<div className="pressable-addons-custom-description__callout">
 					<Icon icon={ info } size={ 16 } />
-					<span>
-						{ translate( 'Site limit will be increased by %(count)d on your Signature plan', {
-							args: { count },
-						} ) }
-					</span>
+					<span>{ getCalloutCopy() }</span>
 				</div>
 			) }
 			<div className="pressable-addons-custom-description__section">
@@ -52,9 +105,7 @@ export default function PressableAddonsCustomDescription( { productName, product
 							'Add-ons let you customize your Pressable plan without upgrading to the next plan tier.'
 						) }
 					</li>
-					<li>
-						{ translate( "Site add-ons raise your plan's limits while your plan is active." ) }
-					</li>
+					<li>{ getDetailLimitCopy() }</li>
 					<li>
 						{ translate(
 							'Add-ons must be attached to an active Pressable plan. If you cancel your Pressable plan, any add-ons will be canceled automatically.'

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/index.tsx
@@ -70,7 +70,9 @@ export default function PressableAddonsCustomDescription( { productName, product
 		}
 
 		if ( addOnType === 'storage' ) {
-			return translate( "Storage add-ons raise your plan's limits while your plan is active." );
+			return translate(
+				"Storage add-ons raise your plan's limits while you plan is active, and are distributed across all your active site installations."
+			);
 		}
 
 		if ( addOnType === 'visits' ) {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/index.tsx
@@ -40,27 +40,27 @@ export default function PressableAddonsCustomDescription( { productName, product
 	const addOnType = getAddonType( productSlug );
 	const count = getAddonValue( productSlug );
 
-	const getCalloutCopy = () => {
+	const getCalloutCopy = ( countValue: string ) => {
 		if ( addOnType === 'sites' ) {
 			return translate( 'Site limit will be increased by %(count)s on your Signature plan', {
-				args: { count },
+				args: { count: countValue },
 			} );
 		}
 
 		if ( addOnType === 'storage' ) {
 			return translate( 'Storage limit will be increased by %(count)s on your Signature plan', {
-				args: { count },
+				args: { count: countValue },
 			} );
 		}
 
 		if ( addOnType === 'visits' ) {
 			return translate( 'Visits limit will be increased by %(count)s on your Signature plan', {
-				args: { count },
+				args: { count: countValue },
 			} );
 		}
 
 		return translate( 'Plan limit will be increased by %(count)s on your Signature plan', {
-			args: { count },
+			args: { count: countValue },
 		} );
 	};
 
@@ -94,7 +94,7 @@ export default function PressableAddonsCustomDescription( { productName, product
 			{ count !== null && (
 				<div className="pressable-addons-custom-description__callout">
 					<Icon icon={ info } size={ 16 } />
-					<span>{ getCalloutCopy() }</span>
+					<span>{ getCalloutCopy( count ) }</span>
 				</div>
 			) }
 			<div className="pressable-addons-custom-description__section">

--- a/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
@@ -120,6 +120,16 @@ export function useProductDescription( productSlug: string ): {
 		let description = '';
 		const features = [];
 
+		if ( productSlug.startsWith( 'pressable-addon-storage-' ) ) {
+			description = translate( 'Add additional storage capacity to your Pressable plan limit.' );
+		}
+
+		if ( productSlug.startsWith( 'pressable-addon-visits-' ) ) {
+			description = translate(
+				'Add additional monthly visits capacity to your Pressable plan limit.'
+			);
+		}
+
 		switch ( productSlug ) {
 			case 'jetpack-complete':
 				description = translate(


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-2136/ui-add-product-description-for-pressable-add-ons-storage-and-visits

## Proposed Changes

* Add short description handling for Pressable add-ons using slug prefixes:
  * `pressable-addon-storage-*` -> `Add additional storage capacity to your Pressable plan limit.`
  * `pressable-addon-visits-*` -> `Add additional monthly visits capacity to your Pressable plan limit.`
* Apply `PressableAddonsCustomDescription` to all `pressable-addon-*` lightbox products (not just Sites).
* Make `PressableAddonsCustomDescription` type-aware for Sites/Storage/Visits:
  * Type-specific top callout copy.
  * Type-specific details bullet copy.
  * Keep shared details content unchanged.

**Add-ons cards**

<img width="1212" height="628" alt="image" src="https://github.com/user-attachments/assets/c293a882-7b79-4ba0-b3a3-12740aae30a9" />

**Storage lightbox**

<img width="1111" height="665" alt="image" src="https://github.com/user-attachments/assets/e356b839-9a17-4929-a44a-c1c3d688bb7f" />

**Visits lightbox**

<img width="1106" height="662" alt="image" src="https://github.com/user-attachments/assets/c3fb4edb-0f2d-4fa9-8ec5-b320bd92ac4a" />

## Why are these changes being made?

* A4A-2136 requests product descriptions for new Pressable add-ons (Storage and Visits).
* Sites add-ons already had custom copy; Storage/Visits needed equivalent behavior for consistency in product cards and lightbox details.

## Testing Instructions

* Checkout this branch and run.
* Or open the live A4A link to test it.
* Activate the feature flag: `?flags=a4a-pressable-addons`
* You will need a Pressable Signature plan active.
* In the "Marketplace > Products", `Pressable Add-ons`, verify card short descriptions:
  * `Sites Add-on` cards still show existing Sites copy.
  * `Storage Add-on` card shows `Add additional storage capacity to your Pressable plan limit.`
  * `Visits Add-on` card shows `Add additional monthly visits capacity to your Pressable plan limit.`
* Open `View details` for each add-on type and verify lightbox copy:
  * Sites: `Site limit will be increased by ...` and `Site add-ons raise your plan's limits while your plan is active.`
  * Storage: `Storage limit will be increased by ...` and `Storage add-ons raise your plan's limits while your plan is active.`
  * Visits: `Visits limit will be increased by ...` and `Visits add-ons raise your plan's limits while your plan is active.`
* Confirm non-Pressable products still render their existing lightbox custom content (e.g. WooPayments) unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
