### PR TITLE
A4A-1558: Update Pressable usage capacity with add-ons

### DIFF
--- a/client/a8c-for-agencies/components/pressable-usage-details/capacity.ts
+++ b/client/a8c-for-agencies/components/pressable-usage-details/capacity.ts
@@ -10,6 +10,10 @@ function getNormalizedLicenseQuantity( quantity: number | null ): number {
 	return quantity && quantity > 0 ? quantity : 1;
 }
 
+function normalizePressableAddonKey( licenseKey: string ): string {
+	return licenseKey.split( '_' )[ 0 ];
+}
+
 export function calculateAddonCapacityFromLicenses( licenses: License[] = [] ): PressableCapacity {
 	return licenses.reduce(
 		( total, license ) => {
@@ -21,7 +25,8 @@ export function calculateAddonCapacityFromLicenses( licenses: License[] = [] ): 
 				return total;
 			}
 
-			const addOnInfo = getPressablePlan( license.licenseKey );
+			const addOnKey = normalizePressableAddonKey( license.licenseKey );
+			const addOnInfo = getPressablePlan( addOnKey );
 
 			if ( ! addOnInfo ) {
 				return total;

--- a/client/a8c-for-agencies/components/pressable-usage-details/capacity.ts
+++ b/client/a8c-for-agencies/components/pressable-usage-details/capacity.ts
@@ -1,0 +1,53 @@
+import { isPressableAddonProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import getPressablePlan, {
+	PressablePlan,
+} from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
+import type { License } from 'calypso/state/partner-portal/types';
+
+export type PressableCapacity = Pick< PressablePlan, 'install' | 'storage' | 'visits' >;
+
+function getNormalizedLicenseQuantity( quantity: number | null ): number {
+	return quantity && quantity > 0 ? quantity : 1;
+}
+
+export function calculateAddonCapacityFromLicenses( licenses: License[] = [] ): PressableCapacity {
+	return licenses.reduce(
+		( total, license ) => {
+			if (
+				license.referral ||
+				license.revokedAt ||
+				! isPressableAddonProduct( license.licenseKey )
+			) {
+				return total;
+			}
+
+			const addOnInfo = getPressablePlan( license.licenseKey );
+
+			if ( ! addOnInfo ) {
+				return total;
+			}
+
+			const quantity = getNormalizedLicenseQuantity( license.quantity );
+
+			return {
+				install: total.install + addOnInfo.install * quantity,
+				storage: total.storage + addOnInfo.storage * quantity,
+				visits: total.visits + addOnInfo.visits * quantity,
+			};
+		},
+		{ install: 0, storage: 0, visits: 0 }
+	);
+}
+
+export function calculateEffectiveCapacity(
+	basePlan: PressableCapacity,
+	licenses: License[] = []
+): PressableCapacity {
+	const addOnCapacity = calculateAddonCapacityFromLicenses( licenses );
+
+	return {
+		install: basePlan.install + addOnCapacity.install,
+		storage: basePlan.storage + addOnCapacity.storage,
+		visits: basePlan.visits + addOnCapacity.visits,
+	};
+}

--- a/client/a8c-for-agencies/components/pressable-usage-details/test/capacity.test.ts
+++ b/client/a8c-for-agencies/components/pressable-usage-details/test/capacity.test.ts
@@ -32,7 +32,12 @@ describe( 'Pressable usage capacity calculations', () => {
 	} );
 
 	it( 'adds sites add-on capacity', () => {
-		const licenses = [ buildLicense( { licenseKey: 'pressable-addon-sites-5', quantity: 1 } ) ];
+		const licenses = [
+			buildLicense( {
+				licenseKey: 'pressable-addon-sites-5_J64c5S2kkNg0laJlaimU5PKpr',
+				quantity: 1,
+			} ),
+		];
 
 		expect( calculateAddonCapacityFromLicenses( licenses ) ).toEqual( {
 			install: 5,
@@ -42,7 +47,12 @@ describe( 'Pressable usage capacity calculations', () => {
 	} );
 
 	it( 'adds storage add-on capacity', () => {
-		const licenses = [ buildLicense( { licenseKey: 'pressable-addon-storage-1gb', quantity: 1 } ) ];
+		const licenses = [
+			buildLicense( {
+				licenseKey: 'pressable-addon-storage-1gb_67tEGzNf2l8Nl001fGg8w9alr',
+				quantity: 1,
+			} ),
+		];
 
 		expect( calculateAddonCapacityFromLicenses( licenses ) ).toEqual( {
 			install: 0,
@@ -52,7 +62,9 @@ describe( 'Pressable usage capacity calculations', () => {
 	} );
 
 	it( 'adds visits add-on capacity', () => {
-		const licenses = [ buildLicense( { licenseKey: 'pressable-addon-visits-10k', quantity: 1 } ) ];
+		const licenses = [
+			buildLicense( { licenseKey: 'pressable-addon-visits-10k_MOCKSUFFIX', quantity: 1 } ),
+		];
 
 		expect( calculateAddonCapacityFromLicenses( licenses ) ).toEqual( {
 			install: 0,
@@ -63,9 +75,9 @@ describe( 'Pressable usage capacity calculations', () => {
 
 	it( 'sums mixed add-ons', () => {
 		const licenses = [
-			buildLicense( { licenseKey: 'pressable-addon-sites-1', quantity: 1 } ),
-			buildLicense( { licenseKey: 'pressable-addon-storage-1gb', quantity: 2 } ),
-			buildLicense( { licenseKey: 'pressable-addon-visits-10k', quantity: 3 } ),
+			buildLicense( { licenseKey: 'pressable-addon-sites-1_SFX1', quantity: 1 } ),
+			buildLicense( { licenseKey: 'pressable-addon-storage-1gb_SFX2', quantity: 2 } ),
+			buildLicense( { licenseKey: 'pressable-addon-visits-10k_SFX3', quantity: 3 } ),
 		];
 
 		expect( calculateAddonCapacityFromLicenses( licenses ) ).toEqual( {

--- a/client/a8c-for-agencies/components/pressable-usage-details/test/capacity.test.ts
+++ b/client/a8c-for-agencies/components/pressable-usage-details/test/capacity.test.ts
@@ -1,0 +1,108 @@
+import { calculateAddonCapacityFromLicenses, calculateEffectiveCapacity } from '../capacity';
+import type { License } from 'calypso/state/partner-portal/types';
+
+function buildLicense( overrides: Partial< License > = {} ): License {
+	return {
+		licenseId: 1,
+		licenseKey: 'pressable-addon-sites-1',
+		productId: 1,
+		product: 'pressable-addon-sites-1',
+		userId: null,
+		username: null,
+		blogId: null,
+		siteUrl: null,
+		hasDownloads: false,
+		issuedAt: '',
+		attachedAt: null,
+		revokedAt: null,
+		ownerType: null,
+		quantity: 1,
+		parentLicenseId: null,
+		meta: {},
+		referral: null,
+		...overrides,
+	};
+}
+
+describe( 'Pressable usage capacity calculations', () => {
+	it( 'keeps base capacities when there are no add-ons', () => {
+		expect( calculateEffectiveCapacity( { install: 5, storage: 35, visits: 75000 }, [] ) ).toEqual(
+			{ install: 5, storage: 35, visits: 75000 }
+		);
+	} );
+
+	it( 'adds sites add-on capacity', () => {
+		const licenses = [ buildLicense( { licenseKey: 'pressable-addon-sites-5', quantity: 1 } ) ];
+
+		expect( calculateAddonCapacityFromLicenses( licenses ) ).toEqual( {
+			install: 5,
+			storage: 20,
+			visits: 50000,
+		} );
+	} );
+
+	it( 'adds storage add-on capacity', () => {
+		const licenses = [ buildLicense( { licenseKey: 'pressable-addon-storage-1gb', quantity: 1 } ) ];
+
+		expect( calculateAddonCapacityFromLicenses( licenses ) ).toEqual( {
+			install: 0,
+			storage: 1,
+			visits: 0,
+		} );
+	} );
+
+	it( 'adds visits add-on capacity', () => {
+		const licenses = [ buildLicense( { licenseKey: 'pressable-addon-visits-10k', quantity: 1 } ) ];
+
+		expect( calculateAddonCapacityFromLicenses( licenses ) ).toEqual( {
+			install: 0,
+			storage: 0,
+			visits: 10000,
+		} );
+	} );
+
+	it( 'sums mixed add-ons', () => {
+		const licenses = [
+			buildLicense( { licenseKey: 'pressable-addon-sites-1', quantity: 1 } ),
+			buildLicense( { licenseKey: 'pressable-addon-storage-1gb', quantity: 2 } ),
+			buildLicense( { licenseKey: 'pressable-addon-visits-10k', quantity: 3 } ),
+		];
+
+		expect( calculateAddonCapacityFromLicenses( licenses ) ).toEqual( {
+			install: 1,
+			storage: 12,
+			visits: 40000,
+		} );
+	} );
+
+	it( 'multiplies by quantity and defaults null quantity to 1', () => {
+		const licenses = [
+			buildLicense( { licenseKey: 'pressable-addon-sites-10', quantity: 2 } ),
+			buildLicense( { licenseKey: 'pressable-addon-storage-1gb', quantity: null } ),
+		];
+
+		expect( calculateAddonCapacityFromLicenses( licenses ) ).toEqual( {
+			install: 20,
+			storage: 41,
+			visits: 200000,
+		} );
+	} );
+
+	it( 'ignores unknown, revoked, referral, and non-add-on licenses', () => {
+		const licenses = [
+			buildLicense( { licenseKey: 'pressable-signature-3' } ),
+			buildLicense( { licenseKey: 'unknown-addon-key' } ),
+			buildLicense( { licenseKey: 'pressable-addon-sites-1', revokedAt: '2026-01-01T00:00:00Z' } ),
+			buildLicense( {
+				licenseKey: 'pressable-addon-visits-10k',
+				referral: { id: 1 } as License[ 'referral' ],
+			} ),
+		];
+
+		expect( calculateAddonCapacityFromLicenses( licenses ) ).toEqual( {
+			install: 0,
+			storage: 0,
+			visits: 0,
+		} );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan.ts
@@ -1,3 +1,4 @@
+import { PRODUCT_CATEGORY_PRESSABLE_ADDON } from '../../constants';
 import {
 	PLAN_CATEGORY_STANDARD,
 	PLAN_CATEGORY_ENTERPRISE,
@@ -13,6 +14,7 @@ export type PressablePlan = {
 	storage: number;
 	category: string;
 	worker?: number;
+	unit?: string;
 };
 
 const PLAN_DATA: Record< string, PressablePlan > = {
@@ -439,6 +441,88 @@ const PLAN_DATA: Record< string, PressablePlan > = {
 		storage: 175,
 		worker: 25,
 		category: PLAN_CATEGORY_PREMIUM,
+	},
+
+	// [Add-ons] Pressable add-ons capacity values.
+	site_addon_1: {
+		slug: 'site_addon_1',
+		install: 1,
+		visits: 10000,
+		storage: 10,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	site_addon_5: {
+		slug: 'site_addon_5',
+		install: 5,
+		visits: 50000,
+		storage: 20,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	site_addon_10: {
+		slug: 'site_addon_10',
+		install: 10,
+		visits: 100000,
+		storage: 20,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	visits_addon_10k: {
+		slug: 'visits_addon_10k',
+		install: 0,
+		visits: 10000,
+		storage: 0,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	storage_addon_1gb: {
+		slug: 'storage_addon_1gb',
+		install: 0,
+		visits: 0,
+		storage: 1,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	titan_addon: {
+		slug: 'titan_addon',
+		install: 0,
+		visits: 0,
+		storage: 0,
+		unit: 'inbox',
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+
+	// [Add-ons] License key aliases used in A4A/Jetpack licensing.
+	'pressable-addon-sites-1': {
+		slug: 'pressable-addon-sites-1',
+		install: 1,
+		visits: 10000,
+		storage: 10,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	'pressable-addon-sites-5': {
+		slug: 'pressable-addon-sites-5',
+		install: 5,
+		visits: 50000,
+		storage: 20,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	'pressable-addon-sites-10': {
+		slug: 'pressable-addon-sites-10',
+		install: 10,
+		visits: 100000,
+		storage: 20,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	'pressable-addon-visits-10k': {
+		slug: 'pressable-addon-visits-10k',
+		install: 0,
+		visits: 10000,
+		storage: 0,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
+	},
+	'pressable-addon-storage-1gb': {
+		slug: 'pressable-addon-storage-1gb',
+		install: 0,
+		visits: 0,
+		storage: 1,
+		category: PRODUCT_CATEGORY_PRESSABLE_ADDON,
 	},
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/test/get-pressable-plan.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/test/get-pressable-plan.test.ts
@@ -1,0 +1,48 @@
+import getPressablePlan from '../get-pressable-plan';
+
+describe( 'getPressablePlan add-on mappings', () => {
+	it( 'returns ticket-defined site add-on capacities', () => {
+		expect( getPressablePlan( 'site_addon_1' ) ).toMatchObject( {
+			install: 1,
+			storage: 10,
+			visits: 10000,
+		} );
+		expect( getPressablePlan( 'site_addon_5' ) ).toMatchObject( {
+			install: 5,
+			storage: 20,
+			visits: 50000,
+		} );
+		expect( getPressablePlan( 'site_addon_10' ) ).toMatchObject( {
+			install: 10,
+			storage: 20,
+			visits: 100000,
+		} );
+	} );
+
+	it( 'returns alias capacities used by license keys', () => {
+		expect( getPressablePlan( 'pressable-addon-sites-1' ) ).toMatchObject( {
+			install: 1,
+			storage: 10,
+			visits: 10000,
+		} );
+		expect( getPressablePlan( 'pressable-addon-visits-10k' ) ).toMatchObject( {
+			install: 0,
+			storage: 0,
+			visits: 10000,
+		} );
+		expect( getPressablePlan( 'pressable-addon-storage-1gb' ) ).toMatchObject( {
+			install: 0,
+			storage: 1,
+			visits: 0,
+		} );
+	} );
+
+	it( 'returns titan add-on with zero usage-impact capacities', () => {
+		expect( getPressablePlan( 'titan_addon' ) ).toMatchObject( {
+			install: 0,
+			storage: 0,
+			visits: 0,
+			unit: 'inbox',
+		} );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -2,7 +2,10 @@ import { Badge, Card, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
-import { isPressableHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import {
+	isPressableAddonProduct,
+	isPressableHostingProduct,
+} from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import useGetPressablePlanByProductId from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-get-pressable-plan-by-product-id';
 import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
@@ -48,6 +51,8 @@ export default function LicenseDetails( {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
+	const isPressableAddonLicense =
+		isPressableAddonProduct( licenseKey ) || isPressableAddonProduct( product );
 	const shouldShowSubscription = subscription && licenseState !== LicenseState.Revoked;
 	const subscriptionDateLabel = ( () => {
 		if ( ! shouldShowSubscription ) {
@@ -126,16 +131,18 @@ export default function LicenseDetails( {
 						</div>
 					</li>
 				) }
-				{ isPressableLicense && licenseState !== LicenseState.Revoked && (
-					<div>
-						<h4 className="license-details__label">
-							{ translate( 'Manage your Pressable licenses' ) }
-						</h4>
-						{ ! referral && pressablePlan && (
-							<PressableUsageDetails existingPlan={ pressablePlan } />
-						) }
-					</div>
-				) }
+				{ isPressableLicense &&
+					! isPressableAddonLicense &&
+					licenseState !== LicenseState.Revoked && (
+						<div>
+							<h4 className="license-details__label">
+								{ translate( 'Manage your Pressable licenses' ) }
+							</h4>
+							{ ! referral && pressablePlan && (
+								<PressableUsageDetails existingPlan={ pressablePlan } />
+							) }
+						</div>
+					) }
 
 				<li className="license-details__list-item-small">
 					<h4 className="license-details__label">{ translate( 'Issued on' ) }</h4>


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/A4A-1558/update-the-agency-data-about-pressable-usage-endpoint

## Proposed Changes

* Update Pressable usage limits to include active Pressable add-on capacity for sites, storage, and monthly visits.
* Add Pressable add-on capacity mappings in `get-pressable-plan.ts` for both canonical task keys and license-key aliases.
* Add pure capacity calculation helper logic and targeted unit tests.

**Before**

<img width="1114" height="363" alt="image" src="https://github.com/user-attachments/assets/52cdeb78-a6b0-4b9b-a731-22c1aa2b4829" />

**After**

<img width="1088" height="373" alt="image" src="https://github.com/user-attachments/assets/85d4b028-c1f2-4e6f-8ba8-8b1bcf6f42fe" />

## Why are these changes being made?

* The Pressable usage UI currently displays base plan capacity only.
* Agencies with add-ons should see effective limits that include purchased add-on capacity, matching backend/license reality.

## Testing Instructions

* Run targeted tests for:
  * `yarn test-client client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/test/get-pressable-plan.test.ts --runInBand`
  * `yarn test-client client/a8c-for-agencies/components/pressable-usage-details/test/capacity.test.ts --runInBand`
* In the Pressable usage card UI, verify max limits for sites/storage/visits reflect base plan + active add-ons.
* Confirm Titan card behavior remains unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
