### PR TITLE
MSD: Hide WP loading logo for CIAB dashboard routes

### DIFF
--- a/client/dashboard/app-ciab/section.ts
+++ b/client/dashboard/app-ciab/section.ts
@@ -1,4 +1,5 @@
 export const CIAB_DASHBOARD_SECTION_DEFINITION = {
 	name: 'dashboard-ciab',
 	module: 'dashboard/app-ciab',
+	hideLoadingLogo: true,
 };

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -63,6 +63,7 @@ class Document extends Component {
 			renderedLayout,
 			sectionGroup,
 			sectionName,
+			hideLoadingLogo,
 			hideWooHostedLogo,
 			storeSandboxHelper,
 			target,
@@ -186,6 +187,7 @@ class Document extends Component {
 										isWCCOM={ isWCCOM }
 										isOneTapAuth={ !! query?.oneTapAuth }
 										showStepContainerV2Loader={ showStepContainerV2Loader }
+										hideLoadingLogo={ hideLoadingLogo }
 										hideWooHostedLogo={ hideWooHostedLogo }
 									/>
 								</div>
@@ -309,8 +311,13 @@ function LoadingPlaceholder( {
 	isWCCOM,
 	isOneTapAuth,
 	showStepContainerV2Loader,
+	hideLoadingLogo,
 	hideWooHostedLogo,
 } ) {
+	if ( hideLoadingLogo ) {
+		return null;
+	}
+
 	const shouldNotShowLoadingLogo =
 		sectionName === 'checkout' ||
 		sectionName === 'stepper' ||

--- a/client/document/test/loading-placeholder.test.tsx
+++ b/client/document/test/loading-placeholder.test.tsx
@@ -76,6 +76,14 @@ describe( 'Document LoadingPlaceholder', () => {
 		expect( html ).not.toContain( 'step-container-v2__top-bar-wordpress-logo-wrapper' );
 	} );
 
+	it( 'renders no logo when hideLoadingLogo is true', () => {
+		const html = renderToStaticMarkup(
+			<Document { ...baseProps } hideLoadingLogo sectionName="dashboard-ciab" />
+		);
+
+		expect( html ).not.toContain( 'wpcom-site__logo' );
+	} );
+
 	it( 'shows the WordPress logo when hideWooHostedLogo is false', () => {
 		const html = renderToStaticMarkup(
 			<Document

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -731,6 +731,10 @@ const setUpSectionContext = ( section, entrypoint ) => ( req, res, next ) => {
 		req.context.sectionGroup = section.group;
 	}
 
+	if ( section.hideLoadingLogo ) {
+		req.context.hideLoadingLogo = true;
+	}
+
 	if ( Array.isArray( section.links ) ) {
 		section.links.forEach( ( link ) => req.context.store.dispatch( setDocumentHeadLink( link ) ) );
 	}


### PR DESCRIPTION
Part of DOTMSD-1089

## Proposed Changes

- Add `hideLoadingLogo: true` to `CIAB_DASHBOARD_SECTION_DEFINITION`
- Propagate `hideLoadingLogo` through `setUpSectionContext` → Document → `LoadingPlaceholder`
- Return `null` from `LoadingPlaceholder` when `hideLoadingLogo` is true

## Why are these changes being made?

CIAB pages flash the WordPress logo during SSR before React hydration replaces it. The CIAB client app already sets `Logo: null`, so after hydration no WP logo shows — but the server-rendered HTML includes a `<WordPressLogo>` in the `LoadingPlaceholder` component, causing a brief flash.

## Testing Instructions

1. `yarn start` → navigate to a CIAB route (e.g. `http://my.localhost:3000/ciab`)
2. Confirm no WP logo flash during initial page load
3. Verify non-CIAB routes (e.g. `/home`) still show the WP loading logo as before

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?