### PR TITLE
Checkout: Add renewal URL without site or product

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -88,6 +88,42 @@ export function checkoutUnifiedSiteless( context, next ) {
 	sitelessCheckout( context, next, { sitelessCheckoutType: 'unified' } );
 }
 
+export function checkoutRenewalBySubscriptionId( context, next ) {
+	const { subscriptionId } = context.params;
+	const state = context.store.getState();
+	const isLoggedOut = ! isUserLoggedIn( state );
+	const isUserComingFromLoginForm = context.query?.flow === 'coming_from_login';
+
+	setSectionMiddleware( { name: 'checkout' } )( context );
+
+	// NOTE: `context.query.code` is deprecated in favor of `context.query.coupon`.
+	const couponCode = context.query.coupon || context.query.code || getRememberedCoupon();
+
+	const CheckoutDocumentTitle = () => {
+		const translate = useTranslate();
+		return <DocumentHead title={ translate( 'Checkout' ) } />;
+	};
+
+	context.primary = (
+		<>
+			<CheckoutDocumentTitle />
+
+			<CheckoutMainWrapper
+				purchaseId={ subscriptionId }
+				productAliasFromUrl={ undefined }
+				couponCode={ couponCode }
+				isComingFromUpsell={ !! context.query.upgrade }
+				redirectTo={ context.query.redirect_to }
+				isLoggedOutCart={ isLoggedOut }
+				sitelessCheckoutType={ undefined }
+				isUserComingFromLoginForm={ isUserComingFromLoginForm }
+			/>
+		</>
+	);
+
+	next();
+}
+
 function sitelessCheckout( context, next, extraProps ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -17,6 +17,7 @@ import {
 	checkoutMarketplaceSiteless,
 	checkoutUnifiedSiteless,
 	checkoutA4ASiteless,
+	checkoutRenewalBySubscriptionId,
 	checkoutThankYou,
 	licensingPendingAsyncActivation,
 	licensingThankYouManualActivationInstructions,
@@ -353,6 +354,19 @@ export default function () {
 		redirectLoggedOut,
 		siteSelection,
 		upsellRedirect,
+		makeLayout,
+		clientRender
+	);
+
+	// A renewal using only a subscription ID. The backend derives the product
+	// and site info from the subscription record. Must be registered before the
+	// generic two-segment /checkout/:product/:domainOrProduct route so "renew"
+	// is not treated as a product slug.
+	page(
+		'/checkout/renew/:subscriptionId',
+		redirectLoggedOut,
+		noSite,
+		checkoutRenewalBySubscriptionId,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -133,6 +133,11 @@ export default function usePrepareProductsForCart( {
 		addHandler,
 		isGiftPurchase,
 	} );
+	useAddRenewalBySubscriptionId( {
+		originalPurchaseId,
+		dispatch,
+		addHandler,
+	} );
 	useNothingToAdd( { addHandler, dispatch } );
 
 	// Do not strip products from url until the URL has been parsed
@@ -193,6 +198,7 @@ function preparedProductsReducer(
 type AddHandler =
 	| 'addProductFromSlug'
 	| 'addRenewalItems'
+	| 'addRenewalBySubscriptionId'
 	| 'doNotAdd'
 	| 'addFromLocalStorage'
 	| 'addProductFromBillingIntent';
@@ -250,6 +256,14 @@ function chooseAddHandler( {
 	 */
 	if ( ! isGiftPurchase && isLoggedOutCart ) {
 		return 'addFromLocalStorage';
+	}
+
+	// If we have a subscription ID but no product alias, add the renewal using
+	// only the subscription ID. The backend will look up product info from the
+	// subscription. This must come before the isNoSiteCart check so that
+	// subscription-ID-only renewals are not sent to localStorage.
+	if ( originalPurchaseId && ! productAliasFromUrl ) {
+		return 'addRenewalBySubscriptionId';
 	}
 
 	if ( isNoSiteCart ) {
@@ -434,6 +448,49 @@ function useAddRenewalItems( {
 	] );
 }
 
+/**
+ * When a URL provides only a subscription ID (no product slug), create a
+ * renewal cart item using just the subscription ID. The backend will derive
+ * the product info (product_id, meta) from the subscription record.
+ */
+function useAddRenewalBySubscriptionId( {
+	originalPurchaseId,
+	dispatch,
+	addHandler,
+}: {
+	originalPurchaseId: string | number | null | undefined;
+	dispatch: ( action: PreparedProductsAction ) => void;
+	addHandler: AddHandler;
+} ) {
+	const translate = useTranslate();
+
+	useEffect( () => {
+		if ( addHandler !== 'addRenewalBySubscriptionId' ) {
+			return;
+		}
+		if ( ! originalPurchaseId ) {
+			dispatch( {
+				type: 'RENEWALS_ADD_ERROR',
+				message: String(
+					translate( 'A subscription ID is required to add a renewal to the cart.', {
+						textOnly: true,
+					} )
+				),
+			} );
+			return;
+		}
+		const cartItem = createRequestCartProduct( {
+			product_slug: '',
+			extra: {
+				purchaseId: String( originalPurchaseId ),
+				purchaseType: 'renewal',
+			},
+		} );
+		debug( 'preparing renewal from subscription ID', originalPurchaseId );
+		dispatch( { type: 'RENEWALS_ADD', products: [ cartItem ] } );
+	}, [ addHandler, dispatch, originalPurchaseId, translate ] );
+}
+
 function useAddProductFromSlug( {
 	productAliasFromUrl,
 	dispatch,
@@ -529,6 +586,7 @@ function useAddProductFromSlug( {
 		dispatch,
 		jetpackSiteSlug,
 		jetpackPurchaseToken,
+		hostingIntent,
 		source,
 	] );
 }

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -142,8 +142,14 @@ export default function usePrepareProductsForCart( {
 
 	// Do not strip products from url until the URL has been parsed
 	const areProductsRetrievedFromUrl = ! state.isLoading;
+
+	// For siteless checkout, we usually want to leave the products in the URL
+	// because the cart is not persisted, so if checkout reloads we need to
+	// recreate the cart from the URL again.
 	const doNotStripProducts = Boolean(
 		! areProductsRetrievedFromUrl ||
+			addHandler === 'doNotAdd' ||
+			addHandler === 'addRenewalBySubscriptionId' ||
 			sitelessCheckoutType === 'jetpack' ||
 			sitelessCheckoutType === 'akismet' ||
 			sitelessCheckoutType === 'marketplace' ||

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -68,7 +68,7 @@ The HOC has the following arguments. In order to set the cart key, you must prov
 
 A helper function that creates a `RequestCartProduct`, which can then be passed to shopping cart functions like `addProductsToCart()`.
 
-It takes one argument, an object which contains some or all of the properties in a `RequestCartProduct`, but must contain at least `product_slug` and `product_id`. The remaining properties, if not set, will be filled with the default values.
+It takes one argument, an object which contains some or all of the properties in a `RequestCartProduct`, but must contain at least `product_slug` or `product_id`. If this is a renewal, you may instead specify just `extra.purchaseId` (the subscription ID) and `extra.purchaseType: 'renewal'`. The remaining properties, if not set, will be filled with the default values or filled in on the server.
 
 ## getEmptyResponseCart
 

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -68,7 +68,7 @@ The HOC has the following arguments. In order to set the cart key, you must prov
 
 A helper function that creates a `RequestCartProduct`, which can then be passed to shopping cart functions like `addProductsToCart()`.
 
-It takes one argument, an object which contains some or all of the properties in a `RequestCartProduct`, but must contain at least `product_slug` or `product_id`. If this is a renewal, you may instead specify just `extra.purchaseId` (the subscription ID) and `extra.purchaseType: 'renewal'`. The remaining properties, if not set, will be filled with the default values or filled in on the server.
+It takes one argument, an object which contains some or all of the properties in a `RequestCartProduct`, but must contain at least `product_slug` unless this is a renewal, in which case you may instead specify just `extra.purchaseId` (the subscription ID). The remaining properties, if not set, will be filled with the default values or filled in on the server.
 
 ## getEmptyResponseCart
 

--- a/packages/shopping-cart/README.md
+++ b/packages/shopping-cart/README.md
@@ -68,7 +68,7 @@ The HOC has the following arguments. In order to set the cart key, you must prov
 
 A helper function that creates a `RequestCartProduct`, which can then be passed to shopping cart functions like `addProductsToCart()`.
 
-It takes one argument, an object which contains some or all of the properties in a `RequestCartProduct`, but must contain at least `product_slug` unless this is a renewal, in which case you may instead specify just `extra.purchaseId` (the subscription ID). The remaining properties, if not set, will be filled with the default values or filled in on the server.
+It takes one argument, an object which contains some or all of the properties in a `RequestCartProduct`, but must contain at least `product_slug` unless this is a renewal, in which case you may instead specify just `extra.purchaseId` (the subscription ID) and set `extra.purchaseType` to `'renewal'`. The remaining properties, if not set, will be filled with the default values or filled in on the server.
 
 ## getEmptyResponseCart
 

--- a/packages/shopping-cart/src/create-request-cart-product.ts
+++ b/packages/shopping-cart/src/create-request-cart-product.ts
@@ -10,7 +10,10 @@ export default function createRequestCartProduct(
 	}
 	const { product_slug, product_id, meta, volume, quantity, extra } = properties;
 	if ( extra?.purchaseId && ! extra.purchaseType ) {
-		extra.purchaseType = 'renewal';
+		// eslint-disable-next-line no-console
+		console.warn(
+			'Creating request cart product with purchaseId but no purchaseType; that might be a mistake if this should be a renewal'
+		);
 	}
 	return {
 		product_slug,

--- a/packages/shopping-cart/src/create-request-cart-product.ts
+++ b/packages/shopping-cart/src/create-request-cart-product.ts
@@ -3,10 +3,15 @@ import type { RequestCartProduct, MinimalRequestCartProduct } from './types';
 export default function createRequestCartProduct(
 	properties: MinimalRequestCartProduct
 ): RequestCartProduct {
-	if ( ! properties.product_slug ) {
-		throw new Error( 'product_slug is required for request cart products' );
+	if ( ! properties.product_slug && ! properties.extra?.purchaseId ) {
+		throw new Error(
+			'product_slug or extra.purchaseId are required to create request cart products'
+		);
 	}
 	const { product_slug, product_id, meta, volume, quantity, extra } = properties;
+	if ( extra?.purchaseId && ! extra.purchaseType ) {
+		extra.purchaseType = 'renewal';
+	}
 	return {
 		product_slug,
 		product_id,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -347,6 +347,14 @@ export type RequestCartTaxData = null | {
  * exist at all (although there will likely be a message if the item failed to
  * be added).
  *
+ * Most cart items require either a `product_slug` or `product_id` to identify
+ * the product. The one exception is a renewal requested by subscription ID
+ * only: in that case `product_slug` may be omitted and the server will look up
+ * the product from the subscription record. To request such a renewal, use
+ * `RequestCartProductRenewalBySubscriptionId` (a member of this union) and set
+ * `extra.purchaseId` to the subscription ID with `extra.purchaseType` set to
+ * `'renewal'`.
+ *
  * See `createRequestCartProduct()` and `createRequestCartProducts()` in this
  * package for a convenient way to create a `RequestCartProduct`.
  *


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/SHILL-1695/support-logged-out-and-logged-in-checkout-renewal-with-only

## Proposed Changes

This PR adds support for a new checkout URL just for adding renewals to the shopping cart: `/checkout/renew/:subscriptionId`.

Depends on 205017-ghe-Automattic/wpcom

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We currently support adding a renewal of an existing subscription to the cart with a URL like this: `/checkout/dotlive_domain:example.com/renew/1044940/example.com`. However, the subscription ID (1044940 in that example) should really be enough. We shouldn't need the product name, meta, or the site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use an existing subscription.
- Craft a renewal URL using the new format and visit it.
- Verify that the shopping cart appears with the renewal added as expected.