### PR TITLE
A4A: Fix checkout layout at large breakpoint

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
@@ -12,6 +12,10 @@
 	flex-direction: column;
 	height: calc(100vh - 32px);
 	overflow: hidden;
+
+	@include break-large {
+		display: block;
+	}
 }
 
 .checkout .hosting-dashboard-layout__body,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-2163/a4a-fix-checkout-layout-at-large-breakpoint

## Proposed Changes

* Ensure the A4A checkout hosting dashboard layout switches to block display at the large breakpoint so the layout doesn’t get constrained by the flex container.

## Why are these changes being made?

* The checkout layout was using a flex container at all breakpoints, which could cause layout issues at larger viewports. Switching to block display at the large breakpoint aligns the layout with the intended full-height design.

## Testing Instructions

* Open the A8C for Agencies marketplace checkout.
* Resize the browser to a large viewport (desktop).
* Confirm the checkout layout fills the available height and no unexpected flex layout issues occur.

| Before | After |
|--------|--------|
| <img width="1920" height="959" alt="Screenshot 2026-02-27 at 3 36 13 PM" src="https://github.com/user-attachments/assets/5aff6a2f-7472-40e0-b8c6-11b0813e8967" /> | <img width="1920" height="959" alt="Screenshot 2026-02-27 at 3 36 37 PM" src="https://github.com/user-attachments/assets/1c66eb78-14de-4efd-b2dd-9694a8119fea" /> |



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites (where applicable)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you considered memoizing expensive computations where applicable?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (if applicable)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

Made with [Cursor](https://cursor.com)
