### PR TITLE
Agents Manager: Self-mount when unified experience is enabled

### DIFF
--- a/apps/agents-manager/agents-manager-wp-admin.js
+++ b/apps/agents-manager/agents-manager-wp-admin.js
@@ -1,3 +1,4 @@
+/* global agentsManagerData */
 import { createRoot } from 'react-dom/client';
 import AgentsManagerWithProvider from './agents-manager-with-provider';
 import HeadlessAgentWithProvider from './headless-agent-with-provider';
@@ -5,8 +6,16 @@ import HeadlessAgentWithProvider from './headless-agent-with-provider';
 const masterbarTarget = document.getElementById( 'agents-manager-masterbar' );
 
 if ( masterbarTarget ) {
-	// Full UI mode: render Agents Manager dock in the masterbar
+	// Full UI mode: render Agents Manager in the admin bar masterbar node
 	createRoot( masterbarTarget ).render( <AgentsManagerWithProvider /> );
+} else if ( agentsManagerData?.useUnifiedExperience ) {
+	// Unified experience without admin bar: create own container and render full UI.
+	// This covers environments like CIAB that enable the unified experience
+	// but don't render the WordPress admin bar.
+	const container = document.createElement( 'div' );
+	container.id = 'agents-manager-root';
+	document.body.appendChild( container );
+	createRoot( container ).render( <AgentsManagerWithProvider /> );
 } else {
 	// Headless mode: just initialize the agent without UI
 	// This allows other components (like Image Studio) to use the shared agent


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [WOOAI-324](https://linear.app/a8c/issue/WOOAI-324)

Part of [WOOAI-253](https://linear.app/a8c/issue/WOOAI-253)

Replaces 3114-ghe-Automattic/ciab-admin

## Proposed Changes

When `agentsManagerData.useUnifiedExperience` is true but no `#agents-manager-masterbar` div exists, create a container and render the full UI.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This removes the dependency on a server-rendered admin bar div for environments like CIAB that don't render the WordPress admin bar.

## Testing Instructions

### Pre-requisites
1. ⚠️ Make sure you are pointing `widgets.wp.com` to your wpcom sandbox (`/etc/hosts`). 
2. Build and sync agents-manager app to your sandbox with `cd apps/agents-manager && yarn dev --sync`
3. Make sure you complete the `./bin/setup-ai.zsh` process in your `ciab-admin` environment.
4. The rest of the testing assumes you test in your `ciab-admin` environment.

### Testing CIAB
1. With [the option] (`pgatNH-1CI-p2`) disabled.
2. Go to your test site: `/wp-admin/admin.php?page=next-admin&p=%2F`.
4. Confirm the legacy experience is loading. Do it by running `document.querySelector('.big-sky-sidebar')` in the console, which **must return you an element**.
5. Enable the option (`pgatNH-1CI-p2`).
6. ⚠️ You might need to wait up to 5 minutes until cache refreshes.
7. Go again to the next-admin page `/wp-admin/admin.php?page=next-admin&p=%2F`.
8. Confirm the new Agents Manager UI appears. Do it by running `document.querySelector('.big-sky-sidebar')` and confirming it **DOES NOT** return any element. Plus, the welcome and options on the sidebar will be different. See screenshots below.

### Testing calypso

1. Run `yarn && yarn start` in the root calypso.
1. Load http://calypso.localhost:3000/ and confirm Unified UI appears when the option is enabled.
2. Only one chat UI should appear (`document.querySelector('.agents-manager-chat')` and not `document.querySelector('.big-sky-sidebar')`)

### Testing big sky site 

1. Use some big-sky site (or create one via https://wordpress.com/setup/ai-site-builder).
2. Go to the editor (page or post).
3. Confirm chat UI shows when option is enabled.
4. Only one chat UI should appear.2. Only one chat UI should appear (`document.querySelector('.agents-manager-chat')` and not `document.querySelector('.big-sky-sidebar')`)

## Screenshots or screencast

### Old experience (CIAB)

<img width="1921" height="931" alt="Screenshot 2026-02-24 at 12 35 46" src="https://github.com/user-attachments/assets/c9ff31a7-bf4f-469c-9965-a8b353067456" />

Note the icon is blue and the welcome message is "store" oriented.


### New experience (CIAB)

<img width="1919" height="1006" alt="Screenshot 2026-02-24 at 12 38 05" src="https://github.com/user-attachments/assets/1051edea-6184-4aa3-90af-2867553fa526" />

Note the icon is white and the welcome message is more generic.  Ticket to look into these differences: https://linear.app/a8c/issue/WOOAI-342/clarify-ui-differences-old-vs-new


### Known limitations in CIAB

This initial PR will have some issues regarding styling and functionality of Agents Manager UI in CIAB.

- Style in design/editor area (e.g: `wp-admin/admin.php?page=next-admin&p=%2Ftypes%2Fpage%2Flist%2Fall`) is all messed up (dark/light issues in docked mode). [[TICKET](https://linear.app/a8c/issue/WOOAI-331/fix-css-issues-in-ciab)]

<img width="1918" height="931" alt="image" src="https://github.com/user-attachments/assets/b87f938e-a97d-476e-8373-f7e1c87ab813" />

- Big sky abilities are not available yet. [[TICKET](https://linear.app/a8c/issue/WOOAI-267/chat-should-know-when-bigsky-abilities-should-be-available)]

- Agents Manager chat interface loading twice in design/editor screens. [[TICKET](https://linear.app/a8c/issue/WOOAI-332/bug-angents-manager-chat-interface-loading-twice-in-designeditor)] to be fixed by 3155-ghe-Automattic/ciab-admin and https://github.com/Automattic/jetpack/pull/47248

- Agents Manager chat interface is missing store customizations. [[TICKET](https://linear.app/a8c/issue/WOOAI-342/clarify-ui-differences-old-vs-new)]

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?