### PR TITLE
MSD: clean up PR reviewer bot prompt

### DIFF
--- a/.github/prompts/dashboard-pr-review.md
+++ b/.github/prompts/dashboard-pr-review.md
@@ -2,9 +2,18 @@
 
 ## Primary Objective
 
-Review the PR based on the below guidelines.
+Review the PR based on the following files:
 
-Consult @client/dashboard/AGENTS.md if you need more information.
+- @packages/api-core/README.md
+- @packages/api-queries/README.md
+- @client/dashboard/docs/data-library.md
+- @client/dashboard/docs/i18n.md
+- @client/dashboard/docs/links.md
+- @client/dashboard/docs/package-imports.md
+- @client/dashboard/docs/router.md
+- @client/dashboard/docs/testing.md
+- @client/dashboard/docs/typography-and-copy.md
+- @client/dashboard/docs/ui-components.md
 
 ## Method
 
@@ -18,85 +27,6 @@ Consult @client/dashboard/AGENTS.md if you need more information.
 - Be concise.
 - Do NOT use checkboxes, todo lists, or progress indicators.
 - Only comment if there are issues worth addressing.
-- DO NOT comment on lines that are not related to the below guidelines.
-
-## Code Review Guidelines
-
-When reviewing dashboard code, watch for these specific patterns and potential issues:
-
-### External Link Handling
-
-- All URLs linking to old WordPress.com/Calypso MUST use `wpcomLink()` function
-    - **Import**: Use `import { wpcomLink } from '@automattic/dashboard/utils/link'`
-    - **Purpose**: Ensures proper environment configuration (dev vs production hostnames)
-- Every link to `/checkout` must have `redirect_to` and `cancel_to` query param
-    - **Purpose**: Ensures correct behaviour when exiting the checkout screen
-- Every link to `/setup/plan-upgrade` must have a `cancel_to` query param
-    - **Purpose**: Ensures correct behaviour when exiting the upgrade screen
-
-```typescript
-// ✅ Correct - wrapped with wpcomLink()
-<a href={ wpcomLink( '/me/security' ) }>Security Settings</a>
-
-// ❌ Incorrect - hardcoded WordPress.com URL
-<a href="https://wordpress.com/me/security">Security Settings</a>
-
-// ❌ Incorrect - relative URL to old dashboard
-<a href="/me/security">Security Settings</a>
-```
-
-### Mutation Callback Handling
-
-- **Component-specific Callbacks**: Attach `onSuccess`/`onError` to the `mutate()` call, not `useMutation()`
-- **Query Options**: Don't override callbacks defined in api-queries mutation options
-- **Cache Updates**: Query option callbacks handle cache invalidation and updates
-
-```typescript
-// ✅ Correct - callback on mutate call
-const { mutate: saveSetting } = useMutation( saveSettingMutation() );
-
-const handleSave = () => {
-  saveSetting( newValue, {
-    onSuccess: () => {
-      // Component-specific success handling
-      setShowSuccessMessage( true );
-    },
-    onError: ( error ) => {
-      // Component-specific error handling
-      setError( error.message );
-    },
-  } );
-};
-
-// ❌ Incorrect - overrides query option callbacks
-const { mutate: saveSetting } = useMutation( {
-  ...saveSettingMutation(),
-  onSuccess: () => setShowSuccessMessage( true ), // Breaks cache updates!
-  onError: ( error ) => setError( error.message ),
-} );
-```
-
-### Typography and Copy Compliance
-
-- **Sentence Case**: Verify buttons, labels, and headings use sentence case (not title case)
-- **Periods**: Check sentences end with periods; buttons and labels do not
-- **Curly Quotes**: Ensure proper curly quotes (“like this”) and apostrophes (it’s) are used
-- **Product Names**: "Hosting Dashboard" should be capitalized as proper noun
-- **Snackbar Patterns**: Follow established patterns for success/error messages
-
-```typescript
-// ✅ Correct copy patterns
-<Button>Save changes</Button>  // No period, sentence case
-<p>Your settings have been saved.</p>  // Period, curly quotes if needed
-
-// Snackbar messages
-`SSH access enabled.`
-`Failed to save PHP version.`
-
-// ❌ Incorrect patterns
-<Button>Save Changes.</Button>  // Has period, title case
-<p>Your settings have been saved</p>  // Missing period
-`SSH Access Enabled`  // Title case, missing period
-```
+- DO NOT comment on lines that are not related to the guidelines.
 
 Remember: This dashboard represents modern React patterns. Prioritize performance, accessibility, and maintainability while leveraging the WordPress ecosystem.

