### PR TITLE
A4A-2153: split Pressable add-on visibility by marketplace mode

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/lib/has-active-referral-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/lib/has-active-referral-pressable-plan.ts
@@ -1,0 +1,34 @@
+import { isPressableAddonProduct, isPressableHostingProduct } from '../../lib/hosting';
+import type { Referral, ReferralPurchase } from 'calypso/a8c-for-agencies/sections/referrals/types';
+
+function hasActiveReferralPressablePlan( purchase: ReferralPurchase ) {
+	const licenseKey = purchase.license?.license_key;
+
+	return (
+		purchase.status === 'active' &&
+		!! licenseKey &&
+		! purchase.license?.revoked_at &&
+		isPressableHostingProduct( licenseKey ) &&
+		! isPressableAddonProduct( licenseKey )
+	);
+}
+
+export default function hasActiveReferralPressablePlanForClient(
+	referrals: Referral[] | undefined,
+	clientEmail: string
+) {
+	if ( ! referrals?.length || ! clientEmail.trim() ) {
+		return false;
+	}
+
+	const normalizedEmail = clientEmail.trim().toLowerCase();
+	const clientReferral = referrals.find(
+		( referral ) => referral.client?.email?.trim().toLowerCase() === normalizedEmail
+	);
+
+	if ( ! clientReferral ) {
+		return false;
+	}
+
+	return clientReferral.purchases.some( hasActiveReferralPressablePlan );
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/lib/test/has-active-referral-pressable-plan.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/lib/test/has-active-referral-pressable-plan.test.ts
@@ -1,0 +1,116 @@
+import hasActiveReferralPressablePlanForClient from '../has-active-referral-pressable-plan';
+import type { Referral } from 'calypso/a8c-for-agencies/sections/referrals/types';
+
+const createReferral = ( {
+	email,
+	purchases,
+}: {
+	email: string;
+	purchases: Referral[ 'purchases' ];
+} ): Referral =>
+	( {
+		id: 1,
+		client: {
+			id: 1,
+			email,
+		},
+		purchases,
+		purchaseStatuses: purchases.map( ( purchase ) => purchase.status ),
+		referralStatuses: [ 'active' ],
+		referrals: [],
+	} ) as Referral;
+
+const createPurchase = ( {
+	licenseKey,
+	status = 'active',
+	revokedAt = null,
+}: {
+	licenseKey: string;
+	status?: string;
+	revokedAt?: string | null;
+} ) =>
+	( {
+		referral_id: 1,
+		status,
+		product_id: 100,
+		quantity: 1,
+		license: {
+			license_key: licenseKey,
+			issued_at: '2026-01-01T00:00:00Z',
+			attached_at: null,
+			revoked_at: revokedAt,
+		},
+		site_assigned: '',
+	} ) as Referral[ 'purchases' ][ number ];
+
+describe( 'hasActiveReferralPressablePlanForClient', () => {
+	it( 'returns true when client has an active referral Pressable plan', () => {
+		const referrals = [
+			createReferral( {
+				email: 'client@example.com',
+				purchases: [ createPurchase( { licenseKey: 'pressable-business' } ) ],
+			} ),
+		];
+
+		expect( hasActiveReferralPressablePlanForClient( referrals, 'client@example.com' ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'returns false when client only has Pressable add-ons', () => {
+		const referrals = [
+			createReferral( {
+				email: 'client@example.com',
+				purchases: [ createPurchase( { licenseKey: 'pressable-addon-sites-1' } ) ],
+			} ),
+		];
+
+		expect( hasActiveReferralPressablePlanForClient( referrals, 'client@example.com' ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'returns false when client has a non-active Pressable plan', () => {
+		const referrals = [
+			createReferral( {
+				email: 'client@example.com',
+				purchases: [ createPurchase( { licenseKey: 'pressable-business', status: 'pending' } ) ],
+			} ),
+		];
+
+		expect( hasActiveReferralPressablePlanForClient( referrals, 'client@example.com' ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'returns false when matching Pressable plan license is revoked', () => {
+		const referrals = [
+			createReferral( {
+				email: 'client@example.com',
+				purchases: [
+					createPurchase( {
+						licenseKey: 'pressable-premium',
+						revokedAt: '2026-01-01T00:00:00Z',
+					} ),
+				],
+			} ),
+		];
+
+		expect( hasActiveReferralPressablePlanForClient( referrals, 'client@example.com' ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'matches emails case-insensitively', () => {
+		const referrals = [
+			createReferral( {
+				email: 'Client@Example.com',
+				purchases: [ createPurchase( { licenseKey: 'pressable-premium' } ) ],
+			} ),
+		];
+
+		expect( hasActiveReferralPressablePlanForClient( referrals, 'client@example.com' ) ).toBe(
+			true
+		);
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -25,6 +25,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
+import useFetchReferrals from '../../referrals/hooks/use-fetch-referrals';
 import withMarketplaceProviders from '../hoc/with-marketplace-providers';
 import {
 	MARKETPLACE_TYPE_SESSION_STORAGE_KEY,
@@ -32,6 +33,8 @@ import {
 } from '../hoc/with-marketplace-type';
 import useRequestClientPaymentMutation from '../hooks/use-request-client-payment-mutation';
 import useShoppingCart from '../hooks/use-shopping-cart';
+import { isPressableAddonProduct } from '../lib/hosting';
+import hasActiveReferralPressablePlanForClient from './lib/has-active-referral-pressable-plan';
 import NoticeSummary from './notice-summary';
 import type { ShoppingCartItem, TermPricingType } from '../types';
 interface Props {
@@ -73,8 +76,13 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	}, [] );
 
 	const { mutate: requestPayment, isPending } = useRequestClientPaymentMutation();
+	const { data: referrals, refetch: refetchReferrals } = useFetchReferrals();
 
 	const hasCompletedForm = !! email && !! message;
+	const hasPressableAddonsInCheckout = useMemo(
+		() => checkoutItems.some( ( item ) => isPressableAddonProduct( item.slug ) ),
+		[ checkoutItems ]
+	);
 
 	const productIds = checkoutItems.map( ( item ) => item.product_id ).join( ',' );
 
@@ -92,7 +100,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const { isFeedbackShown } = useShowFeedback( FeedbackType.ReferralCompleted );
 
 	const handleRequestPayment = useCallback(
-		( flowType: ReferralOrderFlowType ) => {
+		async ( flowType: ReferralOrderFlowType ) => {
 			if ( flowType === 'send' && ! hasCompletedForm ) {
 				return;
 			}
@@ -105,6 +113,41 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 				setValidationError( { email: translate( 'Please provide correct email address' ) } );
 				return;
 			}
+
+			if ( hasPressableAddonsInCheckout ) {
+				let referralsData = referrals;
+
+				if ( ! referralsData ) {
+					try {
+						const { data } = await refetchReferrals();
+						referralsData = data;
+					} catch {
+						dispatch(
+							errorNotice(
+								translate(
+									'We were unable to validate whether this client has an active Pressable plan. Please try again.'
+								)
+							)
+						);
+						return;
+					}
+				}
+
+				const hasClientActiveReferralPressablePlan = hasActiveReferralPressablePlanForClient(
+					referralsData,
+					email
+				);
+
+				if ( ! hasClientActiveReferralPressablePlan ) {
+					setValidationError( {
+						email: translate(
+							'This client does not have an active Pressable plan. An active Pressable plan is required to refer Pressable add-ons.'
+						),
+					} );
+					return;
+				}
+			}
+
 			dispatch(
 				recordTracksEvent(
 					flowType === 'send'
@@ -176,12 +219,16 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 			dispatch,
 			email,
 			hasCompletedForm,
+			hasPressableAddonsInCheckout,
 			isFeedbackShown,
 			licenses,
 			message,
 			onClearCart,
 			productIds,
+			referrals,
+			refetchReferrals,
 			requestPayment,
+			termPricing,
 			translate,
 		]
 	);

--- a/client/a8c-for-agencies/sections/marketplace/hooks/test/use-pressable-addon-visibility.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/test/use-pressable-addon-visibility.test.ts
@@ -1,0 +1,94 @@
+import { getPressableAddonLicenseVisibility } from '../use-pressable-addon-visibility';
+import type { License } from 'calypso/state/partner-portal/types';
+
+const buildLicense = ( {
+	licenseKey,
+	referral = null,
+}: {
+	licenseKey: string;
+	referral?: License[ 'referral' ];
+} ): License =>
+	( {
+		licenseId: 1,
+		licenseKey,
+		productId: 1,
+		product: licenseKey,
+		userId: null,
+		username: null,
+		blogId: null,
+		siteUrl: null,
+		hasDownloads: false,
+		issuedAt: '2026-01-01T00:00:00Z',
+		attachedAt: null,
+		revokedAt: null,
+		ownerType: null,
+		quantity: 1,
+		parentLicenseId: null,
+		meta: {},
+		referral,
+	} ) as License;
+
+describe( 'getPressableAddonLicenseVisibility', () => {
+	it( 'returns no visibility for empty input', () => {
+		expect( getPressableAddonLicenseVisibility( [] ) ).toEqual( {
+			hasActiveAgencyPressablePlanLicense: false,
+			hasActiveReferralPressablePlanLicense: false,
+		} );
+	} );
+
+	it( 'OFF mode case: only referral pressable plan license does not grant agency visibility', () => {
+		const visibility = getPressableAddonLicenseVisibility( [
+			buildLicense( {
+				licenseKey: 'pressable-premium',
+				referral: { id: 10 } as License[ 'referral' ],
+			} ),
+		] );
+
+		expect( visibility ).toEqual( {
+			hasActiveAgencyPressablePlanLicense: false,
+			hasActiveReferralPressablePlanLicense: true,
+		} );
+	} );
+
+	it( 'ON mode case: only non-referral pressable plan license does not grant referral visibility', () => {
+		const visibility = getPressableAddonLicenseVisibility( [
+			buildLicense( { licenseKey: 'pressable-premium' } ),
+		] );
+
+		expect( visibility ).toEqual( {
+			hasActiveAgencyPressablePlanLicense: true,
+			hasActiveReferralPressablePlanLicense: false,
+		} );
+	} );
+
+	it( 'marks both visibilities when both license types exist', () => {
+		const visibility = getPressableAddonLicenseVisibility( [
+			buildLicense( { licenseKey: 'pressable-premium' } ),
+			buildLicense( {
+				licenseKey: 'pressable-signature-3',
+				referral: { id: 20 } as License[ 'referral' ],
+			} ),
+		] );
+
+		expect( visibility ).toEqual( {
+			hasActiveAgencyPressablePlanLicense: true,
+			hasActiveReferralPressablePlanLicense: true,
+		} );
+	} );
+
+	it( 'ignores pressable add-ons and non-pressable products', () => {
+		const visibility = getPressableAddonLicenseVisibility( [
+			buildLicense( { licenseKey: 'pressable-addon-sites-1' } ),
+			buildLicense( {
+				licenseKey: 'pressable-addon-storage-1gb',
+				referral: { id: 11 } as License[ 'referral' ],
+			} ),
+			buildLicense( { licenseKey: 'jetpack-complete' } ),
+		] );
+
+		expect( visibility ).toEqual( {
+			hasActiveAgencyPressablePlanLicense: false,
+			hasActiveReferralPressablePlanLicense: false,
+		} );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-pressable-addon-visibility.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-pressable-addon-visibility.ts
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+import useFetchLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { isPressableAddonProduct, isPressableHostingProduct } from '../lib/hosting';
+import type { License } from 'calypso/state/partner-portal/types';
+
+type PressableAddonLicenseVisibility = {
+	hasActiveAgencyPressablePlanLicense: boolean;
+	hasActiveReferralPressablePlanLicense: boolean;
+};
+
+export const DEFAULT_PRESSABLE_ADDON_VISIBILITY: PressableAddonLicenseVisibility = {
+	hasActiveAgencyPressablePlanLicense: false,
+	hasActiveReferralPressablePlanLicense: false,
+};
+
+export function getPressableAddonLicenseVisibility(
+	licenses: License[] | undefined
+): PressableAddonLicenseVisibility {
+	if ( ! licenses?.length ) {
+		return DEFAULT_PRESSABLE_ADDON_VISIBILITY;
+	}
+
+	return licenses.reduce< PressableAddonLicenseVisibility >(
+		( visibility, license ) => {
+			const isPressablePlan =
+				isPressableHostingProduct( license.licenseKey ) &&
+				! isPressableAddonProduct( license.licenseKey );
+
+			if ( ! isPressablePlan ) {
+				return visibility;
+			}
+
+			if ( license.referral ) {
+				visibility.hasActiveReferralPressablePlanLicense = true;
+			} else {
+				visibility.hasActiveAgencyPressablePlanLicense = true;
+			}
+
+			return visibility;
+		},
+		{ ...DEFAULT_PRESSABLE_ADDON_VISIBILITY }
+	);
+}
+
+export default function usePressableAddonVisibility() {
+	const { data } = useFetchLicenses(
+		LicenseFilter.NotRevoked,
+		'pressable',
+		LicenseSortField.IssuedAt,
+		LicenseSortDirection.Descending,
+		1,
+		100
+	);
+
+	return useMemo( () => getPressableAddonLicenseVisibility( data?.items ), [ data?.items ] );
+}

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -32,9 +32,6 @@ type Props = {
 	productSearchQuery?: string;
 	usePublicQuery?: boolean;
 	selectedProductFilters?: SelectedFilters;
-	isReferralMode?: boolean;
-	hasActiveAgencyPressablePlanLicense?: boolean;
-	hasActiveReferralPressablePlanLicense?: boolean;
 };
 
 // This function gets the displayable Plans based on how it should be arranged in the listing.
@@ -116,9 +113,6 @@ export default function useProductAndPlans( {
 	selectedSite,
 	selectedProductFilters,
 	productSearchQuery,
-	isReferralMode,
-	hasActiveAgencyPressablePlanLicense,
-	hasActiveReferralPressablePlanLicense,
 }: Props ) {
 	const { data, isLoading: isLoadingProducts } = useProductsQuery();
 	const isPressableAddonsEnabled = isEnabled( 'a4a-pressable-addons' );
@@ -146,20 +140,8 @@ export default function useProductAndPlans( {
 			);
 		}
 
-		const hasVisibilityState =
-			typeof isReferralMode === 'boolean' &&
-			typeof hasActiveAgencyPressablePlanLicense === 'boolean' &&
-			typeof hasActiveReferralPressablePlanLicense === 'boolean';
-
 		// Hide Pressable add-ons behind feature flag across marketplace products UI.
-		// When mode visibility state is provided, enforce strict mode-specific license checks.
-		if (
-			! isPressableAddonsEnabled ||
-			( hasVisibilityState &&
-				( isReferralMode
-					? ! hasActiveReferralPressablePlanLicense
-					: ! hasActiveAgencyPressablePlanLicense ) )
-		) {
+		if ( ! isPressableAddonsEnabled ) {
 			const pressableAddonProductIds = new Set(
 				filterProductsAndPlansByType(
 					PRODUCT_TYPE_PRESSABLE_ADDON,
@@ -220,8 +202,5 @@ export default function useProductAndPlans( {
 		addedPlanAndProducts,
 		isLoadingProducts,
 		isPressableAddonsEnabled,
-		isReferralMode,
-		hasActiveAgencyPressablePlanLicense,
-		hasActiveReferralPressablePlanLicense,
 	] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -32,6 +32,9 @@ type Props = {
 	productSearchQuery?: string;
 	usePublicQuery?: boolean;
 	selectedProductFilters?: SelectedFilters;
+	isReferralMode?: boolean;
+	hasActiveAgencyPressablePlanLicense?: boolean;
+	hasActiveReferralPressablePlanLicense?: boolean;
 };
 
 // This function gets the displayable Plans based on how it should be arranged in the listing.
@@ -113,6 +116,9 @@ export default function useProductAndPlans( {
 	selectedSite,
 	selectedProductFilters,
 	productSearchQuery,
+	isReferralMode,
+	hasActiveAgencyPressablePlanLicense,
+	hasActiveReferralPressablePlanLicense,
 }: Props ) {
 	const { data, isLoading: isLoadingProducts } = useProductsQuery();
 	const isPressableAddonsEnabled = isEnabled( 'a4a-pressable-addons' );
@@ -140,8 +146,20 @@ export default function useProductAndPlans( {
 			);
 		}
 
+		const hasVisibilityState =
+			typeof isReferralMode === 'boolean' &&
+			typeof hasActiveAgencyPressablePlanLicense === 'boolean' &&
+			typeof hasActiveReferralPressablePlanLicense === 'boolean';
+
 		// Hide Pressable add-ons behind feature flag across marketplace products UI.
-		if ( ! isPressableAddonsEnabled ) {
+		// When mode visibility state is provided, enforce strict mode-specific license checks.
+		if (
+			! isPressableAddonsEnabled ||
+			( hasVisibilityState &&
+				( isReferralMode
+					? ! hasActiveReferralPressablePlanLicense
+					: ! hasActiveAgencyPressablePlanLicense ) )
+		) {
 			const pressableAddonProductIds = new Set(
 				filterProductsAndPlansByType(
 					PRODUCT_TYPE_PRESSABLE_ADDON,
@@ -202,5 +220,8 @@ export default function useProductAndPlans( {
 		addedPlanAndProducts,
 		isLoadingProducts,
 		isPressableAddonsEnabled,
+		isReferralMode,
+		hasActiveAgencyPressablePlanLicense,
+		hasActiveReferralPressablePlanLicense,
 	] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-product-and-plans-with-pressable-visibility.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-product-and-plans-with-pressable-visibility.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import useProductAndPlans from '../../hooks/use-product-and-plans';
+
+type Args = Parameters< typeof useProductAndPlans >[ 0 ];
+
+export default function useProductAndPlansWithPressableVisibility(
+	args: Args,
+	canShowPressableAddons: boolean
+) {
+	const products = useProductAndPlans( args );
+
+	return useMemo( () => {
+		if ( canShowPressableAddons || ! products.pressableAddons.length ) {
+			return products;
+		}
+
+		const pressableAddonProductIds = new Set(
+			products.pressableAddons.map( ( product ) => product.product_id )
+		);
+
+		return {
+			...products,
+			filteredProductsAndBundles: products.filteredProductsAndBundles.filter(
+				( product ) => ! pressableAddonProductIds.has( product.product_id )
+			),
+			pressableAddons: [],
+		};
+	}, [ canShowPressableAddons, products ] );
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.tsx
@@ -13,6 +13,7 @@ import {
 	next,
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo-color.svg';
 import WooLogoColor from 'calypso/assets/images/icons/Woo_logo_color.svg';
@@ -44,15 +45,24 @@ import {
 	PRODUCT_TYPE_PRODUCT,
 	PRODUCT_VENDOR_WOOCOMMERCE,
 } from '../../../constants';
+import { MarketplaceTypeContext } from '../../../context';
+import usePressableAddonVisibility from '../../../hooks/use-pressable-addon-visibility';
 import { isPressableAddonProduct } from '../../../lib/hosting';
 
 export default function useProductFilterOptions() {
 	const translate = useTranslate();
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const isPressableAddonsEnabled = isEnabled( 'a4a-pressable-addons' );
 	const { data: productsAndPlans = [] } = useProductsQuery();
+	const { hasActiveAgencyPressablePlanLicense, hasActiveReferralPressablePlanLicense } =
+		usePressableAddonVisibility();
 	const hasPressableAddonsAvailable = productsAndPlans.some( ( { family_slug } ) =>
 		isPressableAddonProduct( family_slug )
 	);
+	const canShowPressableAddonsByMode =
+		marketplaceType === 'referral'
+			? hasActiveReferralPressablePlanLicense
+			: hasActiveAgencyPressablePlanLicense;
 
 	return {
 		[ PRODUCT_FILTER_KEY_CATEGORIES ]: [
@@ -66,7 +76,7 @@ export default function useProductFilterOptions() {
 				label: translate( 'WooCommerce' ) as string,
 				image: <img width={ 80 } src={ WooLogoColor } alt="WooCommerce" />,
 			},
-			...( isPressableAddonsEnabled && hasPressableAddonsAvailable
+			...( isPressableAddonsEnabled && hasPressableAddonsAvailable && canShowPressableAddonsByMode
 				? [
 						{
 							key: PRODUCT_CATEGORY_PRESSABLE_ADDON,

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -14,6 +14,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { MarketplaceTypeContext, ShoppingCartContext } from '../../context';
 import { useProductTermAvailabilityTooltip } from '../../hooks/use-marketplace';
+import usePressableAddonVisibility from '../../hooks/use-pressable-addon-visibility';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
 import { SelectedFilters } from '../../lib/product-filter';
 import { getSupportedBundleSizes } from '../hooks/use-product-bundle-size';
@@ -61,6 +62,8 @@ export default function ProductListing( {
 		() => ( isReferralMode ? 1 : selectedBundleSize ),
 		[ isReferralMode, selectedBundleSize ]
 	);
+	const { hasActiveAgencyPressablePlanLicense, hasActiveReferralPressablePlanLicense } =
+		usePressableAddonVisibility();
 
 	const {
 		filteredProductsAndBundles,
@@ -77,6 +80,9 @@ export default function ProductListing( {
 		selectedSite,
 		selectedProductFilters: selectedFilters,
 		productSearchQuery,
+		isReferralMode,
+		hasActiveAgencyPressablePlanLicense,
+		hasActiveReferralPressablePlanLicense,
 	} );
 
 	const isEmptyList = ! filteredProductsAndBundles.length;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -15,8 +15,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { MarketplaceTypeContext, ShoppingCartContext } from '../../context';
 import { useProductTermAvailabilityTooltip } from '../../hooks/use-marketplace';
 import usePressableAddonVisibility from '../../hooks/use-pressable-addon-visibility';
-import useProductAndPlans from '../../hooks/use-product-and-plans';
 import { SelectedFilters } from '../../lib/product-filter';
+import useProductAndPlansWithPressableVisibility from '../hooks/use-product-and-plans-with-pressable-visibility';
 import { getSupportedBundleSizes } from '../hooks/use-product-bundle-size';
 import useSubmitForm from '../hooks/use-submit-form';
 import ProductCard from '../product-card';
@@ -64,6 +64,9 @@ export default function ProductListing( {
 	);
 	const { hasActiveAgencyPressablePlanLicense, hasActiveReferralPressablePlanLicense } =
 		usePressableAddonVisibility();
+	const canShowPressableAddonsByMode = isReferralMode
+		? hasActiveReferralPressablePlanLicense
+		: hasActiveAgencyPressablePlanLicense;
 
 	const {
 		filteredProductsAndBundles,
@@ -76,14 +79,14 @@ export default function ProductListing( {
 		featuredProducts,
 		data,
 		suggestedProductSlugs,
-	} = useProductAndPlans( {
-		selectedSite,
-		selectedProductFilters: selectedFilters,
-		productSearchQuery,
-		isReferralMode,
-		hasActiveAgencyPressablePlanLicense,
-		hasActiveReferralPressablePlanLicense,
-	} );
+	} = useProductAndPlansWithPressableVisibility(
+		{
+			selectedSite,
+			selectedProductFilters: selectedFilters,
+			productSearchQuery,
+		},
+		canShowPressableAddonsByMode
+	);
 
 	const isEmptyList = ! filteredProductsAndBundles.length;
 


### PR DESCRIPTION
Part of A4A-2153

## Proposed Changes

<img width="1527" height="287" alt="image" src="https://github.com/user-attachments/assets/530b0eb8-3ac4-4628-9190-0c8478d4bf2f" />


* Add a shared Pressable add-on visibility helper hook that derives two booleans from non-revoked Pressable plan licenses:
  * `hasActiveAgencyPressablePlanLicense` (non-referral)
  * `hasActiveReferralPressablePlanLicense` (referral)
* Enforce strict mode + license-type split in Marketplace Products visibility:
  * Regular mode (`referral` switcher OFF): show Pressable add-ons only for active non-referral Pressable plan licenses.
  * Referral mode (`referral` switcher ON): show Pressable add-ons only for active referral Pressable plan licenses.
* Apply visibility gating consistently in:
  * product listing/sections (`use-product-and-plans`)
  * Pressable category chip in filter options (`use-product-filter-options`)
* Add targeted unit tests for the mode/license matrix and exclusions.

**Check if the client has an active Pressable plan**

<img width="483" height="147" alt="image" src="https://github.com/user-attachments/assets/3b7b605b-9e14-4bda-8c31-a3b04d40e310" />


## Why are these changes being made?

Referral Pressable licenses were unlocking Pressable add-ons in both modes. The expected behavior is mode-specific visibility by license type, so the Products UI and category chip must enforce a strict split.

## Testing Instructions

1. Run targeted tests:

```
yarn run test-client client/a8c-for-agencies/sections/marketplace/hooks/test/use-pressable-addon-visibility.test.ts --runInBand
```

2. Regular mode (`referral` OFF):
* Agency with only referral Pressable plan license: Pressable add-ons hidden.
* Agency with active non-referral Pressable plan license: Pressable add-ons visible.

3. Referral mode (`referral` ON):
* Agency with only referral Pressable plan license: Pressable add-ons visible.
* Agency with only non-referral Pressable plan license: Pressable add-ons hidden.

4. Feature flag extra-check:
* With `a4a-pressable-addons` disabled, Pressable add-ons are hidden regardless of mode/license.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
