### PR TITLE
Dashboard: add missing startSiteCollisionListener mock in preferences test

### DIFF
--- a/client/dashboard/me/preferences-default-landing/test/index.test.tsx
+++ b/client/dashboard/me/preferences-default-landing/test/index.test.tsx
@@ -27,6 +27,7 @@ jest.mock( '@wordpress/data', () => ( {
 jest.mock(
 	'@automattic/api-queries',
 	() => ( {
+		startSiteCollisionListener: jest.fn( () => jest.fn() ),
 		rawUserPreferencesQuery: jest.fn( () => ( {
 			queryKey: [ 'me', 'preferences' ],
 			queryFn: jest.fn(),

--- a/client/dashboard/me/preferences-primary-site/test/index.test.tsx
+++ b/client/dashboard/me/preferences-primary-site/test/index.test.tsx
@@ -30,6 +30,7 @@ jest.mock( '@wordpress/data', () => ( {
 jest.mock(
 	'@automattic/api-queries',
 	() => ( {
+		startSiteCollisionListener: jest.fn( () => jest.fn() ),
 		userSettingsQuery: jest.fn( () => ( {
 			queryKey: [ 'me', 'settings' ],
 			queryFn: jest.fn(),


### PR DESCRIPTION
Part of #108736

## Proposed Changes

* Add missing `startSiteCollisionListener` mock to the preferences default landing test.

## Why are these changes being made?

#108736 added a `startSiteCollisionListener` export to `@automattic/api-queries`. The preferences test mocks that module but didn't include this new export, causing test failures.

## Testing Instructions

* Run `yarn test-client client/dashboard/me/preferences-default-landing/test/index.test.tsx` and verify it passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?