### PR TITLE
MSD: Display site overview with warning for the disconnected jetpack 

### DIFF
--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -36,6 +36,7 @@ import SiteOverviewFields from '../overview-site-fields';
 import SitePreviewCard from '../overview-site-preview-card';
 import SubscribersCard from '../overview-subscribers-card';
 import VisibilityCard from '../overview-visibility-card';
+import { InaccessibleJetpackNotice } from '../site/notices';
 import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
 import { StorageWarningBanner } from './storage-warning-banner';
 import type { Site } from '@automattic/api-core';
@@ -233,7 +234,12 @@ function SiteOverview( {
 					actions={ renderActions() }
 				/>
 			}
-			notices={ ! isDashboardBackport() && <OptInSurvey /> }
+			notices={
+				<>
+					{ site.__has_inaccessible_jetpack_error && <InaccessibleJetpackNotice /> }
+					{ ! isDashboardBackport() && <OptInSurvey /> }
+				</>
+			}
 		>
 			<VStack alignment="stretch" spacing={ isSmallViewport ? 5 : 10 }>
 				<StorageWarningBanner site={ site } />

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -236,7 +236,9 @@ function SiteOverview( {
 			}
 			notices={
 				<>
-					{ site.__has_inaccessible_jetpack_error && <InaccessibleJetpackNotice /> }
+					{ !! site.__inaccessible_jetpack_error && (
+						<InaccessibleJetpackNotice error={ site.__inaccessible_jetpack_error } />
+					) }
 					{ ! isDashboardBackport() && <OptInSurvey /> }
 				</>
 			}

--- a/client/dashboard/sites/site/error.tsx
+++ b/client/dashboard/sites/site/error.tsx
@@ -1,48 +1,5 @@
-import { isInaccessibleJetpackError } from '@automattic/api-core';
-import { ExternalLink } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import UnknownError from '../../app/500';
-import { siteRoute } from '../../app/router/sites';
-import { Notice } from '../../components/notice';
-import { PageHeader } from '../../components/page-header';
-import PageLayout from '../../components/page-layout';
-import RouterLinkButton from '../../components/router-link-button';
 
 export default function Error( { error }: { error: Error } ) {
-	if ( isInaccessibleJetpackError( error ) ) {
-		return <InaccessibleJetpackError error={ error } />;
-	}
 	return <UnknownError error={ error } />;
-}
-
-function InaccessibleJetpackError( { error }: { error: Error } ) {
-	const { siteSlug } = siteRoute.useParams();
-
-	return (
-		<PageLayout
-			header={
-				<PageHeader
-					title={ siteSlug }
-					actions={
-						<RouterLinkButton to="/sites" variant="primary" __next40pxDefaultSize>
-							{ __( 'Go to Sites' ) }
-						</RouterLinkButton>
-					}
-				/>
-			}
-			notices={
-				<Notice
-					variant="error"
-					title={ __( 'Your Jetpack site can not be reached at this time.' ) }
-					actions={
-						<ExternalLink href="https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/">
-							{ __( 'Troubleshoot your Jetpack site' ) }
-						</ExternalLink>
-					}
-				>
-					{ error.message }
-				</Notice>
-			}
-		></PageLayout>
-	);
 }

--- a/client/dashboard/sites/site/error.tsx
+++ b/client/dashboard/sites/site/error.tsx
@@ -29,7 +29,7 @@ function InaccessibleJetpackError( { error }: { error: Error } ) {
 					}
 				/>
 			}
-			notices={ <InaccessibleJetpackNotice variant="error" error={ error } /> }
+			notices={ <InaccessibleJetpackNotice error={ error } /> }
 		></PageLayout>
 	);
 }

--- a/client/dashboard/sites/site/error.tsx
+++ b/client/dashboard/sites/site/error.tsx
@@ -1,5 +1,35 @@
+import { isInaccessibleJetpackError } from '@automattic/api-core';
+import { __ } from '@wordpress/i18n';
 import UnknownError from '../../app/500';
+import { siteRoute } from '../../app/router/sites';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import RouterLinkButton from '../../components/router-link-button';
+import { InaccessibleJetpackNotice } from './notices';
 
 export default function Error( { error }: { error: Error } ) {
+	if ( isInaccessibleJetpackError( error ) ) {
+		return <InaccessibleJetpackError error={ error } />;
+	}
 	return <UnknownError error={ error } />;
+}
+
+function InaccessibleJetpackError( { error }: { error: Error } ) {
+	const { siteSlug } = siteRoute.useParams();
+
+	return (
+		<PageLayout
+			header={
+				<PageHeader
+					title={ siteSlug }
+					actions={
+						<RouterLinkButton to="/sites" variant="primary" __next40pxDefaultSize>
+							{ __( 'Go to Sites' ) }
+						</RouterLinkButton>
+					}
+				/>
+			}
+			notices={ <InaccessibleJetpackNotice variant="error" error={ error } /> }
+		></PageLayout>
+	);
 }