--- a/client/dashboard/docs/links.md
+++ b/client/dashboard/docs/links.md
@@ -1,0 +1,22 @@
+# Linking from and to the Dashboard
+
+- Every relative URL from the dashboard linking to the Classic WordPress.com/Calypso MUST use `wpcomLink()` function
+    - **Purpose**: Ensures proper environment configuration (dev vs production hostnames)
+
+```typescript
+// ✅ Correct - wrapped with wpcomLink()
+<a href={ wpcomLink( '/start' ) }>Create new site</a>
+
+// ❌ Incorrect - hardcoded WordPress.com URL
+<a href="https://wordpress.com/start">Create new site</a>
+
+// ❌ Incorrect - relative URL to Calypso
+<a href="/start">Create new site</a>
+```
+
+- Every relative URL from the Classic WordPress.com/Calypso to the dashboard MUST use `dashboard()` function
+    - **Purpose**: Ensures proper environment configuration (dev vs production hostnames)
+- Every link to `/checkout` must have `redirect_to` and `cancel_to` query param
+    - **Purpose**: Ensures correct behaviour when exiting the checkout screen
+- Every link to `/setup/plan-upgrade` must have a `cancel_to` query param
+    - **Purpose**: Ensures correct behaviour when exiting the upgrade screen

--- a/client/dashboard/docs/links.md
+++ b/client/dashboard/docs/links.md
@@ -14,7 +14,7 @@
 <a href="/start">Create new site</a>
 ```
 
-- Every relative URL from the Classic WordPress.com/Calypso to the dashboard MUST use `dashboard()` function
+- Every relative URL from the Classic WordPress.com/Calypso to the dashboard MUST use `dashboardLink()` function
     - **Purpose**: Ensures proper environment configuration (dev vs production hostnames)
 - Every link to `/checkout` must have `redirect_to` and `cancel_to` query param
     - **Purpose**: Ensures correct behaviour when exiting the checkout screen

--- a/packages/api-queries/README.md
+++ b/packages/api-queries/README.md
@@ -86,6 +86,33 @@ These guidelines should be followed to ensure reusability of the queries and mut
     } );
     ```
 
+- Examples:
+
+  ```typescript
+  // ✅ Correct - callback on mutate call
+  const { mutate: saveSetting } = useMutation( saveSettingMutation() );
+  
+  const handleSave = () => {
+    saveSetting( newValue, {
+      onSuccess: () => {
+        // Component-specific success handling
+        setShowSuccessMessage( true );
+      },
+      onError: ( error ) => {
+        // Component-specific error handling
+        setError( error.message );
+      },
+    } );
+  };
+
+  // ❌ Incorrect - overrides mutation option callbacks
+  const { mutate: saveSetting } = useMutation( {
+    ...saveSettingMutation(),
+    onSuccess: () => setShowSuccessMessage( true ), // Breaks cache updates!
+    onError: ( error ) => setError( error.message ),
+  } );
+  ```
+
 ### Typings
 
 TanStack Query's types are very fancy. The downside is they can be hard to get write when written by hand. That is why TanStack Query provides the `queryOptions` and `mutationOptions` utility functions as described above. At runtime these functions are a no-op. But by you using them your editor will give you code completion and TypeScript will be able to confirm they are well formed.


### PR DESCRIPTION
Part of Roadmap Reset

## Proposed Changes

- Pull useful instructions from the reviewer prompt to dashboard docs instead
- Reference every single doc files in the reviewer prompt
- Remove explicit instructions that are proven to produce false positives, e.g.:
   - "... must end with period"

## Why are these changes being made?

An experiment to improve the PR review results and the overall docs.
