### PR TITLE
Agents Manager: fix Jetpack subscriber page

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
+++ b/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
@@ -21,3 +21,13 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) 
 		}
 	}
 }
+
+body.agents-manager-sidebar-container--sidebar-open.modal-open:not( .wp-admin ) {
+	overflow: hidden;
+
+	.is-section-subscribers #secondary {
+		position: fixed !important;
+		bottom: 16px !important;
+		top: 48px !important;
+	}
+}

--- a/packages/agents-manager/src/styles/mixins.scss
+++ b/packages/agents-manager/src/styles/mixins.scss
@@ -1,6 +1,6 @@
 // Apply styles to `.agents-manager-chat--docked` only when no modal is open.
 @mixin docked-chat-without-modal {
-	body:not( .modal-open ) .agents-manager-chat--docked {
+	body:not( .modal-open.wp-admin ) .agents-manager-chat--docked {
 		@content;
 	}
 }


### PR DESCRIPTION
The docked Agents Manager breaks the Jetpack subscribers page:

<img width="1270" height="1064" alt="image" src="https://github.com/user-attachments/assets/09df48f2-13f1-4f70-94b3-4e70bcf5be33" />
<img width="1272" height="1100" alt="image" src="https://github.com/user-attachments/assets/a614066a-0d72-426b-bf8a-b4b2b003cd73" />

This fixes that, as well as makes a change to theCSS that excludes `.modal-open` to also include `.wp-admin` as in Calypso, when a modal is open the Agents Manager content disappears. This can be seen on the Jetpack subscribers page.

Fixes AI-896

## Testing Instructions

* `yarn start`
* Go to http://calypso.localhost:3000/subscribers/[SITE] with agents manager open and docked
* Click 'import subscribers'
* Confirm the Jetpack model appears and the contents of the agents manager remain visible
* Resize the window a bit and confirm the Calypso sidebar remains in place
* Try and scroll down the page and confirm you can't, so the problem in the second screenshot doesnt happen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
