### PR TITLE
Agents Manager: fix some style issues on me page

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -191,6 +191,10 @@ body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-c
 			box-sizing: border-box;
 			height: calc( var( --masterbar-height ) + 1px );
 
+			.masterbar__item-wrapper .masterbar__item-my-sites {
+				border-top-left-radius: $main-border-radius;
+			}
+
 			.masterbar__section.masterbar__section--left {
 				overflow: hidden;
 			}
@@ -207,6 +211,12 @@ body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-c
 			.masterbar__item.is-active {
 				cursor: pointer;
 			}
+
+		}
+
+		// Hide the outward border that protrudes into the agents manager sidebar
+		.is-global-sidebar-visible .masterbar__item.has-global-border::after {
+			display: none;
 		}
 
 		#content {


### PR DESCRIPTION
There are a few small issues with the docked agents manager on the Calypso /me page:

<img width="574" height="266" alt="image" src="https://github.com/user-attachments/assets/5edbf1e6-c8c3-4438-9c8b-cfb0ed0699d0" />

Also, the hover over the W logo is cropping the corners.

Fixes AI-901


## Testing Instructions

* `yarn start`
* Load http://calypso.localhost:3000/me with the docked agents manager
* Confirm there is no little tick to the right of your name in the masterbar
* Hover over the W logo and confirm the hover style does not crop the top left corner

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
