### PR TITLE
A4A > Migrations: Add Pressable promo window for migration tagging eligibility

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
@@ -64,11 +64,11 @@ describe( 'useCanTagSitesForCommission', () => {
 		] );
 	} );
 
-	it( 'returns canTagSitesForCommission true when start_date is on or before cutoff (2025-08-11)', () => {
+	it( 'returns true and includes incentive tag when start_date is empty string', () => {
 		const agency = mockActiveAgency( {
 			third_party: {
 				pressable: {
-					usage: { start_date: '2025-08-11T00:00:00Z', end_date: null },
+					usage: { start_date: '', end_date: undefined },
 				},
 			},
 		} );
@@ -81,12 +81,13 @@ describe( 'useCanTagSitesForCommission', () => {
 		const { result } = renderHook( () => useCanTagSitesForCommission() );
 
 		expect( result.current.canTagSitesForCommission ).toBe( true );
-		expect( result.current.migrationTags ).toContain(
-			A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026
-		);
+		expect( result.current.migrationTags ).toEqual( [
+			A4A_MIGRATED_SITE_TAG,
+			A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
+		] );
 	} );
 
-	it( 'returns canTagSitesForCommission true when start_date is before cutoff', () => {
+	it( 'returns true when start_date is on or before cutoff (2025-08-10)', () => {
 		const agency = mockActiveAgency( {
 			third_party: {
 				pressable: {
@@ -109,11 +110,11 @@ describe( 'useCanTagSitesForCommission', () => {
 		] );
 	} );
 
-	it( 'returns canTagSitesForCommission false when start_date is after cutoff', () => {
+	it( 'returns false when start_date is in gap (2025-08-11 to 2026-02-10)', () => {
 		const agency = mockActiveAgency( {
 			third_party: {
 				pressable: {
-					usage: { start_date: '2025-08-12', end_date: null },
+					usage: { start_date: '2025-08-11', end_date: null },
 				},
 			},
 		} );
@@ -129,11 +130,11 @@ describe( 'useCanTagSitesForCommission', () => {
 		expect( result.current.migrationTags ).toEqual( [ A4A_MIGRATED_SITE_TAG ] );
 	} );
 
-	it( 'returns canTagSitesForCommission true when start_date is empty string', () => {
+	it( 'returns true when start_date is on or after promo start (2026-02-11)', () => {
 		const agency = mockActiveAgency( {
 			third_party: {
 				pressable: {
-					usage: { start_date: '', end_date: null },
+					usage: { start_date: '2026-02-11', end_date: null },
 				},
 			},
 		} );

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
@@ -5,20 +5,32 @@ import {
 	A4A_MIGRATED_SITE_TAG,
 	A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
 	PRESSABLE_LAST_PURCHASE_CUTOFF_DATE,
+	PRESSABLE_PROMO_START_DATE,
 } from '../lib/constants';
 
 /**
- * Returns true if the user is eligible to see migration tagging based on Pressable usage start_date.
- * If start_date is not found, always allow (show). Otherwise allow only if start_date is on or before the cut-off.
- * E.g. start_date '2025-12-17' (Dec) > cutoff '2025-08-11' (Aug) → false (do not show).
- *      start_date '2025-08-10' (Aug 10) <= cutoff → true (show).
+ * Returns true if the agency is eligible to see migration tagging based on Pressable usage start_date.
+ * Show tagging if:
+ * - No start_date (never bought) → show.
+ * - start_date on or before PRESSABLE_LAST_PURCHASE_CUTOFF_DATE (bought before the gap) → show.
+ * - start_date on or after PRESSABLE_PROMO_START_DATE (bought when promo started, new customer) → show.
+ * Hide tagging if start_date is in the gap (after cutoff and before promo start).
  */
 function isWithinPressablePurchaseCutoff( startDate: string | undefined | null ): boolean {
 	if ( startDate == null || startDate === '' ) {
 		return true;
 	}
 	const datePart = startDate.slice( 0, 10 );
-	return datePart <= PRESSABLE_LAST_PURCHASE_CUTOFF_DATE;
+	// Bought on or before Aug 10, 2025 → eligible.
+	if ( datePart <= PRESSABLE_LAST_PURCHASE_CUTOFF_DATE ) {
+		return true;
+	}
+	// Bought on or after promo start (Feb 11, 2026) → eligible (new customer during promo).
+	if ( datePart >= PRESSABLE_PROMO_START_DATE ) {
+		return true;
+	}
+	// Bought in the gap (Aug 11, 2025 – Feb 10, 2026) → not eligible.
+	return false;
 }
 
 export default function useCanTagSitesForCommission(): {

--- a/client/a8c-for-agencies/sections/migrations/lib/constants.ts
+++ b/client/a8c-for-agencies/sections/migrations/lib/constants.ts
@@ -3,7 +3,13 @@ export const A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026 =
 	'a4a_self_migrated_site_pressable_incentive_2026';
 
 /**
- * Cut-off date for Pressable subscription start_date.
- * Users with a Pressable purchase (subscription start) after this date do not see the migration tagging option.
+ * Cut-off date: agencies with a Pressable purchase (start_date) after this date and before the promo
+ * start are not eligible for migration tagging (they were already Pressable customers before the promo).
  */
-export const PRESSABLE_LAST_PURCHASE_CUTOFF_DATE = '2025-08-11';
+export const PRESSABLE_LAST_PURCHASE_CUTOFF_DATE = '2025-08-10';
+
+/**
+ * Promotion start date: agencies who first bought Pressable on or after this date are eligible
+ * for migration tagging (new customers during the promotion).
+ */
+export const PRESSABLE_PROMO_START_DATE = '2026-02-11';


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-2160/add-pressable-promo-window-for-migration-tagging-eligibility

## Proposed Changes

* Add `PRESSABLE_PROMO_START_DATE` (2026-02-11) constant; keep `PRESSABLE_LAST_PURCHASE_CUTOFF_DATE` as 2025-08-10.
* Update migration tagging eligibility: show tagging when agency has no Pressable `start_date`, or `start_date` is on/before cutoff, or `start_date` is on/after promo start; hide when `start_date` is in the gap (Aug 11, 2025 – Feb 10, 2026).
* Simplify tests to one `it()` per branch (no start_date, on/before cutoff, in gap, on/after promo start).

## Why are these changes being made?

Agencies that buy Pressable during the promotion (on or after Feb 11, 2026) should remain eligible to tag referred client sites for the migration incentive. The previous rule made any purchase after Aug 10, 2025 ineligible. This change limits ineligibility to the gap period (Aug 11, 2025 – Feb 10, 2026) so new customers who buy when the promo starts can still use the tagging option.

## Testing Instructions

* Start the server locally
* Manually: confirm tagging is shown when agency has no Pressable usage or `start_date` on/after 2026-02-11; confirm tagging is hidden when `start_date` is in the gap (e.g. 2025-12-01).
* We have added test cases, but still better to manually update the start date to ensure we are doing it correctly:

Update the date manually in the following file

https://github.com/Automattic/wp-calypso/blob/271d9454dcd245562115a2281b0d4aaae395b73a/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts#L42-L43

- 2026-02-10T06:37:57.000Z
- 2026-02-11T06:37:57.000Z
- 2026-02-12T06:37:57.000Z

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?