### PR TITLE
Checkout: Clarify siteless checkout flows and user creation

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -158,9 +158,8 @@ export function checkout( context, next ) {
 	const isUserComingFromLoginForm = context.query?.flow === 'coming_from_login';
 	// TODO: The only thing that we really need to check for here is whether or not the user is logged out.
 	// A siteless Jetpack purchase (logged in or out) will be handled by checkoutJetpackSiteless
-	// Additionally, the isJetpackCheckout variable would be more aptly named isJetpackSitelessCheckout
 	// isContextJetpackSitelessCheckout is really checking for whether this is a logged-out purchase, but this is uncelar at first
-	const isJetpackCheckout = isContextJetpackSitelessCheckout( context );
+	const isJetpackCheckoutLoggedOut = isContextJetpackSitelessCheckout( context );
 	const jetpackSiteSlug = context.params.siteSlug;
 
 	const isGiftPurchase = context.pathname.includes( '/gift/' );
@@ -176,7 +175,7 @@ export function checkout( context, next ) {
 		if ( isDisallowedForSitePicker ) {
 			return true;
 		}
-		if ( isJetpackCheckout ) {
+		if ( isJetpackCheckoutLoggedOut ) {
 			return true;
 		}
 		if ( isGiftPurchase ) {
@@ -211,16 +210,47 @@ export function checkout( context, next ) {
 	// NOTE: `context.query.code` is deprecated in favor of `context.query.coupon`.
 	const couponCode = context.query.coupon || context.query.code || getRememberedCoupon();
 
-	const isLoggedOutCart =
-		isJetpackCheckout ||
-		( isLoggedOut &&
-			( context.pathname.includes( '/checkout/no-site' ) ||
-				context.pathname.includes( '/gift/' ) ) );
-	const isNoSiteCart =
-		isJetpackCheckout ||
-		( ! isLoggedOut &&
+	// TODO: This variable is really unclear. It misleads all the components
+	// under here by being called `isLoggedOutCart` when in fact there are many
+	// logged-out carts this does not cover, like unified checkout.
+	const isLoggedOutCart = ( () => {
+		if ( isJetpackCheckoutLoggedOut ) {
+			return true;
+		}
+		if ( ! isLoggedOut ) {
+			return false;
+		}
+		if ( context.pathname.includes( '/checkout/no-site' ) ) {
+			return true;
+		}
+		if ( context.pathname.includes( '/gift/' ) ) {
+			return true;
+		}
+		return false;
+	} )();
+
+	// TODO: This variable is really unclear. Its name suggests that it's true
+	// for siteless carts, but there's lots of siteless carts these conditions
+	// don't cover, like unified checkout or Akismet checkout or A4A. All this
+	// covers is if this is logged-out Jetpack checkout or if this is a
+	// siteless cart with the `no-user` query param which is pretty rare.
+	//
+	// Therea are only two places that set `cart=no-user`:
+	// - PayPal: when createUserAndSiteBeforeTransaction is true — i.e., logged-out flows that need to register a user/site during checkout
+	// - Login redirect from /checkout/no-site: to preserve cart state across login for the onboarding registrationless (stepper) flow
+	const isNoSiteCart = ( () => {
+		if ( isJetpackCheckoutLoggedOut ) {
+			return true;
+		}
+		if (
+			isLoggedOut &&
 			context.pathname.includes( '/checkout/no-site' ) &&
-			'no-user' === context.query.cart );
+			context.query.cart === 'no-user'
+		) {
+			return true;
+		}
+		return false;
+	} )();
 
 	// Tracks if checkout page was unloaded before purchase completion,
 	// to prevent browser back duplicate sites. Check pau2Xa-1Io-p2#comment-6759.
@@ -231,9 +261,9 @@ export function checkout( context, next ) {
 		} );
 	}
 
-	/** @type {import('@automattic/wpcom-checkout').SitelessCheckoutType} */
+	/** @type {import('@automattic/shopping-cart').SitelessCheckoutType} */
 	const sitelessCheckoutType = ( () => {
-		if ( isJetpackCheckout ) {
+		if ( isJetpackCheckoutLoggedOut ) {
 			return 'jetpack';
 		}
 		if ( isDomainOnlyFlow ) {
@@ -258,7 +288,7 @@ export function checkout( context, next ) {
 				redirectTo={ context.query.redirect_to }
 				isLoggedOutCart={ isLoggedOutCart }
 				isNoSiteCart={ isNoSiteCart }
-				// TODO: in theory, isJetpackCheckout should always be false here if it is indicating whether this is a siteless Jetpack purchase
+				// TODO: in theory, isJetpackCheckoutLoggedOut should always be false here if it is indicating whether this is a siteless Jetpack purchase
 				// However, in this case, it's indicating that this checkout is a logged-out site purchase for Jetpack.
 				// This is creating some mixed use cases for the sitelessCheckoutType prop
 				sitelessCheckoutType={ sitelessCheckoutType }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -231,6 +231,17 @@ export function checkout( context, next ) {
 		} );
 	}
 
+	/** @type {import('@automattic/wpcom-checkout').SitelessCheckoutType} */
+	const sitelessCheckoutType = ( () => {
+		if ( isJetpackCheckout ) {
+			return 'jetpack';
+		}
+		if ( isDomainOnlyFlow ) {
+			return 'domainonly';
+		}
+		return undefined;
+	} )();
+
 	context.primary = (
 		<>
 			<CheckoutDocumentTitle />
@@ -250,7 +261,7 @@ export function checkout( context, next ) {
 				// TODO: in theory, isJetpackCheckout should always be false here if it is indicating whether this is a siteless Jetpack purchase
 				// However, in this case, it's indicating that this checkout is a logged-out site purchase for Jetpack.
 				// This is creating some mixed use cases for the sitelessCheckoutType prop
-				sitelessCheckoutType={ isJetpackCheckout ? 'jetpack' : undefined }
+				sitelessCheckoutType={ sitelessCheckoutType }
 				isGiftPurchase={ isGiftPurchase }
 				jetpackSiteSlug={ jetpackSiteSlug }
 				jetpackPurchaseToken={ jetpackPurchaseToken || jetpackPurchaseNonce }

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -188,9 +188,6 @@ export default function CheckoutMain( {
 		if ( sitelessCheckoutType && cartKey === 'no-user' ) {
 			return true;
 		}
-		if ( isLoggedOutCart || isNoSiteCart ) {
-			return true;
-		}
 		return false;
 	} )();
 

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -147,15 +147,55 @@ export default function CheckoutMain( {
 		} ) || sitelessCheckoutType === 'jetpack';
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
 	const isGravatarDomain = useSelector( hasGravatarDomainQueryParam );
-	const isSiteless =
-		sitelessCheckoutType === 'jetpack' ||
-		sitelessCheckoutType === 'akismet' ||
-		sitelessCheckoutType === 'marketplace' ||
-		sitelessCheckoutType === 'a4a';
+	const cartKey = useCartKey();
+
+	/**
+	 * The definition of what makes "siteless checkout" varies considerably.
+	 *
+	 * All subscriptions must be assigned to a user and a site before or during
+	 * their purchase, but which site is used and when that site is created
+	 * differentiates the flows.
+	 *
+	 * If `sitelessCheckoutType` is set, then this checkout is siteless, which
+	 * also means that the shopping cart has no `blog_id` set. However,
+	 * sometimes a `blog_id` will be set automatically on the server by the
+	 * shopping cart (for example, if the cart item is a renewal and the site
+	 * has not already been provided in the checkout URL).
+	 *
+	 * Unified siteless checkout (siteless checkout for wpcom products) creates
+	 * one site per purchase. Jetpack siteless checkout and Domain-only flows
+	 * have a holding site created during the transactions endpoint, one per
+	 * purchase (although the created sites are flagged in special ways).
+	 *
+	 * The same is true for Akismet, A4A, and Marketplace siteless checkout but
+	 * for these we only create one holding site per user and that is re-used
+	 * for additional purchases.
+	 *
+	 * Gift purchases (renewals for another user's subscription) are also
+	 * siteless in the sense that no `blog_id` is set when they are in the
+	 * cart, but they are renewing a subscription on an existing site.
+	 *
+	 * Logged-out siteless checkout flows include a temporary userless and
+	 * siteless cart but then create a user just in time before the transaction
+	 * is submitted, and therefore their carts always have a user by the time
+	 * they are processed. Sometimes a site is also created when the user is
+	 * created (this happens if createUserAndSiteBeforeTransaction is true AND
+	 * newSiteParams is set in the createAccount helper) in which case the
+	 * transaction is also submitted with a `blog_id` and no site is created
+	 * during the transaction itself.
+	 */
+	const createUserAndSiteBeforeTransaction = ( () => {
+		if ( sitelessCheckoutType && cartKey === 'no-user' ) {
+			return true;
+		}
+		if ( isLoggedOutCart || isNoSiteCart ) {
+			return true;
+		}
+		return false;
+	} )();
+
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const { razorpayConfiguration, isRazorpayLoading, razorpayLoadingError } = useRazorpay();
-	const createUserAndSiteBeforeTransaction =
-		Boolean( isLoggedOutCart || isNoSiteCart ) && ! isSiteless;
 	const reduxDispatch = useDispatch();
 
 	const updatedSiteSlug = useMemo( () => {
@@ -226,7 +266,6 @@ export default function CheckoutMain( {
 		hostingIntent,
 	} );
 
-	const cartKey = useCartKey();
 	const {
 		applyCoupon,
 		replaceProductInCart,
@@ -242,8 +281,12 @@ export default function CheckoutMain( {
 	const { shouldSetMigrationSticker, isLoading: isStickerLoading } =
 		useCheckoutMigrationIntroductoryOfferSticker( siteId, reloadFromServer );
 
-	// For site-less checkouts, get the blog ID from the cart response
-	const updatedSiteId = isSiteless ? parseInt( String( responseCart.blog_id ), 10 ) : siteId;
+	// For siteless checkouts, possibly get the blog ID from the cart response
+	// in cases where the server has assigned it automatically. If so, we
+	// override the blog ID set in the checkout URL (if any).
+	const updatedSiteId = sitelessCheckoutType
+		? parseInt( String( responseCart.blog_id ), 10 )
+		: siteId;
 
 	const isInitialCartLoading = useAddProductsFromUrl( {
 		isLoadingCart,
@@ -854,7 +897,10 @@ export default function CheckoutMain( {
 						countriesList={ countriesList }
 						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						infoMessage={
-							<PrePurchaseNotices siteId={ updatedSiteId } isSiteless={ isSiteless } />
+							<PrePurchaseNotices
+								siteId={ updatedSiteId }
+								shouldQueryUserPurchases={ Boolean( sitelessCheckoutType ) }
+							/>
 						}
 						isLoggedOutCart={ !! isLoggedOutCart }
 						onPageLoadError={ onPageLoadError }

--- a/client/my-sites/checkout/src/components/prepurchase-notices/index.tsx
+++ b/client/my-sites/checkout/src/components/prepurchase-notices/index.tsx
@@ -179,15 +179,15 @@ const PrePurchaseNoticesWrapper = () => {
 
 function PrePurchaseNoticesQueryContainer( {
 	siteId,
-	isSiteless,
+	shouldQueryUserPurchases,
 }: {
 	siteId: number | undefined;
-	isSiteless: boolean;
+	shouldQueryUserPurchases: boolean;
 } ) {
 	return (
 		<>
 			<QuerySitePurchases siteId={ siteId } />
-			{ isSiteless && <QueryUserPurchases /> }
+			{ shouldQueryUserPurchases && <QueryUserPurchases /> }
 			<PrePurchaseNoticesWrapper />
 		</>
 	);

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -676,6 +676,7 @@ function createItemToAddToCart( {
 		product_slug: productSlug,
 		quantity,
 		extra: {
+			sitelessCheckoutType,
 			isDomainOnlySitelessCheckout: sitelessCheckoutType === 'domainonly',
 			isUnifiedSitelessCheckout: sitelessCheckoutType === 'unified',
 			isAkismetSitelessCheckout: sitelessCheckoutType === 'akismet',

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -676,6 +676,7 @@ function createItemToAddToCart( {
 		product_slug: productSlug,
 		quantity,
 		extra: {
+			isDomainOnlySitelessCheckout: sitelessCheckoutType === 'domainonly',
 			isUnifiedSitelessCheckout: sitelessCheckoutType === 'unified',
 			isAkismetSitelessCheckout: sitelessCheckoutType === 'akismet',
 			isJetpackCheckout: sitelessCheckoutType === 'jetpack',

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -676,6 +676,7 @@ function createItemToAddToCart( {
 		product_slug: productSlug,
 		quantity,
 		extra: {
+			isUnifiedSitelessCheckout: sitelessCheckoutType === 'unified',
 			isAkismetSitelessCheckout: sitelessCheckoutType === 'akismet',
 			isJetpackCheckout: sitelessCheckoutType === 'jetpack',
 			jetpackSiteSlug,

--- a/client/my-sites/checkout/src/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/src/lib/paypal-express-processor.ts
@@ -94,12 +94,7 @@ async function wpcomPayPalExpress(
 	payload: PayPalExpressEndpointRequestPayload,
 	transactionOptions: PaymentProcessorOptions
 ) {
-	const isUserLessCheckout =
-		payload.cart.products.some(
-			( product ) => product.extra.isJetpackCheckout || product.extra.isAkismetSitelessCheckout
-		) && payload.cart.cart_key === 'no-user';
-
-	if ( transactionOptions.createUserAndSiteBeforeTransaction || isUserLessCheckout ) {
+	if ( transactionOptions.createUserAndSiteBeforeTransaction ) {
 		payload.cart = await createWpcomAccountBeforeTransaction( payload.cart, transactionOptions );
 	}
 

--- a/client/my-sites/checkout/src/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/src/lib/submit-wpcom-transaction.ts
@@ -25,16 +25,7 @@ export default async function submitWpcomTransaction(
 	payload: WPCOMTransactionEndpointRequestPayload,
 	transactionOptions: PaymentProcessorOptions
 ): Promise< WPCOMTransactionEndpointResponse > {
-	const isUserLessCheckout =
-		payload.cart.products.some( ( product ) => {
-			return (
-				product.extra.isJetpackCheckout ||
-				product.extra.isAkismetSitelessCheckout ||
-				product.extra.isA4ASitelessCheckout
-			);
-		} ) && payload.cart.cart_key === 'no-user';
-
-	if ( transactionOptions.createUserAndSiteBeforeTransaction || isUserLessCheckout ) {
+	if ( transactionOptions.createUserAndSiteBeforeTransaction ) {
 		payload.cart = await createWpcomAccountBeforeTransaction( payload.cart, transactionOptions );
 	}
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -932,6 +932,11 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	 */
 	purchaseId?: string;
 
+	/**
+	 * Marks a product as having been added by the siteless `/checkout/unified` route.
+	 */
+	isUnifiedSitelessCheckout?: boolean;
+
 	isAkismetSitelessCheckout?: boolean;
 	isJetpackCheckout?: boolean;
 	isMarketplaceSitelessCheckout?: boolean;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -933,6 +933,11 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	purchaseId?: string;
 
 	/**
+	 * Marks a product as having been added by the siteless domain-only flow.
+	 */
+	isDomainOnlySitelessCheckout?: boolean;
+
+	/**
 	 * Marks a product as having been added by the siteless `/checkout/unified` route.
 	 */
 	isUnifiedSitelessCheckout?: boolean;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -916,6 +916,15 @@ export interface ResponseCartGiftDetails {
 	receiver_blog_url?: string;
 }
 
+export type SitelessCheckoutType =
+	| 'domainonly'
+	| 'jetpack'
+	| 'akismet'
+	| 'marketplace'
+	| 'a4a'
+	| 'unified'
+	| undefined;
+
 /**
  * Miscellaneous data requested to be added to the shopping cart item in a
  * `RequestCart` (in `RequestCartProduct`).
@@ -931,6 +940,8 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	 * and we might find the wrong one.
 	 */
 	purchaseId?: string;
+
+	sitelessCheckoutType?: SitelessCheckoutType;
 
 	/**
 	 * Marks a product as having been added by the siteless domain-only flow.

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -1,5 +1,6 @@
 import type { DomainContactDetails, RequestCart } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';
+export type { SitelessCheckoutType } from '@automattic/shopping-cart';
 
 type PurchaseSiteId = number;
 
@@ -659,15 +660,6 @@ export interface CountryListItemWithVat extends CountryListItemBase {
 	tax_country_codes: string[];
 }
 export type CountryListItem = CountryListItemWithVat | CountryListItemWithoutVat;
-
-export type SitelessCheckoutType =
-	| 'domainonly'
-	| 'jetpack'
-	| 'akismet'
-	| 'marketplace'
-	| 'a4a'
-	| 'unified'
-	| undefined;
 
 /**
  * Copied these types from Redux to avoid needing to import the whole package.

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -661,6 +661,7 @@ export interface CountryListItemWithVat extends CountryListItemBase {
 export type CountryListItem = CountryListItemWithVat | CountryListItemWithoutVat;
 
 export type SitelessCheckoutType =
+	| 'domainonly'
 	| 'jetpack'
 	| 'akismet'
 	| 'marketplace'


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1712/reviewmerge-checkout-clarify-siteless-checkout-flows-and-user-creation

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

In this PR we attempt to create a new user (and possibly a new site) just-in-time before we submit a transaction if  `createUserAndSiteBeforeTransaction` is set, and to always set that variable if we are in a siteless checkout flow. This effectively just cleans up logic and should not change any behavior.

(The decision of whether to create a new site depends on if `newSiteParams` is set in `localStorage`, which only happens in certain signup flows.)

> [!WARNING]
> This changes the behavior for `marketplace` siteless checkout. Prior to this PR, if a user is trying to make a logged-out marketplace siteless checkout purchase, we do not try to create a user for them before submitting the transaction. My guess is that this is unintentional and a bug. After this PR, logged-out marketplace siteless checkout will also create a user before submitting the transaction.

> [!NOTE]
> This adds a `domainonly` siteless checkout type and makes it true for siteless domain-only checkout flows to clarify that it's one of our siteless flows. Previously, these would not be considered siteless and therefore `createUserAndSiteBeforeTransaction` would only be true if `isLoggedOutCart` or `isNoSiteCart` was true, which I think is all the time for this flow. So if I'm right this should not change any behavior.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The definition of "siteless checkout" is a little vague. All subscriptions must be assigned to a user and a site before or during their purchase, but which site is used and when that site is created differentiates the flows.

There's a variable in checkout called `isSiteless` which I believe is intended to cover all of these flows, but it only covers about 2/3 of them. That variable's main purpose is to prevent setting the `createUserAndSiteBeforeTransaction` variable which in turn is used to determine if a user (and possibly a site) should be created just-in-time before the transaction is submitted.

https://github.com/Automattic/wp-calypso/blob/3db0a99c5943b032667f8a361f1dba3da2c80693/client/my-sites/checkout/src/components/checkout-main.tsx#L150-L158

However, then there's special case logic in `submitWpcomTransaction()` where `createUserAndSiteBeforeTransaction` is ignored if any of the cart items contain a siteless checkout product and the cart key is `'no-user'`.

https://github.com/Automattic/wp-calypso/blob/3db0a99c5943b032667f8a361f1dba3da2c80693/client/my-sites/checkout/src/lib/submit-wpcom-transaction.ts#L28-L39

As a result, these two cases cancel each other out. We say "if this is siteless checkout, do not create a user, but ignore that and create a user if this is siteless checkout".

We can therefore simplify this logic, making it easier to add new siteless checkout flows in the future.

## Testing Instructions

To properly test this, we'll need to test each of the siteless checkout flows, which is not trivial.

- Logged-in and logged-out Jetpack siteless checkout.
- Logged-in and logged-out Akismet siteless checkout.
- Logged-in and logged-out Marketplace siteless checkout.
- Logged-in and logged-out Domain-only siteless checkout.
- Logged-in and logged-out Unified checkout (requires 205502-ghe-Automattic/wpcom).

I think that it's probably simpler just to make sure the logic makes sense.