### PR TITLE
Agents Manager: Fix feedback and copy action colors on `/wp-admin`

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -415,7 +415,9 @@ body.post-new-php.agents-manager-sidebar-container {
 			height: 32px;
 
 			.agents-manager-message-action-icon {
-				fill: var( --color-muted-foreground );
+				path {
+					fill: var( --color-muted-foreground );
+				}
 
 				&:not( .agents-manager-message-action-icon--copy ) {
 					width: 30px;
@@ -423,7 +425,7 @@ body.post-new-php.agents-manager-sidebar-container {
 				}
 			}
 
-			&:hover:not( :disabled ) .agents-manager-message-action-icon {
+			&:hover:not( :disabled ) .agents-manager-message-action-icon path {
 				fill: var( --color-foreground );
 			}
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

On `/wp-admin`, the color of the action icons is overridden by HC:

<img width="1422" height="1288" alt="截圖 2026-02-25 下午5 54 33" src="https://github.com/user-attachments/assets/46d79fad-3362-4d6e-8a31-ee8d1a3ede6f" />

## Proposed Changes

* Fix feedback and copy action colors

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix feedback and copy action colors

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

A minor fix will be done through self-review, testing, and merging.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
