### PR TITLE
The Resurrected Modal - Manual Variation Won

### DIFF
--- a/client/components/resurrected-welcome-modal/index.tsx
+++ b/client/components/resurrected-welcome-modal/index.tsx
@@ -1,15 +1,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { BigSkyLogo } from '@automattic/components';
 import { Button, Icon, Modal } from '@wordpress/components';
-import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { close } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useResurrectedFreeUserEligibility } from 'calypso/lib/resurrected-users';
-import {
-	WELCOME_BACK_VARIATIONS,
-	type WelcomeBackVariation,
-} from 'calypso/lib/resurrected-users/constants';
+
 import './style.scss';
 
 const SESSION_STORAGE_KEY = 'wpcom_resurrected_welcome_modal_dismissed';
@@ -17,7 +13,6 @@ const SESSION_STORAGE_KEY = 'wpcom_resurrected_welcome_modal_dismissed';
 type TranslateFn = ReturnType< typeof useTranslate >;
 
 type CtaVariant = 'primary' | 'secondary' | 'tertiary';
-type CtaIcon = 'big-sky';
 
 type CtaConfig = {
 	id: string;
@@ -25,7 +20,6 @@ type CtaConfig = {
 	href?: string;
 	isDismissOnly?: boolean;
 	variant?: CtaVariant;
-	icon?: CtaIcon;
 };
 
 type VariationConfig = {
@@ -34,97 +28,29 @@ type VariationConfig = {
 	ctas: CtaConfig[];
 };
 
-const CTA_TARGETS = {
-	AI: '/setup/ai-site-builder',
-	MANUAL: '/setup/onboarding',
-} as const;
+const ONBOARDING_URL = '/setup/onboarding';
 
-const VARIATION_CONTENT: Partial< Record< WelcomeBackVariation, VariationConfig > > = {
-	[ WELCOME_BACK_VARIATIONS.AI_ONLY ]: {
-		getTitle: ( translate ) => translate( 'Try our new AI website builder' ),
-		getDescription: ( translate ) =>
-			translate( 'Create a fully designed, content-ready WordPress website in no time.' ),
-		ctas: [
-			{
-				id: 'ai-only',
-				getLabel: ( translate ) => translate( 'Create a new site with AI' ),
-				href: CTA_TARGETS.AI,
-				variant: 'primary',
-				icon: 'big-sky',
-			},
-		],
-	},
-	[ WELCOME_BACK_VARIATIONS.MANUAL ]: {
-		getTitle: ( translate ) => translate( 'Welcome back!' ),
-		getDescription: ( translate ) =>
-			translate(
-				'Ready to explore our latest upgrades? All paid plans now include access to new themes and plugins.'
-			),
-		ctas: [
-			{
-				id: 'manual-new',
-				getLabel: ( translate ) => translate( 'Create a new site' ),
-				href: CTA_TARGETS.MANUAL,
-				variant: 'primary',
-			},
-			{
-				id: 'manual-continue',
-				getLabel: ( translate ) => translate( 'Continue where I left off' ),
-				isDismissOnly: true,
-				variant: 'tertiary',
-			},
-		],
-	},
-	[ WELCOME_BACK_VARIATIONS.AI_ONBOARDING ]: {
-		getTitle: ( translate ) => translate( 'Welcome back!' ),
-		getDescription: ( translate ) =>
-			translate(
-				'Ready to explore our latest upgrades? Check out our AI website builder, new themes and plugins.'
-			),
-		ctas: [
-			{
-				id: 'ai-builder',
-				getLabel: ( translate ) => translate( 'Create a new site with AI' ),
-				href: CTA_TARGETS.AI,
-				variant: 'primary',
-				icon: 'big-sky',
-			},
-			{
-				id: 'ai-continue',
-				getLabel: ( translate ) => translate( 'Continue where I left off' ),
-				isDismissOnly: true,
-				variant: 'tertiary',
-			},
-		],
-	},
-	[ WELCOME_BACK_VARIATIONS.ALL_OPTIONS ]: {
-		getTitle: ( translate ) => translate( 'Welcome back!' ),
-		getDescription: ( translate ) =>
-			translate(
-				'Ready to explore our latest upgrades? Check out our AI website builder, new themes and plugins.'
-			),
-		ctas: [
-			{
-				id: 'all-ai',
-				getLabel: ( translate ) => translate( 'Create a new site with AI' ),
-				href: CTA_TARGETS.AI,
-				icon: 'big-sky',
-				variant: 'primary',
-			},
-			{
-				id: 'all-manual',
-				getLabel: ( translate ) => translate( 'Start with a blank site' ),
-				href: CTA_TARGETS.MANUAL,
-				variant: 'secondary',
-			},
-			{
-				id: 'all-continue',
-				getLabel: ( translate ) => translate( 'Continue where I left off' ),
-				isDismissOnly: true,
-				variant: 'tertiary',
-			},
-		],
-	},
+// Rolled-out variation: MANUAL only.
+const MANUAL_VARIATION_CONFIG: VariationConfig = {
+	getTitle: ( translate ) => translate( 'Welcome back!' ),
+	getDescription: ( translate ) =>
+		translate(
+			'Ready to explore our latest upgrades? All paid plans now include access to new themes and plugins.'
+		),
+	ctas: [
+		{
+			id: 'manual-new',
+			getLabel: ( translate ) => translate( 'Create a new site' ),
+			href: ONBOARDING_URL,
+			variant: 'primary',
+		},
+		{
+			id: 'manual-continue',
+			getLabel: ( translate ) => translate( 'Continue where I left off' ),
+			isDismissOnly: true,
+			variant: 'tertiary',
+		},
+	],
 };
 
 const getInitialDismissState = () => {
@@ -152,26 +78,19 @@ export const ResurrectedWelcomeModalGate = ( {
 	const [ hasTrackedImpression, setHasTrackedImpression ] = useState( false );
 	const previousVisibilityRef = useRef( false );
 
-	const variationName = eligibility.variationName as WelcomeBackVariation | null;
-	const variationConfig = useMemo(
-		() => ( variationName ? VARIATION_CONTENT[ variationName ] : undefined ),
-		[ variationName ]
-	);
+	const variationName = eligibility.variationName;
+	const variationConfig = variationName ? MANUAL_VARIATION_CONFIG : undefined;
 	const variationClassName = variationName
 		? `resurrected-welcome-modal--${ variationName.replace( /_/g, '-' ) }`
 		: null;
-	const hasDarkHero =
-		variationName === WELCOME_BACK_VARIATIONS.MANUAL ||
-		variationName === WELCOME_BACK_VARIATIONS.AI_ONBOARDING ||
-		variationName === WELCOME_BACK_VARIATIONS.ALL_OPTIONS;
+	const hasDarkHero = true; // MANUAL variation uses dark hero
 
 	const shouldDisplay =
 		! eligibility.isLoading &&
 		eligibility.isEligible &&
 		! hasDismissedForSession &&
 		! isSuppressed &&
-		!! variationConfig &&
-		variationName !== WELCOME_BACK_VARIATIONS.CONTROL;
+		!! variationConfig;
 
 	useEffect( () => {
 		if ( eligibility.isForcedVariation ) {
@@ -271,17 +190,6 @@ export const ResurrectedWelcomeModalGate = ( {
 					<div className="resurrected-welcome-modal__actions">
 						{ variationConfig.ctas.map( ( cta ) => {
 							const variant = cta.variant ?? 'primary';
-							const icon =
-								cta.icon === 'big-sky' ? (
-									<span
-										key="icon"
-										className="resurrected-welcome-modal__cta-icon"
-										aria-hidden="true"
-									>
-										<BigSkyLogo.CentralLogo size={ 18 } fill="currentColor" />
-									</span>
-								) : null;
-
 							return (
 								<Button
 									key={ cta.id }
@@ -294,7 +202,6 @@ export const ResurrectedWelcomeModalGate = ( {
 									) }
 								>
 									<span className="resurrected-welcome-modal__cta-label">
-										{ icon }
 										{ cta.getLabel( translate ) }
 									</span>
 								</Button>

--- a/client/components/resurrected-welcome-modal/style.scss
+++ b/client/components/resurrected-welcome-modal/style.scss
@@ -124,13 +124,5 @@
 .resurrected-welcome-modal__cta-label {
 	display: inline-flex;
 	align-items: center;
-	gap: 8px;
-}
-
-.resurrected-welcome-modal__cta-icon {
-	display: inline-flex;
-}
-
-.resurrected-welcome-modal--treatment-ai-only .resurrected-welcome-modal__hero {
-	background-image: url( ./media/bg-01.png );
+	justify-content: center;
 }

--- a/client/lib/resurrected-users/README.md
+++ b/client/lib/resurrected-users/README.md
@@ -1,51 +1,23 @@
-# Resurrected Free Users Experiment Foundation
+# Resurrected Free Users – Welcome Back Modal
 
-This module contains the reusable primitives that power the `calypso_resurrected_users_welcome_back_modal_202511`
-experiment:
+This module powers the welcome-back modal for eligible resurrected free users (180-day inactivity, no active paid subscriptions).
 
-- `useResurrectedFreeUserEligibility` - Computes experiment eligibility (180-day inactivity threshold,
-  account-level purchase checks, feature-flag gates, and ExPlat assignment).
-- Analytics helpers - shared constants for Tracks event names and variation keys.
-- `ResurrectedWelcomeModalGate` - A lightweight modal placeholder that renders the correct variant slot and
-  emits impression/CTA events when the user is eligible.
+## Components
 
-## Flow Overview
+- **`useResurrectedFreeUserEligibility`** – Determines eligibility (dormancy threshold, purchase checks) and returns the variation name for analytics. All eligible users see the MANUAL experience.
+- **`ResurrectedWelcomeModalGate`** – Renders the modal when eligible, dedupes per session, and emits impression/CTA analytics.
 
-1. `TrackResurrections` now logs both the legacy 373-day event and a new `calypso_user_resurrected_6m` event so we can
-   keep historical data while powering the shorter threshold experiment.
-2. `useResurrectedFreeUserEligibility`:
-   - waits for user settings + purchases to finish loading,
-   - checks the six-month dormancy threshold via `last_admin_activity_timestamp`,
-   - ensures the user has no active paid subscriptions (account-level),
-   - fetches the ExPlat assignment for `calypso_resurrected_users_welcome_back_modal_202511`,
-   - verifies that the corresponding feature flag is enabled for the assigned variant.
-3. `ResurrectedWelcomeModalGate` consumes the hook, dedupes display per session, emits analytics, and exposes
-   placeholder copy/CTAs for each treatment. The gate is mounted on `/home/:site`, `/sites`, `/reader`, and `/stats`.
+## Feature flag
 
-## Variations & Feature Flags
-
-| Variation Key           | Description            | Config Flag                      | Placeholder CTAs                                       |
-| ----------------------- | ---------------------- | -------------------------------- | ------------------------------------------------------ |
-| `control`               | No modal               | `welcome-back-modal-control`     | -                                                      |
-| `treatment_ai_only`     | AI-only CTA            | `welcome-back-modal-ai-only`     | “Create a new site with AI” → `/setup/ai-site-builder` |
-| `treatment_manual_dual` | Manual + continue      | `welcome-back-modal-manual`      | Manual onboarding + “Continue where I left”            |
-| `treatment_ai_dual`     | AI + continue          | `welcome-back-modal-ai-combo`    | AI builder + “Continue where I left”                   |
-| `treatment_all_options` | Manual + AI + continue | `welcome-back-modal-all-options` | Manual onboarding, AI builder, continue                |
-
-All variants are feature-flagged so that we can selectively enable treatments during incremental rollouts. Control
-remains opt-in so we can disable _all_ UI safely if necessary. Enabling any of the variant flags automatically forces
-that experience to render - even if the user would otherwise be ineligible or the experiment assignment has not loaded -
-which makes it easy to test each treatment locally.
+- **`welcome-back-modal-manual`** – When enabled (e.g. `ENABLE_FEATURES=welcome-back-modal-manual yarn start`), forces the modal to show for the current user regardless of eligibility, for local/testing.
 
 ## Analytics
 
-- `calypso_resurrected_welcome_modal_impression` - Fired once per session when a variant modal opens.
-- `calypso_resurrected_welcome_modal_cta_click` - Fired whenever a CTA is pressed with `{ variation, cta_id }`.
-- `calypso_resurrected_welcome_modal_dismiss` - Fired whenever the modal closes, with `{ variation, source }`
-  capturing whether the dismissal came from a CTA or the close button.
+- `calypso_resurrected_welcome_modal_impression` – Fired once per session when the modal opens (`variation`).
+- `calypso_resurrected_welcome_modal_cta_click` – Fired on CTA press (`variation`, `cta_id`).
+- `calypso_resurrected_welcome_modal_dismiss` – Fired on close (`variation`, `source`: `'cta'` | `'close'`).
 
-## Next Steps
+## Events
 
-- Replace the placeholder modal content with the final Figma designs per variant (request links when starting each task).
-- Wire CTA destinations to the finalized flows (manual onboarding, AI builder, and continue-with-site actions).
-- Hook up the experiment exposure event in ExPlat once the treatment UI ships.
+- `calypso_user_resurrected` – Legacy 373-day resurrection.
+- `calypso_user_resurrected_6m` – 180-day resurrection (used for this modal).

--- a/client/lib/resurrected-users/constants.ts
+++ b/client/lib/resurrected-users/constants.ts
@@ -4,32 +4,8 @@ export const RESURRECTION_DAY_LIMIT_EXPERIMENT = 180;
 export const RESURRECTED_EVENT = 'calypso_user_resurrected';
 export const RESURRECTED_EVENT_6M = 'calypso_user_resurrected_6m';
 
-export const RESURRECTED_FREE_USERS_EXPERIMENT =
-	'calypso_resurrected_users_welcome_back_modal_202511';
+/** Rolled-out welcome-back modal variation (manual onboarding + continue). */
+export const WELCOME_BACK_VARIATION_MANUAL = 'treatment_manual_dual' as const;
 
-export const WELCOME_BACK_VARIATIONS = {
-	CONTROL: 'control',
-	AI_ONLY: 'treatment_ai_only',
-	MANUAL: 'treatment_manual_dual',
-	AI_ONBOARDING: 'treatment_ai_dual',
-	ALL_OPTIONS: 'treatment_all_options',
-} as const;
-
-export type WelcomeBackVariation =
-	( typeof WELCOME_BACK_VARIATIONS )[ keyof typeof WELCOME_BACK_VARIATIONS ];
-
-export const WELCOME_BACK_VARIANT_FLAGS = {
-	control: 'welcome-back-modal-control',
-	aiOnly: 'welcome-back-modal-ai-only',
-	manual: 'welcome-back-modal-manual',
-	aiCombo: 'welcome-back-modal-ai-combo',
-	allOptions: 'welcome-back-modal-all-options',
-} as const;
-
-export const WELCOME_BACK_VARIATION_FLAG_MAP: Record< WelcomeBackVariation, string > = {
-	[ WELCOME_BACK_VARIATIONS.CONTROL ]: WELCOME_BACK_VARIANT_FLAGS.control,
-	[ WELCOME_BACK_VARIATIONS.AI_ONLY ]: WELCOME_BACK_VARIANT_FLAGS.aiOnly,
-	[ WELCOME_BACK_VARIATIONS.MANUAL ]: WELCOME_BACK_VARIANT_FLAGS.manual,
-	[ WELCOME_BACK_VARIATIONS.AI_ONBOARDING ]: WELCOME_BACK_VARIANT_FLAGS.aiCombo,
-	[ WELCOME_BACK_VARIATIONS.ALL_OPTIONS ]: WELCOME_BACK_VARIANT_FLAGS.allOptions,
-};
+/** Feature flag to force the welcome-back modal for local/testing. */
+export const WELCOME_BACK_MODAL_FORCE_FLAG = 'welcome-back-modal-manual';

--- a/client/lib/resurrected-users/test/use-resurrected-free-user-eligibility.test.tsx
+++ b/client/lib/resurrected-users/test/use-resurrected-free-user-eligibility.test.tsx
@@ -3,13 +3,11 @@
  */
 import config from '@automattic/calypso-config';
 import { waitFor } from '@testing-library/react';
-import { useExperiment } from 'calypso/lib/explat';
 import { fetchUserPurchases } from 'calypso/state/purchases/actions';
 import userSettingsReducer from 'calypso/state/user-settings/reducer';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
-import { WELCOME_BACK_VARIATIONS } from '../constants';
+import { WELCOME_BACK_VARIATION_MANUAL } from '../constants';
 import { useResurrectedFreeUserEligibility } from '../use-resurrected-free-user-eligibility';
-import type { ExperimentAssignment } from '@automattic/explat-client';
 
 const selectorsState = {
 	purchases: null as Array< { type: string; status: string } > | null,
@@ -39,15 +37,10 @@ jest.mock( 'calypso/lib/purchases', () => ( {
 	isRenewing: ( purchase: { status: string } ) => purchase.status === 'active',
 } ) );
 
-jest.mock( 'calypso/lib/explat', () => ( {
-	useExperiment: jest.fn(),
-} ) );
-
 jest.mock( 'calypso/state/purchases/actions', () => ( {
 	fetchUserPurchases: jest.fn( () => () => Promise.resolve( [] ) ),
 } ) );
 
-const mockUseExperiment = useExperiment as jest.MockedFunction< typeof useExperiment >;
 const mockFetchUserPurchases = fetchUserPurchases as jest.MockedFunction<
 	typeof fetchUserPurchases
 >;
@@ -88,7 +81,6 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		selectorsState.purchases = null;
 		selectorsState.hasLoaded = false;
 		selectorsState.isFetching = false;
-		mockUseExperiment.mockReturnValue( [ false, null ] );
 		mockIsFeatureEnabled.mockReturnValue( false );
 		mockFetchUserPurchases.mockImplementation( () => () => Promise.resolve( [] ) );
 		mockFetchUserPurchases.mockClear();
@@ -121,20 +113,11 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		expect( result.current.hasActivePaidSubscription ).toBe( true );
 		expect( result.current.isEligible ).toBe( false );
 		expect( result.current.isForcedVariation ).toBe( false );
-		expect( mockUseExperiment ).toHaveBeenCalledWith(
-			'calypso_resurrected_users_welcome_back_modal_202511',
-			expect.objectContaining( { isEligible: false } )
-		);
 	} );
 
-	it( 'returns experiment data when resurrected and free of active subscriptions', () => {
+	it( 'returns MANUAL variation when resurrected and free of active subscriptions', () => {
 		selectorsState.purchases = [];
 		selectorsState.hasLoaded = true;
-
-		mockUseExperiment.mockReturnValue( [
-			false,
-			{ variationName: WELCOME_BACK_VARIATIONS.AI_ONLY } as ExperimentAssignment,
-		] );
 
 		const initialState = createState( { lastSeenOffsetDays: 400 } );
 
@@ -146,31 +129,14 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		expect( result.current.isResurrectedSixMonths ).toBe( true );
 		expect( result.current.hasActivePaidSubscription ).toBe( false );
 		expect( result.current.isEligible ).toBe( true );
-		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATIONS.AI_ONLY );
+		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATION_MANUAL );
 		expect( result.current.isLoading ).toBe( false );
 		expect( result.current.isForcedVariation ).toBe( false );
 	} );
 
-	it( 'remains ineligible when the experiment does not return a variation', () => {
-		selectorsState.purchases = [];
-		selectorsState.hasLoaded = true;
-		mockUseExperiment.mockReturnValue( [ false, null ] );
-
-		const initialState = createState( { lastSeenOffsetDays: 400 } );
-
-		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
-			initialState,
-			reducers,
-		} );
-
-		expect( result.current.variationName ).toBeNull();
-		expect( result.current.isEligible ).toBe( false );
-		expect( result.current.isForcedVariation ).toBe( false );
-	} );
-
-	it( 'forces eligibility when a variation flag is enabled', () => {
+	it( 'forces eligibility when welcome-back-modal-manual flag is enabled', () => {
 		mockIsFeatureEnabled.mockImplementation(
-			( flagName ) => flagName === 'welcome-back-modal-ai-only'
+			( flagName ) => flagName === 'welcome-back-modal-manual'
 		);
 		selectorsState.purchases = null;
 		selectorsState.hasLoaded = false;
@@ -184,7 +150,7 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 
 		expect( result.current.isEligible ).toBe( true );
 		expect( result.current.isLoading ).toBe( false );
-		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATIONS.AI_ONLY );
+		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATION_MANUAL );
 		expect( result.current.isForcedVariation ).toBe( true );
 	} );
 } );

--- a/client/lib/resurrected-users/use-resurrected-free-user-eligibility.ts
+++ b/client/lib/resurrected-users/use-resurrected-free-user-eligibility.ts
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { useEffect, useMemo } from '@wordpress/element';
-import { useExperiment } from 'calypso/lib/explat';
 import { isRenewing, isSubscription } from 'calypso/lib/purchases';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -13,13 +12,11 @@ import {
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import {
-	RESURRECTED_FREE_USERS_EXPERIMENT,
 	RESURRECTION_DAY_LIMIT_EXPERIMENT,
-	WELCOME_BACK_VARIATION_FLAG_MAP,
-	type WelcomeBackVariation,
+	WELCOME_BACK_MODAL_FORCE_FLAG,
+	WELCOME_BACK_VARIATION_MANUAL,
 } from './constants';
 import { hasExceededDormancyThreshold } from './utils';
-import type { ExperimentAssignment } from '@automattic/explat-client';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 interface EligibilityResult {
@@ -27,7 +24,6 @@ interface EligibilityResult {
 	isResurrectedSixMonths: boolean;
 	hasActivePaidSubscription: boolean | null;
 	isEligible: boolean;
-	experimentAssignment: ExperimentAssignment | null;
 	variationName: string | null;
 	isForcedVariation: boolean;
 }
@@ -82,46 +78,28 @@ export function useResurrectedFreeUserEligibility(): EligibilityResult {
 
 	const baseEligibility = isResurrectedSixMonths && hasActiveSubscriptions === false;
 
-	const [ isExperimentLoading, experimentAssignment ] = useExperiment(
-		RESURRECTED_FREE_USERS_EXPERIMENT,
-		{
-			isEligible: baseEligibility,
-		}
-	);
-	const variationName = ( experimentAssignment?.variationName ??
-		null ) as WelcomeBackVariation | null;
+	const isForcedByFlag = config.isEnabled( WELCOME_BACK_MODAL_FORCE_FLAG );
 
-	const forcedVariation =
-		( Object.keys( WELCOME_BACK_VARIATION_FLAG_MAP ) as WelcomeBackVariation[] ).find(
-			( candidate ) => config.isEnabled( WELCOME_BACK_VARIATION_FLAG_MAP[ candidate ] )
-		) ?? null;
-
-	if ( forcedVariation ) {
+	if ( isForcedByFlag ) {
 		return {
 			isLoading: false,
 			isResurrectedSixMonths,
 			hasActivePaidSubscription: hasActiveSubscriptions,
 			isEligible: true,
-			experimentAssignment,
-			variationName: forcedVariation,
+			variationName: WELCOME_BACK_VARIATION_MANUAL,
 			isForcedVariation: true,
 		};
 	}
 
-	const isLoading =
-		isUserSettingsFetching ||
-		! purchasesLoaded ||
-		isUserPurchasesFetching ||
-		( baseEligibility && isExperimentLoading );
+	const isLoading = isUserSettingsFetching || ! purchasesLoaded || isUserPurchasesFetching;
 
-	const experimentReady = ! isExperimentLoading && !! variationName;
+	const variationName = baseEligibility ? WELCOME_BACK_VARIATION_MANUAL : null;
 
 	return {
 		isLoading,
 		isResurrectedSixMonths,
 		hasActivePaidSubscription: hasActiveSubscriptions,
-		isEligible: baseEligibility && experimentReady,
-		experimentAssignment,
+		isEligible: baseEligibility,
 		variationName,
 		isForcedVariation: false,
 	};

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -46,9 +46,9 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/agents-manager": "workspace:^",
 		"@automattic/agenttic-client": "^0.1.46",
 		"@automattic/agenttic-ui": "^0.1.46",
-		"@automattic/agents-manager": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -46,9 +46,9 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agents-manager": "workspace:^",
 		"@automattic/agenttic-client": "^0.1.46",
 		"@automattic/agenttic-ui": "^0.1.46",
+		"@automattic/agents-manager": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1653

## Proposed Changes

* Enable the modal per request by @isatuncman-auto 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* http://calypso.localhost:3000/home/SITE?flags=welcome-back-modal-manual

<img width="452" height="551" alt="Screenshot 2026-02-27 at 11 57 43" src="https://github.com/user-attachments/assets/c9617faf-5e59-4c77-b76a-2a8086a42f7e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
