### PR TITLE
A4A-2156: clarify Pressable add-on capacity impact in Marketplace lightbox

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/index.tsx
@@ -2,6 +2,7 @@ import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import pressableIcon from 'calypso/assets/images/a8c-for-agencies/product-logos/pressable.svg';
 import { useProductDescription } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { getPressableAddonCapacityCopyContext } from './lib/capacity-copy';
 
 import './style.scss';
 
@@ -10,73 +11,96 @@ type Props = {
 	productSlug: string;
 };
 
-type PressableAddonType = 'sites' | 'storage' | 'visits' | 'unknown';
-
-const getAddonType = ( productSlug: string ): PressableAddonType => {
-	if ( productSlug.startsWith( 'pressable-addon-sites-' ) ) {
-		return 'sites';
-	}
-
-	if ( productSlug.startsWith( 'pressable-addon-storage-' ) ) {
-		return 'storage';
-	}
-
-	if ( productSlug.startsWith( 'pressable-addon-visits-' ) ) {
-		return 'visits';
-	}
-
-	return 'unknown';
-};
-
-const getAddonValue = ( productSlug: string ): string | null => {
-	const parts = productSlug.split( '-' );
-	const lastPart = parts[ parts.length - 1 ];
-	return lastPart || null;
-};
-
 export default function PressableAddonsCustomDescription( { productName, productSlug }: Props ) {
 	const translate = useTranslate();
 	const { description } = useProductDescription( productSlug );
-	const addOnType = getAddonType( productSlug );
-	const count = getAddonValue( productSlug );
+	const context = getPressableAddonCapacityCopyContext( productSlug );
+	const addOnType = context?.type ?? 'unknown';
 
-	const getCalloutCopy = ( countValue: string ) => {
+	const getCalloutCopy = () => {
+		if ( ! context ) {
+			return translate(
+				'This add-on increases your Signature plan limits while your plan is active.'
+			);
+		}
+
 		if ( addOnType === 'sites' ) {
-			return translate( 'Site limit will be increased by %(count)s on your Signature plan', {
-				args: { count: countValue },
-			} );
+			return translate(
+				'Site limit will be increased by %(installs)s, storage by %(storage)s, and visits by %(visits)s on your Signature plan.',
+				{
+					args: {
+						installs: context.formattedInstall,
+						storage: context.formattedStorage,
+						visits: context.formattedVisits,
+					},
+				}
+			);
 		}
 
 		if ( addOnType === 'storage' ) {
-			return translate( 'Storage limit will be increased by %(count)s on your Signature plan', {
-				args: { count: countValue },
+			return translate( 'Storage limit will be increased by %(storage)s on your Signature plan.', {
+				args: {
+					storage: context.formattedStorage,
+				},
 			} );
 		}
 
 		if ( addOnType === 'visits' ) {
-			return translate( 'Visits limit will be increased by %(count)s on your Signature plan', {
-				args: { count: countValue },
-			} );
+			return translate(
+				'Visits limit will be increased by %(visits)s monthly visits on your Signature plan.',
+				{
+					args: {
+						visits: context.formattedVisits,
+					},
+				}
+			);
 		}
 
-		return translate( 'Plan limit will be increased by %(count)s on your Signature plan', {
-			args: { count: countValue },
-		} );
+		return translate(
+			'This add-on increases your Signature plan limits while your plan is active.'
+		);
 	};
 
 	const getDetailLimitCopy = () => {
+		if ( ! context ) {
+			return translate( "Add-ons raise your plan's limits while your plan is active." );
+		}
+
 		if ( addOnType === 'sites' ) {
-			return translate( "Site add-ons raise your plan's limits while your plan is active." );
+			return translate(
+				'This add-on increases your Signature plan by %(installs)s site, %(storage)s of storage, and %(visits)s monthly visits while your plan is active.',
+				'This add-on increases your Signature plan by %(installs)s sites, %(storage)s of storage, and %(visits)s monthly visits while your plan is active.',
+				{
+					args: {
+						installs: context.formattedInstall,
+						storage: context.formattedStorage,
+						visits: context.formattedVisits,
+					},
+					count: context.install,
+				}
+			);
 		}
 
 		if ( addOnType === 'storage' ) {
 			return translate(
-				"Storage add-ons raise your plan's limits while you plan is active, and are distributed across all your active site installations."
+				'This add-on increases your Signature plan by %(storage)s of storage while your plan is active.',
+				{
+					args: {
+						storage: context.formattedStorage,
+					},
+				}
 			);
 		}
 
 		if ( addOnType === 'visits' ) {
-			return translate( "Visits add-ons raise your plan's limits while your plan is active." );
+			return translate(
+				'This add-on increases your Signature plan by %(visits)s monthly visits while your plan is active.',
+				{
+					args: {
+						visits: context.formattedVisits,
+					},
+				}
+			);
 		}
 
 		return translate( "Add-ons raise your plan's limits while your plan is active." );
@@ -93,12 +117,10 @@ export default function PressableAddonsCustomDescription( { productName, product
 				</div>
 			</div>
 			{ description && <div className="jetpack-product-info__description">{ description }</div> }
-			{ count !== null && (
-				<div className="pressable-addons-custom-description__callout">
-					<Icon icon={ info } size={ 16 } />
-					<span>{ getCalloutCopy( count ) }</span>
-				</div>
-			) }
+			<div className="pressable-addons-custom-description__callout">
+				<Icon icon={ info } size={ 16 } />
+				<span>{ getCalloutCopy() }</span>
+			</div>
 			<div className="pressable-addons-custom-description__section">
 				<h3 className="jetpack-product-info__section-title">{ translate( 'Details' ) }</h3>
 				<ul className="pressable-addons-custom-description__details">

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/lib/capacity-copy.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/lib/capacity-copy.ts
@@ -1,0 +1,52 @@
+import { formatNumber } from '@automattic/number-formatters';
+import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
+
+export type PressableAddonType = 'sites' | 'storage' | 'visits' | 'unknown';
+
+export type PressableAddonCapacityCopyContext = {
+	type: PressableAddonType;
+	install: number;
+	storage: number;
+	visits: number;
+	formattedInstall: string;
+	formattedStorage: string;
+	formattedVisits: string;
+};
+
+export function getPressableAddonType( productSlug: string ): PressableAddonType {
+	if ( productSlug.startsWith( 'pressable-addon-sites-' ) ) {
+		return 'sites';
+	}
+
+	if ( productSlug.startsWith( 'pressable-addon-storage-' ) ) {
+		return 'storage';
+	}
+
+	if ( productSlug.startsWith( 'pressable-addon-visits-' ) ) {
+		return 'visits';
+	}
+
+	return 'unknown';
+}
+
+export function getPressableAddonCapacityCopyContext(
+	productSlug: string
+): PressableAddonCapacityCopyContext | null {
+	const plan = getPressablePlan( productSlug );
+
+	if ( ! plan ) {
+		return null;
+	}
+
+	const type = getPressableAddonType( productSlug );
+
+	return {
+		type,
+		install: plan.install,
+		storage: plan.storage,
+		visits: plan.visits,
+		formattedInstall: formatNumber( plan.install ),
+		formattedStorage: `${ formatNumber( plan.storage ) } GB`,
+		formattedVisits: formatNumber( plan.visits ),
+	};
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/lib/test/capacity-copy.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/lib/test/capacity-copy.test.ts
@@ -1,0 +1,67 @@
+import { getPressableAddonCapacityCopyContext } from '../capacity-copy';
+
+describe( 'pressable addon capacity copy context', () => {
+	it( 'maps pressable-addon-sites-1 with explicit deltas and exact formats', () => {
+		expect( getPressableAddonCapacityCopyContext( 'pressable-addon-sites-1' ) ).toEqual( {
+			type: 'sites',
+			install: 1,
+			storage: 10,
+			visits: 10000,
+			formattedInstall: '1',
+			formattedStorage: '10 GB',
+			formattedVisits: '10,000',
+		} );
+	} );
+
+	it( 'maps pressable-addon-sites-5 with exact visits format', () => {
+		expect( getPressableAddonCapacityCopyContext( 'pressable-addon-sites-5' ) ).toEqual( {
+			type: 'sites',
+			install: 5,
+			storage: 20,
+			visits: 50000,
+			formattedInstall: '5',
+			formattedStorage: '20 GB',
+			formattedVisits: '50,000',
+		} );
+	} );
+
+	it( 'maps pressable-addon-sites-10 with exact visits format', () => {
+		expect( getPressableAddonCapacityCopyContext( 'pressable-addon-sites-10' ) ).toEqual( {
+			type: 'sites',
+			install: 10,
+			storage: 20,
+			visits: 100000,
+			formattedInstall: '10',
+			formattedStorage: '20 GB',
+			formattedVisits: '100,000',
+		} );
+	} );
+
+	it( 'maps pressable-addon-storage-1gb with exact storage format', () => {
+		expect( getPressableAddonCapacityCopyContext( 'pressable-addon-storage-1gb' ) ).toEqual( {
+			type: 'storage',
+			install: 0,
+			storage: 1,
+			visits: 0,
+			formattedInstall: '0',
+			formattedStorage: '1 GB',
+			formattedVisits: '0',
+		} );
+	} );
+
+	it( 'maps pressable-addon-visits-10k with exact visits format', () => {
+		expect( getPressableAddonCapacityCopyContext( 'pressable-addon-visits-10k' ) ).toEqual( {
+			type: 'visits',
+			install: 0,
+			storage: 0,
+			visits: 10000,
+			formattedInstall: '0',
+			formattedStorage: '0 GB',
+			formattedVisits: '10,000',
+		} );
+	} );
+
+	it( 'returns null for unknown add-on slug', () => {
+		expect( getPressableAddonCapacityCopyContext( 'pressable-addon-sites-999' ) ).toBeNull();
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/style.scss
@@ -29,7 +29,7 @@
 
 .pressable-addons-custom-description__callout {
 	@include body-medium;
-	align-items: center;
+	align-items: flex-start;
 	background: transparent;
 	border: 1px solid var(--color-neutral-10);
 	border-radius: 4px;
@@ -40,7 +40,9 @@
 	padding: 6px 10px;
 
 	svg {
+		align-self: flex-start;
 		flex-shrink: 0;
+		margin-top: 3px;
 	}
 }
 


### PR DESCRIPTION
Part of A4A-2156

## Proposed Changes

* Refactor Pressable add-on lightbox capacity copy to use `getPressablePlan` values (source of truth) instead of slug-tail parsing.
* Add explicit capacity deltas in lightbox callout/details:
  * Sites add-ons: sites + storage + visits
  * Storage add-ons: storage delta in `X GB`
  * Visits add-ons: visits delta in exact format (`10,000`)
* Keep a safe generic fallback message for unknown add-on mappings.
* Add targeted unit tests for capacity-copy mapping scenarios.

**1 Site Add-on**

<img width="595" height="640" alt="image" src="https://github.com/user-attachments/assets/34ac42a2-f826-483f-af21-b96df2367865" />


**5 Sites Add-on**

<img width="594" height="629" alt="image" src="https://github.com/user-attachments/assets/88eb990a-71a6-49fe-a017-ae427af45300" />

**10 Sites Add-on**

<img width="598" height="646" alt="image" src="https://github.com/user-attachments/assets/f3644572-3109-4a2a-baa9-1f96ee5afc85" />


## Why are these changes being made?

* Agencies reported uncertainty about whether Pressable add-ons impact storage/visits.
* This makes add-on capacity impact explicit and consistent at the Marketplace lightbox decision point before purchase.

## Testing Instructions

* Enable `?flags=a4a-pressable-addons`.
* Go to `Marketplace > Products`, filter to `Pressable`.
* Open lightbox for:
  * `Sites Add-on: 1` (and other site add-ons)
  * `Storage Add-on: 1GB`
  * `Visits Add-on: 10K`
* Verify copy shows explicit deltas and exact formatting:
  * Sites includes sites + storage + visits
  * Storage uses `1 GB`
  * Visits uses exact number formatting like `10,000`
* Verify fallback behavior still renders safe generic copy for unknown mappings (unit test coverage).
* Run tests:
  * `yarn run test-client client/a8c-for-agencies/sections/marketplace/products-overview/product-card/pressable-addons-custom-description/lib/test/capacity-copy.test.ts --runInBand`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
