### PR TITLE
A4A: Add Developer tools page under Resources and tools

### DIFF
--- a/client/a8c-for-agencies/sections/dev-tools/primary/dev-tools-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/dev-tools/primary/dev-tools-overview/index.tsx
@@ -100,7 +100,7 @@ export default function DevToolsOverview() {
 								rel="noopener noreferrer"
 								onClick={ handleStudioClick }
 							>
-								{ translate( 'Download Studio' ) }
+								{ translate( 'Start building locally' ) }
 							</Button>
 						</div>
 					</PageSectionColumns.Column>
@@ -154,7 +154,7 @@ export default function DevToolsOverview() {
 								rel="noopener noreferrer"
 								onClick={ handleGithubClick }
 							>
-								{ translate( 'Connect a repository' ) }
+								{ translate( 'Automate your deploys' ) }
 							</Button>
 						</div>
 					</PageSectionColumns.Column>
@@ -204,7 +204,7 @@ export default function DevToolsOverview() {
 								rel="noopener noreferrer"
 								onClick={ handleTelexClick }
 							>
-								{ translate( 'Try Telex' ) }
+								{ translate( 'Create blocks in minutes' ) }
 							</Button>
 						</div>
 					</PageSectionColumns.Column>


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/108932.

## Summary

- Adds a new **Developer tools** page featuring WordPress Studio, GitHub Deployments, and Telex
- Renames the top-level **Learn** nav item to **Resources and tools** with two sub-items: **Guides and articles** and **Developer tools**
- Rewrites copy across both pages using a Jobs to Be Done (JTBD) lens — every label, description, and CTA answers "what can I get done?" not "what is this product?"

## Why

The shaping doc for A4AD-85 proposed a top-level nav item for dev tools. Applying a JTBD governance test ("what job does this do for the agency?"), dev tools and learning resources both serve the same job: **get better at delivering client work**. Rather than adding another top-level item to an already crowded sidebar, we nest both under a single "Resources and tools" section — which maps cleanly to the future IA restructure.

Key decisions driven by JTBD:
- **Nav rename**: "Learn" → "Resources and tools" — signals both halves of what's inside
- **Sub-item labels**: "Guides and articles" (concrete) + "Developer tools" (concrete) — not vague verbs
- **Feature lists**: Outcomes, not feature names ("Pull live sites to test changes safely" not "Pull live sites locally")
- **CTAs**: Outcome-specific ("Start building locally", "Automate your deploys", "Create blocks in minutes") — not "Learn more"
- **Badges**: Describe *how* each tool works ("Open Source", "Git-native", "AI-Powered") — not marketing labels

## Test plan

- [ ] Navigate to `/dev-tools` — Developer tools page renders with three tool sections, images, and CTAs
- [ ] Sidebar shows "Resources and tools" with sub-items "Guides and articles" and "Developer tools"
- [ ] Click each CTA button — opens correct external link and fires tracks event
- [ ] Navigate to `/learn/resource-center` — page title says "Guides and articles", intro copy updated
- [ ] Verify responsive layout on narrow viewport (sections stack vertically)

Made with [Cursor](https://cursor.com)
