### PR TITLE
Agents Manager: Add CIAB connected variant entry point

### DIFF
--- a/apps/agents-manager/agents-manager-ciab.js
+++ b/apps/agents-manager/agents-manager-ciab.js
@@ -1,0 +1,20 @@
+/**
+ * CIAB (Commerce in a Box) connected variant entry point.
+ *
+ * This variant is used when:
+ * - We're in the CIAB admin environment (Next Admin SPA)
+ * - Jetpack is connected
+ *
+ * CIAB doesn't render the classic WordPress admin bar — it uses its own Site Hub.
+ * This variant simply mounts the full Agents Manager UI in its own container,
+ * without touching the admin bar or Site Hub. Help Center continues to manage
+ * its own button in the Site Hub independently.
+ */
+
+import { createRoot } from 'react-dom/client';
+import AgentsManagerWithProvider from './agents-manager-with-provider';
+
+const container = document.createElement( 'div' );
+container.id = 'agents-manager-root';
+document.body.appendChild( container );
+createRoot( container ).render( <AgentsManagerWithProvider /> );

--- a/apps/agents-manager/agents-manager-wp-admin.js
+++ b/apps/agents-manager/agents-manager-wp-admin.js
@@ -1,4 +1,3 @@
-/* global agentsManagerData */
 import { createRoot } from 'react-dom/client';
 import AgentsManagerWithProvider from './agents-manager-with-provider';
 import HeadlessAgentWithProvider from './headless-agent-with-provider';
@@ -6,16 +5,8 @@ import HeadlessAgentWithProvider from './headless-agent-with-provider';
 const masterbarTarget = document.getElementById( 'agents-manager-masterbar' );
 
 if ( masterbarTarget ) {
-	// Full UI mode: render Agents Manager in the admin bar masterbar node
+	// Full UI mode: render Agents Manager dock in the masterbar
 	createRoot( masterbarTarget ).render( <AgentsManagerWithProvider /> );
-} else if ( agentsManagerData?.useUnifiedExperience ) {
-	// Unified experience without admin bar: create own container and render full UI.
-	// This covers environments like CIAB that enable the unified experience
-	// but don't render the WordPress admin bar.
-	const container = document.createElement( 'div' );
-	container.id = 'agents-manager-root';
-	document.body.appendChild( container );
-	createRoot( container ).render( <AgentsManagerWithProvider /> );
 } else {
 	// Headless mode: just initialize the agent without UI
 	// This allows other components (like Image Studio) to use the shared agent

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -99,6 +99,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 		getIndividualConfig( { env, argv, name: 'agents-manager-gutenberg-disconnected' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-wp-admin-disconnected' } ),
 		getIndividualConfig( { env, argv, name: 'agents-manager-ciab-disconnected' } ),
+		getIndividualConfig( { env, argv, name: 'agents-manager-ciab' } ),
 	];
 }
 


### PR DESCRIPTION
## Proposed Changes

* Create `agents-manager-ciab.js` — a dedicated entry point for CIAB (Commerce in a Box) environments when Jetpack is connected.
* Add the new `agents-manager-ciab` variant to the webpack build config.
* Revert the self-mount fallback in the `wp-admin` variant that was added in #108826, since the dedicated CIAB entry point now handles that case.

## Why are these changes being made?

CIAB doesn't render the classic WordPress admin bar — it uses its own Site Hub. The existing `wp-admin` variant expects a `#agents-manager-masterbar` DOM node in the admin bar, which doesn't exist in CIAB.

Previously, #108826 added a `useUnifiedExperience` fallback to the `wp-admin` variant so CIAB could self-mount. With a dedicated `ciab` variant, that fallback is no longer needed and has been reverted — the `wp-admin` variant is back to its simple two-case logic (masterbar present → full UI, otherwise → headless). Help Center continues to manage its own Site Hub button independently via its own `ciab-admin` variant.

Companion Jetpack PR: https://github.com/Automattic/jetpack/pull/47314

## Testing Instructions

* Build the agents-manager app: `cd apps/agents-manager && yarn dev`
* Verify `agents-manager-ciab.min.js` is produced in `dist/`
* Deploy to a CIAB environment and verify the Agents Manager chat UI loads
* Verify Help Center's Site Hub button is not affected
* Verify the wp-admin variant still works: in a regular WordPress.com site the masterbar chat icon should render, and on sites without the masterbar it should fall back to headless mode.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)