### PR TITLE
Reader: Respect explicit featured image instead of content heuristics

### DIFF
--- a/client/blocks/reader-featured-image/style.scss
+++ b/client/blocks/reader-featured-image/style.scss
@@ -10,7 +10,7 @@
 	img {
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 6px;
-		object-fit: cover;
+		object-fit: contain;
 	}
 }
 

--- a/client/blocks/reader-post-card/featured-images.jsx
+++ b/client/blocks/reader-post-card/featured-images.jsx
@@ -9,7 +9,7 @@ import {
 
 const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia, isCompactPost, hasExcerpt } ) => {
 	const numImages = isCompactPost ? 1 : 4;
-	const imagesToDisplay = getImagesFromPostToDisplay( post, numImages );
+	const imagesToDisplay = post.featured_image ? [] : getImagesFromPostToDisplay( post, numImages );
 	if ( imagesToDisplay.length === 0 ) {
 		return (
 			<ReaderFeaturedImage

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -925,7 +925,7 @@
 			width: 100%;
 		}
 		img {
-			object-fit: cover;
+			object-fit: contain;
 		}
 	}
 	.reader-featured-image {

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -83,7 +83,7 @@ export function classifyPost( post ) {
 	const imagesForGallery = getImagesFromPostToDisplay( post, GALLERY_MAX_IMAGES );
 	let displayType = DISPLAY_TYPES.UNCLASSIFIED;
 
-	if ( imagesForGallery.length >= GALLERY_MIN_IMAGES ) {
+	if ( ! post.featured_image && imagesForGallery.length >= GALLERY_MIN_IMAGES ) {
 		displayType ^= DISPLAY_TYPES.GALLERY;
 	} else if (
 		post.content_images?.length === 1 &&

--- a/client/state/reader/posts/test/normalization-rules.js
+++ b/client/state/reader/posts/test/normalization-rules.js
@@ -84,6 +84,22 @@ describe( 'normalization-rules', () => {
 		test( 'should classify an X_POST post', () => {
 			verifyClassification( { tags: { 'p2-xpost': true } }, [ DISPLAY_TYPES.X_POST ] );
 		} );
+
+		test( 'should not classify as GALLERY when post has a featured_image', () => {
+			verifyClassification(
+				{
+					featured_image: 'http://example.com/featured.jpg',
+					images: [
+						{ src: 'http://example.com/foo1.jpg', width: 800, height: 600 },
+						{ src: 'http://example.com/foo2.jpg', width: 1024, height: 768 },
+						{ src: 'http://example.com/foo3.jpg', width: 640, height: 480 },
+						{ src: 'http://example.com/foo4.jpg', width: 1024, height: 768 },
+						{ src: 'http://example.com/foo5.jpg', width: 1024, height: 768 },
+					],
+				},
+				[ DISPLAY_TYPES.UNCLASSIFIED ]
+			);
+		} );
 	} );
 
 	describe( 'isFeaturedImageInContent', () => {


### PR DESCRIPTION
## Proposed Changes

Fixes https://linear.app/a8c/issue/READ-124/featured-image-we-are-grabbing-incorrect-images

- When a post has an explicit `featured_image` set by the author, skip gallery classification and content image scanning so the author's chosen image is displayed instead of heuristically-selected content images.
- Switch featured image rendering from `object-fit: cover` to `object-fit: contain` to prevent heavy zooming and cropping, applied consistently to both the canonical media path and the single content image path.

Before | After
---- | ----
<img width="742" height="645" alt="Screenshot 2026-02-24 at 4 30 19 PM" src="https://github.com/user-attachments/assets/c4155d4c-3919-41c0-a2c0-bc9cc499551d" /> | <img width="740" height="636" alt="Screenshot 2026-02-24 at 4 30 25 PM" src="https://github.com/user-attachments/assets/9ec0cf0d-45d3-4991-b4c1-040de0ee441f" />
<img width="761" height="680" alt="Screenshot 2026-02-24 at 4 29 24 PM" src="https://github.com/user-attachments/assets/9741adf0-5c28-4ab9-a359-b19df8755a7e" /> | <img width="749" height="682" alt="Screenshot 2026-02-24 at 4 29 29 PM" src="https://github.com/user-attachments/assets/2eabb297-9337-4e6d-84dc-ad62534a4f1f" />
<img width="741" height="662" alt="Screenshot 2026-02-24 at 4 28 41 PM" src="https://github.com/user-attachments/assets/e2e5d3dc-cf80-426e-ad52-bdd9e536ecb0" /> | <img width="744" height="658" alt="Screenshot 2026-02-24 at 4 28 49 PM" src="https://github.com/user-attachments/assets/58849bb2-c471-4517-acad-f6335ffccd05" />


### Files changed
- **`client/state/reader/posts/normalization-rules.js`** — Skip GALLERY classification when `post.featured_image` exists.
- **`client/blocks/reader-post-card/featured-images.jsx`** — When `post.featured_image` exists, bypass `getImagesFromPostToDisplay` and use the canonical media (single image) path.
- **`client/blocks/reader-featured-image/style.scss`** — Change `object-fit: cover` to `object-fit: contain` so tall images are fully visible within the 300px max-height.
- **`client/blocks/reader-post-card/style.scss`** — Change `object-fit: cover` to `object-fit: contain` for the single content image (`.one-image`) path to match the canonical media path.
- **`client/state/reader/posts/test/normalization-rules.js`** — Added test verifying posts with `featured_image` are not classified as GALLERY.

## Why are these changes being made?

When a post has an explicit `featured_image` set by the author, the Reader's image heuristics still scan the full post HTML content and can pick up non-content images (avatars, Bitmoji, copyright section profile photos). If 5+ qualifying images are found, the post gets classified as a GALLERY and shows a carousel of these irrelevant images. Even in non-gallery mode, up to 4 content-scanned images are displayed instead of the author's chosen featured image. Additionally, tall/portrait featured images (e.g., comic strips) are heavily cropped by `object-fit: cover`, making them unrecognizable.

## Testing Instructions

- In the Reader, find a post with featured image set and 5+ content images — verify it shows the single featured image, not a gallery carousel.
- Verify that posts without featured images still show a gallery.
- Find a post with a tall/portrait featured image (e.g., a comic strip) — verify the full image is visible without heavy cropping.
- Verify that a post with one image (not a featured image) displays that one image correctly.
- Verify landscape featured images still display correctly.
- Check that featured images look okay on mobile.
- Run `yarn test-client client/state/reader/posts/test/normalization-rules.js` — all tests pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)