### PR TITLE
MSD: prevent PR reviewer bot from listing recent PRs as it's not allowed

### DIFF
--- a/.github/prompts/dashboard-pr-review.md
+++ b/.github/prompts/dashboard-pr-review.md
@@ -20,6 +20,7 @@ Review the PR based on the following documentation files as the guidelines:
 
 ## Method
 
+- Do NOT try to list recent PRs when reviewing - you do not have permission to do so.
 - Use `mcp__github_inline_comment__create_inline_comment` to post feedback directly on specific lines.
 - Provide fix suggestions in each comment.
 - Don't nitpick minor style issues unless they violate project guidelines.


### PR DESCRIPTION
Part of Roadmap Reset

## Proposed Changes

Avoid the Claude reviewer bot from trying to do things it does not have permission to:

<img width="1906" height="1870" alt="image" src="https://github.com/user-attachments/assets/b6dab1ff-6bf2-483a-ae12-e129d6e71c5b" />
