### PR TITLE
A4A-2155: Fix referral checkout ProductInfo for Pressable add-ons

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -25,6 +25,8 @@ export default function ProductInfo( {
 	const { title, product: productInfo } = useLicenseLightboxData( product );
 
 	const isWooCommerceProduct = product.slug.startsWith( 'woocommerce-' );
+	const isPressableAddonProduct =
+		product.family_slug === 'pressable-addon' || product.slug.startsWith( 'pressable-addon-' );
 
 	let productIcon =
 		productInfo?.productSlug && getProductIcon( { productSlug: productInfo?.productSlug } );
@@ -54,6 +56,68 @@ export default function ProductInfo( {
 					'The `install`, `visits` & `storage` are the count of WordPress installs, visits per month, and storage per month in the plan description.',
 			}
 		);
+	}
+
+	if ( isPressableAddonProduct ) {
+		const pressableAddonPlan = getPressablePlan( product.slug );
+
+		productIcon = pressableIcon;
+		productTitle = product.name;
+
+		if ( pressableAddonPlan?.unit === 'inbox' ) {
+			productDescription = translate(
+				'Add %(inboxes)d Titan inbox to your Pressable plan.',
+				'Add %(inboxes)d Titan inboxes to your Pressable plan.',
+				{
+					args: {
+						inboxes: product.quantity,
+					},
+					count: product.quantity,
+					comment: 'The `inboxes` is the number of Titan inboxes included in the add-on.',
+				}
+			);
+		} else if ( pressableAddonPlan?.install ) {
+			productDescription = translate(
+				'Add %(install)d WordPress install, %(visits)s visits per month, and %(storage)dGB of storage to your Pressable plan.',
+				'Add %(install)d WordPress installs, %(visits)s visits per month, and %(storage)dGB of storage to your Pressable plan.',
+				{
+					args: {
+						install: pressableAddonPlan.install,
+						visits: formatNumberCompact( pressableAddonPlan.visits ),
+						storage: pressableAddonPlan.storage,
+					},
+					count: pressableAddonPlan.install,
+					comment:
+						'The `install`, `visits` & `storage` are added capacities for the Pressable add-on.',
+				}
+			);
+		} else if ( pressableAddonPlan?.storage ) {
+			productDescription = translate(
+				'Add %(storage)dGB of storage capacity to your Pressable plan each month.',
+				{
+					args: {
+						storage: pressableAddonPlan.storage,
+					},
+					comment: 'The `storage` is additional monthly storage from the Pressable add-on.',
+				}
+			);
+		} else if ( pressableAddonPlan?.visits ) {
+			productDescription = translate(
+				'Add %(visits)s visits per month capacity to your Pressable plan.',
+				{
+					args: {
+						visits: formatNumberCompact( pressableAddonPlan.visits ),
+					},
+					comment: 'The `visits` is additional monthly visits from the Pressable add-on.',
+				}
+			);
+		}
+
+		if ( ! productDescription ) {
+			productDescription = translate(
+				'Add-on that increases your Pressable plan limits while your plan is active.'
+			);
+		}
 	}
 
 	if ( product.family_slug === 'wpcom-hosting' ) {
@@ -113,10 +177,10 @@ export default function ProductInfo( {
 	return (
 		<div className="product-info">
 			{ isWooCommerceProduct ? (
-				<img className="product-info__icon" src={ productIcon } alt={ title } />
+				<img className="product-info__icon" src={ productIcon } alt={ productTitle } />
 			) : (
 				<div className="product-info__icon">
-					<img src={ productIcon } alt={ title } />
+					<img src={ productIcon } alt={ productTitle } />
 				</div>
 			) }
 			<div className="product-info__text-content">


### PR DESCRIPTION
Part of Linear `A4A-2155`

## Proposed Changes

* Fix checkout `ProductInfo` to render Pressable add-ons in the referral checkout main list.
* Add explicit Pressable add-on handling for `family_slug === "pressable-addon"` and `slug` values starting with `pressable-addon-`.
* Build add-on description copy from `getPressablePlan( product.slug )` mappings for sites/storage/visits/titan.
* Add a generic fallback description so unknown Pressable add-ons still render instead of returning `null`.
* Keep existing WooCommerce, WPCOM hosting, and Pressable hosting behavior unchanged.

**Before:** No items in the main list

<img width="1451" height="478" alt="image" src="https://github.com/user-attachments/assets/1ea98af1-9ccd-4d83-97bf-4b9b658fff48" />


**After**

<img width="1464" height="421" alt="image" src="https://github.com/user-attachments/assets/587f47b4-6b79-4e86-b27b-f21f6ef79093" />


## Why are these changes being made?

* Referral checkout main list was blank for Pressable add-ons because `ProductInfo` returned `null` when no description was available.
* The checkout sidebar correctly showed the add-on, so this created an inconsistent checkout UX.

## Testing Instructions

* Open `http://agencies.localhost:3002/marketplace/products?purchase_type=referral`.
* Add a Pressable add-on to referral cart.
* Go to checkout and verify the left main list (`checkout__main-list`) renders the add-on row.
* Confirm the right pricing summary still reflects the same add-on and total.
* Regression-check a non-add-on product in checkout.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
