### PR TITLE
Add custom schedule to Crons on Settings page

### DIFF
--- a/client/dashboard/sites/settings-crontab/crontab-form.tsx
+++ b/client/dashboard/sites/settings-crontab/crontab-form.tsx
@@ -22,7 +22,8 @@ import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
-import { parseScheduleValue, ScheduleField } from './schedule-field';
+import { parseRequestedScheduleForBackwardCompatibility } from './parse-requested-schedule-for-backward-compatibility';
+import { ScheduleField } from './schedule-field';
 import type { Crontab, CrontabFormData } from '@automattic/api-core';
 
 interface CrontabFormProps {
@@ -41,7 +42,7 @@ export default function CrontabForm( { crontab }: CrontabFormProps ) {
 	const [ formData, setFormData ] = useState< CrontabFormData >( () => {
 		if ( crontab ) {
 			return {
-				schedule: parseScheduleValue( crontab.schedule ),
+				schedule: parseRequestedScheduleForBackwardCompatibility( crontab.requested_schedule ),
 				command: crontab.command,
 			};
 		}

--- a/client/dashboard/sites/settings-crontab/index.tsx
+++ b/client/dashboard/sites/settings-crontab/index.tsx
@@ -13,7 +13,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { scheduled, trash, copy } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import cronstrue from 'cronstrue';
 import { useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useLocale } from '../../app/locale';
@@ -25,14 +24,10 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { hasHostingFeature } from '../../utils/site-features';
 import HostingFeatureGatedWithCallout from '../hosting-feature-gated-with-callout';
-import { parseScheduleValue, PREDEFINED_SCHEDULES } from './schedule-field';
+import { parseRequestedScheduleForBackwardCompatibility } from './parse-requested-schedule-for-backward-compatibility';
+import { formatScheduleLabel, formatScheduleDescription } from './schedules';
 import type { Crontab } from '@automattic/api-core';
 import type { View } from '@wordpress/dataviews';
-
-function getScheduleLabel( schedule: string ): string {
-	const scheduleType = parseScheduleValue( schedule );
-	return PREDEFINED_SCHEDULES.find( ( s ) => s.value === scheduleType )?.label ?? '';
-}
 
 const DEFAULT_VIEW: View = {
 	type: 'table',
@@ -95,24 +90,28 @@ export default function CrontabSettings( { siteSlug }: { siteSlug: string } ) {
 			id: 'schedule',
 			label: __( 'Schedule' ),
 			getValue: ( { item }: { item: Crontab } ) => {
-				const label = getScheduleLabel( item.schedule );
-				const cronDescription = cronstrue.toString( item.schedule, {
-					verbose: true,
-					locale,
-				} );
-				return `${ label } ${ cronDescription } ${ item.schedule }`;
+				const requestedSchedule = parseRequestedScheduleForBackwardCompatibility(
+					item.requested_schedule
+				);
+
+				const label = formatScheduleLabel( requestedSchedule );
+				const description = formatScheduleDescription( requestedSchedule, item.schedule, locale );
+
+				return `${ label } ${ description } ${ item.schedule }`;
 			},
 			render: ( { item }: { item: Crontab } ) => {
-				const cronDescription = cronstrue.toString( item.schedule, {
-					verbose: true,
-					locale,
-				} );
+				const requestedSchedule = parseRequestedScheduleForBackwardCompatibility(
+					item.requested_schedule
+				);
+
+				const label = formatScheduleLabel( requestedSchedule );
+				const description = formatScheduleDescription( requestedSchedule, item.schedule, locale );
 
 				return (
 					<div>
-						<Text>{ getScheduleLabel( item.schedule ) }</Text>{ ' ' }
+						<Text>{ label }</Text>{ ' ' }
 						<Text variant="muted" size={ 12 }>
-							({ cronDescription })
+							({ description })
 						</Text>
 					</div>
 				);

--- a/client/dashboard/sites/settings-crontab/parse-requested-schedule-for-backward-compatibility.ts
+++ b/client/dashboard/sites/settings-crontab/parse-requested-schedule-for-backward-compatibility.ts
@@ -1,0 +1,76 @@
+/**
+ * Parses a requestedSchedule and returns the schedule type.
+ * Previously we din't have requested_schedule field and in this case we receive raw schedule here instead of daily/weekly/2h/5w/etc, so we need to parse it and return expected schedule type.
+ *
+ * Patterns:
+ * - Hourly: `M * * * *`
+ * - Twice daily: `M H1,H2 * * *`
+ * - Daily: `M H * * *`
+ * - Weekly: `M H * * D`
+ */
+export function parseRequestedScheduleForBackwardCompatibility(
+	requestedSchedule: string
+): string {
+	// Predefined schedule names pass through
+	if ( [ 'hourly', 'twicedaily', 'daily', 'weekly' ].includes( requestedSchedule ) ) {
+		return requestedSchedule;
+	}
+
+	// Shorthand notation passes through
+	if ( /^\d+[hdw]$/.test( requestedSchedule ) ) {
+		return requestedSchedule;
+	}
+
+	const parts = requestedSchedule.trim().split( /\s+/ );
+
+	if ( parts.length === 5 ) {
+		const [ minute, hour, dayOfMonth, month, dayOfWeek ] = parts;
+
+		// Hourly: specific minute, wildcard for everything else
+		if (
+			/^\d+$/.test( minute ) &&
+			hour === '*' &&
+			dayOfMonth === '*' &&
+			month === '*' &&
+			dayOfWeek === '*'
+		) {
+			return 'hourly';
+		}
+
+		// Twice daily: specific minute, two hours (comma-separated), wildcard for day/month/weekday
+		if (
+			/^\d+$/.test( minute ) &&
+			/^\d+,\d+$/.test( hour ) &&
+			dayOfMonth === '*' &&
+			month === '*' &&
+			dayOfWeek === '*'
+		) {
+			return 'twicedaily';
+		}
+
+		// Daily: specific minute and hour, wildcard for day/month/weekday
+		if (
+			/^\d+$/.test( minute ) &&
+			/^\d+$/.test( hour ) &&
+			dayOfMonth === '*' &&
+			month === '*' &&
+			dayOfWeek === '*'
+		) {
+			return 'daily';
+		}
+
+		// Weekly: specific minute, hour, and day of week
+		if (
+			/^\d+$/.test( minute ) &&
+			/^\d+$/.test( hour ) &&
+			dayOfMonth === '*' &&
+			month === '*' &&
+			/^\d+$/.test( dayOfWeek )
+		) {
+			return 'weekly';
+		}
+	}
+
+	// Default to hourly for any unrecognized value
+	return 'hourly';
+}

--- a/client/dashboard/sites/settings-crontab/parse-requested-schedule-for-backward-compatibility.ts
+++ b/client/dashboard/sites/settings-crontab/parse-requested-schedule-for-backward-compatibility.ts
@@ -1,6 +1,6 @@
 /**
  * Parses a requestedSchedule and returns the schedule type.
- * Previously we din't have requested_schedule field and in this case we receive raw schedule here instead of daily/weekly/2h/5w/etc, so we need to parse it and return expected schedule type.
+ * Previously we didn't have requested_schedule field and in this case we receive raw schedule here instead of daily/weekly/2h/5w/etc, so we need to parse it and return expected schedule type.
  *
  * Patterns:
  * - Hourly: `M * * * *`
@@ -11,6 +11,11 @@
 export function parseRequestedScheduleForBackwardCompatibility(
 	requestedSchedule: string
 ): string {
+	// Guard against missing values from older API responses.
+	if ( ! requestedSchedule ) {
+		return 'hourly';
+	}
+
 	// Predefined schedule names pass through
 	if ( [ 'hourly', 'twicedaily', 'daily', 'weekly' ].includes( requestedSchedule ) ) {
 		return requestedSchedule;

--- a/client/dashboard/sites/settings-crontab/schedule-field.tsx
+++ b/client/dashboard/sites/settings-crontab/schedule-field.tsx
@@ -1,11 +1,14 @@
 import {
 	SelectControl,
+	TextControl,
 	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-
-export type ScheduleType = 'hourly' | 'twicedaily' | 'daily' | 'weekly';
+import { __, _n } from '@wordpress/i18n';
+import { useMemo } from 'react';
+import { parseSchedule, PREDEFINED_SCHEDULES } from './schedules';
+import { ScheduleType, CustomFrequency } from './types';
 
 interface ScheduleFieldProps {
 	value: string;
@@ -13,119 +16,91 @@ interface ScheduleFieldProps {
 	disabled?: boolean;
 }
 
-export const PREDEFINED_SCHEDULES = [
-	{ value: 'hourly', label: __( 'Every hour' ) },
-	{ value: 'twicedaily', label: __( 'Twice daily' ) },
-	{ value: 'daily', label: __( 'Daily' ) },
-	{ value: 'weekly', label: __( 'Weekly' ) },
-];
-
-/**
- * Parses a cron expression and returns the schedule type.
- *
- * Patterns:
- * - Hourly: `M * * * *`
- * - Twice daily: `M H1,H2 * * *`
- * - Daily: `M H * * *`
- * - Weekly: `M H * * D`
- */
-export function parseScheduleValue( schedule: string ): ScheduleType {
-	// If it's already a schedule type, return it
-	if ( [ 'hourly', 'twicedaily', 'daily', 'weekly' ].includes( schedule ) ) {
-		return schedule as ScheduleType;
-	}
-
-	const parts = schedule.trim().split( /\s+/ );
-
-	if ( parts.length === 5 ) {
-		const [ minute, hour, dayOfMonth, month, dayOfWeek ] = parts;
-
-		// Hourly: specific minute, wildcard for everything else
-		if (
-			/^\d+$/.test( minute ) &&
-			hour === '*' &&
-			dayOfMonth === '*' &&
-			month === '*' &&
-			dayOfWeek === '*'
-		) {
-			return 'hourly';
-		}
-
-		// Twice daily: specific minute, two hours (comma-separated), wildcard for day/month/weekday
-		if (
-			/^\d+$/.test( minute ) &&
-			/^\d+,\d+$/.test( hour ) &&
-			dayOfMonth === '*' &&
-			month === '*' &&
-			dayOfWeek === '*'
-		) {
-			return 'twicedaily';
-		}
-
-		// Daily: specific minute and hour, wildcard for day/month/weekday
-		if (
-			/^\d+$/.test( minute ) &&
-			/^\d+$/.test( hour ) &&
-			dayOfMonth === '*' &&
-			month === '*' &&
-			dayOfWeek === '*'
-		) {
-			return 'daily';
-		}
-
-		// Weekly: specific minute, hour, and day of week
-		if (
-			/^\d+$/.test( minute ) &&
-			/^\d+$/.test( hour ) &&
-			dayOfMonth === '*' &&
-			month === '*' &&
-			/^\d+$/.test( dayOfWeek )
-		) {
-			return 'weekly';
-		}
-	}
-
-	// Default to hourly for any unrecognized value
-	return 'hourly';
+function getFrequencyOptions( number: number ): { value: CustomFrequency; label: string }[] {
+	return [
+		{
+			value: 'h',
+			label: _n( 'time per hour', 'times per hour', number ),
+		},
+		{
+			value: 'd',
+			label: _n( 'time per day', 'times per day', number ),
+		},
+		{
+			value: 'w',
+			label: _n( 'time per week', 'times per week', number ),
+		},
+	];
 }
 
-function formatSchedulePreview( scheduleValue: string ): string {
-	if ( scheduleValue === 'hourly' ) {
-		return __( 'Runs once every hour.' );
-	}
-	if ( scheduleValue === 'twicedaily' ) {
-		return __( 'Runs twice per day.' );
-	}
-	if ( scheduleValue === 'daily' ) {
-		return __( 'Runs once per day.' );
-	}
-	if ( scheduleValue === 'weekly' ) {
-		return __( 'Runs once per week.' );
-	}
-
-	return '';
-}
+const FREQUENCY_MAX: Record< CustomFrequency, number > = {
+	h: 12,
+	d: 23,
+	w: 6,
+};
 
 export function ScheduleField( { value, onChange, disabled }: ScheduleFieldProps ) {
-	const preview = formatSchedulePreview( value );
+	const parsed = useMemo( () => parseSchedule( value ), [ value ] );
+	const { scheduleType, customNumber, customFrequency } = parsed;
+
+	const frequencyOptions = useMemo( () => getFrequencyOptions( customNumber ), [ customNumber ] );
 
 	return (
 		<VStack spacing={ 3 }>
 			<SelectControl
 				label={ __( 'Schedule' ) }
-				value={ value }
+				value={ scheduleType }
 				options={ PREDEFINED_SCHEDULES }
 				onChange={ ( newValue ) => {
-					onChange( newValue );
+					const newScheduleType = newValue as ScheduleType;
+					if ( newScheduleType === 'custom' ) {
+						onChange( `${ customNumber }${ customFrequency }` );
+					} else {
+						onChange( newScheduleType );
+					}
 				} }
 				disabled={ disabled }
 			/>
-			{ preview && (
-				<Text variant="muted" size={ 12 }>
-					{ preview }{ ' ' }
-					{ __( 'The specific execution time is randomized to prevent system overload.' ) }
-				</Text>
+			{ scheduleType === 'custom' && (
+				<HStack spacing={ 2 } alignment="bottom" justify="flex-start">
+					<TextControl
+						label={ __( 'Custom schedule' ) }
+						hideLabelFromVision
+						style={ { width: '80px' } }
+						disabled={ disabled }
+						type="number"
+						min={ 1 }
+						max={ FREQUENCY_MAX[ customFrequency ] }
+						value={ String( customNumber ) }
+						onChange={ ( newValue ) => {
+							const num = parseInt( newValue, 10 );
+
+							if ( ! isNaN( num ) && num >= 1 && num <= FREQUENCY_MAX[ customFrequency ] ) {
+								onChange( `${ num }${ customFrequency }` );
+							} else if ( newValue === '' ) {
+								onChange( `1${ customFrequency }` );
+							}
+						} }
+					/>
+					<SelectControl
+						label={ __( 'Frequency' ) }
+						hideLabelFromVision
+						disabled={ disabled }
+						value={ customFrequency }
+						options={ frequencyOptions }
+						onChange={ ( newValue ) => {
+							const freq = newValue as CustomFrequency;
+
+							const clampedNumber =
+								customNumber > FREQUENCY_MAX[ freq ] ? FREQUENCY_MAX[ freq ] : customNumber;
+							onChange( `${ clampedNumber }${ freq }` );
+						} }
+					/>
+				</HStack>
 			) }
+			<Text variant="muted" size={ 12 }>
+				{ __( 'The specific execution time is randomized to prevent system overload.' ) }
+			</Text>
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/settings-crontab/schedules.ts
+++ b/client/dashboard/sites/settings-crontab/schedules.ts
@@ -22,36 +22,30 @@ export function formatScheduleLabel( requestedSchedule: string ): string {
 		if ( customNumber === 1 ) {
 			return PREDEFINED_SCHEDULES.find( ( s ) => s.value === 'hourly' )?.label ?? '';
 		}
-		const interval = Math.floor( 60 / customNumber );
 		return sprintf(
 			/* translators: %1$d is the number of times cron job runs */
 			__( '%1$d times per hour' ),
-			customNumber,
-			interval
+			customNumber
 		);
 	}
 	if ( customFrequency === 'd' ) {
 		if ( customNumber === 1 ) {
 			return PREDEFINED_SCHEDULES.find( ( s ) => s.value === 'daily' )?.label ?? '';
 		}
-		const interval = Math.floor( 24 / customNumber );
 		return sprintf(
 			/* translators: %1$d is the number of times cron job runs */
 			__( '%1$d times per day' ),
-			customNumber,
-			interval
+			customNumber
 		);
 	}
 	if ( customFrequency === 'w' ) {
 		if ( customNumber === 1 ) {
 			return PREDEFINED_SCHEDULES.find( ( s ) => s.value === 'weekly' )?.label ?? '';
 		}
-		const interval = Math.floor( 7 / customNumber );
 		return sprintf(
 			/* translators: %1$d is the number of times cron job runs */
 			__( '%1$d times per week' ),
-			customNumber,
-			interval
+			customNumber
 		);
 	}
 

--- a/client/dashboard/sites/settings-crontab/schedules.ts
+++ b/client/dashboard/sites/settings-crontab/schedules.ts
@@ -75,31 +75,43 @@ export function formatScheduleDescription(
 
 	// Custom schedule
 	if ( customFrequency === 'h' ) {
-		const interval = Math.floor( 60 / customNumber );
-		return sprintf(
-			/* translators: %1$d is the interval for running cron job */
-			__( 'Every %1$d minutes' ),
-			interval
-		);
+		return 60 % customNumber === 0
+			? sprintf(
+					/* translators: %1$d is the interval in minutes for running cron job */
+					__( 'Every %1$d minutes' ),
+					60 / customNumber
+			  )
+			: sprintf(
+					/* translators: %1$s is the approximate interval in minutes for running cron job */
+					__( 'Approximately every %1$s minutes' ),
+					( 60 / customNumber ).toFixed( 1 )
+			  );
 	}
 	if ( customFrequency === 'd' ) {
-		const interval = Math.floor( 24 / customNumber );
-		return sprintf(
-			/* translators: %1$d is the interval for running cron job */
-			__( 'Every %1$d hours' ),
-			interval
-		);
+		return 24 % customNumber === 0
+			? sprintf(
+					/* translators: %1$d is the interval in hours for running cron job */
+					__( 'Every %1$d hours' ),
+					24 / customNumber
+			  )
+			: sprintf(
+					/* translators: %1$s is the approximate interval in hours for running cron job */
+					__( 'Approximately every %1$s hours' ),
+					( 24 / customNumber ).toFixed( 1 )
+			  );
 	}
 	if ( customFrequency === 'w' ) {
-		const interval = Math.floor( 7 / customNumber );
 		return sprintf(
-			/* translators: %1$d is the interval for running cron job */
-			__( 'Every %1$d days' ),
-			interval
+			/* translators: %1$s is the approximate interval in days for running cron job */
+			__( 'Approximately every %1$s days' ),
+			( 7 / customNumber ).toFixed( 1 )
 		);
 	}
 
-	return '';
+	return cronstrue.toString( rawSchedule, {
+		verbose: true,
+		locale,
+	} );
 }
 
 export function parseSchedule( value: string ): {

--- a/client/dashboard/sites/settings-crontab/schedules.ts
+++ b/client/dashboard/sites/settings-crontab/schedules.ts
@@ -1,0 +1,141 @@
+import { __, sprintf } from '@wordpress/i18n';
+import cronstrue from 'cronstrue';
+import { ScheduleType, CustomFrequency } from './types';
+
+export const PREDEFINED_SCHEDULES: { value: ScheduleType; label: string }[] = [
+	{ value: 'hourly', label: __( 'Every hour' ) },
+	{ value: 'twicedaily', label: __( 'Twice daily' ) },
+	{ value: 'daily', label: __( 'Daily' ) },
+	{ value: 'weekly', label: __( 'Weekly' ) },
+	{ value: 'custom', label: __( 'Custom' ) },
+];
+
+export function formatScheduleLabel( requestedSchedule: string ): string {
+	const { scheduleType, customNumber, customFrequency } = parseSchedule( requestedSchedule );
+
+	if ( [ 'hourly', 'twicedaily', 'daily', 'weekly' ].includes( scheduleType ) ) {
+		return PREDEFINED_SCHEDULES.find( ( s ) => s.value === scheduleType )?.label ?? '';
+	}
+
+	// Custom schedule
+	if ( customFrequency === 'h' ) {
+		if ( customNumber === 1 ) {
+			return PREDEFINED_SCHEDULES.find( ( s ) => s.value === 'hourly' )?.label ?? '';
+		}
+		const interval = Math.floor( 60 / customNumber );
+		return sprintf(
+			/* translators: %1$d is the number of times cron job runs */
+			__( '%1$d times per hour' ),
+			customNumber,
+			interval
+		);
+	}
+	if ( customFrequency === 'd' ) {
+		if ( customNumber === 1 ) {
+			return PREDEFINED_SCHEDULES.find( ( s ) => s.value === 'daily' )?.label ?? '';
+		}
+		const interval = Math.floor( 24 / customNumber );
+		return sprintf(
+			/* translators: %1$d is the number of times cron job runs */
+			__( '%1$d times per day' ),
+			customNumber,
+			interval
+		);
+	}
+	if ( customFrequency === 'w' ) {
+		if ( customNumber === 1 ) {
+			return PREDEFINED_SCHEDULES.find( ( s ) => s.value === 'weekly' )?.label ?? '';
+		}
+		const interval = Math.floor( 7 / customNumber );
+		return sprintf(
+			/* translators: %1$d is the number of times cron job runs */
+			__( '%1$d times per week' ),
+			customNumber,
+			interval
+		);
+	}
+
+	return '';
+}
+
+export function formatScheduleDescription(
+	requestedSchedule: string,
+	rawSchedule: string,
+	locale: string
+): string {
+	if ( [ 'hourly', 'twicedaily', 'daily', 'weekly' ].includes( requestedSchedule ) ) {
+		return cronstrue.toString( rawSchedule, {
+			verbose: true,
+			locale,
+		} );
+	}
+
+	const { customNumber, customFrequency } = parseSchedule( requestedSchedule );
+
+	if ( customNumber === 1 ) {
+		return cronstrue.toString( rawSchedule, {
+			verbose: true,
+			locale,
+		} );
+	}
+
+	// Custom schedule
+	if ( customFrequency === 'h' ) {
+		const interval = Math.floor( 60 / customNumber );
+		return sprintf(
+			/* translators: %1$d is the interval for running cron job */
+			__( 'Every %1$d minutes' ),
+			interval
+		);
+	}
+	if ( customFrequency === 'd' ) {
+		const interval = Math.floor( 24 / customNumber );
+		return sprintf(
+			/* translators: %1$d is the interval for running cron job */
+			__( 'Every %1$d hours' ),
+			interval
+		);
+	}
+	if ( customFrequency === 'w' ) {
+		const interval = Math.floor( 7 / customNumber );
+		return sprintf(
+			/* translators: %1$d is the interval for running cron job */
+			__( 'Every %1$d days' ),
+			interval
+		);
+	}
+
+	return '';
+}
+
+export function parseSchedule( value: string ): {
+	scheduleType: ScheduleType;
+	customNumber: number;
+	customFrequency: CustomFrequency;
+} {
+	// Check if it's a predefined schedule
+	if ( [ 'hourly', 'twicedaily', 'daily', 'weekly' ].includes( value ) ) {
+		return {
+			scheduleType: value as ScheduleType,
+			customNumber: 1,
+			customFrequency: 'h',
+		};
+	}
+
+	// Check if it's shorthand notation (e.g., "2h", "6d", "3w")
+	const shorthandMatch = value.match( /^(\d+)([hdw])$/ );
+	if ( shorthandMatch ) {
+		return {
+			scheduleType: 'custom',
+			customNumber: parseInt( shorthandMatch[ 1 ], 10 ),
+			customFrequency: shorthandMatch[ 2 ] as CustomFrequency,
+		};
+	}
+
+	// Default to custom with raw value
+	return {
+		scheduleType: 'custom',
+		customNumber: 1,
+		customFrequency: 'h',
+	};
+}

--- a/client/dashboard/sites/settings-crontab/test/parse-requested-schedule-for-backward-compatibility.test.ts
+++ b/client/dashboard/sites/settings-crontab/test/parse-requested-schedule-for-backward-compatibility.test.ts
@@ -1,0 +1,125 @@
+import { parseRequestedScheduleForBackwardCompatibility } from '../parse-requested-schedule-for-backward-compatibility';
+
+describe( 'parseRequestedScheduleForBackwardCompatibility', () => {
+	describe( 'predefined schedule names', () => {
+		test( 'returns "hourly" as-is', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( 'hourly' ) ).toBe( 'hourly' );
+		} );
+
+		test( 'returns "twicedaily" as-is', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( 'twicedaily' ) ).toBe( 'twicedaily' );
+		} );
+
+		test( 'returns "daily" as-is', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( 'daily' ) ).toBe( 'daily' );
+		} );
+
+		test( 'returns "weekly" as-is', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( 'weekly' ) ).toBe( 'weekly' );
+		} );
+	} );
+
+	describe( 'shorthand notation', () => {
+		test( 'passes through hour-based shorthand like "2h"', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '2h' ) ).toBe( '2h' );
+		} );
+
+		test( 'passes through day-based shorthand like "5d"', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '5d' ) ).toBe( '5d' );
+		} );
+
+		test( 'passes through week-based shorthand like "3w"', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '3w' ) ).toBe( '3w' );
+		} );
+
+		test( 'passes through single-digit shorthand like "1h"', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '1h' ) ).toBe( '1h' );
+		} );
+
+		test( 'passes through multi-digit shorthand like "12d"', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '12d' ) ).toBe( '12d' );
+		} );
+	} );
+
+	describe( 'raw cron expressions — hourly', () => {
+		test( 'detects "0 * * * *" as hourly', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '0 * * * *' ) ).toBe( 'hourly' );
+		} );
+
+		test( 'detects "30 * * * *" as hourly', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '30 * * * *' ) ).toBe( 'hourly' );
+		} );
+
+		test( 'detects "59 * * * *" as hourly', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '59 * * * *' ) ).toBe( 'hourly' );
+		} );
+	} );
+
+	describe( 'raw cron expressions — twice daily', () => {
+		test( 'detects "0 6,18 * * *" as twicedaily', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '0 6,18 * * *' ) ).toBe(
+				'twicedaily'
+			);
+		} );
+
+		test( 'detects "30 0,12 * * *" as twicedaily', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '30 0,12 * * *' ) ).toBe(
+				'twicedaily'
+			);
+		} );
+	} );
+
+	describe( 'raw cron expressions — daily', () => {
+		test( 'detects "0 0 * * *" as daily', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '0 0 * * *' ) ).toBe( 'daily' );
+		} );
+
+		test( 'detects "45 10 * * *" as daily', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '45 10 * * *' ) ).toBe( 'daily' );
+		} );
+
+		test( 'detects "0 23 * * *" as daily', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '0 23 * * *' ) ).toBe( 'daily' );
+		} );
+	} );
+
+	describe( 'raw cron expressions — weekly', () => {
+		test( 'detects "0 0 * * 0" as weekly', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '0 0 * * 0' ) ).toBe( 'weekly' );
+		} );
+
+		test( 'detects "30 14 * * 5" as weekly', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '30 14 * * 5' ) ).toBe( 'weekly' );
+		} );
+
+		test( 'detects "0 9 * * 1" as weekly', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '0 9 * * 1' ) ).toBe( 'weekly' );
+		} );
+	} );
+
+	describe( 'unrecognized values default to hourly', () => {
+		test( 'returns hourly for non-standard cron with specific day-of-month', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '0 0 15 * *' ) ).toBe( 'hourly' );
+		} );
+
+		test( 'returns hourly for non-standard cron with specific month', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '0 0 * 6 *' ) ).toBe( 'hourly' );
+		} );
+
+		test( 'returns hourly for arbitrary strings', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( 'something' ) ).toBe( 'hourly' );
+		} );
+
+		test( 'returns hourly for empty string', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '' ) ).toBe( 'hourly' );
+		} );
+
+		test( 'returns hourly for malformed cron with too few parts', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '0 *' ) ).toBe( 'hourly' );
+		} );
+
+		test( 'returns hourly for malformed cron with too many parts', () => {
+			expect( parseRequestedScheduleForBackwardCompatibility( '0 * * * * *' ) ).toBe( 'hourly' );
+		} );
+	} );
+} );

