### PR TITLE
Update post-refund message in MSD

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -256,6 +256,11 @@ export const purchaseSettingsRoute = createRoute( {
 		};
 	},
 	path: '$purchaseId',
+	validateSearch: ( search ): { refunded: boolean } => {
+		return {
+			refunded: !! search.refunded,
+		};
+	},
 } );
 
 export const purchaseSettingsIndexRoute = createRoute( {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -887,6 +887,7 @@ export default function CancelPurchase() {
 						navigate( {
 							to: purchaseSettingsRoute.fullPath,
 							params: { purchaseId: purchase.ID },
+							search: { refunded: true },
 						} );
 					},
 					onError: ( error: Error ) => {

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -38,6 +38,7 @@ import type { Purchase } from '@automattic/api-core';
 
 export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
+	const { refunded } = purchaseSettingsRoute.useSearch();
 	const { data: purchaseAttachedTo } = useQuery( {
 		...purchaseQuery( purchase.attached_to_purchase_id ?? 0 ),
 		enabled: Boolean( purchase.attached_to_purchase_id ),
@@ -88,7 +89,13 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	}
 
 	if ( shouldShowExpiredRenewNotice( purchase, purchaseAttachedTo ) ) {
-		return <ExpiredRenewNotice purchase={ purchase } purchaseAttachedTo={ purchaseAttachedTo } />;
+		return (
+			<ExpiredRenewNotice
+				purchase={ purchase }
+				purchaseAttachedTo={ purchaseAttachedTo }
+				refunded={ refunded }
+			/>
+		);
 	}
 
 	if ( purchase.partner_type ) {
@@ -142,9 +149,11 @@ function shouldShowExpiredRenewNotice(
 function ExpiredRenewNotice( {
 	purchase,
 	purchaseAttachedTo,
+	refunded,
 }: {
 	purchase: Purchase;
 	purchaseAttachedTo: Purchase | undefined;
+	refunded?: boolean;
 } ) {
 	// For purchases included with a plan (for example, a domain mapping
 	// bundled with the plan), the plan purchase is used on this page when
@@ -160,6 +169,9 @@ function ExpiredRenewNotice( {
 
 	if ( purchase.is_renewable ) {
 		const noticeText = ( () => {
+			if ( refunded && isExpired( currentPurchase ) ) {
+				return __( 'Your refund has been processed and your purchase removed.' );
+			}
 			if ( isExpired( currentPurchase ) ) {
 				return __( 'This purchase has expired and is no longer in use.' );
 			}
@@ -184,7 +196,7 @@ function ExpiredRenewNotice( {
 
 		return (
 			<Notice
-				variant="error"
+				variant={ refunded ? 'success' : 'error' }
 				actions={
 					shouldShowRenewNoticeAction( purchase ) ? (
 						<RenewNoticeAction

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -196,7 +196,7 @@ function ExpiredRenewNotice( {
 
 		return (
 			<Notice
-				variant={ refunded ? 'success' : 'error' }
+				variant={ refunded && isExpired( currentPurchase ) ? 'success' : 'error' }
 				actions={
 					shouldShowRenewNoticeAction( purchase ) ? (
 						<RenewNoticeAction


### PR DESCRIPTION


Part of DOTCOM-16116

## Proposed Changes

* Requested by @fditrapani - immediately post refund, we show a red notice that doesn't indicate a refund happened. Change it to be green and with an appropriate text

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Using the Store Sandbox, get a plan
* Cancel and refund the plan
* Ensure green success message

<img width="749" height="265" alt="Screenshot 2026-02-26 at 16 09 10" src="https://github.com/user-attachments/assets/043d084c-1944-4e01-9132-935cb2d7b424" />

* Removing a non-refundable subscription (you can add one using Store Admin) leads to no change

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
