### PR TITLE
Create new site for unified checkout when there is no signup

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -2,6 +2,7 @@ import { useRazorpay } from '@automattic/calypso-razorpay';
 import { useStripe } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { CheckoutProvider, checkoutTheme } from '@automattic/composite-checkout';
+import { Visibility } from '@automattic/data-stores';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	isValueTruthy,
@@ -68,6 +69,7 @@ import type {
 	PaymentEventCallbackArguments,
 	PaymentMethod,
 } from '@automattic/composite-checkout';
+import type { CreateSiteParams } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct, ResponseCart } from '@automattic/shopping-cart';
 import type { CheckoutPaymentMethodSlug, SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
@@ -469,6 +471,37 @@ export default function CheckoutMain( {
 		[ addProductsToCart ]
 	);
 
+	const newSiteParams: CreateSiteParams | undefined = useMemo( () => {
+		if ( sitelessCheckoutType !== 'unified' ) {
+			return undefined;
+		}
+
+		let savedNewSiteParams: CreateSiteParams | undefined = undefined;
+		try {
+			savedNewSiteParams = JSON.parse( window.localStorage.getItem( 'siteParams' ) || '{}' );
+		} catch ( err ) {
+			savedNewSiteParams = undefined;
+		}
+		if ( savedNewSiteParams?.blog_title ) {
+			// Typically this comes from signup in which case we don't want to
+			// override it. It will be fetched from localStorage inside
+			// `createAccount()`.
+			return undefined;
+		}
+
+		return {
+			blog_name: '',
+			blog_title: translate( 'My Site' ),
+			public: Visibility.PublicNotIndexed,
+			options: {
+				site_creation_flow: 'unified',
+				wpcom_public_coming_soon: 1,
+			},
+			find_available_url: true,
+			validate: false,
+		};
+	}, [ sitelessCheckoutType, translate ] );
+
 	const isAkismetSitelessCheckout = responseCart.products.some(
 		( product ) => product.extra.isAkismetSitelessCheckout
 	);
@@ -492,6 +525,7 @@ export default function CheckoutMain( {
 			fromSiteSlug,
 			isJetpackNotAtomic,
 			isAkismetSitelessCheckout,
+			newSiteParams,
 		} ),
 		[
 			contactDetails,
@@ -510,6 +544,7 @@ export default function CheckoutMain( {
 			fromSiteSlug,
 			isJetpackNotAtomic,
 			isAkismetSitelessCheckout,
+			newSiteParams,
 		]
 	);
 

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -676,6 +676,7 @@ function createItemToAddToCart( {
 		product_slug: productSlug,
 		quantity,
 		extra: {
+			isUnifiedSitelessCheckout: sitelessCheckoutType === 'unified',
 			isAkismetSitelessCheckout: sitelessCheckoutType === 'akismet',
 			isJetpackCheckout: sitelessCheckoutType === 'jetpack',
 			jetpackSiteSlug,

--- a/client/my-sites/checkout/src/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/src/lib/create-wpcom-account-before-transaction.ts
@@ -46,6 +46,7 @@ export async function createWpcomAccountBeforeTransaction(
 		email: transactionOptions.contactDetails?.email?.value,
 		siteId: transactionOptions.siteId,
 		recaptchaClientId: transactionOptions.recaptchaClientId,
+		newSiteParams: transactionOptions.newSiteParams,
 	} ).then( ( response ) => {
 		const siteIdFromResponse: number | undefined = parseInt(
 			response?.blog_details?.blogid ?? '0'

--- a/client/my-sites/checkout/src/payment-method-helpers.ts
+++ b/client/my-sites/checkout/src/payment-method-helpers.ts
@@ -5,6 +5,7 @@ import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wp from 'calypso/lib/wp';
 import { stringifyBody } from 'calypso/state/login/utils';
+import type { CreateSiteParams } from '@automattic/data-stores';
 
 interface CreateAccountResponse {
 	success: boolean;
@@ -49,17 +50,20 @@ export async function createAccount( {
 	email,
 	siteId,
 	recaptchaClientId,
+	newSiteParams,
 }: {
 	signupFlowName: string;
 	email: string | undefined;
 	siteId: number | undefined;
 	recaptchaClientId: number | undefined;
+	newSiteParams?: CreateSiteParams;
 } ): Promise< CreateAccountResponse > {
-	let newSiteParams = null;
-	try {
-		newSiteParams = JSON.parse( window.localStorage.getItem( 'siteParams' ) || '{}' );
-	} catch ( err ) {
-		newSiteParams = {};
+	if ( ! newSiteParams ) {
+		try {
+			newSiteParams = JSON.parse( window.localStorage.getItem( 'siteParams' ) || '{}' );
+		} catch ( err ) {
+			newSiteParams = undefined;
+		}
 	}
 
 	const isRecaptchaLoaded = typeof recaptchaClientId === 'number';
@@ -91,7 +95,7 @@ export async function createAccount( {
 			extra: { username_hint: blogName },
 			signup_flow_name: signupFlowName,
 			validate: false,
-			new_site_params: newSiteParams,
+			new_site_params: newSiteParams ?? {},
 			should_create_site: ! siteId,
 			locale: getLocaleSlug(),
 			client_id: config( 'wpcom_signup_id' ),

--- a/client/my-sites/checkout/src/types/payment-processors.ts
+++ b/client/my-sites/checkout/src/types/payment-processors.ts
@@ -1,6 +1,7 @@
 import type { GetThankYouUrl } from '../hooks/use-get-thank-you-url';
 import type { RazorpayConfiguration } from '@automattic/calypso-razorpay';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
+import type { CreateSiteParams } from '@automattic/data-stores';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 import type { Stripe } from '@stripe/stripe-js';
@@ -30,4 +31,16 @@ export interface PaymentProcessorOptions {
 	 * logged in).
 	 */
 	fromSiteSlug?: string;
+
+	/**
+	 * Data provided to the new user endpoint when creating a user and site
+	 * before the transaction is submitted (see
+	 * `createWpcomAccountBeforeTransaction()`) for userless checkout. Without this data, a new site will not be created.
+	 *
+	 * If this is set, it will always be used, but most of the time you should
+	 * not need to set it because our signup flows set the `siteParams`
+	 * property of `localStorage` which will be used if this is not set. This
+	 * will always override the localStorage setting so use it with care.
+	 */
+	newSiteParams?: CreateSiteParams;
 }

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -932,6 +932,11 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	 */
 	purchaseId?: string;
 
+	/**
+	 * Marks a product as having been added by the siteless `/checkout/unified` route.
+	 */
+	isUnifiedSitelessCheckout?: boolean;
+
 	isAkismetSitelessCheckout?: boolean;
 	isJetpackCheckout?: boolean;
 	isMarketplaceSitelessCheckout?: boolean;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/SHILL-1700/unified-checkout-flow-cannot-submit-to-transaction-endpoint-for-wpcom

## Proposed Changes

This PR makes sure that a new user and site is created when using the "unified" userless checkout (aka "registrationless") flow without first going through a signup flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There is a guard in the transactions endpoint which prevents siteless checkout except for known cases. In order to support purchasing wpcom products using the logged-out "unified" checkout flow (eg: https://wordpress.com/checkout/unified/personal) we need to pass that guard.

The guard should actually not be triggered because the shopping cart should actually have a `blog_id` set when the transaction is submitted. When using the unified checkout flow, the user must provide an email address during checkout which is then used to create an account just before the transction is submitted. The site created as part of that API call is then substituted in during the transactions endpoint call:

https://github.com/Automattic/wp-calypso/blob/857f422b6c03ff41ddfc8c6678f6fe7ac5892c1d/client/my-sites/checkout/src/lib/create-wpcom-account-before-transaction.ts#L69.

In effect, a userless, siteless checkout using the "unified" flow is actually a regular checkout using a user and site; both are just created behind the scenes just in time.

However, that only works if a site is created alongside the user. That doesn't happen if the `new_site_params` property is not set when calling `/users/new`. Normally that is set during signup but if you start directly from checkout, then it will not be set and no site will be created, leading to an error when the transaction attempts to be submitted with `blog_id: 0`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- When logged-out, visit https://wordpress.com/checkout/unified/personal
- Enter a new email address (it cannot be an a8c address because for some reason we don't allow those) and complete checkout.
- Verify that the purchase completes correctly, creating a new user, new site, and a new personal plan subscription for that site.

> [!IMPORTANT]
> If checkout fails for any reason, the user (and probably the site) will still be created and you'll need to test again with a different email address. 
