### PR TITLE
Refund button color shouldn't be red

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -36,7 +36,7 @@ export default function RefundEligibilityNotice( {
 					refundAmount: <RefundAmountString purchase={ purchase } cancelBundledDomain={ false } />,
 				}
 			) }{ ' ' }
-			<Button variant="link" isDestructive onClick={ onClaimRefund }>
+			<Button variant="link" onClick={ onClaimRefund }>
 				{ __( 'Remove plan and claim refund' ) }
 			</Button>
 		</Notice>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-16115

## Proposed Changes

* Make a button blue instead of red per @fditrapani's request

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistent look

## Testing Instructions

* Get a plan with the store sandbox
* Navigate to the cancellation from  http://my.localhost:3000/ and add ?flags=calypso/refund-eligibility-notice to the url

<img width="755" height="258" alt="Screenshot 2026-02-25 at 17 18 35" src="https://github.com/user-attachments/assets/4fb014ec-d49c-48b4-ba20-d23fc0579bce" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
