### PR TITLE
Podcasting settings: redesign UX with toggle-based enable/disable

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -221,6 +221,13 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					disabled={ disabled }
 					label={ translate( 'Enable podcasting on this site' ) }
 				/>
+				{ isPodcastingEnabled && (
+					<FormSettingExplanation>
+						{ translate(
+							'Disable to stop publishing your podcast feed. You can always set it up again.'
+						) }
+					</FormSettingExplanation>
+				) }
 			</Card>
 
 			{ /* Upsell nudge for audio upload */ }

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -423,7 +423,7 @@ const PodcastingDetails = () => {
 	const translate = useTranslate();
 
 	return (
-		<Main className="site-settings podcasting-details">
+		<Main wideLayout className="site-settings podcasting-details">
 			<DocumentHead title={ translate( 'Podcasting' ) } />
 			<NavigationHeader
 				navigationItems={ [] }

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -106,7 +106,7 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 	const isAudioUploadEnabled =
 		plansDataLoaded && ( site?.options?.upgraded_filetypes_enabled || isJetpack );
 
-	const disabled = isRequestingSettings || isSavingSettings;
+	const disabled = isRequestingSettings || isSavingSettings || isCoverImageUploading;
 
 	const newPostUrl = `/post/${ siteSlug }`;
 
@@ -328,7 +328,7 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 								onRemove={ onCoverImageRemoved }
 								onSelect={ onCoverImageSelected }
 								onUploadStateChange={ setIsCoverImageUploading }
-								isDisabled={ disabled || isCoverImageUploading }
+								isDisabled={ disabled }
 							/>
 							<div className="podcasting-details__title-subtitle-wrapper">
 								{ renderTextField( {

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -4,11 +4,10 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Button, Card, FormLabel } from '@automattic/components';
-import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
-import { pick, flowRight } from 'lodash';
-import { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { pick } from 'lodash';
+import { useState, useCallback } from 'react';
 import TermTreeSelector from 'calypso/blocks/term-tree-selector';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -23,17 +22,16 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import { decodeEntities } from 'calypso/lib/formatting';
-import scrollTo from 'calypso/lib/scroll-to';
 import PodcastCoverImageSetting from 'calypso/my-sites/site-settings/podcast-cover-image-setting';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
+import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
-import { isSavingSiteSettings } from 'calypso/state/site-settings/selectors';
 import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { isRequestingTermsForQueryIgnoringPage } from 'calypso/state/terms/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -46,378 +44,11 @@ import PodcastingPrivateSiteMessage from './private-site';
 import PodcastingPublishNotice from './publish-notice';
 import TopicsSelector from './topics-selector';
 
-/**
- * Selectors, actions, and query components
- */
-
 import './style.scss';
 
-class PodcastingDetails extends Component {
-	constructor() {
-		super();
-		this.state = {
-			isCoverImageUploading: false,
-		};
-	}
-
-	renderExplicitContent() {
-		const { fields, handleSelect, isRequestingSettings, translate, isPodcastingEnabled } =
-			this.props;
-
-		return (
-			<FormFieldset>
-				<FormLabel htmlFor="podcasting_explicit">{ translate( 'Explicit content' ) }</FormLabel>
-				<FormSelect
-					id="podcasting_explicit"
-					name="podcasting_explicit"
-					onChange={ handleSelect }
-					value={ fields.podcasting_explicit || 'no' }
-					disabled={ isRequestingSettings || ! isPodcastingEnabled }
-				>
-					<option value="no">{ translate( 'No' ) }</option>
-					<option value="yes">{ translate( 'Yes' ) }</option>
-					<option value="clean">{ translate( 'Clean' ) }</option>
-				</FormSelect>
-			</FormFieldset>
-		);
-	}
-
-	renderSaveButton( largeButton ) {
-		const {
-			handleSubmitForm,
-			isRequestingSettings,
-			isSavingSettings,
-			isRequestingCategories,
-			translate,
-		} = this.props;
-		const { isCoverImageUploading } = this.state;
-
-		const saveButtonDisabled =
-			isRequestingSettings || isSavingSettings || isRequestingCategories || isCoverImageUploading;
-		let saveButtonText;
-		if ( isCoverImageUploading ) {
-			saveButtonText = translate( 'Image uploading…' );
-		} else if ( isSavingSettings ) {
-			saveButtonText = translate( 'Saving…' );
-		} else {
-			saveButtonText = translate( 'Save Settings' );
-		}
-
-		return (
-			<Button
-				compact={ ! largeButton }
-				onClick={ handleSubmitForm }
-				primary
-				type="submit"
-				disabled={ saveButtonDisabled }
-				busy={ isSavingSettings }
-				className="podcasting-details__save-button"
-			>
-				{ saveButtonText }
-			</Button>
-		);
-	}
-
-	renderTextField( { FormComponent = FormInput, key, label, explanation, isDisabled = false } ) {
-		const { fields, isRequestingSettings, onChangeField, isPodcastingEnabled } = this.props;
-
-		return (
-			<FormFieldset>
-				<FormLabel htmlFor={ key }>{ label }</FormLabel>
-				{ explanation && <FormSettingExplanation>{ explanation }</FormSettingExplanation> }
-				<FormComponent
-					id={ key }
-					name={ key }
-					value={ decodeEntities( fields[ key ] ) || '' }
-					onChange={ onChangeField( key ) }
-					disabled={ isDisabled || isRequestingSettings || ! isPodcastingEnabled }
-				/>
-			</FormFieldset>
-		);
-	}
-
-	renderTopicSelector( key ) {
-		const { fields, handleSelect, isRequestingSettings, isPodcastingEnabled } = this.props;
-		return (
-			<TopicsSelector
-				id={ key }
-				name={ key }
-				onChange={ handleSelect }
-				value={ fields[ key ] || 0 }
-				disabled={ isRequestingSettings || ! isPodcastingEnabled }
-			/>
-		);
-	}
-
-	renderTopics() {
-		const { translate } = this.props;
-
-		return (
-			<FormFieldset>
-				<FormLabel htmlFor="podcasting_category_1">{ translate( 'Podcast topics' ) }</FormLabel>
-				<FormSettingExplanation>
-					{ translate(
-						'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services.'
-					) }
-				</FormSettingExplanation>
-				{ this.renderTopicSelector( 'podcasting_category_1' ) }
-				{ this.renderTopicSelector( 'podcasting_category_2' ) }
-				{ this.renderTopicSelector( 'podcasting_category_3' ) }
-			</FormFieldset>
-		);
-	}
-
-	render() {
-		const {
-			handleSubmitForm,
-			site,
-			siteId,
-			translate,
-			isJetpack,
-			isPodcastingEnabled,
-			isSavingSettings,
-			plansDataLoaded,
-		} = this.props;
-
-		const { isCoverImageUploading } = this.state;
-		const isAudioUploadEnabled =
-			plansDataLoaded && ( site?.options?.upgraded_filetypes_enabled || isJetpack );
-
-		if ( ! site || ! siteId ) {
-			return null;
-		}
-
-		const error = this.renderSettingsError();
-
-		const classes = clsx( 'podcasting-details__wrapper', {
-			'is-disabled': ! error && ! isPodcastingEnabled,
-		} );
-
-		return (
-			<Main wideLayout>
-				<DocumentHead title={ translate( 'Podcasting' ) } />
-				<NavigationHeader
-					navigationItems={ [] }
-					title={ translate( 'Podcasting' ) }
-					subtitle={ translate(
-						'Publish a podcast feed to Apple Podcasts and other podcasting services. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="podcasting" showIcon={ false } />,
-							},
-						}
-					) }
-				/>
-
-				<form id="site-settings" onSubmit={ handleSubmitForm }>
-					{ ! error && plansDataLoaded && ! isAudioUploadEnabled && (
-						<UpsellNudge
-							plan={ PLAN_PERSONAL }
-							title={ translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
-								args: { personalPlanName: getPlan( PLAN_PERSONAL ).getTitle() },
-							} ) }
-							description={ translate(
-								'Embed podcast episodes directly from your media library.'
-							) }
-							feature={ WPCOM_FEATURES_UPLOAD_AUDIO_FILES }
-							event="podcasting_details_upload_audio"
-							tracksImpressionName="calypso_upgrade_nudge_impression"
-							tracksClickName="calypso_upgrade_nudge_cta_click"
-							showIcon
-						/>
-					) }
-					{ ! error && (
-						<Card className="podcasting-details__category-wrapper">
-							{ this.renderCategorySetting() }
-						</Card>
-					) }
-					<Card className={ classes }>{ error || this.renderSettings() }</Card>
-					{ isPodcastingEnabled && (
-						<div className="podcasting-details__disable-podcasting">
-							<Button
-								onClick={ this.onCategoryCleared }
-								scary
-								busy={ isSavingSettings }
-								disabled={ isCoverImageUploading }
-							>
-								{ translate( 'Disable Podcast' ) }
-							</Button>
-							<p>
-								{ translate(
-									'Disable to stop publishing your podcast feed. You can always set it up again.'
-								) }
-							</p>
-						</div>
-					) }
-				</form>
-			</Main>
-		);
-	}
-
-	renderCategorySetting() {
-		const {
-			siteId,
-			isPodcastingEnabled,
-			podcastingCategoryId,
-			isCategoryChanging,
-			translate,
-			newPostUrl,
-		} = this.props;
-
-		return (
-			<Fragment>
-				<QueryTerms siteId={ siteId } taxonomy="category" />
-				<FormFieldset>
-					{ isPodcastingEnabled && (
-						<div className="podcasting-details__publish-wrapper">
-							<PodcastingPublishNotice podcastingCategoryId={ podcastingCategoryId } />
-							<Button className="podcasting-details__publish-button" href={ newPostUrl }>
-								{ translate( 'Create Episode' ) }
-							</Button>
-						</div>
-					) }
-					<FormLabel>{ translate( 'Podcast category' ) }</FormLabel>
-					<FormSettingExplanation>
-						{ translate(
-							'Posts published in this category will be included in your podcast feed.'
-						) }
-					</FormSettingExplanation>
-					<TermTreeSelector
-						taxonomy="category"
-						key="category"
-						selected={ podcastingCategoryId ? [ podcastingCategoryId ] : [] }
-						podcastingCategoryId={ podcastingCategoryId }
-						onChange={ this.onCategorySelected }
-						addTerm
-						onAddTermSuccess={ this.onCategorySelected }
-						height={ 200 }
-					/>
-					{ isCategoryChanging && (
-						<Notice
-							isCompact
-							status="is-info"
-							text={ translate(
-								"If you change categories, you'll need to resubmit your feed to Apple Podcasts and any other podcasting services."
-							) }
-						/>
-					) }
-				</FormFieldset>
-				<PodcastFeedUrl categoryId={ podcastingCategoryId } />
-			</Fragment>
-		);
-	}
-
-	renderSettings() {
-		const { translate, fields, isPodcastingEnabled } = this.props;
-
-		return (
-			<Fragment>
-				<PodcastCoverImageSetting
-					coverImageId={ parseInt( fields.podcasting_image_id, 10 ) || 0 }
-					coverImageUrl={ fields.podcasting_image }
-					onRemove={ this.onCoverImageRemoved }
-					onSelect={ this.onCoverImageSelected }
-					onUploadStateChange={ this.onCoverImageUploadStateChanged }
-					isDisabled={ ! isPodcastingEnabled }
-				/>
-				<div className="podcasting-details__title-subtitle-wrapper">
-					{ this.renderTextField( {
-						key: 'podcasting_title',
-						label: translate( 'Title' ),
-					} ) }
-					{ this.renderTextField( {
-						FormComponent: FormTextarea,
-						key: 'podcasting_summary',
-						label: translate( 'Summary/Description' ),
-					} ) }
-				</div>
-				{ this.renderTopics() }
-				{ this.renderExplicitContent() }
-				{ this.renderTextField( {
-					key: 'podcasting_talent_name',
-					label: translate( 'Hosts/Artist/Producer' ),
-				} ) }
-				{ this.renderTextField( {
-					key: 'podcasting_email',
-					label: translate( 'Email Address' ),
-					explanation: translate(
-						'This email address will be displayed in the feed and is required for some services such as Google Play.'
-					),
-				} ) }
-				{ this.renderTextField( {
-					key: 'podcasting_copyright',
-					label: translate( 'Copyright' ),
-				} ) }
-				{ isPodcastingEnabled && this.renderSaveButton( true ) }
-			</Fragment>
-		);
-	}
-
-	renderSettingsError() {
-		// If there is a reason that we can't display the podcasting settings
-		// screen, it will be rendered here.
-		const { isPrivate, isComingSoon, isUnsupportedSite, userCanManagePodcasting } = this.props;
-
-		if ( isPrivate ) {
-			return <PodcastingPrivateSiteMessage isComingSoon={ isComingSoon } />;
-		}
-
-		if ( ! userCanManagePodcasting ) {
-			return <PodcastingNoPermissionsMessage />;
-		}
-
-		if ( isUnsupportedSite ) {
-			return <PodcastingNotSupportedMessage />;
-		}
-
-		return null;
-	}
-
-	onCategorySelected = ( category ) => {
-		const { settings, fields, isPodcastingEnabled } = this.props;
-
-		const fieldsToUpdate = { podcasting_category_id: String( category.ID ) };
-
-		if ( ! isPodcastingEnabled ) {
-			// If we are newly enabling podcasting, and no podcast title is set,
-			// use the site title.
-			if ( ! fields.podcasting_title ) {
-				fieldsToUpdate.podcasting_title = settings.blogname;
-			}
-		}
-
-		this.props.updateFields( fieldsToUpdate );
-	};
-
-	onCategoryCleared = () => {
-		const { updateFields, submitForm } = this.props;
-
-		updateFields( { podcasting_category_id: '0' }, () => {
-			submitForm();
-			scrollTo( { y: 0 } );
-		} );
-	};
-
-	onCoverImageRemoved = () => {
-		this.props.updateFields( {
-			podcasting_image_id: '0',
-			podcasting_image: '',
-		} );
-	};
-
-	onCoverImageSelected = ( coverId, coverUrl ) => {
-		this.props.updateFields( {
-			podcasting_image_id: String( coverId ),
-			podcasting_image: coverUrl,
-		} );
-	};
-
-	onCoverImageUploadStateChanged = ( isUploading ) => {
-		this.setState( {
-			isCoverImageUploading: isUploading,
-		} );
-	};
-}
+// WordPress always creates category ID 1 as "Uncategorized" on install.
+// It can be renamed but not deleted, so this is safe to use as a default.
+const UNCATEGORIZED_CATEGORY_ID = 1;
 
 const getFormSettings = ( settings ) => {
 	return pick( settings, [
@@ -436,51 +67,371 @@ const getFormSettings = ( settings ) => {
 	] );
 };
 
-const connectComponent = connect( ( state, ownProps ) => {
-	const site = getSelectedSite( state );
-	const siteId = getSelectedSiteId( state );
+const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
+	fields,
+	handleSubmitForm,
+	handleSelect,
+	isRequestingSettings,
+	isSavingSettings,
+	onChangeField,
+	settings,
+	updateFields,
+	submitForm,
+} ) => {
+	const translate = useTranslate();
+	const [ isCoverImageUploading, setIsCoverImageUploading ] = useState( false );
 
-	// The settings form wrapper gives us a string here, but inside this
-	// component, we always want to work with a number.
-	const podcastingCategoryId =
-		ownProps.fields &&
-		ownProps.fields.podcasting_category_id &&
-		Number( ownProps.fields.podcasting_category_id );
+	const siteId = useSelector( getSelectedSiteId );
+	const site = useSelector( getSelectedSite );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isAutomatedTransfer = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+	const isPrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
+	const isComingSoon = useSelector( ( state ) => isSiteComingSoon( state, siteId ) );
+	const userCanManagePodcasting = useSelector( ( state ) =>
+		canCurrentUser( state, siteId, 'manage_options' )
+	);
+	const isUnsupportedSite = isJetpack && ! isAutomatedTransfer;
+	const plansDataLoaded = useSelector( ( state ) => hasLoadedSitePlansFromServer( state, siteId ) );
+
+	const podcastingCategoryId = fields.podcasting_category_id
+		? Number( fields.podcasting_category_id )
+		: 0;
 	const isPodcastingEnabled = podcastingCategoryId > 0;
 
-	const isSavingSettings = isSavingSiteSettings( state, siteId );
 	const isCategoryChanging =
 		! isSavingSettings &&
-		! ownProps.isRequestingSettings &&
-		ownProps.settings &&
-		Number( ownProps.settings.podcasting_category_id ) > 0 &&
-		podcastingCategoryId !== Number( ownProps.settings.podcasting_category_id );
+		! isRequestingSettings &&
+		settings &&
+		Number( settings.podcasting_category_id ) > 0 &&
+		podcastingCategoryId !== Number( settings.podcasting_category_id );
 
-	const isJetpack = isJetpackSite( state, siteId );
-	const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
+	const isAudioUploadEnabled =
+		plansDataLoaded && ( site?.options?.upgraded_filetypes_enabled || isJetpack );
 
-	const siteSlug = getSelectedSiteSlug( state );
+	const disabled = isRequestingSettings || isSavingSettings || isCoverImageUploading;
+
 	const newPostUrl = `/post/${ siteSlug }`;
 
-	return {
-		site,
-		siteId,
-		isJetpack,
-		isPrivate: isPrivateSite( state, siteId ),
-		isComingSoon: isSiteComingSoon( state, siteId ),
-		isPodcastingEnabled,
-		podcastingCategoryId,
-		isCategoryChanging,
-		isRequestingCategories: isRequestingTermsForQueryIgnoringPage( state, siteId, 'category', {} ),
-		userCanManagePodcasting: canCurrentUser( state, siteId, 'manage_options' ),
-		isUnsupportedSite: isJetpack && ! isAutomatedTransfer,
-		isSavingSettings,
-		newPostUrl,
-		plansDataLoaded: hasLoadedSitePlansFromServer( state, siteId ),
-	};
+	const onTogglePodcasting = useCallback(
+		( isEnabled ) => {
+			if ( isEnabled ) {
+				// Enable: set default category and title, but don't auto-save.
+				// Let the user fill in details and save when ready.
+				const fieldsToUpdate = {
+					podcasting_category_id: String( UNCATEGORIZED_CATEGORY_ID ),
+				};
+				if ( ! fields.podcasting_title ) {
+					fieldsToUpdate.podcasting_title = settings?.blogname || '';
+				}
+				updateFields( fieldsToUpdate );
+			} else {
+				// Disable: save immediately to stop the podcast feed.
+				updateFields( { podcasting_category_id: '0' }, () => {
+					submitForm();
+				} );
+			}
+		},
+		[ fields.podcasting_title, settings?.blogname, updateFields, submitForm ]
+	);
+
+	const onCategorySelected = useCallback(
+		( category ) => {
+			updateFields( { podcasting_category_id: String( category.ID ) } );
+		},
+		[ updateFields ]
+	);
+
+	const onCoverImageRemoved = useCallback( () => {
+		updateFields( {
+			podcasting_image_id: '0',
+			podcasting_image: '',
+		} );
+	}, [ updateFields ] );
+
+	const onCoverImageSelected = useCallback(
+		( coverId, coverUrl ) => {
+			updateFields( {
+				podcasting_image_id: String( coverId ),
+				podcasting_image: coverUrl,
+			} );
+		},
+		[ updateFields ]
+	);
+
+	if ( ! site || ! siteId ) {
+		return null;
+	}
+
+	// Error states — render inside a Card so they sit within the page layout.
+	if ( isPrivate ) {
+		return (
+			<Card className="site-settings__card">
+				<PodcastingPrivateSiteMessage isComingSoon={ isComingSoon } />
+			</Card>
+		);
+	}
+	if ( ! userCanManagePodcasting ) {
+		return (
+			<Card className="site-settings__card">
+				<PodcastingNoPermissionsMessage />
+			</Card>
+		);
+	}
+	if ( isUnsupportedSite ) {
+		return (
+			<Card className="site-settings__card">
+				<PodcastingNotSupportedMessage />
+			</Card>
+		);
+	}
+
+	const renderTextField = ( { FormComponent = FormInput, key, label, explanation } ) => (
+		<FormFieldset key={ key }>
+			<FormLabel htmlFor={ key }>{ label }</FormLabel>
+			{ explanation && <FormSettingExplanation>{ explanation }</FormSettingExplanation> }
+			<FormComponent
+				id={ key }
+				name={ key }
+				value={ decodeEntities( fields[ key ] ) || '' }
+				onChange={ onChangeField( key ) }
+				disabled={ disabled || ! isPodcastingEnabled }
+			/>
+		</FormFieldset>
+	);
+
+	return (
+		<form id="site-settings" onSubmit={ handleSubmitForm }>
+			<QueryTerms siteId={ siteId } taxonomy="category" />
+
+			{ /* Podcasting enable toggle */ }
+			<Card className="site-settings__card">
+				<ToggleControl
+					checked={ isPodcastingEnabled }
+					onChange={ onTogglePodcasting }
+					disabled={ disabled }
+					label={ translate( 'Enable podcasting on this site' ) }
+				/>
+				{ isPodcastingEnabled && <PodcastFeedUrl categoryId={ podcastingCategoryId } /> }
+			</Card>
+
+			{ /* Upsell nudge for audio upload */ }
+			{ isPodcastingEnabled && plansDataLoaded && ! isAudioUploadEnabled && (
+				<UpsellNudge
+					plan={ PLAN_PERSONAL }
+					title={ translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
+						args: { personalPlanName: getPlan( PLAN_PERSONAL ).getTitle() },
+					} ) }
+					description={ translate( 'Embed podcast episodes directly from your media library.' ) }
+					feature={ WPCOM_FEATURES_UPLOAD_AUDIO_FILES }
+					event="podcasting_details_upload_audio"
+					tracksImpressionName="calypso_upgrade_nudge_impression"
+					tracksClickName="calypso_upgrade_nudge_cta_click"
+					showIcon
+				/>
+			) }
+
+			{ isPodcastingEnabled && (
+				<>
+					{ /* Podcast category */ }
+					<SettingsSectionHeader
+						disabled={ disabled }
+						id="podcast-category"
+						isSaving={ isSavingSettings }
+						onButtonClick={ handleSubmitForm }
+						showButton
+						title={ translate( 'Podcast category' ) }
+					/>
+					<Card className="site-settings__card">
+						<PodcastingPublishNotice podcastingCategoryId={ podcastingCategoryId } />
+						<FormFieldset>
+							<FormSettingExplanation>
+								{ translate(
+									'Posts published in this category will be included in your podcast feed.'
+								) }
+							</FormSettingExplanation>
+							<TermTreeSelector
+								taxonomy="category"
+								selected={ podcastingCategoryId ? [ podcastingCategoryId ] : [] }
+								podcastingCategoryId={ podcastingCategoryId }
+								onChange={ onCategorySelected }
+								addTerm
+								onAddTermSuccess={ onCategorySelected }
+								height={ 200 }
+							/>
+							{ isCategoryChanging && (
+								<Notice
+									isCompact
+									status="is-info"
+									text={ translate(
+										'If you change categories, you will need to resubmit your feed to Apple Podcasts and any other podcasting services.'
+									) }
+								/>
+							) }
+						</FormFieldset>
+						<Button className="podcasting-details__publish-button" href={ newPostUrl }>
+							{ translate( 'Create Episode' ) }
+						</Button>
+					</Card>
+
+					{ /* Podcast details */ }
+					<SettingsSectionHeader
+						disabled={ disabled }
+						id="podcast-details"
+						isSaving={ isSavingSettings }
+						onButtonClick={ handleSubmitForm }
+						showButton
+						title={ translate( 'Podcast details' ) }
+					/>
+					<Card className="site-settings__card">
+						<FormSettingExplanation>
+							{ translate(
+								'This information appears in podcast apps like Apple Podcasts and Spotify.'
+							) }
+						</FormSettingExplanation>
+						<div className="podcasting-details__cover-and-info">
+							<PodcastCoverImageSetting
+								coverImageId={ parseInt( fields.podcasting_image_id, 10 ) || 0 }
+								coverImageUrl={ fields.podcasting_image }
+								onRemove={ onCoverImageRemoved }
+								onSelect={ onCoverImageSelected }
+								onUploadStateChange={ setIsCoverImageUploading }
+								isDisabled={ disabled }
+							/>
+							<div className="podcasting-details__title-subtitle-wrapper">
+								{ renderTextField( {
+									key: 'podcasting_title',
+									label: translate( 'Title' ),
+								} ) }
+								{ renderTextField( {
+									FormComponent: FormTextarea,
+									key: 'podcasting_summary',
+									label: translate( 'Summary/Description' ),
+								} ) }
+							</div>
+						</div>
+						{ renderTextField( {
+							key: 'podcasting_talent_name',
+							label: translate( 'Hosts/Artist/Producer' ),
+						} ) }
+						{ renderTextField( {
+							key: 'podcasting_copyright',
+							label: translate( 'Copyright' ),
+						} ) }
+					</Card>
+
+					{ /* Feed settings */ }
+					<SettingsSectionHeader
+						disabled={ disabled }
+						id="feed-settings"
+						isSaving={ isSavingSettings }
+						onButtonClick={ handleSubmitForm }
+						showButton
+						title={ translate( 'Feed settings' ) }
+					/>
+					<Card className="site-settings__card">
+						<FormSettingExplanation>
+							{ translate( 'Configure how your podcast appears in directories and apps.' ) }
+						</FormSettingExplanation>
+						<FormFieldset>
+							<FormLabel htmlFor="podcasting_category_1">
+								{ translate( 'Podcast topics' ) }
+							</FormLabel>
+							<FormSettingExplanation>
+								{ translate(
+									'Choose how your podcast should be categorized within Apple Podcasts and other podcasting services.'
+								) }
+							</FormSettingExplanation>
+							<TopicsSelector
+								id="podcasting_category_1"
+								name="podcasting_category_1"
+								onChange={ handleSelect }
+								value={ fields.podcasting_category_1 || 0 }
+								disabled={ disabled }
+							/>
+							<TopicsSelector
+								id="podcasting_category_2"
+								name="podcasting_category_2"
+								onChange={ handleSelect }
+								value={ fields.podcasting_category_2 || 0 }
+								disabled={ disabled }
+							/>
+							<TopicsSelector
+								id="podcasting_category_3"
+								name="podcasting_category_3"
+								onChange={ handleSelect }
+								value={ fields.podcasting_category_3 || 0 }
+								disabled={ disabled }
+							/>
+						</FormFieldset>
+						<FormFieldset>
+							<FormLabel htmlFor="podcasting_explicit">
+								{ translate( 'Explicit content' ) }
+							</FormLabel>
+							<FormSelect
+								id="podcasting_explicit"
+								name="podcasting_explicit"
+								onChange={ handleSelect }
+								value={ fields.podcasting_explicit || 'no' }
+								disabled={ disabled }
+							>
+								<option value="no">{ translate( 'No' ) }</option>
+								<option value="yes">{ translate( 'Yes' ) }</option>
+								<option value="clean">{ translate( 'Clean' ) }</option>
+							</FormSelect>
+						</FormFieldset>
+						{ renderTextField( {
+							key: 'podcasting_email',
+							label: translate( 'Email address' ),
+							explanation: translate(
+								'This email address will be displayed in the feed and is required for some services such as Google Play.'
+							),
+						} ) }
+					</Card>
+
+					{ /* Disable podcasting */ }
+					<Card className="podcasting-details__disable-card">
+						<span className="podcasting-details__disable-text">
+							{ translate(
+								'Disabling will remove your podcast feed. Your posts will not be affected.'
+							) }
+						</span>
+						<Button
+							scary
+							onClick={ () => onTogglePodcasting( false ) }
+							busy={ isSavingSettings }
+							disabled={ isCoverImageUploading }
+						>
+							{ translate( 'Disable Podcasting' ) }
+						</Button>
+					</Card>
+				</>
+			) }
+		</form>
+	);
 } );
 
