### PR TITLE
MSD: Add i18n context to billing-purchases

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/backup-retention-management/retention-confirmation-dialog/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/backup-retention-management/retention-confirmation-dialog/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Spinner, Modal } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { ButtonStack } from '../../../../../components/button-stack';
 
 const BACKUP_RETENTION_UPDATE_REQUEST = {
@@ -41,7 +41,7 @@ const RetentionConfirmationDialog: React.FC< RetentionConfirmationDialogProps > 
 					</p>
 					<ButtonStack justify="flex-start">
 						<Button __next40pxDefaultSize variant="tertiary" key="cancel" onClick={ onClose }>
-							{ __( 'Cancel' ) }
+							{ _x( 'Cancel', 'Deny this change and return to the previous screen' ) }
 						</Button>
 						<Button
 							__next40pxDefaultSize

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-confirmation-step.tsx
@@ -1,7 +1,7 @@
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import { ButtonStack } from '../../../components/button-stack';
 import { SectionHeader } from '../../../components/section-header';
@@ -83,7 +83,7 @@ export default function DomainRemovalConfirmationStep( {
 					onClick={ onCancel }
 					disabled={ isLoading }
 				>
-					{ __( 'Cancel' ) }
+					{ _x( 'Cancel', 'Deny this change and return to the previous screen' ) }
 				</Button>
 				<Button
 					__next40pxDefaultSize

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
@@ -6,7 +6,7 @@ import {
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { ButtonStack } from '../../../components/button-stack';
 import RouterLinkButton from '../../../components/router-link-button';
 import { Text } from '../../../components/text';
@@ -96,7 +96,7 @@ export default function DomainRemovalWarningStep( {
 					onClick={ onCancel }
 					disabled={ isLoading }
 				>
-					{ __( 'Cancel' ) }
+					{ _x( 'Cancel', 'Deny this change and return to the previous screen' ) }
 				</Button>
 				<Button
 					__next40pxDefaultSize
@@ -104,7 +104,7 @@ export default function DomainRemovalWarningStep( {
 					onClick={ onContinue }
 					disabled={ isLoading }
 				>
-					{ __( 'Continue' ) }
+					{ _x( 'Continue', 'Accept this change and continue with this action' ) }
 				</Button>
 			</ButtonStack>
 		</VStack>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/marketplace-subscriptions-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/marketplace-subscriptions-dialog.tsx
@@ -1,5 +1,5 @@
 import { Modal, __experimentalVStack as VStack, Button } from '@wordpress/components';
-import { sprintf, _n, __ } from '@wordpress/i18n';
+import { sprintf, _n, __, _x } from '@wordpress/i18n';
 import * as React from 'react';
 import { ButtonStack } from '../../../components/button-stack';
 import type { Purchase } from '@automattic/api-core';
@@ -67,7 +67,7 @@ const MarketPlaceSubscriptionsWarning = ( {
 							onClick={ closeDialog }
 							disabled={ false /*updateDnsMutation.isPending*/ }
 						>
-							{ __( 'Cancel' ) }
+							{ _x( 'Cancel', 'Deny this change and return to the previous screen' ) }
 						</Button>
 						<Button
 							__next40pxDefaultSize

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -83,7 +83,7 @@ export function PurchasePaymentMethod( {
 							} );
 						} }
 					>
-						{ __( 'Update' ) }
+						{ _x( 'Update', 'Change the payment method used for this purchase' ) }
 					</Button>
 				) }
 			</HStack>
@@ -110,7 +110,7 @@ export function PurchasePaymentMethod( {
 							} );
 						} }
 					>
-						{ __( 'Update' ) }
+						{ _x( 'Update', 'Change the payment method used for this purchase' ) }
 					</Button>
 				) }
 			</HStack>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -39,7 +39,7 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import {
 	moreVertical,
 	calendar,
@@ -271,7 +271,7 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 					upgradePurchase( upgradeUrl );
 				} }
 			>
-				{ __( 'Upgrade' ) }
+				{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
 			</MenuItem>
 		),
 		canBeRenewed && (
@@ -321,7 +321,7 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 							} )
 						}
 					>
-						{ __( 'Cancel' ) }
+						{ _x( 'Cancel', 'Stop the subscription from automatically charging and renewing' ) }
 					</Button>
 				}
 			/>
@@ -344,7 +344,10 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 							} )
 						}
 					>
-						{ __( 'Remove' ) }
+						{ _x(
+							'Remove',
+							'Remove the cancelled or expired subscription from the list of active purchases.'
+						) }
 					</Button>
 				}
 			/>
@@ -378,7 +381,7 @@ function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 						upgradePurchase( upgradeUrl );
 					} }
 				>
-					{ __( 'Upgrade' ) }
+					{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
 				</Button>
 			}
 		/>
@@ -437,7 +440,10 @@ function RenewActionButton( { purchase }: { purchase: Purchase } ) {
 						renewPurchase( purchase );
 					} }
 				>
-					{ __( 'Renew' ) }
+					{ _x(
+						'Renew',
+						'Immediately pay for and receive another term of the subscription, extending the expiration date by another term.'
+					) }
 				</Button>
 			}
 		/>
@@ -1146,7 +1152,7 @@ export default function PurchaseSettings() {
 								<HStack justify="space-between">
 									{ canPurchaseBeUpgraded( purchase ) && upgradeUrl && (
 										<Button __next40pxDefaultSize variant="primary" href={ upgradeUrl }>
-											{ __( 'Upgrade' ) }
+											{ _x( 'Upgrade', 'Change to a plan with more features.' ) }
 										</Button>
 									) }
 									<PageHeader.ActionMenu>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -283,7 +283,10 @@ function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
 					renewPurchase( purchase );
 				} }
 			>
-				{ __( 'Renew' ) }
+				{ _x(
+					'Renew',
+					'Immediately pay for and receive another term of the subscription, extending the expiration date by another term.'
+				) }
 			</MenuItem>
 		),
 	].filter( Boolean );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes CHE-418

## Proposed Changes

* Add i18n context to some single-word buttons in the billing purchases section of the multi-site dashboard.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Without i18n context, words like "Cancel" and "Upgrade" can take on different meanings. For example: cancelling a subscription or cancelling an action, or upgrading to a plan with more features vs upgrading to a newer version of the plan. This was causing inconsistencies in some languages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the billing purchases purchase detail screen in the multi-site dashboard doesn't break. At this point, it shouldn't have the new translations with the given context, so it's possible that these messages may be in English or have the old translations with missing context.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
