### PR TITLE
Fix: Add loading indicator to Skip button on cancel purchase survey

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -387,7 +387,7 @@ function StepButtons( {
 			>
 				{ __( 'Submit' ) }
 			</Button>
-			{ ( ! canGoNext || isCancelling ) && ! hasWarningStep && (
+			{ ! canGoNext && ! hasWarningStep && (
 				<Button
 					variant="tertiary"
 					isBusy={ isCancelling }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/index.tsx
@@ -308,11 +308,16 @@ function StepButtons( {
 	if ( ! isLastStep ) {
 		return (
 			<ButtonStack justify="flex-start">
-				<Button variant="primary" disabled={ ! canGoNext } onClick={ clickNext }>
+				<Button variant="primary" disabled={ ! canGoNext || isCancelling } onClick={ clickNext }>
 					{ __( 'Continue' ) }
 				</Button>
 				{ ! hasWarningStep && (
-					<Button variant="tertiary" onClick={ onSubmit }>
+					<Button
+						variant="tertiary"
+						isBusy={ isCancelling }
+						disabled={ isCancelling }
+						onClick={ onSubmit }
+					>
 						{ __( 'Skip' ) }
 					</Button>
 				) }
@@ -382,8 +387,13 @@ function StepButtons( {
 			>
 				{ __( 'Submit' ) }
 			</Button>
-			{ ! canGoNext && ! isCancelling && ! hasWarningStep && (
-				<Button variant="tertiary" onClick={ onSubmit }>
+			{ ( ! canGoNext || isCancelling ) && ! hasWarningStep && (
+				<Button
+					variant="tertiary"
+					isBusy={ isCancelling }
+					disabled={ isCancelling }
+					onClick={ onSubmit }
+				>
 					{ __( 'Skip' ) }
 				</Button>
 			) }


### PR DESCRIPTION
Fixes DOMENG-447

## Proposed Changes

* Add `isBusy` and `disabled` props to both Skip button instances in the Dashboard cancel-purchase survey form so users see a spinner while API calls are in flight
* Disable the Continue button while Skip is processing to prevent conflicting navigation
* Keep the second Skip button (last step) visible with a spinner instead of vanishing on click

## Why are these changes being made?

When cancelling a domain from the Dashboard, clicking the Skip button on the feedback survey triggers API calls (marketing survey submission + purchase cancellation) but provides no visual feedback. Users wait several seconds with no indication anything is happening. Other buttons in the same form (e.g., Submit) already use `isBusy`/`disabled` props — the Skip buttons were simply missing them.

## Testing Instructions
You'll need a domain to cancel to test this.

1. Go to http://my.localhost:3000/domains
2. Click on "View settings" for the domain you're going to cancel, click "Delete", then "Cancel domain".
3. On the feedback survey step, click **Skip** without selecting a reason
4. Verify the Skip button shows a spinner and the Continue button becomes disabled
5. Verify the page eventually navigates to the success/confirmation page
6. Repeat the flow, but this time fill in the survey and click **Submit** — verify no spurious Skip button appears

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?