### PR TITLE
Prevent multiple requests to the shopping cart when purchasing more than one domain

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -1,5 +1,5 @@
 import { Onboard } from '@automattic/data-stores';
-import { addPlanToCart, addProductsToCart, AI_SITE_BUILDER_FLOW } from '@automattic/onboarding';
+import { addProductsToCart, AI_SITE_BUILDER_FLOW } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { resolveSelect, useDispatch as useWpDataDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -311,13 +311,9 @@ const aiSiteBuilder: FlowV2< typeof initialize > = {
 					const { cartItems } = providedDependencies;
 
 					if ( cartItems && cartItems[ 0 ] && siteSlugFromSiteData ) {
-						await addPlanToCart(
-							siteSlugFromSiteData,
-							AI_SITE_BUILDER_FLOW,
-							true,
-							'assembler',
-							cartItems[ 0 ]
-						);
+						await addProductsToCart( siteSlugFromSiteData, AI_SITE_BUILDER_FLOW, [
+							cartItems[ 0 ],
+						] );
 					}
 
 					// Flow is plan => domain and we are on plans: go to domains

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -56,10 +56,14 @@ const domainUpsell: Flow = {
 			const planCartItem = getPlanCartItem();
 			const domainCartItems = getDomainCartItems();
 
-			await addProductsToCart( siteSlug, flowName, [
+			const cartItems = [
 				...( includePlan && planCartItem ? [ planCartItem ] : [] ),
 				...( domainCartItems && domainCartItems.length > 0 ? domainCartItems : [] ),
-			] );
+			];
+
+			if ( cartItems.length > 0 ) {
+				await addProductsToCart( siteSlug, flowName, cartItems );
+			}
 
 			return window.location.assign(
 				`/checkout/${ siteSlug }?redirect_to=${ encodeURIComponent( returnUrl ) }`

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -4,7 +4,7 @@ import {
 	updateLaunchpadSettings,
 	useLaunchpad,
 } from '@automattic/data-stores';
-import { addPlanToCart, addProductsToCart, DOMAIN_AND_PLAN_FLOW } from '@automattic/onboarding';
+import { addProductsToCart, DOMAIN_AND_PLAN_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect, useRef } from 'react';
@@ -35,9 +35,9 @@ const domainUpsell: Flow = {
 		const site = useSite();
 		const hasQualifyingPlan =
 			!! site?.plan && ! site.plan.is_free && site.plan.billing_period !== 'Monthly';
-		const { getDomainCartItem, getPlanCartItem } = useSelect(
+		const { getDomainCartItems, getPlanCartItem } = useSelect(
 			( select ) => ( {
-				getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
+				getDomainCartItems: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItems,
 				getPlanCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem,
 			} ),
 			[]
@@ -53,17 +53,13 @@ const domainUpsell: Flow = {
 		const submittedDomains = useRef( false );
 
 		async function addToCartAndRedirectToCheckout( { includePlan = true } = {} ) {
-			if ( includePlan ) {
-				const planCartItem = getPlanCartItem();
-				if ( planCartItem ) {
-					await addPlanToCart( siteSlug, flowName, true, '', planCartItem );
-				}
-			}
+			const planCartItem = getPlanCartItem();
+			const domainCartItems = getDomainCartItems();
 
-			const domainCartItem = getDomainCartItem();
-			if ( domainCartItem ) {
-				await addProductsToCart( siteSlug, flowName, [ domainCartItem ] );
-			}
+			await addProductsToCart( siteSlug, flowName, [
+				...( includePlan && planCartItem ? [ planCartItem ] : [] ),
+				...( domainCartItems && domainCartItems.length > 0 ? domainCartItems : [] ),
+			] );
 
 			return window.location.assign(
 				`/checkout/${ siteSlug }?redirect_to=${ encodeURIComponent( returnUrl ) }`

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -4,7 +4,7 @@ import {
 	ENTREPRENEUR_FLOW,
 	StepContainer,
 	addProductsToCart,
-	createSiteWithCart,
+	createSite,
 	isCopySiteFlow,
 	isEntrepreneurFlow,
 	isNewHostedSiteCreationFlow,
@@ -188,11 +188,11 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 	const shouldGoToCheckout = Boolean( planCartItem );
 	const [ , isSimplifiedOnboarding ] = useSimplifiedOnboarding();
 
-	async function createSite() {
+	async function createSiteAction() {
 		if ( isManageSiteFlow ) {
 			const slug = getSignupCompleteSlug();
 
-			if ( theme ) {
+			if ( theme && slug ) {
 				await setThemeOnSite( slug, theme );
 			}
 
@@ -262,7 +262,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			: '';
 
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
-		const site = await createSiteWithCart(
+		const site = await createSite(
 			flow,
 			theme,
 			siteVisibility,
@@ -329,7 +329,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 
 	useEffect( () => {
 		if ( submit ) {
-			setPendingAction( createSite );
+			setPendingAction( createSiteAction );
 			submit();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -288,10 +288,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			throw new Error( 'Failed to create site' );
 		}
 
-		if ( theme ) {
-			await setThemeOnSite( site.siteSlug, theme );
-		}
-
 		const additionalCartItems = [
 			...( planCartItem ? [ planCartItem ] : [] ),
 			...( productCartItems ?? [] ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -3,7 +3,6 @@ import {
 	AI_SITE_BUILDER_FLOW,
 	ENTREPRENEUR_FLOW,
 	StepContainer,
-	addPlanToCart,
 	addProductsToCart,
 	createSiteWithCart,
 	isCopySiteFlow,
@@ -192,12 +191,12 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		if ( isManageSiteFlow ) {
 			const slug = getSignupCompleteSlug();
 
-			if ( planCartItem && slug ) {
-				await addPlanToCart( slug, flow, true, theme, planCartItem );
-			}
-
-			if ( productCartItems?.length && slug ) {
-				await addProductsToCart( slug, flow, productCartItems );
+			const manageFlowCartItems = [
+				...( planCartItem ? [ planCartItem ] : [] ),
+				...( productCartItems ?? [] ),
+			];
+			if ( manageFlowCartItems.length && slug ) {
+				await addProductsToCart( slug, flow, manageFlowCartItems );
 			}
 
 			return {
@@ -297,16 +296,12 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			};
 		}
 
-		if ( planCartItem && site?.siteSlug ) {
-			await addPlanToCart( site.siteSlug, flow, true, theme, planCartItem );
-		}
-
-		if ( productCartItems?.length && site?.siteSlug ) {
-			await addProductsToCart( site.siteSlug, flow, productCartItems );
-		}
-
-		if ( domainCartItems?.length && site?.siteSlug ) {
-			await addProductsToCart( site.siteSlug, flow, domainCartItems );
+		const additionalCartItems = [
+			...( planCartItem ? [ planCartItem ] : [] ),
+			...( productCartItems ?? [] ),
+		];
+		if ( additionalCartItems.length && site?.siteSlug ) {
+			await addProductsToCart( site.siteSlug, flow, additionalCartItems );
 		}
 
 		return {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -201,7 +201,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 				...( productCartItems ?? [] ),
 				...mergedDomainCartItems,
 			];
-			if ( manageFlowCartItems.length && slug ) {
+			if ( manageFlowCartItems.length > 0 && slug ) {
 				await addProductsToCart( slug, flow, manageFlowCartItems );
 			}
 
@@ -298,7 +298,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			...mergedDomainCartItems,
 		];
 
-		if ( additionalCartItems.length ) {
+		if ( additionalCartItems.length > 0 ) {
 			await addProductsToCart( site.siteSlug, flow, additionalCartItems );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -14,6 +14,7 @@ import {
 	isOnboardingFlow,
 	Step,
 	isNewSiteMigrationFlow,
+	setThemeOnSite,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -191,9 +192,14 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		if ( isManageSiteFlow ) {
 			const slug = getSignupCompleteSlug();
 
+			if ( theme ) {
+				await setThemeOnSite( slug, theme );
+			}
+
 			const manageFlowCartItems = [
 				...( planCartItem ? [ planCartItem ] : [] ),
 				...( productCartItems ?? [] ),
+				...mergedDomainCartItems,
 			];
 			if ( manageFlowCartItems.length && slug ) {
 				await addProductsToCart( slug, flow, manageFlowCartItems );
@@ -258,7 +264,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
 		const site = await createSiteWithCart(
 			flow,
-			true,
 			theme,
 			siteVisibility,
 			urlData?.meta.title ?? selectedSiteTitle,
@@ -268,7 +273,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			'#113AF5',
 			useThemeHeadstart,
 			username,
-			mergedDomainCartItems,
 			partnerBundle,
 			siteUrl,
 			domainItem,
@@ -280,12 +284,30 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			urlQueryParams.get( 'spec_id' )
 		);
 
+		if ( ! site ) {
+			throw new Error( 'Failed to create site' );
+		}
+
+		if ( theme ) {
+			await setThemeOnSite( site.siteSlug, theme );
+		}
+
+		const additionalCartItems = [
+			...( planCartItem ? [ planCartItem ] : [] ),
+			...( productCartItems ?? [] ),
+			...mergedDomainCartItems,
+		];
+
+		if ( additionalCartItems.length ) {
+			await addProductsToCart( site.siteSlug, flow, additionalCartItems );
+		}
+
 		// Poll for garden provisioning status if this is a garden site
-		if ( gardenName && site?.siteId ) {
+		if ( gardenName ) {
 			await pollForGardenProvisioning( site.siteId );
 		}
 
-		if ( isEntrepreneurFlow( flow ) && site ) {
+		if ( isEntrepreneurFlow( flow ) ) {
 			await addEcommerceTrial( { siteId: site.siteId } );
 
 			return {
@@ -296,17 +318,9 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			};
 		}
 
-		const additionalCartItems = [
-			...( planCartItem ? [ planCartItem ] : [] ),
-			...( productCartItems ?? [] ),
-		];
-		if ( additionalCartItems.length && site?.siteSlug ) {
-			await addProductsToCart( site.siteSlug, flow, additionalCartItems );
-		}
-
 		return {
-			siteId: site?.siteId,
-			siteSlug: site?.siteSlug,
+			siteId: site.siteId,
+			siteSlug: site.siteSlug,
 			goToCheckout: shouldGoToCheckout,
 			siteCreated: true,
 			platform,

--- a/client/landing/stepper/hooks/use-create-site-hook.ts
+++ b/client/landing/stepper/hooks/use-create-site-hook.ts
@@ -1,11 +1,11 @@
 import config from '@automattic/calypso-config';
 import { getLanguage } from '@automattic/i18n-utils';
-import { addPlanToCart, getNewSiteParams, processItemCart } from '@automattic/onboarding';
+import { addProductsToCart, getNewSiteParams, setThemeOnSite } from '@automattic/onboarding';
 import { useMutation } from '@tanstack/react-query';
 import { getLocaleSlug } from 'i18n-calypso';
 import wpcomRequest from 'wpcom-proxy-request';
 import { useSelector } from 'calypso/state';
-import { getCurrentUserName, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { useFlowState } from '../declarative-flow/internals/state-manager/store';
 import { getFlowFromURL } from '../utils/get-flow-from-url';
 import type { DomainSuggestion } from '@automattic/api-core';
@@ -15,7 +15,6 @@ import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 type Params = {
 	flowName: string;
-	userIsLoggedIn: boolean;
 	themeSlugWithRepo: string;
 	siteVisibility: Site.Visibility;
 	siteTitle: string;
@@ -31,39 +30,8 @@ type Params = {
 	planCartItems?: MinimalRequestCartProduct[] | null;
 };
 
-async function fillCart(
-	siteSlug: string,
-	flowName: string,
-	userIsLoggedIn: boolean,
-	themeSlugWithRepo: string,
-	domainCartItems: MinimalRequestCartProduct[] | null | undefined,
-	planCartItems: MinimalRequestCartProduct[] | null | undefined
-) {
-	if ( siteSlug && planCartItems?.length ) {
-		for ( const planCartItem of planCartItems ) {
-			await addPlanToCart( siteSlug, flowName, true, themeSlugWithRepo, planCartItem );
-		}
-	}
-
-	const isFreeThemePreselected = themeSlugWithRepo.startsWith( 'pub' );
-
-	if ( domainCartItems?.length ) {
-		for ( const domainCartItem of domainCartItems ) {
-			await processItemCart(
-				siteSlug,
-				isFreeThemePreselected,
-				themeSlugWithRepo,
-				flowName,
-				userIsLoggedIn,
-				domainCartItem
-			);
-		}
-	}
-}
-
 export const createSite = async ( {
 	flowName,
-	userIsLoggedIn,
 	themeSlugWithRepo,
 	siteVisibility,
 	siteTitle,
@@ -117,21 +85,16 @@ export const createSite = async ( {
 		goToCheckout: Boolean( planCartItems?.length ),
 	};
 
-	await fillCart(
-		siteSlug,
-		flowName,
-		userIsLoggedIn,
-		themeSlugWithRepo,
-		domainCartItems,
-		planCartItems
-	);
+	await addProductsToCart( siteSlug, flowName, [
+		...( planCartItems && planCartItems.length > 0 ? planCartItems : [] ),
+		...domainCartItems,
+	] );
 
 	return siteDetails;
 };
 
 export const useCreateSite = () => {
 	const flowName = getFlowFromURL();
-	const userIsLoggedIn = useSelector( isUserLoggedIn );
 	const { get, set } = useFlowState();
 	const domains = get( 'domains' );
 	const username = useSelector( getCurrentUserName );
@@ -161,21 +124,19 @@ export const useCreateSite = () => {
 			siteGoals?: SiteGoal[];
 		} ) => {
 			if ( createdSite ) {
+				if ( theme ) {
+					await setThemeOnSite( createdSite.siteSlug, theme );
+				}
 				// If the site already exists, we need to fill the cart with the domain and plan items.
 				// Because the user may have changed their mind about the domain or plan.
-				await fillCart(
-					createdSite.siteSlug,
-					flowName,
-					userIsLoggedIn,
-					theme,
-					mergedDomainCartItems,
-					planCartItems
-				);
+				await addProductsToCart( createdSite.siteSlug, flowName, [
+					...( planCartItems && planCartItems.length > 0 ? planCartItems : [] ),
+					...mergedDomainCartItems,
+				] );
 				return createdSite;
 			}
 			return createSite( {
 				flowName,
-				userIsLoggedIn,
 				themeSlugWithRepo: theme,
 				siteVisibility: 1,
 				siteTitle,

--- a/client/landing/stepper/hooks/use-create-site-hook.ts
+++ b/client/landing/stepper/hooks/use-create-site-hook.ts
@@ -85,10 +85,14 @@ export const createSite = async ( {
 		goToCheckout: Boolean( planCartItems?.length ),
 	};
 
-	await addProductsToCart( siteSlug, flowName, [
+	const cartItems = [
 		...( planCartItems && planCartItems.length > 0 ? planCartItems : [] ),
 		...domainCartItems,
-	] );
+	];
+
+	if ( cartItems.length > 0 ) {
+		await addProductsToCart( siteSlug, flowName, cartItems );
+	}
 
 	return siteDetails;
 };
@@ -127,12 +131,17 @@ export const useCreateSite = () => {
 				if ( theme ) {
 					await setThemeOnSite( createdSite.siteSlug, theme );
 				}
-				// If the site already exists, we need to fill the cart with the domain and plan items.
-				// Because the user may have changed their mind about the domain or plan.
-				await addProductsToCart( createdSite.siteSlug, flowName, [
+
+				const cartItems = [
 					...( planCartItems && planCartItems.length > 0 ? planCartItems : [] ),
 					...mergedDomainCartItems,
-				] );
+				];
+
+				// If the site already exists, we need to fill the cart with the domain and plan items.
+				// Because the user may have changed their mind about the domain or plan.
+				if ( cartItems.length > 0 ) {
+					await addProductsToCart( createdSite.siteSlug, flowName, cartItems );
+				}
 				return createdSite;
 			}
 			return createSite( {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -138,14 +138,12 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 
 export const createSiteWithCart = async (
 	flowName: string,
-	userIsLoggedIn: boolean,
 	themeSlugWithRepo: string,
 	siteVisibility: Site.Visibility,
 	siteTitle: string,
 	siteAccentColor: string,
 	useThemeHeadstart: boolean,
 	username: string,
-	domainCartItems: MinimalRequestCartProduct[],
 	partnerBundle: string | null,
 	storedSiteUrl?: string,
 	domainItem?: DomainSuggestion,
@@ -157,7 +155,6 @@ export const createSiteWithCart = async (
 	specId?: string | null
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
-	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
 
 	const newSiteParams = getNewSiteParams( {
 		flowToCheck: flowName,
@@ -248,13 +245,6 @@ export const createSiteWithCart = async (
 
 	if ( isTailoredSignupFlow( flowName ) || HUNDRED_YEAR_PLAN_FLOW === flowName ) {
 		await setupSiteAfterCreation( { siteId, flowName } );
-	}
-
-	if ( domainCartItems.length ) {
-		if ( isFreeThemePreselected ) {
-			await setThemeOnSite( siteSlug, themeSlugWithRepo );
-		}
-		await addProductsToCart( siteSlug, flowName, domainCartItems );
 	}
 
 	return providedDependencies;

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -136,7 +136,7 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 	return newSiteParams;
 };
 
-export const createSiteWithCart = async (
+export const createSite = async (
 	flowName: string,
 	themeSlugWithRepo: string,
 	siteVisibility: Site.Visibility,

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -251,16 +251,10 @@ export const createSiteWithCart = async (
 	}
 
 	if ( domainCartItems.length ) {
-		for ( const domainCartItem of domainCartItems ) {
-			await processItemCart(
-				siteSlug,
-				isFreeThemePreselected,
-				themeSlugWithRepo,
-				flowName,
-				userIsLoggedIn,
-				domainCartItem
-			);
+		if ( isFreeThemePreselected ) {
+			await setThemeOnSite( siteSlug, themeSlugWithRepo );
 		}
+		await addProductsToCart( siteSlug, flowName, domainCartItems );
 	}
 
 	return providedDependencies;

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -6,7 +6,7 @@ import { getTld } from '@automattic/domain-search';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
 import { getLocaleSlug } from 'i18n-calypso';
-import { startsWith, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import wpcomRequest from 'wpcom-proxy-request';
 import {
 	setupSiteAfterCreation,
@@ -261,30 +261,6 @@ function prepareItemForAddingToCart( item: MinimalRequestCartProduct, lastKnownF
 	};
 }
 
-export async function addPlanToCart(
-	siteSlug: string,
-	flowName: string,
-	userIsLoggedIn: boolean,
-	themeSlugWithRepo: string,
-	cartItem: MinimalRequestCartProduct
-) {
-	if ( isEmpty( cartItem ) ) {
-		// the user selected the free plan
-		return;
-	}
-
-	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
-
-	await processItemCart(
-		siteSlug,
-		isFreeThemePreselected,
-		themeSlugWithRepo,
-		flowName,
-		userIsLoggedIn,
-		cartItem
-	);
-}
-
 export async function replaceProductsInCart(
 	siteSlug: string,
 	cartItems: MinimalRequestCartProduct[]
@@ -301,33 +277,6 @@ export async function replaceProductsInCart(
 		debug( 'product replace request had an error', error );
 	}
 }
-
-const addToCartAndProceed = async (
-	newCartItem: MinimalRequestCartProduct,
-	siteSlug: string,
-	flowName: string
-) => {
-	const cartItem = prepareItemForAddingToCart( newCartItem, flowName );
-
-	if ( cartItem ) {
-		debug( 'adding products to cart', cartItem );
-		const cartKey = await cartManagerClient.getCartKeyForSiteSlug( siteSlug );
-
-		try {
-			const updatedCart = await cartManagerClient
-				.forCartKey( cartKey )
-				.actions.addProductsToCart( [ cartItem ] );
-
-			debug( 'product add request complete', updatedCart );
-		} catch ( error ) {
-			debug( 'product add request had an error', error );
-			//TODO Manage error
-			// reduxStore.dispatch( errorNotice( error.message ) );
-		}
-	} else {
-		debug( 'no cart items to add' );
-	}
-};
 
 export async function addProductsToCart(
 	siteSlug: string,
@@ -377,24 +326,5 @@ export async function setThemeOnSite(
 		} );
 	} catch ( error ) {
 		//TODO: Manage error
-	}
-}
-
-export async function processItemCart(
-	siteSlug: string,
-	isFreeThemePreselected: boolean,
-	themeSlugWithRepo: string,
-	lastKnownFlow: string,
-	userIsLoggedIn: boolean,
-	newCartItem?: MinimalRequestCartProduct
-) {
-	if ( ! userIsLoggedIn && isFreeThemePreselected ) {
-		await setThemeOnSite( siteSlug, themeSlugWithRepo );
-		newCartItem && ( await addToCartAndProceed( newCartItem, siteSlug, lastKnownFlow ) );
-	} else if ( userIsLoggedIn && isFreeThemePreselected ) {
-		await setThemeOnSite( siteSlug, themeSlugWithRepo );
-		newCartItem && ( await addToCartAndProceed( newCartItem, siteSlug, lastKnownFlow ) );
-	} else {
-		newCartItem && ( await addToCartAndProceed( newCartItem, siteSlug, lastKnownFlow ) );
 	}
 }

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -3,8 +3,6 @@ export { useFlowProgress } from './flow-progress/use-flow-progress';
 export { default as ActionButtons, BackButton, NextButton } from './action-buttons';
 export {
 	createSiteWithCart,
-	addPlanToCart,
-	processItemCart,
 	getNewSiteParams,
 	addProductsToCart,
 	replaceProductsInCart,

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -2,7 +2,7 @@ export { Title, SubTitle } from './titles';
 export { useFlowProgress } from './flow-progress/use-flow-progress';
 export { default as ActionButtons, BackButton, NextButton } from './action-buttons';
 export {
-	createSiteWithCart,
+	createSite,
 	getNewSiteParams,
 	addProductsToCart,
 	replaceProductsInCart,


### PR DESCRIPTION


<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of [DOMENG-265: Checkout during onboarding sometimes makes a ton of shopping cart requests](https://linear.app/a8c/issue/DOMENG-265/checkout-during-onboarding-sometimes-makes-a-ton-of-shopping-cart)

## Proposed Changes

* Instead of adding the domains one by one let's batch them in a single cart request
* Do the same for the plan in the `CreateSite` stepper
* Also don't add the domains once again since they were already added inside the `createSiteWithCart`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We were making a lot of cart requests when purchasing more than one domain. Previously, it was sequential, but now it's bulk. It's also significantly faster, too!

**You should see the same products and domains in the cart in both production and Calypso Live when going through `/setup/onboarding`.**

| Before | After |
| --- | --- |
| <img width="573" height="330" alt="image" src="https://github.com/user-attachments/assets/a1bd6597-2467-442a-904d-495a72738c56" /> | <img width="617" height="215" alt="image" src="https://github.com/user-attachments/assets/a3d76c83-5f7a-4012-a75b-4d239cd8579e" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding` flow, add a few domains, pick a plan, and verify that you'll only have 3 requests made to the shopping-cart REST API by the time you get to checkout - one to add the domains, one to add the plan and one to set the tax.
* Create a site, grab its ID, then enter `/setup/ai-site-builder/domains?siteId=%d`. Add domains and a plan, then go to checkout. You should see both cart items and no additional requests as mentioned above.
* Create a site, grab its slug, then enter `/setup/domain-and-plan?siteSlug=%s`. Add domains and a plan, then go to checkout. You should see both cart items and no additional requests as mentioned above.
* Enter `/setup/entrepreneur` and create a Woo trial site. The resulting theme of the site, after its creation, should be `pub/twentytwentytwo`.
* Enter `/setup/newsletter` and create a site. The resulting theme should be `pub/lettre`.
