### PR TITLE
Domain search: show CIAB-specific header and subheader text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -279,8 +279,12 @@ const DomainSearchStep: StepType< {
 			return __( 'Find the perfect domain' );
 		}
 
+		if ( isCiab ) {
+			return __( 'Make your store unforgettable' );
+		}
+
 		return __( 'Claim your space on the web' );
-	}, [ flow, __ ] );
+	}, [ flow, isCiab, __ ] );
 
 	const subHeaderText = useMemo( () => {
 		if ( isNewsletterFlow( flow ) ) {
@@ -294,8 +298,12 @@ const DomainSearchStep: StepType< {
 			return __( 'Secure your 100-Year domain and start building your legacy.' );
 		}
 
+		if ( isCiab ) {
+			return __( 'Choose a site address that puts your brand front and center.' );
+		}
+
 		return __( 'Make it yours with a .com, .blog, or one of 350+ domain options.' );
-	}, [ flow, __ ] );
+	}, [ flow, isCiab, __ ] );
 
 	const domainSearchElement = (
 		<WPCOMDomainSearch


### PR DESCRIPTION
Part of DOMAINS-2051

## Proposed Changes

- Show CIAB-specific header ("Make your store unforgettable") and subheader ("Choose a site address that puts your brand front and center.") on the domain search step when running in the Commerce In A Box context (`dashboard=ciab`).

![Screenshot 2026-02-25 alle 17 39 44](https://github.com/user-attachments/assets/3480942a-fdee-4014-97e0-1d21832c588b)


## Why are these changes being made?

The generic domain search copy doesn't reflect the store-focused experience of the CIAB flow. This updates the messaging to better align with the commerce context.

## Testing Instructions

1. Navigate to the domain search step in the stepper flow with `?dashboard=ciab` in the URL.
2. Verify the header shows "Make your store unforgettable" and the subheader shows "Choose a site address that puts your brand front and center."
3. Without the `dashboard=ciab` param, verify the default copy ("Claim your space on the web" / "Make it yours with a .com, .blog, or one of 350+ domain options.") still appears.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)