### PR TITLE
Agents Manager: fix hosting plans issue

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
+++ b/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
@@ -21,9 +21,3 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) 
 		}
 	}
 }
-
-body.agents-manager-sidebar-container--sidebar-open {
-	.is-section-plans {
-		background-color: inherit;
-	}
-}

--- a/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
+++ b/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
@@ -21,3 +21,9 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) 
 		}
 	}
 }
+
+body.agents-manager-sidebar-container--sidebar-open {
+	.is-section-plans {
+		background-color: inherit;
+	}
+}

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -233,6 +233,10 @@ body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-c
 		.domain-search--step-wrapper .domain-search--initial-state__already-own-domain-cta {
 			position: absolute;
 		}
+
+		.is-section-plans {
+			background-color: inherit;
+		}
 	}
 }
 


### PR DESCRIPTION
Adds a small fix for the hosting plans page when the Agents Manager sidebar is open.

Before:

<img width="1430" height="944" alt="image" src="https://github.com/user-attachments/assets/c0d46b23-7a13-4645-8432-6e8c6a5874a6" />

After:

<img width="838" height="990" alt="image" src="https://github.com/user-attachments/assets/ac1c052a-8477-4bc4-a0f3-94f9c7d95226" />

Fixes AI-897

## Why are these changes being made?

Fixes a style issue with Agents Manager

## Testing Instructions

* `yarn start`
* Load http://calypso.localhost:3000/plans/a8ctesting.wordpress.com and open docked Agents Manager
* Confirm it matches the second screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
