### PR TITLE
Monetize: rename Paid Subscriptions tab and fix empty-state copy

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -53,7 +53,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		'ads-settings': translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
 		'ads-payments': translate( '%(wordads)s Payments', { args: { wordads: adsProgramName } } ),
 		payments: translate( 'Payment Settings' ),
-		'paid-subscriptions': translate( 'Active Paid Subscriptions' ),
+		'paid-subscriptions': translate( 'Paid Subscribers' ),
 		'refer-a-friend': translate( 'Refer-a-Friend Program' ),
 	};
 
@@ -66,7 +66,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				id: 'earn',
 			},
 			{
-				title: translate( 'Active Paid Subscriptions' ),
+				title: translate( 'Paid Subscribers' ),
 				path: earnPath + '/paid-subscriptions' + pathSuffix,
 				id: 'paid-subscriptions',
 			},

--- a/client/my-sites/earn/paid-subscriptions/index.tsx
+++ b/client/my-sites/earn/paid-subscriptions/index.tsx
@@ -81,19 +81,19 @@ const PaidSubscriptionsSection = ( { query }: PaidSubscriptionsSectionProps ) =>
 				{ Object.values( paid_subscriptions ).length === 0 && (
 					<Card>
 						{ translate(
-							"You don't have any active subscriptions yet. {{learnMoreLink}}Learn more{{/learnMoreLink}} about payments.",
+							"You don't have any paid subscribers yet. {{learnMoreLink}}Learn how to start a paid newsletter{{/learnMoreLink}}.",
 							{
 								components: {
 									learnMoreLink: isJetpackCloud() ? (
 										<a
 											href={ localizeUrl(
-												'https://jetpack.com/support/jetpack-blocks/payments-block/'
+												'https://jetpack.com/support/newsletter/paid-newsletters/'
 											) }
 											target="_blank"
 											rel="noopener noreferrer"
 										/>
 									) : (
-										<InlineSupportLink supportContext="payments_blocks" showIcon={ false } />
+										<InlineSupportLink supportContext="paid-newsletters" showIcon={ false } />
 									),
 								},
 							}


### PR DESCRIPTION
Part of NL-455

## Proposed Changes

* Rename the "Active Paid Subscriptions" tab to "Paid Subscribers" (both the tab title and document head)
* Rewrite the empty-state message from "You don't have any active subscriptions yet. Learn more about payments." to "You don't have any paid subscribers yet. Learn how to start a paid newsletter."
* Update the support link from the Payment Button block docs to the paid newsletters support page

## Why are these changes being made?

The current copy is confusing for creators:

1. "Active Paid Subscriptions" is ambiguous. It reads like subscriptions *you* purchased, not people paying *you*. "Paid Subscribers" matches how creators think about their audience.
2. The empty-state "Learn more about payments" links to Payment Button block documentation, which is about one-off digital goods. For a creator on the Monetize page, the most likely next step is setting up a paid newsletter. The new copy points them there.

Observed at ~7:50 in a product walkthrough recording (Feb 20, 2026).

## Testing Instructions

1. Navigate to `/earn/paid-subscriptions/{site}` on a site with no paid subscribers
2. Verify the tab reads "Paid Subscribers" (not "Active Paid Subscriptions")
3. Verify the empty-state message reads "You don't have any paid subscribers yet. Learn how to start a paid newsletter."
4. Verify the "Learn how to start a paid newsletter" link goes to the paid newsletters support page
5. On Jetpack Cloud, verify the link goes to `https://jetpack.com/support/newsletter/paid-newsletters/`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
