### PR TITLE
MSD: hide site visibility settings for CIAB sites

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -599,7 +599,7 @@ export const siteSettingsIndexRoute = createRoute( {
 );
 
 export const siteSettingsSiteVisibilityRoute = createRoute( {
-	staticData: { requiresSiteTypeSupport: 'settingsDotcomSiteVisibility' },
+	staticData: { requiresSiteTypeSupport: 'settingsGeneralDotcomSiteVisibility' },
 	head: () => ( {
 		meta: [
 			{

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -52,7 +52,6 @@ import {
 	canManageSite,
 	canTransferSite,
 	canViewHundredYearPlanSettings,
-	canViewSiteVisibilitySettings,
 	canViewWordPressSettings,
 } from '../../sites/features';
 import {
@@ -600,7 +599,7 @@ export const siteSettingsIndexRoute = createRoute( {
 );
 
 export const siteSettingsSiteVisibilityRoute = createRoute( {
-	staticData: { requiresSiteTypeSupport: 'settingsGeneral' },
+	staticData: { requiresSiteTypeSupport: 'settingsDotcomSiteVisibility' },
 	head: () => ( {
 		meta: [
 			{
@@ -616,7 +615,7 @@ export const siteSettingsSiteVisibilityRoute = createRoute( {
 		}
 
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		if ( ! canViewSiteVisibilitySettings( site ) ) {
+		if ( site.is_wpcom_flex ) {
 			throw redirectAsNotAllowed( { to: siteSettingsRoute.fullPath, params: { siteSlug } } );
 		}
 	},

--- a/client/dashboard/sites/features.ts
+++ b/client/dashboard/sites/features.ts
@@ -38,11 +38,6 @@ export function canViewHundredYearPlanSettings( site: Site ) {
 	);
 }
 
-export function canViewSiteVisibilitySettings( site: Site ) {
-	// Site Visibility is a Jetpack feature; Flex sites don't have Jetpack by default.
-	return ! site.is_wpcom_flex;
-}
-
 // Settings -> Server
 
 export function canViewWordPressSettings( site: Site ) {

--- a/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
@@ -1,0 +1,44 @@
+import { __ } from '@wordpress/i18n';
+import { lockOutline, published } from '@wordpress/icons';
+import { launch } from '../../components/icons';
+import OverviewCard from '../../components/overview-card';
+import type { Site } from '@automattic/api-core';
+
+const CARD_PROPS = {
+	title: __( 'Visibility' ),
+	tracksId: 'site-overview-visibility-ciab',
+};
+
+export default function VisibilityCardCiab( { site }: { site: Site } ) {
+	if ( site.is_coming_soon ) {
+		return (
+			<OverviewCard
+				{ ...CARD_PROPS }
+				icon={ launch }
+				heading={ __( 'Coming soon' ) }
+				description={ __( 'Visitors will see a coming soon page.' ) }
+			/>
+		);
+	}
+
+	if ( site.is_private ) {
+		return (
+			<OverviewCard
+				{ ...CARD_PROPS }
+				icon={ lockOutline }
+				heading={ __( 'Private' ) }
+				description={ __( 'Only invited users can view your site.' ) }
+			/>
+		);
+	}
+
+	return (
+		<OverviewCard
+			{ ...CARD_PROPS }
+			icon={ published }
+			heading={ __( 'Public' ) }
+			description={ __( 'Anyone can view your site.' ) }
+			intent="success"
+		/>
+	);
+}

--- a/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
@@ -1,6 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { lockOutline, published } from '@wordpress/icons';
-import { launch } from '../../components/icons';
+import { published } from '@wordpress/icons';
 import OverviewCard from '../../components/overview-card';
 import type { Site } from '@automattic/api-core';
 
@@ -13,30 +12,6 @@ export default function VisibilityCardCiab( { site }: { site: Site } ) {
 	const link = site.options?.admin_url
 		? `${ site.options.admin_url }admin.php?page=next-admin&p=%2Fwoocommerce%2Fsettings%2Fgeneral`
 		: undefined;
-
-	if ( site.is_coming_soon ) {
-		return (
-			<OverviewCard
-				{ ...CARD_PROPS }
-				link={ link }
-				icon={ launch }
-				heading={ __( 'Coming soon' ) }
-				description={ __( 'Visitors will see a coming soon page.' ) }
-			/>
-		);
-	}
-
-	if ( site.is_private ) {
-		return (
-			<OverviewCard
-				{ ...CARD_PROPS }
-				link={ link }
-				icon={ lockOutline }
-				heading={ __( 'Private' ) }
-				description={ __( 'Only invited users can view your site.' ) }
-			/>
-		);
-	}
 
 	return (
 		<OverviewCard

--- a/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
@@ -10,10 +10,15 @@ const CARD_PROPS = {
 };
 
 export default function VisibilityCardCiab( { site }: { site: Site } ) {
+	const link = site.options?.admin_url
+		? `${ site.options.admin_url }admin.php?page=next-admin&p=%2Fwoocommerce%2Fsettings%2Fgeneral`
+		: undefined;
+
 	if ( site.is_coming_soon ) {
 		return (
 			<OverviewCard
 				{ ...CARD_PROPS }
+				link={ link }
 				icon={ launch }
 				heading={ __( 'Coming soon' ) }
 				description={ __( 'Visitors will see a coming soon page.' ) }
@@ -25,6 +30,7 @@ export default function VisibilityCardCiab( { site }: { site: Site } ) {
 		return (
 			<OverviewCard
 				{ ...CARD_PROPS }
+				link={ link }
 				icon={ lockOutline }
 				heading={ __( 'Private' ) }
 				description={ __( 'Only invited users can view your site.' ) }
@@ -35,6 +41,7 @@ export default function VisibilityCardCiab( { site }: { site: Site } ) {
 	return (
 		<OverviewCard
 			{ ...CARD_PROPS }
+			link={ link }
 			icon={ published }
 			heading={ __( 'Public' ) }
 			description={ __( 'Anyone can view your site.' ) }

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -20,7 +20,6 @@ import PageLayout from '../../components/page-layout';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { isSelfHostedJetpackConnected, isCommerceGarden } from '../../utils/site-types';
-import { canViewSiteVisibilitySettings } from '../features';
 import AgencySiteShareCard from '../overview-agency-site-share-card';
 import BackupCard from '../overview-backup-card';
 import DIFMUpsellCard from '../overview-difm-upsell-card';
@@ -36,6 +35,7 @@ import SiteOverviewFields from '../overview-site-fields';
 import SitePreviewCard from '../overview-site-preview-card';
 import SubscribersCard from '../overview-subscribers-card';
 import VisibilityCard from '../overview-visibility-card';
+import VisibilityCardCiab from '../overview-visibility-card-ciab';
 import { InaccessibleJetpackNotice } from '../site/notices';
 import StagingSiteSyncDropdown from '../staging-site-sync-dropdown';
 import { StorageWarningBanner } from './storage-warning-banner';
@@ -82,7 +82,7 @@ function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: num
 		return (
 			<Grid columns={ 1 } rows={ 2 } gap={ spacing }>
 				<PlanCard site={ site } />
-				<VisibilityCard site={ site } />
+				<VisibilityCardCiab site={ site } />
 			</Grid>
 		);
 	}
@@ -90,7 +90,7 @@ function SiteOverviewPrimaryCards( { site, spacing }: { site: Site; spacing: num
 	return (
 		<>
 			{ ( () => {
-				const showVisibilityCard = canViewSiteVisibilitySettings( site );
+				const showVisibilityCard = ! site.is_wpcom_flex;
 				return (
 					<Grid columns={ 1 } rows={ showVisibilityCard ? 2 : 1 } gap={ spacing }>
 						{ showVisibilityCard && <VisibilityCard site={ site } /> }

--- a/client/dashboard/sites/settings-site-visibility/summary.tsx
+++ b/client/dashboard/sites/settings-site-visibility/summary.tsx
@@ -2,7 +2,7 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { seen } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import { canViewSiteVisibilitySettings } from '../features';
+import { siteTypeSupportsFeature } from '../../utils/site-type-feature-support';
 import type { Site } from '@automattic/api-core';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
@@ -13,7 +13,7 @@ export default function SiteVisibilitySettingsSummary( {
 	site: Site;
 	density?: Density;
 } ) {
-	if ( ! canViewSiteVisibilitySettings( site ) ) {
+	if ( ! siteTypeSupportsFeature( site, 'settingsDotcomSiteVisibility' ) ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/settings-site-visibility/summary.tsx
+++ b/client/dashboard/sites/settings-site-visibility/summary.tsx
@@ -13,7 +13,7 @@ export default function SiteVisibilitySettingsSummary( {
 	site: Site;
 	density?: Density;
 } ) {
-	if ( ! siteTypeSupportsFeature( site, 'settingsDotcomSiteVisibility' ) ) {
+	if ( ! siteTypeSupportsFeature( site, 'settingsGeneralDotcomSiteVisibility' ) ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -51,7 +51,9 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				<VStack spacing={ 3 }>
 					<SectionHeader title={ __( 'General' ) } level={ 3 } />
 					<SummaryButtonList>
-						<SiteVisibilitySettingsSummary site={ site } />
+						{ siteTypeSupports.settingsDotcomSiteVisibility ? (
+							<SiteVisibilitySettingsSummary site={ site } />
+						) : null }
 						{ isEnabled( 'wordpress-ai-tools' ) && siteTypeSupports.settingsGeneralAITools ? (
 							<AISiteToolsSettingsSummary site={ site } />
 						) : null }

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -51,7 +51,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				<VStack spacing={ 3 }>
 					<SectionHeader title={ __( 'General' ) } level={ 3 } />
 					<SummaryButtonList>
-						{ siteTypeSupports.settingsDotcomSiteVisibility ? (
+						{ siteTypeSupports.settingsGeneralDotcomSiteVisibility ? (
 							<SiteVisibilitySettingsSummary site={ site } />
 						) : null }
 						{ isEnabled( 'wordpress-ai-tools' ) && siteTypeSupports.settingsGeneralAITools ? (

--- a/client/dashboard/utils/site-type-feature-support.ts
+++ b/client/dashboard/utils/site-type-feature-support.ts
@@ -16,6 +16,7 @@ export type SiteTypeFeatureSupports = {
 	settingsGeneralRedirect?: boolean;
 	settingsServer?: boolean;
 	settingsSecurity?: boolean;
+	settingsDotcomSiteVisibility?: boolean;
 	settingsExperimental?: boolean;
 };
 
@@ -61,6 +62,7 @@ export function getSiteTypeFeatureSupports( site: Site ): SiteTypeFeatureSupport
 			settingsGeneral: true,
 			settingsGeneralAITools: false,
 			settingsGeneralRedirect: true,
+			settingsDotcomSiteVisibility: false,
 			settingsServer: false,
 			settingsSecurity: false,
 			settingsExperimental: false,
@@ -80,6 +82,7 @@ export function getSiteTypeFeatureSupports( site: Site ): SiteTypeFeatureSupport
 		settingsGeneral: true,
 		settingsGeneralAITools: true,
 		settingsGeneralRedirect: true,
+		settingsDotcomSiteVisibility: true,
 		settingsServer: true,
 		settingsSecurity: true,
 		settingsExperimental: true,

--- a/client/dashboard/utils/site-type-feature-support.ts
+++ b/client/dashboard/utils/site-type-feature-support.ts
@@ -16,7 +16,7 @@ export type SiteTypeFeatureSupports = {
 	settingsGeneralRedirect?: boolean;
 	settingsServer?: boolean;
 	settingsSecurity?: boolean;
-	settingsDotcomSiteVisibility?: boolean;
+	settingsGeneralDotcomSiteVisibility?: boolean;
 	settingsExperimental?: boolean;
 };
 
@@ -62,7 +62,7 @@ export function getSiteTypeFeatureSupports( site: Site ): SiteTypeFeatureSupport
 			settingsGeneral: true,
 			settingsGeneralAITools: false,
 			settingsGeneralRedirect: true,
-			settingsDotcomSiteVisibility: false,
+			settingsGeneralDotcomSiteVisibility: false,
 			settingsServer: false,
 			settingsSecurity: false,
 			settingsExperimental: false,
@@ -82,7 +82,7 @@ export function getSiteTypeFeatureSupports( site: Site ): SiteTypeFeatureSupport
 		settingsGeneral: true,
 		settingsGeneralAITools: true,
 		settingsGeneralRedirect: true,
-		settingsDotcomSiteVisibility: true,
+		settingsGeneralDotcomSiteVisibility: true,
 		settingsServer: true,
 		settingsSecurity: true,
 		settingsExperimental: true,


### PR DESCRIPTION
Part of DOTCOM-16140

## Proposed Changes

- Hide the site visibility settings page for CIAB (WooCommerce) sites since visibility is managed in wp-admin
- Add a dedicated CIAB visibility card on the site overview that links to the wp-admin general settings page
  - This is in preparation for ARC-1296 which needs to fully sync CIAB visibility with MSD

**Linking to wp-admin**

<img width="1516" height="940" alt="CleanShot 2026-02-26 at 16 33 06@2x" src="https://github.com/user-attachments/assets/e2becf18-faba-4d57-96cf-15211bb96953" />

**No site visibility card**

<img width="1950" height="1220" alt="CleanShot 2026-02-26 at 16 33 27@2x" src="https://github.com/user-attachments/assets/c84c74d8-937b-47cc-8eee-0a060f78e986" />


## Why are these changes being made?

Main discussion here: pgz0xU-y0-p2

CIAB sites manage visibility through WooCommerce settings in wp-admin, not through the Dashboard settings page. Showing the Dashboard visibility settings is confusing and potentially conflicting.

## Testing Instructions

- View a CIAB site overview — visibility card should appear and link to wp-admin WooCommerce general settings
- Navigate to a CIAB site's settings — visibility section should not be shown
- Non-CIAB sites should be unaffected

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?