### PR TITLE
Agents manager: apply some fixes for Jetpack social page

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
+++ b/packages/agents-manager/src/components/agent-dock/fixes-jetpack.scss
@@ -20,4 +20,17 @@ body.wp-admin.agents-manager-sidebar-container--sidebar-open:not( .modal-open ) 
 			min-height: inherit;
 		}
 	}
+
+	#jetpack-social-root > div:first-of-type {
+		margin-left: 0;
+	}
+
+	// Lovely
+	#jetpack-social-root > div > div:nth-child(2) > div > div:nth-child(2) > div:nth-child(2) > div {
+		grid-column-end: span 7;
+	}
+
+	&.jetpack_page_jetpack-social #wpbody {
+		z-index: 9990;
+	}
 }


### PR DESCRIPTION
Applies a few fixes for the Jetpack social page when the Agents Manager docked sidebar is enabled.

Before:

<img width="1212" height="1136" alt="image" src="https://github.com/user-attachments/assets/3b7c58ea-1902-4021-af1a-cb910ccaf1b8" />

After:
<img width="1152" height="910" alt="image" src="https://github.com/user-attachments/assets/c4c8c8a2-f34d-4c5a-b5e4-67f91df05cdf" />

Fixes AI-898


## Testing Instructions

* `cd apps/agents-manager`
* `yarn dev --sync`
* Load Jetpack social wp-admin on a site: https://[SITE].wordpress.com/wp-admin/admin.php?page=jetpack-social
* Confirm the fixed status

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
