### PR TITLE
A4A: TMPFRG-239 Avoid fetching WP/PHP versions in A4A dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/hosting/overview.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/hosting/overview.tsx
@@ -79,19 +79,6 @@ const HostingOverviewPreview = ( { site }: Props ) => {
 								</div>
 							</div>
 						) }
-
-						<div className="hosting__content-row">
-							<div className="hosting__content-label">PHP version</div>
-							<div className="hosting__content-value">
-								{ site.php_version ? site.php_version : translate( 'Unknown' ) }
-							</div>
-						</div>
-						<div className="hosting__content-row">
-							<div className="hosting__content-label">WordPress version</div>
-							<div className="hosting__content-value">
-								{ site.wordpress_version ? site.wordpress_version : translate( 'Unknown' ) }
-							</div>
-						</div>
 						<div></div>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

- Avoid depending on PHP and WordPress version fields in the A4A hosting overview so the dashboard no longer requires fetching those values per site.

## Why are these changes being made?

- The Linear task TMPFRG-239 requests avoiding fetching WP and PHP versions in the A4A dashboard, likely for performance and/or reliability reasons when loading many sites.

## Proposed Changes

- Remove the PHP and WordPress version rows from the A4A sites hosting overview panel while keeping the rest of the hosting information unchanged.

## Testing Instructions

- Open the A4A sites dashboard and select a site.
- Open the Hosting tab in the site preview pane.
- Verify that the panel no longer shows PHP version or WordPress version rows, while all other hosting information (host, Pressable CTA, etc.) still renders correctly.

## References

- Part of #TMPFRG-239

## Pre-merge Checklist
- [ ] I have manually tested these changes.
- [ ] I have added or updated unit/integration tests where appropriate.
- [ ] I have checked for a11y regressions (focus states, keyboard nav, screen readers).
- [ ] I have checked for console errors in the browser.
- [ ] I have checked for relevant feature flags and ensured they are documented.


Made with [Cursor](https://cursor.com)