### PR TITLE
Image Studio: Don't persist content aware suggestion prompt

### DIFF
--- a/packages/image-studio/src/hooks/use-async-suggestions-loader.ts
+++ b/packages/image-studio/src/hooks/use-async-suggestions-loader.ts
@@ -112,6 +112,18 @@ Output valid JSON only, nothing else.`;
 		const loadSuggestions = async () => {
 			try {
 				const config = await createDefaultAgentConfig( crypto.randomUUID() );
+				// Apply skipStorage only for this suggestions interaction (do not persist to storage).
+				const baseContextProvider = config.contextProvider;
+				if ( baseContextProvider ) {
+					config.contextProvider = {
+						getClientContext: () => ( {
+							...( typeof baseContextProvider.getClientContext === 'function'
+								? baseContextProvider.getClientContext()
+								: {} ),
+							constructorArguments: { skipStorage: true },
+						} ),
+					};
+				}
 				const client = createClient( config );
 
 				const response = await client.sendMessage( {

--- a/packages/image-studio/src/hooks/use-async-suggestions-loader.ts
+++ b/packages/image-studio/src/hooks/use-async-suggestions-loader.ts
@@ -112,7 +112,7 @@ Output valid JSON only, nothing else.`;
 		const loadSuggestions = async () => {
 			try {
 				const config = await createDefaultAgentConfig( crypto.randomUUID() );
-				// Apply skipStorage only for this suggestions interaction (do not persist to storage).
+				// Apply skip_storage only for this suggestions interaction (do not persist to storage).
 				const baseContextProvider = config.contextProvider;
 				if ( baseContextProvider ) {
 					config.contextProvider = {
@@ -120,7 +120,7 @@ Output valid JSON only, nothing else.`;
 							...( typeof baseContextProvider.getClientContext === 'function'
 								? baseContextProvider.getClientContext()
 								: {} ),
-							constructorArguments: { skipStorage: true },
+							constructorArguments: { skip_storage: true },
 						} ),
 					};
 				}

--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -38,6 +38,9 @@ export interface ImageStudioClientContext extends Record< string, unknown > {
 	environment: 'wp-admin';
 	imageStudio?: ImageStudioData;
 	currentPageContent?: PageContentBlock[];
+	constructorArguments?: {
+		skipStorage?: boolean;
+	};
 }
 
 const TEMPLATE_PART_SLUGS = [ 'header', 'header-hero', 'footer' ];

--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -39,7 +39,7 @@ export interface ImageStudioClientContext extends Record< string, unknown > {
 	imageStudio?: ImageStudioData;
 	currentPageContent?: PageContentBlock[];
 	constructorArguments?: {
-		skipStorage?: boolean;
+		skip_storage?: boolean;
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

Set skipStorage=true when generating the content-aware suggestions.

## Why are these changes being made?

Because we do not want the content-aware suggestion prompt to show up in the conversation history in the sidebar.


## Testing Instructions

See wpcom PR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
