### PR TITLE
MSD: attempt to fix flaky dashboard screen tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
 		"@storybook/react": "^8.6.14",
 		"@tanstack/eslint-plugin-query": "^5.14.6",
 		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/react": "^16.3.0",
 		"@types/chroma-js": "^2.4.5",
 		"@types/eslint": "^9.6.1",
 		"@types/ga-gtag": "^1.2.0",

--- a/test/client/setup-dashboard-test-framework.js
+++ b/test/client/setup-dashboard-test-framework.js
@@ -1,7 +1,10 @@
 import '@testing-library/jest-dom';
 
 const { TextEncoder, TextDecoder } = require( 'util' );
+const { configure } = require( '@testing-library/react' );
 const nock = require( 'nock' );
+
+configure( { asyncUtilTimeout: 5000 } );
 
 // Fail any network requests which aren't mocked.
 nock.disableNetConnect();

--- a/yarn.lock
+++ b/yarn.lock
@@ -37832,6 +37832,7 @@ __metadata:
     "@storybook/react": "npm:^8.6.14"
     "@tanstack/eslint-plugin-query": "npm:^5.14.6"
     "@testing-library/jest-dom": "npm:^6.9.1"
+    "@testing-library/react": "npm:^16.3.0"
     "@types/chroma-js": "npm:^2.4.5"
     "@types/cookie": "npm:^0.6.0"
     "@types/debug": "npm:^4.1.12"


### PR DESCRIPTION
## Proposed Changes

I've seen my PR failed with the following failed unit test:

```
client/dashboard/sites/overview/test/index.test.tsx 
  renders the overview of a site with free plan

  Error: Unable to find role="heading" and name "Test Site"

  Ignored nodes: comments, script, style
  <body>
    <p
  class="a11y-speak-intro-text"
      hidden="hidden"
      id="a11y-speak-intro-text"
      style="position: absolute;margin: -1px;padding: 0;height:
  1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px,
  1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border:
  0;word-wrap: normal !important;"
    >
      Notifications
    </p>
    <div
      aria-atomic="true"
      aria-live="assertive"
      aria-relevant="additions text"
      class="a11y-speak-region"
      id="a11y-speak-assertive"
      style="position: absolute;margin: -1px;padding: 0;height:
  1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px,
  1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border:
  0;word-wrap: normal !important;"
    />
    <div
      aria-atomic="true"
      aria-live="polite"
      aria-relevant="additions text"
      class="a11y-speak-region"
      id="a11y-speak-polite"
      style="position: absolute;margin: -1px;padding: 0;height:
  1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px,
  1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border:
  0;word-wrap: normal !important;"
    />
    <div>
      <div
        data-testid="loading"
      />
    </div>
  </body>

      at waitForWrapper ...
```

Basically the screen is still rendering the loading state when the test is looking for the header.

Claude and I could not find what could have caused this flakiness. Claude suggested to increase the async timeout.

## Testing Instructions

Verify CI passes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
