### PR TITLE
Agents Manager: fix theme & plugin marketplace style

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -298,20 +298,24 @@ body.is-section-stepper.agents-manager-sidebar-container {
 	}
 }
 
-/* Calypso: Fix for the search categories fixed top position on the plugins marketplace page */
+/* Calypso: Fix sticky headers on marketplace pages when the sidebar is open */
 .agents-manager-sidebar-container--sidebar-open
 	.layout__secondary
-	~ .layout__primary
-	.plugins-browser--site-view
-	.search-categories.fixed-top {
-	top: calc( $admin-bar-height + $layout-spacing + 1px );
-	left: -174px;
-	padding-top: 11px;
-	max-width: 1028px;
-	border-bottom: 1px solid var( --color-neutral-5 );
+	~ .layout__primary {
+	.plugins-browser--site-view .search-categories.fixed-top {
+		top: calc( $admin-bar-height + $layout-spacing + 1px );
+		right: calc( $sidebar-width + 1px );
+		left: calc( var(--sidebar-width-max) + 17px );
 
-	&::after {
-		display: none;
+		&::after {
+			width: calc( 100vw - var( --sidebar-width-max ) - $sidebar-width - 18px );
+		}
+	}
+
+	.themes__content .themes__controls.is-sticky:not( .is-global-sidebar-visible ) {
+		top: calc( $admin-bar-height + $layout-spacing + 1px );
+		left: calc( var(--sidebar-width-max) + 17px );
+		width: calc( 100vw - var( --sidebar-width-max ) - $sidebar-width - 18px );
 	}
 }
 


### PR DESCRIPTION
This fixes the theme and plugin marketplace pages, when using the docked Agents Manager sidebar.

Theme from:

<img width="1150" height="440" alt="image" src="https://github.com/user-attachments/assets/6e7a82b3-19fc-45bb-b9f4-bc11faed53f8" />

To:

<img width="746" height="436" alt="image" src="https://github.com/user-attachments/assets/b3136444-a31e-4db5-affa-38db0b556341" />

And plugin from:

<img width="1018" height="518" alt="image" src="https://github.com/user-attachments/assets/0509924d-24f6-4088-ab5d-4febc85d119c" />

To:

<img width="846" height="450" alt="image" src="https://github.com/user-attachments/assets/f38135a3-f2f8-4cc7-8a4d-4c88c4d56868" />

The plugin page was previously fixed in #108512 but it seems this either was insufficient, or another change knocked it out of the place. I think the fix here is less fragile.

Fixes AI-895

## Why are these changes being made?
* Fix the broken thing

## Testing Instructions

* `yarn start`
* Open http://calypso.localhost:3000/plugins/[SITE] with docked Agents Manager open. Scroll down until the fixed header appears. Confirm that it fits within the page, and this adjusts when the browser window is resized
* Open http://calypso.localhost:3000/themes/[SITE] with docked Agents Manager open. Scroll down until the fixed header appears. Confirm that it fits within the page, and this adjusts when the browser window is resized

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
