### PR TITLE
Pressable migration tagging eligibility

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts
@@ -109,7 +109,7 @@ describe( 'useCanTagSitesForCommission', () => {
 		] );
 	} );
 
-	it( 'returns canTagSitesForCommission false when start_date is after cutoff', () => {
+	it( 'returns canTagSitesForCommission false when start_date is in exclusion period (after cutoff, before promo)', () => {
 		const agency = mockActiveAgency( {
 			third_party: {
 				pressable: {
@@ -127,6 +127,92 @@ describe( 'useCanTagSitesForCommission', () => {
 
 		expect( result.current.canTagSitesForCommission ).toBe( false );
 		expect( result.current.migrationTags ).toEqual( [ A4A_MIGRATED_SITE_TAG ] );
+	} );
+
+	it( 'returns canTagSitesForCommission false when start_date is in middle of exclusion period', () => {
+		const agency = mockActiveAgency( {
+			third_party: {
+				pressable: {
+					usage: { start_date: '2025-12-17', end_date: null },
+				},
+			},
+		} );
+		jest
+			.mocked( useSelector )
+			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
+				selector( createState( agency ) )
+			);
+
+		const { result } = renderHook( () => useCanTagSitesForCommission() );
+
+		expect( result.current.canTagSitesForCommission ).toBe( false );
+		expect( result.current.migrationTags ).toEqual( [ A4A_MIGRATED_SITE_TAG ] );
+	} );
+
+	it( 'returns canTagSitesForCommission false when start_date is day before promo start', () => {
+		const agency = mockActiveAgency( {
+			third_party: {
+				pressable: {
+					usage: { start_date: '2026-02-10', end_date: null },
+				},
+			},
+		} );
+		jest
+			.mocked( useSelector )
+			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
+				selector( createState( agency ) )
+			);
+
+		const { result } = renderHook( () => useCanTagSitesForCommission() );
+
+		expect( result.current.canTagSitesForCommission ).toBe( false );
+		expect( result.current.migrationTags ).toEqual( [ A4A_MIGRATED_SITE_TAG ] );
+	} );
+
+	it( 'returns canTagSitesForCommission true when start_date is on promo start date', () => {
+		const agency = mockActiveAgency( {
+			third_party: {
+				pressable: {
+					usage: { start_date: '2026-02-11', end_date: null },
+				},
+			},
+		} );
+		jest
+			.mocked( useSelector )
+			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
+				selector( createState( agency ) )
+			);
+
+		const { result } = renderHook( () => useCanTagSitesForCommission() );
+
+		expect( result.current.canTagSitesForCommission ).toBe( true );
+		expect( result.current.migrationTags ).toEqual( [
+			A4A_MIGRATED_SITE_TAG,
+			A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
+		] );
+	} );
+
+	it( 'returns canTagSitesForCommission true when start_date is after promo start date', () => {
+		const agency = mockActiveAgency( {
+			third_party: {
+				pressable: {
+					usage: { start_date: '2026-02-18T17:09:20+00:00', end_date: null },
+				},
+			},
+		} );
+		jest
+			.mocked( useSelector )
+			.mockImplementation( ( selector: ( s: unknown ) => unknown ) =>
+				selector( createState( agency ) )
+			);
+
+		const { result } = renderHook( () => useCanTagSitesForCommission() );
+
+		expect( result.current.canTagSitesForCommission ).toBe( true );
+		expect( result.current.migrationTags ).toEqual( [
+			A4A_MIGRATED_SITE_TAG,
+			A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
+		] );
 	} );
 
 	it( 'returns canTagSitesForCommission true when start_date is empty string', () => {

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-can-tag-sites-for-commission.ts
@@ -5,20 +5,29 @@ import {
 	A4A_MIGRATED_SITE_TAG,
 	A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026,
 	PRESSABLE_LAST_PURCHASE_CUTOFF_DATE,
+	PRESSABLE_PROMO_START_DATE,
 } from '../lib/constants';
 
 /**
  * Returns true if the user is eligible to see migration tagging based on Pressable usage start_date.
- * If start_date is not found, always allow (show). Otherwise allow only if start_date is on or before the cut-off.
- * E.g. start_date '2025-12-17' (Dec) > cutoff '2025-08-11' (Aug) → false (do not show).
- *      start_date '2025-08-10' (Aug 10) <= cutoff → true (show).
+ * Eligible if:
+ * - start_date is not found (null/empty) → always allow
+ * - start_date is on or before 2025-08-11 → allow (existing customers before exclusion period)
+ * - start_date is on or after 2026-02-11 → allow (new customers during promo period)
+ * Not eligible if start_date falls between 2025-08-12 and 2026-02-10 (exclusion period).
+ *
+ * Examples:
+ * - start_date '2025-08-10' → true (before cutoff)
+ * - start_date '2025-12-17' → false (in exclusion period)
+ * - start_date '2026-02-11' → true (promo start date)
+ * - start_date '2026-02-18' → true (during promo period)
  */
 function isWithinPressablePurchaseCutoff( startDate: string | undefined | null ): boolean {
 	if ( startDate == null || startDate === '' ) {
 		return true;
 	}
 	const datePart = startDate.slice( 0, 10 );
-	return datePart <= PRESSABLE_LAST_PURCHASE_CUTOFF_DATE;
+	return datePart <= PRESSABLE_LAST_PURCHASE_CUTOFF_DATE || datePart >= PRESSABLE_PROMO_START_DATE;
 }
 
 export default function useCanTagSitesForCommission(): {

--- a/client/a8c-for-agencies/sections/migrations/lib/constants.ts
+++ b/client/a8c-for-agencies/sections/migrations/lib/constants.ts
@@ -7,3 +7,9 @@ export const A4A_MIGRATED_SITE_TAG_PRESSABLE_INCENTIVE_2026 =
  * Users with a Pressable purchase (subscription start) after this date do not see the migration tagging option.
  */
 export const PRESSABLE_LAST_PURCHASE_CUTOFF_DATE = '2025-08-11';
+
+/**
+ * Pressable migration incentive promo start date.
+ * Users who purchased Pressable on or after this date are eligible for migration tagging.
+ */
+export const PRESSABLE_PROMO_START_DATE = '2026-02-11';


### PR DESCRIPTION
Part of #

## Proposed Changes

*   Add `PRESSABLE_PROMO_START_DATE` constant (2026-02-11)
*   Update eligibility logic in `isWithinPressablePurchaseCutoff` to allow tagging for agencies who purchased Pressable on or after the promo start date
*   Add comprehensive tests covering exclusion period and promo period scenarios

## Why are these changes being made?

The current logic only checked if agencies purchased Pressable on or before August 11, 2025. This incorrectly blocked new agencies who purchased Pressable as part of the February 2026 migration promotion from tagging their sites.

The new logic allows tagging if:
*   No Pressable usage (null/empty start_date), OR
*   Purchased on or before 2025-08-11 (pre-exclusion period), OR
*   Purchased on or after 2026-02-11 (promo period)

Agencies who purchased between 2025-08-12 and 2026-02-10 remain ineligible (exclusion period).

## Testing Instructions

### Unit Tests
`yarn test-client client/a8c-for-agencies/sections/migrations/hooks/test/use-can-tag-sites-for-commission.test.ts`

### Test Cases
*   Agency with no Pressable usage: ✅ Can tag
*   Agency with start_date 2025-08-10: ✅ Can tag
*   Agency with start_date 2025-08-11: ✅ Can tag
*   Agency with start_date 2025-08-12: ❌ Cannot tag (exclusion period)
*   Agency with start_date 2025-12-17: ❌ Cannot tag (exclusion period)
*   Agency with start_date 2026-02-10: ❌ Cannot tag (exclusion period)
*   Agency with start_date 2026-02-11: ✅ Can tag (promo start)
*   Agency with start_date 2026-02-18: ✅ Can tag (during promo)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
