### PR TITLE
Domain search: improve CIAB domain purchase flow

### DIFF
--- a/client/dashboard/domains/add-domain-button.tsx
+++ b/client/dashboard/domains/add-domain-button.tsx
@@ -1,3 +1,5 @@
+import { siteBySlugQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Button, Dropdown, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -9,7 +11,7 @@ import { getCurrentDashboard } from '../app/routing';
 import { getDomainConnectionSetupTemplateUrl } from '../utils/domain-url';
 import { wpcomLink } from '../utils/link';
 
-function buildDomainQueryArgs( siteSlug?: string ) {
+function buildDomainQueryArgs( siteSlug?: string, adminUrl?: string ) {
 	const queryArgs: Record< string, string > = {};
 
 	if ( siteSlug ) {
@@ -17,7 +19,12 @@ function buildDomainQueryArgs( siteSlug?: string ) {
 		queryArgs.domainConnectionSetupUrl = getDomainConnectionSetupTemplateUrl();
 	}
 
-	queryArgs.dashboard = getCurrentDashboard();
+	const dashboard = getCurrentDashboard();
+	queryArgs.dashboard = dashboard;
+
+	if ( dashboard === 'ciab' && adminUrl ) {
+		queryArgs.redirect_to = `${ adminUrl }admin.php?page=next-admin&p=%2Fwoocommerce%2Fonboarding`;
+	}
 
 	return queryArgs;
 }
@@ -25,7 +32,8 @@ function buildDomainQueryArgs( siteSlug?: string ) {
 function DomainOnlyAddDomainButton() {
 	const router = useRouter();
 	const { siteSlug } = router.matchRoute( siteRoute.fullPath );
-	const queryArgs = buildDomainQueryArgs( siteSlug );
+	const { data: site } = useQuery( siteBySlugQuery( siteSlug ) );
+	const queryArgs = buildDomainQueryArgs( siteSlug, site?.options?.admin_url );
 
 	const onSearchClick = () => {
 		window.location.href = addQueryArgs(
@@ -53,7 +61,8 @@ function DomainOnlyAddDomainButton() {
 function DefaultAddDomainButton() {
 	const router = useRouter();
 	const { siteSlug } = router.matchRoute( siteRoute.fullPath );
-	const queryArgs = buildDomainQueryArgs( siteSlug );
+	const { data: site } = useQuery( siteBySlugQuery( siteSlug ) );
+	const queryArgs = buildDomainQueryArgs( siteSlug, site?.options?.admin_url );
 
 	const onSearchClick = () => {
 		window.location.href = addQueryArgs( wpcomLink( '/setup/domain' ), queryArgs );

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -100,10 +100,6 @@ const domain: FlowV2< typeof initialize > = {
 
 		const redirectTo = useQuery().get( 'redirect_to' ) || undefined;
 		const defaultRedirect = dashboardLink( `/sites/${ siteSlug }/domains` );
-		const ciabRedirect =
-			isCiab && site?.options?.admin_url
-				? `${ site.options.admin_url }admin.php?page=next-admin&p=%2Fwoocommerce%2Fonboarding`
-				: undefined;
 
 		const goToCheckout = ( siteSlug: string ) => {
 			// Check if cart contains only one domain product and it's a domain connection
@@ -116,8 +112,7 @@ const domain: FlowV2< typeof initialize > = {
 				domainCartItems && domainCartItems.length === 1 && isDomainTransfer( domainCartItems[ 0 ] );
 
 			// Use the redirect_to query param if provided, otherwise fall back to v2 domains
-			let destination =
-				redirectTo || ciabRedirect || dashboardLink( `/sites/${ siteSlug }/domains` );
+			let destination = redirectTo || dashboardLink( `/sites/${ siteSlug }/domains` );
 
 			// But send domain-only connects to domain-connection-setup.
 			if ( ! redirectTo && hasOnlyDomainConnection ) {
@@ -190,7 +185,7 @@ const domain: FlowV2< typeof initialize > = {
 					// replace the location to delete processing step from history.
 					return window.location.assign(
 						addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-							redirect_to: redirectTo || ciabRedirect || defaultRedirect,
+							redirect_to: redirectTo || defaultRedirect,
 							signup: 0,
 							cancel_to: new URL(
 								addQueryArgs( '/setup/domain', {

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -99,6 +99,10 @@ const domain: FlowV2< typeof initialize > = {
 
 		const redirectTo = useQuery().get( 'redirect_to' ) || undefined;
 		const defaultRedirect = dashboardLink( `/sites/${ siteSlug }/domains` );
+		const ciabRedirect =
+			isCiab && site?.options?.admin_url
+				? `${ site.options.admin_url }admin.php?page=next-admin&p=%2Fwoocommerce%2Fonboarding`
+				: undefined;
 
 		const goToCheckout = ( siteSlug: string ) => {
 			// Check if cart contains only one domain product and it's a domain connection
@@ -111,7 +115,8 @@ const domain: FlowV2< typeof initialize > = {
 				domainCartItems && domainCartItems.length === 1 && isDomainTransfer( domainCartItems[ 0 ] );
 
 			// Use the redirect_to query param if provided, otherwise fall back to v2 domains
-			let destination = redirectTo || dashboardLink( `/sites/${ siteSlug }/domains` );
+			let destination =
+				redirectTo || ciabRedirect || dashboardLink( `/sites/${ siteSlug }/domains` );
 
 			// But send domain-only connects to domain-connection-setup.
 			if ( ! redirectTo && hasOnlyDomainConnection ) {
@@ -180,7 +185,7 @@ const domain: FlowV2< typeof initialize > = {
 					// replace the location to delete processing step from history.
 					return window.location.assign(
 						addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-							redirect_to: redirectTo || defaultRedirect,
+							redirect_to: redirectTo || ciabRedirect || defaultRedirect,
 							signup: 0,
 							cancel_to: new URL(
 								addQueryArgs( '/setup/domain', { siteSlug, redirect_to: redirectTo } ),

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -140,7 +140,11 @@ const domain: FlowV2< typeof initialize > = {
 					redirect_to: destination,
 					signup: 1,
 					cancel_to: new URL(
-						addQueryArgs( '/setup/domain', { siteSlug, redirect_to: redirectTo } ),
+						addQueryArgs( '/setup/domain', {
+							siteSlug,
+							redirect_to: redirectTo,
+							...( isCiab && { dashboard: 'ciab' } ),
+						} ),
 						window.location.href
 					).href,
 				} )
@@ -188,7 +192,11 @@ const domain: FlowV2< typeof initialize > = {
 							redirect_to: redirectTo || ciabRedirect || defaultRedirect,
 							signup: 0,
 							cancel_to: new URL(
-								addQueryArgs( '/setup/domain', { siteSlug, redirect_to: redirectTo } ),
+								addQueryArgs( '/setup/domain', {
+									siteSlug,
+									redirect_to: redirectTo,
+									...( isCiab && { dashboard: 'ciab' } ),
+								} ),
 								window.location.href
 							).href,
 						} )

--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -95,7 +95,8 @@ const domain: FlowV2< typeof initialize > = {
 			[]
 		);
 
-		const isCiab = useQuery().get( 'dashboard' ) === 'ciab';
+		const dashboard = useQuery().get( 'dashboard' ) || undefined;
+		const isCiab = dashboard === 'ciab';
 
 		const redirectTo = useQuery().get( 'redirect_to' ) || undefined;
 		const defaultRedirect = dashboardLink( `/sites/${ siteSlug }/domains` );
@@ -143,7 +144,7 @@ const domain: FlowV2< typeof initialize > = {
 						addQueryArgs( '/setup/domain', {
 							siteSlug,
 							redirect_to: redirectTo,
-							...( isCiab && { dashboard: 'ciab' } ),
+							...( dashboard && { dashboard } ),
 						} ),
 						window.location.href
 					).href,
@@ -195,7 +196,7 @@ const domain: FlowV2< typeof initialize > = {
 								addQueryArgs( '/setup/domain', {
 									siteSlug,
 									redirect_to: redirectTo,
-									...( isCiab && { dashboard: 'ciab' } ),
+									...( dashboard && { dashboard } ),
 								} ),
 								window.location.href
 							).href,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -78,7 +78,7 @@ const DomainSearchStep: StepType< {
 	const siteSlug = useSiteSlugParam();
 	const siteId = useSiteIdParam();
 	const queryParams = useQuery();
-	const initialQuery = queryParams.get( 'new' ) ?? '';
+	const queryParamNew = queryParams.get( 'new' ) ?? '';
 	const tldQuery = queryParams.get( 'tld' );
 	const source = queryParams.get( 'source' );
 	const backTo = queryParams.get( 'back_to' ) ?? '';
@@ -87,6 +87,11 @@ const DomainSearchStep: StepType< {
 	const { __ } = useI18n();
 
 	const isCiab = dashboard === 'ciab';
+
+	// For CIAB sites, prefer the site title over the slug for domain suggestions
+	// since the slug is often randomly generated.
+	const siteTitle = isCiab && site?.name?.trim() ? site.name.trim() : '';
+	const initialQuery = queryParamNew || siteTitle;
 
 	// eslint-disable-next-line no-nested-ternary
 	const currentSiteUrl = site?.URL ? site.URL : siteSlug ? `https://${ siteSlug }` : undefined;


### PR DESCRIPTION
Part of DOMAINS-2044
Part of DOMENG-417

## Proposed Changes

- After a CIAB user completes a domain purchase, redirect them back to the wp-admin onboarding dashboard instead of the Multi-Site Dashboard domain management page.
- Preserve the `dashboard=ciab` query param in checkout cancel URLs so that CIAB context is maintained if the user cancels and retries.
- Default the domain search input to the site title instead of the site slug, which is often randomly generated and produces irrelevant domain suggestions.
- Handle edge cases where site titles are empty or whitespace-only, falling back to the URL slug.

## Why are these changes being made?

CIAB (Commerce in a Box) users enter the domain purchase flow from the wp-admin onboarding dashboard. Previously, after completing checkout they were redirected to MSD domain management — an unfamiliar UI with no context. This change keeps them in the CIAB onboarding flow so they can continue with their setup tasks.

## Testing Instructions

- Start with a CIAB site that has not yet purchased a domain.
- Navigate to the domain search flow from the CIAB wp-admin onboarding dashboard.
- Verify the search input defaults to the site title (not the slug).
- Complete a domain purchase through checkout.
- After purchase, confirm you are redirected back to the wp-admin onboarding page, not to MSD.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?