### PR TITLE
Podcasting: update header & use Page component

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -431,10 +431,11 @@ const PodcastingDetails = () => {
 	const translate = useTranslate();
 
 	return (
-		<Main wideLayout className="site-settings podcasting-details">
+		<Main fullWidthLayout className="site-settings podcasting-details">
 			<DocumentHead title={ translate( 'Podcasting' ) } />
 			<Page
-				title={ <JetpackTitle title={ translate( 'Podcasting' ) } /> }
+				hasPadding
+				showSidebarToggle={ false }
 				subTitle={ translate(
 					'Publish a podcast feed to Apple Podcasts and other podcasting services. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{
@@ -443,8 +444,7 @@ const PodcastingDetails = () => {
 						},
 					}
 				) }
-				showSidebarToggle={ false }
-				hasPadding={ false }
+				title={ <JetpackTitle title={ translate( 'Podcasting' ) } /> }
 			>
 				<PodcastingSettingsForm />
 			</Page>

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -4,6 +4,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Button, Card, FormLabel } from '@automattic/components';
+import { Page } from '@wordpress/admin-ui';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { pick } from 'lodash';
@@ -20,7 +21,6 @@ import FormTextarea from 'calypso/components/forms/form-textarea';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import { decodeEntities } from 'calypso/lib/formatting';
 import PodcastCoverImageSetting from 'calypso/my-sites/site-settings/podcast-cover-image-setting';
@@ -433,10 +433,9 @@ const PodcastingDetails = () => {
 	return (
 		<Main wideLayout className="site-settings podcasting-details">
 			<DocumentHead title={ translate( 'Podcasting' ) } />
-			<NavigationHeader
-				navigationItems={ [] }
+			<Page
 				title={ <JetpackTitle title={ translate( 'Podcasting' ) } /> }
-				subtitle={ translate(
+				subTitle={ translate(
 					'Publish a podcast feed to Apple Podcasts and other podcasting services. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{
 						components: {
@@ -444,8 +443,11 @@ const PodcastingDetails = () => {
 						},
 					}
 				) }
-			/>
-			<PodcastingSettingsForm />
+				showSidebarToggle={ false }
+				hasPadding={ false }
+			>
+				<PodcastingSettingsForm />
+			</Page>
 		</Main>
 	);
 };

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/admin-ui/build-style/style.css';
+
 .podcasting-details__publish-wrapper {
 	display: flex;
 	align-items: flex-start;

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -1,8 +1,14 @@
+@use '@wordpress/base-styles/breakpoints' as breakpoints;
 @import '@wordpress/admin-ui/build-style/style.css';
 
 body.is-section-settings-podcasting {
 	.layout:not(.has-no-sidebar) .layout__content {
 		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
+
+		// Full width when sidebar is collapsed
+		@media ( max-width: breakpoints.$break-medium ) {
+			padding-left: 0;
+		}
 	}
 
 	.layout__primary .main {

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -1,5 +1,25 @@
 @import '@wordpress/admin-ui/build-style/style.css';
 
+body.is-section-settings-podcasting {
+	.layout:not(.has-no-sidebar) .layout__content {
+		padding: calc(var(--masterbar-height)) 0 0 calc(var(--sidebar-width-max));
+	}
+
+	.layout__primary .main {
+		padding-bottom: 0;
+	}
+
+	// Tempoarily here until constrained content width is implemented in Admin-UI
+	.admin-ui-page__content {
+		> * {
+			max-width: 660px;
+			width: 100%;
+			margin: 0 auto;
+			box-sizing: border-box;
+		}
+	}
+}
+
 .podcasting-details__publish-wrapper {
 	display: flex;
 	align-items: flex-start;

--- a/client/my-sites/site-settings/settings-podcast/controller.ts
+++ b/client/my-sites/site-settings/settings-podcast/controller.ts
@@ -3,6 +3,7 @@ import PodcastingDetails from '../podcasting-details';
 import type { Callback } from '@automattic/calypso-router';
 
 export const createPodcastSettings: Callback = ( context, next ) => {
+	context.section.name = 'settings-podcasting';
 	context.primary = createElement( PodcastingDetails );
 	next();
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves JETPACK-1365

## Proposed Changes

- Wraps Podcasting page with `@wordpress/admin-ui` Page component, thus adding a new header and page background
- Adjusts page container spacing to truly full-width; in follow-ups, this could be moved to Layout as a setting.
- Constraints content; in future iteration, this should be part of the Admin UI Page component.

Before
<img width="1315" height="592" alt="image" src="https://github.com/user-attachments/assets/63b549e1-16db-4f0f-ba76-b903bc1d670f" />

 
After
<img width="1316" height="671" alt="image" src="https://github.com/user-attachments/assets/baae8488-ba8f-4bda-9b84-1b0ed6d92a13" />

Collapsing menu works:

<img width="1315" height="1227" alt="Screenshot 2026-03-25 at 17 14 55" src="https://github.com/user-attachments/assets/e99150a2-6bf8-4ac0-9ec1-68cd67ca6eff" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
