### PR TITLE
Personalize Get Apps page order based on site count

### DIFF
--- a/client/blocks/get-apps/index.tsx
+++ b/client/blocks/get-apps/index.tsx
@@ -17,9 +17,10 @@ export const GetApps = () => {
 	const siteCount = useSelector( getCurrentUserSiteCount );
 	const isMultiSiteUser = ( siteCount ?? 0 ) >= 2;
 
-	const desktopApps = isMultiSiteUser
-		? [ createWordPressStudioConfig( translate ), createWordPressDesktopConfig( translate ) ]
-		: [ createWordPressDesktopConfig( translate ), createWordPressStudioConfig( translate ) ];
+	const desktopApps = [
+		createWordPressStudioConfig( translate ),
+		createWordPressDesktopConfig( translate ),
+	];
 
 	return (
 		<>

--- a/client/blocks/get-apps/index.tsx
+++ b/client/blocks/get-apps/index.tsx
@@ -17,37 +17,30 @@ export const GetApps = () => {
 	const siteCount = useSelector( getCurrentUserSiteCount );
 	const isMultiSiteUser = ( siteCount ?? 0 ) >= 2;
 
-	const desktopApps = [
-		createWordPressStudioConfig( translate ),
-		createWordPressDesktopConfig( translate ),
-	];
+	const studioConfig = createWordPressStudioConfig( translate );
+	const desktopConfig = createWordPressDesktopConfig( translate );
 
 	return (
 		<>
 			<NavigationHeader title={ translate( 'Apps' ) } />
 			<div className="get-apps__wrapper">
-				{ ! isMultiSiteUser && (
+				{ isMultiSiteUser ? (
 					<>
-						<h2 className="get-apps__section-title">{ translate( 'Mobile' ) }</h2>
-						<div className="get-apps__section">
-							<MobileDownloadCard />
-						</div>
+						{ ! isDesktopEnv && (
+							<DesktopDownloadCard appConfig={ studioConfig } />
+						) }
+						<MobileDownloadCard />
+					</>
+				) : (
+					<>
+						<MobileDownloadCard />
+						{ ! isDesktopEnv && (
+							<DesktopDownloadCard appConfig={ studioConfig } />
+						) }
 					</>
 				) }
-				<h2 className="get-apps__section-title">{ translate( 'Desktop' ) }</h2>
-				<div className="get-apps__section">
-					{ ! isDesktopEnv &&
-						desktopApps.map( ( appConfig ) => (
-							<DesktopDownloadCard key={ appConfig.id } appConfig={ appConfig } />
-						) ) }
-				</div>
-				{ isMultiSiteUser && (
-					<>
-						<h2 className="get-apps__section-title">{ translate( 'Mobile' ) }</h2>
-						<div className="get-apps__section">
-							<MobileDownloadCard />
-						</div>
-					</>
+				{ ! isDesktopEnv && (
+					<DesktopDownloadCard appConfig={ desktopConfig } />
 				) }
 			</div>
 		</>

--- a/client/blocks/get-apps/index.tsx
+++ b/client/blocks/get-apps/index.tsx
@@ -1,6 +1,8 @@
 import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { createWordPressDesktopConfig, createWordPressStudioConfig } from './apps-config';
 import DesktopDownloadCard from './desktop-download-card';
 import MobileDownloadCard from './mobile-download-card';
@@ -12,15 +14,25 @@ export const GetApps = () => {
 	const envId = config( 'env_id' );
 	const isDesktopEnv = typeof envId === 'string' && envId.startsWith( 'desktop' );
 
-	const desktopApps = [
-		createWordPressStudioConfig( translate ),
-		createWordPressDesktopConfig( translate ),
-	];
+	const siteCount = useSelector( getCurrentUserSiteCount );
+	const isMultiSiteUser = ( siteCount ?? 0 ) >= 2;
+
+	const desktopApps = isMultiSiteUser
+		? [ createWordPressStudioConfig( translate ), createWordPressDesktopConfig( translate ) ]
+		: [ createWordPressDesktopConfig( translate ), createWordPressStudioConfig( translate ) ];
 
 	return (
 		<>
 			<NavigationHeader title={ translate( 'Apps' ) } />
 			<div className="get-apps__wrapper">
+				{ ! isMultiSiteUser && (
+					<>
+						<h2 className="get-apps__section-title">{ translate( 'Mobile' ) }</h2>
+						<div className="get-apps__section">
+							<MobileDownloadCard />
+						</div>
+					</>
+				) }
 				<h2 className="get-apps__section-title">{ translate( 'Desktop' ) }</h2>
 				<div className="get-apps__section">
 					{ ! isDesktopEnv &&
@@ -28,10 +40,14 @@ export const GetApps = () => {
 							<DesktopDownloadCard key={ appConfig.id } appConfig={ appConfig } />
 						) ) }
 				</div>
-				<h2 className="get-apps__section-title">{ translate( 'Mobile' ) }</h2>
-				<div className="get-apps__section">
-					<MobileDownloadCard />
-				</div>
+				{ isMultiSiteUser && (
+					<>
+						<h2 className="get-apps__section-title">{ translate( 'Mobile' ) }</h2>
+						<div className="get-apps__section">
+							<MobileDownloadCard />
+						</div>
+					</>
+				) }
 			</div>
 		</>
 	);

--- a/client/blocks/get-apps/test/index.test.tsx
+++ b/client/blocks/get-apps/test/index.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import GetApps from '../index';
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUserSiteCount: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/calypso-config', () => {
+	const mock = ( key: string ) => {
+		if ( key === 'env_id' ) {
+			return 'production';
+		}
+		return null;
+	};
+	mock.isEnabled = jest.fn( () => false );
+	return { __esModule: true, default: mock };
+} );
+
+jest.mock( 'calypso/components/navigation-header', () => ( {
+	__esModule: true,
+	default: ( { title }: { title: string } ) => <h1>{ title }</h1>,
+} ) );
+
+jest.mock( '../desktop-download-card', () => ( {
+	__esModule: true,
+	default: ( { appConfig }: { appConfig: { id: string; title: string } } ) => (
+		<div data-testid={ `desktop-app-${ appConfig.id }` }>{ appConfig.title }</div>
+	),
+} ) );
+
+jest.mock( '../mobile-download-card', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="mobile-download-card">Jetpack mobile app</div>,
+} ) );
+
+describe( 'GetApps', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'shows Mobile section before Desktop for single-site users', () => {
+		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( 1 );
+
+		renderWithProvider( <GetApps /> );
+
+		const headings = screen.getAllByRole( 'heading', { level: 2 } );
+		const headingTexts = headings.map( ( h ) => h.textContent );
+
+		expect( headingTexts.indexOf( 'Mobile' ) ).toBeLessThan(
+			headingTexts.indexOf( 'Desktop' )
+		);
+	} );
+
+	it( 'shows Desktop section before Mobile for multi-site users', () => {
+		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( 2 );
+
+		renderWithProvider( <GetApps /> );
+
+		const headings = screen.getAllByRole( 'heading', { level: 2 } );
+		const headingTexts = headings.map( ( h ) => h.textContent );
+
+		expect( headingTexts.indexOf( 'Desktop' ) ).toBeLessThan(
+			headingTexts.indexOf( 'Mobile' )
+		);
+	} );
+
+	it( 'shows WordPress.com desktop app before Studio for single-site users', () => {
+		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( 1 );
+
+		renderWithProvider( <GetApps /> );
+
+		const desktopApp = screen.getByTestId( 'desktop-app-wordpress' );
+		const studio = screen.getByTestId( 'desktop-app-wordpress-studio' );
+
+		expect(
+			desktopApp.compareDocumentPosition( studio ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+	} );
+
+	it( 'shows Studio before WordPress.com desktop app for multi-site users', () => {
+		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( 2 );
+
+		renderWithProvider( <GetApps /> );
+
+		const studio = screen.getByTestId( 'desktop-app-wordpress-studio' );
+		const desktopApp = screen.getByTestId( 'desktop-app-wordpress' );
+
+		expect(
+			studio.compareDocumentPosition( desktopApp ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+	} );
+
+	it( 'treats null site count as single-site user', () => {
+		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( null );
+
+		renderWithProvider( <GetApps /> );
+
+		const headings = screen.getAllByRole( 'heading', { level: 2 } );
+		const headingTexts = headings.map( ( h ) => h.textContent );
+
+		expect( headingTexts.indexOf( 'Mobile' ) ).toBeLessThan(
+			headingTexts.indexOf( 'Desktop' )
+		);
+	} );
+} );

--- a/client/blocks/get-apps/test/index.test.tsx
+++ b/client/blocks/get-apps/test/index.test.tsx
@@ -69,32 +69,6 @@ describe( 'GetApps', () => {
 		);
 	} );
 
-	it( 'shows WordPress.com desktop app before Studio for single-site users', () => {
-		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( 1 );
-
-		renderWithProvider( <GetApps /> );
-
-		const desktopApp = screen.getByTestId( 'desktop-app-wordpress' );
-		const studio = screen.getByTestId( 'desktop-app-wordpress-studio' );
-
-		expect(
-			desktopApp.compareDocumentPosition( studio ) & Node.DOCUMENT_POSITION_FOLLOWING
-		).toBeTruthy();
-	} );
-
-	it( 'shows Studio before WordPress.com desktop app for multi-site users', () => {
-		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( 2 );
-
-		renderWithProvider( <GetApps /> );
-
-		const studio = screen.getByTestId( 'desktop-app-wordpress-studio' );
-		const desktopApp = screen.getByTestId( 'desktop-app-wordpress' );
-
-		expect(
-			studio.compareDocumentPosition( desktopApp ) & Node.DOCUMENT_POSITION_FOLLOWING
-		).toBeTruthy();
-	} );
-
 	it( 'treats null site count as single-site user', () => {
 		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( null );
 

--- a/client/blocks/get-apps/test/index.test.tsx
+++ b/client/blocks/get-apps/test/index.test.tsx
@@ -43,30 +43,49 @@ describe( 'GetApps', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'shows Mobile section before Desktop for single-site users', () => {
+	it( 'shows Jetpack mobile first for single-site users', () => {
 		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( 1 );
 
 		renderWithProvider( <GetApps /> );
 
-		const headings = screen.getAllByRole( 'heading', { level: 2 } );
-		const headingTexts = headings.map( ( h ) => h.textContent );
+		const mobile = screen.getByTestId( 'mobile-download-card' );
+		const studio = screen.getByTestId( 'desktop-app-wordpress-studio' );
+		const desktop = screen.getByTestId( 'desktop-app-wordpress' );
 
-		expect( headingTexts.indexOf( 'Mobile' ) ).toBeLessThan(
-			headingTexts.indexOf( 'Desktop' )
-		);
+		expect(
+			mobile.compareDocumentPosition( studio ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+		expect(
+			studio.compareDocumentPosition( desktop ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
 	} );
 
-	it( 'shows Desktop section before Mobile for multi-site users', () => {
+	it( 'shows Studio first for multi-site users', () => {
 		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( 2 );
 
 		renderWithProvider( <GetApps /> );
 
-		const headings = screen.getAllByRole( 'heading', { level: 2 } );
-		const headingTexts = headings.map( ( h ) => h.textContent );
+		const studio = screen.getByTestId( 'desktop-app-wordpress-studio' );
+		const mobile = screen.getByTestId( 'mobile-download-card' );
+		const desktop = screen.getByTestId( 'desktop-app-wordpress' );
 
-		expect( headingTexts.indexOf( 'Desktop' ) ).toBeLessThan(
-			headingTexts.indexOf( 'Mobile' )
-		);
+		expect(
+			studio.compareDocumentPosition( mobile ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+		expect(
+			mobile.compareDocumentPosition( desktop ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+	} );
+
+	it( 'always shows WordPress.com desktop app last', () => {
+		( getCurrentUserSiteCount as jest.Mock ).mockReturnValue( 5 );
+
+		renderWithProvider( <GetApps /> );
+
+		const desktop = screen.getByTestId( 'desktop-app-wordpress' );
+		const allTestIds = screen.getAllByTestId( /desktop-app-|mobile-download/ );
+
+		expect( allTestIds[ allTestIds.length - 1 ] ).toBe( desktop );
 	} );
 
 	it( 'treats null site count as single-site user', () => {
@@ -74,11 +93,11 @@ describe( 'GetApps', () => {
 
 		renderWithProvider( <GetApps /> );
 
-		const headings = screen.getAllByRole( 'heading', { level: 2 } );
-		const headingTexts = headings.map( ( h ) => h.textContent );
+		const mobile = screen.getByTestId( 'mobile-download-card' );
+		const studio = screen.getByTestId( 'desktop-app-wordpress-studio' );
 
-		expect( headingTexts.indexOf( 'Mobile' ) ).toBeLessThan(
-			headingTexts.indexOf( 'Desktop' )
-		);
+		expect(
+			mobile.compareDocumentPosition( studio ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
 	} );
 } );


### PR DESCRIPTION
Part of DOTCOM-16096

## Proposed Changes

* Personalize the app ordering on `/me/get-apps` based on the user's site count
* Single-site users (1 site): Jetpack mobile section appears first, then Desktop app, then Studio
* Multi-site users (2+ sites): Studio appears first, then Desktop app, then Jetpack mobile (current behavior)

## Why are these changes being made?

The Get Apps page shows Studio first for everyone, but most creators have a single site and benefit more from the Jetpack mobile app. Studio is a local development tool most useful for developers managing multiple sites. This change uses the existing `getCurrentUserSiteCount` Redux selector to reorder both the desktop apps and the page sections so the most relevant app appears first.

Observed during a product walkthrough (Feb 20, 2026, 6:45 mark): after creating a new single Business site, the app download prompt showed the desktop app before Jetpack mobile.

## Testing Instructions

* Log in as a user with 1 site, visit `/me/get-apps` -- Jetpack mobile section should appear above the Desktop section, and within Desktop, the WordPress.com desktop app should appear before Studio
* Log in as a user with 2+ sites, visit `/me/get-apps` -- Desktop section should appear first with Studio listed before the desktop app, then the Mobile section below

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
