### PR TITLE
MSD: Show correct name and URL fields for site redirects

### DIFF
--- a/client/dashboard/components/site-icon/index.tsx
+++ b/client/dashboard/components/site-icon/index.tsx
@@ -10,6 +10,7 @@ import './style.scss';
 export default function SiteIcon( { site, size = 48 }: { site: Site; size?: number } ) {
 	const status = getSiteBlockingStatus( site );
 	const isMigration = status === 'migration_pending' || status === 'migration_started';
+	const isRedirect = site.options?.is_redirect;
 	const fallbackInitial = getSiteDisplayName( site ).charAt( 0 );
 	const dims = { width: size, height: size };
 	const ico = site.icon?.img || site.icon?.ico;
@@ -30,7 +31,7 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 		'is-small': size <= 16,
 	} );
 
-	if ( ico ) {
+	if ( ico && ! isRedirect ) {
 		return (
 			<img
 				className={ clsx( 'site-icon', className ) }

--- a/client/dashboard/sites/overview-site-fields/index.tsx
+++ b/client/dashboard/sites/overview-site-fields/index.tsx
@@ -62,7 +62,7 @@ const SiteOverviewFields = ( { site }: { site: Site } ) => {
 						{
 							link: (
 								<ExternalLink href={ site.URL } style={ { overflowWrap: 'anywhere' } }>
-									{ site.URL }
+									{ getSiteDisplayUrl( site ) }
 								</ExternalLink>
 							),
 						}

--- a/client/dashboard/sites/overview-site-fields/index.tsx
+++ b/client/dashboard/sites/overview-site-fields/index.tsx
@@ -3,12 +3,13 @@ import { siteAgencyBlogQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { __experimentalText as Text, ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { MetadataList, MetadataItem } from '../../components/metadata-list';
 import { hasHostingFeature } from '../../utils/site-features';
 import { getSiteProviderName, DEFAULT_PROVIDER_NAME } from '../../utils/site-provider';
 import { isSelfHostedJetpackConnected, isCommerceGarden } from '../../utils/site-types';
-import { getSiteDisplayUrl, getSiteFormattedUrl } from '../../utils/site-url';
+import { getSiteDisplayUrl } from '../../utils/site-url';
 import { getFormattedWordPressVersion } from '../../utils/wp-version';
 import { PHPVersion } from '../site-fields';
 import type { Site } from '@automattic/api-core';
@@ -44,29 +45,37 @@ const HostingProvider = ( { site }: { site: Site } ) => {
 };
 
 const SiteOverviewFields = ( { site }: { site: Site } ) => {
-	const url = getSiteFormattedUrl( site );
+	const url = site.URL;
 	const wpVersion = getFormattedWordPressVersion( site );
 	const hasPHPFeature = hasHostingFeature( site, HostingFeatures.PHP );
 	const hasSiteRedirect = site.options?.is_redirect;
 
-	const fields: React.ReactElement[] = [
-		<MetadataItem key="url">
-			<ExternalLink href={ url } style={ { overflowWrap: 'anywhere' } }>
-				{ getSiteDisplayUrl( site ) }
-			</ExternalLink>
-		</MetadataItem>,
-	];
+	const fields: React.ReactElement[] = [];
 
 	if ( hasSiteRedirect ) {
 		fields.push(
 			<MetadataItem key="redirect">
 				<Text variant="muted">
-					{ sprintf(
-						/* translators: %s: the URL this site is redirected to, e.g.: http://example.com */
-						__( 'Redirects to %s' ),
-						site.URL
+					{ createInterpolateElement(
+						/* translators: link: the URL this site is redirected to, e.g.: http://example.com */
+						__( 'Redirects to <link />' ),
+						{
+							link: (
+								<ExternalLink href={ site.URL } style={ { overflowWrap: 'anywhere' } }>
+									{ site.URL }
+								</ExternalLink>
+							),
+						}
 					) }
 				</Text>
+			</MetadataItem>
+		);
+	} else {
+		fields.push(
+			<MetadataItem key="url">
+				<ExternalLink href={ url } style={ { overflowWrap: 'anywhere' } }>
+					{ getSiteDisplayUrl( site ) }
+				</ExternalLink>
 			</MetadataItem>
 		);
 	}

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -99,6 +99,8 @@ export function NameRenderer( {
 } ) {
 	const renderBadge = () => {
 		switch ( badge ) {
+			case 'redirect':
+				return <Badge>{ __( 'Redirect' ) }</Badge>;
 			case 'staging':
 				return <Badge>{ __( 'Staging' ) }</Badge>;
 			case 'trial':

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -28,7 +28,6 @@ import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
 import { getSiteBadge } from '../../utils/site-badge';
 import { hasHostingFeature, hasJetpackModule } from '../../utils/site-features';
-import { getSiteFormattedUrl } from '../../utils/site-url';
 import { getVisibilityLabels } from '../../utils/site-visibility';
 import { canManageSite } from '../features';
 import { isSitePlanTrial, isSitePlanWooHosted } from '../plans';
@@ -140,7 +139,7 @@ export function URL( { site, value }: { site: Site; value: string } ) {
 		<ExternalLink
 			className="dataviews-url-field"
 			style={ titleFieldTextOverflowStyles }
-			href={ getSiteFormattedUrl( site ) }
+			href={ site.URL }
 		>
 			{ value }
 		</ExternalLink>

--- a/client/dashboard/types/site.ts
+++ b/client/dashboard/types/site.ts
@@ -12,4 +12,4 @@ export type SiteBlockingStatus =
 	| 'difm_lite_in_progress'
 	| null;
 
-export type SiteBadge = 'staging' | 'trial' | 'p2' | SiteBlockingStatus;
+export type SiteBadge = 'redirect' | 'staging' | 'trial' | 'p2' | SiteBlockingStatus;

--- a/client/dashboard/utils/site-badge.ts
+++ b/client/dashboard/utils/site-badge.ts
@@ -10,6 +10,9 @@ export function getSiteBadge( site: Site ): SiteBadge {
 		return status;
 	}
 
+	if ( site.options?.is_redirect ) {
+		return 'redirect';
+	}
 	if ( site.is_wpcom_staging_site ) {
 		return 'staging';
 	}

--- a/client/dashboard/utils/site-name.ts
+++ b/client/dashboard/utils/site-name.ts
@@ -8,5 +8,10 @@ export function getSiteDisplayName( site: Site ) {
 	if ( status === 'migration_pending' || status === 'migration_started' ) {
 		return __( 'Incoming Migration' );
 	}
+
+	if ( site.options?.is_redirect ) {
+		return site.slug;
+	}
+
 	return site.name || getSiteDisplayUrl( site );
 }

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -10,21 +10,7 @@ import type { Site } from '@automattic/api-core';
  * installations.
  */
 export function getSiteDisplayUrl( site: Site ) {
-	if ( site.is_garden || site.options?.is_redirect ) {
-		return site.slug;
-	}
-
 	return site.URL.replace( 'https://', '' ).replace( 'http://', '' );
-}
-
-/**
- * Returns the actual formatted URL for the site considering site redirects
- */
-export function getSiteFormattedUrl( site: Site ) {
-	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
-		return site.options.unmapped_url;
-	}
-	return site.URL;
 }
 
 /**


### PR DESCRIPTION
Fixes DOTCOM-16086

## Proposed Changes

Show correct URLs for site redirects as follows. Basically, we always rely on the correct, final URL, in `site.URL`, and keep the original `site.slug` for navigation.

### Site List

Adds a new badge:

|Before|After|
|-|-|
|<img width="300" height="120" alt="image" src="https://github.com/user-attachments/assets/9b98606a-cb54-4c03-94aa-57a992596ba7" />|<img width="330" height="126" alt="image" src="https://github.com/user-attachments/assets/9828a5d9-1c27-4a48-a11a-2144ad1a7a9d" />

### Site Overview

|Before|After|
|-|-|
|<img width="698" height="113" alt="image" src="https://github.com/user-attachments/assets/8d98e6bb-6fb2-4fb9-9a02-62d981fcbf93" />|<img width="684" height="124" alt="image" src="https://github.com/user-attachments/assets/e8995760-c5d3-4a45-97cf-34ce2c8f52d5" />

## Testing Instructions

1. Create site redirect based on this docs: https://wordpress.com/support/domains/site-redirect/#create-a-site-redirect
2. Open `/sites`:
    - Verify you see the redirected URL as shown in the above screenshot.
4. Open `/sites/:siteSlug`:
    - Verify you see the redirected URL as shown in the above screenshot.
    - Verify all navigations still work and uses the original `site.slug` in the URLs.
        - (for example, if you click Settings, you should land in `/sites/original-slug.wordpress.com/settings`).
5. REGRESSION: Verify the experience is still correct with regular sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
