### PR TITLE
Revert "Fix Cover block e2e test timeout in iframed canvas editor"

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/cover-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/cover-block.ts
@@ -39,8 +39,8 @@ export class CoverBlock {
 
 		// After uploading the image the focus is switched to the inner
 		// paragraph block (Cover title), so we need to switch it back outside.
-		const editorCanvas = await this.editor.canvas();
-		await editorCanvas
+		const editorParent = await this.editor.parent();
+		await editorParent
 			.locator( CoverBlock.blockEditorSelector )
 			.click( { position: { x: 1, y: 1 } } );
 	}
@@ -77,7 +77,6 @@ export class CoverBlock {
 		const styleSelector = `.is-style-${ style.toLowerCase().replace( ' ', '-' ) }`;
 		const blockSelector = `[data-block="${ blockId }"]`;
 
-		const editorCanvas = await this.editor.canvas();
-		await editorCanvas.locator( blockSelector + styleSelector ).waitFor();
+		await editorParent.locator( blockSelector + styleSelector ).waitFor();
 	}
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#108807