### PR TITLE
Fix Cover block e2e test timeout in iframed canvas editor

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/cover-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/cover-block.ts
@@ -39,8 +39,8 @@ export class CoverBlock {
 
 		// After uploading the image the focus is switched to the inner
 		// paragraph block (Cover title), so we need to switch it back outside.
-		const editorParent = await this.editor.parent();
-		await editorParent
+		const editorCanvas = await this.editor.canvas();
+		await editorCanvas
 			.locator( CoverBlock.blockEditorSelector )
 			.click( { position: { x: 1, y: 1 } } );
 	}
@@ -77,6 +77,7 @@ export class CoverBlock {
 		const styleSelector = `.is-style-${ style.toLowerCase().replace( ' ', '-' ) }`;
 		const blockSelector = `[data-block="${ blockId }"]`;
 
-		await editorParent.locator( blockSelector + styleSelector ).waitFor();
+		const editorCanvas = await this.editor.canvas();
+		await editorCanvas.locator( blockSelector + styleSelector ).waitFor();
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Use `editor.canvas()` instead of `editor.parent()` when locating block elements in the `CoverBlock` e2e helper
* Keep `editor.parent()` for sidebar UI elements (settings tabs, style buttons) which live outside the canvas iframe

## Why are these changes being made?

The `blocks__coblocks__extensions__cover-styles` e2e test is failing in TeamCity with a 15s timeout on the "Upload image" step:

```
locator.click: Timeout 15000ms exceeded.
Call log:
  - waiting for locator('body.block-editor-page').locator('[aria-label="Block: Cover"]')
```

The `CoverBlock.upload()` method uses `this.editor.parent()` to locate the block after image upload. In editors with an iframed canvas, `parent()` returns `body.block-editor-page` which is **outside** the canvas iframe, while the block element lives **inside** it. Switching to `this.editor.canvas()` correctly traverses into the iframe to find the block.

The same issue also affected `setCoverStyle()` which waited for the block's style class from the parent scope.

## Testing Instructions

* Run the affected e2e test: `CALYPSO_BASE_URL=https://wpcalypso.wordpress.com yarn workspace wp-e2e-tests test -- specs/blocks/blocks__coblocks__extensions__cover-styles.ts`
* The "Upload image" step should no longer time out

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?