### PR TITLE
Agents Manager: use same HC logic for loading

### DIFF
--- a/client/layout/agents-manager-loader.tsx
+++ b/client/layout/agents-manager-loader.tsx
@@ -5,14 +5,13 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { shouldLoadInlineHelp } from './utils';
 
 export default function AgentsManagerLoader( {
 	sectionName,
-	currentRoute,
+	loadAgentsManager,
 }: {
 	sectionName: string;
-	currentRoute: string;
+	loadAgentsManager: boolean;
 } ) {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 	const user = useSelector( getCurrentUser );
@@ -20,7 +19,7 @@ export default function AgentsManagerLoader( {
 	const primarySiteSlug = useSelector( getPrimarySiteSlug );
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
 
-	if ( ! shouldUseUnifiedAgent || ! shouldLoadInlineHelp( sectionName, currentRoute ) ) {
+	if ( ! shouldUseUnifiedAgent || ! loadAgentsManager ) {
 		return null;
 	}
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -258,6 +258,10 @@ class Layout extends Component {
 				shouldLoadInlineHelp( this.props.sectionName, this.props.currentRoute ) ) &&
 			this.props.userAllowedToHelpCenter;
 
+		const loadAgentsManager =
+			[ 'home', 'help' ].includes( this.props.sectionName ) ||
+			shouldLoadInlineHelp( this.props.sectionName, this.props.currentRoute );
+
 		const shouldDisableSidebarScrollSynchronizer =
 			this.props.isGlobalSidebarVisible || this.props.isGlobalSidebarCollapsed;
 
@@ -270,7 +274,7 @@ class Layout extends Component {
 				/>
 				<AgentsManagerLoader
 					sectionName={ this.props.sectionName }
-					currentRoute={ this.props.currentRoute }
+					loadAgentsManager={ loadAgentsManager }
 				/>
 				{ ! shouldDisableSidebarScrollSynchronizer && (
 					<SidebarScrollSynchronizer layoutFocus={ this.props.currentLayoutFocus } />


### PR DESCRIPTION
Use same method as HC for determining whether Agents Manager should load. This means we do load on the home page, even though it is excluded in `shouldLoadInlineHelp`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes agents manager not loading on /home page

## Testing Instructions

* `yarn start`
* Load http://calypso.localhost:3000/home/ and confirm agents manager appears
* Load http://calypso.localhost:3000/sites/ and confirm agents manager appears
* Load http://calypso.localhost:3000/jetpack/connect/authorize and confirm agents manager does not appear (it would without the check)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