--- a/client/dashboard/sites/settings-crontab/test/parse-requested-schedule-for-backward-compatibility.test.ts
+++ b/client/dashboard/sites/settings-crontab/test/parse-requested-schedule-for-backward-compatibility.test.ts
@@ -114,6 +114,12 @@ describe( 'parseRequestedScheduleForBackwardCompatibility', () => {
 			expect( parseRequestedScheduleForBackwardCompatibility( '' ) ).toBe( 'hourly' );
 		} );
 
+		test( 'returns hourly for undefined', () => {
+			expect(
+				parseRequestedScheduleForBackwardCompatibility( undefined as unknown as string )
+			).toBe( 'hourly' );
+		} );
+
 		test( 'returns hourly for malformed cron with too few parts', () => {
 			expect( parseRequestedScheduleForBackwardCompatibility( '0 *' ) ).toBe( 'hourly' );
 		} );

--- a/client/dashboard/sites/settings-crontab/test/schedules.test.ts
+++ b/client/dashboard/sites/settings-crontab/test/schedules.test.ts
@@ -1,0 +1,121 @@
+import { parseSchedule } from '../schedules';
+
+describe( 'parseSchedule', () => {
+	describe( 'predefined schedules', () => {
+		test( 'parses "hourly"', () => {
+			expect( parseSchedule( 'hourly' ) ).toEqual( {
+				scheduleType: 'hourly',
+				customNumber: 1,
+				customFrequency: 'h',
+			} );
+		} );
+
+		test( 'parses "twicedaily"', () => {
+			expect( parseSchedule( 'twicedaily' ) ).toEqual( {
+				scheduleType: 'twicedaily',
+				customNumber: 1,
+				customFrequency: 'h',
+			} );
+		} );
+
+		test( 'parses "daily"', () => {
+			expect( parseSchedule( 'daily' ) ).toEqual( {
+				scheduleType: 'daily',
+				customNumber: 1,
+				customFrequency: 'h',
+			} );
+		} );
+
+		test( 'parses "weekly"', () => {
+			expect( parseSchedule( 'weekly' ) ).toEqual( {
+				scheduleType: 'weekly',
+				customNumber: 1,
+				customFrequency: 'h',
+			} );
+		} );
+	} );
+
+	describe( 'shorthand notation', () => {
+		test( 'parses hour-based shorthand "2h"', () => {
+			expect( parseSchedule( '2h' ) ).toEqual( {
+				scheduleType: 'custom',
+				customNumber: 2,
+				customFrequency: 'h',
+			} );
+		} );
+
+		test( 'parses day-based shorthand "6d"', () => {
+			expect( parseSchedule( '6d' ) ).toEqual( {
+				scheduleType: 'custom',
+				customNumber: 6,
+				customFrequency: 'd',
+			} );
+		} );
+
+		test( 'parses week-based shorthand "3w"', () => {
+			expect( parseSchedule( '3w' ) ).toEqual( {
+				scheduleType: 'custom',
+				customNumber: 3,
+				customFrequency: 'w',
+			} );
+		} );
+
+		test( 'parses single-digit shorthand "1d"', () => {
+			expect( parseSchedule( '1d' ) ).toEqual( {
+				scheduleType: 'custom',
+				customNumber: 1,
+				customFrequency: 'd',
+			} );
+		} );
+
+		test( 'parses multi-digit shorthand "12h"', () => {
+			expect( parseSchedule( '12h' ) ).toEqual( {
+				scheduleType: 'custom',
+				customNumber: 12,
+				customFrequency: 'h',
+			} );
+		} );
+	} );
+
+	describe( 'unrecognized values default to custom hourly', () => {
+		test( 'defaults for a raw cron expression', () => {
+			expect( parseSchedule( '0 * * * *' ) ).toEqual( {
+				scheduleType: 'custom',
+				customNumber: 1,
+				customFrequency: 'h',
+			} );
+		} );
+
+		test( 'defaults for an arbitrary string', () => {
+			expect( parseSchedule( 'something' ) ).toEqual( {
+				scheduleType: 'custom',
+				customNumber: 1,
+				customFrequency: 'h',
+			} );
+		} );
+
+		test( 'defaults for an empty string', () => {
+			expect( parseSchedule( '' ) ).toEqual( {
+				scheduleType: 'custom',
+				customNumber: 1,
+				customFrequency: 'h',
+			} );
+		} );
+
+		test( 'does not match shorthand with invalid frequency letter', () => {
+			expect( parseSchedule( '5x' ) ).toEqual( {
+				scheduleType: 'custom',
+				customNumber: 1,
+				customFrequency: 'h',
+			} );
+		} );
+
+		test( 'does not match shorthand without a number', () => {
+			expect( parseSchedule( 'h' ) ).toEqual( {
+				scheduleType: 'custom',
+				customNumber: 1,
+				customFrequency: 'h',
+			} );
+		} );
+	} );
+} );

