### PR TITLE
Initial attempt to add Stripe UPI

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -542,6 +542,8 @@ export default function CheckoutMain( {
 				genericRedirectProcessor( 'sofort', transactionData, dataForProcessor ),
 			eps: ( transactionData: unknown ) =>
 				genericRedirectProcessor( 'eps', transactionData, dataForProcessor ),
+			'stripe-upi': ( transactionData: unknown ) =>
+				genericRedirectProcessor( 'stripe-upi', transactionData, dataForProcessor ),
 			'existing-card': ( transactionData: unknown ) =>
 				existingCardProcessor( transactionData, dataForProcessor ),
 			'existing-card-ebanx': ( transactionData: unknown ) =>

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -14,6 +14,7 @@ import {
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,
 	createRazorpayMethod,
+	createStripeUpiMethod,
 	isValueTruthy,
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	type StoredPaymentMethod,
@@ -357,6 +358,26 @@ function useCreateGooglePay( {
 	}, [ stripe, stripeConfiguration, isStripeReady, cartKey ] );
 }
 
+function useCreateStripeUpi( {
+	isStripeLoading,
+	stripeLoadingError,
+}: {
+	isStripeLoading: boolean;
+	stripeLoadingError: StripeLoadingError;
+} ): PaymentMethod | null {
+	const shouldLoad =
+		! isStripeLoading && ! stripeLoadingError && isEnabled( 'checkout/stripe-upi' );
+	return useMemo(
+		() =>
+			shouldLoad
+				? createStripeUpiMethod( {
+						submitButtonContent: <CheckoutSubmitButtonContent />,
+				  } )
+				: null,
+		[ shouldLoad ]
+	);
+}
+
 function useCreateRazorpay( {
 	isRazorpayLoading,
 	razorpayLoadingError,
@@ -524,6 +545,11 @@ export default function useCreatePaymentMethods( {
 		cartKey,
 	} );
 
+	const stripeUpiMethod = useCreateStripeUpi( {
+		isStripeLoading,
+		stripeLoadingError,
+	} );
+
 	const razorpayMethod = useCreateRazorpay( {
 		isRazorpayLoading,
 		razorpayLoadingError,
@@ -555,6 +581,7 @@ export default function useCreatePaymentMethods( {
 		wechatMethod,
 		bancontactMethod,
 		razorpayMethod,
+		stripeUpiMethod,
 	].filter( isValueTruthy );
 
 	// In Germany, PayPal is the preferred option, so we display it before
@@ -579,6 +606,7 @@ export default function useCreatePaymentMethods( {
 			wechatMethod,
 			bancontactMethod,
 			razorpayMethod,
+			stripeUpiMethod,
 		].filter( isValueTruthy );
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -49,6 +49,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": true,
+		"checkout/stripe-upi": true,
 		"comments/filters-in-posts": true,
 		"cookie-banner": false,
 		"current-site/domain-warning": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -24,6 +24,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": true,
+		"checkout/stripe-upi": true,
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,

--- a/config/production.json
+++ b/config/production.json
@@ -36,6 +36,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": false,
+		"checkout/stripe-upi": false,
 		"cookie-banner": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -34,6 +34,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": true,
+		"checkout/stripe-upi": true,
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -32,6 +32,7 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": true,
+		"checkout/stripe-upi": true,
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -35,6 +35,7 @@
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": false,
 		"checkout/razorpay": true,
+		"checkout/stripe-upi": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dashboard/opt-in-banners": false,

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -18,6 +18,7 @@ export * from './payment-methods/p24';
 export * from './payment-methods/eps';
 export * from './payment-methods/alipay';
 export * from './payment-methods/razorpay';
+export * from './payment-methods/stripe-upi';
 export * from './payment-methods/web-pay-utils';
 export * from './payment-methods/google-pay';
 export { isWpComProductRenewal } from './is-wpcom-product-renewal';

--- a/packages/wpcom-checkout/src/payment-methods/stripe-upi.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/stripe-upi.tsx
@@ -83,7 +83,6 @@ class StripeUpiPaymentMethodState {
 		const fields: StripeUpiPaymentMethodKey[] = [
 			'customerName',
 			'address',
-			'streetNumber',
 			'city',
 			'state',
 			'postalCode',
@@ -208,7 +207,7 @@ function StripeUpiFields( { state }: { state: StripeUpiPaymentMethodState } ) {
 				label={ __( 'Address line 2' ) }
 				value={ streetNumber.value }
 				onChange={ ( value: string ) => state.change( 'streetNumber', value ) }
-				isError={ streetNumber.isTouched && streetNumber.value.length === 0 }
+				isError={ false }
 				errorMessage={ __( 'This field is required' ) }
 				disabled={ isDisabled }
 			/>

--- a/packages/wpcom-checkout/src/payment-methods/stripe-upi.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/stripe-upi.tsx
@@ -1,0 +1,400 @@
+import { Button, useFormStatus, FormStatus } from '@automattic/composite-checkout';
+import styled from '@emotion/styled';
+import { useSelect } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import debugFactory from 'debug';
+import { Fragment, ReactNode, useEffect, useState } from 'react';
+import Field from '../field';
+import { PaymentMethodLogos } from '../payment-method-logos';
+import { SummaryLine, SummaryDetails } from '../summary-details';
+import type { ManagedContactDetails } from '../types';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
+
+const debug = debugFactory( 'wpcom-checkout:stripe-upi-payment-method' );
+
+interface StripeUpiPaymentMethodStateShape {
+	customerName: string;
+	address: string;
+	streetNumber: string;
+	city: string;
+	state: string;
+	postalCode: string;
+	country: string;
+}
+
+type StripeUpiPaymentMethodKey = keyof StripeUpiPaymentMethodStateShape;
+
+interface StripeUpiFieldState {
+	value: string;
+	isTouched: boolean;
+}
+
+type StateSubscriber = () => void;
+
+class StripeUpiPaymentMethodState {
+	data: StripeUpiPaymentMethodStateShape = {
+		customerName: '',
+		address: '',
+		streetNumber: '',
+		city: '',
+		state: '',
+		postalCode: '',
+		country: '',
+	};
+
+	touched: Record< StripeUpiPaymentMethodKey, boolean > = {
+		customerName: false,
+		address: false,
+		streetNumber: false,
+		city: false,
+		state: false,
+		postalCode: false,
+		country: false,
+	};
+
+	subscribers: StateSubscriber[] = [];
+
+	change = ( field: StripeUpiPaymentMethodKey, newValue: string ): void => {
+		this.data[ field ] = newValue;
+		this.touched[ field ] = true;
+		this.notifySubscribers();
+	};
+
+	getFieldState = ( field: StripeUpiPaymentMethodKey ): StripeUpiFieldState => {
+		return {
+			value: this.data[ field ],
+			isTouched: this.touched[ field ],
+		};
+	};
+
+	subscribe = ( callback: () => void ): ( () => void ) => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( subscriber ) => subscriber !== callback );
+		};
+	};
+
+	notifySubscribers = (): void => {
+		this.subscribers.forEach( ( subscriber ) => subscriber() );
+	};
+
+	isValid = (): boolean => {
+		// Touch all fields that are empty so they display validation errors
+		const fields: StripeUpiPaymentMethodKey[] = [
+			'customerName',
+			'address',
+			'streetNumber',
+			'city',
+			'state',
+			'postalCode',
+			'country',
+		];
+
+		fields.forEach( ( field ) => {
+			if ( ! this.data[ field ].length ) {
+				this.change( field, '' );
+			}
+		} );
+
+		// Check if all required fields have values
+		return fields.every( ( field ) => this.data[ field ].length > 0 );
+	};
+}
+
+function useSubscribeToEventEmitter( state: StripeUpiPaymentMethodState ) {
+	const [ , forceReload ] = useState( 0 );
+	useEffect( () => {
+		return state.subscribe( () => {
+			forceReload( ( val: number ) => val + 1 );
+		} );
+	}, [ state ] );
+}
+
+const StripeUpiFormWrapper = styled.div`
+	padding: 16px;
+	position: relative;
+
+	::after {
+		display: block;
+		width: calc( 100% - 6px );
+		height: 1px;
+		content: '';
+		background: ${ ( props ) => props.theme.colors.borderColorLight };
+		position: absolute;
+		top: 0;
+		left: 3px;
+
+		.rtl & {
+			right: 3px;
+			left: auto;
+		}
+	}
+`;
+
+const StripeUpiField = styled( Field )`
+	margin-top: 16px;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+function StripeUpiFields( { state }: { state: StripeUpiPaymentMethodState } ) {
+	const { __ } = useI18n();
+	useSubscribeToEventEmitter( state );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+
+	// Get live contact details from checkout store
+	const checkoutContactDetails = useSelect( ( select ) => {
+		const store = select( 'wpcom-checkout' );
+		return store && typeof store === 'object' && 'getContactInfo' in store
+			? ( store as { getContactInfo: () => ManagedContactDetails } ).getContactInfo()
+			: null;
+	}, [] ) as ManagedContactDetails | null;
+
+	// Keep state, postalCode, and country synced with live checkout contact details.
+	// These fields are disabled/readonly, so they should always reflect billing info.
+	useEffect( () => {
+		if ( checkoutContactDetails ) {
+			if ( checkoutContactDetails.state?.value ) {
+				state.change( 'state', checkoutContactDetails.state.value );
+			}
+			if ( checkoutContactDetails.postalCode?.value ) {
+				state.change( 'postalCode', checkoutContactDetails.postalCode.value );
+			}
+			if ( checkoutContactDetails.countryCode?.value ) {
+				state.change( 'country', checkoutContactDetails.countryCode.value );
+			}
+		}
+	}, [ checkoutContactDetails, state ] );
+
+	const customerName = state.getFieldState( 'customerName' );
+	const address = state.getFieldState( 'address' );
+	const streetNumber = state.getFieldState( 'streetNumber' );
+	const city = state.getFieldState( 'city' );
+	const stateField = state.getFieldState( 'state' );
+	const postalCode = state.getFieldState( 'postalCode' );
+	const country = state.getFieldState( 'country' );
+
+	return (
+		<StripeUpiFormWrapper>
+			<StripeUpiField
+				id="stripe-upi-cardholder-name"
+				type="Text"
+				autoComplete="name"
+				label={ __( 'Your name' ) }
+				value={ customerName.value }
+				onChange={ ( value: string ) => state.change( 'customerName', value ) }
+				isError={ customerName.isTouched && customerName.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<StripeUpiField
+				id="stripe-upi-address-1"
+				type="Text"
+				autoComplete="address-line1"
+				label={ __( 'Address line 1' ) }
+				value={ address.value }
+				onChange={ ( value: string ) => state.change( 'address', value ) }
+				isError={ address.isTouched && address.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<StripeUpiField
+				id="stripe-upi-address-2"
+				type="Text"
+				autoComplete="address-line2"
+				label={ __( 'Address line 2' ) }
+				value={ streetNumber.value }
+				onChange={ ( value: string ) => state.change( 'streetNumber', value ) }
+				isError={ streetNumber.isTouched && streetNumber.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<StripeUpiField
+				id="stripe-upi-city"
+				type="Text"
+				autoComplete="address-level2"
+				label={ __( 'City' ) }
+				value={ city.value }
+				onChange={ ( value: string ) => state.change( 'city', value ) }
+				isError={ city.isTouched && city.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<StripeUpiField
+				id="stripe-upi-state"
+				type="Text"
+				autoComplete="address-level1"
+				label={ __( 'State' ) }
+				value={ stateField.value }
+				onChange={ ( value: string ) => state.change( 'state', value ) }
+				isError={ stateField.isTouched && stateField.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled
+			/>
+			<StripeUpiField
+				id="stripe-upi-postal-code"
+				type="Text"
+				autoComplete="postal-code"
+				label={ __( 'Postcode' ) }
+				value={ postalCode.value }
+				onChange={ ( value: string ) => state.change( 'postalCode', value ) }
+				isError={ postalCode.isTouched && postalCode.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled
+			/>
+			<StripeUpiField
+				id="stripe-upi-country"
+				type="Text"
+				autoComplete="country"
+				label={ __( 'Country' ) }
+				value={ country.value }
+				onChange={ ( value: string ) => state.change( 'country', value ) }
+				isError={ country.isTouched && country.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled
+			/>
+		</StripeUpiFormWrapper>
+	);
+}
+
+export function createStripeUpiMethod( {
+	submitButtonContent,
+}: {
+	submitButtonContent: ReactNode;
+} ): PaymentMethod {
+	const state = new StripeUpiPaymentMethodState();
+
+	return {
+		id: 'stripe-upi',
+		hasRequiredFields: true,
+		paymentProcessorId: 'stripe-upi',
+		label: <StripeUpiLabel />,
+		activeContent: <StripeUpiFields state={ state } />,
+		submitButton: (
+			<StripeUpiSubmitButton submitButtonContent={ submitButtonContent } state={ state } />
+		),
+		inactiveContent: <StripeUpiSummary state={ state } />,
+		// translators: UPI stands for Unified Payments Interface and may not need to be translated.
+		getAriaLabel: ( __ ) => __( 'UPI' ),
+	};
+}
+
+export function StripeUpiLabel() {
+	const { __ } = useI18n();
+
+	return (
+		<Fragment>
+			<span>{ __( 'UPI' ) }</span>
+			<PaymentMethodLogos className="stripe-upi__logo payment-logos">
+				<StripeUpiIcon />
+			</PaymentMethodLogos>
+		</Fragment>
+	);
+}
+
+export function StripeUpiSummary( { state }: { state: StripeUpiPaymentMethodState } ) {
+	useSubscribeToEventEmitter( state );
+
+	const customerName = state.getFieldState( 'customerName' );
+	const address = state.getFieldState( 'address' );
+	const streetNumber = state.getFieldState( 'streetNumber' );
+	const city = state.getFieldState( 'city' );
+	const stateField = state.getFieldState( 'state' );
+	const postalCode = state.getFieldState( 'postalCode' );
+	const country = state.getFieldState( 'country' );
+
+	return (
+		<SummaryDetails>
+			<SummaryLine>{ customerName.value }</SummaryLine>
+			<SummaryLine>{ address.value }</SummaryLine>
+			{ streetNumber.value && <SummaryLine>{ streetNumber.value }</SummaryLine> }
+			<SummaryLine>
+				{ city.value }
+				{ city.value && stateField.value ? ', ' : '' }
+				{ stateField.value } { postalCode.value }
+			</SummaryLine>
+			<SummaryLine>{ country.value }</SummaryLine>
+		</SummaryDetails>
+	);
+}
+
+export function StripeUpiSubmitButton( {
+	disabled,
+	onClick,
+	submitButtonContent,
+	state,
+}: {
+	disabled?: boolean;
+	onClick?: ProcessPayment;
+	submitButtonContent: ReactNode;
+	state: StripeUpiPaymentMethodState;
+} ) {
+	const { formStatus } = useFormStatus();
+	useSubscribeToEventEmitter( state );
+
+	// This must be typed as optional because it's injected by cloning the
+	// element in CheckoutSubmitButton, but the uncloned element does not have
+	// this prop yet.
+	if ( ! onClick ) {
+		throw new Error(
+			'Missing onClick prop; StripeUpiSubmitButton must be used as a payment button in CheckoutSubmitButton'
+		);
+	}
+
+	return (
+		<Button
+			disabled={ disabled }
+			onClick={ ( ev ) => {
+				ev.preventDefault();
+				if ( state.isValid() ) {
+					debug( 'Initiate Stripe UPI payment' );
+					onClick( {
+						name: state.data.customerName,
+						address: state.data.address,
+						streetNumber: state.data.streetNumber,
+						city: state.data.city,
+						state: state.data.state,
+						postalCode: state.data.postalCode,
+						country: state.data.country,
+					} );
+				}
+			} }
+			buttonType="primary"
+			isBusy={ FormStatus.SUBMITTING === formStatus }
+			fullWidth
+		>
+			{ submitButtonContent }
+		</Button>
+	);
+}
+
+// UPI logo based on the NPCI UPI brand mark
+export function StripeUpiIcon() {
+	return (
+		<svg
+			width="50"
+			height="20"
+			viewBox="0 0 126 50"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<rect width="126" height="50" rx="4" fill="#F5F5F5" />
+			<path d="M18 10 L10 40 H18 L26 10 Z" fill="#097939" />
+			<path d="M28 10 L20 40 H28 L36 10 Z" fill="#ED752E" />
+			<text
+				x="50"
+				y="34"
+				fontFamily="Arial, sans-serif"
+				fontSize="22"
+				fontWeight="bold"
+				fill="#333333"
+				letterSpacing="1"
+			>
+				UPI
+			</text>
+		</svg>
+	);
+}

--- a/packages/wpcom-checkout/src/translate-payment-method-names.ts
+++ b/packages/wpcom-checkout/src/translate-payment-method-names.ts
@@ -45,6 +45,8 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 			return 'existingCard';
 		case 'WPCOM_Billing_Razorpay':
 			return 'razorpay';
+		case 'WPCOM_Billing_Stripe_Upi':
+			return 'stripe-upi';
 		default:
 			throw new Error( `Unknown payment method '${ paymentMethod }'` );
 	}
@@ -97,6 +99,8 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 			return 'WPCOM_Billing_WPCOM';
 		case 'razorpay':
 			return 'WPCOM_Billing_Razorpay';
+		case 'stripe-upi':
+			return 'WPCOM_Billing_Stripe_Upi';
 	}
 	return null;
 }
@@ -119,6 +123,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_Stripe_Wechat_Pay':
 		case 'WPCOM_Billing_Web_Payment':
 		case 'WPCOM_Billing_Razorpay':
+		case 'WPCOM_Billing_Stripe_Upi':
 			return slug;
 	}
 	return null;
@@ -153,6 +158,7 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 		case 'web-pay':
 		case 'free-purchase':
 		case 'razorpay':
+		case 'stripe-upi':
 			return slug;
 		case 'apple-pay':
 		case 'google-pay':
@@ -192,6 +198,7 @@ export function isRedirectPaymentMethod( slug: CheckoutPaymentMethodSlug ): bool
 		'paypal-express',
 		'paypal-js',
 		'p24',
+		'stripe-upi',
 		'wechat',
 	];
 	return redirectPaymentMethods.includes( slug );

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -346,7 +346,8 @@ export type CheckoutPaymentMethodSlug =
 	| 'stripe' // a synonym for 'card'
 	| 'apple-pay' // a synonym for 'web-pay'
 	| 'google-pay' // a synonym for 'web-pay'
-	| 'razorpay';
+	| 'razorpay'
+	| 'stripe-upi';
 
 /**
  * Payment method slugs as returned by the WPCOM backend.
@@ -369,7 +370,8 @@ export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_Stripe_Wechat_Pay'
 	| 'WPCOM_Billing_Web_Payment'
 	| 'WPCOM_Billing_Ebanx_Redirect_Brazil_Pix'
-	| 'WPCOM_Billing_Razorpay';
+	| 'WPCOM_Billing_Razorpay'
+	| 'WPCOM_Billing_Stripe_Upi';
 
 export type ContactDetailsType = 'gsuite' | 'tax' | 'domain' | 'none';
 


### PR DESCRIPTION
Part of SHILL-1681

## Proposed Changes

* Adds `stripe-upi` as a new checkout payment method in `packages/wpcom-checkout`, following the same pattern as Razorpay and other redirect methods
* Collects the full billing address required by Stripe for UPI payments (name, address line 1, optional address line 2, city, state, postcode, country); state, postcode, and country are read-only fields pre-populated from the checkout contact details store
* Registers `stripe-upi` as a redirect payment method and adds the `WPCOM_Billing_Stripe_Upi` ↔ `stripe-upi` slug mapping
* Wires up the `genericRedirectProcessor` for the `stripe-upi` payment method in checkout
* Gates the method behind a `checkout/stripe-upi` feature flag — enabled in development, staging, and test environments; **off in production**

## Why are these changes being made?

UPI (Unified Payments Interface) is a widely-used payment rail in India. Adding Stripe UPI support allows Indian customers to pay at checkout using their preferred method. Stripe requires a full billing address to be submitted with UPI payments, so the form collects those fields in addition to what's already captured in the contact details step.

## Testing Instructions

This PR requires the companion wpcom backend change to land first (see SHILL-1681). Once both are in place:

1. Enable the `checkout/stripe-upi` feature flag locally (already on by default in `development.json`) and sandbox store in the backend.
2. Set your currency to INR in store admin
3. Navigate to checkout with a product and set your address to India, with a valid postal code and state.
4. Verify the UPI payment method appears in the list with the UPI logo. There should be two, one is Razorpay, the other is UPI. 
5. Fill in the billing address form — state, postcode, and country should auto-populate from the contact details step and be non-editable
6. Submit — you should be redirected to the Stripe UPI redirect flow, and you can mark the payment as successful. This should complete the checkout.
7. Confirm that leaving required fields empty triggers validation errors
8. Make sure that the UPI option does not appear if you are not sandboxing store.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?