### PR TITLE
Domain suggestions: add CIAB suggestion vendor

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -106,6 +106,7 @@ const DomainSearchStep: StepType< {
 				isSignup:
 					! isDomainAndPlanFlow( flow ) && ! isCopySiteFlow( flow ) && ! isDomainFlow( flow ),
 				isDomainOnly: isDomainFlow( flow ),
+				isCiab,
 				flowName: flow,
 			} ),
 			priceRules: {
@@ -129,7 +130,7 @@ const DomainSearchStep: StepType< {
 				! isHundredYearPlanFlow( flow ) &&
 				( isHundredYearDomainFlow( flow ) ? !! query : true ),
 		};
-	}, [ flow, tldQuery, query ] );
+	}, [ flow, isCiab, tldQuery, query ] );
 
 	const { submit } = navigation;
 

--- a/client/lib/domains/suggestions/index.ts
+++ b/client/lib/domains/suggestions/index.ts
@@ -11,6 +11,7 @@ interface DomainSuggestionsVendorOptions {
 	isSignup?: boolean;
 	isDomainOnly?: boolean;
 	isPremium?: boolean;
+	isCiab?: boolean;
 	flowName?: string;
 }
 
@@ -20,17 +21,22 @@ interface DomainSuggestionsVendorOptions {
  * @param {boolean} [options.isSignup] Flag to indicate that we're in a signup context
  * @param {boolean} [options.isDomainOnly] Flag to indicate that we're in a domain-only context
  * @param {boolean} [options.isPremium] Flag to show premium domains.
+ * @param {boolean} [options.isCiab] Flag to indicate that we're in a Commerce in a Box context.
  * @param {string} [options.flowName] The flow name (used to determine the vender).
  * @returns {string} Vendor string to pass as part of the domain suggestions query.
  */
 export const getSuggestionsVendor = ( {
 	isPremium = true,
+	isCiab,
 	flowName,
 	isSignup,
 	isDomainOnly,
 }: DomainSuggestionsVendorOptions = {} ): DomainSuggestionQueryVendor => {
 	const isEnabledSuggestionsPP = isEnabled( 'domains/suggestions-pp' );
 
+	if ( isCiab ) {
+		return 'ciab';
+	}
 	if ( isDomainForGravatarFlow( flowName ) ) {
 		return 'gravatar';
 	}

--- a/client/lib/domains/suggestions/test/index.ts
+++ b/client/lib/domains/suggestions/test/index.ts
@@ -1,0 +1,34 @@
+import { getSuggestionsVendor } from '../index';
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn( () => false ),
+} ) );
+
+jest.mock( '@automattic/onboarding', () => ( {
+	isDomainForGravatarFlow: jest.fn( () => false ),
+	isHundredYearPlanFlow: jest.fn( () => false ),
+	isHundredYearDomainFlow: jest.fn( () => false ),
+	isNewsletterFlow: jest.fn( () => false ),
+} ) );
+
+describe( 'getSuggestionsVendor', () => {
+	test( 'should return ciab when isCiab is true', () => {
+		expect( getSuggestionsVendor( { isCiab: true } ) ).toBe( 'ciab' );
+	} );
+
+	test( 'should return ciab for isCiab regardless of other options', () => {
+		expect(
+			getSuggestionsVendor( {
+				isCiab: true,
+				isSignup: true,
+				isDomainOnly: false,
+				isPremium: true,
+				flowName: 'domain',
+			} )
+		).toBe( 'ciab' );
+	} );
+
+	test( 'should not return ciab when isCiab is false', () => {
+		expect( getSuggestionsVendor( { isCiab: false } ) ).not.toBe( 'ciab' );
+	} );
+} );

--- a/packages/api-core/src/domain-suggestions/types.ts
+++ b/packages/api-core/src/domain-suggestions/types.ts
@@ -2,6 +2,7 @@ export type DomainSuggestionQueryVendor =
 	| 'variation2_front'
 	| 'variation4_front'
 	| 'variation8_front'
+	| 'ciab'
 	| 'newsletter'
 	| 'ecommerce'
 	| 'gravatar'


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/DOMENG-452/pass-the-new-vendor-string-in-ciab-domain-search-flow

## Proposed Changes

* Add a new `ciab` domain suggestion vendor to be used when the domain flow is accessed in a Commerce in a Box context (`?dashboard=ciab`).
* Add `isCiab` option to `getSuggestionsVendor` with an early-return check.
* Add `ciab` to the `DomainSuggestionQueryVendor` type union.

## Why are these changes being made?

When the domain flow is used in a CIAB context, we need to use a dedicated suggestion vendor (`ciab`) so the API returns domain suggestions tailored for commerce sites. This vendor is used regardless of the `domains/suggestions-pp` feature flag.

## Testing Instructions

* Navigate to the domain flow with `?dashboard=ciab` query parameter.
* Verify that the domain suggestions API request uses the `ciab` vendor.
* Navigate to the domain flow without the CIAB parameter and verify the vendor is unchanged from current behavior.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)