### PR TITLE
Help Center: Add AI agent specs (AGENTS.md / CLAUDE.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,12 @@
 
 ## Packages
 
-- **Help Center** (`packages/help-center`) — shared component library for WordPress.com support. Also deployed via `apps/help-center/` to `widgets.wp.com`. See `packages/help-center/AGENTS.md`.
+- **Help Center** (`packages/help-center`) — shared component library for WordPress.com support. Also deployed via `apps/help-center/` to `widgets.wp.com`.
 - **Image Studio** (`packages/image-studio`) — AI-powered image editing and generation
 
 ## Apps
 
-- **Help Center** (`apps/help-center`) — build/deploy layer that bundles `packages/help-center` into webpack entry points served from `widgets.wp.com`. See `apps/help-center/AGENTS.md`.
+- **Help Center** (`apps/help-center`) — build/deploy layer that bundles `packages/help-center` into webpack entry points served from `widgets.wp.com`.
 
 ## Development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 
 ## Packages
 
+- **Help Center** (`packages/help-center`) — shared component library for WordPress.com support. Also deployed via `apps/help-center/` to `widgets.wp.com`. See `packages/help-center/AGENTS.md`.
 - **Image Studio** (`packages/image-studio`) — AI-powered image editing and generation
 
 ## Development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@
 - **Help Center** (`packages/help-center`) — shared component library for WordPress.com support. Also deployed via `apps/help-center/` to `widgets.wp.com`. See `packages/help-center/AGENTS.md`.
 - **Image Studio** (`packages/image-studio`) — AI-powered image editing and generation
 
+## Apps
+
+- **Help Center** (`apps/help-center`) — build/deploy layer that bundles `packages/help-center` into webpack entry points served from `widgets.wp.com`. See `apps/help-center/AGENTS.md`.
+
 ## Development
 
 ```bash

--- a/apps/help-center/AGENTS.md
+++ b/apps/help-center/AGENTS.md
@@ -8,16 +8,16 @@ This app takes `@automattic/help-center` and bundles it into 8 separate webpack 
 
 ## Entry Points
 
-| Entry point | Context |
-|---|---|
-| `help-center-gutenberg.js` | Gutenberg editor (connected) |
-| `help-center-gutenberg-disconnected.js` | Gutenberg editor (disconnected from Jetpack) |
-| `help-center-wp-admin.js` | wp-admin bar (connected) |
-| `help-center-wp-admin-disconnected.js` | wp-admin bar (disconnected from Jetpack) |
-| `help-center-ciab-admin.js` | CIAB admin (connected) |
-| `help-center-ciab-admin-disconnected.js` | CIAB admin (disconnected) |
-| `help-center-customizer.js` | Customizer |
-| `help-center-logged-out.js` | Logged-out view |
+| Entry point                              | Context                                      |
+| ---------------------------------------- | -------------------------------------------- |
+| `help-center-gutenberg.js`               | Gutenberg editor (connected)                 |
+| `help-center-gutenberg-disconnected.js`  | Gutenberg editor (disconnected from Jetpack) |
+| `help-center-wp-admin.js`                | wp-admin bar (connected)                     |
+| `help-center-wp-admin-disconnected.js`   | wp-admin bar (disconnected from Jetpack)     |
+| `help-center-ciab-admin.js`              | CIAB admin (connected)                       |
+| `help-center-ciab-admin-disconnected.js` | CIAB admin (disconnected)                    |
+| `help-center-customizer.js`              | Customizer                                   |
+| `help-center-logged-out.js`              | Logged-out view                              |
 
 Each entry point is a standalone JS file in the app root (e.g., `help-center-gutenberg.js`) that imports from `@automattic/help-center` and wires up the environment-specific bootstrap logic.
 

--- a/apps/help-center/AGENTS.md
+++ b/apps/help-center/AGENTS.md
@@ -1,0 +1,66 @@
+# Help Center App
+
+Build and deployment layer for the Help Center on Simple and Atomic sites. Most Help Center code lives in `packages/help-center/` — see `packages/help-center/AGENTS.md` for the primary spec.
+
+## Overview
+
+This app takes `@automattic/help-center` and bundles it into 8 separate webpack entry points deployed to `widgets.wp.com/help-center/`. Jetpack enqueues these bundles on various types of websites and pages (editor, wp-admin, logged out pages (/support and /forums), CIAB)
+
+## Entry Points
+
+| Entry point | Context |
+|---|---|
+| `help-center-gutenberg.js` | Gutenberg editor (connected) |
+| `help-center-gutenberg-disconnected.js` | Gutenberg editor (disconnected from Jetpack) |
+| `help-center-wp-admin.js` | wp-admin bar (connected) |
+| `help-center-wp-admin-disconnected.js` | wp-admin bar (disconnected from Jetpack) |
+| `help-center-ciab-admin.js` | CIAB admin (connected) |
+| `help-center-ciab-admin-disconnected.js` | CIAB admin (disconnected) |
+| `help-center-customizer.js` | Customizer |
+| `help-center-logged-out.js` | Logged-out view |
+
+Each entry point is a standalone JS file in the app root (e.g., `help-center-gutenberg.js`) that imports from `@automattic/help-center` and wires up the environment-specific bootstrap logic.
+
+## Build & Sync Commands
+
+```bash
+# Dev build + sync to sandbox (use during development)
+cd apps/help-center
+yarn dev --sync
+
+# Production build + sync (use before deploying)
+cd apps/help-center
+yarn build --sync
+```
+
+Both commands use `calypso-apps-builder` to compile webpack bundles and sync them to `widgets.wp.com/help-center/` on your sandbox.
+
+## Sandbox Testing
+
+1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
+2. Run `yarn dev --sync` from `apps/help-center/`.
+3. Visit any Simple, Atomic, or CIAB site.
+4. Open the Help Center and verify your changes.
+
+## Deployment
+
+1. Connect to your sandbox and run: `install-plugin.sh hc --release`
+2. Merge the PR.
+3. Deploy wpcom: `deploy wpcom`
+
+This deploys the Help Center bundles and language files for Jetpack consumption (and to then serve it via widgets).
+
+## PR Guidelines
+
+For PRs that **only** touch `apps/help-center/` (build config, entry point wiring):
+
+```markdown
+## Testing Instructions
+
+1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
+2. Run `cd apps/help-center && yarn dev --sync`.
+3. Visit any Simple, Atomic, or CIAB site.
+4. Open the Help Center and verify it loads and functions correctly.
+```
+
+For PRs that also touch `packages/help-center/`, follow the PR guidelines in `packages/help-center/AGENTS.md` instead (which includes both Calypso and Simple/Atomic testing).

--- a/apps/help-center/CLAUDE.md
+++ b/apps/help-center/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/help-center/AGENTS.md
+++ b/packages/help-center/AGENTS.md
@@ -1,0 +1,97 @@
+# Help Center
+
+## Package Overview
+
+`@automattic/help-center` is the shared component library for WordPress.com's in-app support experience. It runs in three environments:
+
+1. **Calypso** — embedded directly as a React component in the WordPress.com dashboard.
+2. **Simple sites** — loaded via `widgets.wp.com` as a Gutenberg editor plugin and wp-admin bar menu item.
+3. **Atomic sites** — same as Simple when the site is connected to Jetpack. Falls back to a minimal link to wp.com/help when disconnected.
+4. **CIAB (Calypso-in-a-Box)** — effectively an Atomic site for Help Center purposes. Also loaded via `widgets.wp.com`, not through Calypso.
+
+Most code lives here in `packages/help-center/`. The `apps/help-center/` app handles building and deploying the webpack bundles that serve Simple sites, Atomic sites, and CIAB.
+
+## Architecture
+
+### State Management
+
+Help Center uses WordPress `@wordpress/data` stores and TanStack Query for server state. Data-fetching hooks live in `src/data/`.
+
+### Key Directories
+
+```
+src/
+├── index.ts              # Entry point & exports
+├── components/           # React components (Help Center UI)
+├── hooks/                # Custom React hooks
+├── data/                 # Data-fetching hooks (TanStack Query, support tickets, site analysis)
+├── contexts/             # React contexts
+├── types/                # TypeScript type definitions
+├── constants.ts          # Shared constants
+├── stores.ts             # WordPress data store registrations
+├── query-client.ts       # TanStack Query client setup
+├── route-to-query-mapping.ts  # URL-to-search-query mapping for contextual articles
+├── styles.scss           # Global styles
+└── test/                 # Unit tests
+```
+
+### How Changes Flow to Simple/Atomic
+
+Changes in `packages/help-center/src/` are consumed by `apps/help-center/` via its webpack entry points. The app bundles the package into 8 separate JS files (e.g., `help-center-gutenberg.min.js`, `help-center-wp-admin.min.js`) deployed to `widgets.wp.com/help-center/`. Jetpack enqueues these bundles on WordPress.com Simple and Atomic sites.
+
+## Testing
+
+### Unit Tests
+
+```bash
+# Run from repo root
+yarn jest packages/help-center
+```
+
+Test files live in `src/test/` and alongside source files.
+
+### Sandbox Testing (Simple/Atomic/CIAB)
+
+To verify changes on Simple, Atomic, and CIAB sites you only need to sandbox `widgets.wp.com` — the sites themselves do not need sandboxing:
+
+1. Sandbox `widgets.wp.com`.
+2. Run `cd apps/help-center && yarn dev --sync` — this builds the webpack bundles and syncs them to your sandbox.
+3. Visit any Simple, Atomic, or CIAB site and verify the Help Center works correctly.
+
+See `apps/help-center/AGENTS.md` for more details on the build/sync layer.
+
+## PR Guidelines
+
+**Every PR touching `packages/help-center/`** must include testing instructions for both Calypso and Simple/Atomic/CIAB environments:
+
+### Testing Instructions Template
+
+```markdown
+## Testing Instructions
+
+### Calypso
+1. Run `yarn start`.
+2. Open the Help Center and verify [describe expected behavior].
+
+### Simple/Atomic/CIAB
+1. Sandbox `widgets.wp.com`.
+2. Run `cd apps/help-center && yarn dev --sync`.
+3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
+4. Open the Help Center and verify [describe expected behavior].
+```
+
+This "always include both" rule exists because nearly everything in `packages/help-center/src/` flows through to the Simple/Atomic/CIAB bundles. Missing sandbox testing steps is costly; including them when not strictly needed is cheap.
+
+## Conventions
+
+- **i18n**: Use `@wordpress/i18n` for all user-facing strings. New strings won't be translated on Atomic until the next `jetpack-mu-plugin` release (twice daily).
+- **Components**: Prefer `@wordpress/components` over custom UI primitives.
+- **Data fetching**: Use TanStack Query hooks in `src/data/`. Follow existing patterns.
+- **Styling**: SCSS. Global styles in `src/styles.scss`.
+
+## Common Pitfalls
+
+- **Two deployment targets**: Changes must work in both Calypso (SPA) and Simple/Atomic/CIAB (via `widgets.wp.com`). Always test both. You only need to sandbox `widgets.wp.com` — the sites themselves don't need sandboxing.
+- **Multiple entry points**: `apps/help-center/` has 8 webpack entry points for different contexts (Gutenberg, wp-admin, disconnected, etc.). A change may behave differently across entry points.
+- **asset.json sync limitation**: If you add or remove `@wordpress/*` dependencies, the `.asset.json` files won't sync to the sandbox because Jetpack fetches them from production. You must deploy for dependency changes to take effect on Atomic.
+- **Disconnected variants**: Some entry points have "disconnected" versions (e.g., `help-center-gutenberg-disconnected.js`) that show a minimal UI. Make sure changes don't break these variants.

--- a/packages/help-center/CLAUDE.md
+++ b/packages/help-center/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Proposed Changes

- Create `packages/help-center/AGENTS.md` with architecture overview, testing instructions, PR guidelines, and common pitfalls.
- Create `apps/help-center/AGENTS.md` with entry points table, build/sync commands, and sandbox testing steps.
- Create `CLAUDE.md` in both directories (single-line `@AGENTS.md` per repo convention).
- Add Help Center entry to the root `AGENTS.md` Packages section.

## Why are these changes being made?

When an AI agent creates a PR touching help-center code, there's no guidance to include the sandbox/sync testing steps needed for Simple/Atomic/CIAB sites. These specs ensure every help-center PR automatically gets testing instructions that tell the tester to sandbox `widgets.wp.com` and run `yarn dev --sync`.

## Testing Instructions

- Verify the new files exist and render correctly on GitHub:
  - `packages/help-center/AGENTS.md`
  - `packages/help-center/CLAUDE.md`
  - `apps/help-center/AGENTS.md`
  - `apps/help-center/CLAUDE.md`
- Verify the root `AGENTS.md` now lists Help Center in the Packages section.
