### PR TITLE
e2e: Fix Form block Name field variant change

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -52,7 +52,7 @@ export class AllFormFieldsFlow implements BlockFlow {
 
 		// Add remaining field blocks, labeling as we go.
 		const remainingBlocksToAdd = [
-			[ 'Name field', 'Add label…' ],
+			[ 'Name', 'Add label…', 'Name field' ],
 			[ 'Email field', 'Add label…' ],
 			[ 'Website field', 'Add label…' ],
 			[ 'Date picker', 'Add label…' ],
@@ -64,12 +64,18 @@ export class AllFormFieldsFlow implements BlockFlow {
 			[ 'Dropdown field', 'Add label' ],
 			[ 'Terms consent', 'Add implicit consent message…' ],
 		];
-		for ( const [ blockName, accessibleLabelName ] of remainingBlocksToAdd ) {
-			await this.addFieldBlockToForm( context, blockName, lastBlockName, isRefactor );
+		for ( const [ blockName, accessibleLabelName, inserterBlockName ] of remainingBlocksToAdd ) {
+			await this.addFieldBlockToForm(
+				context,
+				inserterBlockName ?? blockName,
+				blockName,
+				lastBlockName,
+				isRefactor
+			);
 			await labelFormFieldBlock( context.addedBlockLocator, {
 				blockName,
 				accessibleLabelName,
-				labelText: this.addLabelPrefix( blockName ),
+				labelText: this.addLabelPrefix( inserterBlockName ?? blockName ),
 				isRefactor,
 			} );
 			lastBlockName = blockName;
@@ -148,13 +154,15 @@ export class AllFormFieldsFlow implements BlockFlow {
 	 * Adds a field block to the form using the inline inserter.
 	 *
 	 * @param {EditorContext} context The editor context object.
-	 * @param {string} blockName Name of the block.
+	 * @param {string} inserterBlockName Name of the block in the inserter.
+	 * @param {string} selectorBlockName Name of the block for the selector.
 	 * @param {string} lastBlockName The name of the previously inserted block.
 	 * @param {boolean} isRefactor Whether the block is part of the refactored form fields.
 	 */
 	private async addFieldBlockToForm(
 		context: EditorContext,
-		blockName: string,
+		inserterBlockName: string,
+		selectorBlockName: string,
 		lastBlockName: string,
 		isRefactor: boolean
 	) {
@@ -169,8 +177,8 @@ export class AllFormFieldsFlow implements BlockFlow {
 			await editorCanvas.getByRole( 'button', { name: 'Add block' } ).first().click();
 		};
 		await context.editorPage.addBlockInline(
-			blockName,
-			makeSelectorFromBlockName( blockName ),
+			inserterBlockName,
+			makeSelectorFromBlockName( selectorBlockName ),
 			openInlineInserter
 		);
 	}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/contact-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/contact-form.ts
@@ -36,7 +36,7 @@ export class ContactFormFlow implements BlockFlow {
 		// Name and Email are common fields shared amongst all Form patterns.
 		// So let's make them unique here!
 		await labelFormFieldBlock( context.addedBlockLocator, {
-			blockName: 'Name field',
+			blockName: 'Name',
 			accessibleLabelName: 'Add label…',
 			labelText: this.addLabelPrefix( 'Name field' ),
 		} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Update E2E test to account for block default variant change.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Automattic/jetpack#47266 changed the default variant from none to "Name", which changed the aria-label of the inserted block from "Block: Name field" to "Block: Name". Update the test to match.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Jetpack Edge, desktop: `yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts`
* Jetpack Edge, mobile: `yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts`
* Simple, desktop: `yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop"  yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts`
* Simple, mobile: `yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="mobile"  yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts`

I note this will break non-Jetpack-Edge WP Cloud tests (e.g. `yarn workspace wp-e2e-tests build && CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME="desktop" TEST_ON_ATOMIC="true" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts`) until next week's Jetpack deploy to WP Cloud. But since the TC Gutenberg runs have been failing more often than not lately, and we got no complaints when #108673 got merged early, I'm going to assume that's ok.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
