### PR TITLE
Agents Manager: Wire up image upload '+' button in chat input

### DIFF
--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -4,13 +4,14 @@ import {
 	createMessageRenderer,
 	EmptyView,
 	ImageUploader,
+	type ImageUploaderHandle,
 	type MarkdownComponents,
 	type MarkdownExtensions,
 	type Suggestion,
 	type ChatState,
 } from '@automattic/agenttic-ui';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { AGENTS_MANAGER_STORE } from '../../stores';
@@ -101,6 +102,7 @@ export default function AgentChat( {
 	onSubmitFeedbackText = () => Promise.resolve(),
 	onCancelFeedback = () => {},
 }: Props ) {
+	const imageUploaderRef = useRef< ImageUploaderHandle >( null );
 	const { setFloatingPosition } = useDispatch( AGENTS_MANAGER_STORE );
 	const { floatingPosition } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
@@ -171,6 +173,7 @@ export default function AgentChat( {
 					<AgentUI.Notice />
 					{ imageUpload && (
 						<ImageUploader
+							ref={ imageUploaderRef }
 							images={ imageUpload.pendingImages }
 							uploadingImages={ imageUpload.uploadingImages }
 							onFilesSelected={ imageUpload.handleFilesSelected }
@@ -189,7 +192,7 @@ export default function AgentChat( {
 					) }
 
 					<SelectedBlock />
-					<AgentUI.Input />
+					<AgentUI.Input imageUploaderRef={ imageUpload ? imageUploaderRef : undefined } />
 				</AgentUI.Footer>
 			</AgentUI.ConversationView>
 		</AgentUI.Container>


### PR DESCRIPTION
Part of WOOAI-366

## Proposed Changes

* Connect `ImageUploader` ref to `AgentUI.Input` via the `imageUploaderRef` prop from agenttic-ui
* When image upload is enabled, a "+" button renders in the chat input that opens the file browser
* The stacked layout (textarea above, actions below) activates automatically when the ref is provided

## Why are these changes being made?

Currently there's no visual indication that users can upload images in the AI chat. This wires up the image upload affordance from agenttic-ui ([agenttic#285](https://github.com/Automattic/agenttic/pull/285)) so a "+" button appears at the bottom-left of the input.

Backwards-compatible: if the deployed agenttic-ui version doesn't support `imageUploaderRef` yet, the prop is silently ignored and behavior is unchanged.

## Testing Instructions

* Once agenttic-ui with `imageUploaderRef` support is deployed, open CIAB admin with the AI chat docked
* A "+" button should appear at the bottom-left of the chat input
* Clicking it should open the OS file browser filtered to image types
* Without image upload enabled, the chat input should look unchanged (no "+" button)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?