### PR TITLE
MSD: attempt to fix flaky dashboard tests by skipping site collision listener

### DIFF
--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -119,6 +119,7 @@ describe( '<Sites>', () => {
 			user: {
 				site_count: 13, // more than 12 sites to force the table layout
 			} as User,
+			useSiteCollisionListener: true,
 		} );
 
 		// The collision listener (started by test-utils) should auto-detect the

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { startSiteCollisionListener } from '@automattic/api-queries';
 import { screen, waitFor, within } from '@testing-library/react';
 import nock from 'nock';
 import { render } from '../../test-utils';
@@ -115,12 +116,12 @@ describe( '<Sites>', () => {
 			} as unknown as Site,
 		] );
 
-		render( <Sites />, {
+		const { queryClient } = render( <Sites />, {
 			user: {
 				site_count: 13, // more than 12 sites to force the table layout
 			} as User,
-			useSiteCollisionListener: true,
 		} );
+		startSiteCollisionListener( queryClient );
 
 		// The collision listener (started by test-utils) should auto-detect the
 		// Jetpack site and fix the wpcom site's slug without manual intervention.

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -39,6 +39,7 @@ type RenderResult = ReturnType< typeof testingLibraryRender > &
 interface RenderOptions {
 	user?: User;
 	queryClient?: QueryClient;
+	useSiteCollisionListener?: boolean;
 }
 
 export function render( ui: React.ReactElement, options: RenderOptions = {} ): RenderResult {
@@ -51,7 +52,10 @@ export function render( ui: React.ReactElement, options: RenderOptions = {} ): R
 			},
 		} );
 	const router = createTestRouter( ui );
-	startSiteCollisionListener( queryClient );
+
+	if ( options.useSiteCollisionListener ) {
+		startSiteCollisionListener( queryClient );
+	}
 
 	const recordTracksEvent = jest.fn();
 	const recordPageView = jest.fn();

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -1,4 +1,3 @@
-import { startSiteCollisionListener } from '@automattic/api-queries';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createRouter, createRootRoute } from '@tanstack/react-router';
 import { render as testingLibraryRender } from '@testing-library/react';
@@ -39,7 +38,6 @@ type RenderResult = ReturnType< typeof testingLibraryRender > &
 interface RenderOptions {
 	user?: User;
 	queryClient?: QueryClient;
-	useSiteCollisionListener?: boolean;
 }
 
 export function render( ui: React.ReactElement, options: RenderOptions = {} ): RenderResult {
@@ -52,10 +50,6 @@ export function render( ui: React.ReactElement, options: RenderOptions = {} ): R
 			},
 		} );
 	const router = createTestRouter( ui );
-
-	if ( options.useSiteCollisionListener ) {
-		startSiteCollisionListener( queryClient );
-	}
 
 	const recordTracksEvent = jest.fn();
 	const recordPageView = jest.fn();


### PR DESCRIPTION
After https://github.com/Automattic/wp-calypso/pull/108736 merged, I started seeing my PR failed with the following failed unit test, e.g. 3a793-pb

```
client/dashboard/sites/overview/test/index.test.tsx 
  renders the overview of a site with free plan

  Error: Unable to find role="heading" and name "Test Site"

  Ignored nodes: comments, script, style
  <body>
    <p
  class="a11y-speak-intro-text"
      hidden="hidden"
      id="a11y-speak-intro-text"
      style="position: absolute;margin: -1px;padding: 0;height:
  1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px,
  1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border:
  0;word-wrap: normal !important;"
    >
      Notifications
    </p>
    <div
      aria-atomic="true"
      aria-live="assertive"
      aria-relevant="additions text"
      class="a11y-speak-region"
      id="a11y-speak-assertive"
      style="position: absolute;margin: -1px;padding: 0;height:
  1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px,
  1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border:
  0;word-wrap: normal !important;"
    />
    <div
      aria-atomic="true"
      aria-live="polite"
      aria-relevant="additions text"
      class="a11y-speak-region"
      id="a11y-speak-polite"
      style="position: absolute;margin: -1px;padding: 0;height:
  1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px,
  1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border:
  0;word-wrap: normal !important;"
    />
    <div>
      <div
        data-testid="loading"
      />
    </div>
  </body>

      at waitForWrapper ...
```

Basically the render is stuck in a loading state.

After a debugging session with Claude, it seems the most likely culprit is that we call `startSiteCollisionListener()` in `test-utils`. It thinks that it can cause timing issues because it starts a new subscription when running the tests, causing flakiness with `useSuspenseQuery(siteBySlugQuery(...)`. So, in this PR, I'm proposing to make that listener optional by adding a new option.

I'm not 100% sure about this, though. But it's true that we started seeing this flakiness after we introduced the collision listener, so I believe it's worth trying.

## Why are these changes being made?

Fixing flaky tests.

## Testing Instructions

Verify CI passes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?