### PR TITLE
Add themes/showcase-modern feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -191,6 +191,7 @@
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,
+		"themes/showcase-modern": true,
 		"themes/subscription-purchases": true,
 		"themes/universal-header": true,
 		"plugins/universal-header": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -124,6 +124,7 @@
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,
+		"themes/showcase-modern": false,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": true,
 		"plugins/universal-header": true,

--- a/config/production.json
+++ b/config/production.json
@@ -160,6 +160,7 @@
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,
+		"themes/showcase-modern": false,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": true,
 		"plugins/universal-header": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -156,6 +156,7 @@
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,
+		"themes/showcase-modern": false,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": true,
 		"plugins/universal-header": true,

--- a/config/test.json
+++ b/config/test.json
@@ -109,6 +109,7 @@
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"themes/premium": true,
+		"themes/showcase-modern": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -161,6 +161,7 @@
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,
+		"themes/showcase-modern": false,
 		"themes/subscription-purchases": false,
 		"themes/universal-header": true,
 		"plugins/universal-header": true,


### PR DESCRIPTION
Fixes DOTTHEM-299

## Proposed Changes

* Add `themes/showcase-modern` feature flag to all config files
* Enabled in `development` and `test`
* Disabled in `production`, `stage`, `horizon`, and `wpcalypso`

## Why are these changes being made?

This adds the feature flag needed to gate the upcoming logged-out Theme Showcase work behind a flag, allowing development without affecting production.

## Testing Instructions

* Verify the flag appears in each config file in alphabetical order among the `themes/` flags
* In development, confirm `config.isEnabled( 'themes/showcase-modern' )` returns `true`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?