### PR TITLE
Support: Open Help Center on Contact us click for logged-in users

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/includes.php
+++ b/apps/happy-blocks/block-library/support-content-footer/includes.php
@@ -24,10 +24,10 @@ if ( ! function_exists( 'happy_blocks_get_content_footer_asset' ) ) {
 $css = happy_blocks_get_content_footer_asset( is_rtl() ? 'view.rtl.css' : 'view.css' );
 wp_enqueue_style( 'happy-blocks-support-footer-style', $css['path'], array(), $css['version'] );
 
-$enable_odie_answers = ! is_user_logged_in() && ( 'treatment' === \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages_v2' )
+$enable_help_center_on_contact_us = is_user_logged_in() || ( 'treatment' === \ExPlat\assign_maybe_anon_user( 'wpcom_ai_on_logged_out_support_pages_v2' )
 	|| ( isset( $_GET['dotcom_support_enable_odie_answers'] ) && $_GET['dotcom_support_enable_odie_answers'] === 'true' ) );
 
-if ( $enable_odie_answers ) {
+if ( $enable_help_center_on_contact_us ) {
 	$js = happy_blocks_get_content_footer_asset( 'view.js' );
 	wp_enqueue_script( 'happy-blocks-support-footer-view', $js['path'], array(), $js['version'], true );
 }

--- a/apps/happy-blocks/block-library/support-content-footer/view.js
+++ b/apps/happy-blocks/block-library/support-content-footer/view.js
@@ -12,6 +12,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	helpCenterLinks.forEach( ( link ) =>
 		link.addEventListener( 'click', function ( e ) {
 			if ( window.helpCenter?.loadHelpCenter ) {
+				// Logged-out: load Help Center widget, then open it.
 				e.preventDefault();
 
 				window.helpCenter.loadHelpCenter().then( () => {
@@ -21,6 +22,13 @@ document.addEventListener( 'DOMContentLoaded', function () {
 						helpCenterDispatch.setShowHelpCenter( true );
 					}
 				} );
+			} else if ( window.wp?.data?.dispatch ) {
+				// Logged-in: Help Center is already loaded via Calypso layout.
+				e.preventDefault();
+
+				const helpCenterDispatch = window.wp.data.dispatch( 'automattic/help-center' );
+				helpCenterDispatch.setNavigateToRoute( '/odie' );
+				helpCenterDispatch.setShowHelpCenter( true );
 			}
 		} )
 	);


### PR DESCRIPTION
Part of DOTCOM-16135

## Proposed Changes

- Always load the support-content-footer `view.js` script for logged-in users (not just logged-out users in the experiment treatment).
- Add a fallback branch in `view.js` that uses `wp.data.dispatch('automattic/help-center')` directly for logged-in users, since the Help Center is already loaded via Calypso layout and `window.helpCenter.loadHelpCenter` is not available.

## Why are these changes being made?

Previously, clicking "Contact us" in the support content footer on wordpress.com/support would only open the Help Center for logged-out users in the `wpcom_ai_on_logged_out_support_pages_v2` experiment treatment variant. Logged-in users were navigated to a separate contact page instead. This change makes logged-in users also get the Help Center experience when clicking "Contact us".

## Testing Instructions

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/happy-blocks && yarn dev --sync` (or `yarn build --sync`).
3. Visit `wordpress.com/support` while **logged in**.
4. Scroll to the bottom and click the "Contact us" card.
5. Verify the Help Center opens with the Odie chat instead of navigating to `/support/contact/`.
6. Also verify logged-out behavior still works (in the experiment treatment variant or with `?dotcom_support_enable_odie_answers=true`).
