### PR TITLE
Domain Flow: Add items to cart if picking the free plan through the escape hatch

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -326,6 +326,8 @@ const domain: FlowV2< typeof initialize > = {
 
 				case STEPS.SITE_PICKER.slug: {
 					if ( ! siteHasPaidPlan( providedDependencies.site ) ) {
+						setSiteUrl( providedDependencies.siteSlug );
+
 						return navigate(
 							`${ STEPS.UNIFIED_PLANS.slug }?siteSlug=${ providedDependencies.siteSlug }`
 						);
@@ -382,21 +384,7 @@ const domain: FlowV2< typeof initialize > = {
 					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.
 					setProductCartItems( addOns );
 
-					if ( ! pickedPlan ) {
-						// Since we're removing the paid domain, it means that the user chose to continue
-						// with a free domain. Because signupDomainOrigin should reflect the last domain
-						// selection status before they land on the checkout page, this value can be
-						// 'free' or 'choose-later'
-						if ( signupDomainOrigin === 'choose-later' ) {
-							setSignupDomainOrigin( signupDomainOrigin );
-						} else {
-							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
-						}
-
-						if ( siteSlug ) {
-							return goToCheckout( siteSlug );
-						}
-					} else if ( siteSlug ) {
+					const addItemsToCartAndGoToCheckout = () => {
 						setPendingAction( async () => {
 							const aggregatedCartItems = [
 								...( pickedPlan ? [ pickedPlan ] : [] ),
@@ -418,6 +406,24 @@ const domain: FlowV2< typeof initialize > = {
 						} );
 
 						return navigate( STEPS.PROCESSING.slug );
+					};
+
+					if ( ! pickedPlan ) {
+						// Since we're removing the paid domain, it means that the user chose to continue
+						// with a free domain. Because signupDomainOrigin should reflect the last domain
+						// selection status before they land on the checkout page, this value can be
+						// 'free' or 'choose-later'
+						if ( signupDomainOrigin === 'choose-later' ) {
+							setSignupDomainOrigin( signupDomainOrigin );
+						} else {
+							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
+						}
+
+						if ( siteSlug ) {
+							return addItemsToCartAndGoToCheckout();
+						}
+					} else if ( siteSlug ) {
+						return addItemsToCartAndGoToCheckout();
 					}
 
 					setSignupCompleteFlowName( this.name );

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -34,12 +34,6 @@ const selectors = {
 		}
 		return `button.is-${ name.toLowerCase() }-plan:visible`;
 	},
-	selectModalUpsellPlanButton: ( name: 'Free' | 'Personal' ) => {
-		if ( name === 'Free' ) {
-			return 'button.is-upsell-modal-free-plan:visible';
-		}
-		return `button.is-upsell-modal-${ name.toLowerCase() }-plan:visible`;
-	},
 
 	// Navigation
 	mobileNavTabsToggle: 'button.section-nav__mobile-header',
@@ -133,13 +127,22 @@ export class PlansPage {
 	 * @param {Plans} plan Plan to select.
 	 */
 	async selectModalUpsellPlan( plan: Plans ): Promise< void > {
-		if ( plan !== 'Free' && plan !== 'Personal' ) {
+		if ( plan !== 'Free' && plan !== 'Personal' && plan !== 'Premium' ) {
 			throw Error( `Unsupported plan to be selected in modal upsell: ${ plan }` );
 		}
 
-		const locator = this.page.locator( selectors.selectModalUpsellPlanButton( plan ) );
+		const locator = this.page.getByText( 'start with a free plan' );
 
 		await locator.first().click();
+
+		const continueWithPlanButton = this.page.getByRole( 'button', {
+			name: `Continue with ${ plan } plan`,
+		} );
+		if ( await continueWithPlanButton.isVisible() ) {
+			await continueWithPlanButton.click();
+		} else {
+			await this.page.getByRole( 'button', { name: `Get ${ plan } plan` } ).click();
+		}
 	}
 
 	/* Generic */

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -104,4 +104,27 @@ export class SignupPickPlanPage {
 
 		await Promise.all( actions );
 	}
+
+	/**
+	 * Selects the Free plan escape hatch on the modal upsell.
+	 *
+	 * @param {Plans} planName Name of the plan.
+	 * @param {RegExp} redirectUrl Optional redirect URL to wait for.
+	 * @returns {Promise<void>}
+	 */
+	async selectEscapeHatchWithoutSiteCreation(
+		planName: Plans,
+		redirectUrl?: RegExp
+	): Promise< void > {
+		await this.page.waitForURL( plansPageUrl );
+
+		redirectUrl ??= new RegExp( '.*checkout.*' );
+
+		const actions = [
+			this.page.waitForURL( redirectUrl, { timeout: 30 * 1000 } ),
+			this.plansPage.selectModalUpsellPlan( planName ),
+		];
+
+		await Promise.all( actions );
+	}
 }

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -32,24 +32,41 @@ export class SignupPickPlanPage {
 	}
 
 	/**
-	 * Captures the response from the site creation API endpoint.
+	 * Captures the response from the site creation API endpoint via route
+	 * interception to avoid the race where the page navigates away before
+	 * the response body can be read through CDP.
+	 *
+	 * @see test/e2e/docs-new/creating_reliable_tests.md
 	 * @returns {Promise<NewSiteResponse>}
 	 */
-	private async captureNewSiteResponse(): Promise< NewSiteResponse > {
-		const response = await this.page.waitForResponse( /.*\/sites\/new\?.*/, {
-			timeout: 60 * 1000,
+	private captureNewSiteResponse(): Promise< NewSiteResponse > {
+		return new Promise< NewSiteResponse >( ( resolve, reject ) => {
+			this.page.route(
+				/.*\/sites\/new\?.*/,
+				async ( route ) => {
+					try {
+						const response = await route.fetch();
+						const body = await response.body();
+						await route.fulfill( { response } );
+
+						const parsed = JSON.parse( body.toString() );
+						const siteDetails: NewSiteResponse = parsed.body;
+
+						if ( ! siteDetails.blog_details.blogid ) {
+							console.error( siteDetails );
+							reject( new Error( 'Failed to locate blog ID for the created site.' ) );
+							return;
+						}
+
+						siteDetails.blog_details.blogid = Number( siteDetails.blog_details.blogid );
+						resolve( siteDetails );
+					} catch ( error ) {
+						reject( error );
+					}
+				},
+				{ times: 1 }
+			);
 		} );
-
-		const responseJSON = await response.json();
-		const body: NewSiteResponse = responseJSON.body;
-
-		if ( ! body.blog_details.blogid ) {
-			console.error( body );
-			throw new Error( 'Failed to locate blog ID for the created site.' );
-		}
-
-		body.blog_details.blogid = Number( body.blog_details.blogid );
-		return body;
 	}
 
 	/**
@@ -68,13 +85,14 @@ export class SignupPickPlanPage {
 			redirectUrl ??= new RegExp( '.*(setup/site-setup|home/.+ref=onboarding).*' );
 		}
 
-		const [ , , response ] = await Promise.all( [
+		const responsePromise = this.captureNewSiteResponse();
+
+		await Promise.all( [
 			this.page.waitForURL( redirectUrl, { timeout: 60 * 1000 } ),
 			this.plansPage.selectPlan( name ),
-			this.captureNewSiteResponse(),
 		] );
 
-		return response;
+		return responsePromise;
 	}
 
 	/**


### PR DESCRIPTION
Reverts Automattic/wp-calypso#108760.

## Proposed changes

This PR reverts a revert due to flaky E2E tests.

The proposed fix for the E2E tests' flakiness is included in a new commit. Here's an explanation of the changes:

Root cause: The captureNewSiteResponse() method in signup-pick-plan-page.ts used waitForResponse() followed by response.json().

When the original PR changed the domain flow to go through a processing step (via addItemsToCartAndGoToCheckout), it introduced an extra navigation hop. This made the existing race condition more likely to trigger: the page navigates away before .json() can read the response body via CDP, causing a crash.
Fix: Replaced the fragile waitForResponse + response.json() pattern with route interception, exactly as documented in test/e2e/docs-new/creating_reliable_tests.md and already used by captureNewUserResponse() in user-signup-page.ts.

The route handler:
1. Intercepts the /sites/new request before it reaches the browser
2. Fetches the response and reads the body immediately (before any navigation can happen)
3. Fulfills the route back to the browser
4. Resolves the promise with the parsed site details

In selectPlan(), the route handler is now registered before the plan click happens (instead of running concurrently in Promise.all), ensuring the interception is always in place when the request fires.
