### PR TITLE
Fix plan ownership notice flicker on Woo Hosted plans page

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -62,7 +62,7 @@ function useResolveNoticeType(
 
 	if ( isNoticeDismissed || isInSignup ) {
 		return NO_NOTICE;
-	} else if ( ! canUserPurchasePlan ) {
+	} else if ( ! canUserPurchasePlan && currentPlan !== null ) {
 		return USER_CANNOT_PURCHASE_NOTICE;
 	} else if ( isCurrentPlanRetired ) {
 		return PLAN_RETIREMENT_NOTICE;


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/SHILL-1696

## Proposed Changes

* Add a `currentPlan !== null` guard to the `USER_CANNOT_PURCHASE_NOTICE` condition in `useResolveNoticeType`, so the "purchased by a different account" notice only renders after plan data has loaded.

## Why are these changes being made?

When a Woo Hosted user removes an item from checkout, they're redirected back to the plans page. During the redirect, site plan data loads in two phases:

1. `isCurrentPlanPaid` resolves `true` first (from the site object, available early)
2. `isCurrentUserCurrentPlanOwner` defaults to `false` while `getCurrentPlan()` is still `null` (plan details not yet fetched)

This causes `canUserPurchasePlan` to briefly evaluate as `false`, flashing the grey "This plan was purchased by a different WordPress.com account" notice. Once plan data finishes loading, `userIsOwner` resolves to `true` and the notice disappears — but the flicker is visible.

The fix adds `currentPlan !== null` to the condition, which uses the same `getCurrentPlan()` value already retrieved on line 58. When `currentPlan` is `null`, plan data hasn't loaded yet, so we skip the ownership notice. Once data loads, `useSelector` triggers a re-render and the full notice logic runs correctly.

This follows the established pattern used by other components (e.g., `stats-notices`, `purchases-listing`) that check `hasLoadedSitePlansFromServer` or `currentPlan` before rendering plan-dependent notices.

## Testing Instructions

**Environment:**
- [ ] Local: `calypso.localhost:3000`
- [ ] Test on: CIAB / Woo Hosted sites

** Prerequisites:**
  - The test site must already be on a paid Woo Hosted plan (Basic or Pro) — free/trial sites won't trigger the ownership notice
  
Note: throttling CPU in browser dev tools x20 makes this easier to see/reproduce.

**Steps:**
1. Create a new CIAB site: [https://my.wordpress.com/ciab/sites](https://href.li/?https://my.wordpress.com/ciab/sites)
3. Select a plan to go to checkout
4. Remove the plan from checkout to return to the plans page
5. Observe the`USER_CANNOT_PURCHASE_NOTICE` notice between the heading and the plan toggle

**Before this change:**
- A "This plan was purchased by a different WordPress.com account" notice flickers briefly on page load

**After this change:**
- No flicker — the plans page loads cleanly


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

