### PR TITLE
Fix Big Sky trial sites redirecting to site-editor 

### DIFF
--- a/client/state/sites/plans/selectors/is-site-big-sky-trial.ts
+++ b/client/state/sites/plans/selectors/is-site-big-sky-trial.ts
@@ -7,6 +7,10 @@ import {
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PREMIUM_3_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PERSONAL_3_YEARS,
 } from '@automattic/calypso-products';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getCurrentPlan } from '.';
@@ -35,6 +39,10 @@ export default function isSiteBigSkyTrial( state: AppState, siteId: number ) {
 		PLAN_PREMIUM_MONTHLY,
 		PLAN_PREMIUM_2_YEARS,
 		PLAN_PREMIUM_3_YEARS,
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_MONTHLY,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_PERSONAL_3_YEARS,
 	];
 
 	const productSlug = currentPlan?.productSlug || site?.plan?.product_slug;


### PR DESCRIPTION


<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes BSKY-1621

## Proposed Changes

Add personal plan to the list of Big Sky supported plans.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To prevent sites on Personal plan be redirected to the editor when navigating through Calypso

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get a free trial Big Sky site
* Purchase a Personal plan 
* Navigate to `/home/[YOUR_SITE]`
* Verify you see Calypso dashboard instead of being redirected to site editor

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
