### PR TITLE
Update number-formatters package to 1.1

### DIFF
--- a/apps/blaze-dashboard/package.json
+++ b/apps/blaze-dashboard/package.json
@@ -33,7 +33,7 @@
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.0.1",
+		"@automattic/number-formatters": "^1.1.0",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/data": "^10.23.0",

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -29,7 +29,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
-		"@automattic/number-formatters": "^1.0.1",
+		"@automattic/number-formatters": "^1.1.0",
 		"@automattic/typography": "workspace:^",
 		"@automattic/wp-babel-makepot": "workspace:^",
 		"@automattic/wpcom-template-parts": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/languages": "workspace:^",
 		"@automattic/launchpad": "workspace:^",
-		"@automattic/number-formatters": "^1.0.1",
+		"@automattic/number-formatters": "^1.1.0",
 		"@automattic/plans-grid-next": "workspace:^",
 		"@automattic/privacy-toolset": "workspace:^",
 		"@automattic/typography": "workspace:^",

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -47,7 +47,7 @@
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.0.1",
+		"@automattic/number-formatters": "^1.1.0",
 		"@automattic/shopping-cart": "workspace:^",
 		"@automattic/urls": "workspace:^",
 		"i18n-calypso": "workspace:^"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,7 +49,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/load-script": "workspace:^",
 		"@automattic/material-design-icons": "workspace:^",
-		"@automattic/number-formatters": "^1.0.1",
+		"@automattic/number-formatters": "^1.1.0",
 		"@automattic/typography": "workspace:^",
 		"@automattic/ui": "workspace:^",
 		"@automattic/viewport-react": "workspace:^",

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -50,7 +50,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.0.1",
+		"@automattic/number-formatters": "^1.1.0",
 		"@automattic/oauth-token": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",

--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -47,7 +47,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/mini-cart#readme",
 	"dependencies": {
 		"@automattic/composite-checkout": "workspace:^",
-		"@automattic/number-formatters": "^1.0.1",
+		"@automattic/number-formatters": "^1.1.0",
 		"@automattic/shopping-cart": "workspace:^",
 		"@automattic/wpcom-checkout": "workspace:^",
 		"@emotion/styled": "^11.11.0",

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -49,7 +49,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
-		"@automattic/number-formatters": "^1.0.1",
+		"@automattic/number-formatters": "^1.1.0",
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@emotion/react": "11.11.1",

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -50,7 +50,7 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.0.1",
+		"@automattic/number-formatters": "^1.1.0",
 		"@automattic/shopping-cart": "workspace:^",
 		"@emotion/styled": "^11.11.0",
 		"@fnando/cnpj": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,18 +1846,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15":
-  version: 1.0.15
-  resolution: "@automattic/number-formatters@npm:1.0.15"
-  dependencies:
-    "@wordpress/date": "npm:^5.19.0"
-    debug: "npm:^4.4.0"
-    tslib: "npm:^2.5.0"
-  checksum: 033aee63dbb320d3ab6e34eec73453bf434911123371501014027fed5251793bedf96047d7158ef326cfc35fe75175dbe48a6c53f2343ec91004d43c007ea022
-  languageName: node
-  linkType: hard
-
-"@automattic/number-formatters@npm:^1.1.0":
+"@automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15, @automattic/number-formatters@npm:^1.1.0":
   version: 1.1.0
   resolution: "@automattic/number-formatters@npm:1.1.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,7 +488,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.0.1"
+    "@automattic/number-formatters": "npm:^1.1.0"
     "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
     "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
@@ -805,7 +805,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.0.1"
+    "@automattic/number-formatters": "npm:^1.1.0"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/urls": "workspace:^"
     "@wordpress/data": "npm:^10.23.0"
@@ -1013,7 +1013,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/load-script": "workspace:^"
     "@automattic/material-design-icons": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.0.1"
+    "@automattic/number-formatters": "npm:^1.1.0"
     "@automattic/typography": "workspace:^"
     "@automattic/ui": "workspace:^"
     "@automattic/viewport-react": "workspace:^"
@@ -1113,7 +1113,7 @@ __metadata:
     "@automattic/design-picker": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/js-utils": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.0.1"
+    "@automattic/number-formatters": "npm:^1.1.0"
     "@automattic/oauth-token": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@remix-run/router": "npm:^1.5.0"
@@ -1785,7 +1785,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.0.1"
+    "@automattic/number-formatters": "npm:^1.1.0"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/wpcom-checkout": "workspace:^"
     "@emotion/styled": "npm:^11.11.0"
@@ -1846,7 +1846,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.0.1, @automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15":
+"@automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15":
   version: 1.0.15
   resolution: "@automattic/number-formatters@npm:1.0.15"
   dependencies:
@@ -1854,6 +1854,17 @@ __metadata:
     debug: "npm:^4.4.0"
     tslib: "npm:^2.5.0"
   checksum: 033aee63dbb320d3ab6e34eec73453bf434911123371501014027fed5251793bedf96047d7158ef326cfc35fe75175dbe48a6c53f2343ec91004d43c007ea022
+  languageName: node
+  linkType: hard
+
+"@automattic/number-formatters@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@automattic/number-formatters@npm:1.1.0"
+  dependencies:
+    "@wordpress/date": "npm:^5.19.0"
+    debug: "npm:^4.4.0"
+    tslib: "npm:^2.5.0"
+  checksum: 277a5dd990141795cf11efcad0a0a5e072c92cb91915f6ce3cc0d834527744bf518977da0ea48566480da845e901d28969783236ed1ebd582265aec714b5a1a8
   languageName: node
   linkType: hard
 
@@ -2037,7 +2048,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.0.1"
+    "@automattic/number-formatters": "npm:^1.1.0"
     "@automattic/onboarding": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/typography": "workspace:^"
@@ -2580,7 +2591,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
     "@automattic/js-utils": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.0.1"
+    "@automattic/number-formatters": "npm:^1.1.0"
     "@automattic/shopping-cart": "workspace:^"
     "@emotion/styled": "npm:^11.11.0"
     "@fnando/cnpj": "npm:2.0.0"
@@ -21474,7 +21485,7 @@ __metadata:
     "@automattic/calypso-products": "workspace:^"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.0.1"
+    "@automattic/number-formatters": "npm:^1.1.0"
     "@automattic/typography": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
     "@automattic/wpcom-template-parts": "workspace:^"
@@ -37815,7 +37826,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/launchpad": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.0.1"
+    "@automattic/number-formatters": "npm:^1.1.0"
     "@automattic/plans-grid-next": "workspace:^"
     "@automattic/privacy-toolset": "workspace:^"
     "@automattic/typography": "workspace:^"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/CHE-413/provide-non-deprecated-float-values-of-integer-prices-to-analytics-in

## Proposed Changes

In order to use the float value of an integer currency in https://github.com/Automattic/wp-calypso/pull/108780 we need a way to reliably convert integer currency amounts to floats. The `@automattic/number-formatters` package already has this capability in its `getCurrencyObject` method, but it was not exposed as a return value. In https://github.com/Automattic/jetpack/pull/47203 we added that feature and bumped the package to version 1.1.0.

This PR updates all of the calypso monorepo to use version 1.1.0 of the `number-formatters` package.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I don't think any testing is particularly necessary as the changes are very minor; this just adds a new return value. Also the semver requirement in all these packages would already have picked up v1.1.
