### PR TITLE
Email Forwards: Add the ability to edit an email forward

### DIFF
--- a/client/dashboard/emails/dataviews/actions/delete-email-forward.tsx
+++ b/client/dashboard/emails/dataviews/actions/delete-email-forward.tsx
@@ -109,6 +109,6 @@ export const useDeleteEmailForwardAction = (): Action< Email > => {
 				</VStack>
 			);
 		},
-		isEligible: ( item: Email ) => item.type === 'forwarding' && !! ( item?.forwardingTo ?? false ),
+		isEligible: ( item: Email ) => item.type === 'forwarding' && !! item.forwardingTo,
 	};
 };

--- a/client/dashboard/emails/dataviews/actions/edit-email-forward.tsx
+++ b/client/dashboard/emails/dataviews/actions/edit-email-forward.tsx
@@ -1,0 +1,135 @@
+import { updateEmailForwardMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+	TextControl,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import emailValidator from 'email-validator';
+import { useEffect, useState } from 'react';
+import { useAnalytics } from '../../../app/analytics';
+import { Text } from '../../../components/text';
+import type { Email } from '../../types';
+import type { Action } from '@wordpress/dataviews';
+
+export const useEditEmailForwardAction = (): Action< Email > => {
+	return {
+		id: 'edit-email-forward',
+		label: __( 'Edit forwarder' ),
+		callback: () => {},
+		RenderModal: ( { items, closeModal, onActionPerformed } ) => {
+			const { mutateAsync: updateEmailForward, isPending } = useMutation(
+				updateEmailForwardMutation()
+			);
+			const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+			const { recordTracksEvent } = useAnalytics();
+
+			const email = items[ 0 ];
+			const mailbox = email.emailAddress.split( '@' )[ 0 ];
+			const currentDestination = email.forwardingTo ?? '';
+
+			const [ newDestination, setNewDestination ] = useState( currentDestination );
+
+			useEffect( () => {
+				recordTracksEvent( 'calypso_dashboard_emails_action_click', {
+					action_id: 'edit-email-forward',
+				} );
+			}, [ recordTracksEvent ] );
+
+			const isUnchanged = newDestination.trim() === currentDestination;
+			const isValid = emailValidator.validate( newDestination.trim() );
+
+			const onConfirm = async () => {
+				recordTracksEvent( 'calypso_dashboard_emails_action_confirm_click', {
+					action_id: 'edit-email-forward',
+				} );
+				try {
+					await updateEmailForward( {
+						domainName: email.domainName,
+						mailbox,
+						destination: currentDestination,
+						newDestination: newDestination.trim(),
+					} );
+					createSuccessNotice(
+						sprintf(
+							/* translators: %s is the new forwarding destination email. */
+							__( 'Email forward updated. Please check %s to verify the new address.' ),
+							newDestination.trim()
+						),
+						{ type: 'snackbar' }
+					);
+					onActionPerformed?.( items );
+					closeModal?.();
+				} catch ( _e ) {
+					createErrorNotice(
+						sprintf(
+							/* translators: %1$s is the email address. */
+							__( 'Failed to update forwarder %1$s. Please try again.' ),
+							email.emailAddress
+						),
+						{ type: 'snackbar' }
+					);
+				}
+			};
+
+			const handleCancel = () => {
+				recordTracksEvent( 'calypso_dashboard_emails_action_cancel_click', {
+					action_id: 'edit-email-forward',
+				} );
+				closeModal?.();
+			};
+
+			return (
+				<VStack spacing={ 4 }>
+					<Text>
+						{ sprintf(
+							/* translators: %s is the email address being edited. */
+							__( 'Edit the forwarding destination for %s.' ),
+							email.emailAddress
+						) }
+					</Text>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Forward to' ) }
+						value={ newDestination }
+						onChange={ setNewDestination }
+						type="email"
+						disabled={ isPending }
+						help={
+							! isUnchanged && newDestination.trim() && ! isValid
+								? __( 'Please enter a valid email address.' )
+								: undefined
+						}
+					/>
+					<HStack justify="right">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ handleCancel }
+							disabled={ isPending }
+							accessibleWhenDisabled
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							onClick={ onConfirm }
+							isBusy={ isPending }
+							disabled={ isPending || isUnchanged || ! isValid }
+							accessibleWhenDisabled
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			);
+		},
+		isEligible: ( item: Email ) => item.type === 'forwarding' && !! ( item?.forwardingTo ?? false ),
+	};
+};

