### PR TITLE
FORNO-209: Image Studio – Show feedback input on thumbs down

### DIFF
--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -67,12 +67,10 @@
 		"typescript": "^5.8.3"
 	},
 	"peerDependencies": {
-		"@automattic/calypso-router": "workspace:^",
 		"@wordpress/data": "^10.23.0",
 		"@wordpress/element": "^6.23.0",
 		"react": "^18.3.1",
-		"react-dom": "^18.3.1",
-		"redux": "^5.0.1"
+		"react-dom": "^18.3.1"
 	},
 	"private": true
 }

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -9,18 +9,18 @@ import type { Message } from '@automattic/agenttic-ui/dist/types';
 
 const FEEDBACK_API_BASE = 'https://public-api.wordpress.com/wpcom/v2/ai/feedback';
 
-interface UseFeedbackConfig {
+export interface UseFeedbackConfig {
 	registerMessageActions: UseAgentChatReturn[ 'registerMessageActions' ];
 	messages: Message[];
 }
 
-interface UseFeedbackReturn {
+export interface UseFeedbackReturn {
 	showFeedbackInput: boolean;
 	submitFeedbackText: ( feedbackText: string ) => Promise< void >;
 	resetFeedback: () => void;
 }
 
-async function rateMessage(
+export async function rateMessage(
 	authProvider: AuthProvider,
 	sessionId: string,
 	messageId: string,
@@ -47,7 +47,7 @@ interface PreviousMessage {
 	text: string;
 }
 
-async function submitFeedback(
+export async function submitFeedback(
 	authProvider: AuthProvider,
 	sessionId: string,
 	messageId: string,

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -25,14 +25,18 @@ export async function rateMessage(
 	sessionId: string,
 	messageId: string,
 	rating: 'up' | 'down',
-	messageText?: string
+	messageText?: string,
+	metadata?: Record< string, unknown >
 ): Promise< void > {
 	const headers = await authProvider();
 	const url = `${ FEEDBACK_API_BASE }/${ encodeURIComponent( sessionId ) }/rate`;
 
-	const body: Record< string, string > = { message_id: messageId, rating };
+	const body: Record< string, unknown > = { message_id: messageId, rating };
 	if ( messageText ) {
 		body.message_text = messageText;
+	}
+	if ( metadata ) {
+		body.metadata = metadata;
 	}
 
 	fetch( url, {

--- a/packages/agents-manager/src/hooks/use-feedback/index.ts
+++ b/packages/agents-manager/src/hooks/use-feedback/index.ts
@@ -26,15 +26,22 @@ export async function rateMessage(
 	messageId: string,
 	rating: 'up' | 'down',
 	messageText?: string,
-	metadata?: Record< string, unknown >
+	metadata?: Record< string, string >
 ): Promise< void > {
 	const headers = await authProvider();
 	const url = `${ FEEDBACK_API_BASE }/${ encodeURIComponent( sessionId ) }/rate`;
 
-	const body: Record< string, unknown > = { message_id: messageId, rating };
+	const body: {
+		message_id: string;
+		rating: 'up' | 'down';
+		message_text?: string;
+		metadata?: Record< string, string >;
+	} = { message_id: messageId, rating };
+
 	if ( messageText ) {
 		body.message_text = messageText;
 	}
+
 	if ( metadata ) {
 		body.metadata = metadata;
 	}

--- a/packages/agents-manager/src/index.ts
+++ b/packages/agents-manager/src/index.ts
@@ -21,3 +21,8 @@ export type {
 } from './types';
 
 export { useShouldUseUnifiedAgent } from './hooks/use-should-use-unified-agent';
+
+// Feedback exports
+export { default as useFeedback, submitFeedback, rateMessage } from './hooks/use-feedback';
+export type { UseFeedbackConfig, UseFeedbackReturn } from './hooks/use-feedback';
+export { default as FeedbackInput } from './components/feedback-input';

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -48,6 +48,7 @@
 	"dependencies": {
 		"@automattic/agenttic-client": "^0.1.46",
 		"@automattic/agenttic-ui": "^0.1.46",
+		"@automattic/agents-manager": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",

--- a/packages/image-studio/src/components/canvas-controls/index.tsx
+++ b/packages/image-studio/src/components/canvas-controls/index.tsx
@@ -5,12 +5,9 @@
  * Uses the Agenttic UI MessageActions component for consistent styling and behavior.
  */
 import { MessageActions, ThumbsDownIcon, ThumbsUpIcon } from '@automattic/agenttic-ui';
-import apiFetch from '@wordpress/api-fetch';
 import { __unstableMotion as motion } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { store as imageStudioStore } from '../../store';
 import { trackImageStudioImageFeedback } from '../../utils/tracking';
 import { ImageActionsMenu } from '../image-actions-menu';
 import { RevisionNavigator } from './revision-navigator';
@@ -20,78 +17,25 @@ import './style.scss';
 interface CanvasControlsProps {
 	imageUrl: string;
 	attachmentId: number | null;
-	sessionId: string;
 	mode: ImageStudioMode;
 	showFeedbackButtons: boolean;
 	showImageActionsMenu?: boolean;
 	onSave?: () => void;
 	onRevertToOriginal?: () => void;
-}
-
-/**
- * Submit feedback for an image to the API and track the event
- * @param {string}          imageUrl     - URL of the image being rated
- * @param {'up' | 'down'}   feedback     - User's feedback rating
- * @param {string}          sessionId    - Current session ID
- * @param {ImageStudioMode} mode         - Image Studio mode (edit or generate)
- * @param {number | null}   attachmentId - WordPress attachment ID if available
- * @param {string | null}   messageId    - Agent message ID for feedback tracking
- */
-function submitImageFeedback(
-	imageUrl: string,
-	feedback: 'up' | 'down',
-	sessionId: string,
-	mode: ImageStudioMode,
-	attachmentId: number | null,
-	messageId: string | null
-): void {
-	// Track the feedback event
-	trackImageStudioImageFeedback( {
-		feedback,
-		attachmentId,
-		mode,
-	} );
-
-	// Send feedback to the API
-	if ( sessionId && messageId ) {
-		apiFetch( {
-			path: '/wpcom/v2/big-sky/v1/wp-orchestrator/' + encodeURIComponent( sessionId ) + '/rate',
-			method: 'POST',
-			data: {
-				message_id: messageId,
-				rating: feedback,
-				big_sky_version:
-					(
-						window as unknown as {
-							bigSkyInitialState?: { bigSkyVersion?: string };
-						}
-					 )?.bigSkyInitialState?.bigSkyVersion ?? '0',
-				metadata: {
-					image_url: imageUrl,
-					mode,
-				},
-			},
-		} );
-	}
+	onFeedback?: ( feedback: 'up' | 'down' ) => void;
 }
 
 export const CanvasControls = ( {
 	imageUrl,
 	attachmentId,
-	sessionId,
 	mode,
 	showFeedbackButtons,
 	showImageActionsMenu = false,
 	onSave,
 	onRevertToOriginal,
+	onFeedback,
 }: CanvasControlsProps ) => {
 	const [ selectedFeedback, setSelectedFeedback ] = useState< 'up' | 'down' | null >( null );
-
-	// Get the last agent message ID from the store for feedback tracking
-	const lastAgentMessageId = useSelect(
-		( select ) => select( imageStudioStore ).getLastAgentMessageId(),
-		[]
-	);
 
 	// Reset feedback when image changes
 	useEffect( () => {
@@ -106,9 +50,10 @@ export const CanvasControls = ( {
 			}
 
 			setSelectedFeedback( feedback );
-			submitImageFeedback( imageUrl, feedback, sessionId, mode, attachmentId, lastAgentMessageId );
+			trackImageStudioImageFeedback( { feedback, attachmentId, mode } );
+			onFeedback?.( feedback );
 		},
-		[ imageUrl, sessionId, mode, attachmentId, selectedFeedback, lastAgentMessageId ]
+		[ mode, attachmentId, selectedFeedback, onFeedback ]
 	);
 
 	// Create a synthetic message object to use with MessageActions component

--- a/packages/image-studio/src/components/canvas-controls/index.tsx
+++ b/packages/image-studio/src/components/canvas-controls/index.tsx
@@ -3,10 +3,12 @@
  *
  * Displays thumbs up/down feedback buttons overlaid on the bottom-left of the generated image.
  * Uses the Agenttic UI MessageActions component for consistent styling and behavior.
+ * Shows a feedback text input popover when the thumbs down button is clicked.
  */
+import { FeedbackInput } from '@automattic/agents-manager';
 import { MessageActions, ThumbsDownIcon, ThumbsUpIcon } from '@automattic/agenttic-ui';
-import { __unstableMotion as motion } from '@wordpress/components';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { Popover, __unstableMotion as motion } from '@wordpress/components';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { trackImageStudioImageFeedback } from '../../utils/tracking';
 import { ImageActionsMenu } from '../image-actions-menu';
@@ -23,6 +25,7 @@ interface CanvasControlsProps {
 	onSave?: () => void;
 	onRevertToOriginal?: () => void;
 	onFeedback?: ( feedback: 'up' | 'down' ) => void;
+	onSubmitFeedbackText?: ( feedbackText: string ) => Promise< void >;
 }
 
 export const CanvasControls = ( {
@@ -34,12 +37,16 @@ export const CanvasControls = ( {
 	onSave,
 	onRevertToOriginal,
 	onFeedback,
+	onSubmitFeedbackText,
 }: CanvasControlsProps ) => {
 	const [ selectedFeedback, setSelectedFeedback ] = useState< 'up' | 'down' | null >( null );
+	const [ showFeedbackPopover, setShowFeedbackPopover ] = useState( false );
+	const feedbackAnchorRef = useRef< HTMLDivElement | null >( null );
 
 	// Reset feedback when image changes
 	useEffect( () => {
 		setSelectedFeedback( null );
+		setShowFeedbackPopover( false );
 	}, [ imageUrl ] );
 
 	const handleFeedback = useCallback(
@@ -52,9 +59,17 @@ export const CanvasControls = ( {
 			setSelectedFeedback( feedback );
 			trackImageStudioImageFeedback( { feedback, attachmentId, mode } );
 			onFeedback?.( feedback );
+
+			if ( feedback === 'down' && onSubmitFeedbackText ) {
+				setShowFeedbackPopover( true );
+			}
 		},
-		[ mode, attachmentId, selectedFeedback, onFeedback ]
+		[ mode, attachmentId, selectedFeedback, onFeedback, onSubmitFeedbackText ]
 	);
+
+	const handleCloseFeedbackPopover = useCallback( () => {
+		setShowFeedbackPopover( false );
+	}, [] );
 
 	// Create a synthetic message object to use with MessageActions component
 	const actionMessage = useMemo(
@@ -98,10 +113,26 @@ export const CanvasControls = ( {
 			exit={ { opacity: 0 } }
 			transition={ { duration: 0.3 } }
 		>
-			<div className="canvas-controls__left">
+			<div className="canvas-controls__left" ref={ feedbackAnchorRef }>
 				{ showFeedbackButtons && <MessageActions message={ actionMessage } /> }
 				{ showImageActionsMenu && (
 					<ImageActionsMenu onSave={ onSave } onRevertToOriginal={ onRevertToOriginal } />
+				) }
+				{ showFeedbackPopover && onSubmitFeedbackText && (
+					<Popover
+						className="canvas-controls__feedback-popover dark"
+						placement="bottom-start"
+						anchor={ feedbackAnchorRef.current }
+						onClose={ handleCloseFeedbackPopover }
+						variant="unstyled"
+						offset={ 12 }
+						shift
+					>
+						<FeedbackInput
+							onSubmit={ onSubmitFeedbackText }
+							onCancel={ handleCloseFeedbackPopover }
+						/>
+					</Popover>
 				) }
 			</div>
 			<div className="canvas-controls__right">

--- a/packages/image-studio/src/components/canvas-controls/index.tsx
+++ b/packages/image-studio/src/components/canvas-controls/index.tsx
@@ -120,7 +120,7 @@ export const CanvasControls = ( {
 				) }
 				{ showFeedbackPopover && onSubmitFeedbackText && (
 					<Popover
-						className="canvas-controls__feedback-popover dark"
+						className="canvas-controls__feedback-popover"
 						placement="bottom-start"
 						anchor={ feedbackAnchorRef.current }
 						onClose={ handleCloseFeedbackPopover }

--- a/packages/image-studio/src/components/canvas-controls/style.scss
+++ b/packages/image-studio/src/components/canvas-controls/style.scss
@@ -5,6 +5,8 @@
  * Now uses MessageActions component for consistent styling
  */
 
+ @import "../styles/variables";
+
 .canvas-controls {
 	z-index: 100;
 	width: 100%;
@@ -53,11 +55,45 @@
 	align-items: center;
 }
 
-.canvas-controls__feedback-popover.dark .agents-manager-feedback-input {
+.canvas-controls__feedback-popover {
 	background-color: #2a2a2a;
-	border: 1px solid #2f2f2f;
+	border: 1px solid $color-border;
 	border-radius: 4px;
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-	width: 250px;
-	margin-top: 0;
+
+	.agents-manager-feedback-input {
+		background-color: #2a2a2a;
+		border: none;
+		width: 300px;
+		margin-top: 0;
+		padding: 12px;
+	}
+
+	.components-base-control__label {
+		color: $color-foreground;
+	}
+
+	.components-textarea-control__input {
+		background: #404040;
+		border-color: transparent;
+		color: $color-foreground;
+
+		&::placeholder {
+			color: $color-foreground;
+		}
+	}
+
+	.components-button.is-tertiary {
+		color: #ccc;
+
+		&:hover,
+		&:focus {
+			color: $color-foreground;
+		}
+	}
+
+	.components-button.is-primary:not(:disabled) {
+		background: var(--wp-components-color-accent, #3858e9);
+		color: $color-foreground;
+	}
 }

--- a/packages/image-studio/src/components/canvas-controls/style.scss
+++ b/packages/image-studio/src/components/canvas-controls/style.scss
@@ -52,3 +52,12 @@
 	display: flex;
 	align-items: center;
 }
+
+.canvas-controls__feedback-popover.dark .agents-manager-feedback-input {
+	background-color: #2a2a2a;
+	border: 1px solid #2f2f2f;
+	border-radius: 4px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+	width: 250px;
+	margin-top: 0;
+}

--- a/packages/image-studio/src/components/canvas-controls/style.scss
+++ b/packages/image-studio/src/components/canvas-controls/style.scss
@@ -6,6 +6,7 @@
  */
 
  @import "../styles/variables";
+ @import "../styles/mixins";
 
 .canvas-controls {
 	z-index: 100;
@@ -56,44 +57,25 @@
 }
 
 .canvas-controls__feedback-popover {
-	background-color: #2a2a2a;
+	// FeedbackInput normally inherits theme variables from Agenttic.
+	// This popover renders outside that context, so we set them explicitly.
+	@include image-studio-theme-variables();
+	background-color: $color-background;
 	border: 1px solid $color-border;
 	border-radius: 4px;
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+	padding: 12px;
 
 	.agents-manager-feedback-input {
-		background-color: #2a2a2a;
-		border: none;
 		width: 300px;
-		margin-top: 0;
-		padding: 12px;
-	}
 
-	.components-base-control__label {
-		color: $color-foreground;
-	}
-
-	.components-textarea-control__input {
-		background: #404040;
-		border-color: transparent;
-		color: $color-foreground;
-
-		&::placeholder {
-			color: $color-foreground;
+		&,
+		&__inner {
+			margin: 0;
+			padding: 0;
+			border: none;
+			background-color: transparent;
+			border-radius: 0;
 		}
-	}
-
-	.components-button.is-tertiary {
-		color: #ccc;
-
-		&:hover,
-		&:focus {
-			color: $color-foreground;
-		}
-	}
-
-	.components-button.is-primary:not(:disabled) {
-		background: var(--wp-components-color-accent, #3858e9);
-		color: $color-foreground;
 	}
 }

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -1,4 +1,3 @@
-import { FeedbackInput } from '@automattic/agents-manager';
 import { getAgentManager, useAgentChat } from '@automattic/agenttic-client';
 import { AgentUI, cn, ThinkingMessage } from '@automattic/agenttic-ui';
 import {
@@ -46,17 +45,11 @@ function ImageStudioAgentChat( {
 	attachmentId,
 	mode,
 	onChatSubmit,
-	showFeedbackInput = false,
-	handleSubmitFeedbackText,
-	onFeedbackDone,
 }: {
 	agentConfig: any;
 	attachmentId?: number;
 	mode: ImageStudioMode;
 	onChatSubmit?: () => Promise< void > | void;
-	showFeedbackInput?: boolean;
-	handleSubmitFeedbackText: ( feedbackText: string ) => Promise< void >;
-	onFeedbackDone?: () => void;
 } ) {
 	const agentChatProps = useAgentChat( agentConfigProp );
 	const { addNotice } = useDispatch( imageStudioStore );
@@ -182,9 +175,6 @@ function ImageStudioAgentChat( {
 		>
 			<AgentUI.ConversationView showHeader={ false }>
 				<AgentUI.Messages />
-				{ showFeedbackInput && onFeedbackDone && (
-					<FeedbackInput onSubmit={ handleSubmitFeedbackText } onCancel={ onFeedbackDone } />
-				) }
 				<AgentUI.Footer>
 					{ suggestionsComponent }
 					<AgentUI.Notice />
@@ -205,18 +195,12 @@ const ImageStudioAgentUIComponent = ( {
 	modalOpenKey,
 	onChatSubmit,
 	mode,
-	showFeedbackInput = false,
-	handleSubmitFeedbackText,
-	onFeedbackDone,
 }: {
 	agentConfig: any;
 	attachmentId?: number;
 	modalOpenKey?: number;
 	onChatSubmit?: () => void;
 	mode: ImageStudioMode;
-	showFeedbackInput?: boolean;
-	handleSubmitFeedbackText: ( feedbackText: string ) => Promise< void >;
-	onFeedbackDone?: () => void;
 } ) => {
 	return (
 		<ImageStudioAgentChat
@@ -225,9 +209,6 @@ const ImageStudioAgentUIComponent = ( {
 			attachmentId={ attachmentId }
 			mode={ mode }
 			onChatSubmit={ onChatSubmit }
-			showFeedbackInput={ showFeedbackInput }
-			handleSubmitFeedbackText={ handleSubmitFeedbackText }
-			onFeedbackDone={ onFeedbackDone }
 		/>
 	);
 };
@@ -301,12 +282,12 @@ const ImageStudioContent = withInstanceId(
 			null
 		);
 		const [ isSaving, setIsSaving ] = useState( false );
-		const { showFeedbackInput, handleFeedback, handleCancelFeedback, handleSubmitFeedbackText } =
-			useImageStudioFeedback( {
-				displayImageUrl,
-				authProvider: agentConfigState?.authProvider,
-				sessionId: agentConfigState?.sessionId,
-			} );
+		const { handleFeedback, handleSubmitFeedbackText } = useImageStudioFeedback( {
+			authProvider: agentConfigState?.authProvider,
+			sessionId: agentConfigState?.sessionId,
+			displayImageUrl,
+			mode: config?.attachmentId ? ImageStudioMode.Edit : ImageStudioMode.Generate,
+		} );
 
 		// Track the last modal key to detect when modal reopens
 		const lastModalOpenKey = useRef< number | undefined >();
@@ -474,6 +455,7 @@ const ImageStudioContent = withInstanceId(
 				onSave={ handleSaveWithNotification }
 				onRevertToOriginal={ handleRevertToOriginal }
 				onFeedback={ handleFeedback }
+				onSubmitFeedbackText={ handleSubmitFeedbackText }
 			/>
 		) : null;
 
@@ -537,9 +519,6 @@ const ImageStudioContent = withInstanceId(
 										modalOpenKey={ modalOpenKey }
 										onChatSubmit={ handleChatSubmit }
 										mode={ mode }
-										showFeedbackInput={ showFeedbackInput }
-										handleSubmitFeedbackText={ handleSubmitFeedbackText }
-										onFeedbackDone={ handleCancelFeedback }
 									/>
 								) : (
 									<div className="image-studio-agent-loading">

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -1,3 +1,4 @@
+import { FeedbackInput } from '@automattic/agents-manager';
 import { getAgentManager, useAgentChat } from '@automattic/agenttic-client';
 import { AgentUI, cn, ThinkingMessage } from '@automattic/agenttic-ui';
 import {
@@ -15,6 +16,7 @@ import { useBeforeUnload } from '../hooks/use-beforeunload';
 import { useDraftCleanup } from '../hooks/use-draft-cleanup';
 import { useImageLoaded } from '../hooks/use-image-loaded';
 import { useImageStudioAgentSync } from '../hooks/use-image-studio-agent-sync';
+import { useImageStudioFeedback } from '../hooks/use-image-studio-feedback';
 import { useImageStudioMessageDisplay } from '../hooks/use-image-studio-message-display';
 import { useImageStudioSuggestions } from '../hooks/use-image-studio-suggestions';
 import { useImageUrl } from '../hooks/use-image-url';
@@ -22,14 +24,8 @@ import { useRevertToOriginal } from '../hooks/use-revert-to-original';
 import { useSaveShortcut } from '../hooks/use-save-shortcut';
 import { useUnsavedChangesConfirmation } from '../hooks/use-unsaved-changes-confirmation';
 import { type ImageStudioActions, store as imageStudioStore } from '../store';
-import {
-	type ImageStudioConfig,
-	ImageStudioMode,
-	type ImageStudioProps,
-	ToolbarOption,
-} from '../types';
-import { defaultAgentConfigFactory, type AgentConfigFactory } from '../utils/agent-config';
-import { getSessionId } from '../utils/session';
+import { ImageStudioMode, type ImageStudioProps, ToolbarOption } from '../types';
+import { defaultAgentConfigFactory } from '../utils/agent-config';
 import { trackImageStudioError, trackImageStudioPromptSent } from '../utils/tracking';
 import AnnotationCanvas from './annotation-canvas';
 import { AspectRatioPicker } from './aspect-ratio-picker';
@@ -50,11 +46,17 @@ function ImageStudioAgentChat( {
 	attachmentId,
 	mode,
 	onChatSubmit,
+	showFeedbackInput = false,
+	handleSubmitFeedbackText,
+	onFeedbackDone,
 }: {
 	agentConfig: any;
 	attachmentId?: number;
 	mode: ImageStudioMode;
 	onChatSubmit?: () => Promise< void > | void;
+	showFeedbackInput?: boolean;
+	handleSubmitFeedbackText: ( feedbackText: string ) => Promise< void >;
+	onFeedbackDone?: () => void;
 } ) {
 	const agentChatProps = useAgentChat( agentConfigProp );
 	const { addNotice } = useDispatch( imageStudioStore );
@@ -180,6 +182,9 @@ function ImageStudioAgentChat( {
 		>
 			<AgentUI.ConversationView showHeader={ false }>
 				<AgentUI.Messages />
+				{ showFeedbackInput && onFeedbackDone && (
+					<FeedbackInput onSubmit={ handleSubmitFeedbackText } onCancel={ onFeedbackDone } />
+				) }
 				<AgentUI.Footer>
 					{ suggestionsComponent }
 					<AgentUI.Notice />
@@ -195,36 +200,34 @@ function ImageStudioAgentChat( {
 }
 
 const ImageStudioAgentUIComponent = ( {
-	config,
+	agentConfig,
+	attachmentId,
 	modalOpenKey,
 	onChatSubmit,
 	mode,
-	agentConfigFactory = defaultAgentConfigFactory,
+	showFeedbackInput = false,
+	handleSubmitFeedbackText,
+	onFeedbackDone,
 }: {
-	config: ImageStudioConfig;
+	agentConfig: any;
+	attachmentId?: number;
 	modalOpenKey?: number;
 	onChatSubmit?: () => void;
 	mode: ImageStudioMode;
-	agentConfigFactory?: AgentConfigFactory;
+	showFeedbackInput?: boolean;
+	handleSubmitFeedbackText: ( feedbackText: string ) => Promise< void >;
+	onFeedbackDone?: () => void;
 } ) => {
-	const attachmentId = config?.attachmentId;
-	const agentConfigState = useAgentConfig( agentConfigFactory, modalOpenKey );
-
-	if ( ! agentConfigState ) {
-		return (
-			<div className="image-studio-agent-loading">
-				{ __( 'Loading AI assistant…', __i18n_text_domain__ ) }
-			</div>
-		);
-	}
-
 	return (
 		<ImageStudioAgentChat
 			key={ `agentchat-${ modalOpenKey || 'default' }` }
-			agentConfig={ agentConfigState }
+			agentConfig={ agentConfig }
 			attachmentId={ attachmentId }
 			mode={ mode }
 			onChatSubmit={ onChatSubmit }
+			showFeedbackInput={ showFeedbackInput }
+			handleSubmitFeedbackText={ handleSubmitFeedbackText }
+			onFeedbackDone={ onFeedbackDone }
 		/>
 	);
 };
@@ -281,9 +284,6 @@ const ImageStudioContent = withInstanceId(
 
 		const { addNotice, setIsSidebarOpen } = useDispatch( imageStudioStore ) as ImageStudioActions;
 
-		// Get session ID (persistent across sessions)
-		const sessionId = getSessionId();
-
 		const {
 			handleAnnotationDone,
 			hasAnnotations,
@@ -294,11 +294,19 @@ const ImageStudioContent = withInstanceId(
 			originalImageUrl,
 		} );
 
+		const agentConfigState = useAgentConfig( agentConfigFactory, modalOpenKey );
+
 		const [ isPromptSent, setIsPromptSent ] = useState( false );
 		const [ activeToolbarOption, setActiveToolbarOption ] = useState< ToolbarOption | null >(
 			null
 		);
 		const [ isSaving, setIsSaving ] = useState( false );
+		const { showFeedbackInput, handleFeedback, handleCancelFeedback, handleSubmitFeedbackText } =
+			useImageStudioFeedback( {
+				displayImageUrl,
+				authProvider: agentConfigState?.authProvider,
+				sessionId: agentConfigState?.sessionId,
+			} );
 
 		// Track the last modal key to detect when modal reopens
 		const lastModalOpenKey = useRef< number | undefined >();
@@ -460,12 +468,12 @@ const ImageStudioContent = withInstanceId(
 			<CanvasControls
 				imageUrl={ finalDisplayUrl }
 				attachmentId={ attachmentId }
-				sessionId={ sessionId }
 				mode={ mode }
 				showFeedbackButtons={ showFeedbackButtons }
 				showImageActionsMenu={ showImageActionsMenu }
 				onSave={ handleSaveWithNotification }
 				onRevertToOriginal={ handleRevertToOriginal }
+				onFeedback={ handleFeedback }
 			/>
 		) : null;
 
@@ -522,13 +530,22 @@ const ImageStudioContent = withInstanceId(
 
 						<Footer
 							chatComponent={
-								<ImageStudioAgentUI
-									config={ memoizedConfig }
-									modalOpenKey={ modalOpenKey }
-									onChatSubmit={ handleChatSubmit }
-									mode={ mode }
-									agentConfigFactory={ agentConfigFactory }
-								/>
+								agentConfigState ? (
+									<ImageStudioAgentUI
+										agentConfig={ agentConfigState }
+										attachmentId={ attachmentId ?? undefined }
+										modalOpenKey={ modalOpenKey }
+										onChatSubmit={ handleChatSubmit }
+										mode={ mode }
+										showFeedbackInput={ showFeedbackInput }
+										handleSubmitFeedbackText={ handleSubmitFeedbackText }
+										onFeedbackDone={ handleCancelFeedback }
+									/>
+								) : (
+									<div className="image-studio-agent-loading">
+										{ __( 'Loading AI assistant…', 'big-sky' ) }
+									</div>
+								)
 							}
 						></Footer>
 					</div>

--- a/packages/image-studio/src/components/styles/_mixins.scss
+++ b/packages/image-studio/src/components/styles/_mixins.scss
@@ -1,3 +1,5 @@
+@import "variables";
+
 @mixin visually-hidden() {
 	position: absolute;
 	width: 1px;
@@ -8,4 +10,18 @@
 	clip: rect(0, 0, 0, 0);
 	white-space: nowrap;
 	border-width: 0;
+}
+
+@mixin image-studio-theme-variables() {
+	--color-primary: var(--wp-components-color-accent, #3858e9);
+	--color-primary-foreground: #{$color-foreground};
+	--color-background:#{$color-background};
+    --color-foreground:#{$color-foreground};
+    --color-popover: #{$color-background};
+    --color-popover-muted: #{$color-border};
+    --color-muted: #{$color-border};
+    --color-muted-foreground: #ccc;
+    --color-success-background: #1F2E1F;
+	--color-success: #fff;
+	--color-warning-background: #2E281F;
 }

--- a/packages/image-studio/src/hooks/use-image-studio-feedback.ts
+++ b/packages/image-studio/src/hooks/use-image-studio-feedback.ts
@@ -21,7 +21,7 @@ export const useImageStudioFeedback = ( config: UseImageStudioFeedbackConfig = {
 	);
 
 	const metadata = useMemo( () => {
-		const meta: Record< string, unknown > = {};
+		const meta: Record< string, string > = {};
 		if ( displayImageUrl ) {
 			meta.image_url = displayImageUrl;
 		}

--- a/packages/image-studio/src/hooks/use-image-studio-feedback.ts
+++ b/packages/image-studio/src/hooks/use-image-studio-feedback.ts
@@ -1,52 +1,44 @@
 import { rateMessage, submitFeedback } from '@automattic/agents-manager';
 import { useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { store as imageStudioStore } from '../store';
+import type { ImageStudioMode } from '../types';
 import type { AuthProvider } from '@automattic/agenttic-client';
 
 interface UseImageStudioFeedbackConfig {
-	/** Current displayed image URL — resets feedback state on change. */
-	displayImageUrl?: string | null;
-	/** Auth provider for API calls. */
 	authProvider?: AuthProvider;
-	/** Session ID for API calls. */
 	sessionId?: string;
+	displayImageUrl?: string | null;
+	mode?: ImageStudioMode;
 }
 
-/**
- * Manages feedback for the image studio — both UI state and API calls.
- */
 export const useImageStudioFeedback = ( config: UseImageStudioFeedbackConfig = {} ) => {
-	const { displayImageUrl, authProvider, sessionId } = config;
-
-	const [ showFeedbackInput, setShowFeedbackInput ] = useState( false );
-
-	// Reset feedback state when the displayed image changes
-	useEffect( () => {
-		setShowFeedbackInput( false );
-	}, [ displayImageUrl ] );
+	const { authProvider, sessionId, displayImageUrl, mode } = config;
 
 	const lastAgentMessageId = useSelect(
 		( select ) => select( imageStudioStore ).getLastAgentMessageId(),
 		[]
 	);
 
+	const metadata = useMemo( () => {
+		const meta: Record< string, unknown > = {};
+		if ( displayImageUrl ) {
+			meta.image_url = displayImageUrl;
+		}
+		if ( mode ) {
+			meta.mode = mode;
+		}
+		return Object.keys( meta ).length > 0 ? meta : undefined;
+	}, [ displayImageUrl, mode ] );
+
 	const handleFeedback = useCallback(
 		( feedback: 'up' | 'down' ) => {
-			if ( feedback === 'down' ) {
-				setShowFeedbackInput( true );
-			}
-
 			if ( authProvider && sessionId && lastAgentMessageId ) {
-				rateMessage( authProvider, sessionId, lastAgentMessageId, feedback );
+				rateMessage( authProvider, sessionId, lastAgentMessageId, feedback, undefined, metadata );
 			}
 		},
-		[ authProvider, sessionId, lastAgentMessageId ]
+		[ authProvider, sessionId, lastAgentMessageId, metadata ]
 	);
-
-	const handleCancelFeedback = useCallback( () => {
-		setShowFeedbackInput( false );
-	}, [] );
 
 	const handleSubmitFeedbackText = useCallback(
 		async ( feedbackText: string ) => {
@@ -55,15 +47,12 @@ export const useImageStudioFeedback = ( config: UseImageStudioFeedbackConfig = {
 			}
 
 			await submitFeedback( authProvider, sessionId, lastAgentMessageId, feedbackText.trim() );
-			setShowFeedbackInput( false );
 		},
 		[ sessionId, authProvider, lastAgentMessageId ]
 	);
 
 	return {
-		showFeedbackInput,
 		handleFeedback,
-		handleCancelFeedback,
 		handleSubmitFeedbackText,
 	};
 };

--- a/packages/image-studio/src/hooks/use-image-studio-feedback.ts
+++ b/packages/image-studio/src/hooks/use-image-studio-feedback.ts
@@ -1,0 +1,69 @@
+import { rateMessage, submitFeedback } from '@automattic/agents-manager';
+import { useSelect } from '@wordpress/data';
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import { store as imageStudioStore } from '../store';
+import type { AuthProvider } from '@automattic/agenttic-client';
+
+interface UseImageStudioFeedbackConfig {
+	/** Current displayed image URL — resets feedback state on change. */
+	displayImageUrl?: string | null;
+	/** Auth provider for API calls. */
+	authProvider?: AuthProvider;
+	/** Session ID for API calls. */
+	sessionId?: string;
+}
+
+/**
+ * Manages feedback for the image studio — both UI state and API calls.
+ */
+export const useImageStudioFeedback = ( config: UseImageStudioFeedbackConfig = {} ) => {
+	const { displayImageUrl, authProvider, sessionId } = config;
+
+	const [ showFeedbackInput, setShowFeedbackInput ] = useState( false );
+
+	// Reset feedback state when the displayed image changes
+	useEffect( () => {
+		setShowFeedbackInput( false );
+	}, [ displayImageUrl ] );
+
+	const lastAgentMessageId = useSelect(
+		( select ) => select( imageStudioStore ).getLastAgentMessageId(),
+		[]
+	);
+
+	const handleFeedback = useCallback(
+		( feedback: 'up' | 'down' ) => {
+			if ( feedback === 'down' ) {
+				setShowFeedbackInput( true );
+			}
+
+			if ( authProvider && sessionId && lastAgentMessageId ) {
+				rateMessage( authProvider, sessionId, lastAgentMessageId, feedback );
+			}
+		},
+		[ authProvider, sessionId, lastAgentMessageId ]
+	);
+
+	const handleCancelFeedback = useCallback( () => {
+		setShowFeedbackInput( false );
+	}, [] );
+
+	const handleSubmitFeedbackText = useCallback(
+		async ( feedbackText: string ) => {
+			if ( ! feedbackText.trim() || ! sessionId || ! lastAgentMessageId || ! authProvider ) {
+				return;
+			}
+
+			await submitFeedback( authProvider, sessionId, lastAgentMessageId, feedbackText.trim() );
+			setShowFeedbackInput( false );
+		},
+		[ sessionId, authProvider, lastAgentMessageId ]
+	);
+
+	return {
+		showFeedbackInput,
+		handleFeedback,
+		handleCancelFeedback,
+		handleSubmitFeedbackText,
+	};
+};

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -65,7 +65,7 @@ function recordImageStudioEvent(
 	const entryPoint = getImageStudioEntryPoint();
 	const baseProps: Record< string, string | number | boolean > = {
 		...properties,
-		sessionId: getSessionId(),
+		sessionid: getSessionId(),
 	};
 
 	if ( entryPoint ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,12 +348,10 @@ __metadata:
     typescript: "npm:^5.8.3"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
-    "@automattic/calypso-router": "workspace:^"
     "@wordpress/data": ^10.23.0
     "@wordpress/element": ^6.23.0
     react: ^18.3.1
     react-dom: ^18.3.1
-    redux: ^5.0.1
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,6 +1572,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
+    "@automattic/agents-manager": "workspace:^"
     "@automattic/agenttic-client": "npm:^0.1.46"
     "@automattic/agenttic-ui": "npm:^0.1.46"
     "@automattic/calypso-analytics": "workspace:^"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Update Image Studio feedback buttons to use the same endpoint used by Agents Manager
* When an image is downvoted, show the Agents Manager feedback input to enable users to provide a reason for their rating

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To enable receiving feedback about generated images

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From your sandbox run `install-plugin.sh am image-studio-feedback-input`
* Visit the media library from your test site and edit an image
* Click the thumbs down icon from the canvas controls
* Provide a message and submit
* Check that the message was received in Slack: slack-C091LBVNVS9

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
