### PR TITLE
Agents Manager: Fix chat header buttons invisible in dark mode

### DIFF
--- a/packages/agents-manager/src/components/chat-header/style.scss
+++ b/packages/agents-manager/src/components/chat-header/style.scss
@@ -35,8 +35,15 @@
 	&__more-options,
 	&__history-btn,
 	&__close-btn {
-		svg {
-			fill: var(--color-foreground);
+		// Increase specificity to override .components-button svg { fill: currentColor }
+		// from @wordpress/components, which makes SVGs invisible in dark mode.
+		// Descendant selector handles DropdownMenu (class on wrapper div),
+		// compound selector handles Button (class directly on element).
+		&.components-button,
+		.components-button {
+			svg {
+				fill: var(--color-foreground);
+			}
 		}
 	}
 


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/WOOAI-365/chat-header-buttons-invisible-in-dark-mode-due-to-css-specificity

## Proposed Changes

* Increase CSS specificity of SVG fill rules for chat header buttons (ellipsis, history, close) to override `@wordpress/components`' `.components-button svg { fill: currentColor }`.

## Why are these changes being made?

In CIAB dark mode, the chat header buttons are nearly invisible because their SVG fill inherits `currentColor` (a dark text color) instead of `var(--color-foreground)`. This happens because WordPress components' `.components-button svg { fill: currentColor }` has equal specificity to the agents-manager rule and wins due to source order. The fix uses compound/descendant selectors with `.components-button` to bump specificity from (0,1,1) to (0,2,1), ensuring the agents-manager `fill` value takes precedence.

## Testing Instructions

### Setup

1. Run `cd apps/agents-manager && yarn dev --sync`. (requires a ssh host configuration for `wpcom-sandbox`).
2. Point `widgets.wp.com` to your wpcom sandbox.


### Actual Testing

1. Open CIAB admin with Agents Manager docked (dark sidebar visible)
4. Observe the chat header buttons (three-dot menu ⋮, history clock 🕐, close ✕)
5. **Before:** Buttons are barely visible / invisible against the dark background
6. **After:** Buttons use `var(--color-foreground)` and are clearly visible

## Screenshot

Buttons show now correctly.

<img width="766" height="562" alt="image" src="https://github.com/user-attachments/assets/99a92083-d182-4862-a1a6-c1f5d33425ff" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).