### PR TITLE
Invites: use connect-screen components in logged-out flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -100,6 +100,7 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		useConnectScreenActions: PropTypes.bool,
 		disableTosText: PropTypes.bool,
 		allowedSocialServices: PropTypes.arrayOf( PropTypes.string ),
 
@@ -786,6 +787,7 @@ class SignupForm extends Component {
 						onInputChange={ this.handleChangeEvent }
 						onCreateAccountError={ this.handleCreateAccountError }
 						onCreateAccountSuccess={ this.props.handleCreateAccountSuccess }
+						useConnectScreenActions={ this.props.useConnectScreenActions }
 						{ ...formProps }
 					>
 						{ emailErrorMessage && (
@@ -811,6 +813,7 @@ class SignupForm extends Component {
 							onInputChange={ this.handleChangeEvent }
 							onCreateAccountError={ this.handleCreateAccountError }
 							onCreateAccountSuccess={ this.props.handleCreateAccountSuccess }
+							useConnectScreenActions={ this.props.useConnectScreenActions }
 							{ ...formProps }
 						>
 							{ emailErrorMessage && (

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -8,6 +8,7 @@ import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
@@ -35,10 +36,12 @@ class PasswordlessSignupForm extends Component {
 		onCreateAccountError: PropTypes.func,
 		onCreateAccountSuccess: PropTypes.func,
 		disableTosText: PropTypes.bool,
+		useConnectScreenActions: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		locale: 'en',
+		useConnectScreenActions: false,
 	};
 
 	state = {
@@ -307,16 +310,30 @@ class PasswordlessSignupForm extends Component {
 
 	formFooter() {
 		const { isSubmitting } = this.state;
+		const isPrimaryDisabled =
+			isSubmitting || !! this.props.disabled || !! this.props.disableSubmitButton;
 		const submitButtonText = isSubmitting
 			? this.props.submitButtonLoadingLabel || this.props.translate( 'Creating Your Account…' )
 			: this.props.submitButtonLabel || this.props.translate( 'Create your account' );
 
+		if ( this.props.useConnectScreenActions ) {
+			return (
+				<>
+					<ActionButtons
+						className="signup-form__action-buttons"
+						primaryLabel={ submitButtonText }
+						primaryType="submit"
+						primaryLoading={ isSubmitting }
+						primaryDisabled={ isPrimaryDisabled }
+					/>
+					{ this.props.secondaryFooterButton }
+				</>
+			);
+		}
+
 		return (
 			<LoggedOutFormFooter>
-				<SignupSubmitButton
-					isBusy={ isSubmitting }
-					isDisabled={ isSubmitting || !! this.props.disabled || !! this.props.disableSubmitButton }
-				>
+				<SignupSubmitButton isBusy={ isSubmitting } isDisabled={ isPrimaryDisabled }>
 					{ submitButtonText }
 				</SignupSubmitButton>
 				{ this.props.secondaryFooterButton }

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -1,11 +1,11 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
-@import "@automattic/onboarding/styles/mixins";
-@import "../../assets/stylesheets/shared/mixins/breakpoints";
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@automattic/onboarding/styles/mixins';
+@import '../../assets/stylesheets/shared/mixins/breakpoints';
 
 .signup-form-social-first {
 	display: grid;
-	grid-template-areas: "stack";
+	grid-template-areas: 'stack';
 
 	&-screen {
 		grid-area: stack;
@@ -26,15 +26,15 @@
 	transition: none;
 
 	&.is-error,
-	&[type="password"],
-	&[name="password"] {
+	&[type='password'],
+	&[name='password'] {
 		margin-bottom: 0;
 		text-align: left;
 		/*!rtl:ignore*/
 		direction: ltr;
 	}
 
-	&[name="username"] {
+	&[name='username'] {
 		text-align: left;
 		/*!rtl:ignore*/
 		direction: ltr;
@@ -47,7 +47,7 @@
 	text-align: left;
 
 	a {
-		@include breakpoint-deprecated(">480px") {
+		@include breakpoint-deprecated( '>480px' ) {
 			white-space: pre;
 		}
 	}
@@ -63,7 +63,7 @@
 
 	p {
 		font-size: $font-body-small;
-		color: var(--color-text-inverted);
+		color: var( --color-text-inverted );
 		margin: 0 0 12px;
 		text-align: center;
 
@@ -95,7 +95,7 @@
 	display: none;
 	padding: 20px 10px 10px;
 	font-size: $font-body-small;
-	color: var(--studio-blue-5);
+	color: var( --studio-blue-5 );
 	text-align: center;
 
 	p {
@@ -104,7 +104,7 @@
 	}
 
 	a {
-		color: var(--studio-blue-5);
+		color: var( --studio-blue-5 );
 		text-decoration: underline;
 	}
 }
@@ -117,17 +117,17 @@
 	margin-right: 16px;
 
 	// 32px is the column margins
-	width: calc(var(--signup-form-column-max-width) - 32px);
+	width: calc( var( --signup-form-column-max-width ) - 32px );
 
 	@include break-medium {
 		// 2 columns + the 60px wide "or" element
-		width: calc(var(--signup-form-column-max-width) * 2 + 60px - 32px);
+		width: calc( var( --signup-form-column-max-width ) * 2 + 60px - 32px );
 	}
 }
 
 // Replace recaptcha badge with ToS text and space
 // everything out a little more.
-@media (max-width: 660px) {
+@media ( max-width: 660px ) {
 	.signup-form__recaptcha-tos {
 		display: block;
 	}
@@ -164,7 +164,7 @@ body.is-section-accept-invite {
 				margin-right: 0;
 
 				&.is-transparent-info {
-					color: var(--studio-gray-80, #2c3338);
+					color: var( --studio-gray-80, #2c3338 );
 				}
 			}
 
@@ -174,8 +174,8 @@ body.is-section-accept-invite {
 
 			.signup-form-social-first__tos-link,
 			.signup-form-social-first__email-tos-link {
-				color: var(--studio-gray-60, #646970);
-				font-family: "SF Pro Text", sans-serif;
+				color: var( --studio-gray-60, #646970 );
+				font-family: 'SF Pro Text', sans-serif;
 				font-size: 0.875rem;
 				font-style: normal;
 				font-weight: 400;
@@ -184,7 +184,7 @@ body.is-section-accept-invite {
 				margin-bottom: 2rem;
 
 				a {
-					color: var(--studio-gray-50, #646970);
+					color: var( --studio-gray-50, #646970 );
 					text-decoration-line: underline;
 				}
 			}
@@ -201,35 +201,35 @@ body.is-section-accept-invite {
 				padding-right: 0;
 				background-color: unset;
 
-				button:not(.is-borderless, .signup-form__domain-suggestion-confirmation) {
+				button:not( .is-borderless, .signup-form__domain-suggestion-confirmation ) {
 					display: block;
 					max-width: 327px;
 					margin: 0 auto;
 				}
 
 				button.signup-form__domain-suggestion-confirmation {
-					color: var(--color-link);
+					color: var( --color-link );
 					cursor: pointer;
 					text-decoration: none;
 
 					&:hover {
-						color: var(--color-link-dark);
+						color: var( --color-link-dark );
 					}
 				}
 
 				button.is-borderless {
-					color: var(--color-link);
+					color: var( --color-link );
 					padding: 0;
 
 					&:hover {
-						color: var(--color-link-dark);
+						color: var( --color-link-dark );
 					}
 				}
 			}
 
 			.form-label {
-				color: var(--studio-gray-60, #50575e);
-				font-family: "SF Pro Text", sans-serif;
+				color: var( --studio-gray-60, #50575e );
+				font-family: 'SF Pro Text', sans-serif;
 				font-size: 0.875rem;
 				font-style: normal;
 				font-weight: 500;
@@ -244,7 +244,7 @@ body.is-section-accept-invite {
 			button.back-button {
 				color: #1d2327;
 				text-align: center;
-				font-family: "SF Pro Text", sans-serif;
+				font-family: 'SF Pro Text', sans-serif;
 				font-size: 0.875rem;
 				font-style: normal;
 				font-weight: 500;
@@ -256,23 +256,23 @@ body.is-section-accept-invite {
 				top: 0;
 
 				&:hover {
-					color: var(--studio-blue-50, #0675c4);
+					color: var( --studio-blue-50, #0675c4 );
 				}
 
 				&:focus {
-					outline: 1px dashed var(--studio-blue-50, #0675c4);
+					outline: 1px dashed var( --studio-blue-50, #0675c4 );
 					outline-offset: 3px;
 					box-shadow: none;
 					border-radius: 0;
 				}
 			}
 
-			button.button:not(.is-borderless) {
+			button.button:not( .is-borderless ) {
 				border-radius: 4px;
 
 				&:focus {
 					box-shadow: none;
-					outline: 2px solid var(--studio-blue-60, #055d9c);
+					outline: 2px solid var( --studio-blue-60, #055d9c );
 					outline-offset: 1px;
 				}
 			}
@@ -353,6 +353,33 @@ body.is-section-accept-invite {
 				}
 			}
 		}
+	}
+}
+
+.signup-form--connect-screen {
+	.card.auth-form__social.is-signup {
+		width: 100%;
+		max-width: none;
+		margin: 0;
+		padding: 0;
+		box-shadow: none;
+		background: none;
+	}
+
+	.auth-form__social-buttons,
+	.auth-form__social-buttons-container {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		gap: 10px;
+	}
+
+	.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
+		width: 100%;
+	}
+
+	.signup-form__passwordless-form-wrapper .signup-form__action-buttons {
+		margin-top: 16px;
 	}
 }
 

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -12,6 +12,19 @@ import PasswordlessSignupForm from '../passwordless';
 describe( 'createAccountError', () => {
 	const mockStore = configureStore( [ thunk ] );
 
+	it( 'renders connect-screen action buttons when enabled', () => {
+		const store = mockStore( {} );
+
+		render(
+			<Provider store={ store }>
+				<PasswordlessSignupForm useConnectScreenActions submitButtonLabel="Continue" />
+			</Provider>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Continue' } ) ).toBeInTheDocument();
+		expect( document.querySelector( '.connect-screen-action-buttons' ) ).toBeInTheDocument();
+	} );
+
 	const renderFormAndSubmit = async () => {
 		const onCreateAccountError = jest.fn();
 		const store = mockStore( {} );

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -183,6 +183,7 @@ class InviteAcceptLoggedOut extends Component {
 				<div className="invite-accept-logged-out-wrapper">
 					{ this.renderFormHeader() }
 					<SignupForm
+						className="signup-form--connect-screen"
 						redirectToAfterLoginUrl={ window.location.href }
 						isPasswordless
 						displayUsernameInput={ false }

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -12,7 +12,7 @@ import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
-import InviteFormHeader from 'calypso/my-sites/invites/invite-form-header';
+import InviteFormHeaderLoggedOut from 'calypso/my-sites/invites/invite-form-header-logged-out';
 import P2InviteAcceptLoggedOut from 'calypso/my-sites/invites/p2/invite-accept-logged-out';
 import WpcomLoginForm from 'calypso/signup/wpcom-login-form';
 import { createAccount, acceptInvite } from 'calypso/state/invites/actions';
@@ -85,7 +85,7 @@ class InviteAcceptLoggedOut extends Component {
 	};
 
 	renderFormHeader = () => {
-		return <InviteFormHeader { ...this.props.invite } />;
+		return <InviteFormHeaderLoggedOut site={ this.props.invite?.site } />;
 	};
 
 	loginUser = () => {
@@ -204,6 +204,7 @@ class InviteAcceptLoggedOut extends Component {
 						) }
 						submitButtonLabel={ this.props.translate( 'Create an account' ) }
 						labelText={ this.props.translate( 'Your email address' ) }
+						useConnectScreenActions
 					/>
 					{ this.state.userData && this.loginUser() }
 				</div>

--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -99,10 +99,6 @@ body.is-section-accept-invite {
 	}
 
 	.signup-form__passwordless-form-wrapper {
-		.signup-form__action-buttons {
-			margin-top: 16px;
-		}
-
 		.signup-form__terms-of-service-link {
 			margin: 30px 0 16px;
 			color: var( --studio-gray-50, #2c3338 );

--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -49,6 +49,10 @@ body.is-section-accept-invite {
 		text-underline-position: from-font;
 	}
 
+	.invite-form-header--logged-out .connect-screen-brand-header__title a {
+		text-decoration: none;
+	}
+
 	.card.logged-out-form {
 		box-shadow: none;
 		padding: 0;

--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -99,6 +99,10 @@ body.is-section-accept-invite {
 	}
 
 	.signup-form__passwordless-form-wrapper {
+		.signup-form__action-buttons {
+			margin-top: 16px;
+		}
+
 		.signup-form__terms-of-service-link {
 			margin: 30px 0 16px;
 			color: var( --studio-gray-50, #2c3338 );

--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -1,8 +1,7 @@
-@import "@automattic/typography/styles/variables";
-@import "@wordpress/base-styles/breakpoints";
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
 
-$recoleta-font-family: "Recoleta", sans-serif;
-$font-sf-pro-text: "SF Pro Text", $sans;
+$font-sf-pro-text: 'SF Pro Text', $sans;
 body.is-section-accept-invite {
 	.logged-out-wp-logo {
 		position: absolute;
@@ -12,7 +11,7 @@ body.is-section-accept-invite {
 	background: #fdfdfd;
 	.invite-accept {
 		padding-top: 50px;
-		height: calc(100vh - 100px);
+		height: calc( 100vh - 100px );
 	}
 	.invite-accept__form {
 		height: 100%;
@@ -40,22 +39,14 @@ body.is-section-accept-invite {
 		max-height: 340px;
 	}
 
-	.invite-form-header__title {
-		color: var(--studio-gray-100, #2c3338);
-		text-align: center;
-		font-family: $recoleta-font-family;
-		font-size: 2rem;
-		line-height: 1.26;
-		a {
-			text-decoration: none;
-		}
-	}
-
-	.invite-form-header__explanation {
-		color: var(--studio-gray-50, #2c3338);
-		text-align: center;
-		margin-top: 6px;
-		font-size: 14px;
+	.invite-form-header--logged-out .connect-screen-brand-header__description a {
+		color: var( --studio-gray-70 );
+		text-decoration-line: underline;
+		text-decoration-style: solid;
+		text-decoration-skip-ink: none;
+		text-decoration-thickness: auto;
+		text-underline-offset: auto;
+		text-underline-position: from-font;
 	}
 
 	.card.logged-out-form {
@@ -66,27 +57,27 @@ body.is-section-accept-invite {
 
 		button.is-primary {
 			border-radius: 2px;
-			border: 1px solid var(--studio-wordpress-blue, #3858e9);
-			background: var(--studio-wordpress-blue, #3858e9);
+			border: 1px solid var( --studio-wordpress-blue, #3858e9 );
+			background: var( --studio-wordpress-blue, #3858e9 );
 			height: 48px;
 			font-weight: 500;
 			&:hover {
-				background: var(--studio-wordpress-blue-60);
+				background: var( --studio-wordpress-blue-60 );
 			}
 			&:focus {
-				background-color: var(--studio-wordpress-blue-60);
-				border-color: var(--studio-wordpress-blue-60);
-				color: var(--color-text-inverted);
+				background-color: var( --studio-wordpress-blue-60 );
+				border-color: var( --studio-wordpress-blue-60 );
+				color: var( --color-text-inverted );
 				box-shadow: none;
 			}
 			&:disabled {
-				background: var(--studio-gray-20);
-				border: 1px solid var(--studio-gray-20);
-				color: var(--color-surface);
+				background: var( --studio-gray-20 );
+				border: 1px solid var( --studio-gray-20 );
+				color: var( --color-surface );
 			}
 		}
 		label.form-label {
-			color: var(--studio-gray-60, #50575e);
+			color: var( --studio-gray-60, #50575e );
 			font-size: 0.875rem;
 			font-weight: 500;
 			line-height: 20px;
@@ -106,7 +97,7 @@ body.is-section-accept-invite {
 	.signup-form__passwordless-form-wrapper {
 		.signup-form__terms-of-service-link {
 			margin: 30px 0 16px;
-			color: var(--studio-gray-50, #2c3338);
+			color: var( --studio-gray-50, #2c3338 );
 			font-size: $font-body-small; // 14px
 			line-height: 20px;
 		}
@@ -117,7 +108,7 @@ body.is-section-accept-invite {
 		padding: 0;
 	}
 	.logged-out-form__link-item {
-		color: var(--color-link);
+		color: var( --color-link );
 		font-size: 12px;
 	}
 }

--- a/client/my-sites/invites/invite-form-header-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-form-header-logged-out/index.jsx
@@ -1,0 +1,47 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { createInterpolateElement } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
+import { BrandHeader } from 'calypso/components/connect-screen/brand-header';
+
+function InviteFormHeaderLoggedOut( { site } ) {
+	const translate = useTranslate();
+	const siteName = site?.title || site?.domain || translate( 'this site' );
+
+	const description = createInterpolateElement(
+		translate(
+			'Just a little reminder that by continuing with any of the options below, you agree to our <tosLink>Terms of Service</tosLink> and <privacyLink>Privacy Policy</privacyLink>.'
+		),
+		{
+			tosLink: (
+				<a
+					href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+					onClick={ () => recordTracksEvent( 'calypso_signup_tos_link_click' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+			privacyLink: (
+				<a
+					href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+					onClick={ () => recordTracksEvent( 'calypso_signup_privacy_link_click' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+		}
+	);
+
+	return (
+		<div className="invite-form-header invite-form-header--logged-out">
+			<BrandHeader
+				title={ translate( 'Create an account for %(siteName)s', {
+					args: { siteName },
+				} ) }
+				description={ description }
+			/>
+		</div>
+	);
+}
+
+export default InviteFormHeaderLoggedOut;

--- a/client/my-sites/invites/invite-form-header-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-form-header-logged-out/index.jsx
@@ -7,6 +7,23 @@ import { BrandHeader } from 'calypso/components/connect-screen/brand-header';
 function InviteFormHeaderLoggedOut( { site } ) {
 	const translate = useTranslate();
 	const siteName = site?.title || site?.domain || translate( 'this site' );
+	const siteUrl = site?.URL;
+
+	const title = createInterpolateElement(
+		translate( 'Create an account for <siteLink>%(siteName)s</siteLink>', {
+			args: { siteName },
+		} ),
+		{
+			siteLink: siteUrl ? (
+				<a
+					href={ siteUrl }
+					onClick={ () => recordTracksEvent( 'calypso_invite_accept_form_header_site_link_click' ) }
+				/>
+			) : (
+				<span />
+			),
+		}
+	);
 
 	const description = createInterpolateElement(
 		translate(
@@ -34,12 +51,7 @@ function InviteFormHeaderLoggedOut( { site } ) {
 
 	return (
 		<div className="invite-form-header invite-form-header--logged-out">
-			<BrandHeader
-				title={ translate( 'Create an account for %(siteName)s', {
-					args: { siteName },
-				} ) }
-				description={ description }
-			/>
+			<BrandHeader title={ title } description={ description } />
 		</div>
 	);
 }

--- a/client/my-sites/invites/test/invite-form-header-logged-out.jsx
+++ b/client/my-sites/invites/test/invite-form-header-logged-out.jsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import InviteFormHeaderLoggedOut from '../invite-form-header-logged-out';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/i18n-utils', () => ( {
+	localizeUrl: ( url ) => url,
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate:
+		() =>
+		( text, options = {} ) => {
+			const args = options.args || {};
+			return Object.entries( args ).reduce(
+				( result, [ key, value ] ) => result.replace( `%(${ key })s`, value ),
+				text
+			);
+		},
+} ) );
+
+describe( 'InviteFormHeaderLoggedOut', () => {
+	it( 'renders a same-tab title link to the invited site', () => {
+		render(
+			<InviteFormHeaderLoggedOut
+				site={ {
+					title: 'Example Blog',
+					URL: 'https://example.blog',
+				} }
+			/>
+		);
+
+		const siteLink = screen.getByRole( 'link', { name: 'Example Blog' } );
+
+		expect( siteLink ).toHaveAttribute( 'href', 'https://example.blog' );
+		expect( siteLink ).not.toHaveAttribute( 'target' );
+	} );
+} );


### PR DESCRIPTION
Part of ARC-1486

## Proposed Changes

* Update logged-out invite acceptance to use connect-screen patterns by introducing a dedicated logged-out invite header component based on `BrandHeader`.
* Add optional `useConnectScreenActions` support to signup forms and use `ActionButtons` in the passwordless flow when enabled.
* Render the invited site name inside the logged-out BrandHeader title as a same-tab link to the site URL, with invite site-link click tracking.
* Keep logged-out invite header link presentation aligned with design by removing title-link text decoration while preserving blue link color.
* Wire the invite logged-out screen to opt into the new action buttons and add unit tests covering connect-screen action buttons and the logged-out invite title link.

## Why are these changes being made?

* The logged-out invite accept flow should align with the connect-screen UX and shared components, reducing visual and behavioral drift across onboarding and invite surfaces while preserving expected invite navigation behavior.

## Testing Instructions

*Manual Testing*
- Run this patch locally
- Invite a user to a store ( can user your own account with a suffix as in "example+store001@gmail.com" )
- From your Inbox, copy the link on the bottom of the invite e-mail, replace `wordpress.com` with `calypso.localhost:3000` 
- You should see the refactored UI with the unified components

<img width="3002" height="1668" alt="image" src="https://github.com/user-attachments/assets/6aa34b90-1d05-4a89-861c-12bd2afc115c" />

*Unit tests*

* Run: `yarn test-client client/blocks/signup-form/test/passwordless.jsx --runInBand`
* Run: `yarn test-client client/my-sites/invites/test/invite-form-header-logged-out.jsx --runInBand`
* Open an invite-accept-logged-out flow and verify:
  * Header uses the connect-screen style title/description with Terms and Privacy links.
  * Site name in the title links to the invited site in the same tab.
  * Site title link uses blue ink and no underline decoration.
  * Primary CTA renders with connect-screen action button styling.
  * Existing submit/loading/disabled states still behave correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?