### PR TITLE
Dashboard: Note US English spelling in copy guidelines

### DIFF
--- a/client/dashboard/docs/typography-and-copy.md
+++ b/client/dashboard/docs/typography-and-copy.md
@@ -2,6 +2,8 @@
 
 ## General
 
+Use US English spelling (e.g. "customize" not "customise", "color" not "colour").
+
 End sentences with a period. Even short ones. Button and form labels do not end in periods, and neither do headings.
 
 Use curly quotes and apostrophes.


### PR DESCRIPTION
## Summary
- Add note to typography-and-copy.md that our copy uses US English spelling.

## Test plan
- [ ] Review the docs change.