### PR TITLE
Add useIsThemeShowcaseModernEnabled hook

### DIFF
--- a/client/my-sites/themes/hooks/test/use-is-theme-showcase-modern-enabled.test.tsx
+++ b/client/my-sites/themes/hooks/test/use-is-theme-showcase-modern-enabled.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import config from '@automattic/calypso-config';
+import { renderHook } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+import { useIsThemeShowcaseModernEnabled } from '../use-is-theme-showcase-modern-enabled';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const original = jest.requireActual( '@automattic/calypso-config' );
+	return {
+		...original,
+		isEnabled: jest.fn(),
+	};
+} );
+
+jest.mock( 'react-redux', () => ( {
+	useSelector: jest.fn(),
+} ) );
+
+describe( 'useIsThemeShowcaseModernEnabled', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'returns true when feature flag is on and user is logged out', () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( true );
+		( useSelector as unknown as jest.Mock ).mockImplementation( ( selector ) =>
+			selector( { currentUser: { id: null } } )
+		);
+		const { result } = renderHook( () => useIsThemeShowcaseModernEnabled() );
+		expect( result.current ).toBe( true );
+	} );
+
+	test( 'returns false when feature flag is off', () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( false );
+		( useSelector as unknown as jest.Mock ).mockImplementation( ( selector ) =>
+			selector( { currentUser: { id: null } } )
+		);
+		const { result } = renderHook( () => useIsThemeShowcaseModernEnabled() );
+		expect( result.current ).toBe( false );
+	} );
+
+	test( 'returns false when user is logged in', () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( true );
+		( useSelector as unknown as jest.Mock ).mockImplementation( ( selector ) =>
+			selector( { currentUser: { id: 123, user: { ID: 123 } } } )
+		);
+		const { result } = renderHook( () => useIsThemeShowcaseModernEnabled() );
+		expect( result.current ).toBe( false );
+	} );
+} );

--- a/client/my-sites/themes/hooks/use-is-theme-showcase-modern-enabled.ts
+++ b/client/my-sites/themes/hooks/use-is-theme-showcase-modern-enabled.ts
@@ -1,0 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useSelector } from 'react-redux';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+
+export function useIsThemeShowcaseModernEnabled(): boolean {
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	return isEnabled( 'themes/showcase-modern' ) && ! isLoggedIn;
+}


### PR DESCRIPTION
Fixes DOTTHEM-300

## Proposed Changes

* Add `useIsThemeShowcaseModernEnabled` hook that returns `true` when the `themes/showcase-modern` feature flag is enabled and the user is logged out.
* Add unit tests covering all three cases: flag on + logged out, flag off, and logged in.

## Why are these changes being made?

This hook encapsulates the gating logic for the upcoming Themes Landing Page redesign. It ensures that the modernized UI is only shown to logged-out users when the feature flag is active, keeping the existing logged-in experience unchanged.

## Testing Instructions

* Run the unit tests:
  ```
  yarn test-client client/my-sites/themes/hooks/test/use-is-theme-showcase-modern-enabled.test.tsx
  ```
* Verify all 3 tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?