### PR TITLE
Partner Branding: detect partner from domain and redirect URLs

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -31,7 +31,7 @@ import {
 	isGravatarOAuth2Client,
 	isGravPoweredOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { getEffectivePartnerAllowedSocialServices } from 'calypso/lib/partner-branding';
+import { getPartnerAllowedSocialServices } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -981,10 +981,7 @@ export default connect(
 			oauth2Client,
 			isFromAutomatticForAgenciesPlugin:
 				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ),
-			allowedSocialServices: getEffectivePartnerAllowedSocialServices(
-				get( getCurrentQueryArguments( state ), 'from' ),
-				get( getInitialQueryArguments( state ), 'from' )
-			),
+			allowedSocialServices: getPartnerAllowedSocialServices(),
 			isWooJPC: isWooJPCFlow( state ),
 			isWoo: getIsWoo( state ),
 			redirectTo: getRedirectToOriginal( state ),

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -75,7 +75,7 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		},
 		ssoProviders: [ 'paypal', 'google', 'apple', 'magic-login' ],
 		fontStyle: 'system',
-		domains: [ 'my.woo.ai' ],
+		domains: [ 'my.woo.ai', 'my.localhost' ],
 	},
 };
 

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -29,7 +29,7 @@ interface LogoConfig {
  * All partner-specific settings are centralized here
  */
 export interface CiabPartnerConfig {
-	/** Partner identifier (matches URL ?from= param) */
+	/** Partner identifier */
 	id: string;
 	/** Display name shown in UI (e.g., "Woo") */
 	displayName: string;
@@ -43,6 +43,8 @@ export interface CiabPartnerConfig {
 	ssoProviders: SignupAllowedService[];
 	/** Font style identifier for login/signup headings */
 	fontStyle?: 'system';
+	/** Domains that identify this partner in redirect URLs (e.g., ['my.woo.ai']) */
+	domains?: string[];
 }
 
 /**
@@ -73,6 +75,7 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		},
 		ssoProviders: [ 'paypal', 'google', 'apple', 'magic-login' ],
 		fontStyle: 'system',
+		domains: [ 'my.woo.ai' ],
 	},
 };
 
@@ -184,6 +187,72 @@ export function getCiabConfig( from: string | string[] | undefined ): CiabPartne
 	}
 
 	return null;
+}
+
+/**
+ * Get CIAB partner config by matching the current page's hostname against partner domains.
+ */
+export function getCiabConfigFromCurrentDomain(): CiabPartnerConfig | null {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+
+	const { hostname } = window.location;
+
+	for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
+		if ( partnerConfig.domains?.includes( hostname ) ) {
+			if ( config.isEnabled( partnerConfig.featureFlag ) ) {
+				return partnerConfig;
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Get CIAB partner config by matching a redirect URL's hostname against partner domains.
+ * Checks redirect_to and oauth2_redirect query params for known partner domains.
+ */
+export function getCiabConfigFromRedirectUrl(
+	redirectUrl: string | string[] | undefined
+): CiabPartnerConfig | null {
+	const urlValue = Array.isArray( redirectUrl ) ? redirectUrl[ 0 ] : redirectUrl;
+
+	if ( ! urlValue ) {
+		return null;
+	}
+
+	try {
+		const { hostname } = new URL( urlValue );
+
+		for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
+			if ( partnerConfig.domains?.includes( hostname ) ) {
+				if ( config.isEnabled( partnerConfig.featureFlag ) ) {
+					return partnerConfig;
+				}
+			}
+		}
+	} catch {
+		// Invalid URL, ignore
+	}
+
+	return null;
+}
+
+/**
+ * Detect CIAB partner config from the current domain and redirect URL params.
+ * Checks in order: current page domain, redirect_to, oauth2_redirect.
+ */
+export function detectCiabConfig(
+	redirectTo?: string | string[],
+	oauth2Redirect?: string | string[]
+): CiabPartnerConfig | null {
+	return (
+		getCiabConfigFromCurrentDomain() ??
+		getCiabConfigFromRedirectUrl( redirectTo ) ??
+		getCiabConfigFromRedirectUrl( oauth2Redirect )
+	);
 }
 
 export function getEffectiveCiabConfig(

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -3,7 +3,6 @@ import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { get } from 'lodash';
 import { useMemo } from 'react';
 import wooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
 import { useSelector } from 'calypso/state';
@@ -80,14 +79,6 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 };
 
 const CIAB_PARTNER_SESSION_KEY = 'calypso.ciab.partner-id';
-
-function getFirstFromValue( from: string | string[] | undefined ): string | undefined {
-	if ( Array.isArray( from ) ) {
-		return from[ 0 ];
-	}
-
-	return from;
-}
 
 function getSessionStorage(): Storage | null {
 	if ( typeof window === 'undefined' ) {
@@ -172,20 +163,16 @@ export function getCiabConfigFromGarden(
 }
 
 /**
- * Get CIAB partner config from URL 'from' param
- * Returns the full partner config or null if not a CIAB partner
+ * Get CIAB partner config by matching a hostname against partner domains.
  */
-export function getCiabConfig( from: string | string[] | undefined ): CiabPartnerConfig | null {
-	const fromValue = getFirstFromValue( from );
-
-	if ( fromValue && CIAB_PARTNERS[ fromValue ] ) {
-		const partnerConfig = CIAB_PARTNERS[ fromValue ];
-		// Check if feature flag is enabled
-		if ( config.isEnabled( partnerConfig.featureFlag ) ) {
-			return partnerConfig;
+function getCiabConfigByHostname( hostname: string ): CiabPartnerConfig | null {
+	for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
+		if ( partnerConfig.domains?.includes( hostname ) ) {
+			if ( config.isEnabled( partnerConfig.featureFlag ) ) {
+				return partnerConfig;
+			}
 		}
 	}
-
 	return null;
 }
 
@@ -196,14 +183,28 @@ export function getCiabConfigFromCurrentDomain(): CiabPartnerConfig | null {
 	if ( typeof window === 'undefined' ) {
 		return null;
 	}
+	return getCiabConfigByHostname( window.location.hostname );
+}
 
-	const { hostname } = window.location;
+/**
+ * Get CIAB partner config from the branding code query parameter.
+ *
+ * TODO: The `from` parameter is transitional — it provides backward compatibility
+ * with existing flows (e.g. ?from=woo). In a follow-up, replace it with a dedicated
+ * global branding-code parameter (e.g. ?branding=woo) and remove this fallback.
+ */
+export function getCiabConfigFromBrandingCode(): CiabPartnerConfig | null {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
 
-	for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
-		if ( partnerConfig.domains?.includes( hostname ) ) {
-			if ( config.isEnabled( partnerConfig.featureFlag ) ) {
-				return partnerConfig;
-			}
+	const params = new URLSearchParams( window.location.search );
+	const from = params.get( 'from' );
+
+	if ( from && CIAB_PARTNERS[ from ] ) {
+		const partnerConfig = CIAB_PARTNERS[ from ];
+		if ( config.isEnabled( partnerConfig.featureFlag ) ) {
+			return partnerConfig;
 		}
 	}
 
@@ -212,10 +213,9 @@ export function getCiabConfigFromCurrentDomain(): CiabPartnerConfig | null {
 
 /**
  * Get CIAB partner config by matching a redirect URL's hostname against partner domains.
- * Checks redirect_to and oauth2_redirect query params for known partner domains.
  */
 export function getCiabConfigFromRedirectUrl(
-	redirectUrl: string | string[] | undefined
+	redirectUrl: string | string[] | undefined | null
 ): CiabPartnerConfig | null {
 	const urlValue = Array.isArray( redirectUrl ) ? redirectUrl[ 0 ] : redirectUrl;
 
@@ -224,15 +224,7 @@ export function getCiabConfigFromRedirectUrl(
 	}
 
 	try {
-		const { hostname } = new URL( urlValue );
-
-		for ( const partnerConfig of Object.values( CIAB_PARTNERS ) ) {
-			if ( partnerConfig.domains?.includes( hostname ) ) {
-				if ( config.isEnabled( partnerConfig.featureFlag ) ) {
-					return partnerConfig;
-				}
-			}
-		}
+		return getCiabConfigByHostname( new URL( urlValue ).hostname );
 	} catch {
 		// Invalid URL, ignore
 	}
@@ -241,80 +233,64 @@ export function getCiabConfigFromRedirectUrl(
 }
 
 /**
- * Detect CIAB partner config from the current domain and redirect URL params.
- * Checks in order: current page domain, redirect_to, oauth2_redirect.
+ * Read a query parameter from the current URL.
  */
-export function detectCiabConfig(
-	redirectTo?: string | string[],
-	oauth2Redirect?: string | string[]
-): CiabPartnerConfig | null {
-	return (
-		getCiabConfigFromCurrentDomain() ??
-		getCiabConfigFromRedirectUrl( redirectTo ) ??
-		getCiabConfigFromRedirectUrl( oauth2Redirect )
-	);
-}
-
-export function getEffectiveCiabConfig(
-	currentFrom: string | string[] | undefined,
-	initialFrom: string | string[] | undefined = undefined
-): CiabPartnerConfig | null {
-	const currentFromValue = getFirstFromValue( currentFrom );
-
-	if ( currentFromValue !== undefined ) {
-		const currentCiabConfig = getCiabConfig( currentFromValue );
-
-		if ( currentCiabConfig ) {
-			persistCiabPartnerId( currentCiabConfig.id );
-			return currentCiabConfig;
-		}
-
-		clearPersistedCiabPartnerId();
+function getSearchParam( name: string ): string | null {
+	if ( typeof window === 'undefined' ) {
 		return null;
 	}
-
-	const initialCiabConfig = getCiabConfig( initialFrom );
-
-	if ( initialCiabConfig ) {
-		persistCiabPartnerId( initialCiabConfig.id );
-		return initialCiabConfig;
-	}
-
-	const persistedPartnerId = readPersistedCiabPartnerId();
-
-	if ( ! persistedPartnerId ) {
-		return null;
-	}
-
-	const persistedCiabConfig = getCiabConfig( persistedPartnerId );
-
-	if ( ! persistedCiabConfig ) {
-		clearPersistedCiabPartnerId();
-		return null;
-	}
-
-	return persistedCiabConfig;
+	return new URLSearchParams( window.location.search ).get( name );
 }
 
 /**
- * Get allowed social services for a partner from URL 'from' param
- * Returns the array of allowed SSO providers or null if no restrictions apply
- * @param from - The 'from' query parameter value
- * @returns Array of allowed service names (e.g., ['paypal', 'google', 'apple']) or null
+ * Detect CIAB partner config from globally available values.
+ *
+ * Callers should NOT pass values — the detector reads from window.location internally.
+ *
+ * Detection precedence (first match wins):
+ *   1. hostname           — window.location.hostname against partner domains
+ *   2. branding code      — ?from= query param (transitional, see getCiabConfigFromBrandingCode)
+ *   3. redirect_to        — hostname inside ?redirect_to= URL
+ *   4. oauth2_redirect    — hostname inside ?oauth2_redirect= URL
+ *   5. session storage    — persisted partner from a previous detection in this session
  */
-export function getPartnerAllowedSocialServices(
-	from: string | string[] | undefined
-): AllowedSocialService[] | null {
-	const ciabConfig = getCiabConfig( from );
-	return ciabConfig?.ssoProviders ?? null;
+export function detectCiabConfig(): CiabPartnerConfig | null {
+	const detected =
+		getCiabConfigFromCurrentDomain() ??
+		getCiabConfigFromBrandingCode() ??
+		getCiabConfigFromRedirectUrl( getSearchParam( 'redirect_to' ) ) ??
+		getCiabConfigFromRedirectUrl( getSearchParam( 'oauth2_redirect' ) );
+
+	if ( detected ) {
+		persistCiabPartnerId( detected.id );
+		return detected;
+	}
+
+	// Session persistence fallback: if no detection source matches,
+	// check if a partner was previously detected in this session.
+	const persistedPartnerId = readPersistedCiabPartnerId();
+
+	if ( persistedPartnerId ) {
+		const persistedConfig = CIAB_PARTNERS[ persistedPartnerId ];
+
+		if ( persistedConfig && config.isEnabled( persistedConfig.featureFlag ) ) {
+			return persistedConfig;
+		}
+
+		clearPersistedCiabPartnerId();
+	}
+
+	return null;
 }
 
-export function getEffectivePartnerAllowedSocialServices(
-	currentFrom: string | string[] | undefined,
-	initialFrom: string | string[] | undefined = undefined
-): AllowedSocialService[] | null {
-	const ciabConfig = getEffectiveCiabConfig( currentFrom, initialFrom );
-
+/**
+ * Get allowed social services for a partner.
+ * Detects partner from globally available values (see detectCiabConfig).
+ * Returns the array of allowed SSO providers or null if no restrictions apply.
+ * @returns Array of allowed service names (e.g., ['paypal', 'google', 'apple']) or null
+ */
+export function getPartnerAllowedSocialServices(): AllowedSocialService[] | null {
+	const ciabConfig = detectCiabConfig();
 	return ciabConfig?.ssoProviders ?? null;
 }
 
@@ -333,7 +309,9 @@ export interface UsePartnerBrandingResult {
 }
 
 /**
- * Hook to get current partner branding based on URL params and feature flags
+ * Hook to get current partner branding based on URL params and feature flags.
+ * Internally calls detectCiabConfig() — callers do not need to pass any values.
+ *
  * @example
  * const { topBarLogo, ciabConfig, signupTosElement } = usePartnerBranding();
  *
@@ -352,11 +330,17 @@ export interface UsePartnerBrandingResult {
  */
 export function usePartnerBranding(): UsePartnerBrandingResult {
 	const translate = useTranslate();
-	const fromCurrent = useSelector( ( state ) => get( getCurrentQueryArguments( state ), 'from' ) );
-	const fromInitial = useSelector( ( state ) => get( getInitialQueryArguments( state ), 'from' ) );
+
+	// Redux selectors are used only as memo-invalidation triggers.
+	// The actual detection reads from window.location via detectCiabConfig().
+	const currentQuery = useSelector( getCurrentQueryArguments );
+	const initialQuery = useSelector( getInitialQueryArguments );
+	const from = currentQuery?.from || initialQuery?.from;
+	const redirectTo = currentQuery?.redirect_to || initialQuery?.redirect_to;
+	const oauth2Redirect = currentQuery?.oauth2_redirect || initialQuery?.oauth2_redirect;
 
 	return useMemo( () => {
-		const ciabConfig = getEffectiveCiabConfig( fromCurrent, fromInitial );
+		const ciabConfig = detectCiabConfig();
 		const hasCustomBranding = ciabConfig !== null;
 
 		// Build logo element for TopBar
@@ -380,7 +364,7 @@ export function usePartnerBranding(): UsePartnerBrandingResult {
 			topBarLogo,
 			signupTosElement,
 		};
-	}, [ fromCurrent, fromInitial, translate ] );
+	}, [ from, redirectTo, oauth2Redirect, translate ] );
 }
 
 /**

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -74,7 +74,7 @@ export const CIAB_PARTNERS: Record< string, CiabPartnerConfig > = {
 		},
 		ssoProviders: [ 'paypal', 'google', 'apple', 'magic-login' ],
 		fontStyle: 'system',
-		domains: [ 'my.woo.ai', 'my.localhost' ],
+		domains: [ 'my.woo.ai', 'my.woo.localhost' ],
 	},
 };
 

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -3,12 +3,8 @@
  */
 import config from '@automattic/calypso-config';
 import {
-	CIAB_PARTNERS,
-	clearPersistedCiabPartnerId,
-	getEffectiveCiabConfig,
-	getEffectivePartnerAllowedSocialServices,
-	getCiabConfig,
 	getCiabConfigFromCurrentDomain,
+	getCiabConfigFromBrandingCode,
 	getCiabConfigFromRedirectUrl,
 	getCiabConfigFromGarden,
 	detectCiabConfig,
@@ -16,6 +12,8 @@ import {
 	getPartnerSignupTosElement,
 	persistCiabPartnerId,
 	readPersistedCiabPartnerId,
+	clearPersistedCiabPartnerId,
+	CIAB_PARTNERS,
 } from '../partner-branding';
 import type { useTranslate } from 'i18n-calypso';
 
@@ -32,6 +30,15 @@ jest.mock( '@automattic/calypso-config', () => {
 } );
 
 describe( 'partner-branding', () => {
+	const originalLocation = window.location;
+
+	function setLocation( hostname: string, search = '' ) {
+		Object.defineProperty( window, 'location', {
+			value: { hostname, search },
+			writable: true,
+		} );
+	}
+
 	beforeEach( () => {
 		clearPersistedCiabPartnerId();
 		( config.isEnabled as jest.Mock ).mockImplementation( ( feature: string ) => {
@@ -43,50 +50,16 @@ describe( 'partner-branding', () => {
 		} );
 	} );
 
-	describe( 'getCiabConfig', () => {
-		test( 'returns partner config when from param matches a valid partner', () => {
-			const config = getCiabConfig( 'woo' );
-
-			expect( config ).not.toBeNull();
-			expect( config?.id ).toBe( 'woo' );
-			expect( config?.displayName ).toBe( 'Woo' );
-		} );
-
-		test( 'returns null when from param does not match any partner', () => {
-			const config = getCiabConfig( 'unknown-partner' );
-
-			expect( config ).toBeNull();
-		} );
-
-		test( 'returns null when from param is undefined', () => {
-			const config = getCiabConfig( undefined );
-
-			expect( config ).toBeNull();
-		} );
-
-		test( 'handles array of from params by using first value', () => {
-			const config = getCiabConfig( [ 'woo', 'other' ] );
-
-			expect( config ).not.toBeNull();
-			expect( config?.id ).toBe( 'woo' );
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: originalLocation,
+			writable: true,
 		} );
 	} );
 
 	describe( 'getCiabConfigFromCurrentDomain', () => {
-		const originalLocation = window.location;
-
-		afterEach( () => {
-			Object.defineProperty( window, 'location', {
-				value: originalLocation,
-				writable: true,
-			} );
-		} );
-
 		test( 'returns partner config when current domain matches', () => {
-			Object.defineProperty( window, 'location', {
-				value: { hostname: 'my.woo.ai' },
-				writable: true,
-			} );
+			setLocation( 'my.woo.ai' );
 
 			const result = getCiabConfigFromCurrentDomain();
 
@@ -95,12 +68,36 @@ describe( 'partner-branding', () => {
 		} );
 
 		test( 'returns null when current domain does not match any partner', () => {
-			Object.defineProperty( window, 'location', {
-				value: { hostname: 'wordpress.com' },
-				writable: true,
-			} );
+			setLocation( 'wordpress.com' );
 
 			const result = getCiabConfigFromCurrentDomain();
+
+			expect( result ).toBeNull();
+		} );
+	} );
+
+	describe( 'getCiabConfigFromBrandingCode', () => {
+		test( 'returns partner config when from param matches a valid partner', () => {
+			setLocation( 'wordpress.com', '?from=woo' );
+
+			const result = getCiabConfigFromBrandingCode();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'returns null when from param does not match any partner', () => {
+			setLocation( 'wordpress.com', '?from=unknown' );
+
+			const result = getCiabConfigFromBrandingCode();
+
+			expect( result ).toBeNull();
+		} );
+
+		test( 'returns null when from param is absent', () => {
+			setLocation( 'wordpress.com' );
+
+			const result = getCiabConfigFromBrandingCode();
 
 			expect( result ).toBeNull();
 		} );
@@ -158,81 +155,96 @@ describe( 'partner-branding', () => {
 		} );
 	} );
 
-	describe( 'detectCiabConfig', () => {
-		test( 'detects from redirect_to param', () => {
-			const result = detectCiabConfig( 'https://my.woo.ai/dashboard' );
+	describe( 'detectCiabConfig — precedence', () => {
+		test( 'hostname wins over conflicting from query param', () => {
+			setLocation( 'my.woo.ai', '?from=other' );
+
+			const result = detectCiabConfig();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
-		test( 'detects from oauth2_redirect param', () => {
-			const result = detectCiabConfig( undefined, 'https://my.woo.ai/dashboard' );
+		test( 'hostname wins over conflicting redirect_to', () => {
+			setLocation( 'my.woo.ai', '?redirect_to=https://example.com' );
+
+			const result = detectCiabConfig();
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
-		test( 'prefers redirect_to over oauth2_redirect', () => {
-			const result = detectCiabConfig(
-				'https://my.woo.ai/from-redirect',
-				'https://example.com/from-oauth'
+		test( 'from=woo still works when hostname does not match', () => {
+			setLocation( 'wordpress.com', '?from=woo' );
+
+			const result = detectCiabConfig();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'from wins over redirect_to when conflicting', () => {
+			setLocation( 'wordpress.com', '?from=woo&redirect_to=https://example.com' );
+
+			const result = detectCiabConfig();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'from wins over oauth2_redirect when conflicting', () => {
+			setLocation( 'wordpress.com', '?from=woo&oauth2_redirect=https://example.com' );
+
+			const result = detectCiabConfig();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'redirect_to matching still works when no hostname or from match', () => {
+			setLocation( 'wordpress.com', '?redirect_to=https://my.woo.ai/dashboard' );
+
+			const result = detectCiabConfig();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'oauth2_redirect matching still works when nothing else matches', () => {
+			setLocation( 'wordpress.com', '?oauth2_redirect=https://my.woo.ai/dashboard' );
+
+			const result = detectCiabConfig();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'redirect_to wins over oauth2_redirect when conflicting', () => {
+			setLocation(
+				'wordpress.com',
+				'?redirect_to=https://my.woo.ai&oauth2_redirect=https://example.com'
 			);
 
+			const result = detectCiabConfig();
+
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );
 		} );
 
-		test( 'returns null when no params match', () => {
-			const result = detectCiabConfig( 'https://example.com', 'https://other.com' );
+		test( 'returns null when nothing matches', () => {
+			setLocation( 'wordpress.com', '?redirect_to=https://example.com' );
+
+			const result = detectCiabConfig();
 
 			expect( result ).toBeNull();
 		} );
 
-		test( 'returns null when both params are undefined', () => {
-			const result = detectCiabConfig( undefined, undefined );
+		test( 'returns null when no query params are present', () => {
+			setLocation( 'wordpress.com' );
+
+			const result = detectCiabConfig();
 
 			expect( result ).toBeNull();
-		} );
-	} );
-
-	describe( 'getPartnerAllowedSocialServices', () => {
-		test( 'returns ssoProviders array for valid partner', () => {
-			const services = getPartnerAllowedSocialServices( 'woo' );
-
-			expect( services ).toEqual( CIAB_PARTNERS.woo.ssoProviders );
-		} );
-
-		test( 'returns null for unknown partner', () => {
-			const services = getPartnerAllowedSocialServices( 'unknown' );
-
-			expect( services ).toBeNull();
-		} );
-
-		test( 'returns null when from is undefined', () => {
-			const services = getPartnerAllowedSocialServices( undefined );
-
-			expect( services ).toBeNull();
-		} );
-	} );
-
-	describe( 'getCiabConfigFromGarden', () => {
-		test( 'returns woo config for commerce garden partner mapping', () => {
-			const config = getCiabConfigFromGarden( 'woo', 'commerce' );
-
-			expect( config ).toEqual( CIAB_PARTNERS.woo );
-		} );
-
-		test( 'returns null for unsupported garden mapping', () => {
-			const config = getCiabConfigFromGarden( 'woo', 'unknown' );
-
-			expect( config ).toBeNull();
-		} );
-
-		test( 'persists partner id when requested', () => {
-			getCiabConfigFromGarden( 'woo', 'commerce', { persistToSession: true } );
-
-			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
 		} );
 	} );
 
@@ -243,46 +255,86 @@ describe( 'partner-branding', () => {
 			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
 		} );
 
-		test( 'uses current from when present and persists it', () => {
-			const config = getEffectiveCiabConfig( 'woo', undefined );
+		test( 'detectCiabConfig persists partner when detected', () => {
+			setLocation( 'wordpress.com', '?from=woo' );
 
-			expect( config?.id ).toBe( 'woo' );
+			detectCiabConfig();
+
 			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
 		} );
 
-		test( 'uses persisted partner when from params are missing', () => {
+		test( 'detectCiabConfig uses persisted partner when nothing else matches', () => {
 			persistCiabPartnerId( 'woo' );
+			setLocation( 'wordpress.com' );
 
-			const config = getEffectiveCiabConfig( undefined, undefined );
+			const result = detectCiabConfig();
 
-			expect( config?.id ).toBe( 'woo' );
+			expect( result?.id ).toBe( 'woo' );
 		} );
 
-		test( 'clears persisted partner when current from is invalid', () => {
-			persistCiabPartnerId( 'woo' );
-
-			const config = getEffectiveCiabConfig( 'unknown', undefined );
-
-			expect( config ).toBeNull();
-			expect( readPersistedCiabPartnerId() ).toBeNull();
-		} );
-
-		test( 'clears persisted partner when feature flag is disabled', () => {
+		test( 'detectCiabConfig clears persisted partner when feature flag is disabled', () => {
 			persistCiabPartnerId( 'woo' );
 			( config.isEnabled as jest.Mock ).mockReturnValue( false );
+			setLocation( 'wordpress.com' );
 
-			const effectiveConfig = getEffectiveCiabConfig( undefined, undefined );
+			const result = detectCiabConfig();
 
-			expect( effectiveConfig ).toBeNull();
+			expect( result ).toBeNull();
 			expect( readPersistedCiabPartnerId() ).toBeNull();
 		} );
+	} );
 
-		test( 'returns social services from persisted partner', () => {
-			persistCiabPartnerId( 'woo' );
+	describe( 'getPartnerAllowedSocialServices', () => {
+		test( 'returns ssoProviders array when from param matches partner', () => {
+			setLocation( 'wordpress.com', '?from=woo' );
 
-			const services = getEffectivePartnerAllowedSocialServices( undefined, undefined );
+			const services = getPartnerAllowedSocialServices();
 
 			expect( services ).toEqual( CIAB_PARTNERS.woo.ssoProviders );
+		} );
+
+		test( 'returns ssoProviders array when redirect URL matches partner', () => {
+			setLocation( 'wordpress.com', '?redirect_to=https://my.woo.ai/dashboard' );
+
+			const services = getPartnerAllowedSocialServices();
+
+			expect( services ).toEqual( CIAB_PARTNERS.woo.ssoProviders );
+		} );
+
+		test( 'returns null when nothing matches', () => {
+			setLocation( 'wordpress.com', '?redirect_to=https://example.com' );
+
+			const services = getPartnerAllowedSocialServices();
+
+			expect( services ).toBeNull();
+		} );
+
+		test( 'returns null when no query params', () => {
+			setLocation( 'wordpress.com' );
+
+			const services = getPartnerAllowedSocialServices();
+
+			expect( services ).toBeNull();
+		} );
+	} );
+
+	describe( 'getCiabConfigFromGarden', () => {
+		test( 'returns woo config for commerce garden partner mapping', () => {
+			const result = getCiabConfigFromGarden( 'woo', 'commerce' );
+
+			expect( result ).toEqual( CIAB_PARTNERS.woo );
+		} );
+
+		test( 'returns null for unsupported garden mapping', () => {
+			const result = getCiabConfigFromGarden( 'woo', 'unknown' );
+
+			expect( result ).toBeNull();
+		} );
+
+		test( 'persists partner id when requested', () => {
+			getCiabConfigFromGarden( 'woo', 'commerce', { persistToSession: true } );
+
+			expect( readPersistedCiabPartnerId() ).toBe( 'woo' );
 		} );
 	} );
 

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -8,7 +8,10 @@ import {
 	getEffectiveCiabConfig,
 	getEffectivePartnerAllowedSocialServices,
 	getCiabConfig,
+	getCiabConfigFromCurrentDomain,
+	getCiabConfigFromRedirectUrl,
 	getCiabConfigFromGarden,
+	detectCiabConfig,
 	getPartnerAllowedSocialServices,
 	getPartnerSignupTosElement,
 	persistCiabPartnerId,
@@ -66,6 +69,130 @@ describe( 'partner-branding', () => {
 
 			expect( config ).not.toBeNull();
 			expect( config?.id ).toBe( 'woo' );
+		} );
+	} );
+
+	describe( 'getCiabConfigFromCurrentDomain', () => {
+		const originalLocation = window.location;
+
+		afterEach( () => {
+			Object.defineProperty( window, 'location', {
+				value: originalLocation,
+				writable: true,
+			} );
+		} );
+
+		test( 'returns partner config when current domain matches', () => {
+			Object.defineProperty( window, 'location', {
+				value: { hostname: 'my.woo.ai' },
+				writable: true,
+			} );
+
+			const result = getCiabConfigFromCurrentDomain();
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'returns null when current domain does not match any partner', () => {
+			Object.defineProperty( window, 'location', {
+				value: { hostname: 'wordpress.com' },
+				writable: true,
+			} );
+
+			const result = getCiabConfigFromCurrentDomain();
+
+			expect( result ).toBeNull();
+		} );
+	} );
+
+	describe( 'getCiabConfigFromRedirectUrl', () => {
+		test( 'returns partner config when redirect URL hostname matches a partner domain', () => {
+			const result = getCiabConfigFromRedirectUrl( 'https://my.woo.ai/dashboard' );
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'returns partner config when redirect URL has path and query params', () => {
+			const result = getCiabConfigFromRedirectUrl(
+				'https://my.woo.ai/some/path?foo=bar&baz=1'
+			);
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'returns null when redirect URL hostname does not match any partner', () => {
+			const result = getCiabConfigFromRedirectUrl( 'https://example.com/dashboard' );
+
+			expect( result ).toBeNull();
+		} );
+
+		test( 'returns null when redirect URL is undefined', () => {
+			const result = getCiabConfigFromRedirectUrl( undefined );
+
+			expect( result ).toBeNull();
+		} );
+
+		test( 'returns null when redirect URL is an invalid URL', () => {
+			const result = getCiabConfigFromRedirectUrl( 'not-a-url' );
+
+			expect( result ).toBeNull();
+		} );
+
+		test( 'handles array of redirect URLs by using first value', () => {
+			const result = getCiabConfigFromRedirectUrl( [
+				'https://my.woo.ai/dashboard',
+				'https://example.com',
+			] );
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'does not match subdomains of partner domains', () => {
+			const result = getCiabConfigFromRedirectUrl( 'https://sub.my.woo.ai/dashboard' );
+
+			expect( result ).toBeNull();
+		} );
+	} );
+
+	describe( 'detectCiabConfig', () => {
+		test( 'detects from redirect_to param', () => {
+			const result = detectCiabConfig( 'https://my.woo.ai/dashboard' );
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'detects from oauth2_redirect param', () => {
+			const result = detectCiabConfig( undefined, 'https://my.woo.ai/dashboard' );
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'prefers redirect_to over oauth2_redirect', () => {
+			const result = detectCiabConfig(
+				'https://my.woo.ai/from-redirect',
+				'https://example.com/from-oauth'
+			);
+
+			expect( result ).not.toBeNull();
+			expect( result?.id ).toBe( 'woo' );
+		} );
+
+		test( 'returns null when no params match', () => {
+			const result = detectCiabConfig( 'https://example.com', 'https://other.com' );
+
+			expect( result ).toBeNull();
+		} );
+
+		test( 'returns null when both params are undefined', () => {
+			const result = detectCiabConfig( undefined, undefined );
+
+			expect( result ).toBeNull();
 		} );
 	} );
 
@@ -187,6 +314,7 @@ describe( 'partner-branding', () => {
 			expect( wooConfig.logo.src ).toBeDefined();
 			expect( wooConfig.ssoProviders ).toBeInstanceOf( Array );
 			expect( wooConfig.ssoProviders.length ).toBeGreaterThan( 0 );
+			expect( wooConfig.domains ).toContain( 'my.woo.ai' );
 		} );
 	} );
 } );

--- a/client/lib/test/partner-branding.tsx
+++ b/client/lib/test/partner-branding.tsx
@@ -112,9 +112,7 @@ describe( 'partner-branding', () => {
 		} );
 
 		test( 'returns partner config when redirect URL has path and query params', () => {
-			const result = getCiabConfigFromRedirectUrl(
-				'https://my.woo.ai/some/path?foo=bar&baz=1'
-			);
+			const result = getCiabConfigFromRedirectUrl( 'https://my.woo.ai/some/path?foo=bar&baz=1' );
 
 			expect( result ).not.toBeNull();
 			expect( result?.id ).toBe( 'woo' );

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -15,7 +15,7 @@ import {
 	isIosOAuth2Client,
 	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { getEffectiveCiabConfig, getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
+import { detectCiabConfig, getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import OneLoginFooter from 'calypso/login/wp-login/components/one-login-footer';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
@@ -396,7 +396,7 @@ const mapState = ( state ) => {
 			'jetpack-onboarding',
 		isWooJPC: isWooJPCFlow( state ),
 		publicToken: getMagicLoginPublicToken( state ),
-		ciabConfig: getEffectiveCiabConfig( currentQuery.from, initialQuery.from ),
+		ciabConfig: detectCiabConfig(),
 	};
 };
 

--- a/client/login/magic-login/test/index.test.jsx
+++ b/client/login/magic-login/test/index.test.jsx
@@ -4,7 +4,7 @@ import { getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
 import { getMagicLoginInitialHeaders, MagicLogin } from '../index';
 
 jest.mock( 'calypso/lib/partner-branding', () => ( {
-	getEffectiveCiabConfig: jest.fn(),
+	detectCiabConfig: jest.fn(),
 	getPartnerSignupTosElement: jest.fn(),
 } ) );
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -21,7 +21,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { getEffectiveCiabConfig } from 'calypso/lib/partner-branding';
+import { detectCiabConfig } from 'calypso/lib/partner-branding';
 import isPassportRedirect from 'calypso/lib/passport/is-passport-redirect';
 import { login } from 'calypso/lib/paths';
 import { getHeaderText } from 'calypso/login/wp-login/hooks/get-header-text';
@@ -494,10 +494,7 @@ export default connect(
 				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ) ||
 				'automattic-for-agencies-client' ===
 					new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
-			ciabConfig: getEffectiveCiabConfig(
-				get( getCurrentQueryArguments( state ), 'from' ),
-				get( getInitialQueryArguments( state ), 'from' )
-			),
+			ciabConfig: detectCiabConfig(),
 			isManualRenewalImmediateLoginAttempt: wasManualRenewalImmediateLoginAttempted( state ),
 			isUserLoggedIn: isUserLoggedIn( state ),
 			isWooPaymentsFlow: isWooCommercePaymentsOnboardingFlow( state ),

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -24,7 +24,7 @@ import {
 	isVIPOAuth2Client,
 	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { getEffectivePartnerAllowedSocialServices } from 'calypso/lib/partner-branding';
+import { getPartnerAllowedSocialServices } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import LoginContextProvider, { useLoginContext } from 'calypso/login/login-context';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
@@ -46,7 +46,6 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
@@ -546,7 +545,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, isWoo, currentFrom, initialFrom } = this.props;
+		const { oauth2Client, isWoo } = this.props;
 		const isPasswordless = true;
 		let socialService;
 		let socialServiceResponse;
@@ -561,10 +560,7 @@ export class UserStep extends Component {
 			}
 		}
 
-		const allowedSocialServices = getEffectivePartnerAllowedSocialServices(
-			currentFrom,
-			initialFrom
-		);
+		const allowedSocialServices = getPartnerAllowedSocialServices();
 
 		return (
 			<>
@@ -712,8 +708,6 @@ const ConnectedUser = connect(
 			isWooJPC: isWooJPCFlow( state ),
 			isBlazePro,
 			from: get( getCurrentQueryArguments( state ), 'from' ),
-			currentFrom: get( getCurrentQueryArguments( state ), 'from' ),
-			initialFrom: get( getInitialQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 			isOnboardingAffiliateFlow: getIsOnboardingAffiliateFlow( state ),
 			isA4A,


### PR DESCRIPTION
## Summary
- Replace `?from=` param-based partner detection with domain-based detection
- Partners are now identified by matching the current page's hostname or the hostname inside `redirect_to`/`oauth2_redirect` URL params against configured partner domains
- Add `domains` field to `CiabPartnerConfig` (e.g., `['my.woo.ai']` for Woo)
- Add `getCiabConfigFromCurrentDomain()`, `getCiabConfigFromRedirectUrl()`, and `detectCiabConfig()` functions
- Update all callers: `usePartnerBranding` hook, `wp-login`, `login-form`, and `signup/steps/user`

## Test plan
- [ ] Visit http://my.localhost:3000/log-in?redirect_to=http%3A%2F%2Fmy.localhost%3A3000%2Fciab%2Fsites and verify Woo branding is shown on the login page
- [ ] Click "Create account" on the login page and verify Woo branding persists on the sign-up page
- [ ] Verify branding activates when visiting from `my.woo.ai` domain
- [ ] Verify branding activates with `?redirect_to=https://my.woo.ai/dashboard`
- [ ] Verify branding activates with `?oauth2_redirect=https://my.woo.ai/path`
- [ ] Verify no branding for unrecognized domains/redirect URLs
- [ ] Verify `?from=woo` no longer triggers branding
- [ ] Unit tests pass: `yarn test-client client/lib/test/partner-branding.tsx`