### PR TITLE
Reader: Fix infinite loading on Full Post View

### DIFF
--- a/client/state/reader/posts/selectors.js
+++ b/client/state/reader/posts/selectors.js
@@ -19,19 +19,25 @@ const getPostMapByPostKey = treeSelect(
 		const postMap = {};
 
 		Object.values( posts ).forEach( ( post ) => {
-			const { feed_item_IDs = [] } = post ?? {};
+			const { feed_item_IDs = [], site_ID, ID, feed_ID, feed_item_ID } = post;
 
-			// Default case when the post matches only one feed_item_ID, if available.
-			if ( feed_item_IDs.length <= 1 ) {
-				postMap[ keyToString( keyForPost( post ) ) ] = post;
-				return;
+			// Add blog post with a blog post key.
+			if ( site_ID && ID ) {
+				const postKey = keyForPost( { site_ID, ID } );
+				postMap[ keyToString( postKey ) ] = post;
+			}
+
+			// Add feed item with a feed item key.
+			if ( feed_ID && feed_item_ID ) {
+				const postKey = keyForPost( { feed_ID, feed_item_ID } );
+				postMap[ keyToString( postKey ) ] = post;
 			}
 
 			// Edge case when the post matches multiple feed_item_IDs.
 			// Insert one entry per feed_item_ID to the post map.
 			// See: https://github.com/Automattic/wp-calypso/pull/88408
-			feed_item_IDs.forEach( ( feed_item_ID ) => {
-				const postKey = keyForPost( { feed_ID: post.feed_ID, feed_item_ID } );
+			feed_item_IDs.forEach( ( feedItemId ) => {
+				const postKey = keyForPost( { feed_ID, feed_item_ID: feedItemId } );
 				postMap[ keyToString( postKey ) ] = post;
 			} );
 		} );

--- a/client/state/reader/posts/test/selectors.js
+++ b/client/state/reader/posts/test/selectors.js
@@ -48,6 +48,46 @@ describe( 'selectors', () => {
 			);
 			expect( call1 ).toBe( call2 );
 		} );
+
+		describe( 'verify getPostMapByPostKey method', () => {
+			test( 'returns the same post when looked up by blogId or feedId key format', () => {
+				const post = { global_ID: 3333, ID: 5, site_ID: 100, feed_ID: 200, feed_item_ID: 50 };
+				const newState = {
+					reader: { posts: { items: { [ post.global_ID ]: post } } },
+				};
+
+				const byBlogKey = getPostByKey( newState, { postId: 5, blogId: 100 } );
+				const byFeedKey = getPostByKey( newState, { postId: 50, feedId: 200 } );
+
+				expect( byBlogKey ).toBe( post );
+				expect( byFeedKey ).toBe( post );
+				expect( byBlogKey ).toBe( byFeedKey );
+			} );
+
+			test( 'returns the same post for any of multiple feed_item_IDs', () => {
+				const post = {
+					global_ID: 4444,
+					ID: 6,
+					site_ID: 101,
+					feed_ID: 201,
+					feed_item_ID: 60,
+					feed_item_IDs: [ 60, 61, 62 ],
+				};
+				const newState = {
+					reader: { posts: { items: { [ post.global_ID ]: post } } },
+				};
+
+				const byFirstFeedItemId = getPostByKey( newState, { postId: 60, feedId: 201 } );
+				const bySecondFeedItemId = getPostByKey( newState, { postId: 61, feedId: 201 } );
+				const byThirdFeedItemId = getPostByKey( newState, { postId: 62, feedId: 201 } );
+				const byBlogKey = getPostByKey( newState, { postId: 6, blogId: 101 } );
+
+				expect( byFirstFeedItemId ).toBe( post );
+				expect( bySecondFeedItemId ).toBe( post );
+				expect( byThirdFeedItemId ).toBe( post );
+				expect( byBlogKey ).toBe( post );
+			} );
+		} );
 	} );
 
 	describe( '#getPostsByKeys()', () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-315](https://linear.app/a8c/issue/READ-315/reader-sidebar-post-counts-blink-for-some-posts)

## Proposed Changes

Modified `getPostMapByPostKey` selector to explicitly create separate entries for both blog post keys and feed item keys

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We've introduced [Previous and Next navigations](https://github.com/Automattic/wp-calypso/pull/108481) last week. Almost in all cases there should be different post in main view, next and previous navigation but in case of P2 posts we can have same post on main view and on of the Prev/Next navigation (example: XPost). So due to this behavior there will be infinite loads on all posts that have same post as xPost right after or before the post.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /reader/a8c
- Find a post that have an xPost right after it.
- Open either the post or xPost and note infinite load.
- Checkout this PR and repeat same steps.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
