### PR TITLE
Invites: apply CIAB branding in logged-out accept flow

### DIFF
--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -46,7 +46,7 @@ export interface CiabPartnerConfig {
  *
  * To add a new partner:
  * 1. Add entry here with all config
- * 2. Add the translated ToS text in getSignupTosElement() below (required for i18n extraction)
+ * 2. Add the translated ToS text in getPartnerSignupTosElement() below (required for i18n extraction)
  * 3. Add feature flag to config/_shared.json and config/development.json
  * 4. Done! No other code changes needed.
  */
@@ -180,7 +180,7 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 			) : undefined;
 
 		// Build ToS element for signup
-		const signupTosElement = getSignupTosElement( ciabConfig, translate );
+		const signupTosElement = getPartnerSignupTosElement( ciabConfig, translate );
 
 		return {
 			hasCustomBranding,
@@ -195,7 +195,7 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
  * Get the signup ToS element for a partner.
  * Each partner's ToS text must be a string literal for i18n extraction.
  */
-function getSignupTosElement(
+export function getPartnerSignupTosElement(
 	ciabConfig: CiabPartnerConfig | null,
 	translate: ReturnType< typeof useTranslate >
 ): JSX.Element | undefined {

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -1,7 +1,14 @@
 /**
  * @jest-environment jsdom
  */
-import { getCiabConfig, getPartnerAllowedSocialServices, CIAB_PARTNERS } from '../partner-branding';
+import {
+	CIAB_PARTNERS,
+	getCiabConfig,
+	getCiabConfigFromGarden,
+	getPartnerAllowedSocialServices,
+	getPartnerSignupTosElement,
+} from '../partner-branding';
+import type { useTranslate } from 'i18n-calypso';
 
 // Mock the config module
 jest.mock( '@automattic/calypso-config', () => {
@@ -62,6 +69,36 @@ describe( 'partner-branding', () => {
 			const services = getPartnerAllowedSocialServices( undefined );
 
 			expect( services ).toBeNull();
+		} );
+	} );
+
+	describe( 'getCiabConfigFromGarden', () => {
+		test( 'returns woo config for commerce garden partner mapping', () => {
+			const config = getCiabConfigFromGarden( 'woo', 'commerce' );
+
+			expect( config ).toEqual( CIAB_PARTNERS.woo );
+		} );
+
+		test( 'returns null for unsupported garden mapping', () => {
+			const config = getCiabConfigFromGarden( 'woo', 'unknown' );
+
+			expect( config ).toBeNull();
+		} );
+	} );
+
+	describe( 'getPartnerSignupTosElement', () => {
+		const mockTranslate = ( ( original: string ) => original ) as ReturnType< typeof useTranslate >;
+
+		test( 'returns a ToS element for supported partners', () => {
+			const tosElement = getPartnerSignupTosElement( CIAB_PARTNERS.woo, mockTranslate );
+
+			expect( tosElement ).toBeDefined();
+		} );
+
+		test( 'returns undefined when no partner config is provided', () => {
+			const tosElement = getPartnerSignupTosElement( null, mockTranslate );
+
+			expect( tosElement ).toBeUndefined();
 		} );
 	} );
 

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -229,12 +229,13 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 	const description = getRoleDescription( roleName, siteDomain, translate );
 
 	// Build logo element for TopBar
-	const topBarLogo = branding?.logo?.src ? (
+	const topBarLogoConfig = branding?.compactLogo ?? branding?.logo;
+	const topBarLogo = topBarLogoConfig?.src ? (
 		<img
-			src={ branding.logo.src }
-			alt={ branding.logo.alt }
-			width={ branding.logo.width }
-			height={ branding.logo.height }
+			src={ topBarLogoConfig.src }
+			alt={ topBarLogoConfig.alt }
+			width={ topBarLogoConfig.width }
+			height={ topBarLogoConfig.height }
 		/>
 	) : undefined;
 

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { ActionButtons } from 'calypso/components/connect-screen/action-buttons';
 import { ConsentText } from 'calypso/components/connect-screen/consent-text';
@@ -170,12 +170,15 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 		avatarUrl: user?.avatar_URL,
 	};
 
-	const trackingProps = {
-		role: roleName,
-		garden_name: gardenName,
-		garden_partner: gardenPartner,
-		unified: true,
-	};
+	const trackingProps = useMemo(
+		() => ( {
+			role: roleName,
+			garden_name: gardenName,
+			garden_partner: gardenPartner,
+			unified: true,
+		} ),
+		[ roleName, gardenName, gardenPartner ]
+	);
 
 	useEffect( () => {
 		dispatch( hideMasterbar() );
@@ -231,12 +234,7 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 	// Build logo element for TopBar
 	const topBarLogoConfig = branding?.compactLogo ?? branding?.logo;
 	const topBarLogo = topBarLogoConfig?.src ? (
-		<img
-			src={ topBarLogoConfig.src }
-			alt={ topBarLogoConfig.alt }
-			width={ topBarLogoConfig.width }
-			height={ topBarLogoConfig.height }
-		/>
+		<img { ...topBarLogoConfig } alt={ topBarLogoConfig.alt } />
 	) : undefined;
 
 	const heading = <Step.Heading text={ title } subText={ description } />;

--- a/client/my-sites/invites-unified/screens/already-member-screen.tsx
+++ b/client/my-sites/invites-unified/screens/already-member-screen.tsx
@@ -61,12 +61,13 @@ export function AlreadyMemberScreen( { blogDetails }: AlreadyMemberScreenProps )
 		? getCiabConfigFromGarden( blogDetails.garden.partner, blogDetails.garden.name )
 		: null;
 
-	const topBarLogo = branding?.logo?.src ? (
+	const topBarLogoConfig = branding?.compactLogo ?? branding?.logo;
+	const topBarLogo = topBarLogoConfig?.src ? (
 		<img
-			src={ branding.logo.src }
-			alt={ branding.logo.alt }
-			width={ branding.logo.width }
-			height={ branding.logo.height }
+			src={ topBarLogoConfig.src }
+			alt={ topBarLogoConfig.alt }
+			width={ topBarLogoConfig.width }
+			height={ topBarLogoConfig.height }
 		/>
 	) : undefined;
 

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -554,5 +554,29 @@ describe( 'AcceptInviteScreen', () => {
 			expect( logo ).toHaveAttribute( 'src', 'https://example.com/woo-logo.png' );
 			expect( logo ).toHaveAttribute( 'alt', 'Woo' );
 		} );
+
+		test( 'does not show logo for non-CIAB garden sites', () => {
+			const store = createStore();
+			const invite = createInvite( {
+				blog_details: {
+					title: 'Non CIAB Store',
+					domain: 'non-ciab.store',
+					URL: 'https://non-ciab.store',
+					is_garden_site: true,
+					garden: {
+						partner: 'woo',
+						name: 'enterprise',
+					},
+				},
+			} );
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect( screen.queryByRole( 'img', { name: 'Woo' } ) ).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -133,6 +133,12 @@ const mockWooBranding = {
 		width: 100,
 		height: 30,
 	},
+	compactLogo: {
+		src: 'https://example.com/woo-logo-compact.png',
+		alt: 'Woo compact',
+		width: 72,
+		height: 24,
+	},
 };
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
@@ -551,8 +557,8 @@ describe( 'AcceptInviteScreen', () => {
 			);
 
 			const logo = screen.getByRole( 'img' );
-			expect( logo ).toHaveAttribute( 'src', 'https://example.com/woo-logo.png' );
-			expect( logo ).toHaveAttribute( 'alt', 'Woo' );
+			expect( logo ).toHaveAttribute( 'src', 'https://example.com/woo-logo-compact.png' );
+			expect( logo ).toHaveAttribute( 'alt', 'Woo compact' );
 		} );
 
 		test( 'does not show logo for non-CIAB garden sites', () => {

--- a/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
@@ -212,6 +212,26 @@ describe( 'AlreadyMemberScreen', () => {
 			expect( logo ).toHaveAttribute( 'src', 'https://example.com/woo-logo.png' );
 			expect( logo ).toHaveAttribute( 'alt', 'Woo' );
 		} );
+
+		test( 'does not show branding logo for non-CIAB sites', () => {
+			const store = createStore();
+
+			render(
+				<Provider store={ store }>
+					<AlreadyMemberScreen
+						blogDetails={ {
+							title: '',
+							domain: '',
+							URL: '',
+							is_garden_site: true,
+							garden: { partner: 'woo', name: 'enterprise' },
+						} }
+					/>
+				</Provider>
+			);
+
+			expect( screen.queryByRole( 'img', { name: 'Woo' } ) ).not.toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'switch account flow', () => {

--- a/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx
@@ -96,6 +96,12 @@ jest.mock( 'calypso/lib/partner-branding', () => ( {
 					width: 100,
 					height: 30,
 				},
+				compactLogo: {
+					src: 'https://example.com/woo-logo-compact.png',
+					alt: 'Woo compact',
+					width: 72,
+					height: 24,
+				},
 			};
 		}
 		return null;
@@ -209,8 +215,8 @@ describe( 'AlreadyMemberScreen', () => {
 			);
 
 			const logo = screen.getByRole( 'img' );
-			expect( logo ).toHaveAttribute( 'src', 'https://example.com/woo-logo.png' );
-			expect( logo ).toHaveAttribute( 'alt', 'Woo' );
+			expect( logo ).toHaveAttribute( 'src', 'https://example.com/woo-logo-compact.png' );
+			expect( logo ).toHaveAttribute( 'alt', 'Woo compact' );
 		} );
 
 		test( 'does not show branding logo for non-CIAB sites', () => {

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -9,7 +9,9 @@ import SignupForm from 'calypso/blocks/signup-form';
 import FormButton from 'calypso/components/forms/form-button';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getCiabConfigFromGarden } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
 import InviteFormHeaderLoggedOut from 'calypso/my-sites/invites/invite-form-header-logged-out';
@@ -85,7 +87,20 @@ class InviteAcceptLoggedOut extends Component {
 	};
 
 	renderFormHeader = () => {
-		return <InviteFormHeaderLoggedOut site={ this.props.invite?.site } />;
+		return (
+			<InviteFormHeaderLoggedOut
+				site={ this.props.invite?.site }
+				ciabConfig={ this.getCiabConfig() }
+			/>
+		);
+	};
+
+	getCiabConfig = () => {
+		const site = this.props.invite?.site;
+		const gardenName = site?.garden?.name || site?.garden_name;
+		const gardenPartner = site?.garden?.partner || site?.garden_partner;
+
+		return getCiabConfigFromGarden( gardenPartner, gardenName );
 	};
 
 	loginUser = () => {
@@ -161,8 +176,18 @@ class InviteAcceptLoggedOut extends Component {
 	};
 
 	render() {
+		const ciabConfig = this.getCiabConfig();
+
 		if ( this.props.forceMatchingEmail && this.props.invite.knownUser ) {
-			return this.renderSignInLinkOnly();
+			return (
+				<>
+					<BodySectionCssClass
+						bodyClass={ ciabConfig?.fontStyle === 'system' ? [ 'is-ciab-font-system' ] : [] }
+					/>
+					<WpLoggedOutInviteLogo ciabConfig={ ciabConfig } />
+					{ this.renderSignInLinkOnly() }
+				</>
+			);
 		}
 
 		if ( get( this.props.invite, 'site.is_wpforteams_site', false ) ) {
@@ -179,7 +204,10 @@ class InviteAcceptLoggedOut extends Component {
 
 		return (
 			<>
-				<WpLoggedOutInviteLogo />
+				<BodySectionCssClass
+					bodyClass={ ciabConfig?.fontStyle === 'system' ? [ 'is-ciab-font-system' ] : [] }
+				/>
+				<WpLoggedOutInviteLogo ciabConfig={ ciabConfig } />
 				<div className="invite-accept-logged-out-wrapper">
 					{ this.renderFormHeader() }
 					<SignupForm

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -97,8 +97,8 @@ class InviteAcceptLoggedOut extends Component {
 
 	getCiabConfig = () => {
 		const site = this.props.invite?.site;
-		const gardenName = site?.garden?.name || site?.garden_name;
-		const gardenPartner = site?.garden?.partner || site?.garden_partner;
+		const gardenName = site?.garden?.name;
+		const gardenPartner = site?.garden?.partner;
 
 		return getCiabConfigFromGarden( gardenPartner, gardenName );
 	};

--- a/client/my-sites/invites/invite-accept-logged-out/wp-logo.tsx
+++ b/client/my-sites/invites/invite-accept-logged-out/wp-logo.tsx
@@ -1,6 +1,25 @@
 import React from 'react';
+import type { CiabPartnerConfig } from 'calypso/lib/partner-branding';
 
-export const WpLoggedOutInviteLogo: React.FC = () => {
+interface WpLoggedOutInviteLogoProps {
+	ciabConfig?: CiabPartnerConfig | null;
+}
+
+export const WpLoggedOutInviteLogo: React.FC< WpLoggedOutInviteLogoProps > = ( { ciabConfig } ) => {
+	const logo = ciabConfig?.logo;
+
+	if ( logo?.src ) {
+		return (
+			<img
+				className="logged-out-wp-logo"
+				src={ logo.src }
+				alt={ logo.alt }
+				width={ logo.width }
+				height={ logo.height }
+			/>
+		);
+	}
+
 	return (
 		<svg
 			className="logged-out-wp-logo"

--- a/client/my-sites/invites/invite-form-header-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-form-header-logged-out/index.jsx
@@ -3,8 +3,9 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { BrandHeader } from 'calypso/components/connect-screen/brand-header';
+import { getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
 
-function InviteFormHeaderLoggedOut( { site } ) {
+function InviteFormHeaderLoggedOut( { site, ciabConfig } ) {
 	const translate = useTranslate();
 	const siteName = site?.title || site?.domain || translate( 'this site' );
 	const siteUrl = site?.URL;
@@ -25,29 +26,31 @@ function InviteFormHeaderLoggedOut( { site } ) {
 		}
 	);
 
-	const description = createInterpolateElement(
-		translate(
-			'Just a little reminder that by continuing with any of the options below, you agree to our <tosLink>Terms of Service</tosLink> and <privacyLink>Privacy Policy</privacyLink>.'
-		),
-		{
-			tosLink: (
-				<a
-					href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-					onClick={ () => recordTracksEvent( 'calypso_signup_tos_link_click' ) }
-					target="_blank"
-					rel="noopener noreferrer"
-				/>
+	const description =
+		getPartnerSignupTosElement( ciabConfig, translate ) ||
+		createInterpolateElement(
+			translate(
+				'Just a little reminder that by continuing with any of the options below, you agree to our <tosLink>Terms of Service</tosLink> and <privacyLink>Privacy Policy</privacyLink>.'
 			),
-			privacyLink: (
-				<a
-					href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-					onClick={ () => recordTracksEvent( 'calypso_signup_privacy_link_click' ) }
-					target="_blank"
-					rel="noopener noreferrer"
-				/>
-			),
-		}
-	);
+			{
+				tosLink: (
+					<a
+						href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+						onClick={ () => recordTracksEvent( 'calypso_signup_tos_link_click' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+				privacyLink: (
+					<a
+						href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+						onClick={ () => recordTracksEvent( 'calypso_signup_privacy_link_click' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		);
 
 	return (
 		<div className="invite-form-header invite-form-header--logged-out">

--- a/client/my-sites/invites/test/invite-accept-logged-out.jsx
+++ b/client/my-sites/invites/test/invite-accept-logged-out.jsx
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import InviteAcceptLoggedOut from '../invite-accept-logged-out';
+
+const mockGetCiabConfigFromGarden = jest.fn();
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: ( Component ) => ( props ) => <Component { ...props } translate={ ( text ) => text } />,
+} ) );
+
+jest.mock( 'calypso/blocks/signup-form', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="signup-form" />,
+} ) );
+
+jest.mock( 'calypso/components/forms/form-button', () => ( {
+	__esModule: true,
+	default: ( { children } ) => <button>{ children }</button>,
+} ) );
+
+jest.mock( 'calypso/components/logged-out-form/link-item', () => ( {
+	__esModule: true,
+	default: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( 'calypso/components/logged-out-form/links', () => ( {
+	__esModule: true,
+	default: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( 'calypso/layout/body-section-css-class', () => ( {
+	__esModule: true,
+	default: ( { bodyClass } ) => (
+		<div data-testid="body-section-css-class">
+			{ Array.isArray( bodyClass ) ? bodyClass.join( ' ' ) : '' }
+		</div>
+	),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/partner-branding', () => ( {
+	getCiabConfigFromGarden: ( ...args ) => mockGetCiabConfigFromGarden( ...args ),
+} ) );
+
+jest.mock( 'calypso/lib/paths', () => ( {
+	login: () => '/log-in',
+} ) );
+
+jest.mock( 'calypso/lib/route', () => ( {
+	addQueryArgs: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/my-sites/invites/invite-form-header-logged-out', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="invite-form-header-logged-out" />,
+} ) );
+
+jest.mock( 'calypso/my-sites/invites/p2/invite-accept-logged-out', () => jest.fn() );
+
+jest.mock( 'calypso/signup/wpcom-login-form', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/state/invites/actions', () => ( {
+	createAccount: jest.fn(),
+	acceptInvite: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/selectors/get-current-query-arguments', () => ( {
+	__esModule: true,
+	default: () => ( {} ),
+} ) );
+
+jest.mock( '../invite-accept-logged-out/style.scss', () => ( {} ) );
+
+const mockStore = configureStore();
+
+const buildInvite = ( siteOverrides = {} ) => ( {
+	role: 'administrator',
+	sentTo: 'invited@example.com',
+	knownUser: false,
+	site: {
+		title: 'Test Store',
+		domain: 'test.store',
+		URL: 'https://test.store',
+		...siteOverrides,
+	},
+} );
+
+describe( 'InviteAcceptLoggedOut branding', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetCiabConfigFromGarden.mockReturnValue( null );
+	} );
+
+	test( 'renders custom partner branding when invite site is Woo commerce garden', () => {
+		mockGetCiabConfigFromGarden.mockReturnValue( {
+			id: 'woo',
+			fontStyle: 'system',
+			logo: {
+				src: 'https://example.com/woo-logo.png',
+				alt: 'Woo',
+			},
+		} );
+
+		const store = mockStore( {} );
+
+		render(
+			<Provider store={ store }>
+				<InviteAcceptLoggedOut
+					invite={ buildInvite( { garden_name: 'commerce', garden_partner: 'woo' } ) }
+				/>
+			</Provider>
+		);
+
+		expect( mockGetCiabConfigFromGarden ).toHaveBeenCalledWith( 'woo', 'commerce' );
+		expect( screen.getByRole( 'img', { name: 'Woo' } ) ).toBeVisible();
+		expect( screen.getByTestId( 'body-section-css-class' ) ).toHaveTextContent(
+			'is-ciab-font-system'
+		);
+	} );
+
+	test( 'falls back to WordPress logo for non-CIAB invites', () => {
+		const store = mockStore( {} );
+
+		render(
+			<Provider store={ store }>
+				<InviteAcceptLoggedOut
+					invite={ buildInvite( { garden_name: 'enterprise', garden_partner: 'woo' } ) }
+				/>
+			</Provider>
+		);
+
+		expect( mockGetCiabConfigFromGarden ).toHaveBeenCalledWith( 'woo', 'enterprise' );
+		expect( screen.queryByRole( 'img', { name: 'Woo' } ) ).not.toBeInTheDocument();
+		expect( document.querySelector( '.logged-out-wp-logo' )?.tagName.toLowerCase() ).toBe( 'svg' );
+		expect( screen.getByTestId( 'body-section-css-class' ) ).toHaveTextContent( '' );
+	} );
+} );

--- a/client/my-sites/invites/test/invite-accept-logged-out.jsx
+++ b/client/my-sites/invites/test/invite-accept-logged-out.jsx
@@ -117,7 +117,7 @@ describe( 'InviteAcceptLoggedOut branding', () => {
 		render(
 			<Provider store={ store }>
 				<InviteAcceptLoggedOut
-					invite={ buildInvite( { garden_name: 'commerce', garden_partner: 'woo' } ) }
+					invite={ buildInvite( { garden: { name: 'commerce', partner: 'woo' } } ) }
 				/>
 			</Provider>
 		);
@@ -135,7 +135,7 @@ describe( 'InviteAcceptLoggedOut branding', () => {
 		render(
 			<Provider store={ store }>
 				<InviteAcceptLoggedOut
-					invite={ buildInvite( { garden_name: 'enterprise', garden_partner: 'woo' } ) }
+					invite={ buildInvite( { garden: { name: 'enterprise', partner: 'woo' } } ) }
 				/>
 			</Provider>
 		);
@@ -144,5 +144,19 @@ describe( 'InviteAcceptLoggedOut branding', () => {
 		expect( screen.queryByRole( 'img', { name: 'Woo' } ) ).not.toBeInTheDocument();
 		expect( document.querySelector( '.logged-out-wp-logo' )?.tagName.toLowerCase() ).toBe( 'svg' );
 		expect( screen.getByTestId( 'body-section-css-class' ) ).toHaveTextContent( '' );
+	} );
+
+	test( 'falls back to WordPress logo when site.garden is missing', () => {
+		const store = mockStore( {} );
+
+		render(
+			<Provider store={ store }>
+				<InviteAcceptLoggedOut invite={ buildInvite() } />
+			</Provider>
+		);
+
+		expect( mockGetCiabConfigFromGarden ).toHaveBeenCalledWith( undefined, undefined );
+		expect( screen.queryByRole( 'img', { name: 'Woo' } ) ).not.toBeInTheDocument();
+		expect( document.querySelector( '.logged-out-wp-logo' )?.tagName.toLowerCase() ).toBe( 'svg' );
 	} );
 } );

--- a/client/my-sites/invites/test/invite-form-header-logged-out.jsx
+++ b/client/my-sites/invites/test/invite-form-header-logged-out.jsx
@@ -5,6 +5,8 @@
 import { render, screen } from '@testing-library/react';
 import InviteFormHeaderLoggedOut from '../invite-form-header-logged-out';
 
+const mockGetPartnerSignupTosElement = jest.fn();
+
 jest.mock( '@automattic/calypso-analytics', () => ( {
 	recordTracksEvent: jest.fn(),
 } ) );
@@ -25,7 +27,16 @@ jest.mock( 'i18n-calypso', () => ( {
 		},
 } ) );
 
+jest.mock( 'calypso/lib/partner-branding', () => ( {
+	getPartnerSignupTosElement: ( ...args ) => mockGetPartnerSignupTosElement( ...args ),
+} ) );
+
 describe( 'InviteFormHeaderLoggedOut', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetPartnerSignupTosElement.mockReturnValue( undefined );
+	} );
+
 	it( 'renders a same-tab title link to the invited site', () => {
 		render(
 			<InviteFormHeaderLoggedOut
@@ -40,5 +51,25 @@ describe( 'InviteFormHeaderLoggedOut', () => {
 
 		expect( siteLink ).toHaveAttribute( 'href', 'https://example.blog' );
 		expect( siteLink ).not.toHaveAttribute( 'target' );
+	} );
+
+	it( 'uses partner ToS copy when a CIAB config is provided', () => {
+		mockGetPartnerSignupTosElement.mockReturnValue( <span>Partner ToS Copy</span> );
+
+		render(
+			<InviteFormHeaderLoggedOut
+				site={ {
+					title: 'Woo Store',
+					URL: 'https://woo.store',
+				} }
+				ciabConfig={ { id: 'woo' } }
+			/>
+		);
+
+		expect( screen.getByText( 'Partner ToS Copy' ) ).toBeVisible();
+		expect( mockGetPartnerSignupTosElement ).toHaveBeenCalledWith(
+			expect.objectContaining( { id: 'woo' } ),
+			expect.any( Function )
+		);
 	} );
 } );


### PR DESCRIPTION
Part of ARC-1486

## Proposed Changes

* Apply partner branding in the unauthenticated `/accept-invite` legacy logged-out flow by resolving CIAB config from invite garden data (`commerce` + `woo`) through `client/lib/partner-branding.tsx`.
* Render Woo partner logo conditionally in the logged-out invite logo component, while preserving the existing WordPress logo fallback for non-CIAB invites.
* Reuse partner-specific ToS copy in the logged-out invite header via a shared helper exported from `partner-branding`, with the existing default copy as fallback.
* Add conditional `is-ciab-font-system` body class in logged-out invite screens to match existing unified invite branding behavior.
* Add/extend unit tests to cover CIAB positive and non-CIAB fallback scenarios in legacy logged-out invite flow, partner-branding helpers, and unified invite branding screens.

## Why are these changes being made?

* The logged-out invite acceptance experience should apply the same partner-branding rules as the rest of the invite flows, so Woo commerce garden invites consistently show partner branding while non-CIAB invites keep the default WordPress presentation.

<img width="2984" height="1728" alt="image" src="https://github.com/user-attachments/assets/3bc945e4-a6d6-4563-8fad-b4bf322f8b67" />


## Testing Instructions

* Run:
  * `yarn eslint client/lib/partner-branding.tsx client/lib/test/partner-branding.tsx client/my-sites/invites/invite-form-header-logged-out/index.jsx client/my-sites/invites/invite-accept-logged-out/index.jsx client/my-sites/invites/invite-accept-logged-out/wp-logo.tsx client/my-sites/invites/test/invite-form-header-logged-out.jsx client/my-sites/invites/test/invite-accept-logged-out.jsx client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx`
  * `yarn test-client client/lib/test/partner-branding.tsx client/my-sites/invites/test/invite-form-header-logged-out.jsx client/my-sites/invites/test/invite-accept-logged-out.jsx client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx client/my-sites/invites-unified/screens/test/already-member-screen.test.tsx --runInBand`
* Manual verification:
  * Open a logged-out `/accept-invite` link for a Woo commerce garden invite and confirm Woo logo and partner ToS copy are shown.
  * Open a logged-out `/accept-invite` link for a non-CIAB invite and confirm the default WordPress logo/copy are shown.
  * Confirm force-matching-email logged-out state still renders correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector, Using memoizing selectors, and Our Approach to Data.
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?