### PR TITLE
A4A: Add create-a4a-pr skill

### DIFF
--- a/.claude/skills/create-a4a-pr/README.md
+++ b/.claude/skills/create-a4a-pr/README.md
@@ -1,0 +1,18 @@
+# create-a4a-pr
+
+Skill for creating A4A-related pull requests with consistent conventions (title prefix, reviewer, label, PR body template). The workflow is in **SKILL.md**.
+
+## Usage
+
+- **Cursor / Claude** — Enter `/create-a4a-pr` > Enter
+- **Codex** — Codex loads skills from `$CODEX_HOME/skills` (default `~/.codex/skills`). Install from this repo once, then restart Codex.
+
+### Codex install
+
+1. Open Codex.
+2. Enter `/`.
+3. Select **Skill Installer**.
+4. Enter the URL:  
+   `https://github.com/Automattic/wp-calypso/tree/trunk/.claude/skills/create-a4a-pr/SKILL.md`
+
+After installing, restart Codex to pick up the skill.

--- a/.claude/skills/create-a4a-pr/SKILL.md
+++ b/.claude/skills/create-a4a-pr/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: create-a4a-pr
+description: Create or edit A4A-related pull requests with consistent titles, reviewers, labels, and body conventions
+---
+
+# Create A4A PR
+
+When the user runs `/create-a4a-pr` or asks to create/open/raise a PR for A4A work (`client/a8c-for-agencies/**`), do the following, then reply with the **full PR link** pasted in the message.
+
+## Steps
+
+1. **Branch** — Create a new branch from the base (`trunk` or the one they specify). Use a descriptive name (e.g. `add/feature-name`, `fix/bug-name`).
+2. **Commit** — Stage and commit with a clear message. Use `A4A: ` prefix in the commit when it's A4A work.
+3. **Create PR** — `gh pr create` with base, title, body. Default base is `trunk` unless they said "on top of PR #…" (then use that PR's branch).
+4. **Conventions** — Add reviewer `Automattic/a4a-genesis`, label `A8c Agencies`, assign to the branch author. Use `gh pr edit` if needed.
+5. **Body** — If built on another PR/branch: put `This PR is built on top of {pr-url}.` at the very top. If they gave a Linear link: add `Fixes` / `Resolves` / `Part of {link}` right after that.
+6. **Reply** — Paste the full PR URL so they can click it.
+
+## Conventions summary
+
+- **Title:** Prefix with `A4A: ` (e.g. `A4A: Add PR review workflow`).
+- **Reviewer:** `Automattic/a4a-genesis`.
+- **Label:** `A8c Agencies`.

--- a/.claude/skills/create-a4a-pr/SKILL.md
+++ b/.claude/skills/create-a4a-pr/SKILL.md
@@ -11,10 +11,9 @@ When the user runs `/create-a4a-pr` or asks to create/open/raise a PR for A4A wo
 
 1. **Branch** — Create a new branch from the base (`trunk` or the one they specify). Use a descriptive name (e.g. `add/feature-name`, `fix/bug-name`).
 2. **Commit** — Stage and commit with a clear message. Use `A4A: ` prefix in the commit when it's A4A work.
-3. **Create PR** — `gh pr create` with base, title, body. Default base is `trunk` unless they said "on top of PR #…" (then use that PR's branch).
+3. **Create PR** — `gh pr create` with base, title, body. Default base is `trunk` unless they said "on top of PR #…" (then use that PR's branch). **Body must follow** `.github/PULL_REQUEST_TEMPLATE.md`: put "This PR is built on top of {pr-url}." at the very top when applicable; then "Part of #" or Fixes/Resolves with the Linear link; then fill Proposed Changes, Why are these changes being made?, Testing Instructions, and Pre-merge Checklist per the template.
 4. **Conventions** — Add reviewer `Automattic/a4a-genesis`, label `A8c Agencies`, assign to the branch author. Use `gh pr edit` if needed.
-5. **Body** — If built on another PR/branch: put `This PR is built on top of {pr-url}.` at the very top. If they gave a Linear link: add `Fixes` / `Resolves` / `Part of {link}` right after that.
-6. **Reply** — Paste the full PR URL so they can click it.
+5. **Reply** — Paste the full PR URL in the message so they can click it.
 
 ## Conventions summary
 


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add the `create-a4a-pr` skill (`.claude/skills/create-a4a-pr/SKILL.md`) so A4A PRs are created with consistent conventions. The skill requires the PR body to follow `.github/PULL_REQUEST_TEMPLATE.md`.

## Why are these changes being made?

* Single source of truth for A4A PR workflow (branch, commit, title prefix, reviewer, label, body format) so Cursor, Claude, Codex can follow the same steps. Aligning with the repo PR template keeps A4A PRs consistent with the rest of Calypso.

## Testing Instructions

* In the agent window (or equivalent), try `/create-a4a-pr` and verify the skill shows up and is available.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
