### PR TITLE
MSD: clean up dashboard docs and AGENTS.md

### DIFF
--- a/client/dashboard/AGENTS.md
+++ b/client/dashboard/AGENTS.md
@@ -1,16 +1,12 @@
-You are an expert AI programming assistant specializing in the WordPress.com Dashboard. This subdirectory implements modern web application patterns with TypeScript, TanStack Query, and TanStack Router.
+# Multi-site Dashboard
+
+This is the new hosting dashboard for WordPress.com.
 
 ## Sub-area Guides
 
 - **me/billing-purchases/** — Billing & purchase management (cancel flows, payment methods, DataViews)
 
-## Documentation
+## Conventions
 
-For detailed implementation guidance, refer to:
-
-- docs/data-library.md - TanStack Query usage, loaders, caching
-- docs/ui-components.md - WordPress components, placeholders, DataViews
-- docs/router.md - TanStack Router patterns, lazy loading
-- docs/i18n.md - Translation patterns, CSS logical properties
-- docs/typography-and-copy.md - Capitalization, snackbar messages
-- docs/testing.md - Testing strategies
+- Use TanStack Query and TanStack Router.
+- Don't use Redux and `calypso/state`.

--- a/client/dashboard/README.md
+++ b/client/dashboard/README.md
@@ -1,44 +1,34 @@
-# Hosting Dashboard
+# Multi-site Dashboard
 
-Build a new Hosting Dashboard for WordPress.com based on the new design. The same dashboard with different entry points is used for different products (WordPress.com, Jetpack Cloud and a4a).
+This is the new hosting dashboard for WordPress.com. It serves the WordPress.com dashboard (at my.wordpress.com) and Commerce-in-a-Box dashboard (CIAB, at my.woo.ai).
+
+This dashboard uses TanStack Query and TanStack Router.
 
 ## Some principles
 
-- @wordpress/components and design system based, avoid CSS as much as possible.
-- Prefer VStack, HStack over Flex components.
-- Build as a separate Calypso configuration (c.f. Jetpack Cloud), but avoid importing Calypso's components, CSS and state.
-- Be very explicit about what dependencies we include.
-- Don't use Redux and calypso/state.
-- Use lib/wp for REST API calls.
-- Use TanStack based stack (Query and Router). Prefer using loaders over adhoc queries.
 - If hacks are used, document them in the README and propose a long term solution.
-- Use TypeScript, but prefer simple, concrete types.
-- Use @wordpress/i18n package for translation.
 - Performance testing and e2e testing are key.
-- Document all the architecture decisions (design docs)
+- Document all the architecture decisions.
 
-## Dashboard Design Documentation
+## Documentation
 
-This `docs` directory contains comprehensive design documentation for the `/client/dashboard`, a new Hosting Dashboard for WordPress.com based on modern design principles.
-
-- [Running dev server](./docs/dev-server.md) - Documentation for running the development server
-- [Router and Routes](./docs/router.md) - Documentation for the routing system based on @tanstack/react-router
-- [Data Library and Layer](./docs/data-library.md) - Documentation for the data fetching and state management approach
-- [UI Components](./docs/ui-components.md) - Documentation for the component architecture and design principles
-- [Testing Strategy](./docs/testing.md) - Documentation for the testing approach and best practices
-- [Entry Points](./docs/entry-points.md) - Documentation for the entry points and how to define new ones (a4a, WordPress.com, etc.)
-- [Internationalization](./docs/i18n.md) - Documentation for internationalization and translation practices
-- [Typography and Copy](./docs/typography-and-copy.md) - Documentation for typography guidelines and copy standards
-- [Package Imports](./docs/package-imports.md) - Documentation for package import restrictions and policy
+- [Running Dev Server](./docs/dev-server.md) - running the development server
+- [Router and Routes](./docs/router.md) - the routing system based on @tanstack/react-router
+- [Data Library and Layer](./docs/data-library.md) - the data fetching and state management approach
+- [UI Components](./docs/ui-components.md) - the component architecture and design principles
+- [Testing Strategy](./docs/testing.md) - the testing approach and best practices
+- [Entry Points](./docs/entry-points.md) - the entry points and how to define new ones (a4a, WordPress.com, etc.)
+- [Internationalization](./docs/i18n.md) - internationalization and translation practices
+- [Typography and Copy](./docs/typography-and-copy.md) - typography guidelines and copy standards
+- [Package Imports](./docs/package-imports.md) - package import restrictions and policy
 
 ## Bugs
 
-- Importing SASS files bring unexpected CSS variables to our bundles (masterbar, sidebar), it also brings fonts (Recoleta, Noto) and some global classes. Why? Imports should ideally be explicit.
+- Importing SASS files bring unexpected CSS variables to our bundles (e.g., --masterbar-height, --sidebar-width), it also brings fonts (Recoleta, Noto) and some global classes. Why? Imports should ideally be explicit.
 
 ## Hacks
 
-- We want to use the core `Badge` component but there are limitations in its functionality right now. Specifically we want a way to apply the colors (by `intent` prop), but sometimes override the used `icon`. For now we are using `TrendComparisonBadge` with some hacky css to hide the icon.
-- Grouping by a field in the core `DataViews` component uses `getValue` to display the grouping header. To group by a value but display something else in the header, we're generating an ID containing a unique number of zero-width space characters in `scheduled-updates`. This should be removed once we're able to edit the header value.
+- `client/dashboard/plugins/scheduled-updates/index.tsx`: Grouping by a field in the core `DataViews` component uses `getValue` to display the grouping header. To group by a value but display something else in the header, we're generating an ID containing a unique number of zero-width space characters. This should be removed once we're able to edit the header value.
 
 ## E2E testing
 
@@ -59,8 +49,4 @@ The new Hosting Dashboard has stricter guidelines (see above) and ESlint rules, 
 
 Shared components:
 
-- `/client/dashboard/sites/add-new-site/` - Add new site dropdown/modal content.
-
-### Next
-
-Consider a lighter, less abstracted way of writing tests, without page objects. I don't think the new dashboard justifies the added complexity.
+- `client/dashboard/sites/add-new-site/` - Add new site dropdown/modal content.

--- a/client/dashboard/docs/entry-points.md
+++ b/client/dashboard/docs/entry-points.md
@@ -18,19 +18,7 @@ This multi-entry point approach allows us to reuse the same codebase while tailo
 
 To create a new entry point for the dashboard, follow these steps:
 
-### 1. Create a Section Definition
-
-Add a new section definition in `client/dashboard/section.ts`:
-
-```typescript
-export const DASHBOARD_NEWPRODUCT_SECTION_DEFINITION = {
-  name: 'dashboard-newproduct',
-  paths: [ '/newproduct' ],
-  module: 'dashboard/app-newproduct',
-};
-```
-
-### 2. Create the Entry Point Module
+### 1. Create the Entry Point Module
 
 Create a new directory under `client/dashboard` called `app-newproduct` with the following files:
 
@@ -80,9 +68,25 @@ export default Logo;
 // These will be loaded when your entry point is active
 ```
 
-### 3. Register the Section in Calypso
+### 2. Create and Register the Routing
 
-To make your entry point available, you'll need to register the section in Calypso's main sections file. Typically this would be in `client/sections.js`.
+There is only a single dashboard instance for all entry points. The dashboard will route requests based on the request hostname and/or paths. See the following examples for CIAB, and follow similarly for the new entry point:
+
+- `client/dashboard/app-ciab/routing.ts`
+- `client/dashboard/app-ciab/section.ts`
+
+Then, we need to register the routing in `client/server/pages/index.js`. Look for the following code which registers `app-ciab`:
+
+```js
+DASHBOARD_SECTION_PATHS.forEach( ( route ) => {
+	handleRoute( CIAB_DASHBOARD_SECTION_DEFINITION, route, 'entry-dashboard-ciab', ( req ) =>
+		isAllowedCiabDashboardHostname( req.hostname )
+	);
+} );
+handleRoute( CIAB_DASHBOARD_SECTION_DEFINITION, '/ciab', 'entry-dashboard-ciab', ( req ) => {
+	return isAllowedDotcomDashboardHostname( req.hostname );
+} );
+```
 
 ## Customizing Branding
 

--- a/client/dashboard/docs/testing.md
+++ b/client/dashboard/docs/testing.md
@@ -76,12 +76,10 @@ nock( 'https://public-api.wordpress.com:443' )
 
 **Tips:**
 
-- Always call `nock.cleanAll()` in `afterEach` to avoid leaking interceptors between tests.
 - Avoid `nock.delay()` — it leaves open handles causing "Jest did not exit" warnings.
 - Use `scope.isDone()` to assert the request was actually made.
 - Use `.query( true )` when you don't care about specific query string values.
-- Capture the request body and assert with Jest (as below) rather than asserting inside
-  nock's body callback — Jest matchers produce clearer diffs on failure.
+- Capture the request body and assert with Jest (as below) rather than asserting inside nock's body callback — Jest matchers produce clearer diffs on failure.
 
 #### Asserting the request body
 

--- a/client/dashboard/docs/ui-components.md
+++ b/client/dashboard/docs/ui-components.md
@@ -42,6 +42,7 @@ In addition to the core components, the dashboard includes several reusable layo
 
 - **Page Layout**: The main container for every dashboard page.
 - **Menu** and **Responsive Menu**: Reusable components to render mobile-friendly navigation menus.
+- **DataViews**: A wrapper for core's DataViews, which supports view persistence.
 - **DataViews Card**: A card component for displaying data views.
 - **Overview Card**: Standard card for data display
 - **Header Bar**: A reusable header bar component for displaying a header bar (main and secondary headers).


### PR DESCRIPTION
Part of Roadmap Reset

## Proposed Changes

- Cleans up redundant information from `client/dashboard/AGENTS.md` if the information is already there in `client/AGENTS.md`, `client/dashboard/README.md`, or related docs (agents can already discover them).
- Make sure the docs in `client/dashboard/docs/*` are up-to-date.