--- a/client/dashboard/emails/dataviews/actions/edit-email-forward.tsx
+++ b/client/dashboard/emails/dataviews/actions/edit-email-forward.tsx
@@ -130,6 +130,6 @@ export const useEditEmailForwardAction = (): Action< Email > => {
 				</VStack>
 			);
 		},
-		isEligible: ( item: Email ) => item.type === 'forwarding' && !! ( item?.forwardingTo ?? false ),
+		isEligible: ( item: Email ) => item.type === 'forwarding' && !! item.forwardingTo,
 	};
 };

--- a/client/dashboard/emails/dataviews/actions/index.ts
+++ b/client/dashboard/emails/dataviews/actions/index.ts
@@ -1,5 +1,6 @@
 import { useDeleteEmailForwardAction } from './delete-email-forward';
 import { useDeleteTitanMailboxAction } from './delete-titan-mailbox';
+import { useEditEmailForwardAction } from './edit-email-forward';
 import { useFinishSetupAction } from './finish-setup';
 import { useManageGoogleWorkspaceAction } from './manage-google-workspace';
 import { usePaymentDetailsAction } from './payment-details';
@@ -15,6 +16,7 @@ export function useActions(): Action< Email >[] {
 		useManageGoogleWorkspaceAction(),
 		usePaymentDetailsAction(),
 		useResendVerificationAction(),
+		useEditEmailForwardAction(),
 		useDeleteTitanMailboxAction(),
 		useDeleteEmailForwardAction(),
 	];

--- a/client/dashboard/emails/dataviews/actions/resend-verification.ts
+++ b/client/dashboard/emails/dataviews/actions/resend-verification.ts
@@ -60,8 +60,6 @@ export const useResendVerificationAction = (): Action< Email > => {
 				} );
 		},
 		isEligible: ( item: Email ) =>
-			item.type === 'forwarding' &&
-			item.status === 'unverified_forwards' &&
-			!! ( item?.forwardingTo ?? false ),
+			item.type === 'forwarding' && item.status === 'unverified_forwards' && !! item.forwardingTo,
 	};
 };

--- a/client/data/emails/use-update-email-forward-mutation.tsx
+++ b/client/data/emails/use-update-email-forward-mutation.tsx
@@ -7,6 +7,7 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getCacheKey as getEmailAccountsQueryKey } from './use-get-email-accounts-query';
 import type { AlterDestinationParams, EmailAccountEmail } from './types';
