### PR TITLE
Agents Manager: fix unordered list style

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -240,6 +240,28 @@ body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-c
 	}
 }
 
+// Fix Calypso list styles
+body:is( [class*='is-group-'], [class*='is-section-'] ):not( .wp-admin ) {
+	.agents-manager-chat.agents-manager-chat--docked,
+	.agents-manager-chat.agents-manager-chat--undocked {
+		ul, ol {
+			padding-left: 0;
+		}
+
+		ul {
+			margin-left: 2em;
+		}
+
+		ol {
+			margin-left: 1em;
+		}
+
+		li > ul {
+			margin-top: 0.5em;
+		}
+	}
+}
+
 /* Calypso MSD */
 body.is-section-dashboard-dotcom.agents-manager-sidebar-container {
 	@include sidebar-base( '#wpcom .dashboard-root__layout' );

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/style.scss
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/style.scss
@@ -130,6 +130,9 @@
 		}
 
 		#wp-admin-bar-agents-manager {
+			ol {
+				padding-left: 1em;
+			}
 
 			li {
 


### PR DESCRIPTION
Fixes a style issue with the Agents Manager and unordered lists, for both wp-admin and Calypso.

<img width="680" height="1106" alt="image" src="https://github.com/user-attachments/assets/8ae22e94-8d02-4b8b-b9c0-fd32b0145ddc" />

Becomes:
<img width="622" height="810" alt="image" src="https://github.com/user-attachments/assets/3fed9edc-94cf-480e-803c-5e8b98a3d4a9" />

Fixes AI-902

## Why are these changes being made?

* Style bad, make good

## Testing Instructions

* `cd apps/agents-manager`
* `yarn dev --sync`
* Visit a wp-admin site and open agents manager (docked or undocked) and enter `how do I get started with wordpress`
* Wait a good while and confirm the ordered list fits in with the style, as per the above screenshot
* `yarn start`
* Visit a page like http://calypso.localhost:3000/sites/[SITE]
* Repeat the same test and confirm the same result

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
