### PR TITLE
Stats: Fix UTM date range calculation

### DIFF
--- a/client/my-sites/stats/hooks/test/utils.test.ts
+++ b/client/my-sites/stats/hooks/test/utils.test.ts
@@ -1,0 +1,117 @@
+import { processQueryParams } from '../utils';
+
+describe( 'processQueryParams', () => {
+	describe( 'days calculation', () => {
+		it( 'should default to 1 day when period is "day" and no date range is provided', () => {
+			const result = processQueryParams( { period: 'day' } );
+			expect( result.days ).toBe( 1 );
+		} );
+
+		it( 'should use num when provided for period "day"', () => {
+			const result = processQueryParams( { period: 'day', num: 7 } );
+			expect( result.days ).toBe( 7 );
+		} );
+
+		it( 'should calculate days from date range when start_date and date are provided', () => {
+			const result = processQueryParams( {
+				period: 'day',
+				start_date: '2026-02-01',
+				date: '2026-02-07',
+			} );
+			// 7 days from Feb 1 to Feb 7 inclusive
+			expect( result.days ).toBe( 7 );
+		} );
+
+		it( 'should calculate days correctly for single day range', () => {
+			const result = processQueryParams( {
+				period: 'day',
+				start_date: '2026-02-15',
+				date: '2026-02-15',
+			} );
+			// Same start and end date should be 1 day
+			expect( result.days ).toBe( 1 );
+		} );
+
+		it( 'should calculate days correctly for a longer range', () => {
+			const result = processQueryParams( {
+				period: 'day',
+				start_date: '2026-01-01',
+				date: '2026-01-31',
+			} );
+			// 31 days in January
+			expect( result.days ).toBe( 31 );
+		} );
+
+		it( 'should override period-based days when date range is provided', () => {
+			// Even with period 'week', if start_date and date are provided,
+			// days should be calculated from the date range
+			const result = processQueryParams( {
+				period: 'week',
+				start_date: '2026-02-01',
+				date: '2026-02-28',
+			} );
+			// 28 days from Feb 1 to Feb 28
+			expect( result.days ).toBe( 28 );
+		} );
+
+		it( 'should return 7 days for period "week" without date range', () => {
+			const result = processQueryParams( { period: 'week' } );
+			expect( result.days ).toBe( 7 );
+		} );
+
+		it( 'should calculate month days correctly without date range', () => {
+			const result = processQueryParams( { period: 'month', date: '2026-02-15' } );
+			// February 2026 has 28 days
+			expect( result.days ).toBe( 28 );
+		} );
+
+		it( 'should calculate year days correctly for non-leap year without date range', () => {
+			const result = processQueryParams( { period: 'year', date: '2026-06-15' } );
+			// 2026 is not a leap year
+			expect( result.days ).toBe( 365 );
+		} );
+
+		it( 'should calculate year days correctly for leap year without date range', () => {
+			const result = processQueryParams( { period: 'year', date: '2024-06-15' } );
+			// 2024 is a leap year
+			expect( result.days ).toBe( 366 );
+		} );
+	} );
+
+	describe( 'other query params', () => {
+		it( 'should preserve existing query params', () => {
+			const result = processQueryParams( {
+				period: 'day',
+				max: 20,
+				summarize: 1,
+			} );
+			expect( result.max ).toBe( 20 );
+			expect( result.summarize ).toBe( 1 );
+		} );
+
+		it( 'should default max to 10 when not provided', () => {
+			const result = processQueryParams( {} );
+			expect( result.max ).toBe( 10 );
+		} );
+
+		it( 'should allow max to be 0', () => {
+			const result = processQueryParams( { max: 0 } );
+			expect( result.max ).toBe( 0 );
+		} );
+
+		it( 'should default start_date to empty string when not provided', () => {
+			const result = processQueryParams( {} );
+			expect( result.start_date ).toBe( '' );
+		} );
+
+		it( 'should preserve start_date when provided', () => {
+			const result = processQueryParams( { start_date: '2026-01-15' } );
+			expect( result.start_date ).toBe( '2026-01-15' );
+		} );
+
+		it( 'should default num to 1 when not provided', () => {
+			const result = processQueryParams( {} );
+			expect( result.num ).toBe( 1 );
+		} );
+	} );
+} );

--- a/client/my-sites/stats/hooks/utils.ts
+++ b/client/my-sites/stats/hooks/utils.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 export interface QueryStatsParams {
 	date?: string;
 	start_date?: string;
@@ -24,6 +26,17 @@ const daysInYearFromDate = ( date: string ) => {
 	return ( year % 4 === 0 && year % 100 > 0 ) || year % 400 === 0 ? 366 : 365;
 };
 
+/**
+ * Calculate the number of days between two dates (inclusive).
+ * @param startDate - The start date in 'YYYY-MM-DD' format.
+ * @param endDate   - The end date in 'YYYY-MM-DD' format.
+ * @returns The number of days between the two dates (inclusive).
+ */
+const getDaysBetweenDates = ( startDate: string, endDate: string ): number => {
+	// Add 1 to include both the start and end dates.
+	return Math.abs( moment( endDate ).diff( moment( startDate ), 'days' ) ) + 1;
+};
+
 export const processQueryParams = ( query: QueryStatsParams ) => {
 	// `num` is only for the period `day`.
 	const num = query.num || 1;
@@ -43,6 +56,12 @@ export const processQueryParams = ( query: QueryStatsParams ) => {
 		case 'year':
 			days = daysInYearFromDate( date );
 			break;
+	}
+
+	// When a custom date range is provided via start_date and date,
+	// calculate days based on the actual date range instead of the period.
+	if ( query.start_date && query.date ) {
+		days = getDaysBetweenDates( query.start_date, query.date );
 	}
 
 	return {


### PR DESCRIPTION
Part of STATS-213

## Proposed Changes

- Fix `processQueryParams` to calculate `days` based on the actual date range when both `start_date` and `date` are provided
- Add `getDaysBetweenDates` helper function using moment.js for reliable date diff calculation
- Add comprehensive tests for `processQueryParams`

## Why are these changes being made?

When a custom date range was selected in the Stats UI, the query object was populated with `start_date` and `date`, but `days` was incorrectly set to 1 for period 'day'. This caused the UTM stats API to only fetch today's data instead of the full date range, resulting in:
- UTM stats not showing data for the selected date range
- The UTM parameter toggle (source/medium, campaign, etc.) not appearing when there was no data for today

This fix ensures the API fetches data for the entire selected date range. Location views and device stats also use this function, so they benefit from this fix as well.

## Testing Instructions

1. Go to Stats > Traffic on an Atomic site
2. Select a custom date range (e.g., last 30 days)
3. Scroll down to the UTM section
4. Verify that UTM data is displayed for the selected date range (if any UTM-tagged visits exist)
5. Verify the parameter dropdown (Source/Medium, Campaign, etc.) appears when data is available

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?