### PR TITLE
MSD: use HStack with expanded={false} instead of width: auto

### DIFF
--- a/client/dashboard/README.md
+++ b/client/dashboard/README.md
@@ -33,7 +33,6 @@ This `docs` directory contains comprehensive design documentation for the `/clie
 
 ## Bugs
 
-- The need to pass `{ width: 'auto' }` to some HStack components to make them work like regular divs.
 - Importing SASS files bring unexpected CSS variables to our bundles (masterbar, sidebar), it also brings fonts (Recoleta, Noto) and some global classes. Why? Imports should ideally be explicit.
 
 ## Hacks

--- a/client/dashboard/components/environment/index.tsx
+++ b/client/dashboard/components/environment/index.tsx
@@ -11,7 +11,7 @@ interface EnvironmentProps {
 const Environment = ( { environmentType }: EnvironmentProps ) => {
 	if ( environmentType === 'staging' ) {
 		return (
-			<HStack justify="flex-start" spacing={ 1 } style={ { width: 'auto', flexShrink: 0 } }>
+			<HStack justify="flex-start" spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
 				<Icon icon={ staging } />
 				<span>{ __( 'Staging' ) }</span>
 			</HStack>
@@ -19,7 +19,7 @@ const Environment = ( { environmentType }: EnvironmentProps ) => {
 	}
 
 	return (
-		<HStack justify="flex-start" spacing={ 1 } style={ { width: 'auto', flexShrink: 0 } }>
+		<HStack justify="flex-start" spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
 			<Icon icon={ production } />
 			<span>{ __( 'Production' ) }</span>
 		</HStack>

--- a/client/dashboard/components/metadata-list/index.tsx
+++ b/client/dashboard/components/metadata-list/index.tsx
@@ -30,7 +30,8 @@ const MetadataItem = ( { children, title }: MetadataItemProps ) => {
 		<HStack
 			className="dashboard-metadata-list-item"
 			spacing={ 1 }
-			style={ { width: 'auto', flexShrink: 0 } }
+			expanded={ false }
+			style={ { flexShrink: 0 } }
 		>
 			{ title && <Text variant="muted">{ title }</Text> }
 			{ children && <div className="dashboard-metadata-list-item-children">{ children }</div> }

--- a/client/dashboard/sites/deployments-list/branch-display.tsx
+++ b/client/dashboard/sites/deployments-list/branch-display.tsx
@@ -8,7 +8,7 @@ interface BranchDisplayProps {
 
 export function BranchDisplay( { branchName, color = '#3b3b3b' }: BranchDisplayProps ) {
 	return (
-		<HStack spacing={ 1 } alignment="left" style={ { width: 'auto', color } }>
+		<HStack spacing={ 1 } alignment="left" expanded={ false } style={ { color } }>
 			<BranchIcon width={ 16 } height={ 16 } style={ { flexShrink: 0 } } />
 			<Text
 				as="code"

--- a/client/dashboard/sites/deployments-list/dataviews/fields.tsx
+++ b/client/dashboard/sites/deployments-list/dataviews/fields.tsx
@@ -91,7 +91,7 @@ export function useFields( {
 									</Text>
 								</ExternalLink>
 								<BranchDisplay branchName={ item.branch_name } />
-								<HStack spacing={ 1.5 } alignment="left" style={ { width: 'auto' } }>
+								<HStack spacing={ 1.5 } alignment="left" expanded={ false }>
 									<img
 										src={ author.avatar_url }
 										alt={ author.name }

--- a/client/dashboard/sites/deployments-list/deployment-logs/deployment-logs-modal-content.tsx
+++ b/client/dashboard/sites/deployments-list/deployment-logs/deployment-logs-modal-content.tsx
@@ -81,7 +81,7 @@ export function DeploymentLogsModalContent( {
 						<BranchDisplay branchName={ deployment.branch_name } />
 					</div>
 
-					<HStack spacing={ 1.5 } alignment="left" style={ { width: 'auto', flexShrink: 0 } }>
+					<HStack spacing={ 1.5 } alignment="left" expanded={ false } style={ { flexShrink: 0 } }>
 						<img
 							src={ author.avatar_url }
 							alt={ author.name }

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -367,7 +367,7 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 	};
 
 	return (
-		<HStack style={ { width: 'auto', flexShrink: 0 } }>
+		<HStack expanded={ false } style={ { flexShrink: 0 } }>
 			<Dropdown
 				renderToggle={ ( { isOpen, onToggle } ) => {
 					// TODO: Let's make sure to revise these conditions and simplify them once we have the design and the full understanding of how the


### PR DESCRIPTION
## Proposed Changes

Cleans up this "bug" mentioned in the dashboard README:

> - The need to pass `{ width: 'auto' }` to some HStack components to make them work like regular divs.

by passing `expanded={false}` to `<HStack/>` instead.

## Why are these changes being made?

Wanted to keep the doc up-to-date for better LLM consumption.

## Testing Instructions

Verify no regression in the following components:

- Production/Staging environment switcher
- Site -> Deployments table, and the modal when you click View logs
- Subtitle in the page header in Profile -> Billing -> Active Upgrades

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
