### PR TITLE
A4A: Add PR review workflow

### DIFF
--- a/.github/prompts/a4a-pr-review.md
+++ b/.github/prompts/a4a-pr-review.md
@@ -1,0 +1,37 @@
+# Code Review Instructions (A4A)
+
+## Primary Objective
+
+Review the PR against the Automattic for Agencies (A4A) guidelines in the following documentation files:
+
+- @AGENTS.md
+- @client/AGENTS.md
+- @client/a8c-for-agencies/AGENTS.md
+
+If other shared packages or docs are directly referenced in the PR description, treat them as additional guidance, but prioritize the files above.
+
+If the PR changes shared code (e.g. `client/state`, `client/components`), consider impact on both A4A and other clients and call it out.
+
+## Review focus (when applicable)
+
+- **Feature flags:** Only when the feature is already behind a feature flag in A4A — flag if new behaviour bypasses or is not correctly wired into the existing flag where the rest of the codebase does so.
+- **Translations:** New user-visible strings should use the project’s i18n approach; call out potentially missing translations or hardcoded copy.
+
+## Method
+
+- Do NOT try to list recent PRs when reviewing - you do not have permission to do so.
+- Use `mcp__github_inline_comment__create_inline_comment` to post feedback directly on specific lines.
+- Provide fix suggestions in each comment.
+- Don't nitpick minor style issues unless they violate the documented guidelines.
+- Before suggesting alternative implementations, check if the PR description already addresses why that approach wasn't used.
+
+## Output Format
+
+- Be concise.
+- Do NOT use checkboxes, todo lists, or progress indicators.
+- Only comment if there are issues worth addressing.
+- DO NOT comment on lines that are not related to the guidelines listed above.
+- For each comment, cite the source documentation file as a clickable link in the format of `https://github.com/Automattic/wp-calypso/blob/trunk/<path to the file relative to the project>`.
+- For each comment, quote the specific sentence(s) from the cited source that justifies the comment, in a blockquote.
+
+Remember: A4A builds on Calypso client patterns. Prioritize performance, accessibility, and maintainability while following the A4A code style, layout, and typography guidance described in the referenced docs. We also use modern React patterns.

--- a/.github/workflows/a4a-pr-review.yml
+++ b/.github/workflows/a4a-pr-review.yml
@@ -1,0 +1,44 @@
+name: A4A PR Review
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+
+  pull_request:
+    types: [opened, ready_for_review]
+    paths:
+      - 'client/a8c-for-agencies/**'
+
+concurrency:
+  group: a4a-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run A4A PR Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Read and follow the instructions in .github/prompts/a4a-pr-review.md
+
+            Use `mcp__github_inline_comment__create_inline_comment` for review.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git show:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *)"


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/108931.

## Proposed Changes

Add an A4A-specific PR review workflow and prompt that mirror the Dashboard PR review setup, but scoped to A4A code under `client/a8c-for-agencies/**`.

- New workflow: `.github/workflows/a4a-pr-review.yml` (A4A PR Review)
  - Triggers on A4A PRs and via manual `workflow_dispatch`.
  - Uses `anthropics/claude-code-action@v1` with an A4A-focused prompt.
  - Adds a job-level timeout to avoid long-running/stuck reviews.
- New prompt: `.github/prompts/a4a-pr-review.md`
  - Points the reviewer at A4A-specific `AGENTS.md` docs.
  - Emphasizes shared-code impact, feature flags (when already present), translations, and modern React patterns.

## Why are these changes being made?

- To give A4A PRs the same automated review support that the Dashboard client already has, but with guidance that is specific to A4A’s code and style conventions.
- To make it easier for reviewers (and AI agents) to catch issues around shared code impact, feature flags, i18n, and React patterns in the A4A client.

## Testing Instructions

- Open this PR in GitHub and confirm that the **A4A PR Review** workflow appears in the checks list.
- Optionally, push an additional commit that touches `client/a8c-for-agencies/**` and verify that the workflow re-runs and posts inline comments.
- Optionally, use **Actions → A4A PR Review → Run workflow** with this PR’s branch and PR number to confirm the manual trigger works.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
  - N/A — workflow + prompt only.
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
  - N/A — workflow + prompt only.
- [ ] Have you checked for TypeScript, React or other console errors?
  - N/A — workflow + prompt only.
- [ ] Have you tested accessibility for your changes?
  - N/A — workflow + prompt only.
- [ ] Have you used memoizing on expensive computations?
  - N/A — workflow + prompt only.
- [ ] Have we added the "[Status] String Freeze" label…?
  - N/A — no new user-facing strings in product UIs.
- [ ] For changes affecting Jetpack…?
  - N/A — A4A workflow + prompt only.

Made with [Cursor](https://cursor.com)
