### PR TITLE
Add wideLayout to Jetpack pages for 1040px max-width consistency

### DIFF
--- a/client/components/jetpack/threat-list-header/style.scss
+++ b/client/components/jetpack/threat-list-header/style.scss
@@ -1,6 +1,6 @@
 // /* Layout
 // ================================================== */
-.threat-list-header__wrapper {
+.threat-list-header__wrapper.threat-list-header__wrapper {
 	display: flex;
 	align-items: flex-start;
 	color: #50575e;

--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -136,7 +136,10 @@ function UpsellSwitch( props: Props ) {
 
 	if ( UI_STATE_LOADED !== uiState ) {
 		return (
-			<Main className={ clsx( 'upsell-switch__loading', { is_jetpackcom: isJetpackCloud() } ) }>
+			<Main
+				className={ clsx( 'upsell-switch__loading', { is_jetpackcom: isJetpackCloud() } ) }
+				wideLayout
+			>
 				<QueryComponent siteId={ siteId } />
 				{ /* render placeholder */ }
 				{ children }

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -12,7 +12,7 @@
 		--masterbar-height: 46px;
 	}
 
-	.main {
+	.main:not(.is-wide-layout) {
 		box-sizing: border-box;
 		padding-left: 16px;
 		padding-right: 16px;

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -120,7 +120,7 @@ const ActivityLogV2: FunctionComponent = () => {
 			className={ clsx( 'activity-log-v2', {
 				wordpressdotcom: ! ( isJetpackCloud() || isA8CForAgencies() ),
 			} ) }
-			wideLayout={ ! ( isJetpackCloud() || isA8CForAgencies() ) }
+			wideLayout={ ! isA8CForAgencies() }
 		>
 			{ siteId && <QuerySitePlans siteId={ siteId } /> }
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }

--- a/client/my-sites/backup/backup-contents-page/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/index.tsx
@@ -86,7 +86,7 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 	return (
 		<>
 			<QuerySiteCredentials siteId={ siteId } />
-			<Main className="backup-contents-page">
+			<Main wideLayout className="backup-contents-page">
 				<DocumentHead title={ translate( 'Backup contents' ) } />
 				{ isJetpackCloud() && <SidebarNavigation /> }
 				<Button

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -81,6 +81,7 @@ const BackupPage = ( { queryDate } ) => {
 			} ) }
 		>
 			<Main
+				wideLayout
 				className={ clsx( {
 					is_jetpackcom: isJetpackCloud(),
 				} ) }

--- a/client/my-sites/backup/rewind-flow/index.tsx
+++ b/client/my-sites/backup/rewind-flow/index.tsx
@@ -133,7 +133,7 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 	};
 
 	return (
-		<Main className="rewind-flow">
+		<Main wideLayout className="rewind-flow">
 			<DocumentHead
 				title={
 					purpose === RewindFlowPurpose.RESTORE ? translate( 'Restore' ) : translate( 'Download' )

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -278,7 +278,7 @@ export default function WPCOMUpsellPage( { reason }: { reason: string } ) {
 			body = <BackupUpsellBody />;
 	}
 	return (
-		<Main className="backup__main backup__wpcom-upsell">
+		<Main wideLayout className="backup__main backup__wpcom-upsell">
 			<DocumentHead title="Jetpack VaultPress Backup" />
 			<PageViewTracker path="/backup/:site" title="VaultPress Backup" />
 			<NavigationHeader navigationItems={ [] } title={ translate( 'Jetpack VaultPress Backup' ) } />

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -49,7 +49,7 @@ export default function WPCOMUpsellPage() {
 	};
 
 	return (
-		<Main className="backup__main backup__wpcom-upsell">
+		<Main wideLayout className="backup__main backup__wpcom-upsell">
 			<DocumentHead title="Jetpack VaultPress Backup" />
 			<PageViewTracker path="/backup/:site" title="VaultPress Backup" />
 

--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -56,7 +56,7 @@ export default function SearchMain() {
 			: `/settings/performance/${ siteSlug }`;
 
 	return (
-		<Main className="jetpack-search">
+		<Main wideLayout className="jetpack-search">
 			<DocumentHead title="Jetpack Search" />
 			{ isCloud && <SidebarNavigation /> }
 			<PageViewTracker path="/jetpack-search/:site" title="Jetpack Search" />

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -23,6 +23,7 @@ export default function ScanHistoryPage( { filter }: Props ) {
 
 	return (
 		<Main
+			wideLayout
 			className={ clsx( 'scan history', {
 				is_jetpackcom: isJetpackPlatform,
 			} ) }

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -337,6 +337,7 @@ class ScanPage extends Component< Props > {
 
 		return (
 			<Main
+				wideLayout
 				className={ clsx( mainClass, {
 					is_jetpackcom: isJetpackPlatform,
 				} ) }

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -22,7 +22,7 @@ export default function WPCOMScanUpsellPage() {
 	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 
 	return (
-		<Main className="scan scan__wpcom-upsell">
+		<Main wideLayout className="scan scan__wpcom-upsell">
 			<DocumentHead title="Scanner" />
 			<PageViewTracker path="/scan/:site" title="Scanner" />
 

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -194,7 +194,7 @@ class PodcastingDetails extends Component {
 		} );
 
 		return (
-			<Main>
+			<Main wideLayout>
 				<DocumentHead title={ translate( 'Podcasting' ) } />
 				<NavigationHeader
 					navigationItems={ [] }

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -400,7 +400,7 @@ const NewsletterSettings = () => {
 	const translate = useTranslate();
 
 	return (
-		<Main className="site-settings">
+		<Main wideLayout className="site-settings">
 			<DocumentHead title={ translate( 'Newsletter Settings' ) } />
 			<NavigationHeader
 				navigationItems={ [] }

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -84,7 +84,7 @@ body.is-section-subscribers,
 				flex-direction: column;
 
 				.navigation-header {
-					padding: $padding-standard 48px;
+					padding: $padding-standard 24px;
 
 					// 430px is the DataViews padding breakpoint.
 					@media ( max-width: 430px ) {

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -37,10 +37,6 @@ body.is-section-subscribers,
 
 	.subscribers.main,
 	.main.is-wide-layout {
-		max-width: none;
-		padding: 0;
-		margin: 0;
-
 		.subscriber-data-views {
 			display: flex;
 			flex-direction: row;

--- a/client/my-sites/subscribers/components/subscriber-totals/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-totals/style.scss
@@ -2,7 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 
 .subscriber-totals {
-	padding: 0 48px;
+	padding: 0 24px;
 	margin-bottom: 8px;
 	font-size: $font-code;
 


### PR DESCRIPTION
Part of DOTCOM-16125

## Proposed Changes


- Add `wideLayout` prop to the `<Main>` component on 5 Jetpack pages: Scan, Backup, Podcasting, Newsletter Settings, and Jetpack Search.
- This changes their max-width from the default 720px to 1040px, aligning them with the other constrained Calypso pages (Activity Log, Earn, Traffic) that already use `wideLayout`.

## Screenshots

| Before | After |
| --- | --- |
| <img width="2786" height="1926" alt="wordpress com_subscribers_abstracting blog (3)" src="https://github.com/user-attachments/assets/396189ae-a738-4201-b50d-eb75e055fdb7" />  |  <img width="2894" height="2498" alt="calypso localhost_3000_home_abstracting blog (1)" src="https://github.com/user-attachments/assets/a3ee9ef6-3fef-4707-80ce-5cdb7c23d5f9" /> |
| <img width="2786" height="1926" alt="wordpress com_subscribers_abstracting blog (2)" src="https://github.com/user-attachments/assets/99ae5643-96ef-4269-9b30-52c207821d21" />  |  <img width="2914" height="6054" alt="calypso localhost_3000_home_abstracting blog" src="https://github.com/user-attachments/assets/d3fa7d7c-752f-48f4-aa6e-f09ac5d6b44a" /> |
| <img width="2786" height="1926" alt="wordpress com_jetpack-search_abstracting blog" src="https://github.com/user-attachments/assets/62291268-595b-439f-9b80-b2ffbd76de98" />  |  <img width="2914" height="1954" alt="calypso localhost_3000_jetpack-search_abstracting blog" src="https://github.com/user-attachments/assets/b44f58d3-5dd4-46d8-9acd-f0fe36dbb9cb" /> |
|  <img width="2786" height="1926" alt="wordpress com_subscribers_abstracting blog (4)" src="https://github.com/user-attachments/assets/c8ff491b-b693-4e3b-81ea-21d970da5f9d" /> | <img width="2894" height="2336" alt="calypso localhost_3000_sites (1)" src="https://github.com/user-attachments/assets/bf14933d-0699-41ef-81b5-bfb8c4815e6d" />  |
|  <img width="2786" height="1926" alt="wordpress com_subscribers_abstracting blog (6)" src="https://github.com/user-attachments/assets/fad5918b-a81c-4128-a6d9-f0c29fd3c4e6" /> |  <img width="2894" height="2558" alt="calypso localhost_3000_sites (2)" src="https://github.com/user-attachments/assets/4de45e01-27cf-427f-b175-c79d54b04b75" /> |
|  <img width="2786" height="1926" alt="wordpress com_subscribers_abstracting blog (1)" src="https://github.com/user-attachments/assets/2cf8d9e8-d40e-4486-883b-4ae0b17d9c03" /> |  <img width="2894" height="1926" alt="calypso localhost_3000_sites" src="https://github.com/user-attachments/assets/15410388-32eb-4e3d-ad97-b5bca1972ce4" /> |
| <img width="3066" height="1926" alt="container-busy-dhawan calypso live_settings_newsletter_abstracting blog" src="https://github.com/user-attachments/assets/be3d74e5-345e-496b-a612-6ad47ed0baec" /> |  <img width="3066" height="1926" alt="calypso localhost_3000_scan_history_abstracting blog" src="https://github.com/user-attachments/assets/fd23ddba-72cc-4914-8f82-3a9fc8adeb8c" /> |
|  <img width="2786" height="5140" alt="wordpress com_settings_newsletter_abstracting blog" src="https://github.com/user-attachments/assets/018ff5a2-a267-46ae-9e3c-7e368d46419b" />  |  <img width="2894" height="4712" alt="calypso localhost_3000_settings_newsletter_abstracting blog" src="https://github.com/user-attachments/assets/40254aa3-b3c1-4159-a3a8-74516215b2c6" /> |
| <img width="3156" height="1858" alt="wordpress com_subscribers_testmdom wpcomstaging com" src="https://github.com/user-attachments/assets/36eab2c1-ce0c-435e-8087-d50bb52d0b03" />  | <img width="3156" height="1858" alt="calypso localhost_3000_scan_testoverviewcardstatus1234 wordpress com (2)" src="https://github.com/user-attachments/assets/59d211b7-8340-4b05-9673-8168f861edb0" />  |






## Why are these changes being made?

As part of the Jetpack page max-width cleanup, all constrained Calypso pages should use a consistent 1040px max-width. These 5 pages were still using the `<Main>` component's default 720px. The `wideLayout` prop adds the `.is-wide-layout` CSS class which sets `max-width: 1040px`.

Full-width pages (Subscribers, Advertising) are intentionally left untouched.

## Testing Instructions

For each of the 5 pages below, verify that the page content area now renders at **1040px** max-width instead of the previous 720px:

### 1. Scan (`/scan/:site`)
- Navigate to **Jetpack → Scan** for a site with Jetpack Scan enabled.
- Open browser DevTools and inspect the `<main>` element.
- Confirm it has the `is-wide-layout` class and `max-width: 1040px` is applied.

### 2. Backup (`/backup/:site`)
- Navigate to **Jetpack → VaultPress Backup** for a site with Jetpack Backup enabled.
- Inspect the `<main>` element.
- Confirm it has the `is-wide-layout` class and `max-width: 1040px`.

### 3. Podcasting Settings (`/settings/podcasting/:site`)
- Navigate to **Settings → Podcasting** for a site.
- Inspect the `<main>` element.
- Confirm it has the `is-wide-layout` class and `max-width: 1040px`.

### 4. Newsletter Settings (`/settings/newsletter/:site`)
- Navigate to **Settings → Newsletter** for a site.
- Inspect the `<main>` element.
- Confirm it has the `is-wide-layout` class and `max-width: 1040px`.

### 5. Jetpack Search (`/jetpack-search/:site`)
- Navigate to **Jetpack → Search** for a site with Jetpack Search enabled.
- Inspect the `<main>` element.
- Confirm it has the `is-wide-layout` class and `max-width: 1040px`.

### 6. Subscribers (`/subscribers/:site`)
- Navigate to **Jetpack → Subscribers** for a site with Jetpack Search enabled.
- Verify the header padding matches the content.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Using memoizing selectors and Our Approach to Data
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?