### PR TITLE
Fix: Skip non-primary domain warning for .home.blog sites

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -12,6 +12,7 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { CompactCard, Gridicon } from '@automattic/components';
+import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -224,7 +225,14 @@ class RemovePurchase extends Component {
 	);
 
 	shouldShowNonPrimaryDomainWarning() {
-		const { hasNonPrimaryDomainsFlag, isAtomicSite, hasCustomPrimaryDomain, purchase } = this.props;
+		const { hasNonPrimaryDomainsFlag, isAtomicSite, hasCustomPrimaryDomain, purchase, site } =
+			this.props;
+
+		// Free subdomains like .home.blog stay as primary after downgrade, so don't show the warning
+		if ( site?.domain && isFreeUrlDomainName( site.domain ) ) {
+			return false;
+		}
+
 		return (
 			hasNonPrimaryDomainsFlag && isPlan( purchase ) && ! isAtomicSite && hasCustomPrimaryDomain
 		);


### PR DESCRIPTION
Part of CHE-352

## Proposed Changes

* Add a check using `isFreeUrlDomainName()` to skip showing the non-primary domain warning when the site's domain is a free WPCOM subdomain (like `.home.blog`, `.art.blog`, etc.)

## Why are these changes being made?

* When users with a `.home.blog` subdomain try to cancel their plan, they see a warning saying their domain will redirect to `.wordpress.com`
* This is incorrect - free WPCOM subdomains like `.home.blog` stay as the primary domain after downgrade and don't require a paid plan
* The warning was confusing users because it implied their domain would change when it wouldn't

## Testing Instructions

1. Access a site with a paid plan and a free `.home.blog` subdomain (or other free subdomain like `.art.blog`)
2. Go to https://wordpress.com/me/purchases, click on the plan, and click the cancellation link
3. **Before this fix:** You would see a warning about the domain redirecting to `.wordpress.com`
4. **After this fix:** The warning should not appear for free subdomain sites

> Note: This fix was verified with linting and type-checking from a local checkout. Visual and cross-platform testing on a sandbox is still needed before merge.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?