### PR TITLE
Domain-Only Flow: Preserve dashboard parameter until the user gets to the thank-you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only-new/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only-new/index.tsx
@@ -1,7 +1,9 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { Step } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { OptionContent } from 'calypso/components/option-content';
+import { getDashboardFromQuery } from 'calypso/dashboard/app/routing';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import {
 	createSiteFromDomainOnly,
@@ -106,7 +108,10 @@ export default function DomainOnlyNew( {
 				/>
 				<Step.LinkButton
 					className="domain-only-new__migrate-link"
-					href={ `/setup/site-migration?siteSlug=${ domainPurchase.meta }` }
+					href={ addQueryArgs( '/setup/site-migration', {
+						dashboard: getDashboardFromQuery(),
+						siteSlug: domainPurchase.meta,
+					} ) }
 				>
 					{ translate( 'Migrate an existing site' ) }
 				</Step.LinkButton>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only-new/test/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only-new/test/index.tsx
@@ -3,6 +3,7 @@
  */
 
 import { screen } from '@testing-library/react';
+import { getDashboardFromQuery } from 'calypso/dashboard/app/routing';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import {
 	createSiteFromDomainOnly,
@@ -31,6 +32,11 @@ jest.mock(
 		useDomainToPlanCreditsApplicable: jest.fn(),
 	} )
 );
+
+jest.mock( 'calypso/dashboard/app/routing', () => ( {
+	...jest.requireActual( 'calypso/dashboard/app/routing' ),
+	getDashboardFromQuery: jest.fn(),
+} ) );
 
 const mockDomainPurchase: ReceiptPurchase = {
 	meta: 'example.com',
@@ -198,6 +204,16 @@ describe( 'DomainOnlyNew', () => {
 			expect( screen.getByRole( 'link', { name: /Migrate an existing site/ } ) ).toHaveAttribute(
 				'href',
 				`/setup/site-migration?siteSlug=${ mockDomainPurchase.meta }`
+			);
+		} );
+
+		it( 'links to the site migration setup flow with dashboard query param if present', () => {
+			jest.mocked( getDashboardFromQuery ).mockReturnValue( 'ciab' );
+			renderComponent();
+
+			expect( screen.getByRole( 'link', { name: /Migrate an existing site/ } ) ).toHaveAttribute(
+				'href',
+				`/setup/site-migration?dashboard=ciab&siteSlug=${ mockDomainPurchase.meta }`
 			);
 		} );
 	} );

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -25,6 +25,7 @@ import {
 } from '@automattic/calypso-url';
 import { isTailoredSignupFlow } from '@automattic/onboarding';
 import debugFactory from 'debug';
+import { getDashboardFromQuery } from 'calypso/dashboard/app/routing';
 import { REMOTE_PATH_AUTH } from 'calypso/jetpack-connect/constants';
 import {
 	getGoogleApps,
@@ -461,7 +462,16 @@ export default function getThankYouPageUrl( {
 		debug( 'adding Gravatar domain query param to fallback URL', fallbackUrl );
 	}
 
-	return getUrlWithQueryParam( fallbackUrl );
+	const queryParams: Record< string, string > = {};
+
+	const dashboard = getDashboardFromQuery();
+
+	if ( dashboard ) {
+		queryParams.dashboard = dashboard;
+		debug( 'adding dashboard query param to fallback URL', dashboard );
+	}
+
+	return getUrlWithQueryParam( fallbackUrl, queryParams );
 }
 
 function updateUrlInCookie( {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -7,6 +7,7 @@ import {
 import { DOMAIN_FOR_GRAVATAR_FLOW, isDomainForGravatarFlow } from '@automattic/onboarding';
 import { isURL } from '@wordpress/url';
 import { get, includes, reject } from 'lodash';
+import { getDashboardFromQuery } from 'calypso/dashboard/app/routing';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { getOnboardingPostCheckoutDestination } from 'calypso/landing/stepper/declarative-flow/helpers/get-onboarding-post-checkout-destination';
 import { getQueryArgs } from 'calypso/lib/query-args';
@@ -42,6 +43,8 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 		? addQueryArgs( { skippedCheckout: 1, celebrateLaunch: 'true' }, checkoutBackUrl )
 		: addQueryArgs( { skippedCheckout: 1 }, checkoutBackUrl );
 
+	const dashboard = getDashboardFromQuery();
+
 	return addQueryArgs(
 		{
 			signup: 1,
@@ -52,6 +55,7 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 			checkoutBackUrl: finalCheckoutBackUrl,
 			// Pass the final destination as redirect_to so checkout knows where to go after completion
 			...( destination && { redirect_to: destination } ),
+			...( dashboard && { dashboard } ),
 		},
 		checkoutURL
 	);
@@ -120,10 +124,6 @@ function getDomainSignupFlowDestination( { siteId, designType, siteSlug } ) {
 
 		// Redirection URL handled by the checkout controller
 		return '';
-	}
-
-	if ( dashboardType ) {
-		return dashboardLink( '/domains' );
 	}
 
 	// Redirection URL handled by the checkout controller


### PR DESCRIPTION
Addresses p1771517132141589/1770164256.252079-slack-C04H4NY6STW.

## Proposed Changes

When the user starts the `/start/domain` flow from the dashboard (/domains, whether CIAB or MSD), we add the `dashboard` query parameter so Start and Stepper know to redirect the user back when the flow finishes.

The presence of this query parameter meant the user would be sent back to the dashboard immediately, as written in `getDomainSignupFlowDestination`, **not giving the user a chance to see the new domain-only thank-you page**.

To fix this, we're removing the hardcoded redirect URL from the flow destination function and preserving the dashboard parameter even after checkout redirect, so when we get to the thank you page, we can decide whether we want to send the user back to the dashboard (in case they purchase more than one domain) or not.

## Testing Instructions

**Test the PR locally, as there are some redirection problems with Calypso Live environments.**

Enter `/domains` (Dotcom dashboard), click "Add domain name" then "Search domain names". Pick only one domain, then choose the domain-only option in the next step.

Purchase the domain and verify you end up at the redesigned domain-only thank you page:

<img width="1783" height="1122" alt="image" src="https://github.com/user-attachments/assets/ea47bafe-5387-4d81-92d3-7b4f7b1b6ef3" />

Go through the flow again, but this time purchase two domains. You should be redirected back to the dashboard directly.

For the final test and to make sure we're not adding regressions, enter `/start/domain` directly, without the `?dashboard` query parameter. Go through the flow and verify that you still land on the redesigned thank-you page.