### PR TITLE
Update Agenttic package version and CSS cleanup

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.44",
+		"@automattic/agenttic-ui": "^0.1.45",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
 		"whybundled:server": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons CONCATENATE_MODULES=false yarn run build-server && whybundled client/stats-server.json"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.44",
+		"@automattic/agenttic-ui": "^0.1.45",
 		"@automattic/calypso-babel-config": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.44",
-		"@automattic/agenttic-ui": "^0.1.44",
+		"@automattic/agenttic-client": "^0.1.45",
+		"@automattic/agenttic-ui": "^0.1.45",
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -161,7 +161,7 @@ export default function AgentChat( {
 			}
 		>
 			<AgentUI.ConversationView>
-				<ChatHeader isChatDocked={ isDocked } onClose={ onClose } options={ chatHeaderOptions } />
+				<ChatHeader onClose={ onClose } options={ chatHeaderOptions } />
 				{ isLoadingConversation ? <ChatMessageSkeleton count={ 3 } /> : <AgentUI.Messages /> }
 				{ showFeedbackInput && (
 					<FeedbackInput onSubmit={ onSubmitFeedbackText } onCancel={ onCancelFeedback } />

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -142,6 +142,7 @@ export default function AgentChat( {
 			messageRenderer={ messageRenderer }
 			inputValue={ inputValue }
 			onInputChange={ onInputChange }
+			messagesPosition="bottom"
 			emptyView={
 				isLoadingConversation ? (
 					<ChatMessageSkeleton count={ 3 } />
@@ -154,7 +155,7 @@ export default function AgentChat( {
 								: undefined
 						}
 						suggestions={ emptyViewSuggestions }
-						icon={ isDocked ? <AI /> : <AI size={ 41 } color="#3858e8" /> }
+						icon={ <AI size={ 32 } /> }
 					/>
 				)
 			}

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -404,22 +404,7 @@ body.post-new-php.agents-manager-sidebar-container {
 
 /* Agenttic UI: Styles for both docked and undocked chat */
 .agenttic {
-	.Message-module_message ul {
-		margin-left: var( --spacing-2 );
-	}
-
 	.Messages-module_container {
-		padding-bottom: 24px;
-
-		&.Messages-module_emptyState {
-			justify-content: start;
-		}
-
-		.EmptyView-module_container {
-			height: auto;
-			padding-block: 8px;
-		}
-
 		.big-sky__completed-plan:first-child {
 			margin-top: 0;
 		}
@@ -427,41 +412,6 @@ body.post-new-php.agents-manager-sidebar-container {
 		.big-sky-next-step-button {
 			margin-top: 20px;
 		}
-
-		// Add spacing after picker messages when followed by a message without completed-plan
-		.Message-module_message:has(
-				.big-sky__dock__menu__variation-picker,
-				.big-sky__dock__menu__pattern-picker
-			):has( + .Message-module_message ):not(
-				:has( + .Message-module_message .big-sky__completed-plan )
-			) {
-			margin-bottom: 24px;
-		}
-	}
-
-	.ChatFooter-module_container {
-		&:has( .Suggestions-module_container ) {
-			margin-top: 48px;
-		}
-
-		.Notice-module_container {
-			// Only override the default BG color
-			&:not( [class*='Notice-module_is'] ) {
-				background-color: #e9e9e9;
-			}
-
-			.Notice-module_content p {
-				margin: 0;
-			}
-		}
-	}
-
-	.EmptyView-module_container .Suggestions-module_container {
-		padding: 0;
-	}
-
-	.Textarea-module_textarea {
-		line-height: 1.8;
 	}
 
 	.big-sky__chat-actions {
@@ -618,38 +568,7 @@ body.post-new-php.agents-manager-sidebar-container {
 
 /* Agenttic UI: Styles for the docked chat */
 .agents-manager-chat--docked .agenttic {
-	.ConversationView-module_container {
-		position: relative;
-	}
-
-	.Messages-module_container {
-		margin-top: $chat-header-height;
-		padding-top: 0;
-
-		// Push messages to the bottom while maintaining scroll functionality in a dynamic height container
-		> *:first-child {
-			margin-top: auto;
-		}
-	}
-
 	.Message-module_message {
-		color: $white;
-		font-size: 0.875rem;
-		line-height: 1.6;
-
-		p {
-			font-size: inherit;
-			line-height: inherit;
-		}
-
-		ul {
-			list-style: disc;
-		}
-
-		a {
-			color: $white;
-		}
-
 		.big-sky__dock__menu__variation-picker {
 			min-height: unset;
 
@@ -707,123 +626,6 @@ body.post-new-php.agents-manager-sidebar-container {
 	// Prevent item picker content overflow (e.g., Patterns)
 	.Message-module_content {
 		width: 100%;
-
-		// Fix extra top margin on the first paragraph
-		.Message-module_bubble > p:first-of-type {
-			margin-top: 0;
-		}
-	}
-
-	.Message-module_user {
-		padding: 0 12px;
-
-		.Message-module_bubble {
-			border-radius: 24px 24px 8px 24px;
-			background: #484848;
-
-			p {
-				color: $gray-100;
-				margin: 0;
-			}
-		}
-	}
-
-	.EmptyView-module {
-		&_container {
-			width: 100%;
-			height: auto;
-			align-items: start;
-			padding: 0;
-		}
-
-		&_icon {
-			width: 40px;
-			height: 40px;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			margin-left: 12px;
-
-			svg {
-				width: 32px;
-				height: 32px;
-				color: $white;
-			}
-		}
-
-		&_heading,
-		&_help {
-			font-size: 0.875rem;
-			line-height: 1.6;
-			color: $white;
-			padding: 0 12px;
-		}
-
-		&_suggestionsWrapper .Suggestions-module_container {
-			flex-direction: column;
-			gap: 0;
-			padding: 0;
-
-			.button-module_button {
-				width: 100%;
-				height: unset;
-				justify-content: start;
-				border-radius: 0;
-				background-color: unset;
-				padding: 14px 16px;
-				color: $gray-200;
-				font-size: 13px;
-				line-height: 20px;
-				border: 1px solid #545454;
-
-				&:hover {
-					background-color: $gray-800;
-				}
-
-				&:focus-visible {
-					outline-offset: -3px;
-					outline-color: var( --wp-admin-theme-color );
-				}
-			}
-
-			> div + div .button-module_button {
-				margin-top: -1px;
-			}
-
-			> div:only-of-type .button-module_button {
-				border-radius: 8px;
-			}
-
-			> div:first-of-type:not( :only-of-type ) .button-module_button {
-				border-radius: 8px 8px 0 0;
-			}
-
-			> div:last-of-type:not( :only-of-type ) .button-module_button {
-				border-radius: 0 0 8px 8px;
-			}
-		}
-	}
-
-	.ChatFooter-module_container {
-		background-color: $gray-800;
-		transition: margin-top 0.3s ease;
-
-		.Suggestions-module_container .button-module_outline {
-			color: $gray-100;
-			background-color: #484848;
-		}
-	}
-
-	.Textarea-module_textarea {
-		color: $gray-200;
-		font-size: 0.875rem;
-		line-height: 1.625;
-		box-shadow: none;
-	}
-
-	.ChatInput-module_button:disabled {
-		background-color: $gray-700;
-		color: $gray-400;
 	}
 }
 
@@ -831,22 +633,6 @@ body.post-new-php.agents-manager-sidebar-container {
 .agents-manager-chat--undocked .agenttic.Chat-module_container.Chat-module_floating {
 	// Fix the undocked chat overlapping with the nav menu
 	z-index: 9999;
-
-	p {
-		font-size: inherit;
-		line-height: inherit;
-		margin: inherit;
-	}
-
-	ul {
-		list-style: disc;
-		margin-top: var( --spacing-3 );
-	}
-
-	.Messages-module_container.Messages-module_emptyState {
-		padding-bottom: 0;
-		padding-top: 0;
-	}
 
 	.big-sky__dock__menu__variation-picker .edit-site-global-styles-variations_item {
 		&.is-active,

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -2,6 +2,7 @@ import { AgentUI } from '@automattic/agenttic-ui';
 import { AgentsManagerSelect } from '@automattic/data-stores';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { LocalConversationListItem } from '../../types';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
@@ -46,7 +47,7 @@ export default function AgentHistory( {
 		<AgentUI.Container
 			initialChatPosition={ floatingPosition }
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
-			className="agenttic"
+			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ [] }
 			isProcessing={ false }
 			error={ null }

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -60,7 +60,6 @@ export default function AgentHistory( {
 		>
 			<AgentUI.ConversationView>
 				<ChatHeader
-					isChatDocked={ isDocked }
 					onClose={ onClose }
 					options={ chatHeaderOptions }
 					title={ __( 'Past chats', '__i18n_text_domain__' ) }

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -15,10 +15,8 @@ interface Props {
 	onBack?: () => void;
 }
 
-export default function ChatHeader( { isChatDocked, onClose, options, title, onBack }: Props ) {
+export default function ChatHeader( { onClose, options, title, onBack }: Props ) {
 	const navigate = useNavigate();
-
-	const buttonSize = ! isChatDocked ? 'small' : undefined;
 
 	return (
 		<div className="agents-manager-chat-header">
@@ -27,6 +25,7 @@ export default function ChatHeader( { isChatDocked, onClose, options, title, onB
 					className="agents-manager-chat-header__back-btn"
 					onClick={ onBack }
 					aria-label={ __( 'Go Back', '__i18n_text_domain__' ) }
+					size="small"
 				>
 					<Icon icon={ chevronLeft } />
 				</Button>
@@ -38,21 +37,21 @@ export default function ChatHeader( { isChatDocked, onClose, options, title, onB
 					controls={ options }
 					icon={ moreVertical }
 					label={ __( 'More Options', '__i18n_text_domain__' ) }
-					toggleProps={ { size: buttonSize } }
+					toggleProps={ { size: 'small' } }
 				/>
 				<Button
 					className="agents-manager-chat-header__history-btn"
 					icon={ backup }
 					onClick={ () => navigate( '/history' ) }
 					label={ __( 'View history', '__i18n_text_domain__' ) }
-					size={ buttonSize }
+					size="small"
 				/>
 				<Button
 					className="agents-manager-chat-header__close-btn"
 					icon={ close }
 					onClick={ onClose }
 					label={ __( 'Close', '__i18n_text_domain__' ) }
-					size={ buttonSize }
+					size="small"
 				/>
 			</div>
 		</div>

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -9,7 +9,6 @@ export type Options = ComponentProps< typeof DropdownMenu >[ 'controls' ];
 
 interface Props {
 	title?: string;
-	isChatDocked: boolean;
 	onClose: () => void;
 	options: Options;
 	onBack?: () => void;

--- a/packages/agents-manager/src/components/chat-header/style.scss
+++ b/packages/agents-manager/src/components/chat-header/style.scss
@@ -6,12 +6,12 @@
 	display: flex;
 	align-items: center;
 	justify-content: end;
-	height: 56px;
-	padding: 4px 16px;
+	gap: 4px;
+	padding-bottom: 4px;
 
 	.agents-manager-chat-header__back-btn {
+		color: var(--color-foreground);
 		padding: 0;
-		padding-right: 4px;
 	}
 
 	&:has( .agents-manager-chat-header__title ) {
@@ -21,58 +21,27 @@
 	&__title {
 		font-size: 14px;
 		font-weight: 600;
-		color: #1f1f1f;
+		color: var(--color-foreground);
 		flex-grow: 1;
 	}
 
 	&__actions {
 		display: flex;
-		gap: 4px;
+		gap: 8px;
 		align-items: center;
+		padding-block: 2px;
 	}
 
 	&__more-options,
 	&__history-btn,
 	&__close-btn {
 		svg {
-			fill: #1f1f1f;
+			fill: var(--color-foreground);
 		}
 	}
-}
 
-// Dark theme overrides for the docked chat
-@include docked-chat-without-modal {
-	.agents-manager-chat-header {
-		position: absolute;
-		top: 0;
-		width: 100%;
-		height: $chat-header-height;
-		margin: 0;
-		padding: 0;
-
-		&__title {
-			color: $gray-100;
-		}
-
-		&__back-btn,
-		&__more-options,
-		&__history-btn,
-		&__close-btn {
-			svg {
-				fill: $gray-100;
-			}
-
-			& .components-dropdown-menu__toggle.has-icon,
-			&.has-icon {
-				min-width: unset;
-				width: 32px;
-				height: 32px;
-				padding: 0;
-			}
-		}
-
-		&__back-btn svg {
-			margin-left: 0;
-		}
+	&__close-btn svg {
+		width: 20px;
+		height: 20px;
 	}
 }

--- a/packages/agents-manager/src/components/conversation-history-view/style.scss
+++ b/packages/agents-manager/src/components/conversation-history-view/style.scss
@@ -7,6 +7,7 @@
 	flex: 1;
 	width: 100%;
 	min-height: 0;
+	padding-top: 12px;
 
 	&__content {
 		flex: 1;
@@ -81,8 +82,6 @@
 // Dark theme overrides for the docked chat
 @include docked-chat-without-modal {
 	.agents-manager-conversation-history-view {
-		padding-top: 48px;
-
 		&__content {
 			padding-top: 0;
 			padding-left: 0;

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -65,7 +65,6 @@ export default function SupportGuide( {
 		>
 			<AgentUI.ConversationView>
 				<ChatHeader
-					isChatDocked={ isDocked }
 					onClose={ onClose }
 					onBack={ () => navigate( -1 ) }
 					options={ chatHeaderOptions }

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -4,6 +4,7 @@ import { HelpCenterArticle } from '@automattic/support-articles';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
@@ -52,7 +53,7 @@ export default function SupportGuide( {
 		<AgentUI.Container
 			initialChatPosition={ floatingPosition }
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
-			className="agenttic"
+			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ [] }
 			isProcessing={ false }
 			error={ null }

--- a/packages/agents-manager/src/components/support-guide/style.scss
+++ b/packages/agents-manager/src/components/support-guide/style.scss
@@ -15,7 +15,7 @@
 		padding: 16px;
 		display: flex;
 		justify-content: stretch;
-		
+
 		button {
 			flex: 1
 		}
@@ -62,10 +62,6 @@
 		}
 	}
 
-	.agenttic {
-		--color-background: #{$gray-800};
-		--color-foreground: #{$gray-200};
-	}
 	.agent-manager-support-guide-content {
 		scrollbar-color: #3f3f3f transparent;
 	}

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -102,7 +102,6 @@ export default function SupportGuides( {
 		>
 			<AgentUI.ConversationView>
 				<ChatHeader
-					isChatDocked={ isDocked }
 					onClose={ onClose }
 					options={ chatHeaderOptions }
 					title={ __( 'Support Guides', '__i18n_text_domain__' ) }

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { getLocaleSlug } from 'i18n-calypso';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -89,7 +90,7 @@ export default function SupportGuides( {
 		<AgentUI.Container
 			initialChatPosition={ floatingPosition }
 			onChatPositionChange={ ( position ) => setFloatingPosition( position ) }
-			className="agenttic"
+			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ [] }
 			isProcessing={ false }
 			error={ null }

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/README.md
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/README.md
@@ -34,7 +34,6 @@ function App() {
 		<AgentUI.Container variant={ isDocked ? 'embedded' : 'floating' }>
 			<AgentUI.ConversationView>
 				<ChatHeader
-					isChatDocked={ isDocked }
 					onClose={ isDocked ? closeSidebar : handleClose }
 					onDock={ dock }
 					onUndock={ undock }

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -46,8 +46,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.44",
-		"@automattic/agenttic-ui": "^0.1.44",
+		"@automattic/agenttic-client": "^0.1.45",
+		"@automattic/agenttic-ui": "^0.1.45",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.44",
+		"@automattic/agenttic-ui": "^0.1.45",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,8 +325,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.44"
-    "@automattic/agenttic-ui": "npm:^0.1.44"
+    "@automattic/agenttic-client": "npm:^0.1.45"
+    "@automattic/agenttic-ui": "npm:^0.1.45"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -357,9 +357,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.44":
-  version: 0.1.44
-  resolution: "@automattic/agenttic-client@npm:0.1.44"
+"@automattic/agenttic-client@npm:^0.1.45":
+  version: 0.1.45
+  resolution: "@automattic/agenttic-client@npm:0.1.45"
   dependencies:
     "@types/react": "npm:^18.0.0"
     marked: "npm:^16.2.1"
@@ -373,13 +373,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: 3faf13d1825411602d48faa3ede9a45c6395478496280ebd6710af27327081a55bfd458cc8d028d6be435bf4330d478fc39e705df0f27c3416867789e3ba2107
+  checksum: 7a0f5d38360f03bd532a16ce12047eec1facd9be46dc3392277403b7e9f372ecdf2106228e84865e191511c022bfc4e897eeb83d75c6e4d2fa821fe6ffad70f7
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.44":
-  version: 0.1.44
-  resolution: "@automattic/agenttic-ui@npm:0.1.44"
+"@automattic/agenttic-ui@npm:^0.1.45":
+  version: 0.1.45
+  resolution: "@automattic/agenttic-ui@npm:0.1.45"
   dependencies:
     "@automattic/charts": "npm:>=0.14.0 <1.0.0"
     "@floating-ui/react-dom": "npm:^2.1.6"
@@ -405,7 +405,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: a53459bd04a275fea4eda3eacec2222aac1178a1f386d1c209f79649e5ef00610d763706bbf9f627b01c5250574a468df234b9596861fc54c2d1ff6b7f08a106
+  checksum: 6ff064e327f40c729c8436d64e915b2965cd56dd488fe9ddab9ca6fc78ec12240be3456a37154738688dbf5add81277a4407adddc390501adc9a679f0c9fca6c
   languageName: node
   linkType: hard
 
@@ -1572,8 +1572,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.44"
-    "@automattic/agenttic-ui": "npm:^0.1.44"
+    "@automattic/agenttic-client": "npm:^0.1.45"
+    "@automattic/agenttic-ui": "npm:^0.1.45"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1906,7 +1906,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.44"
+    "@automattic/agenttic-ui": "npm:^0.1.45"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -14822,7 +14822,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.44"
+    "@automattic/agenttic-ui": "npm:^0.1.45"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"
@@ -37795,7 +37795,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wp-calypso@workspace:."
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.44"
+    "@automattic/agenttic-ui": "npm:^0.1.45"
     "@automattic/calypso-babel-config": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

* Updates agenttic package version to v0.1.45
* Removes unnecessary CSS customization

## Testing Instructions

* Pair with 5666-gh-Automattic/big-sky-plugin for a more realistic view of the final result
* Sync `apps/agents-manager` to your sandbox: `yarn dev --sync`
* Sync `apps/help-center` to your sandbox: `yarn dev --sync`
* Enable the Unified AI experience on https://wordpress.com/wp-admin/profile.php
* Go to the site editor and play with the AI Agent -- The styles should look good and similar to Figma (YOOc2u9JNpRoFSptuZ4SV8-fi-1332_16472)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?