### PR TITLE
CIAB: Show coming soon notice on site visibility for trial sites

### DIFF
--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -11,7 +11,9 @@ import PageLayout from '../../components/page-layout';
 import SnackbarBackButton, {
 	getSnackbarBackButtonText,
 } from '../../components/snackbar-back-button';
-import { LaunchAgencyDevelopmentSiteForm, LaunchForm } from './launch-form';
+import { isCommerceGarden } from '../../utils/site-types';
+import { isSitePlanTrial } from '../plans';
+import { CiabTrialLaunchNotice, LaunchAgencyDevelopmentSiteForm, LaunchForm } from './launch-form';
 import { PrivacyForm } from './privacy-form';
 import { ShareSiteForm } from './share-site-form';
 
@@ -23,6 +25,10 @@ export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string
 	} );
 
 	const renderContent = () => {
+		if ( isCommerceGarden( site ) && isSitePlanTrial( site ) ) {
+			return <CiabTrialLaunchNotice site={ site } />;
+		}
+
 		if ( site.launch_status === 'unlaunched' ) {
 			return (
 				<>

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -141,7 +141,7 @@ export function LaunchForm( { site }: { site: Site } ) {
 export function CiabTrialLaunchNotice( { site }: { site: Site } ) {
 	return (
 		<Notice
-			title={ __( 'Your site is in coming soon mode' ) }
+			title={ __( 'Your site is in Coming Soon mode' ) }
 			actions={
 				<>
 					<Button
@@ -161,7 +161,7 @@ export function CiabTrialLaunchNotice( { site }: { site: Site } ) {
 			}
 		>
 			{ __(
-				'Select a plan to launch your site and make it visible to everyone. Visitors will see a “Coming soon” page while you finish setting up.'
+				'Select a plan to launch your site and make it visible to everyone. Visitors will see a “Coming Soon” page while you finish setting up.'
 			) }
 		</Notice>
 	);

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -9,8 +9,10 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { getCurrentDashboard } from '../../app/routing';
 import Notice from '../../components/notice';
-import { a4aLink } from '../../utils/link';
+import { a4aLink, wpcomLink } from '../../utils/link';
 import { SiteLaunchButton } from '../site-launch-button';
 import AgencyDevelopmentSiteLaunchModal from '../site-launch-button/agency-development-site-launch-modal';
 import TrialUpsellNotice from './trial-upsell-notice';
@@ -133,5 +135,34 @@ export function LaunchForm( { site }: { site: Site } ) {
 				{ __( 'It is hidden from visitors behind a “Coming Soon” notice until it is launched.' ) }
 			</Notice>
 		</>
+	);
+}
+
+export function CiabTrialLaunchNotice( { site }: { site: Site } ) {
+	return (
+		<Notice
+			title={ __( 'Your site is in coming soon mode' ) }
+			actions={
+				<>
+					<Button
+						size="compact"
+						variant="primary"
+						href={ addQueryArgs( wpcomLink( '/setup/woo-hosted-plans' ), {
+							siteSlug: site.slug,
+							dashboard: getCurrentDashboard(),
+						} ) }
+					>
+						{ __( 'View plans' ) }
+					</Button>
+					<Button size="compact" variant="secondary" href={ site.options?.admin_url }>
+						{ __( 'Manage store' ) }
+					</Button>
+				</>
+			}
+		>
+			{ __(
+				'Select a plan to launch your site and make it visible to everyone. Visitors will see a “Coming soon” page while you finish setting up.'
+			) }
+		</Notice>
 	);
 }


### PR DESCRIPTION
Related to WOOPRD-1709

## Summary
- Adds a "coming soon mode" notice on the site visibility settings page for CIAB sites on a trial plan.
- The notice informs users their site is in coming soon mode and provides a "View plans" button (linking to the Woo hosted plans setup flow) and a "Manage store" button (linking to WP Admin).
- The notice takes priority over the default launch/privacy forms when the site is a commerce garden on a trial plan.

<img width="718" height="338" alt="Captura de Tela 2026-02-22 às 22 58 07" src="https://github.com/user-attachments/assets/6c801f12-a210-4d82-b598-6d1d87d865b6" />


## Test plan
- Navigate to a CIAB trial site's site visibility settings page.
- Verify the "Your site is in coming soon mode" notice is displayed with both buttons.
- Verify "View plans" navigates to `/setup/woo-hosted-plans` with the correct query args.
- Verify "Manage store" navigates to the site's WP Admin.
- Verify that non-trial CIAB sites still show the regular privacy form.
- Verify that non-CIAB sites are unaffected.