### PR TITLE
MSD: attempt to fix flaky dashboard tests by persisting fetchSite nock

### DIFF
--- a/client/dashboard/sites/backups/test/index.test.tsx
+++ b/client/dashboard/sites/backups/test/index.test.tsx
@@ -157,7 +157,11 @@ function renderBackupsListPage( {
 	backupEntries?: ActivityLogEntry[];
 	activityLogTimes?: number;
 } = {} ) {
-	nock( API_BASE ).get( '/rest/v1.1/sites/test-site' ).query( true ).reply( 200, mockSite );
+	nock( API_BASE )
+		.persist()
+		.get( '/rest/v1.1/sites/test-site' )
+		.query( true )
+		.reply( 200, mockSite );
 
 	nock( API_BASE )
 		.get( `/rest/v1.4/sites/${ mockSiteId }/settings` )

--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -158,6 +158,7 @@ function nockSiteAndSettings( {
 	timezoneString = '',
 }: { gmtOffset?: number; timezoneString?: string } = {} ) {
 	nock( API_BASE )
+		.persist()
 		.get( '/rest/v1.1/sites/test-site' )
 		.query( true )
 		.reply( 200, {

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -40,6 +40,7 @@ const site = {
 
 function mockSite( mockedSite: Site ) {
 	nock( 'https://public-api.wordpress.com' )
+		.persist()
 		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
 		.query( true )
 		.reply( 200, mockedSite );

--- a/client/dashboard/sites/settings-php/test/index.test.tsx
+++ b/client/dashboard/sites/settings-php/test/index.test.tsx
@@ -25,6 +25,7 @@ const site = {
 
 function mockSite( mockedSite: Site ) {
 	nock( 'https://public-api.wordpress.com' )
+		.persist()
 		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
 		.query( true )
 		.reply( 200, mockedSite );

--- a/client/dashboard/sites/settings-site-visibility/test/index.test.tsx
+++ b/client/dashboard/sites/settings-site-visibility/test/index.test.tsx
@@ -43,6 +43,7 @@ function mockSite(
 	} );
 
 	nock( 'https://public-api.wordpress.com' )
+		.persist()
 		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
 		.query( true )
 		.reply( 200, mockedSite )

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -19,6 +19,7 @@ const site = {
 
 function mockSite( mockedSite: Site ) {
 	nock( 'https://public-api.wordpress.com' )
+		.persist()
 		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
 		.query( true )
 		.reply( 200, mockedSite );

--- a/client/dashboard/sites/site/test/environment-switcher.test.tsx
+++ b/client/dashboard/sites/site/test/environment-switcher.test.tsx
@@ -84,12 +84,14 @@ function setupNock(
 		} );
 
 	nock( 'https://public-api.wordpress.com:443' )
+		.persist()
 		.get( `/rest/v1.1/sites/${ productionSite.ID }` )
 		.query( true )
 		.reply( 200, productionSite );
 
 	if ( extra.stagingSite ) {
 		nock( 'https://public-api.wordpress.com:443' )
+			.persist()
 			.get( `/rest/v1.1/sites/${ extra.stagingSite.ID }` )
 			.query( true )
 			.reply( 200, extra.stagingSite );

--- a/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-delete-modal/test/index.test.tsx
@@ -52,6 +52,7 @@ const mockStagingSiteWithoutProductionId = createMockSite( {
 
 function mockProductionSite() {
 	return nock( 'https://public-api.wordpress.com' )
+		.persist()
 		.get( '/rest/v1.1/sites/1' )
 		.query( true )
 		.reply( 200, {

--- a/client/dashboard/sites/staging-site-sync-dropdown/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-sync-dropdown/test/index.test.tsx
@@ -40,6 +40,7 @@ const createMockStagingSite = ( options = {} ): Site =>
 
 function mockSiteBySlug( site: Site ) {
 	nock( 'https://public-api.wordpress.com' )
+		.persist()
 		.get( `/rest/v1.1/sites/${ site.slug }` )
 		.query( true )
 		.reply( 200, site );

--- a/client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx
@@ -118,6 +118,7 @@ const defaultProps = {
 
 function mockSite( site: Site ) {
 	nock( 'https://public-api.wordpress.com' )
+		.persist()
 		.get( `/rest/v1.1/sites/${ site.ID }` )
 		.query( true )
 		.reply( 200, site );


### PR DESCRIPTION
## Proposed Changes

I've seen my PR failed with the following failed unit test:

```
client/dashboard/sites/overview/test/index.test.tsx 
  renders the overview of a site with free plan

  Error: Unable to find role="heading" and name "Test Site"

  Ignored nodes: comments, script, style
  <body>
    <p
  class="a11y-speak-intro-text"
      hidden="hidden"
      id="a11y-speak-intro-text"
      style="position: absolute;margin: -1px;padding: 0;height:
  1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px,
  1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border:
  0;word-wrap: normal !important;"
    >
      Notifications
    </p>
    <div
      aria-atomic="true"
      aria-live="assertive"
      aria-relevant="additions text"
      class="a11y-speak-region"
      id="a11y-speak-assertive"
      style="position: absolute;margin: -1px;padding: 0;height:
  1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px,
  1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border:
  0;word-wrap: normal !important;"
    />
    <div
      aria-atomic="true"
      aria-live="polite"
      aria-relevant="additions text"
      class="a11y-speak-region"
      id="a11y-speak-polite"
      style="position: absolute;margin: -1px;padding: 0;height:
  1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px,
  1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border:
  0;word-wrap: normal !important;"
    />
    <div>
      <div
        data-testid="loading"
      />
    </div>
  </body>

      at waitForWrapper ...
```

Basically the screen is still rendering the loading state when the test is looking for the header.

Claude and I could not find what could have caused this flakiness. Claude suggested to increase the async timeout.

## Testing Instructions

Verify CI passes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
