### PR TITLE
Fix the comparison grid for plan-upgrade flow when on Business

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -238,6 +238,9 @@ const PlansFeaturesMain = ( {
 	// eslint-disable-next-line
 	const [ lastClickedPlan, setLastClickedPlan ] = useState< string | null >( null );
 	const [ showPlansComparisonGrid, setShowPlansComparisonGrid ] = useState( false );
+	const [ comparisonGridVisiblePlansCount, setComparisonGridVisiblePlansCount ] = useState<
+		number | null
+	>( null );
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
 
@@ -707,6 +710,18 @@ const PlansFeaturesMain = ( {
 		'is-hidden': ! showPlansComparisonGrid,
 	} );
 
+	// Match comparison grid width constants: feature column 450px + 290px per plan column
+	const comparisonGridContainerStyle = useMemo( () => {
+		if (
+			comparisonGridVisiblePlansCount !== null &&
+			comparisonGridVisiblePlansCount >= 1 &&
+			comparisonGridVisiblePlansCount <= 3
+		) {
+			return { maxWidth: 450 + 290 * comparisonGridVisiblePlansCount };
+		}
+		return undefined;
+	}, [ comparisonGridVisiblePlansCount ] );
+
 	const isLoadingGridPlans = Boolean(
 		! intent ||
 			! defaultWpcomPlansIntent || // this may be unnecessary, but just in case
@@ -976,6 +991,7 @@ const PlansFeaturesMain = ( {
 										<div
 											ref={ plansComparisonGridRef }
 											className={ comparisonGridContainerClasses }
+											style={ comparisonGridContainerStyle }
 										>
 											<PlanComparisonHeader className="wp-brand-font">
 												{ translate( 'Compare our plans and find yours' ) }
@@ -1004,6 +1020,7 @@ const PlansFeaturesMain = ( {
 													isInAdmin={ ! isInSignup }
 													isInSiteDashboard={ isInSiteDashboard }
 													isInSignup={ isInSignup }
+													onVisiblePlansCountChange={ setComparisonGridVisiblePlansCount }
 													onStorageAddOnClick={ handleStorageAddOnClick }
 													planTypeSelectorProps={
 														! hidePlanSelector

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -14,7 +14,15 @@ import { useRef, useMemo } from '@wordpress/element';
 import { Icon, chevronRightSmall } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback, ChangeEvent, Dispatch, SetStateAction, forwardRef } from 'react';
+import {
+	useState,
+	useCallback,
+	useEffect,
+	ChangeEvent,
+	Dispatch,
+	SetStateAction,
+	forwardRef,
+} from 'react';
 import { useInView } from 'react-intersection-observer';
 import { plansGridMediumLarge } from '../../css-mixins';
 import PlansGridContextProvider, { usePlansGridContext } from '../../grid-context';
@@ -1033,6 +1041,7 @@ const ComparisonGrid = ( {
 	planTypeSelectorProps,
 	gridSize,
 	siteId,
+	onVisiblePlansCountChange,
 }: ComparisonGridProps ) => {
 	const { gridPlans, featureGroupMap } = usePlansGridContext();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
@@ -1043,6 +1052,10 @@ const ComparisonGrid = ( {
 		siteId,
 		intervalType,
 	} );
+
+	useEffect( () => {
+		onVisiblePlansCountChange?.( visibleGridPlans.length );
+	}, [ visibleGridPlans.length, onVisiblePlansCountChange ] );
 
 	const planFeatureFootnotes = useMemo( () => {
 		// This is the main list of all footnotes. It is displayed at the bottom of the comparison grid.

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -167,6 +167,8 @@ export interface ComparisonGridProps extends CommonGridProps {
 	// Value of the `?plan=` query param, so we can highlight a given plan.
 	selectedPlan?: string;
 	intervalType: SupportedUrlFriendlyTermType;
+	/** Called when the number of visible plans in the grid changes (e.g. for narrowing the container). */
+	onVisiblePlansCountChange?: ( count: number ) => void;
 }
 
 export type UseActionCallback = ( {


### PR DESCRIPTION

Part of M4R73CH-1494

## Proposed Changes

* Style a max-width for the container of the comparison grid if 3 or fewer plans need to be compared

## Why are these changes being made?

before:

<img width="1458" height="671" alt="Screenshot 2026-02-27 at 15 07 58" src="https://github.com/user-attachments/assets/5dd3f53b-568b-4034-916a-688ce9e0e042" />


## Testing Instructions

* With the Store Sandbox, get Business
* http://calypso.localhost:3000/setup/plan-upgrade/plans?siteSlug=yoursite

<img width="1302" height="767" alt="Screenshot 2026-02-27 at 15 36 47" src="https://github.com/user-attachments/assets/c6c6d1f5-cf92-405f-b957-7bbf562963fb" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