--- a/client/dashboard/sites/settings-crontab/types.ts
+++ b/client/dashboard/sites/settings-crontab/types.ts
@@ -1,0 +1,2 @@
+export type ScheduleType = 'hourly' | 'twicedaily' | 'daily' | 'weekly' | 'custom';
+export type CustomFrequency = 'h' | 'd' | 'w';

--- a/packages/api-core/src/site-hosting-crontab/types.ts
+++ b/packages/api-core/src/site-hosting-crontab/types.ts
@@ -1,8 +1,9 @@
 export interface Crontab extends CrontabFormData {
 	cron_id: number;
+	requested_schedule: string;
 }
 
 export interface CrontabFormData {
 	schedule: string;
-	command: string;
+	command: string; // this item we should send to backend, and backend return the value inside requested_schedule field. command will have raw cron schedule, e.g. "45 10 * * *"
 }

--- a/packages/api-core/src/site-hosting-crontab/types.ts
+++ b/packages/api-core/src/site-hosting-crontab/types.ts
@@ -4,6 +4,6 @@ export interface Crontab extends CrontabFormData {
 }
 
 export interface CrontabFormData {
-	schedule: string;
-	command: string; // this item we should send to backend, and backend return the value inside requested_schedule field. command will have raw cron schedule, e.g. "45 10 * * *"
+	schedule: string; // this item we should send to backend, and backend return the value inside requested_schedule field. The "schedule" will contain raw cron schedule, e.g. "45 10 * * *"
+	command: string;
 }


### PR DESCRIPTION
Fixes DOTCOM-16012

## Proposed Changes
Previously we wanted to add custom schedule for cron jobs, but we had limitations with implementing it. Now we are unblocked (long story short - now API returns extra property requested_schedule, which is essential for frontend).
So with this PR, we are adding a custom schedule to extend the UI WordPress functionality for our users.

## Testing Instructions
1. Don't checkout to thsi branch (stay on `trunk`)
1. Create atomic website
2. Open http://my.localhost:3000/sites/<DOMAIN_NAME>/settings
3. Click on "Cron" button
4. Create all possible cron schedules (hourly, daily, twice dayly and weekly)
5. Assert that they are rendered well in the list<br /><img width="410" height="113" alt="Screenshot 2026-02-20 at 16 22 08" src="https://github.com/user-attachments/assets/9adb0ff1-6c9f-45ef-8e90-af144b60366f" />
6. Checkout to this branch
7. Reload cron page
8. Assert that everything looks still good
9. Holistically try to update existing jobs, create new with predefined schedules and new with custom schedules