### PR TITLE
Fix Docker build failure caused by @automattic/ui package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ bin/build-docker.sh
 /cached-requests.json
 **/node_modules
 /public
+/config/secrets.json
 /packages/calypso-e2e/src/secrets/*.json
 /client/server/bundler/*.json
 /client/server/devdocs/components-usage-stats.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,13 +74,6 @@ RUN node --version && yarn --version && npm --version
 ENV NODE_ENV production
 RUN yarn run build 2>&1 | tee /tmp/build_log.txt
 
-# Ensure lang-revisions.json exists so the server doesn't 500.
-# When BUILD_TRANSLATION_CHUNKS is false or the CDN is unreachable, the build
-# skips language downloads. An empty JSON object lets the server start without
-# translations instead of crashing.
-RUN mkdir -p /calypso/public/languages && \
-    [ -f /calypso/public/languages/lang-revisions.json ] || echo '{}' > /calypso/public/languages/lang-revisions.json
-
 # This will output a service message to TeamCity if the build cache was invalidated as seen in the build_log file.
 RUN ./bin/check-log-for-cache-invalidation.sh /tmp/build_log.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,13 @@ RUN node --version && yarn --version && npm --version
 ENV NODE_ENV production
 RUN yarn run build 2>&1 | tee /tmp/build_log.txt
 
+# Ensure lang-revisions.json exists so the server doesn't 500.
+# When BUILD_TRANSLATION_CHUNKS is false or the CDN is unreachable, the build
+# skips language downloads. An empty JSON object lets the server start without
+# translations instead of crashing.
+RUN mkdir -p /calypso/public/languages && \
+    [ -f /calypso/public/languages/lang-revisions.json ] || echo '{}' > /calypso/public/languages/lang-revisions.json
+
 # This will output a service message to TeamCity if the build cache was invalidated as seen in the build_log file.
 RUN ./bin/check-log-for-cache-invalidation.sh /tmp/build_log.txt
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"build-docker": "node bin/build-docker.js",
 		"build-languages": "yarn run translate && node bin/build-languages.js",
 		"build-languages-if-enabled": "node -e \"(process.env.BUILD_TRANSLATION_CHUNKS === 'true' || process.env.ENABLE_FEATURES === 'use-translation-chunks') && process.exit(1)\" || yarn run build-languages",
-		"build-packages": "{ [ \"${SKIP_TSC:-}\" = \"true\" ] || tsc --build packages/tsconfig.json; } && yarn workspaces foreach --all --parallel --verbose run prepare",
+		"build-packages": "{ [ \"${SKIP_TSC:-}\" = \"true\" ] || tsc --build packages/tsconfig.json; } && yarn workspaces foreach --all --parallel --topological --verbose run prepare",
 		"build-server": "mkdir -p build && BROWSERSLIST_ENV=server webpack --config client/webpack.config.node.js --stats-preset errors-only && yarn run build-server:copy-modules",
 		"build-server-stats": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=true yarn run build-server",
 		"build-server:copy-modules": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || node bin/copy-production-modules.js",

--- a/package.json
+++ b/package.json
@@ -431,6 +431,9 @@
 	"dependenciesMeta": {
 		"@react-spring/core@9.3.0": {
 			"built": false
+		},
+		"lzma-native": {
+			"built": false
 		}
 	}
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -106,6 +106,7 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"prepare": "yarn build",
 		"prepack": "yarn run clean && yarn run build",
 		"storybook:start": "storybook dev -p 56833",
 		"storybook:build": "storybook build"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -77,6 +77,7 @@
 	"scripts": {
 		"clean": "rm -rf dist",
 		"build": "yarn clean && tsup",
+		"prepare": "yarn build",
 		"prepack": "yarn build",
 		"storybook:start": "storybook dev -p 56851"
 	}

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -31,6 +31,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",
+		"@automattic/data-stores": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/api-fetch": "^7.23.0",
 		"@wordpress/element": "^6.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2626,6 +2626,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/data-stores": "workspace:^"
     "@tanstack/react-query": "npm:^5.83.0"
     "@wordpress/api-fetch": "npm:^7.23.0"
     "@wordpress/element": "npm:^6.23.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -37971,6 +37971,8 @@ __metadata:
       built: false
     fsevents:
       optional: true
+    lzma-native:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Proposed Changes

- Add `prepare` scripts to `@automattic/ui` and `@automattic/components` so they build during the `yarn workspaces foreach run prepare` step
- Add `--topological` flag to the `build-packages` foreach command so Yarn respects the dependency graph when running parallel builds
- Add missing `@automattic/data-stores` dependency to `@automattic/zendesk-client` to align its `package.json` with its TypeScript project references

## Why are these changes being made?

The Docker build fails during `yarn install` because packages that transitively depend on `@automattic/ui` cannot resolve its type declarations. Three issues combine to cause this:

1. `.dockerignore` strips all `/packages/*/dist/` directories from the build context
2. The Dockerfile sets `SKIP_TSC=true`, skipping the global `tsc --build` that would normally build types in the correct dependency order
3. The `build-packages` script runs `yarn workspaces foreach --parallel` without `--topological`, so Yarn launches all package `prepare` scripts simultaneously with no dependency ordering — packages that need `@automattic/ui` types start before `@automattic/ui` finishes building

## Testing Instructions

- Run `docker build -t calypso .` from the repo root
- Verify the `yarn install` step passes without `Cannot find module '@automattic/ui'` errors

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?