### PR TITLE
Help Center: Fix loading jankiness by coordinating content rendering

### DIFF
--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -1,15 +1,22 @@
 /* eslint-disable no-restricted-imports */
+import { useLocale } from '@automattic/i18n-utils';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import InlineHelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
 import { useFeatureConfig, useHelpCenterContext } from '../contexts/HelpCenterContext';
-import { useHelpCenterSearch } from '../hooks';
+import { useHelpCenterSearch, useGetHistoryChats } from '../hooks';
+import { useContextBasedSearchMapping } from '../hooks/use-context-based-search-mapping';
+import { useHelpSearchQuery } from '../hooks/use-help-search-query';
+import { HELP_CENTER_STORE } from '../stores';
 import { HelpCenterLaunchpad } from './help-center-launchpad';
 import { HelpCenterMoreResources } from './help-center-more-resources';
 import HelpCenterRecentConversations from './help-center-recent-conversations';
 import HelpCenterSearchResults from './help-center-search-results';
 import { BlockedZendeskNotice } from './notices';
+import PlaceholderLines from './placeholder-lines';
 import './help-center-search.scss';
 import './help-center-launchpad.scss';
+import type { HelpCenterSelect } from '@automattic/data-stores';
 
 type HelpCenterSearchProps = {
 	onSearchChange?: ( query: string ) => void;
@@ -24,6 +31,33 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 
 	const isSiteOwner = site?.site_owner === currentUser?.ID;
 	const launchpadEnabled = site?.options?.launchpad_screen === 'full' && isSiteOwner;
+
+	// Track loading states to coordinate rendering and avoid content popping in at different times.
+	const { isLoadingInteractions } = useGetHistoryChats();
+	const locale = useLocale();
+	const contextTerm = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getContextTerm(),
+		[]
+	);
+	const { contextSearch } = useContextBasedSearchMapping( currentRoute );
+	const { isLoading: isLoadingSearchResults } = useHelpSearchQuery(
+		searchQuery || contextTerm || contextSearch,
+		locale,
+		currentRoute,
+		source
+	);
+
+	const isInitialLoading =
+		! searchQuery &&
+		( isLoadingSearchResults || ( ! disableChatSupport && isLoadingInteractions ) );
+
+	if ( isInitialLoading ) {
+		return (
+			<div className="inline-help__search">
+				<PlaceholderLines lines={ 4 } />
+			</div>
+		);
+	}
 
 	return (
 		<div className="inline-help__search">

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -24,7 +24,7 @@ type HelpCenterSearchProps = {
 };
 
 export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSearchProps ) => {
-	const { sectionName, site, currentUser } = useHelpCenterContext();
+	const { sectionName, site, currentUser, product } = useHelpCenterContext();
 	const featureConfig = useFeatureConfig();
 	const { searchQuery, setSearchQueryAndEmailSubject, redirectToArticle } =
 		useHelpCenterSearch( onSearchChange );
@@ -44,12 +44,12 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 		searchQuery || contextTerm || contextSearch,
 		locale,
 		currentRoute,
-		source
+		product
 	);
 
 	const isInitialLoading =
 		! searchQuery &&
