### PR TITLE
Newsletter Settings: fix general settings link pointing to writing settings

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/BylineSettings.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/BylineSettings.tsx
@@ -103,6 +103,9 @@ export const BylineSettings = ( {
 						'You can customize the date format in your site’s {{link}}general settings{{/link}}',
 						{
 							components: {
+								// ExternalLink opens in a new tab with an external link icon.
+								// Space child satisfies its required children prop;
+								// translate() replaces it with the interpolated text at runtime.
 								link: <ExternalLink href={ generalSettingsUrl }> </ExternalLink>,
 							},
 						}

--- a/client/my-sites/site-settings/settings-newsletter/BylineSettings.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/BylineSettings.tsx
@@ -1,5 +1,5 @@
 import { Gravatar, FormLabel } from '@automattic/components';
-import { ToggleControl, Button } from '@wordpress/components';
+import { ExternalLink, ToggleControl, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import {
@@ -103,7 +103,7 @@ export const BylineSettings = ( {
 						'You can customize the date format in your site’s {{link}}general settings{{/link}}',
 						{
 							components: {
-								link: <a href={ generalSettingsUrl } />,
+								link: <ExternalLink href={ generalSettingsUrl }> </ExternalLink>,
 							},
 						}
 					) }

--- a/client/my-sites/site-settings/settings-newsletter/BylineSettings.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/BylineSettings.tsx
@@ -9,6 +9,7 @@ import {
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { BylinePreview } from './BylinePreview';
 
@@ -36,10 +37,14 @@ export const BylineSettings = ( {
 	const translate = useTranslate();
 	const site = useSelector( getSelectedSite );
 	const user = useSelector( getCurrentUser );
-	const siteSlug = site?.slug || '';
 	const timezone = useSelector( ( state ) =>
 		site?.ID ? getSiteTimezoneValue( state, Number( site.ID ) ) : null
 	);
+	const siteSlug = site?.slug || '';
+	const generalSettingsUrl =
+		useSelector( ( state ) =>
+			getSiteAdminUrl( state, site?.ID ? Number( site.ID ) : null, 'options-general.php' )
+		) ?? `/settings/general/${ siteSlug }`;
 
 	const localizedDate = getLocalizedDate( timezone || 'UTC' );
 	const formattedDate = phpToMomentDatetimeFormat( localizedDate, dateFormat );
@@ -98,7 +103,7 @@ export const BylineSettings = ( {
 						'You can customize the date format in your site’s {{link}}general settings{{/link}}',
 						{
 							components: {
-								link: <a href={ `/settings/writing/${ siteSlug }` } />,
+								link: <a href={ generalSettingsUrl } />,
 							},
 						}
 					) }


### PR DESCRIPTION
## Proposed Changes

Fixes https://linear.app/a8c/issue/NL-451/link-says-general-settings-but-goes-to-writing-settings

* Fix the "general settings" link in the newsletter byline date format section to point to `wp-admin/options-general.php` instead of `/settings/writing/`
* Fall back to `/settings/general/{siteSlug}` if the admin URL is unavailable
* Switch to `ExternalLink` component that opens in a new tab, to match Jetpack behavior

Before | After | Jetpack
---- | ---- | ----
<img width="736" height="371" alt="Screenshot 2026-02-20 at 10 49 06 AM" src="https://github.com/user-attachments/assets/05eca2cd-bf18-4902-8f74-60cb29b1a545" /> | <img width="738" height="377" alt="Screenshot 2026-02-20 at 9 48 16 AM" src="https://github.com/user-attachments/assets/e7b67063-5ac3-4af3-b904-2116553eb7c3" /> | <img width="1088" height="386" alt="Screenshot 2026-02-20 at 10 47 51 AM" src="https://github.com/user-attachments/assets/4dc6e3a2-ac81-4d80-80d5-434d36d0e89d" />


## Why are these changes being made?

On the newsletter settings page (`/settings/newsletter/{site}`), the text says "You can customize the date format in your site's general settings" with a link. The link incorrectly pointed to `/settings/writing/`, which is the writing settings page — not general settings. Additionally, using the Calypso `/settings/general/` route causes a redirect loop when trying to navigate back. This fix links directly to `wp-admin/options-general.php` to avoid both issues.

## Testing Instructions

1. Go to `/settings/newsletter/{site}`
2. Enable "Add the post date" toggle
3. Click the "general settings" link
4. Verify it navigates to `wp-admin/options-general.php` (general settings) in a new tab instead of writing settings

Note the sentence is missing a period, but fixing that here would require a new translation.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)