-export default flowRight(
-	wrapSettingsForm( getFormSettings ),
-	connectComponent
-)( localize( PodcastingDetails ) );
+const PodcastingDetails = () => {
+	const translate = useTranslate();
+
+	return (
+		<Main className="site-settings podcasting-details">
+			<DocumentHead title={ translate( 'Podcasting' ) } />
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Podcasting' ) }
+				subtitle={ translate(
+					'Publish a podcast feed to Apple Podcasts and other podcasting services. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="podcasting" showIcon={ false } />,
+						},
+					}
+				) }
+			/>
+			<PodcastingSettingsForm />
+		</Main>
+	);
+};
+
+export default PodcastingDetails;

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -133,7 +133,14 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				}
 			}
 		},
-		[ disabled, isPodcastingEnabled, fields.podcasting_title, settings?.blogname, updateFields, submitForm ]
+		[
+			disabled,
+			isPodcastingEnabled,
+			fields.podcasting_title,
+			settings?.blogname,
+			updateFields,
+			submitForm,
+		]
 	);
 
 	const onCategorySelected = useCallback(
@@ -214,7 +221,6 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					disabled={ disabled }
 					label={ translate( 'Enable podcasting on this site' ) }
 				/>
-				{ isPodcastingEnabled && <PodcastFeedUrl categoryId={ podcastingCategoryId } /> }
 			</Card>
 
 			{ /* Upsell nudge for audio upload */ }
@@ -285,6 +291,7 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 								/>
 							) }
 						</FormFieldset>
