### PR TITLE
Stats: Show UTM parameter dropdown in empty state

### DIFF
--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -178,6 +178,18 @@ const StatsModuleUTM = ( {
 		</StatsInfoArea>
 	);
 
+	const toggleControl = (
+		<div className="stats-module__extended-toggle">
+			<UTMBuilder />
+			<UTMDropdown
+				buttonLabel={ optionLabels[ selectedOption ].selectLabel }
+				onSelect={ setSelectedOption }
+				selectOptions={ optionLabels }
+				selected={ selectedOption }
+			/>
+		</div>
+	);
+
 	return (
 		<>
 			{ showLoader && (
@@ -193,13 +205,15 @@ const StatsModuleUTM = ( {
 					<StatsCard
 						className={ className }
 						title={ moduleStrings.title }
-						titleNodes={ <StatsInfoArea /> }
+						titleNodes={ titleNodes }
+						splitHeader
+						toggleControl={ toggleControl }
 						isEmpty
 						emptyMessage={
 							<EmptyModuleCard
 								icon={ trendingUp }
 								description={ translate(
-									'Your {{link}}campaign UTM performance data{{/link}} will display here once readers click on your URLs with UTM codes. Get started!',
+									'No data yet for this {{link}}UTM{{/link}} parameter. Try selecting a different combination above, or generate a URL with our builder below to get started.',
 									{
 										comment: '{{link}} links to support documentation.',
 										components: {
@@ -252,17 +266,7 @@ const StatsModuleUTM = ( {
 						error={ hasError && <ErrorPanel /> }
 						splitHeader
 						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
-						toggleControl={
-							<div className="stats-module__extended-toggle">
-								<UTMBuilder />
-								<UTMDropdown
-									buttonLabel={ optionLabels[ selectedOption ].selectLabel }
-									onSelect={ setSelectedOption }
-									selectOptions={ optionLabels }
-									selected={ selectedOption }
-								/>
-							</div>
-						}
+						toggleControl={ toggleControl }
 					/>
 				) }
 		</>


### PR DESCRIPTION
Part of STATS-213

## Proposed Changes

* Show the UTM parameter dropdown (Source/Medium, Campaign, etc.) even when there's no data for the current selection
* Extract `toggleControl` into a variable to deduplicate code between empty and data states
* Use the descriptive `titleNodes` tooltip in empty state for consistency

## Why are these changes being made?

When the UTM module has no data for the default "Source / Medium" selection, the dropdown to switch between UTM parameters was hidden. This prevented users from discovering they might have data for other UTM parameters (like "Campaign").

As described in the Linear issue comment, users had to first switch to a larger time window (which was more likely to have data) just to see the dropdown, then switch parameters, and finally go back to the original time period. This fix makes the dropdown always visible so users can switch parameters regardless of whether data exists for the current selection.

## Testing Instructions

1. Go to Stats > Traffic on a site that has UTM data for "Campaign" but not for "Source / Medium" (or vice versa)
2. Verify the UTM parameter dropdown is visible even when the empty state is shown
3. Switch between different UTM parameters and verify the module updates correctly
4. Confirm the UTM Builder button is also visible in the empty state

**Before:** Dropdown hidden when no data exists
**After:** Dropdown visible, allowing users to switch UTM parameters

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?