### PR TITLE
Help Center: Fix support doc link showing wrong article

### DIFF
--- a/packages/help-center/src/hooks/use-persisted-history.ts
+++ b/packages/help-center/src/hooks/use-persisted-history.ts
@@ -131,10 +131,13 @@ export const usePersistedHistory = () => {
 		action: history.action,
 		location: history.location,
 	} );
-	const persistedHistory = useSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getHelpCenterRouterHistory(),
-		[]
-	);
+	const { persistedHistory, navigateToRoute } = useSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return {
+			persistedHistory: store.getHelpCenterRouterHistory(),
+			navigateToRoute: store.getNavigateToRoute(),
+		};
+	}, [] );
 
 	// Track if we've already restored history to prevent infinite loop.
 	// The loop happens because: navigation -> notifyListeners -> setHelpCenterRouterHistory
@@ -147,6 +150,15 @@ export const usePersistedHistory = () => {
 
 	useEffect( () => {
 		if ( hasRestoredHistory.current ) {
+			return;
+		}
+
+		// Skip restoring persisted history when there's a pending navigation route
+		// (e.g., from a "Learn more" link calling setShowSupportDoc). The navigateToRoute
+		// will handle navigation in HelpCenterContent, and restoring old history here
+		// would show the wrong article.
+		if ( navigateToRoute?.route ) {
+			hasRestoredHistory.current = true;
 			return;
 		}
 
@@ -164,7 +176,7 @@ export const usePersistedHistory = () => {
 				location: history.location,
 			} );
 		}
-	}, [ persistedHistory ] );
+	}, [ persistedHistory, navigateToRoute ] );
 
 	return { history, state };
 };


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DSGCOM-467/help-center-link-opens-the-last-support-guide-not-the-correct-one

## Proposed Changes

- Skip restoring persisted Help Center history when there's a pending `navigateToRoute` (e.g., from a "Learn more" link calling `setShowSupportDoc`).

## Why are these changes being made?

When clicking a "Learn more" link (e.g., on the AI tools settings page), the Help Center would sometimes show a previously viewed support article instead of the correct one. This was a race condition: `usePersistedHistory` restored saved navigation history before `HelpCenterContent` could process the pending `navigateToRoute`, overwriting the intended destination.

The resolver for `getHelpCenterRouterHistory` already had a guard to skip fetching persisted history when `navigateToRoute` was set, but the `useEffect` in `usePersistedHistory` lacked an equivalent check. This fix adds that check so persisted history restoration is skipped when a programmatic navigation is pending.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Navigate to a site's AI tools settings page (`/sites/{site}/settings/ai-tools`).
3. Click the "Learn more" link — the Help Center should open showing the **"Build a website with AI"** article.
4. Close the Help Center, browse to a different support article, then go back to the AI tools page and click "Learn more" again — it should show the correct article, not the previously viewed one.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open a support article in the Help Center, then trigger a "Learn more" / support doc link — it should navigate to the correct article, not the previously viewed one.

