### PR TITLE
Add InvalidInviteScreen and extract shared InviteScreenLayout

### DIFF
--- a/client/my-sites/invites-unified/controller.tsx
+++ b/client/my-sites/invites-unified/controller.tsx
@@ -1,7 +1,7 @@
 import { type Context } from '@automattic/calypso-router';
 import { getQueryArg } from '@wordpress/url';
 import wpcom from 'calypso/lib/wp';
-import { isAlreadyMemberError } from './utils';
+import { isAlreadyMemberError, isInvalidInviteError } from './utils';
 import UnifiedInviteAccept from './index';
 import type { InviteBlogDetails } from './types';
 
@@ -82,7 +82,10 @@ export async function maybeUseUnifiedInvite( context: Context, next: () => void 
 		// Handle "already a member" errors in unified flow.
 		// The error response may include garden data we use to determine if the site is CIAB.
 		const apiError = error as ApiError;
-		if ( apiError.error && isAlreadyMemberError( apiError.error ) ) {
+		if (
+			apiError.error &&
+			( isAlreadyMemberError( apiError.error ) || isInvalidInviteError( apiError.error ) )
+		) {
 			const blogDetails = getBlogDetailsFromError( apiError );
 
 			if ( shouldUseUnifiedFlow( blogDetails ) ) {

--- a/client/my-sites/invites-unified/index.tsx
+++ b/client/my-sites/invites-unified/index.tsx
@@ -7,7 +7,8 @@ import LoggedOutInviteAccept from 'calypso/my-sites/invites/invite-accept-logged
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import AcceptInviteScreen from './screens/accept-invite-screen';
 import AlreadyMemberScreen from './screens/already-member-screen';
-import { isAlreadyMemberError } from './utils';
+import InvalidInviteScreen from './screens/invalid-invite-screen';
+import { isAlreadyMemberError, isInvalidInviteError } from './utils';
 import type { Invite, InviteBlogDetails, InviteError } from './types';
 
 import './style.scss';
@@ -82,9 +83,16 @@ export function UnifiedInviteAccept( {
 		);
 	}
 
+	const blogDetails = ( inviteData as { blog_details?: InviteBlogDetails } )?.blog_details;
+
 	// Already a member → show already-member screen
 	if ( inviteError?.error && isAlreadyMemberError( inviteError.error ) ) {
 		return <AlreadyMemberScreen blogDetails={ blogDetails } />;
+	}
+
+	// Invalid invite → show invalid-invite screen
+	if ( inviteError?.error && isInvalidInviteError( inviteError.error ) ) {
+		return <InvalidInviteScreen blogDetails={ blogDetails } inviteError={ inviteError } />;
 	}
 
 	const invite = { ...inviteData, inviteKey, activationKey } as Invite;

--- a/client/my-sites/invites-unified/index.tsx
+++ b/client/my-sites/invites-unified/index.tsx
@@ -69,6 +69,11 @@ export function UnifiedInviteAccept( {
 
 	// Render logged-out invite signup in unified flow.
 	if ( ! isLoggedIn ) {
+		// Invalid invite → show invalid-invite screen (no user card needed)
+		if ( inviteError?.error && isInvalidInviteError( inviteError.error ) ) {
+			return <InvalidInviteScreen blogDetails={ blogDetails } inviteError={ inviteError } />;
+		}
+
 		if ( ! legacyLoggedOutInvite ) {
 			return null;
 		}
@@ -82,8 +87,6 @@ export function UnifiedInviteAccept( {
 			</div>
 		);
 	}
-
-	const blogDetails = ( inviteData as { blog_details?: InviteBlogDetails } )?.blog_details;
 
 	// Already a member → show already-member screen
 	if ( inviteError?.error && isAlreadyMemberError( inviteError.error ) ) {

--- a/client/my-sites/invites-unified/screens/already-member-screen.tsx
+++ b/client/my-sites/invites-unified/screens/already-member-screen.tsx
@@ -1,21 +1,6 @@
-import { Step } from '@automattic/onboarding';
-import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import { UserCard, type UserCardUser } from 'calypso/components/connect-screen/user-card';
-import DocumentHead from 'calypso/components/data/document-head';
-import BodySectionCssClass from 'calypso/layout/body-section-css-class';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { navigate } from 'calypso/lib/navigate';
-import { getCiabConfigFromGarden } from 'calypso/lib/partner-branding';
-import { login } from 'calypso/lib/paths';
-import { useDispatch } from 'calypso/state';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { hideMasterbar } from 'calypso/state/ui/actions';
+import { InviteScreenLayout } from './invite-screen-layout';
 import type { InviteBlogDetails } from '../types';
-
-import './style.scss';
 
 interface AlreadyMemberScreenProps {
 	blogDetails?: InviteBlogDetails;
@@ -23,85 +8,14 @@ interface AlreadyMemberScreenProps {
 
 export function AlreadyMemberScreen( { blogDetails }: AlreadyMemberScreenProps ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
-	const user = useSelector( getCurrentUser );
-
-	const gardenName = blogDetails?.garden?.name || null;
-	const gardenPartner = blogDetails?.garden?.partner || null;
-
-	const trackingProps = useMemo(
-		() => ( {
-			garden_name: gardenName,
-			garden_partner: gardenPartner,
-			unified: true,
-		} ),
-		[ gardenName, gardenPartner ]
-	);
-
-	useEffect( () => {
-		dispatch( hideMasterbar() );
-		recordTracksEvent( 'calypso_invite_already_member_load_page', {
-			...trackingProps,
-			logged_in: true,
-		} );
-	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
-
-	const handleSwitchAccount = useCallback( () => {
-		recordTracksEvent( 'calypso_invite_already_member_switch_account_click', trackingProps );
-		navigate( login( { redirectTo: window.location.href } ) );
-	}, [ trackingProps ] );
-
-	const userCardData: UserCardUser = {
-		displayName: user?.display_name || '',
-		email: user?.email || '',
-		avatarUrl: user?.avatar_URL,
-	};
-
-	const branding = blogDetails?.garden
-		? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
-				persistToSession: true,
-		  } )
-		: null;
-
-	const topBarLogoConfig = branding?.compactLogo ?? branding?.logo;
-	const topBarLogo = topBarLogoConfig?.src ? (
-		<img
-			src={ topBarLogoConfig.src }
-			alt={ topBarLogoConfig.alt }
-			width={ topBarLogoConfig.width }
-			height={ topBarLogoConfig.height }
-		/>
-	) : undefined;
-
-	const title = translate( 'You are already a member of this site' );
-	const description = translate( 'Would you like to accept the invite with a different account?' );
-
-	const heading = <Step.Heading text={ title } subText={ description } />;
-	const topBar = <Step.TopBar logo={ topBarLogo } />;
 
 	return (
-		<>
-			<DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />
-			<BodySectionCssClass
-				bodyClass={ [
-					'is-section-accept-invite-unified',
-					...( branding?.fontStyle === 'system' ? [ 'is-ciab-font-system' ] : [] ),
-				] }
-			/>
-			<Step.CenteredColumnLayout
-				columnWidth={ 4 }
-				heading={ heading }
-				verticalAlign="center"
-				topBar={ topBar }
-			>
-				<UserCard user={ userCardData } size="large" />
-				<div className="already-member-screen-switch-account">
-					<Button variant="link" onClick={ handleSwitchAccount }>
-						{ translate( 'Log in with a different account' ) }
-					</Button>
-				</div>
-			</Step.CenteredColumnLayout>
-		</>
+		<InviteScreenLayout
+			title={ translate( 'You are already a member of this site' ) }
+			description={ translate( 'Would you like to accept the invite with a different account?' ) }
+			blogDetails={ blogDetails }
+			trackingEventPrefix="calypso_invite_already_member"
+		/>
 	);
 }
 

--- a/client/my-sites/invites-unified/screens/invalid-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/invalid-invite-screen.tsx
@@ -1,0 +1,23 @@
+import { useTranslate } from 'i18n-calypso';
+import { InviteScreenLayout } from './invite-screen-layout';
+import type { InviteBlogDetails, InviteError } from '../types';
+
+interface InvalidInviteScreenProps {
+	blogDetails?: InviteBlogDetails;
+	inviteError: InviteError;
+}
+
+export function InvalidInviteScreen( { blogDetails, inviteError }: InvalidInviteScreenProps ) {
+	const translate = useTranslate();
+
+	return (
+		<InviteScreenLayout
+			title={ translate( 'The invite is not valid' ) }
+			description={ inviteError.message }
+			blogDetails={ blogDetails }
+			trackingEventPrefix="calypso_invite_invalid"
+		/>
+	);
+}
+
+export default InvalidInviteScreen;

--- a/client/my-sites/invites-unified/screens/invalid-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/invalid-invite-screen.tsx
@@ -10,12 +10,15 @@ interface InvalidInviteScreenProps {
 export function InvalidInviteScreen( { blogDetails, inviteError }: InvalidInviteScreenProps ) {
 	const translate = useTranslate();
 
+	const showUserCard = inviteError.error === 'unauthorized_created_by_self';
+
 	return (
 		<InviteScreenLayout
 			title={ translate( 'The invite is not valid' ) }
 			description={ inviteError.message }
 			blogDetails={ blogDetails }
 			trackingEventPrefix="calypso_invite_invalid"
+			showUserCard={ showUserCard }
 		/>
 	);
 }

--- a/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
+++ b/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
@@ -1,0 +1,111 @@
+import { Step } from '@automattic/onboarding';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { UserCard, type UserCardUser } from 'calypso/components/connect-screen/user-card';
+import DocumentHead from 'calypso/components/data/document-head';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { navigate } from 'calypso/lib/navigate';
+import { getCiabConfigFromGarden } from 'calypso/lib/partner-branding';
+import { login } from 'calypso/lib/paths';
+import { useDispatch } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { hideMasterbar } from 'calypso/state/ui/actions';
+import type { InviteBlogDetails } from '../types';
+
+import './style.scss';
+
+interface InviteScreenLayoutProps {
+	title: string;
+	description: string;
+	blogDetails?: InviteBlogDetails;
+	trackingEventPrefix: string;
+	trackingProps?: Record< string, unknown >;
+}
+
+export function InviteScreenLayout( {
+	title,
+	description,
+	blogDetails,
+	trackingEventPrefix,
+	trackingProps: extraTrackingProps,
+}: InviteScreenLayoutProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const user = useSelector( getCurrentUser );
+
+	const gardenName = blogDetails?.garden?.name || null;
+	const gardenPartner = blogDetails?.garden?.partner || null;
+
+	const trackingProps = useMemo(
+		() => ( {
+			garden_name: gardenName,
+			garden_partner: gardenPartner,
+			unified: true,
+			...extraTrackingProps,
+		} ),
+		[ gardenName, gardenPartner, extraTrackingProps ]
+	);
+
+	useEffect( () => {
+		dispatch( hideMasterbar() );
+		recordTracksEvent( `${ trackingEventPrefix }_load_page`, {
+			...trackingProps,
+			logged_in: true,
+		} );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	const handleSwitchAccount = useCallback( () => {
+		recordTracksEvent( `${ trackingEventPrefix }_switch_account_click`, trackingProps );
+		navigate( login( { redirectTo: window.location.href } ) );
+	}, [ trackingEventPrefix, trackingProps ] );
+
+	const userCardData: UserCardUser = {
+		displayName: user?.display_name || '',
+		email: user?.email || '',
+		avatarUrl: user?.avatar_URL,
+	};
+
+	const branding = blogDetails?.garden
+		? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name )
+		: null;
+
+	const topBarLogo = branding?.logo?.src ? (
+		<img
+			src={ branding.logo.src }
+			alt={ branding.logo.alt }
+			width={ branding.logo.width }
+			height={ branding.logo.height }
+		/>
+	) : undefined;
+
+	const heading = <Step.Heading text={ title } subText={ description } />;
+	const topBar = <Step.TopBar logo={ topBarLogo } />;
+
+	return (
+		<>
+			<DocumentHead title={ translate( 'Accept Invite', { textOnly: true } ) } />
+			<BodySectionCssClass
+				bodyClass={ [
+					'is-section-accept-invite-unified',
+					...( branding?.fontStyle === 'system' ? [ 'is-ciab-font-system' ] : [] ),
+				] }
+			/>
+			<Step.CenteredColumnLayout
+				columnWidth={ 4 }
+				heading={ heading }
+				verticalAlign="center"
+				topBar={ topBar }
+			>
+				<UserCard user={ userCardData } size="large" />
+				<div className="invite-screen-switch-account">
+					<Button variant="link" onClick={ handleSwitchAccount }>
+						{ translate( 'Log in with a different account' ) }
+					</Button>
+				</div>
+			</Step.CenteredColumnLayout>
+		</>
+	);
+}

--- a/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
+++ b/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
@@ -23,6 +23,7 @@ interface InviteScreenLayoutProps {
 	blogDetails?: InviteBlogDetails;
 	trackingEventPrefix: string;
 	trackingProps?: Record< string, unknown >;
+	showUserCard?: boolean;
 }
 
 export function InviteScreenLayout( {
@@ -31,6 +32,7 @@ export function InviteScreenLayout( {
 	blogDetails,
 	trackingEventPrefix,
 	trackingProps: extraTrackingProps,
+	showUserCard = true,
 }: InviteScreenLayoutProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -72,12 +74,13 @@ export function InviteScreenLayout( {
 		? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name )
 		: null;
 
-	const topBarLogo = branding?.logo?.src ? (
+	const topBarLogoConfig = branding?.compactLogo ?? branding?.logo;
+	const topBarLogo = topBarLogoConfig?.src ? (
 		<img
-			src={ branding.logo.src }
-			alt={ branding.logo.alt }
-			width={ branding.logo.width }
-			height={ branding.logo.height }
+			src={ topBarLogoConfig.src }
+			alt={ topBarLogoConfig.alt }
+			width={ topBarLogoConfig.width }
+			height={ topBarLogoConfig.height }
 		/>
 	) : undefined;
 
@@ -99,12 +102,16 @@ export function InviteScreenLayout( {
 				verticalAlign="center"
 				topBar={ topBar }
 			>
-				<UserCard user={ userCardData } size="large" />
-				<div className="invite-screen-switch-account">
-					<Button variant="link" onClick={ handleSwitchAccount }>
-						{ translate( 'Log in with a different account' ) }
-					</Button>
-				</div>
+				{ showUserCard && (
+					<>
+						<UserCard user={ userCardData } size="large" />
+						<div className="invite-screen-switch-account">
+							<Button variant="link" onClick={ handleSwitchAccount }>
+								{ translate( 'Log in with a different account' ) }
+							</Button>
+						</div>
+					</>
+				) }
 			</Step.CenteredColumnLayout>
 		</>
 	);

--- a/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
+++ b/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
@@ -71,7 +71,9 @@ export function InviteScreenLayout( {
 	};
 
 	const branding = blogDetails?.garden
-		? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name )
+		? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name, {
+				persistToSession: true,
+		  } )
 		: null;
 
 	const topBarLogoConfig = branding?.compactLogo ?? branding?.logo;

--- a/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
+++ b/client/my-sites/invites-unified/screens/invite-screen-layout.tsx
@@ -55,7 +55,7 @@ export function InviteScreenLayout( {
 		dispatch( hideMasterbar() );
 		recordTracksEvent( `${ trackingEventPrefix }_load_page`, {
 			...trackingProps,
-			logged_in: true,
+			logged_in: !! user,
 		} );
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/client/my-sites/invites-unified/screens/style.scss
+++ b/client/my-sites/invites-unified/screens/style.scss
@@ -1,4 +1,4 @@
-@import "@wordpress/base-styles/variables";
+@import '@wordpress/base-styles/variables';
 
 // Remove layout padding for the unified invite accept screen
 body.is-section-accept-invite-unified {
@@ -18,7 +18,7 @@ body.is-section-accept-invite-unified.is-ciab-font-system {
 	margin-bottom: 1.5rem;
 }
 
-.already-member-screen-switch-account {
+.invite-screen-switch-account {
 	margin-top: 1.5rem;
 	text-align: center;
 }

--- a/client/my-sites/invites-unified/test/controller.test.tsx
+++ b/client/my-sites/invites-unified/test/controller.test.tsx
@@ -291,4 +291,85 @@ describe( 'maybeUseUnifiedInvite', () => {
 			expect( next ).toHaveBeenCalled();
 		} );
 	} );
+
+	describe( 'invalid invite errors', () => {
+		test.each( [
+			[ 'unauthorized_created_by_self', 'You cannot use an invite that you created' ],
+			[ 'invalid_input_invite_used', 'This invite has already been used' ],
+			[ 'invalid_input_incorrect_site', 'This invite is for a different site' ],
+			[ 'unknown_invite', 'This invite does not exist' ],
+		] )( 'uses unified flow for %s error with garden data', async ( errorCode, errorMessage ) => {
+			const apiError = {
+				error: errorCode,
+				message: errorMessage,
+				data: {
+					garden_name: 'commerce',
+					garden_partner: 'woo',
+				},
+			};
+			mockWpcomGet.mockRejectedValue( apiError );
+
+			await maybeUseUnifiedInvite( context as never, next );
+
+			expect( context.useUnifiedInvite ).toBe( true );
+			expect( context.inviteError ).toEqual( {
+				error: errorCode,
+				message: errorMessage,
+			} );
+			expect( context.primary ).toBeDefined();
+			expect( next ).toHaveBeenCalled();
+		} );
+
+		test.each( [
+			[ 'unauthorized_created_by_self', 'You cannot use an invite that you created' ],
+			[ 'invalid_input_invite_used', 'This invite has already been used' ],
+			[ 'invalid_input_incorrect_site', 'This invite is for a different site' ],
+			[ 'unknown_invite', 'This invite does not exist' ],
+		] )( 'uses unified flow for %s error with unified flag', async ( errorCode, errorMessage ) => {
+			mockGetQueryArg.mockImplementation( ( _url: string, param: string ) => {
+				if ( param === 'unified' ) {
+					return '1';
+				}
+				return undefined;
+			} );
+
+			const apiError = {
+				error: errorCode,
+				message: errorMessage,
+			};
+			mockWpcomGet.mockRejectedValue( apiError );
+
+			await maybeUseUnifiedInvite( context as never, next );
+
+			expect( context.useUnifiedInvite ).toBe( true );
+			expect( context.inviteError ).toEqual( {
+				error: errorCode,
+				message: errorMessage,
+			} );
+			expect( context.primary ).toBeDefined();
+			expect( next ).toHaveBeenCalled();
+		} );
+
+		test.each( [
+			[ 'unauthorized_created_by_self', 'You cannot use an invite that you created' ],
+			[ 'invalid_input_invite_used', 'This invite has already been used' ],
+			[ 'invalid_input_incorrect_site', 'This invite is for a different site' ],
+			[ 'unknown_invite', 'This invite does not exist' ],
+		] )(
+			'falls back to legacy for %s error without garden data or unified flag',
+			async ( errorCode, errorMessage ) => {
+				const apiError = {
+					error: errorCode,
+					message: errorMessage,
+				};
+				mockWpcomGet.mockRejectedValue( apiError );
+
+				await maybeUseUnifiedInvite( context as never, next );
+
+				expect( context.useUnifiedInvite ).toBeUndefined();
+				expect( context.primary ).toBeUndefined();
+				expect( next ).toHaveBeenCalled();
+			}
+		);
+	} );
 } );

--- a/client/my-sites/invites-unified/test/index.test.tsx
+++ b/client/my-sites/invites-unified/test/index.test.tsx
@@ -47,6 +47,7 @@ jest.mock( 'calypso/my-sites/invites/invite-accept/utils/normalize-invite', () =
 
 const mockLoggedOutInviteAccept = jest.fn();
 const mockAlreadyMemberScreen = jest.fn();
+const mockInvalidInviteScreen = jest.fn();
 
 jest.mock( 'calypso/my-sites/invites/invite-accept-logged-out', () => ( {
 	__esModule: true,
@@ -67,6 +68,14 @@ jest.mock( '../screens/already-member-screen', () => ( {
 	default: ( props: unknown ) => {
 		mockAlreadyMemberScreen( props );
 		return <div data-testid="already-member-screen">AlreadyMemberScreen</div>;
+	},
+} ) );
+
+jest.mock( '../screens/invalid-invite-screen', () => ( {
+	__esModule: true,
+	default: ( props: unknown ) => {
+		mockInvalidInviteScreen( props );
+		return <div data-testid="invalid-invite-screen">InvalidInviteScreen</div>;
 	},
 } ) );
 
@@ -101,6 +110,7 @@ describe( 'UnifiedInviteAccept', () => {
 		mockTopBar.mockClear();
 		mockLoggedOutInviteAccept.mockClear();
 		mockAlreadyMemberScreen.mockClear();
+		mockInvalidInviteScreen.mockClear();
 		mockNormalizeInvite.mockReturnValue( {
 			inviteKey: 'abc123',
 			role: 'administrator',
@@ -277,5 +287,62 @@ describe( 'UnifiedInviteAccept', () => {
 
 		expect( screen.queryByTestId( 'already-member-screen' ) ).not.toBeInTheDocument();
 		expect( screen.getByTestId( 'accept-invite-screen' ) ).toBeVisible();
+	} );
+
+	describe( 'invalid invite errors', () => {
+		test.each( [
+			[ 'unauthorized_created_by_self', 'You cannot use an invite that you created' ],
+			[ 'invalid_input_invite_used', 'This invite has already been used' ],
+			[ 'invalid_input_incorrect_site', 'This invite is for a different site' ],
+			[ 'unknown_invite', 'This invite does not exist' ],
+		] )( 'renders InvalidInviteScreen for %s error when logged in', ( errorCode, errorMessage ) => {
+			const store = mockStore( { currentUser: { id: 1 } } );
+
+			render(
+				<Provider store={ store }>
+					<UnifiedInviteAccept
+						{ ...defaultProps }
+						inviteError={ { error: errorCode, message: errorMessage } }
+					/>
+				</Provider>
+			);
+
+			expect( screen.getByTestId( 'invalid-invite-screen' ) ).toBeVisible();
+			expect( screen.queryByTestId( 'accept-invite-screen' ) ).not.toBeInTheDocument();
+			expect( mockInvalidInviteScreen ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					inviteError: { error: errorCode, message: errorMessage },
+				} )
+			);
+		} );
+
+		test.each( [
+			[ 'unauthorized_created_by_self', 'You cannot use an invite that you created' ],
+			[ 'invalid_input_invite_used', 'This invite has already been used' ],
+			[ 'invalid_input_incorrect_site', 'This invite is for a different site' ],
+			[ 'unknown_invite', 'This invite does not exist' ],
+		] )(
+			'renders InvalidInviteScreen for %s error when logged out',
+			( errorCode, errorMessage ) => {
+				const store = mockStore( { currentUser: { id: null } } );
+
+				render(
+					<Provider store={ store }>
+						<UnifiedInviteAccept
+							{ ...defaultProps }
+							inviteError={ { error: errorCode, message: errorMessage } }
+						/>
+					</Provider>
+				);
+
+				expect( screen.getByTestId( 'invalid-invite-screen' ) ).toBeVisible();
+				expect( screen.queryByTestId( 'logged-out-invite-screen' ) ).not.toBeInTheDocument();
+				expect( mockInvalidInviteScreen ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						inviteError: { error: errorCode, message: errorMessage },
+					} )
+				);
+			}
+		);
 	} );
 } );

--- a/client/my-sites/invites-unified/utils.ts
+++ b/client/my-sites/invites-unified/utils.ts
@@ -7,7 +7,12 @@ export function isAlreadyMemberError( error: string ): boolean {
 	return ALREADY_MEMBER_ERRORS.includes( error );
 }
 
-const INVALID_INVITE_ERRORS = [ 'unauthorized_created_by_self', 'invalid_input_invite_used' ];
+const INVALID_INVITE_ERRORS = [
+	'unauthorized_created_by_self',
+	'invalid_input_invite_used',
+	'invalid_input_incorrect_site',
+	'unknown_invite',
+];
 
 /**
  * Check if an error string indicates the invite is not valid

--- a/client/my-sites/invites-unified/utils.ts
+++ b/client/my-sites/invites-unified/utils.ts
@@ -6,3 +6,12 @@ const ALREADY_MEMBER_ERRORS = [ 'already_member', 'already_subscribed' ];
 export function isAlreadyMemberError( error: string ): boolean {
 	return ALREADY_MEMBER_ERRORS.includes( error );
 }
+
+const INVALID_INVITE_ERRORS = [ 'unauthorized_created_by_self', 'invalid_input_invite_used' ];
+
+/**
+ * Check if an error string indicates the invite is not valid
+ */
+export function isInvalidInviteError( error: string ): boolean {
+	return INVALID_INVITE_ERRORS.includes( error );
+}


### PR DESCRIPTION
## Proposed Changes

- Extract shared `InviteScreenLayout` component from `AlreadyMemberScreen` (partner branding top bar, centered heading, user card, switch-account link, tracks events)
- Refactor `AlreadyMemberScreen` into a thin wrapper around the shared layout
- Add new `InvalidInviteScreen` that reuses the same layout, showing the API error message as description
- Add `isInvalidInviteError` utility for `unauthorized_created_by_self` and `invalid_input_invite_used` errors
- Wire invalid invite errors through `controller.tsx` and `index.tsx` to render the new screen

<img width="1562" height="874" alt="Captura de Tela 2026-02-23 às 16 16 20" src="https://github.com/user-attachments/assets/34f1c405-9256-4d34-a34f-c1108fe66bd6" />

## Why are these changes being made?

The unified invite flow currently only handles "already a member" errors with a dedicated screen. Other invalid invite errors (e.g., trying to use an invite you created for someone else, or a used invite) fall through to the legacy flow. This change adds a proper screen for those cases while extracting the shared layout to avoid duplication.

## Testing Instructions

- Existing tests: `yarn test-client client/my-sites/invites-unified/` — all 38 tests pass
- Manual: trigger an `unauthorized_created_by_self` or `invalid_input_invite_used` error on a CIAB invite and verify the "The invite is not valid" screen appears with the correct error message
- You can also simply change the invite token to make it invalid.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)