### PR TITLE
Add wideLayout to WPCOMBusinessAT component

### DIFF
--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -280,7 +280,7 @@ export default function WPCOMBusinessAT( {
 	// If features are not loaded yet, show loading state
 	if ( featuresNotLoaded ) {
 		return (
-			<Main className="wpcom-business-at">
+			<Main wideLayout className="wpcom-business-at">
 				<QuerySiteFeatures siteIds={ [ siteId ] } />
 				<DocumentHead title={ content.documentHeadTitle } />
 				<FormattedHeader
@@ -303,7 +303,7 @@ export default function WPCOMBusinessAT( {
 	}
 
 	return (
-		<Main className="wpcom-business-at">
+		<Main wideLayout className="wpcom-business-at">
 			<QueryAutomatedTransferEligibility siteId={ siteId } />
 			<DocumentHead title={ content.documentHeadTitle } />
 			<PageViewTracker path="/backup/:site" title="Business Plan Automated Transfer" />


### PR DESCRIPTION
Part of DOTCOM-16125

## Proposed Changes

* Add `wideLayout` prop to the `<Main>` component in `WPCOMBusinessAT` for both the loading and main render paths.

| Before | After |
| --- | --- |
| <img width="1232" height="1162" alt="Screenshot 2026-02-25 at 6 31 08 PM" src="https://github.com/user-attachments/assets/c486cf74-fa24-4e99-b03f-efe855b27e0d" /> |  <img width="1178" height="1160" alt="Screenshot 2026-02-25 at 6 31 27 PM" src="https://github.com/user-attachments/assets/9673dc2c-ca6f-4cd6-9b56-b74e9d67ef66" /> |


## Why are these changes being made?

* Follow-up to #108891 which added `wideLayout` to Jetpack pages for 1040px max-width consistency. The `WPCOMBusinessAT` component was missed in that change.

## Testing Instructions

* Navigate to a WPCOM Business site's automated transfer page and verify the layout uses the wider 1040px max-width, consistent with other Jetpack pages.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?