### PR TITLE
Fix plugin upload error not showing proper message for HTTP 413

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -86,13 +86,11 @@ const MarketplaceProductInstall = ( {
 	const pluginUploadError = useSelector( ( state ) => getPluginUploadError( state, siteId ) );
 	const pluginExists = pluginUploadError?.error === 'folder_exists';
 	const pluginMalicious = pluginUploadError?.error === 'plugin_malicious';
-	const pluginTooBig = ( () => {
-		if ( ! pluginUploadError ) {
-			return false;
-		}
-		const errorString = `${ pluginUploadError.error }${ pluginUploadError.message }`.toLowerCase();
-		return errorString.includes( 'too large' ) || errorString.includes( 'http 413' );
-	} )();
+	const pluginTooBigError = pluginUploadError
+		? `${ pluginUploadError.error }${ pluginUploadError.message }`.toLowerCase()
+		: '';
+	const pluginTooBig =
+		pluginTooBigError.includes( 'too large' ) || pluginTooBigError.includes( 'http 413' );
 	const wporgPlugin = useSelector( ( state ) => getPlugin( state, pluginSlug ) );
 	const isWporgPluginFetched = useSelector( ( state ) => isFetched( state, pluginSlug ) );
 	const uploadedPluginSlug = useSelector( ( state ) =>

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -86,7 +86,13 @@ const MarketplaceProductInstall = ( {
 	const pluginUploadError = useSelector( ( state ) => getPluginUploadError( state, siteId ) );
 	const pluginExists = pluginUploadError?.error === 'folder_exists';
 	const pluginMalicious = pluginUploadError?.error === 'plugin_malicious';
-	const pluginTooBig = pluginUploadError?.statusCode === 413;
+	const pluginTooBig = ( () => {
+		if ( ! pluginUploadError ) {
+			return false;
+		}
+		const errorString = `${ pluginUploadError.error }${ pluginUploadError.message }`.toLowerCase();
+		return errorString.includes( 'too large' ) || errorString.includes( 'http 413' );
+	} )();
 	const wporgPlugin = useSelector( ( state ) => getPlugin( state, pluginSlug ) );
 	const isWporgPluginFetched = useSelector( ( state ) => isFetched( state, pluginSlug ) );
 	const uploadedPluginSlug = useSelector( ( state ) =>

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -30,10 +30,15 @@ export const uploadPlugin = ( action ) => {
 	];
 };
 
+const PLUGIN_UPLOAD_SIZE_LIMIT = '100MB';
+
 const showErrorNotice = ( error ) => {
+	const fileTooLargeMessage = translate( 'The plugin zip file must be smaller than %(limit)s.', {
+		args: { limit: PLUGIN_UPLOAD_SIZE_LIMIT },
+	} );
 	const knownErrors = {
-		'too large': translate( 'The plugin zip file is too large.' ),
-		'http 413': translate( 'The plugin zip file is too large.' ),
+		'too large': fileTooLargeMessage,
+		'http 413': fileTooLargeMessage,
 		incompatible: translate( 'The uploaded file is not a compatible plugin.' ),
 		unsupported_mime_type: translate( 'The uploaded file is not a valid zip.' ),
 	};

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -32,7 +32,8 @@ export const uploadPlugin = ( action ) => {
 
 const showErrorNotice = ( error ) => {
 	const knownErrors = {
-		'too large': translate( 'The plugin zip file must be smaller than 10MB.' ),
+		'too large': translate( 'The plugin zip file is too large.' ),
+		'http 413': translate( 'The plugin zip file is too large.' ),
 		incompatible: translate( 'The uploaded file is not a compatible plugin.' ),
 		unsupported_mime_type: translate( 'The uploaded file is not a valid zip.' ),
 	};

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -126,7 +126,7 @@ describe( 'receiveError', () => {
 				type: 'NOTICE_CREATE',
 				notice: expect.objectContaining( {
 					status: 'is-error',
-					text: 'The plugin zip file is too large.',
+					text: 'The plugin zip file must be smaller than 100MB.',
 					showDismiss: true,
 				} ),
 			} )
@@ -149,7 +149,7 @@ describe( 'receiveError', () => {
 				type: 'NOTICE_CREATE',
 				notice: expect.objectContaining( {
 					status: 'is-error',
-					text: 'The plugin zip file is too large.',
+					text: 'The plugin zip file must be smaller than 100MB.',
 					showDismiss: true,
 				} ),
 			} )

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -126,7 +126,30 @@ describe( 'receiveError', () => {
 				type: 'NOTICE_CREATE',
 				notice: expect.objectContaining( {
 					status: 'is-error',
-					text: 'The plugin zip file must be smaller than 10MB.',
+					text: 'The plugin zip file is too large.',
+					showDismiss: true,
+				} ),
+			} )
+		);
+	} );
+
+	test( 'should return expected actions for HTTP 413 error (http_error)', () => {
+		const error = { error: 'http_error', message: 'HTTP 413' };
+		const actions = receiveError( { siteId }, error );
+
+		expect( actions[ 0 ] ).toEqual(
+			recordTracksEvent( 'calypso_plugin_upload_error', {
+				error_code: error.error,
+				error_message: error.message,
+			} )
+		);
+		expect( actions[ 1 ] ).toEqual( pluginUploadError( siteId, error ) );
+		expect( actions[ 2 ] ).toEqual(
+			expect.objectContaining( {
+				type: 'NOTICE_CREATE',
+				notice: expect.objectContaining( {
+					status: 'is-error',
+					text: 'The plugin zip file is too large.',
 					showDismiss: true,
 				} ),
 			} )

--- a/client/state/selectors/get-plugin-upload-error.js
+++ b/client/state/selectors/get-plugin-upload-error.js
@@ -7,7 +7,7 @@ import 'calypso/state/plugins/init';
  * null if currently no error.
  * @param {Object} state Global state tree
  * @param {number} siteId the site ID
- * @returns {null|{error?: string, statusCode: number}} Error from upload, if any
+ * @returns {null|{error?: string, message?: string, statusCode?: number}} Error from upload, if any
  */
 export default function getPluginUploadError( state, siteId ) {
 	return get( state.plugins.upload.uploadError, siteId, null );


### PR DESCRIPTION
Related to DOTDEV-295.
Related to pMz3w-ns9-p2.

## Proposed Changes

| Before | After |
|--------|--------|
| <img width="2662" height="1454" alt="CleanShot 2026-02-20 at 11 41 11@2x" src="https://github.com/user-attachments/assets/b0113a71-3d28-4618-9053-bf990c6dd4f4" /> | <img width="2616" height="1428" alt="CleanShot 2026-02-24 at 13 19 20@2x" src="https://github.com/user-attachments/assets/0b2d4f16-7957-45f7-939b-5c5bab652d10" /> | 


- Add `'http 413'` to the known errors map in the plugin upload data layer so that HTTP 413 responses are recognized as file-too-large errors
- Fix `pluginTooBig` detection in the marketplace install component to use string matching instead of the broken `statusCode === 413` check
- Update the error message to show the specific size limit (100MB) using translation interpolation, so changing the limit doesn't require retranslation
- Fix the JSDoc return type for `getPluginUploadError` to include `message`

## Why are these changes being made?

When uploading a plugin zip that exceeds the server size limit, the proxy returns `{ error: "http_error", message: "HTTP 413" }`. The frontend had two detection paths for oversized plugins, both of which failed:

1. The `knownErrors` string matching only checked for `"too large"`, but the error string was `"http_errorhttp 413"`
2. The component checked `pluginUploadError?.statusCode === 413`, but the error object has no `statusCode` property

This caused a generic "Upload problem: http_error." notice and "An error occurred while installing the plugin." screen, instead of the specific error screen that tells the user the file is too big and offers a link to re-upload via WP Admin.

## Testing Instructions

1. Use an existing testing WoA site (or create a new one for testing).
2. Create a plugin zip file larger than the upload limit (e.g., 20MB) - or - use this testing plugin of the same size: https://drive.google.com/file/d/1VfLZFRtZECNRAHo1sfKZARkEucjG-RhY/view?usp=sharing.
3. Go to `/plugins/upload/{site-slug}` and upload the zip.
4. Verify that the error screen shows "This plugin is too big to be installed via this page" with a "Re-upload plugin" link to WP Admin, instead of the generic "An error occurred while installing the plugin." message.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?