+						<PodcastFeedUrl categoryId={ podcastingCategoryId } />
 						{ isPodcastingEnabled && (
 							<Button className="podcasting-details__publish-button" href={ newPostUrl }>
 								{ translate( 'Create Episode' ) }

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -46,10 +46,6 @@ import TopicsSelector from './topics-selector';
 
 import './style.scss';
 
-// WordPress always creates category ID 1 as "Uncategorized" on install.
-// It can be renamed but not deleted, so this is safe to use as a default.
-const UNCATEGORIZED_CATEGORY_ID = 1;
-
 const getFormSettings = ( settings ) => {
 	return pick( settings, [
 		'podcasting_category_id',
@@ -80,6 +76,7 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 } ) => {
 	const translate = useTranslate();
 	const [ isCoverImageUploading, setIsCoverImageUploading ] = useState( false );
+	const [ isEnabling, setIsEnabling ] = useState( false );
 
 	const siteId = useSelector( getSelectedSiteId );
 	const site = useSelector( getSelectedSite );
@@ -109,35 +106,40 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 	const isAudioUploadEnabled =
 		plansDataLoaded && ( site?.options?.upgraded_filetypes_enabled || isJetpack );
 
-	const disabled = isRequestingSettings || isSavingSettings || isCoverImageUploading;
+	const disabled = isRequestingSettings || isSavingSettings;
 
 	const newPostUrl = `/post/${ siteSlug }`;
 
 	const onTogglePodcasting = useCallback(
 		( isEnabled ) => {
+			if ( disabled ) {
+				return;
+			}
+
 			if ( isEnabled ) {
-				// Enable: set default category and title, but don't auto-save.
-				// Let the user fill in details and save when ready.
-				const fieldsToUpdate = {
-					podcasting_category_id: String( UNCATEGORIZED_CATEGORY_ID ),
-				};
+				// Show settings so the user can pick a category and fill in details.
+				// Pre-fill the title from the site name if not already set.
+				setIsEnabling( true );
 				if ( ! fields.podcasting_title ) {
-					fieldsToUpdate.podcasting_title = settings?.blogname || '';
+					updateFields( { podcasting_title: settings?.blogname || '' } );
 				}
-				updateFields( fieldsToUpdate );
 			} else {
-				// Disable: save immediately to stop the podcast feed.
-				updateFields( { podcasting_category_id: '0' }, () => {
-					submitForm();
-				} );
+				setIsEnabling( false );
+				if ( isPodcastingEnabled ) {
+					// Disable: clear category and save immediately to stop the feed.
+					updateFields( { podcasting_category_id: '0' }, () => {
+						submitForm();
+					} );
+				}
 			}
 		},
-		[ fields.podcasting_title, settings?.blogname, updateFields, submitForm ]
+		[ disabled, isPodcastingEnabled, fields.podcasting_title, settings?.blogname, updateFields, submitForm ]
 	);
 
 	const onCategorySelected = useCallback(
 		( category ) => {
 			updateFields( { podcasting_category_id: String( category.ID ) } );
+			setIsEnabling( false );
 		},
 		[ updateFields ]
 	);
@@ -195,7 +197,7 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				name={ key }
 				value={ decodeEntities( fields[ key ] ) || '' }
 				onChange={ onChangeField( key ) }
-				disabled={ disabled || ! isPodcastingEnabled }
+				disabled={ disabled }
 			/>
 		</FormFieldset>
 	);
@@ -207,7 +209,7 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 			{ /* Podcasting enable toggle */ }
 			<Card className="site-settings__card">
 				<ToggleControl
-					checked={ isPodcastingEnabled }
+					checked={ isPodcastingEnabled || isEnabling }
 					onChange={ onTogglePodcasting }
 					disabled={ disabled }
 					label={ translate( 'Enable podcasting on this site' ) }
@@ -216,7 +218,7 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 			</Card>
 
 			{ /* Upsell nudge for audio upload */ }
-			{ isPodcastingEnabled && plansDataLoaded && ! isAudioUploadEnabled && (
+			{ ( isPodcastingEnabled || isEnabling ) && plansDataLoaded && ! isAudioUploadEnabled && (
 				<UpsellNudge
 					plan={ PLAN_PERSONAL }
 					title={ translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
@@ -231,11 +233,11 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				/>
 			) }
 
-			{ isPodcastingEnabled && (
+			{ ( isPodcastingEnabled || isEnabling ) && (
 				<>
 					{ /* Podcast category */ }
 					<SettingsSectionHeader
-						disabled={ disabled }
+						disabled={ disabled || ! isPodcastingEnabled }
 						id="podcast-category"
 						isSaving={ isSavingSettings }
 						onButtonClick={ handleSubmitForm }
@@ -243,7 +245,21 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 						title={ translate( 'Podcast category' ) }
 					/>
 					<Card className="site-settings__card">
-						<PodcastingPublishNotice podcastingCategoryId={ podcastingCategoryId } />
+						{ isEnabling && ! isPodcastingEnabled && (
+							<Notice
+								isCompact
+								status="is-info"
+								showDismiss={ false }
+								text={ translate(
+									'Select a category for your podcast feed, then save your settings.'
+								) }
+							/>
+						) }
+						{ isPodcastingEnabled && (
+							<div className="podcasting-details__publish-wrapper">
+								<PodcastingPublishNotice podcastingCategoryId={ podcastingCategoryId } />
+							</div>
+						) }
 						<FormFieldset>
 							<FormSettingExplanation>
 								{ translate(
@@ -269,14 +285,16 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 								/>
 							) }
 						</FormFieldset>
-						<Button className="podcasting-details__publish-button" href={ newPostUrl }>
-							{ translate( 'Create Episode' ) }
-						</Button>
+						{ isPodcastingEnabled && (
+							<Button className="podcasting-details__publish-button" href={ newPostUrl }>
+								{ translate( 'Create Episode' ) }
+							</Button>
+						) }
 					</Card>
 
 					{ /* Podcast details */ }
 					<SettingsSectionHeader
-						disabled={ disabled }
+						disabled={ disabled || ! isPodcastingEnabled }
 						id="podcast-details"
 						isSaving={ isSavingSettings }
 						onButtonClick={ handleSubmitForm }
@@ -296,7 +314,7 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 								onRemove={ onCoverImageRemoved }
 								onSelect={ onCoverImageSelected }
 								onUploadStateChange={ setIsCoverImageUploading }
-								isDisabled={ disabled }
+								isDisabled={ disabled || isCoverImageUploading }
 							/>
 							<div className="podcasting-details__title-subtitle-wrapper">
 								{ renderTextField( {
@@ -322,7 +340,7 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 
 					{ /* Feed settings */ }
 					<SettingsSectionHeader
-						disabled={ disabled }
+						disabled={ disabled || ! isPodcastingEnabled }
 						id="feed-settings"
 						isSaving={ isSavingSettings }
 						onButtonClick={ handleSubmitForm }
@@ -387,23 +405,6 @@ const PodcastingSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 								'This email address will be displayed in the feed and is required for some services such as Google Play.'
 							),
 						} ) }
-					</Card>
-
-					{ /* Disable podcasting */ }
-					<Card className="podcasting-details__disable-card">
-						<span className="podcasting-details__disable-text">
-							{ translate(
-								'Disabling will remove your podcast feed. Your posts will not be affected.'
-							) }
-						</span>
-						<Button
-							scary
-							onClick={ () => onTogglePodcasting( false ) }
-							busy={ isSavingSettings }
-							disabled={ isCoverImageUploading }
-						>
-							{ translate( 'Disable Podcasting' ) }
-						</Button>
 					</Card>
 				</>
 			) }

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -6,93 +6,65 @@
 
 .podcasting-details__publish-notice {
 	position: relative;
-	background: var(--color-neutral-0);
+	background: var( --color-neutral-0 );
 	border-radius: 2px;
 	align-self: stretch;
 	padding: 6px;
 	font-size: $font-body-small;
 	text-align: left;
-	// Center contents vertically
-	// Note this element contains a <span> container to ensure normal
-	// display (whitespace) between text items
 	display: flex;
 	flex-grow: 1;
 	align-items: center;
+	margin-bottom: 16px;
 
 	.gridicons-microphone {
 		flex-shrink: 0;
-		margin-right: 6px;
-		color: var(--color-podcasting);
+		margin-inline-end: 6px;
+		color: var( --color-podcasting );
 	}
 
 	a {
-		color: var(--color-neutral-70);
+		color: var( --color-neutral-70 );
 		text-decoration: underline;
 	}
 }
 
 .podcasting-details__publish-button {
-	color: var(--color-neutral-50);
+	color: var( --color-neutral-50 );
 	font-weight: 600;
 	flex-shrink: 0;
-	margin-left: 12px;
-	// For viewports/translations when the text is taller than the button
-	align-self: center;
 }
 
-// Podcasting details page
-
-.podcasting-details__wrapper .form-setting-explanation,
-.podcasting-details__category-wrapper .form-setting-explanation {
+.podcasting-details .form-setting-explanation {
 	margin-bottom: 6px;
 }
 
-.podcasting-details__category-wrapper .calypso-notice.is-compact {
+.podcasting-details .calypso-notice.is-compact {
 	width: 100%;
 }
 
-.podcasting-details__category-wrapper.card {
-	width: 100%;
-	margin-bottom: 0;
-	padding-bottom: 0;
-}
+.podcasting-details__cover-and-info {
+	display: flex;
+	gap: 24px;
+	margin-bottom: 16px;
 
-.podcasting-details__title-subtitle-wrapper {
-	@include breakpoint-deprecated( ">960px" ) {
-		float: left;
-		width: 80%;
-	}
-}
-
-.podcasting-details__wrapper {
 	.podcast-cover-image-setting {
-		float: left;
-		margin-right: 24px;
+		flex-shrink: 0;
 	}
 
-	.form-select {
-		margin-right: 12px;
-
-		@include breakpoint-deprecated( "<480px" ) {
-			margin-right: 0;
-			width: 100%;
-		}
+	.podcasting-details__title-subtitle-wrapper {
+		flex: 1;
+		min-width: 0;
 	}
+}
 
-	&.is-disabled {
-		background-color: var(--color-neutral-0);
-		border-color: var(--color-neutral-10);
-	}
+.podcasting-details .form-select {
+	margin-inline-end: 12px;
+	margin-bottom: 8px;
 
-	&.is-disabled label,
-	&.is-disabled .form-setting-explanation {
-		color: var(--color-neutral-20);
-	}
-
-	&.is-disabled .form-text-input,
-	&.is-disabled .form-textarea {
-		color: var(--color-neutral-20);
-		border-color: var(--color-neutral-10);
+	@include breakpoint-deprecated( '<480px' ) {
+		margin-inline-end: 0;
+		width: 100%;
 	}
 }
 
@@ -103,13 +75,14 @@
 	}
 }
 
-.podcasting-details__disable-podcasting {
-	color: var(--color-text-subtle);
-	text-align: center;
-	width: 80%;
-	margin: 0 auto;
+.podcasting-details__disable-card.card {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+}
 
-	.button {
-		margin: 12px 0 6px;
-	}
+.podcasting-details__disable-text {
+	color: var( --color-text-subtle );
+	font-size: $font-body-small;
 }

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -75,14 +75,3 @@
 	}
 }
 
-.podcasting-details__disable-card.card {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 16px;
-}
-
-.podcasting-details__disable-text {
-	color: var( --color-text-subtle );
-	font-size: $font-body-small;
-}


### PR DESCRIPTION
Fixes CM-556

## Proposed Changes

- Replace the confusing category-selection-as-activation UX with an explicit toggle to enable/disable podcasting
- Reorganize settings into logical card sections (Podcast category, Podcast details, Feed settings) matching the Newsletter settings page pattern
- Convert the class component to a functional component with hooks
- Add per-section save buttons via `SettingsSectionHeader`
- Add a "Disable Podcasting" card at the bottom with clear messaging
- Remove the greyed-out disabled state styling

## Why are these changes being made?

The current Podcasting settings page has a confusing activation flow. Everything appears greyed out with no clear call to action. Users must click a radio button in the category list to "enable" podcasting, but this isn't obvious. The only way to disable is a button buried at the bottom.

This redesign matches the Newsletter settings pattern: a clear toggle at the top, with settings organized into card sections that only appear when podcasting is enabled.

## Testing Instructions

1. Navigate to `/settings/podcasting/:site_id` on a test site
2. Verify the page shows a single card with an "Enable podcasting on this site" toggle (OFF by default)
3. Toggle ON:
   - Settings sections should appear (Podcast category, Podcast details, Feed settings)
   - Feed URL should display in the toggle card
   - Category should default to "Uncategorized"
   - All fields (title, summary, topics, etc.) should be editable
   - Each section should have its own "Save settings" button
4. Toggle OFF:
   - All settings sections should hide
   - Podcasting should be disabled (category set to 0)
5. Test the "Disable Podcasting" button at the bottom (should disable and hide settings)
6. Verify error states still work: private site, no permissions, unsupported site

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="1110" height="208" alt="image" src="https://github.com/user-attachments/assets/c21aec08-5e2e-40b2-b53c-1aa981c94452" />

<img width="1138" height="799" alt="image" src="https://github.com/user-attachments/assets/fd127bab-16d9-448d-b6fb-c54838d6df89" />

<img width="1088" height="570" alt="Screenshot 2026-02-25 at 18 47 22" src="https://github.com/user-attachments/assets/4e984302-5a5e-4c13-9c02-c346a4be6b13" />
<img width="1128" height="531" alt="Screenshot 2026-02-25 at 18 47 07" src="https://github.com/user-attachments/assets/0eed9cf4-1815-41b1-a5dc-10a3b1ec787f" />

