### PR TITLE
FORNO-216: Image Studio: upgrade path handling in error notices

### DIFF
--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -14,6 +14,7 @@ import { useAnnotation } from '../hooks/use-annotation';
 import { useBeforeUnload } from '../hooks/use-beforeunload';
 import { useDeletePermanently } from '../hooks/use-delete-permanently';
 import { useDraftCleanup } from '../hooks/use-draft-cleanup';
+import { useErrorNotice } from '../hooks/use-error-notice';
 import { useImageLoaded } from '../hooks/use-image-loaded';
 import { useImageStudioAgentSync } from '../hooks/use-image-studio-agent-sync';
 import { useImageStudioFeedback } from '../hooks/use-image-studio-feedback';
@@ -136,16 +137,7 @@ function ImageStudioAgentChat( {
 
 	const { error: agentError, ...agentUiProps } = agentChatProps;
 
-	useEffect( () => {
-		if ( ! agentError ) {
-			return;
-		}
-		const errorMessage =
-			( agentError as unknown as Error )?.message ||
-			String( agentError ) ||
-			__( 'An error occurred while generating content.', __i18n_text_domain__ );
-		addNotice( errorMessage, 'error' );
-	}, [ agentError, addNotice ] );
+	useErrorNotice( agentError, addNotice );
 
 	const isProcessing = agentChatProps.isProcessing || isAnnotationSaving;
 

--- a/packages/image-studio/src/components/notice/index.tsx
+++ b/packages/image-studio/src/components/notice/index.tsx
@@ -14,6 +14,7 @@ function WarningNotice( { notice }: { notice: NoticeType } ) {
 	return (
 		<Notice
 			status="warning"
+			// Intentionally non-dismissible: upgrade prompts should persist until user takes action
 			isDismissible={ false }
 			actions={
 				notice.actions?.map( ( action ) => ( {

--- a/packages/image-studio/src/components/notice/index.tsx
+++ b/packages/image-studio/src/components/notice/index.tsx
@@ -24,6 +24,9 @@ export function ImageStudioNotice() {
 				id: notice.id,
 				content: notice.content,
 				explicitDismiss: notice.type === 'error',
+				...( notice.actions?.length && {
+					actions: notice.actions,
+				} ),
 			} ) ) }
 			onRemove={ removeNotice }
 		/>

--- a/packages/image-studio/src/components/notice/index.tsx
+++ b/packages/image-studio/src/components/notice/index.tsx
@@ -19,7 +19,12 @@ function WarningNotice( { notice }: { notice: NoticeType } ) {
 			actions={
 				notice.actions?.map( ( action ) => ( {
 					label: action.label,
-					onClick: () => window.open( action.url, '_blank' ),
+					onClick: () => {
+						const newWindow = window.open( action.url, '_blank' );
+						if ( newWindow ) {
+							newWindow.opener = null;
+						}
+					},
 				} ) ) ?? []
 			}
 		>
@@ -53,7 +58,15 @@ export function ImageStudioNotice() {
 						content: notice.content,
 						explicitDismiss: notice.type === 'error',
 						...( notice.actions?.length && {
-							actions: notice.actions,
+							actions: notice.actions.map( ( action ) => ( {
+								label: action.label,
+								onClick: () => {
+									const newWindow = window.open( action.url, '_blank' );
+									if ( newWindow ) {
+										newWindow.opener = null;
+									}
+								},
+							} ) ),
 						} ),
 					} ) ) }
 					onRemove={ removeNotice }

--- a/packages/image-studio/src/components/notice/index.tsx
+++ b/packages/image-studio/src/components/notice/index.tsx
@@ -1,8 +1,31 @@
-import { SnackbarList } from '@wordpress/components';
+import { Notice, SnackbarList } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as imageStudioStore } from '../../store';
-import type { ImageStudioActions } from '../../store';
+import type { ImageStudioActions, Notice as NoticeType } from '../../store';
 import './style.scss';
+
+/**
+ * Renders a single warning notice using the core Notice component.
+ * Opens links in new tab to preserve Image Studio modal context.
+ * @param root0        - Component props.
+ * @param root0.notice - The notice object to render.
+ */
+function WarningNotice( { notice }: { notice: NoticeType } ) {
+	return (
+		<Notice
+			status="warning"
+			isDismissible={ false }
+			actions={
+				notice.actions?.map( ( action ) => ( {
+					label: action.label,
+					onClick: () => window.open( action.url, '_blank' ),
+				} ) ) ?? []
+			}
+		>
+			{ notice.content }
+		</Notice>
+	);
+}
 
 export function ImageStudioNotice() {
 	const notices = useSelect( ( select ) => {
@@ -16,19 +39,29 @@ export function ImageStudioNotice() {
 		return null;
 	}
 
+	const warningNotices = notices.filter( ( n ) => n.type === 'warning' );
+	const snackbarNotices = notices.filter( ( n ) => n.type !== 'warning' );
+
 	return (
-		<SnackbarList
-			className="image-studio-notice"
-			notices={ notices.map( ( notice ) => ( {
-				className: `image-studio-notice-${ notice.type }`,
-				id: notice.id,
-				content: notice.content,
-				explicitDismiss: notice.type === 'error',
-				...( notice.actions?.length && {
-					actions: notice.actions,
-				} ),
-			} ) ) }
-			onRemove={ removeNotice }
-		/>
+		<>
+			{ warningNotices.map( ( notice ) => (
+				<WarningNotice key={ notice.id } notice={ notice } />
+			) ) }
+			{ snackbarNotices.length > 0 && (
+				<SnackbarList
+					className="image-studio-notice"
+					notices={ snackbarNotices.map( ( notice ) => ( {
+						className: `image-studio-notice-${ notice.type }`,
+						id: notice.id,
+						content: notice.content,
+						explicitDismiss: notice.type === 'error',
+						...( notice.actions?.length && {
+							actions: notice.actions,
+						} ),
+					} ) ) }
+					onRemove={ removeNotice }
+				/>
+			) }
+		</>
 	);
 }

--- a/packages/image-studio/src/components/notice/index.tsx
+++ b/packages/image-studio/src/components/notice/index.tsx
@@ -35,12 +35,8 @@ export function ImageStudioNotice() {
 
 	const { removeNotice } = useDispatch( imageStudioStore ) as ImageStudioActions;
 
-	if ( ! notices || notices.length === 0 ) {
-		return null;
-	}
-
-	const warningNotices = notices.filter( ( n ) => n.type === 'warning' );
-	const snackbarNotices = notices.filter( ( n ) => n.type !== 'warning' );
+	const warningNotices = ( notices ?? [] ).filter( ( n ) => n.type === 'warning' );
+	const snackbarNotices = ( notices ?? [] ).filter( ( n ) => n.type !== 'warning' );
 
 	return (
 		<>

--- a/packages/image-studio/src/components/notice/style.scss
+++ b/packages/image-studio/src/components/notice/style.scss
@@ -1,4 +1,4 @@
-@import "../styles/variables";
+@import '../styles/variables';
 
 .image-studio-notice {
 	position: relative;
@@ -25,12 +25,12 @@
 			grid-row: 2;
 			margin-left: 0;
 			margin-top: 4px;
-			color: var(--wp-admin-theme-color, #0069b0);
+			color: var( --wp-admin-theme-color, #0069b0 );
 			text-decoration: underline;
 			font-weight: 400;
 
 			&:hover {
-				color: var(--wp-admin-theme-color-darker-10, #004c82);
+				color: var( --wp-admin-theme-color-darker-10, #004c82 );
 				text-decoration: none;
 			}
 		}
@@ -53,5 +53,9 @@
 	.components-notice.is-warning {
 		max-width: 400px;
 		margin: 0 0 8px;
+
+		.components-notice__action.components-button {
+			margin-left: 0;
+		}
 	}
 }

--- a/packages/image-studio/src/components/notice/style.scss
+++ b/packages/image-studio/src/components/notice/style.scss
@@ -51,6 +51,7 @@
 // Warning notice styling (quota exceeded)
 .image-studio-modal__notices {
 	.components-notice.is-warning {
+		max-width: 400px;
 		margin: 0 0 8px;
 	}
 }

--- a/packages/image-studio/src/components/notice/style.scss
+++ b/packages/image-studio/src/components/notice/style.scss
@@ -13,6 +13,33 @@
 	&-error {
 		background-color: #f4a2a2;
 		border-left: 3px solid #cc1818;
+
+		.components-snackbar__content {
+			display: grid;
+			grid-template-columns: 1fr auto;
+			align-items: start;
+		}
+
+		.components-snackbar__action {
+			grid-column: 1;
+			grid-row: 2;
+			margin-left: 0;
+			margin-top: 4px;
+			color: var(--wp-admin-theme-color, #0069b0);
+			text-decoration: underline;
+			font-weight: 400;
+
+			&:hover {
+				color: var(--wp-admin-theme-color-darker-10, #004c82);
+				text-decoration: none;
+			}
+		}
+
+		.components-snackbar__dismiss-button {
+			grid-column: 2;
+			grid-row: 1;
+			align-self: start;
+		}
 	}
 
 	&-success {

--- a/packages/image-studio/src/components/notice/style.scss
+++ b/packages/image-studio/src/components/notice/style.scss
@@ -47,3 +47,10 @@
 		border-left: 3px solid #4ab866;
 	}
 }
+
+// Warning notice styling (quota exceeded)
+.image-studio-modal__notices {
+	.components-notice.is-warning {
+		margin: 0 0 8px;
+	}
+}

--- a/packages/image-studio/src/components/sidebar/editable-field.tsx
+++ b/packages/image-studio/src/components/sidebar/editable-field.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useAgentConfig } from '../../hooks/use-agent-config';
+import { useErrorNotice } from '../../hooks/use-error-notice';
 import { store as imageStudioStore } from '../../store';
 import { defaultAgentConfigFactory } from '../../utils/agent-config';
 import { trackImageStudioGenAIButtonClick } from '../../utils/tracking';
@@ -33,17 +34,7 @@ function GenAIButton( {
 		setProcessing( agentChatProps.isProcessing );
 	}, [ agentChatProps.isProcessing, setProcessing ] );
 
-	useEffect( () => {
-		if ( ! agentChatProps.error ) {
-			return;
-		}
-
-		const errorMessage =
-			( agentChatProps.error as unknown as Error )?.message ||
-			String( agentChatProps.error ) ||
-			__( 'An error occurred while generating content.', __i18n_text_domain__ );
-		addNotice( errorMessage, 'error' );
-	}, [ agentChatProps.error, addNotice ] );
+	useErrorNotice( agentChatProps.error, addNotice );
 
 	const handleClick = () => {
 		// Track the GenAI button click

--- a/packages/image-studio/src/hooks/use-error-notice.test.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.test.ts
@@ -105,17 +105,13 @@ describe( 'useErrorNotice', () => {
 				useErrorNotice( 'Upgrade required https://wordpress.com/plans/example.com', mockAddNotice )
 			);
 
-			expect( mockAddNotice ).toHaveBeenCalledWith(
-				"You've reached your free AI limit. Unlock more generations with a paid plan.",
-				'warning',
-				[
-					{
-						label: 'See plans',
-						url: 'https://wordpress.com/plans/example.com',
-						openInNewTab: true,
-					},
-				]
-			);
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Upgrade required', 'warning', [
+				{
+					label: 'See plans',
+					url: 'https://wordpress.com/plans/example.com',
+					openInNewTab: true,
+				},
+			] );
 		} );
 
 		it( 'shows warning notice with "Upgrade plan" for /upgrade URL', () => {
@@ -123,17 +119,13 @@ describe( 'useErrorNotice', () => {
 				useErrorNotice( 'Upgrade required https://wordpress.com/upgrade/premium', mockAddNotice )
 			);
 
-			expect( mockAddNotice ).toHaveBeenCalledWith(
-				"You've reached your free AI limit. Unlock more generations with a paid plan.",
-				'warning',
-				[
-					{
-						label: 'Upgrade plan',
-						url: 'https://wordpress.com/upgrade/premium',
-						openInNewTab: true,
-					},
-				]
-			);
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Upgrade required', 'warning', [
+				{
+					label: 'Upgrade plan',
+					url: 'https://wordpress.com/upgrade/premium',
+					openInNewTab: true,
+				},
+			] );
 		} );
 
 		it( 'shows warning notice with "Upgrade plan" for jetpack.com/redirect URL', () => {
@@ -144,17 +136,13 @@ describe( 'useErrorNotice', () => {
 				)
 			);
 
-			expect( mockAddNotice ).toHaveBeenCalledWith(
-				"You've reached your free AI limit. Unlock more generations with a paid plan.",
-				'warning',
-				[
-					{
-						label: 'Upgrade plan',
-						url: 'https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
-						openInNewTab: true,
-					},
-				]
-			);
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Limit reached', 'warning', [
+				{
+					label: 'Upgrade plan',
+					url: 'https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
+					openInNewTab: true,
+				},
+			] );
 		} );
 
 		it( 'shows warning notice with "Upgrade plan" for my-jetpack URL', () => {
@@ -165,17 +153,13 @@ describe( 'useErrorNotice', () => {
 				)
 			);
 
-			expect( mockAddNotice ).toHaveBeenCalledWith(
-				"You've reached your free AI limit. Unlock more generations with a paid plan.",
-				'warning',
-				[
-					{
-						label: 'Upgrade plan',
-						url: 'https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
-						openInNewTab: true,
-					},
-				]
-			);
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Please upgrade', 'warning', [
+				{
+					label: 'Upgrade plan',
+					url: 'https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
+					openInNewTab: true,
+				},
+			] );
 		} );
 
 		it( 'handles real-world streaming error with upgrade URL', () => {
@@ -187,7 +171,7 @@ describe( 'useErrorNotice', () => {
 			);
 
 			expect( mockAddNotice ).toHaveBeenCalledWith(
-				"You've reached your free AI limit. Unlock more generations with a paid plan.",
+				'Congratulations on exploring Image Studio and reaching the free requests limit! Upgrade now to keep using it.',
 				'warning',
 				[
 					{
@@ -207,17 +191,13 @@ describe( 'useErrorNotice', () => {
 			);
 			renderHook( () => useErrorNotice( error, mockAddNotice ) );
 
-			expect( mockAddNotice ).toHaveBeenCalledWith(
-				"You've reached your free AI limit. Unlock more generations with a paid plan.",
-				'warning',
-				[
-					{
-						label: 'See plans',
-						url: 'https://wordpress.com/plans/example.com',
-						openInNewTab: true,
-					},
-				]
-			);
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Quota exceeded. Upgrade at', 'warning', [
+				{
+					label: 'See plans',
+					url: 'https://wordpress.com/plans/example.com',
+					openInNewTab: true,
+				},
+			] );
 		} );
 
 		it( 'handles object with message property', () => {

--- a/packages/image-studio/src/hooks/use-error-notice.test.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for useErrorNotice hook
+ *
+ * Tests the error notice display logic:
+ * - No-op when error is falsy
+ * - Plain errors show as snackbar
+ * - Errors with URLs show "Learn more" action
+ * - Upgrade URLs show persistent warning notice with correct label
+ */
+import { renderHook } from '@testing-library/react';
+import { useErrorNotice } from './use-error-notice';
+
+jest.mock( '@wordpress/element', () => ( {
+	useEffect: ( fn: () => void ) => fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str: string ) => str,
+} ) );
+
+describe( 'useErrorNotice', () => {
+	let mockAddNotice: jest.Mock;
+
+	beforeEach( () => {
+		mockAddNotice = jest.fn();
+	} );
+
+	describe( 'no error', () => {
+		it( 'does not call addNotice when error is null', () => {
+			renderHook( () => useErrorNotice( null, mockAddNotice ) );
+			expect( mockAddNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not call addNotice when error is undefined', () => {
+			renderHook( () => useErrorNotice( undefined, mockAddNotice ) );
+			expect( mockAddNotice ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not call addNotice when error is empty string', () => {
+			renderHook( () => useErrorNotice( '', mockAddNotice ) );
+			expect( mockAddNotice ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'plain errors without URL', () => {
+		it( 'shows error snackbar for plain error message', () => {
+			renderHook( () => useErrorNotice( 'Something went wrong', mockAddNotice ) );
+
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Something went wrong', 'error' );
+		} );
+
+		it( 'extracts message from Error object', () => {
+			const error = new Error( 'Network failure' );
+			renderHook( () => useErrorNotice( error, mockAddNotice ) );
+
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Network failure', 'error' );
+		} );
+
+		it( 'converts non-string errors to string', () => {
+			renderHook( () => useErrorNotice( 42, mockAddNotice ) );
+
+			expect( mockAddNotice ).toHaveBeenCalledWith( '42', 'error' );
+		} );
+
+		it( 'strips "Streaming error:" prefix from message', () => {
+			renderHook( () => useErrorNotice( 'Streaming error: Connection lost', mockAddNotice ) );
+
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Connection lost', 'error' );
+		} );
+	} );
+
+	describe( 'errors with non-upgrade URLs', () => {
+		it( 'shows error snackbar with "Learn more" action', () => {
+			renderHook( () =>
+				useErrorNotice( 'Error occurred. See https://example.com/help for details.', mockAddNotice )
+			);
+
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Error occurred. See for details.', 'error', [
+				{
+					label: 'Learn more',
+					url: 'https://example.com/help',
+					openInNewTab: true,
+				},
+			] );
+		} );
+
+		it( 'extracts URL from middle of message', () => {
+			renderHook( () =>
+				useErrorNotice( 'Visit https://docs.example.com for help', mockAddNotice )
+			);
+
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Visit for help', 'error', [
+				{
+					label: 'Learn more',
+					url: 'https://docs.example.com',
+					openInNewTab: true,
+				},
+			] );
+		} );
+	} );
+
+	describe( 'errors with upgrade URLs', () => {
+		it( 'shows warning notice with "See plans" for /plans/ URL', () => {
+			renderHook( () =>
+				useErrorNotice( 'Upgrade required https://wordpress.com/plans/example.com', mockAddNotice )
+			);
+
+			expect( mockAddNotice ).toHaveBeenCalledWith(
+				"You've reached your free AI limit. Unlock more generations with a paid plan.",
+				'warning',
+				[
+					{
+						label: 'See plans',
+						url: 'https://wordpress.com/plans/example.com',
+						openInNewTab: true,
+					},
+				]
+			);
+		} );
+
+		it( 'shows warning notice with "Upgrade plan" for /upgrade URL', () => {
+			renderHook( () =>
+				useErrorNotice( 'Upgrade required https://wordpress.com/upgrade/premium', mockAddNotice )
+			);
+
+			expect( mockAddNotice ).toHaveBeenCalledWith(
+				"You've reached your free AI limit. Unlock more generations with a paid plan.",
+				'warning',
+				[
+					{
+						label: 'Upgrade plan',
+						url: 'https://wordpress.com/upgrade/premium',
+						openInNewTab: true,
+					},
+				]
+			);
+		} );
+
+		it( 'shows warning notice with "Upgrade plan" for jetpack.com/redirect URL', () => {
+			renderHook( () =>
+				useErrorNotice(
+					'Limit reached https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
+					mockAddNotice
+				)
+			);
+
+			expect( mockAddNotice ).toHaveBeenCalledWith(
+				"You've reached your free AI limit. Unlock more generations with a paid plan.",
+				'warning',
+				[
+					{
+						label: 'Upgrade plan',
+						url: 'https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
+						openInNewTab: true,
+					},
+				]
+			);
+		} );
+
+		it( 'shows warning notice with "Upgrade plan" for my-jetpack URL', () => {
+			renderHook( () =>
+				useErrorNotice(
+					'Please upgrade https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
+					mockAddNotice
+				)
+			);
+
+			expect( mockAddNotice ).toHaveBeenCalledWith(
+				"You've reached your free AI limit. Unlock more generations with a paid plan.",
+				'warning',
+				[
+					{
+						label: 'Upgrade plan',
+						url: 'https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
+						openInNewTab: true,
+					},
+				]
+			);
+		} );
+
+		it( 'handles real-world streaming error with upgrade URL', () => {
+			renderHook( () =>
+				useErrorNotice(
+					'Streaming error: Congratulations on exploring Image Studio and reaching the free requests limit! Upgrade now to keep using it. https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
+					mockAddNotice
+				)
+			);
+
+			expect( mockAddNotice ).toHaveBeenCalledWith(
+				"You've reached your free AI limit. Unlock more generations with a paid plan.",
+				'warning',
+				[
+					{
+						label: 'Upgrade plan',
+						url: 'https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge',
+						openInNewTab: true,
+					},
+				]
+			);
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'handles Error object with upgrade URL in message', () => {
+			const error = new Error(
+				'Quota exceeded. Upgrade at https://wordpress.com/plans/example.com'
+			);
+			renderHook( () => useErrorNotice( error, mockAddNotice ) );
+
+			expect( mockAddNotice ).toHaveBeenCalledWith(
+				"You've reached your free AI limit. Unlock more generations with a paid plan.",
+				'warning',
+				[
+					{
+						label: 'See plans',
+						url: 'https://wordpress.com/plans/example.com',
+						openInNewTab: true,
+					},
+				]
+			);
+		} );
+
+		it( 'handles object with message property', () => {
+			const error = { message: 'Custom error object' };
+			renderHook( () => useErrorNotice( error, mockAddNotice ) );
+
+			expect( mockAddNotice ).toHaveBeenCalledWith( 'Custom error object', 'error' );
+		} );
+	} );
+} );

--- a/packages/image-studio/src/hooks/use-error-notice.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.ts
@@ -1,17 +1,14 @@
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { parseErrorUrl } from '../utils/parse-error-url';
-import type { NoticeAction } from '../store';
+import type { NoticeAction, NoticeType } from '../store';
 
-type AddNoticeFunc = (
-	content: string,
-	type: 'error' | 'success',
-	actions?: NoticeAction[]
-) => void;
+type AddNoticeFunc = ( content: string, type: NoticeType, actions?: NoticeAction[] ) => void;
 
 /**
  * Hook that displays an error notice when an error occurs.
  * Extracts URLs from error messages and shows appropriate action buttons.
+ * Upgrade URLs show as persistent warning notices, other errors as snackbars.
  * @param error     - The error to display
  * @param addNotice - Function to add a notice to the store
  */
@@ -26,19 +23,37 @@ export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void
 			String( error ) ||
 			__( 'An error occurred while generating content.', __i18n_text_domain__ );
 
-		const { content, url, isUpgradeUrl } = parseErrorUrl( errorMessage );
+		const { content, url, isUpgradeUrl, isPlansPageUrl } = parseErrorUrl( errorMessage );
 
-		if ( url ) {
+		if ( url && isUpgradeUrl ) {
+			// Show upgrade notices as persistent warning notices with new copy
+			addNotice(
+				__(
+					"You've reached your free AI limit. Unlock more generations with a paid plan.",
+					__i18n_text_domain__
+				),
+				'warning',
+				[
+					{
+						label: isPlansPageUrl
+							? __( 'See plans', __i18n_text_domain__ )
+							: __( 'Upgrade plan', __i18n_text_domain__ ),
+						url,
+						openInNewTab: true,
+					},
+				]
+			);
+		} else if ( url ) {
+			// Non-upgrade URLs show as error snackbar with Learn more link
 			addNotice( content, 'error', [
 				{
-					label: isUpgradeUrl
-						? __( 'Upgrade', __i18n_text_domain__ )
-						: __( 'Learn more', __i18n_text_domain__ ),
+					label: __( 'Learn more', __i18n_text_domain__ ),
 					url,
 					openInNewTab: true,
 				},
 			] );
 		} else {
+			// Plain errors show as snackbar
 			addNotice( content, 'error' );
 		}
 	}, [ error, addNotice ] );

--- a/packages/image-studio/src/hooks/use-error-notice.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.ts
@@ -26,23 +26,16 @@ export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void
 		const { content, url, isUpgradeUrl, isPlansPageUrl } = parseErrorUrl( errorMessage );
 
 		if ( url && isUpgradeUrl ) {
-			// Show upgrade notices as persistent warning notices with new copy
-			addNotice(
-				__(
-					"You've reached your free AI limit. Unlock more generations with a paid plan.",
-					__i18n_text_domain__
-				),
-				'warning',
-				[
-					{
-						label: isPlansPageUrl
-							? __( 'See plans', __i18n_text_domain__ )
-							: __( 'Upgrade plan', __i18n_text_domain__ ),
-						url,
-						openInNewTab: true,
-					},
-				]
-			);
+			// Show upgrade notices as persistent warning notices
+			addNotice( content, 'warning', [
+				{
+					label: isPlansPageUrl
+						? __( 'See plans', __i18n_text_domain__ )
+						: __( 'Upgrade plan', __i18n_text_domain__ ),
+					url,
+					openInNewTab: true,
+				},
+			] );
 		} else if ( url ) {
 			// Non-upgrade URLs show as error snackbar with Learn more link
 			addNotice( content, 'error', [

--- a/packages/image-studio/src/hooks/use-error-notice.ts
+++ b/packages/image-studio/src/hooks/use-error-notice.ts
@@ -1,0 +1,45 @@
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { parseErrorUrl } from '../utils/parse-error-url';
+import type { NoticeAction } from '../store';
+
+type AddNoticeFunc = (
+	content: string,
+	type: 'error' | 'success',
+	actions?: NoticeAction[]
+) => void;
+
+/**
+ * Hook that displays an error notice when an error occurs.
+ * Extracts URLs from error messages and shows appropriate action buttons.
+ * @param error     - The error to display
+ * @param addNotice - Function to add a notice to the store
+ */
+export function useErrorNotice( error: unknown, addNotice: AddNoticeFunc ): void {
+	useEffect( () => {
+		if ( ! error ) {
+			return;
+		}
+
+		const errorMessage =
+			( error as Error )?.message ||
+			String( error ) ||
+			__( 'An error occurred while generating content.', __i18n_text_domain__ );
+
+		const { content, url, isUpgradeUrl } = parseErrorUrl( errorMessage );
+
+		if ( url ) {
+			addNotice( content, 'error', [
+				{
+					label: isUpgradeUrl
+						? __( 'Upgrade', __i18n_text_domain__ )
+						: __( 'Learn more', __i18n_text_domain__ ),
+					url,
+					openInNewTab: true,
+				},
+			] );
+		} else {
+			addNotice( content, 'error' );
+		}
+	}, [ error, addNotice ] );
+}

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -26,7 +26,7 @@ export interface CanvasMetadata {
 	alt_text?: string | null;
 }
 
-export type NoticeType = 'error' | 'success';
+export type NoticeType = 'error' | 'success' | 'warning';
 export interface NoticeAction {
 	label: string;
 	url: string;
@@ -658,7 +658,7 @@ export interface ImageStudioActions {
 	setIsExitConfirmed: ( value: boolean ) => Promise< SetIsExitConfirmedAction >;
 	addNotice: (
 		content: string,
-		type: 'error' | 'success',
+		type: NoticeType,
 		noticeActions?: NoticeAction[]
 	) => Promise< AddNoticeAction >;
 	removeNotice: ( noticeId: string ) => Promise< RemoveNoticeAction >;

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -27,10 +27,16 @@ export interface CanvasMetadata {
 }
 
 export type NoticeType = 'error' | 'success';
+export interface NoticeAction {
+	label: string;
+	url: string;
+	openInNewTab?: boolean;
+}
 export interface Notice {
 	id: string;
 	content: string;
 	type: NoticeType;
+	actions?: NoticeAction[];
 }
 
 export enum ImageStudioEntryPoint {
@@ -650,7 +656,11 @@ export interface ImageStudioActions {
 	) => Promise< SetLastSavedAttachmentIdAction >;
 	addSavedAttachmentId: ( attachmentId: number ) => Promise< AddSavedAttachmentIdAction >;
 	setIsExitConfirmed: ( value: boolean ) => Promise< SetIsExitConfirmedAction >;
-	addNotice: ( content: string, type: 'error' | 'success' ) => Promise< AddNoticeAction >;
+	addNotice: (
+		content: string,
+		type: 'error' | 'success',
+		noticeActions?: NoticeAction[]
+	) => Promise< AddNoticeAction >;
 	removeNotice: ( noticeId: string ) => Promise< RemoveNoticeAction >;
 	setNavigableAttachmentIds: (
 		attachmentIds: number[],
@@ -797,7 +807,7 @@ const actions = {
 		};
 	},
 
-	addNotice( content: string, type: NoticeType ): AddNoticeAction {
+	addNotice( content: string, type: NoticeType, noticeActions?: NoticeAction[] ): AddNoticeAction {
 		return {
 			type: 'ADD_NOTICE',
 			payload: {
@@ -805,6 +815,9 @@ const actions = {
 				id: `${ Math.random().toString( 36 ).substring( 2, 9 ) }`,
 				content,
 				type,
+				...( noticeActions?.length && {
+					actions: noticeActions,
+				} ),
 			},
 		};
 	},

--- a/packages/image-studio/src/utils/parse-error-url.test.ts
+++ b/packages/image-studio/src/utils/parse-error-url.test.ts
@@ -146,6 +146,37 @@ describe( 'parseErrorUrl', () => {
 		} );
 	} );
 
+	describe( 'isPlansPageUrl detection', () => {
+		it( 'identifies /plans/ URL as plans page', () => {
+			const result = parseErrorUrl( 'Upgrade required https://wordpress.com/plans/example.com' );
+			expect( result.isPlansPageUrl ).toBe( true );
+		} );
+
+		it( 'returns false for Jetpack redirect URL', () => {
+			const result = parseErrorUrl(
+				'Upgrade required https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge&site=example.com'
+			);
+			expect( result.isPlansPageUrl ).toBe( false );
+		} );
+
+		it( 'returns false for my-jetpack URL', () => {
+			const result = parseErrorUrl(
+				'Upgrade required https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai'
+			);
+			expect( result.isPlansPageUrl ).toBe( false );
+		} );
+
+		it( 'returns false for /upgrade URL', () => {
+			const result = parseErrorUrl( 'Upgrade required https://wordpress.com/upgrade' );
+			expect( result.isPlansPageUrl ).toBe( false );
+		} );
+
+		it( 'returns false for non-upgrade URLs', () => {
+			const result = parseErrorUrl( 'See https://example.com/help' );
+			expect( result.isPlansPageUrl ).toBe( false );
+		} );
+	} );
+
 	describe( 'edge cases', () => {
 		it( 'handles URL with fragment', () => {
 			const result = parseErrorUrl( 'See https://example.com/docs#section' );

--- a/packages/image-studio/src/utils/parse-error-url.test.ts
+++ b/packages/image-studio/src/utils/parse-error-url.test.ts
@@ -1,0 +1,165 @@
+import { parseErrorUrl } from './parse-error-url';
+
+describe( 'parseErrorUrl', () => {
+	describe( 'Streaming error prefix stripping', () => {
+		it( 'strips "Streaming error: " prefix', () => {
+			const result = parseErrorUrl( 'Streaming error: Something went wrong.' );
+			expect( result.content ).toBe( 'Something went wrong.' );
+		} );
+
+		it( 'strips prefix case-insensitively', () => {
+			const result = parseErrorUrl( 'streaming error: Something went wrong.' );
+			expect( result.content ).toBe( 'Something went wrong.' );
+		} );
+
+		it( 'strips prefix and extracts upgrade URL', () => {
+			const result = parseErrorUrl(
+				'Streaming error: Congratulations on exploring Image Studio and reaching the free requests limit! Upgrade now to keep using it. https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge'
+			);
+			expect( result.content ).toBe(
+				'Congratulations on exploring Image Studio and reaching the free requests limit! Upgrade now to keep using it.'
+			);
+			expect( result.isUpgradeUrl ).toBe( true );
+		} );
+
+		it( 'does not strip prefix mid-message', () => {
+			const result = parseErrorUrl( 'There was a Streaming error: in the pipeline.' );
+			expect( result.content ).toBe( 'There was a Streaming error: in the pipeline.' );
+		} );
+	} );
+
+	describe( 'no URL present', () => {
+		it( 'returns original content when no URL', () => {
+			const result = parseErrorUrl( 'An error occurred.' );
+			expect( result ).toEqual( {
+				content: 'An error occurred.',
+				url: null,
+				isUpgradeUrl: false,
+			} );
+		} );
+
+		it( 'returns empty string for empty input', () => {
+			const result = parseErrorUrl( '' );
+			expect( result ).toEqual( {
+				content: '',
+				url: null,
+				isUpgradeUrl: false,
+			} );
+		} );
+	} );
+
+	describe( 'URL extraction', () => {
+		it( 'extracts http URL from message', () => {
+			const result = parseErrorUrl( 'Error occurred. See http://example.com for details.' );
+			expect( result.url ).toBe( 'http://example.com' );
+			expect( result.content ).toBe( 'Error occurred. See for details.' );
+		} );
+
+		it( 'extracts https URL from message', () => {
+			const result = parseErrorUrl( 'Error occurred. See https://example.com for details.' );
+			expect( result.url ).toBe( 'https://example.com' );
+			expect( result.content ).toBe( 'Error occurred. See for details.' );
+		} );
+
+		it( 'extracts URL with path and query params', () => {
+			const result = parseErrorUrl( 'Visit https://example.com/path?foo=bar&baz=qux' );
+			expect( result.url ).toBe( 'https://example.com/path?foo=bar&baz=qux' );
+			expect( result.content ).toBe( 'Visit' );
+		} );
+
+		it( 'extracts first URL when multiple present', () => {
+			const result = parseErrorUrl( 'See https://first.com or https://second.com' );
+			expect( result.url ).toBe( 'https://first.com' );
+		} );
+
+		it( 'trims content after URL removal', () => {
+			const result = parseErrorUrl( 'https://example.com' );
+			expect( result.content ).toBe( '' );
+		} );
+
+		it( 'handles URL at start of message', () => {
+			const result = parseErrorUrl( 'https://example.com - click here for help' );
+			expect( result.url ).toBe( 'https://example.com' );
+			expect( result.content ).toBe( '- click here for help' );
+		} );
+
+		it( 'handles URL at end of message', () => {
+			const result = parseErrorUrl( 'For more information visit https://example.com' );
+			expect( result.url ).toBe( 'https://example.com' );
+			expect( result.content ).toBe( 'For more information visit' );
+		} );
+	} );
+
+	describe( 'upgrade URL detection', () => {
+		it( 'identifies /plans/ URL as upgrade', () => {
+			const result = parseErrorUrl( 'Upgrade required https://wordpress.com/plans/example.com' );
+			expect( result.isUpgradeUrl ).toBe( true );
+		} );
+
+		it( 'identifies /upgrade URL as upgrade', () => {
+			const result = parseErrorUrl( 'Upgrade required https://wordpress.com/upgrade' );
+			expect( result.isUpgradeUrl ).toBe( true );
+		} );
+
+		it( 'identifies /upgrade/ with path as upgrade', () => {
+			const result = parseErrorUrl( 'See https://example.com/upgrade/premium' );
+			expect( result.isUpgradeUrl ).toBe( true );
+		} );
+
+		it( 'identifies jetpack.com/redirect URL as upgrade', () => {
+			const result = parseErrorUrl(
+				'Upgrade required https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge&site=example.com'
+			);
+			expect( result.isUpgradeUrl ).toBe( true );
+		} );
+
+		it( 'identifies my-jetpack URL as upgrade', () => {
+			const result = parseErrorUrl(
+				'Upgrade required https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai'
+			);
+			expect( result.isUpgradeUrl ).toBe( true );
+		} );
+
+		it( 'returns false for non-upgrade URLs', () => {
+			const result = parseErrorUrl( 'See https://example.com/help' );
+			expect( result.isUpgradeUrl ).toBe( false );
+		} );
+
+		it( 'returns false for URL with "plans" not in path', () => {
+			const result = parseErrorUrl( 'See https://example.com?plans=true' );
+			expect( result.isUpgradeUrl ).toBe( false );
+		} );
+
+		it( 'returns false for URL with "upgrade" in domain', () => {
+			const result = parseErrorUrl( 'See https://upgrade.example.com' );
+			expect( result.isUpgradeUrl ).toBe( false );
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'handles URL with fragment', () => {
+			const result = parseErrorUrl( 'See https://example.com/docs#section' );
+			expect( result.url ).toBe( 'https://example.com/docs#section' );
+		} );
+
+		it( 'handles URL with port', () => {
+			const result = parseErrorUrl( 'See https://example.com:8080/path' );
+			expect( result.url ).toBe( 'https://example.com:8080/path' );
+		} );
+
+		it( 'handles URL with encoded characters', () => {
+			const result = parseErrorUrl( 'See https://example.com/path%20with%20spaces' );
+			expect( result.url ).toBe( 'https://example.com/path%20with%20spaces' );
+		} );
+
+		it( 'does not match ftp URLs', () => {
+			const result = parseErrorUrl( 'See ftp://example.com' );
+			expect( result.url ).toBeNull();
+		} );
+
+		it( 'does not match mailto links', () => {
+			const result = parseErrorUrl( 'Contact mailto:test@example.com' );
+			expect( result.url ).toBeNull();
+		} );
+	} );
+} );

--- a/packages/image-studio/src/utils/parse-error-url.test.ts
+++ b/packages/image-studio/src/utils/parse-error-url.test.ts
@@ -35,6 +35,7 @@ describe( 'parseErrorUrl', () => {
 				content: 'An error occurred.',
 				url: null,
 				isUpgradeUrl: false,
+				isPlansPageUrl: false,
 			} );
 		} );
 
@@ -44,6 +45,7 @@ describe( 'parseErrorUrl', () => {
 				content: '',
 				url: null,
 				isUpgradeUrl: false,
+				isPlansPageUrl: false,
 			} );
 		} );
 	} );
@@ -91,48 +93,56 @@ describe( 'parseErrorUrl', () => {
 	} );
 
 	describe( 'upgrade URL detection', () => {
-		it( 'identifies /plans/ URL as upgrade', () => {
+		it( 'identifies /plans/ URL as upgrade and plans page', () => {
 			const result = parseErrorUrl( 'Upgrade required https://wordpress.com/plans/example.com' );
 			expect( result.isUpgradeUrl ).toBe( true );
+			expect( result.isPlansPageUrl ).toBe( true );
 		} );
 
-		it( 'identifies /upgrade URL as upgrade', () => {
+		it( 'identifies /upgrade URL as upgrade but not plans page', () => {
 			const result = parseErrorUrl( 'Upgrade required https://wordpress.com/upgrade' );
 			expect( result.isUpgradeUrl ).toBe( true );
+			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 
-		it( 'identifies /upgrade/ with path as upgrade', () => {
+		it( 'identifies /upgrade/ with path as upgrade but not plans page', () => {
 			const result = parseErrorUrl( 'See https://example.com/upgrade/premium' );
 			expect( result.isUpgradeUrl ).toBe( true );
+			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 
-		it( 'identifies jetpack.com/redirect URL as upgrade', () => {
+		it( 'identifies jetpack.com/redirect URL as upgrade but not plans page', () => {
 			const result = parseErrorUrl(
 				'Upgrade required https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge&site=example.com'
 			);
 			expect( result.isUpgradeUrl ).toBe( true );
+			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 
-		it( 'identifies my-jetpack URL as upgrade', () => {
+		it( 'identifies my-jetpack URL as upgrade but not plans page', () => {
 			const result = parseErrorUrl(
 				'Upgrade required https://example.com/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai'
 			);
 			expect( result.isUpgradeUrl ).toBe( true );
+			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 
 		it( 'returns false for non-upgrade URLs', () => {
 			const result = parseErrorUrl( 'See https://example.com/help' );
 			expect( result.isUpgradeUrl ).toBe( false );
+			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 
 		it( 'returns false for URL with "plans" not in path', () => {
 			const result = parseErrorUrl( 'See https://example.com?plans=true' );
 			expect( result.isUpgradeUrl ).toBe( false );
+			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 
 		it( 'returns false for URL with "upgrade" in domain', () => {
 			const result = parseErrorUrl( 'See https://upgrade.example.com' );
 			expect( result.isUpgradeUrl ).toBe( false );
+			expect( result.isPlansPageUrl ).toBe( false );
 		} );
 	} );
 

--- a/packages/image-studio/src/utils/parse-error-url.test.ts
+++ b/packages/image-studio/src/utils/parse-error-url.test.ts
@@ -144,6 +144,12 @@ describe( 'parseErrorUrl', () => {
 			expect( result.isUpgradeUrl ).toBe( false );
 			expect( result.isPlansPageUrl ).toBe( false );
 		} );
+
+		it( 'returns false for URL with "jetpack.com/redirect" in path but different hostname', () => {
+			const result = parseErrorUrl( 'See https://evil.com/jetpack.com/redirect' );
+			expect( result.isUpgradeUrl ).toBe( false );
+			expect( result.isPlansPageUrl ).toBe( false );
+		} );
 	} );
 
 	describe( 'isPlansPageUrl detection', () => {

--- a/packages/image-studio/src/utils/parse-error-url.ts
+++ b/packages/image-studio/src/utils/parse-error-url.ts
@@ -1,0 +1,50 @@
+/**
+ * Result of parsing an error message for URLs.
+ */
+export interface ParsedErrorUrl {
+	/** The error message content with the URL removed (or original if no URL) */
+	content: string;
+	/** The extracted URL, or null if none found */
+	url: string | null;
+	/** Whether the URL points to an upgrade/plans page */
+	isUpgradeUrl: boolean;
+}
+
+/**
+ * Parses an error message to extract a URL and determine if it's an upgrade URL.
+ * @param errorMessage - The error message that may contain a URL
+ * @returns Parsed result with content, url, and isUpgradeUrl flag
+ */
+export function parseErrorUrl( errorMessage: string ): ParsedErrorUrl {
+	const message = errorMessage.replace( /^Streaming error:\s*/i, '' );
+	const urlMatch = message.match( /(https?:\/\/[^\s]+)/ );
+
+	if ( ! urlMatch ) {
+		return {
+			content: message,
+			url: null,
+			isUpgradeUrl: false,
+		};
+	}
+
+	const url = urlMatch[ 1 ];
+	const content = message.replace( url, '' ).replace( /\s+/g, ' ' ).trim();
+
+	// Check for upgrade URLs by examining the path portion (after the domain)
+	// Remove protocol to avoid false positives like https://upgrade.example.com
+	const urlWithoutProtocol = url.replace( /^https?:\/\//, '' );
+	const pathStart = urlWithoutProtocol.indexOf( '/' );
+	const pathAndQuery = pathStart >= 0 ? urlWithoutProtocol.slice( pathStart ) : '';
+
+	const isUpgradeUrl =
+		pathAndQuery.includes( '/plans/' ) ||
+		pathAndQuery.startsWith( '/upgrade' ) ||
+		url.includes( 'jetpack.com/redirect' ) ||
+		pathAndQuery.includes( 'my-jetpack' );
+
+	return {
+		content,
+		url,
+		isUpgradeUrl,
+	};
+}

--- a/packages/image-studio/src/utils/parse-error-url.ts
+++ b/packages/image-studio/src/utils/parse-error-url.ts
@@ -8,6 +8,8 @@ export interface ParsedErrorUrl {
 	url: string | null;
 	/** Whether the URL points to an upgrade/plans page */
 	isUpgradeUrl: boolean;
+	/** Whether the URL points to a plans comparison page (vs checkout) */
+	isPlansPageUrl: boolean;
 }
 
 /**
@@ -24,6 +26,7 @@ export function parseErrorUrl( errorMessage: string ): ParsedErrorUrl {
 			content: message,
 			url: null,
 			isUpgradeUrl: false,
+			isPlansPageUrl: false,
 		};
 	}
 
@@ -42,9 +45,12 @@ export function parseErrorUrl( errorMessage: string ): ParsedErrorUrl {
 		url.includes( 'jetpack.com/redirect' ) ||
 		pathAndQuery.includes( 'my-jetpack' );
 
+	const isPlansPageUrl = pathAndQuery.includes( '/plans/' );
+
 	return {
 		content,
 		url,
 		isUpgradeUrl,
+		isPlansPageUrl,
 	};
 }

--- a/packages/image-studio/src/utils/parse-error-url.ts
+++ b/packages/image-studio/src/utils/parse-error-url.ts
@@ -38,11 +38,12 @@ export function parseErrorUrl( errorMessage: string ): ParsedErrorUrl {
 	const urlWithoutProtocol = url.replace( /^https?:\/\//, '' );
 	const pathStart = urlWithoutProtocol.indexOf( '/' );
 	const pathAndQuery = pathStart >= 0 ? urlWithoutProtocol.slice( pathStart ) : '';
+	const hostname = pathStart >= 0 ? urlWithoutProtocol.slice( 0, pathStart ) : urlWithoutProtocol;
 
 	const isUpgradeUrl =
 		pathAndQuery.includes( '/plans/' ) ||
 		pathAndQuery.startsWith( '/upgrade' ) ||
-		url.includes( 'jetpack.com/redirect' ) ||
+		( hostname === 'jetpack.com' && pathAndQuery.startsWith( '/redirect' ) ) ||
 		pathAndQuery.includes( 'my-jetpack' );
 
 	const isPlansPageUrl = pathAndQuery.includes( '/plans/' );


### PR DESCRIPTION
Part of FORNO-216

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Before
<img width="805" height="651" alt="image" src="https://github.com/user-attachments/assets/683db77e-ed62-43ef-aac8-c0ff6dd33aec" />


After 
<img width="1238" height="925" alt="image" src="https://github.com/user-attachments/assets/045b4b7f-95ff-49b8-aa26-009f63a2640b" />


## Proposed changes

  - Move quota check from permission_callback to execute_callback so errors propagate to the frontend
  - Add Image_Usage::get_upgrade_url() to return the appropriate upgrade URL (Big Sky → plans page, Jetpack AI → tier upgrade page)
  - Append upgrade URL to the error message for frontend rendering



  
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To help with parity with Jetpack AI users, who already see  styled error message with an upgrade path when they hit usage limits. Previously, Image Studio users on free plan saw a generic "Streaming error" with no way to upgrade.

## Testing Instructions

- Follow the test instructions from wpcom 203931


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