--- a/client/dashboard/sites/site/notices.tsx
+++ b/client/dashboard/sites/site/notices.tsx
@@ -1,18 +1,11 @@
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '../../components/notice';
-import type { ComponentProps } from 'react';
 
-export function InaccessibleJetpackNotice( {
-	variant = 'warning',
-	error,
-}: {
-	variant?: ComponentProps< typeof Notice >[ 'variant' ];
-	error: Error;
-} ) {
+export function InaccessibleJetpackNotice( { error }: { error: Error } ) {
 	return (
 		<Notice
-			variant={ variant }
+			variant="error"
 			title={ __( 'Your Jetpack site can not be reached at this time.' ) }
 			actions={
 				<ExternalLink href="https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/">

--- a/client/dashboard/sites/site/notices.tsx
+++ b/client/dashboard/sites/site/notices.tsx
@@ -1,11 +1,18 @@
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '../../components/notice';
+import type { ComponentProps } from 'react';
 
-export function InaccessibleJetpackNotice( { error }: { error: Error } ) {
+export function InaccessibleJetpackNotice( {
+	variant = 'warning',
+	error,
+}: {
+	variant?: ComponentProps< typeof Notice >[ 'variant' ];
+	error: Error;
+} ) {
 	return (
 		<Notice
-			variant="warning"
+			variant={ variant }
 			title={ __( 'Your Jetpack site can not be reached at this time.' ) }
 			actions={
 				<ExternalLink href="https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/">

--- a/client/dashboard/sites/site/notices.tsx
+++ b/client/dashboard/sites/site/notices.tsx
@@ -2,7 +2,7 @@ import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '../../components/notice';
 
-export function InaccessibleJetpackNotice() {
+export function InaccessibleJetpackNotice( { error }: { error: Error } ) {
 	return (
 		<Notice
 			variant="warning"
@@ -13,9 +13,7 @@ export function InaccessibleJetpackNotice() {
 				</ExternalLink>
 			}
 		>
-			{ __(
-				'We‘re having trouble connecting to your site, so we can‘t sync data or make updates at the moment. Your site may still be working normally for visitors.'
-			) }
+			{ error.message }
 		</Notice>
 	);
 }

--- a/client/dashboard/sites/site/notices.tsx
+++ b/client/dashboard/sites/site/notices.tsx
@@ -1,0 +1,21 @@
+import { ExternalLink } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Notice } from '../../components/notice';
+
+export function InaccessibleJetpackNotice() {
+	return (
+		<Notice
+			variant="warning"
+			title={ __( 'Your Jetpack site can not be reached at this time.' ) }
+			actions={
+				<ExternalLink href="https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/">
+					{ __( 'Troubleshoot your Jetpack connection' ) }
+				</ExternalLink>
+			}
+		>
+			{ __(
+				'We‘re having trouble connecting to your site, so we can‘t sync data or make updates at the moment. Your site may still be working normally for visitors.'
+			) }
+		</Notice>
+	);
+}

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -1,6 +1,10 @@
 import { wpcom } from '../wpcom-fetcher';
 import type { Site } from './types';
 
+export interface FetchSiteOptions {
+	force?: 'wpcom';
+}
+
 export const SITE_FIELDS = [
 	'ID',
 	'slug',
@@ -61,9 +65,12 @@ export const SITE_OPTIONS = [
 
 export const JOINED_SITE_OPTIONS = SITE_OPTIONS.join( ',' );
 
-export async function fetchSite( siteIdOrSlug: number | string ): Promise< Site > {
+export async function fetchSite(
+	siteIdOrSlug: number | string,
+	options: FetchSiteOptions = {}
+): Promise< Site > {
 	return await wpcom.req.get(
 		{ path: `/sites/${ siteIdOrSlug }` },
-		{ fields: JOINED_SITE_FIELDS, options: JOINED_SITE_OPTIONS }
+		{ ...options, fields: JOINED_SITE_FIELDS, options: JOINED_SITE_OPTIONS }
 	);
 }

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -84,5 +84,5 @@ export interface Site {
 	garden_is_provisioned: boolean | null;
 
 	// Injected local properties
-	__has_inaccessible_jetpack_error?: boolean;
+	__inaccessible_jetpack_error?: Error;
 }

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -82,4 +82,7 @@ export interface Site {
 	garden_name: string | null;
 	garden_partner: string | null;
 	garden_is_provisioned: boolean | null;
+
+	// Injected local properties
+	__has_inaccessible_jetpack_error?: boolean;
 }

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -41,11 +41,19 @@ export function siteBySlugQuery( siteSlug: string ) {
 			try {
 				return await fetchSite( siteSlug );
 			} catch ( e ) {
-				if ( isSiteNotFoundError( e ) && ! isInaccessibleJetpackError( e ) ) {
-					throw notFound();
+				if ( ! isInaccessibleJetpackError( e ) ) {
+					if ( isSiteNotFoundError( e ) ) {
+						throw notFound();
+					}
+					throw e;
 				}
-				throw e;
 			}
+
+			const site = await fetchSite( siteSlug, { force: 'wpcom' } );
+			return {
+				...site,
+				__has_inaccessible_jetpack_error: true,
+			};
 		},
 		retry: ( failureCount, e: { isNotFound?: boolean } ) => {
 			if ( e.isNotFound || isInaccessibleJetpackError( e ) ) {
@@ -84,11 +92,19 @@ export function siteByIdQuery( siteId: number ) {
 			try {
 				return await fetchSite( siteId );
 			} catch ( e ) {
-				if ( isSiteNotFoundError( e ) && ! isInaccessibleJetpackError( e ) ) {
-					throw notFound();
+				if ( ! isInaccessibleJetpackError( e ) ) {
+					if ( isSiteNotFoundError( e ) ) {
+						throw notFound();
+					}
+					throw e;
 				}
-				throw e;
 			}
+
+			const site = await fetchSite( siteId, { force: 'wpcom' } );
+			return {
+				...site,
+				__has_inaccessible_jetpack_error: true,
+			};
 		},
 		retry: ( failureCount, e: { isNotFound?: boolean } ) => {
 			if ( e.isNotFound || isInaccessibleJetpackError( e ) ) {

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -41,19 +41,21 @@ export function siteBySlugQuery( siteSlug: string ) {
 			try {
 				return await fetchSite( siteSlug );
 			} catch ( e ) {
-				if ( ! isInaccessibleJetpackError( e ) ) {
-					if ( isSiteNotFoundError( e ) ) {
-						throw notFound();
-					}
-					throw e;
+				// Force the site to be retrieved from wpcom if there is any issue with the Jetpack connection.
+				if ( isInaccessibleJetpackError( e ) ) {
+					const site = await fetchSite( siteSlug, { force: 'wpcom' } );
+					return {
+						...site,
+						__has_inaccessible_jetpack_error: true,
+					};
 				}
-			}
 
-			const site = await fetchSite( siteSlug, { force: 'wpcom' } );
-			return {
-				...site,
-				__has_inaccessible_jetpack_error: true,
-			};
+				if ( isSiteNotFoundError( e ) ) {
+					throw notFound();
+				}
+
+				throw e;
+			}
 		},
 		retry: ( failureCount, e: { isNotFound?: boolean } ) => {
 			if ( e.isNotFound || isInaccessibleJetpackError( e ) ) {
@@ -92,19 +94,21 @@ export function siteByIdQuery( siteId: number ) {
 			try {
 				return await fetchSite( siteId );
 			} catch ( e ) {
-				if ( ! isInaccessibleJetpackError( e ) ) {
-					if ( isSiteNotFoundError( e ) ) {
-						throw notFound();
-					}
-					throw e;
+				// Force the site to be retrieved from wpcom if there is any issue with the Jetpack connection.
+				if ( isInaccessibleJetpackError( e ) ) {
+					const site = await fetchSite( siteId, { force: 'wpcom' } );
+					return {
+						...site,
+						__has_inaccessible_jetpack_error: true,
+					};
 				}
-			}
 
-			const site = await fetchSite( siteId, { force: 'wpcom' } );
-			return {
-				...site,
-				__has_inaccessible_jetpack_error: true,
-			};
+				if ( isSiteNotFoundError( e ) ) {
+					throw notFound();
+				}
+
+				throw e;
+			}
 		},
 		retry: ( failureCount, e: { isNotFound?: boolean } ) => {
 			if ( e.isNotFound || isInaccessibleJetpackError( e ) ) {

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -20,6 +20,33 @@ function isSiteNotFoundError( error: unknown ) {
 	);
 }
 
+async function getSite( siteIdOrSlug: number | string ) {
+	try {
+		return await fetchSite( siteIdOrSlug );
+	} catch ( e ) {
+		// Force the site to be retrieved from wpcom if there is any issue with the Jetpack connection.
+		if ( isInaccessibleJetpackError( e ) ) {
+			const site = await fetchSite( siteIdOrSlug, { force: 'wpcom' } );
+
+			// Throw an error if site.slug is not available because it means there is a site slug collision.
+			if ( ! site.slug ) {
+				throw e;
+			}
+
+			return {
+				...site,
+				__inaccessible_jetpack_error: e as Error,
+			};
+		}
+
+		if ( isSiteNotFoundError( e ) ) {
+			throw notFound();
+		}
+
+		throw e;
+	}
+}
+
 export function siteBySlugQuery( siteSlug: string ) {
 	// Used to find an existing Site object which is already in the `site-by-id` cache.
 	const getFromCache = () =>
@@ -37,26 +64,7 @@ export function siteBySlugQuery( siteSlug: string ) {
 
 	return queryOptions( {
 		queryKey: [ 'site-by-slug', siteSlug, SITE_FIELDS, SITE_OPTIONS ],
-		queryFn: async () => {
-			try {
-				return await fetchSite( siteSlug );
-			} catch ( e ) {
-				// Force the site to be retrieved from wpcom if there is any issue with the Jetpack connection.
-				if ( isInaccessibleJetpackError( e ) ) {
-					const site = await fetchSite( siteSlug, { force: 'wpcom' } );
-					return {
-						...site,
-						__inaccessible_jetpack_error: e as Error,
-					};
-				}
-
-				if ( isSiteNotFoundError( e ) ) {
-					throw notFound();
-				}
-
-				throw e;
-			}
-		},
+		queryFn: () => getSite( siteSlug ),
 		retry: ( failureCount, e: { isNotFound?: boolean } ) => {
 			if ( e.isNotFound || isInaccessibleJetpackError( e ) ) {
 				return false;
@@ -90,26 +98,7 @@ export function siteByIdQuery( siteId: number ) {
 
 	return queryOptions( {
 		queryKey: [ 'site-by-id', siteId, SITE_FIELDS, SITE_OPTIONS ],
-		queryFn: async () => {
-			try {
-				return await fetchSite( siteId );
-			} catch ( e ) {
-				// Force the site to be retrieved from wpcom if there is any issue with the Jetpack connection.
-				if ( isInaccessibleJetpackError( e ) ) {
-					const site = await fetchSite( siteId, { force: 'wpcom' } );
-					return {
-						...site,
-						__inaccessible_jetpack_error: e as Error,
-					};
-				}
-
-				if ( isSiteNotFoundError( e ) ) {
-					throw notFound();
-				}
-
-				throw e;
-			}
-		},
+		queryFn: () => getSite( siteId ),
 		retry: ( failureCount, e: { isNotFound?: boolean } ) => {
 			if ( e.isNotFound || isInaccessibleJetpackError( e ) ) {
 				return false;

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -46,7 +46,7 @@ export function siteBySlugQuery( siteSlug: string ) {
 					const site = await fetchSite( siteSlug, { force: 'wpcom' } );
 					return {
 						...site,
-						__has_inaccessible_jetpack_error: true,
+						__inaccessible_jetpack_error: e as Error,
 					};
 				}
 
@@ -99,7 +99,7 @@ export function siteByIdQuery( siteId: number ) {
 					const site = await fetchSite( siteId, { force: 'wpcom' } );
 					return {
 						...site,
-						__has_inaccessible_jetpack_error: true,
+						__inaccessible_jetpack_error: e as Error,
 					};
 				}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of pgz0xU-tB-p2, DOTMSD-1084

## Proposed Changes

* Handle disconnected Jetpack sites by displaying the Overview content along with a disconnection warning, allowing users to access the Overview page instead of encountering an error notice.
* The idea is to retry fetching the site using the `force=wpcom` option when a Jetpack site is disconnected, and then inject a `__has_inaccessible_jetpack_error` property into the site data to indicate the connection issue.
* I considered separating the `force=wpcom` call into its own request. However, that would require handling errors in multiple places, determining whether a retry with this option is necessary based on the specific error, waiting for the second response instead of simply suspending the original query, and etc. Although injecting the property locally is somewhat unconventional, the current approach keeps the logic centralized and simpler overall.
* Handle the edge case where the site slug is not available after the `force=wpcom` retry (e.g., slug collision). In this case, display a dedicated error page with the `InaccessibleJetpackNotice` (as an error variant) and a "Go to Sites" button, instead of falling through to the overview.
* Refactor the duplicated fetch-and-retry logic in `siteBySlugQuery` and `siteByIdQuery` into a shared `getSite` helper function.

| Warning for force=wpcom | Error for unavailable site slug |
| - | - |
|<img width="1478" height="804" alt="image" src="https://github.com/user-attachments/assets/b9678504-6fa7-470f-ada4-d1b8415d558e" />| <img width="1465" height="690" alt="image" src="https://github.com/user-attachments/assets/c8c222dd-992d-49f1-880e-b3dffb3b0d90" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the experience of disconnected Jetpack sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any disconnected Jetpack site
* Ensure you can see the Overview page
* Ensure you can see the warning of "Your Jetpack site can not be reached at this time"
* For a disconnected Jetpack site with a slug collision (slug not available via `force=wpcom`), ensure you see an error page with an error notice and a "Go to Sites" button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?