-		( isLoadingSearchResults || ( ! disableChatSupport && isLoadingInteractions ) );
+		( isLoadingSearchResults || ( featureConfig.chat.enabled && isLoadingInteractions ) );
 
 	if ( isInitialLoading ) {
 		return (

--- a/packages/help-center/src/components/placeholder-lines.scss
+++ b/packages/help-center/src/components/placeholder-lines.scss
@@ -10,20 +10,27 @@
 	border-radius: 16px;
 	background-color: var( --color-neutral-0 );
 	color: transparent;
-	animation: placeholder-lines__help-center-loading 2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 )
-		infinite;
-	animation-delay: 0s;
+	animation: placeholder-lines__help-center-loading 1.5s ease-in-out infinite;
+	width: 80%;
 
 	&:nth-child( 1 ) {
-		animation-delay: -1.3s;
+		width: 85%;
+		animation-delay: -0.3s;
 	}
 
 	&:nth-child( 2 ) {
-		animation-delay: -2.5s;
+		width: 65%;
+		animation-delay: -0.6s;
 	}
 
 	&:nth-child( 3 ) {
-		animation-delay: -3.8s;
+		width: 75%;
+		animation-delay: -0.9s;
+	}
+
+	&:nth-child( 4 ) {
+		width: 55%;
+		animation-delay: -1.2s;
 	}
 
 	&::after {
@@ -32,24 +39,11 @@
 }
 
 @keyframes placeholder-lines__help-center-loading {
-	0% {
-		opacity: 0.3;
-		width: 65%;
-	}
-	25% {
-		opacity: 0.6;
-		width: 90%;
-	}
-	50% {
-		opacity: 0.5;
-		width: 18%;
-	}
-	75% {
-		opacity: 0.8;
-		width: 75%;
-	}
+	0%,
 	100% {
 		opacity: 0.3;
-		width: 65%;
+	}
+	50% {
+		opacity: 0.7;
 	}
 }

--- a/packages/help-center/src/hooks/use-get-history-chats.ts
+++ b/packages/help-center/src/hooks/use-get-history-chats.ts
@@ -149,10 +149,12 @@ export const useGetHistoryChats = (): UseGetHistoryChatsResult => {
 		loggedOutSession ? loggedOutSession.botSlug : undefined
 	);
 
+	const chatEnabled = featureConfig.chat.enabled;
+
 	const { data: otherSupportInteractions, isLoading: isLoadingOtherSupportInteractions } =
-		useGetSupportInteractions( 'zendesk' );
+		useGetSupportInteractions( 'zendesk', chatEnabled );
 	const { data: odieSupportInteractions, isLoading: isLoadingOdieSupportInteractions } =
-		useGetSupportInteractions( 'odie' );
+		useGetSupportInteractions( 'odie', chatEnabled );
 
 	// When filtering by bot slug is enabled (e.g. CIAB context), only show
 	// conversations matching the current bot slug.
@@ -175,7 +177,7 @@ export const useGetHistoryChats = (): UseGetHistoryChatsResult => {
 	}, [ featureConfig.chat.filterByBotSlug, newInteractionsBotSlug, otherSupportInteractions ] );
 
 	const { data: odieConversations, isLoading: isLoadingOdieConversations } =
-		useGetOdieConversations( filteredOdieSupportInteractions );
+		useGetOdieConversations( filteredOdieSupportInteractions, chatEnabled );
 
 	const isLoadingInteractions =
 		isLoadingOtherSupportInteractions ||
@@ -191,7 +193,7 @@ export const useGetHistoryChats = (): UseGetHistoryChatsResult => {
 	);
 
 	useEffect( () => {
-		if ( isLoadingInteractions ) {
+		if ( ! chatEnabled || isLoadingInteractions ) {
 			return;
 		}
 
@@ -221,6 +223,7 @@ export const useGetHistoryChats = (): UseGetHistoryChatsResult => {
 		setRecentConversations( recent );
 		setArchivedConversations( archived );
 	}, [
+		chatEnabled,
 		isChatLoaded,
 		isLoadingInteractions,
 		loggedOutSession,


### PR DESCRIPTION
Fixes WOOPRD-2109

## Proposed Changes

* Coordinate loading states in `HelpCenterSearch` so all content appears at once instead of different sections popping in at different times.
* Replace the bouncy placeholder animation with a calm opacity pulse and fixed widths.

## Why are these changes being made?

When the Help Center opens, different parts of the interface (search results, recent conversations, "More resources") load at different times. The search input and "More resources" appear immediately while articles are still loading as placeholder lines, and recent conversations may pop in even later. This creates a janky, disjointed experience.

<img width="531" height="732" alt="image" src="https://github.com/user-attachments/assets/2e1a2760-4e8a-4189-872b-503478b21053" />


This fix tracks the loading states of both search results (`useHelpSearchQuery`) and conversation history (`useGetHistoryChats`) at the `HelpCenterSearch` parent level. While either is still loading on initial open, only placeholder lines are shown. Once all data is ready, the full UI renders at once — preserving the original layout order.

The placeholder animation is also calmed down: the bouncy `cubic-bezier(0.175, 0.885, 0.32, 1.275)` with oscillating widths (18%–90%) is replaced with a gentle `ease-in-out` opacity pulse and fixed widths per line.

## Testing Instructions

* Open the Help Center on any page, best if throttling down to something slow.
* On initial open, you should see only placeholder lines — no search input, no "More resources" visible yet.
* Once data loads, all content (recent conversations if any, search input, recommended guides, more resources) should appear together.
* Close and reopen the Help Center — cached data should render instantly with no placeholder flash.
* Type a search query — search results should load with their own inline placeholder as before (coordinated loading only applies to the initial open without a search query).
