### PR TITLE
Domain-Only Thank You Page: Refine mailbox CTA copy

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/index.tsx
@@ -36,6 +36,13 @@ export default function DomainOnly( {
 
 	const planUpgradeCreditsApplicable = useDomainToPlanCreditsApplicable( domainPurchase.blogId );
 
+	// translators: %(domain)s is a domain name, like example.com
+	const topTextCopy = translate( 'Create a professional email address on %(domain)s.', {
+		args: {
+			domain: domainPurchase.meta,
+		},
+	} );
+
 	return (
 		<div className="checkout-thank-you__domain-only-container">
 			<Step.CenteredColumnLayout
@@ -75,11 +82,7 @@ export default function DomainOnly( {
 				<OptionContent
 					illustration={ <img src={ addMailbox } alt="" aria-hidden /> }
 					titleText={ translate( 'Add a mailbox' ) }
-					topText={ translate( 'Get a professional email like hello@%(domain)s.', {
-						args: {
-							domain: domainPurchase.meta,
-						},
-					} ) }
+					topText={ topTextCopy }
 					href={
 						dashboardOptIn
 							? dashboardLink( `/emails/choose-email-solution/${ domainPurchase.meta }` )

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/index.tsx
@@ -75,7 +75,11 @@ export default function DomainOnly( {
 				<OptionContent
 					illustration={ <img src={ addMailbox } alt="" aria-hidden /> }
 					titleText={ translate( 'Add a mailbox' ) }
-					topText={ translate( 'Stand out with a professional email address.' ) }
+					topText={ translate( 'Get a professional email like hello@%(domain)s.', {
+						args: {
+							domain: domainPurchase.meta,
+						},
+					} ) }
 					href={
 						dashboardOptIn
 							? dashboardLink( `/emails/choose-email-solution/${ domainPurchase.meta }` )

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/test/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/test/index.tsx
@@ -138,7 +138,7 @@ describe( 'DomainOnly', () => {
 			renderComponent();
 
 			expect(
-				screen.getByText( `Get a professional email like hello@${ mockDomainPurchase.meta }.` )
+				screen.getByText( `Create a professional email address on ${ mockDomainPurchase.meta }.` )
 			).toBeVisible();
 		} );
 	} );

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/test/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/test/index.tsx
@@ -133,6 +133,14 @@ describe( 'DomainOnly', () => {
 				dashboardLink( `/emails/choose-email-solution/${ mockDomainPurchase.meta }` )
 			);
 		} );
+
+		it( 'renders the top text with the domain name', () => {
+			renderComponent();
+
+			expect(
+				screen.getByText( `Get a professional email like hello@${ mockDomainPurchase.meta }.` )
+			).toBeVisible();
+		} );
 	} );
 
 	describe( 'Attach to an existing site', () => {


### PR DESCRIPTION
Addresses p1771880169783249-slack-C04H4NY6STW.

## Proposed Changes

Modifies the "Add mailbox" copy for something with a clearer value proposition:

<img width="1169" height="889" alt="image" src="https://github.com/user-attachments/assets/611747a6-5d1e-486a-99e1-868638ecbf3e" />



## Testing Instructions

Purchase a single domain through the `/start/domain` flow and verify that you see the new copy below the "Add mailbox" CTA.