+import type { UpdateEmailForwardResponse } from '@automattic/api-core';
 import type { UseMutationOptions } from '@tanstack/react-query';
 
 type UpdateEmailForwardParams = AlterDestinationParams & {
@@ -28,7 +29,7 @@ const MUTATION_KEY = 'updateEmailForward';
 export default function useUpdateEmailForwardMutation(
 	domainName: string,
 	mutationOptions: Omit<
-		UseMutationOptions< any, unknown, UpdateEmailForwardParams, Context >,
+		UseMutationOptions< UpdateEmailForwardResponse, unknown, UpdateEmailForwardParams, Context >,
 		'mutationFn'
 	> = {}
 ) {
@@ -135,7 +136,7 @@ export default function useUpdateEmailForwardMutation(
 		);
 	};
 
-	return useMutation< any, unknown, UpdateEmailForwardParams, Context >( {
+	return useMutation< UpdateEmailForwardResponse, unknown, UpdateEmailForwardParams, Context >( {
 		mutationFn: ( { mailbox, destination, newDestination } ) => {
 			return wp.req.post(
 				`/domains/${ encodeURIComponent( domainName ) }/email/${ encodeURIComponent( mailbox ) }`,

--- a/client/data/emails/use-update-email-forward-mutation.tsx
+++ b/client/data/emails/use-update-email-forward-mutation.tsx
@@ -1,0 +1,150 @@
+import { CALYPSO_CONTACT } from '@automattic/urls';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
+import wp from 'calypso/lib/wp';
+import { useDispatch, useSelector } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getCacheKey as getEmailAccountsQueryKey } from './use-get-email-accounts-query';
+import type { AlterDestinationParams, EmailAccountEmail } from './types';
+import type { UseMutationOptions } from '@tanstack/react-query';
+
+type UpdateEmailForwardParams = AlterDestinationParams & {
+	newDestination: string;
+};
+
+type Context = {
+	[ key: string ]: any;
+};
+
+const MUTATION_KEY = 'updateEmailForward';
+
+/**
+ * Updates an email forward's destination, including relevant optimistic data mutations.
+ * @param domainName The domain name of the mailbox
+ * @param mutationOptions Mutation options passed on to `useMutation`
+ * @returns Returns the result of the `useMutation` call
+ */
+export default function useUpdateEmailForwardMutation(
+	domainName: string,
+	mutationOptions: Omit<
+		UseMutationOptions< any, unknown, UpdateEmailForwardParams, Context >,
+		'mutationFn'
+	> = {}
+) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const queryClient = useQueryClient();
+
+	const selectedSiteId = useSelector( getSelectedSiteId );
+
+	const emailAccountsQueryKey = getEmailAccountsQueryKey( selectedSiteId, domainName );
+
+	const suppliedOnSettled = mutationOptions.onSettled;
+	const suppliedOnSuccess = mutationOptions.onSuccess;
+	const suppliedOnMutate = mutationOptions.onMutate;
+	const suppliedOnError = mutationOptions.onError;
+
+	mutationOptions.mutationKey = [ MUTATION_KEY ];
+
+	mutationOptions.onSettled = ( data, error, variables, context ) => {
+		suppliedOnSettled?.( data, error, variables, context );
+
+		queryClient.invalidateQueries( { queryKey: emailAccountsQueryKey } );
+	};
+
+	mutationOptions.onSuccess = ( data, params, context ) => {
+		suppliedOnSuccess?.( data, params, context );
+
+		dispatch(
+			successNotice(
+				translate(
+					'Email forward updated. Please check %(newDestination)s to verify the new address.',
+					{
+						args: { newDestination: params.newDestination },
+					}
+				),
+				{ duration: 10000 }
+			)
+		);
+	};
+
+	mutationOptions.onMutate = async ( params ) => {
+		suppliedOnMutate?.( params );
+
+		await queryClient.cancelQueries( { queryKey: emailAccountsQueryKey } );
+
+		const previousEmailAccountsQueryData = queryClient.getQueryData< any >( emailAccountsQueryKey );
+
+		const emailForwards = previousEmailAccountsQueryData?.accounts?.[ 0 ]?.emails;
+
+		// Optimistically update the forward's target in `useGetEmailAccountsQuery` data
+		if ( emailForwards ) {
+			queryClient.setQueryData( emailAccountsQueryKey, {
+				...previousEmailAccountsQueryData,
+				accounts: [
+					{
+						...previousEmailAccountsQueryData.accounts[ 0 ],
+						emails: emailForwards.map( ( forward: EmailAccountEmail ) => {
+							if ( forward.mailbox === params.mailbox && forward.target === params.destination ) {
+								return {
+									...forward,
+									target: params.newDestination,
+									is_verified: false,
+								};
+							}
+							return forward;
+						} ),
+					},
+				],
+			} );
+		}
+
+		return {
+			[ JSON.stringify( emailAccountsQueryKey ) ]: previousEmailAccountsQueryData,
+		};
+	};
+
+	mutationOptions.onError = ( error, params, context ) => {
+		suppliedOnError?.( error, params, context );
+
+		if ( context ) {
+			queryClient.setQueryData(
+				emailAccountsQueryKey,
+				context[ JSON.stringify( emailAccountsQueryKey ) ]
+			);
+		}
+
+		dispatch(
+			errorNotice(
+				translate(
+					'Failed to update email forward for {{strong}}%(mailbox)s@%(domain)s{{/strong}}. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
+					{
+						args: {
+							mailbox: params.mailbox,
+							domain: params.domain,
+						},
+						components: {
+							contactSupportLink: <a href={ CALYPSO_CONTACT } />,
+							strong: <strong />,
+						},
+					}
+				),
+				{ duration: 7000 }
+			)
+		);
+	};
+
+	return useMutation< any, unknown, UpdateEmailForwardParams, Context >( {
+		mutationFn: ( { mailbox, destination, newDestination } ) => {
+			return wp.req.post(
+				`/domains/${ encodeURIComponent( domainName ) }/email/${ encodeURIComponent( mailbox ) }`,
+				{
+					destination,
+					new_destination: newDestination,
+				}
+			);
+		},
+		...mutationOptions,
+	} );
+}

--- a/client/my-sites/email/email-forwarding/actions-menu/index.tsx
+++ b/client/my-sites/email/email-forwarding/actions-menu/index.tsx
@@ -113,12 +113,12 @@ function EditModal( {
 }: {
 	mailbox: Mailbox;
 	currentDestination: string;
-	onEdit: (
-		mailbox: string,
-		domain: string,
-		destination: string,
-		newDestination: string
-	) => Promise< unknown >;
+	onEdit: ( params: {
+		mailbox: string;
+		domain: string;
+		destination: string;
+		newDestination: string;
+	} ) => Promise< unknown >;
 	isPending: boolean;
 	onClose: () => void;
 } ) {
@@ -129,7 +129,12 @@ function EditModal( {
 	const isValid = emailValidator.validate( newDestination.trim() );
 
 	const handleSave = async () => {
-		await onEdit( mailbox.mailbox, mailbox.domain, currentDestination, newDestination.trim() );
+		await onEdit( {
+			mailbox: mailbox.mailbox,
+			domain: mailbox.domain,
+			destination: currentDestination,
+			newDestination: newDestination.trim(),
+		} );
 		onClose();
 	};
 

--- a/client/my-sites/email/email-forwarding/actions-menu/index.tsx
+++ b/client/my-sites/email/email-forwarding/actions-menu/index.tsx
@@ -24,7 +24,7 @@ export const ActionsMenu = ( { mailbox }: { mailbox: Mailbox } ) => {
 	const [ isEditOpen, setIsEditOpen ] = useState( false );
 	const remove = useRemove( { mailbox } );
 	const resend = useResend( { mailbox } );
-	const { edit, isPending: isEditPending } = useEdit( { mailbox } );
+	const { edit, isPending } = useEdit( { mailbox } );
 	const translate = useTranslate();
 
 	const currentDestination = getEmailForwardAddress( mailbox );
@@ -91,7 +91,7 @@ export const ActionsMenu = ( { mailbox }: { mailbox: Mailbox } ) => {
 					mailbox={ mailbox }
 					currentDestination={ currentDestination }
 					onEdit={ edit }
-					isPending={ isEditPending }
+					isPending={ isPending }
 					onClose={ () => setIsEditOpen( false ) }
 				/>
 			) }

--- a/client/my-sites/email/email-forwarding/actions-menu/index.tsx
+++ b/client/my-sites/email/email-forwarding/actions-menu/index.tsx
@@ -24,7 +24,7 @@ export const ActionsMenu = ( { mailbox }: { mailbox: Mailbox } ) => {
 	const [ isEditOpen, setIsEditOpen ] = useState( false );
 	const remove = useRemove( { mailbox } );
 	const resend = useResend( { mailbox } );
-	const edit = useEdit( { mailbox } );
+	const { edit, isPending: isEditPending } = useEdit( { mailbox } );
 	const translate = useTranslate();
 
 	const currentDestination = getEmailForwardAddress( mailbox );
@@ -91,6 +91,7 @@ export const ActionsMenu = ( { mailbox }: { mailbox: Mailbox } ) => {
 					mailbox={ mailbox }
 					currentDestination={ currentDestination }
 					onEdit={ edit }
+					isPending={ isEditPending }
 					onClose={ () => setIsEditOpen( false ) }
 				/>
 			) }
@@ -107,6 +108,7 @@ function EditModal( {
 	mailbox,
 	currentDestination,
 	onEdit,
+	isPending,
 	onClose,
 }: {
 	mailbox: Mailbox;
@@ -117,23 +119,18 @@ function EditModal( {
 		destination: string,
 		newDestination: string
 	) => Promise< unknown >;
+	isPending: boolean;
 	onClose: () => void;
 } ) {
 	const translate = useTranslate();
 	const [ newDestination, setNewDestination ] = useState( currentDestination );
-	const [ isSaving, setIsSaving ] = useState( false );
 
 	const isUnchanged = newDestination.trim() === currentDestination;
 	const isValid = emailValidator.validate( newDestination.trim() );
 
 	const handleSave = async () => {
-		setIsSaving( true );
-		try {
-			await onEdit( mailbox.mailbox, mailbox.domain, currentDestination, newDestination.trim() );
-			onClose();
-		} finally {
-			setIsSaving( false );
-		}
+		await onEdit( mailbox.mailbox, mailbox.domain, currentDestination, newDestination.trim() );
+		onClose();
 	};
 
 	return (
@@ -153,7 +150,7 @@ function EditModal( {
 					value={ newDestination }
 					onChange={ setNewDestination }
 					type="email"
-					disabled={ isSaving }
+					disabled={ isPending }
 					help={
 						! isUnchanged && newDestination.trim() && ! isValid
 							? translate( 'Please enter a valid email address.' )
@@ -165,7 +162,7 @@ function EditModal( {
 						__next40pxDefaultSize
 						variant="tertiary"
 						onClick={ onClose }
-						disabled={ isSaving }
+						disabled={ isPending }
 						accessibleWhenDisabled
 					>
 						{ translate( 'Cancel' ) }
@@ -174,8 +171,8 @@ function EditModal( {
 						__next40pxDefaultSize
 						variant="primary"
 						onClick={ handleSave }
-						isBusy={ isSaving }
-						disabled={ isSaving || isUnchanged || ! isValid }
+						isBusy={ isPending }
+						disabled={ isPending || isUnchanged || ! isValid }
 						accessibleWhenDisabled
 					>
 						{ translate( 'Save' ) }

--- a/client/my-sites/email/email-forwarding/actions-menu/index.tsx
+++ b/client/my-sites/email/email-forwarding/actions-menu/index.tsx
@@ -1,39 +1,77 @@
 import {
 	__experimentalConfirmDialog as ConfirmDialog,
 	__experimentalHeading as Heading,
+	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
+	Button,
 	DropdownMenu,
+	Modal,
+	TextControl,
 } from '@wordpress/components';
-import { rotateLeft, trash, moreVertical } from '@wordpress/icons';
+import { pencil, rotateLeft, trash, moreVertical } from '@wordpress/icons';
+import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { getEmailForwardAddress } from 'calypso/lib/emails';
-import { useResend, useRemove } from '../hooks';
+import { useEdit, useResend, useRemove } from '../hooks';
 import type { Mailbox } from '../../../../data/emails/types';
+
 import './style.scss';
 
 export const ActionsMenu = ( { mailbox }: { mailbox: Mailbox } ) => {
-	const [ isOpen, setIsOpen ] = useState( false );
+	const [ isRemoveOpen, setIsRemoveOpen ] = useState( false );
+	const [ isEditOpen, setIsEditOpen ] = useState( false );
 	const remove = useRemove( { mailbox } );
 	const resend = useResend( { mailbox } );
+	const edit = useEdit( { mailbox } );
 	const translate = useTranslate();
 
-	const handleConfirm = () => {
-		remove( mailbox.mailbox, mailbox.domain, getEmailForwardAddress( mailbox ) );
-		setIsOpen( false );
+	const currentDestination = getEmailForwardAddress( mailbox );
+
+	const handleRemoveConfirm = () => {
+		remove( mailbox.mailbox, mailbox.domain, currentDestination );
+		setIsRemoveOpen( false );
 	};
 
-	const handleCancel = () => {
-		setIsOpen( false );
+	const handleRemoveCancel = () => {
+		setIsRemoveOpen( false );
 	};
+
+	const editControl = {
+		title: translate( 'Edit', {
+			comment: 'Edit email forward destination',
+		} ) as string,
+		icon: pencil,
+		onClick: () => setIsEditOpen( true ),
+	};
+
+	const removeControl = {
+		title: translate( 'Remove', {
+			comment: 'Remove email forward',
+		} ) as string,
+		icon: trash,
+		onClick: () => setIsRemoveOpen( true ),
+	};
+
+	const resendControl = {
+		title: translate( 'Resend', {
+			comment: 'Resend verification email',
+		} ) as string,
+		icon: rotateLeft,
+		onClick: () => resend( mailbox.mailbox, mailbox.domain, currentDestination ),
+	};
+
+	const controls = mailbox.warnings?.length
+		? [ editControl, resendControl, removeControl ]
+		: [ editControl, removeControl ];
 
 	return (
 		<>
 			<ConfirmDialog
-				isOpen={ isOpen }
-				onConfirm={ handleConfirm }
-				onCancel={ handleCancel }
+				isOpen={ isRemoveOpen }
+				onConfirm={ handleRemoveConfirm }
+				onCancel={ handleRemoveCancel }
 				cancelButtonText={ translate( 'Cancel' ) }
 				confirmButtonText={ translate( 'Remove' ) }
 			>
@@ -48,39 +86,102 @@ export const ActionsMenu = ( { mailbox }: { mailbox: Mailbox } ) => {
 					</Text>
 				</VStack>
 			</ConfirmDialog>
+			{ isEditOpen && (
+				<EditModal
+					mailbox={ mailbox }
+					currentDestination={ currentDestination }
+					onEdit={ edit }
+					onClose={ () => setIsEditOpen( false ) }
+				/>
+			) }
 			<DropdownMenu
 				icon={ moreVertical }
 				label={ translate( 'More options' ) }
-				controls={
-					mailbox.warnings?.length
-						? [
-								{
-									title: translate( 'Resend', {
-										comment: 'Resend verification email',
-									} ) as string,
-									icon: rotateLeft,
-									onClick: () =>
-										resend( mailbox.mailbox, mailbox.domain, getEmailForwardAddress( mailbox ) ),
-								},
-								{
-									title: translate( 'Remove', {
-										comment: 'Remove email forward',
-									} ) as string,
-									icon: trash,
-									onClick: () => setIsOpen( true ),
-								},
-						  ]
-						: [
-								{
-									title: translate( 'Remove', {
-										comment: 'Remove email forward',
-									} ) as string,
-									icon: trash,
-									onClick: () => setIsOpen( true ),
-								},
-						  ]
-				}
+				controls={ controls }
 			/>
 		</>
 	);
 };
+
+function EditModal( {
+	mailbox,
+	currentDestination,
+	onEdit,
+	onClose,
+}: {
+	mailbox: Mailbox;
+	currentDestination: string;
+	onEdit: (
+		mailbox: string,
+		domain: string,
+		destination: string,
+		newDestination: string
+	) => Promise< unknown >;
+	onClose: () => void;
+} ) {
+	const translate = useTranslate();
+	const [ newDestination, setNewDestination ] = useState( currentDestination );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const isUnchanged = newDestination.trim() === currentDestination;
+	const isValid = emailValidator.validate( newDestination.trim() );
+
+	const handleSave = async () => {
+		setIsSaving( true );
+		try {
+			await onEdit( mailbox.mailbox, mailbox.domain, currentDestination, newDestination.trim() );
+			onClose();
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	return (
+		<Modal title={ translate( 'Edit email forward' ) } onRequestClose={ onClose }>
+			<VStack spacing={ 4 }>
+				<Text>
+					{ translate( 'Edit the forwarding destination for %(emailAddress)s.', {
+						args: {
+							emailAddress: `${ mailbox.mailbox }@${ mailbox.domain }`,
+						},
+					} ) }
+				</Text>
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ translate( 'Forward to' ) }
+					value={ newDestination }
+					onChange={ setNewDestination }
+					type="email"
+					disabled={ isSaving }
+					help={
+						! isUnchanged && newDestination.trim() && ! isValid
+							? translate( 'Please enter a valid email address.' )
+							: undefined
+					}
+				/>
+				<HStack justify="right">
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ onClose }
+						disabled={ isSaving }
+						accessibleWhenDisabled
+					>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						onClick={ handleSave }
+						isBusy={ isSaving }
+						disabled={ isSaving || isUnchanged || ! isValid }
+						accessibleWhenDisabled
+					>
+						{ translate( 'Save' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/my-sites/email/email-forwarding/hooks.ts
+++ b/client/my-sites/email/email-forwarding/hooks.ts
@@ -52,20 +52,20 @@ export function useEdit( { mailbox }: { mailbox: Mailbox } ) {
 	);
 
 	const edit = useCallback(
-		( mailboxName: string, domain: string, destination: string, newDestination: string ) => {
+		( params: {
+			mailbox: string;
+			domain: string;
+			destination: string;
+			newDestination: string;
+		} ) => {
 			recordTracksEvent( 'calypso_email_management_email_forwarding_edit_click', {
-				destination,
-				new_destination: newDestination,
-				domain_name: domain,
-				mailbox: mailboxName,
+				destination: params.destination,
+				new_destination: params.newDestination,
+				domain_name: params.domain,
+				mailbox: params.mailbox,
 			} );
 
-			return updateEmailForward( {
-				mailbox: mailboxName,
-				destination,
-				newDestination,
-				domain,
-			} );
+			return updateEmailForward( params );
 		},
 		[ updateEmailForward ]
 	);

--- a/client/my-sites/email/email-forwarding/hooks.ts
+++ b/client/my-sites/email/email-forwarding/hooks.ts
@@ -47,9 +47,11 @@ export function useResend( { mailbox }: { mailbox: Mailbox } ) {
 }
 
 export function useEdit( { mailbox }: { mailbox: Mailbox } ) {
-	const { mutateAsync: updateEmailForward } = useUpdateEmailForwardMutation( mailbox.domain );
+	const { mutateAsync: updateEmailForward, isPending } = useUpdateEmailForwardMutation(
+		mailbox.domain
+	);
 
-	return useCallback(
+	const edit = useCallback(
 		( mailboxName: string, domain: string, destination: string, newDestination: string ) => {
 			recordTracksEvent( 'calypso_email_management_email_forwarding_edit_click', {
 				destination,
@@ -67,4 +69,6 @@ export function useEdit( { mailbox }: { mailbox: Mailbox } ) {
 		},
 		[ updateEmailForward ]
 	);
+
+	return { edit, isPending };
 }

--- a/client/my-sites/email/email-forwarding/hooks.ts
+++ b/client/my-sites/email/email-forwarding/hooks.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import useRemoveEmailForwardMutation from 'calypso/data/emails/use-remove-email-forward-mutation';
 import useResendVerifyEmailForwardMutation from 'calypso/data/emails/use-resend-verify-email-forward-mutation';
+import useUpdateEmailForwardMutation from 'calypso/data/emails/use-update-email-forward-mutation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Mailbox } from 'calypso/data/emails/types';
 
@@ -42,5 +43,28 @@ export function useResend( { mailbox }: { mailbox: Mailbox } ) {
 			resendVerificationEmail( { mailbox, destination, domain } );
 		},
 		[ resendVerificationEmail ]
+	);
+}
+
+export function useEdit( { mailbox }: { mailbox: Mailbox } ) {
+	const { mutateAsync: updateEmailForward } = useUpdateEmailForwardMutation( mailbox.domain );
+
+	return useCallback(
+		( mailboxName: string, domain: string, destination: string, newDestination: string ) => {
+			recordTracksEvent( 'calypso_email_management_email_forwarding_edit_click', {
+				destination,
+				new_destination: newDestination,
+				domain_name: domain,
+				mailbox: mailboxName,
+			} );
+
+			return updateEmailForward( {
+				mailbox: mailboxName,
+				destination,
+				newDestination,
+				domain,
+			} );
+		},
+		[ updateEmailForward ]
 	);
 }

--- a/packages/api-core/src/domain/mutators.ts
+++ b/packages/api-core/src/domain/mutators.ts
@@ -1,4 +1,5 @@
 import { wpcom } from '../wpcom-fetcher';
+import type { UpdateEmailForwardResponse } from './types';
 
 export function disconnectDomain( domainName: string ): Promise< void > {
 	return wpcom.req.get( {
@@ -41,7 +42,7 @@ export function updateEmailForward(
 	mailbox: string,
 	destination: string,
 	newDestination: string
-): Promise< { updated: boolean; verified: boolean } > {
+): Promise< UpdateEmailForwardResponse > {
 	return wpcom.req.post(
 		`/domains/${ encodeURIComponent( domainName ) }/email/${ encodeURIComponent( mailbox ) }`,
 		{

--- a/packages/api-core/src/domain/mutators.ts
+++ b/packages/api-core/src/domain/mutators.ts
@@ -35,3 +35,18 @@ export function deleteEmailForward(
 		) }/${ encodeURIComponent( destination ) }/delete`
 	);
 }
+
+export function updateEmailForward(
+	domainName: string,
+	mailbox: string,
+	destination: string,
+	newDestination: string
+): Promise< { updated: boolean; verified: boolean } > {
+	return wpcom.req.post(
+		`/domains/${ encodeURIComponent( domainName ) }/email/${ encodeURIComponent( mailbox ) }`,
+		{
+			destination,
+			new_destination: newDestination,
+		}
+	);
+}

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -34,6 +34,11 @@ export interface TitanEmailSubscription extends EmailSubscription {
 	maximum_mailbox_count: number;
 }
 
+export interface UpdateEmailForwardResponse {
+	updated: boolean;
+	verified: boolean;
+}
+
 export interface Domain extends DomainSummary {
 	a_records_required_for_mapping?: string[];
 	auth_code_required: boolean;

--- a/packages/api-queries/src/domain.ts
+++ b/packages/api-queries/src/domain.ts
@@ -4,6 +4,7 @@ import {
 	resendIcannVerificationEmail,
 	resendVerifyEmailForward,
 	deleteEmailForward,
+	updateEmailForward,
 } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { userMailboxesQuery } from './me-mailboxes';
@@ -39,6 +40,21 @@ export const deleteEmailForwardMutation = () => {
 	return mutationOptions( {
 		mutationFn: ( vars: { domainName: string; mailbox: string; destination: string } ) =>
 			deleteEmailForward( vars.domainName, vars.mailbox, vars.destination ),
+		onSuccess: () => {
+			queryClient.resetQueries( userMailboxesQuery() );
+		},
+	} );
+};
+
+export const updateEmailForwardMutation = () => {
+	return mutationOptions( {
+		mutationFn: ( vars: {
+			domainName: string;
+			mailbox: string;
+			destination: string;
+			newDestination: string;
+		} ) =>
+			updateEmailForward( vars.domainName, vars.mailbox, vars.destination, vars.newDestination ),
 		onSuccess: () => {
 			queryClient.resetQueries( userMailboxesQuery() );
 		},

--- a/packages/api-queries/src/domain.ts
+++ b/packages/api-queries/src/domain.ts
@@ -41,7 +41,7 @@ export const deleteEmailForwardMutation = () => {
 		mutationFn: ( vars: { domainName: string; mailbox: string; destination: string } ) =>
 			deleteEmailForward( vars.domainName, vars.mailbox, vars.destination ),
 		onSuccess: () => {
-			queryClient.resetQueries( userMailboxesQuery() );
+			queryClient.invalidateQueries( userMailboxesQuery() );
 		},
 	} );
 };
@@ -56,7 +56,7 @@ export const updateEmailForwardMutation = () => {
 		} ) =>
 			updateEmailForward( vars.domainName, vars.mailbox, vars.destination, vars.newDestination ),
 		onSuccess: () => {
-			queryClient.resetQueries( userMailboxesQuery() );
+			queryClient.invalidateQueries( userMailboxesQuery() );
 		},
 	} );
 };


### PR DESCRIPTION
### Related issues
- Resolves DOTDEV-239
- Related to 205244-ghe-Automattic/wpcom

### Proposed Changes

The changes proposed in this PR are adding `Edit` action for Email Forwards setting in both dashboards:

| Old dashboard | new dashboard |
|--------|--------|
| <img width="2180" height="1256" alt="CleanShot 2026-02-27 at 11 01 58@2x" src="https://github.com/user-attachments/assets/7d52ca64-56ad-49b0-bd49-7a932e4f18fb" /> | <img width="2812" height="960" alt="CleanShot 2026-02-27 at 10 54 54@2x" src="https://github.com/user-attachments/assets/2a229ef6-e1ae-4689-82fa-7f92226be4d2" /> | 

There's a related backend change proposed in 205244-ghe-Automattic/wpcom.

Specific changes introduced in this PR:

- Add `updateEmailForward()` API mutator to `@automattic/api-core` calling `POST /domains/{domain}/email/{mailbox}` with `{ destination, new_destination }`
- Add `updateEmailForwardMutation()` to `@automattic/api-queries` for TanStack Query integration
- Add "Edit forwarder" DataViews action to the Dashboard emails view (`/emails`) with a modal for changing the forwarding destination
- Add "Edit" action to the classic Calypso email forwarding actions menu (`/email/.../manage/...` and `/domains/manage/all/email/...`) with a modal for changing the forwarding destination
- Show a success notice after editing, prompting the user to verify the new address if the destination is unverified
- Use `email-validator` package for destination validation, consistent with the existing add forward form

### Testing Instructions
1. If you don't have any, register a custom test domain with one of your test sites.
2. Check out the PR branch and build the app with `yarn && yarn start` (or use the _Calypso Live_ / _Dashboard Live (dotcom)_ links from the [comment below](https://github.com/Automattic/wp-calypso/pull/108952#issuecomment-3967287650)).
3. Apply 205244-ghe-Automattic/wpcom to your sandbox, sandbox `public-api.wordpress.com` and **enable write mode**.

We will test the `Edit` action in both dashboards.

**Old dashboard:**

4. Head over to `http://calypso.localhost:3000/email/{domain-name}/manage/{domain-name}`.
5. Add a new email forward and confirm it by clicking the link in the confirmation email sent.
6. Once the new email forward is in place, click the three dots menu and then Edit option to trigger modal.
7. Update the email address and observe the notification in the UI.
8. Head over to your email inbox and confirm the email change.
9. Try to send yourself an email to check the email forwarding works as expected.
10. Other existing actions (Resend, Remove) should still work without any issues.

**New dashboard:**

11. Navigate to http://my.localhost:3000/emails and try to repeat similar steps there as well.

### Pre-merge Checklist
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Has the feature been tested on mobile viewports?