### PR TITLE
Always use current URL when redirecting back to checkout from login

### DIFF
--- a/client/my-sites/checkout/src/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/src/lib/contact-validation.tsx
@@ -43,19 +43,21 @@ const getEmailTakenLoginRedirectMessage = (
 	translate: ReturnType< typeof useTranslate >
 ) => {
 	const { href, pathname } = window.location;
-	const isJetpackCheckout = pathname.includes( '/checkout/jetpack' );
-	const isAkismetCheckout = pathname.includes( '/checkout/akismet' );
-	const isA4AExpressCheckout = pathname.includes( '/checkout/agency/referral' );
-	const isGiftingCheckout = pathname.includes( '/gift/' );
 
 	// Users with a WP.com account should return to the checkout page
 	// once they are logged in to complete the process. The flow for them is
 	// checkout -> login -> checkout.
 	const currentURLQueryParameters = Object.fromEntries( new URL( href ).searchParams.entries() );
-	const redirectTo =
-		isJetpackCheckout || isAkismetCheckout || isGiftingCheckout || isA4AExpressCheckout
-			? addQueryArgs( { ...currentURLQueryParameters, flow: 'coming_from_login' }, pathname )
-			: '/checkout/no-site?cart=no-user';
+	const redirectTo = addQueryArgs(
+		{
+			...currentURLQueryParameters,
+			// For /checkout/no-site, ensure cart=no-user is present so that post-login product
+			// loading from localStorage works (needed by the onboarding-registrationless flow).
+			...( pathname.includes( '/checkout/no-site' ) && { cart: 'no-user' } ),
+			flow: 'coming_from_login',
+		},
+		pathname
+	);
 
 	const loginUrl = login( { redirectTo, emailAddress } );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1694/unified-logged-out-checkout-does-not-preserve-cart-on-log-in-redirect

## Proposed Changes

Remove the special-case conditions and always build the login redirect URL from the current page URL, appending `flow=coming_from_login`. This matches the behavior that was already in place for Jetpack, Akismet, Gifting, and A4A, and extends it universally to all siteless checkout flows including unified.

One backward-compatibility exception is preserved: for `/checkout/no-site` paths, `cart=no-user` is explicitly added to the redirect URL. This is required because `use-cart-key.ts` uses the presence of `?cart=no-user` to set `isNoSiteCart = true` for logged-in users, which in turn triggers product loading from `localStorage` — the mechanism used by the legacy `onboarding-registrationless` signup flow. As a side benefit, the other original query parameters on `/checkout/no-site` (e.g. `isDomainOnly=1`, `cancel_to`) are now also preserved through the redirect, which the old hardcoded fallback discarded.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When a logged-out user enters an email address that's already associated with a WordPress.com account during siteless checkout, they see an inline error message with a "please log in" link. After logging in, the link was supposed to return them to checkout so they could complete their purchase.

However, the redirect URL was hardcoded to `/checkout/no-site?cart=no-user` for most flows. This was correct when the feature was first introduced in 2020, when the only registrationless checkout path was `/checkout/no-site`. Over time, new siteless checkout flows were added (Jetpack, Akismet, Gifting, A4A), each requiring a one-off exception to preserve the original URL. Any flow without an exception — most notably the unified siteless checkout at `/checkout/unified/:plan` — would redirect the user to the wrong page after login, losing their product context entirely.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

A visual check should be sufficient.
