### PR TITLE
[DO NOT MERGE] MSD: use custom DataViewsSearch which skips props-state sync

### DIFF
--- a/client/dashboard/components/dataviews/dataviews-search.tsx
+++ b/client/dashboard/components/dataviews/dataviews-search.tsx
@@ -1,0 +1,46 @@
+import { SearchControl } from '@wordpress/components';
+import { useDebouncedInput } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef } from 'react';
+import type { View } from '@wordpress/dataviews';
+
+interface DataViewsSearchProps {
+	label?: string;
+	view: View;
+	onChangeView: ( view: View ) => void;
+}
+
+export function DataViewsSearch( { label, view, onChangeView }: DataViewsSearchProps ) {
+	const [ search, setSearch, debouncedSearch ] = useDebouncedInput( view.search );
+	useEffect( () => {
+		if ( view.search !== debouncedSearch ) {
+			setSearch( view.search ?? '' );
+		}
+	}, [ view.search, setSearch ] );
+	const onChangeViewRef = useRef( onChangeView );
+	const viewRef = useRef( view );
+	useEffect( () => {
+		onChangeViewRef.current = onChangeView;
+		viewRef.current = view;
+	}, [ onChangeView, view ] );
+	useEffect( () => {
+		if ( debouncedSearch !== viewRef.current?.search ) {
+			onChangeViewRef.current( {
+				...viewRef.current,
+				page: 1,
+				search: debouncedSearch,
+			} );
+		}
+	}, [ debouncedSearch ] );
+	const searchLabel = label || __( 'Search' );
+	return (
+		<SearchControl
+			className="dataviews-search"
+			onChange={ setSearch }
+			value={ search }
+			label={ searchLabel }
+			placeholder={ searchLabel }
+			size="compact"
+		/>
+	);
+}

--- a/client/dashboard/components/dataviews/dataviews.tsx
+++ b/client/dashboard/components/dataviews/dataviews.tsx
@@ -3,6 +3,7 @@ import { DataViews as WPDataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
+import { DataViewsSearch } from './dataviews-search';
 import { sanitizeView } from './sanitize-view';
 import type { ComponentProps } from 'react';
 
@@ -16,6 +17,7 @@ export type DataViewsProps< Item > = WPDataViewsProps< Item > & {
 export function DataViews< Item >( {
 	view,
 	isPlaceholderData,
+	onChangeView,
 	onResetView,
 	header,
 	search = true,
@@ -71,7 +73,9 @@ export function DataViews< Item >( {
 					spacing={ 1 }
 				>
 					<HStack justify="start" expanded={ false } className="dataviews__search">
-						{ search && <WPDataViews.Search label={ searchLabel } /> }
+						{ search && (
+							<DataViewsSearch label={ searchLabel } view={ view } onChangeView={ onChangeView } />
+						) }
 						<WPDataViews.FiltersToggle />
 					</HStack>
 					<HStack spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
@@ -92,6 +96,7 @@ export function DataViews< Item >( {
 	return (
 		<WPDataViews< Item >
 			view={ sanitizedView }
+			onChangeView={ onChangeView }
 			header={ header }
 			search={ search }
 			searchLabel={ searchLabel }


### PR DESCRIPTION
Fixes DOTMSD-128

## Proposed Changes

This is just a copy-paste of the changes from https://github.com/WordPress/gutenberg/pull/75810, for easier testing on MSD side.

This fixes the issue where sometimes characters get lost when typing in the search box of DataViews.

## Testing Instructions

1. Go to /sites
2. Type in the search box, slowly and quickly, and something in-between... verify no characters are lost and the search is processed correctly.
3. Try browser back-forward buttons, manual query param modification... verify the behavior is still correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
