### PR TITLE
Theme Showcase: Add HeroModern component

### DIFF
--- a/client/my-sites/themes/hero-modern/illustration.svg
+++ b/client/my-sites/themes/hero-modern/illustration.svg
@@ -1,0 +1,281 @@
+<svg width="483" height="318" viewBox="0 0 483 318" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<rect x="61.7344" y="6.02979" width="260.477" height="159.318" stroke="#2A46CE" stroke-width="0.923077"/>
+<g filter="url(#filter0_dddd_2202_52477)">
+<rect x="317.58" y="1.08008" width="10" height="10" rx="5" fill="white"/>
+<rect x="317.58" y="1.08008" width="10" height="10" rx="5" stroke="#2A46CE" stroke-width="0.923077"/>
+</g>
+<g filter="url(#filter1_dddd_2202_52477)">
+<rect x="57.5801" y="1.08008" width="10" height="10" rx="5" fill="white"/>
+<rect x="57.5801" y="1.08008" width="10" height="10" rx="5" stroke="#2A46CE" stroke-width="0.923077"/>
+</g>
+<g filter="url(#filter2_dddd_2202_52477)">
+<rect x="317.58" y="160.08" width="10" height="10" rx="5" fill="white"/>
+<rect x="317.58" y="160.08" width="10" height="10" rx="5" stroke="#2A46CE" stroke-width="0.923077"/>
+</g>
+<g filter="url(#filter3_dddd_2202_52477)">
+<rect x="57.5801" y="160.08" width="10" height="10" rx="5" fill="white"/>
+<rect x="57.5801" y="160.08" width="10" height="10" rx="5" stroke="#2A46CE" stroke-width="0.923077"/>
+</g>
+<rect x="466.58" y="108.08" width="207" height="99" transform="rotate(90 466.58 108.08)" fill="url(#pattern0_2202_52477)"/>
+<rect x="470.58" y="108.08" width="207" height="3.99999" transform="rotate(90 470.58 108.08)" fill="url(#pattern1_2202_52477)"/>
+<rect x="477.58" y="108.08" width="207" height="3.99999" transform="rotate(90 477.58 108.08)" fill="url(#pattern2_2202_52477)"/>
+<g style="mix-blend-mode:multiply">
+<rect x="466.58" y="108.08" width="207" height="99" transform="rotate(90 466.58 108.08)" fill="url(#pattern3_2202_52477)"/>
+<rect x="470.58" y="108.08" width="207" height="3.99999" transform="rotate(90 470.58 108.08)" fill="url(#pattern4_2202_52477)"/>
+<rect x="477.58" y="108.08" width="207" height="3.99999" transform="rotate(90 477.58 108.08)" fill="url(#pattern5_2202_52477)"/>
+</g>
+<g style="mix-blend-mode:multiply">
+<rect x="466.58" y="108.08" width="207" height="99" transform="rotate(90 466.58 108.08)" fill="url(#pattern6_2202_52477)"/>
+<rect x="470.58" y="108.08" width="207" height="3.99999" transform="rotate(90 470.58 108.08)" fill="url(#pattern7_2202_52477)"/>
+<rect x="477.58" y="108.08" width="207" height="3.99999" transform="rotate(90 477.58 108.08)" fill="url(#pattern8_2202_52477)"/>
+</g>
+<path d="M361.58 115.411C361.58 110.47 365.586 106.465 370.527 106.465H472.634C477.575 106.465 481.58 110.47 481.58 115.411V314.441C481.58 319.382 477.575 323.388 472.634 323.388H370.527C365.586 323.388 361.58 319.382 361.58 314.441V115.411Z" stroke="#2A46CE"/>
+<path d="M150.985 24.626L151.093 24.9258L193.743 143.08L193.963 143.688H174.405L174.297 143.387L163.469 113.056H119.272L108.444 143.387L108.336 143.688H88.7783L88.998 143.08L131.648 24.9258L131.757 24.626H150.985ZM250.083 45.1826C255.289 45.1826 259.791 45.7881 263.577 47.0098C267.484 48.1119 270.737 49.9518 273.32 52.5361C276.391 55.3672 278.416 58.9351 279.396 63.2236L279.573 64.0098C280.428 67.9924 280.852 72.7618 280.852 78.3105V128.131C280.852 131.105 281.21 133.166 281.866 134.388C282.604 135.429 283.766 135.98 285.45 135.98C286.573 135.98 287.64 135.7 288.657 135.135L288.666 135.13L288.675 135.126C289.843 134.542 291.201 133.658 292.751 132.465L293.159 132.151L293.42 132.595L295.224 135.662L295.422 136L295.118 136.246C292.568 138.311 289.951 139.956 287.268 141.177C284.66 142.419 281.34 143.027 277.329 143.027C273.438 143.027 270.233 142.419 267.743 141.174C265.256 139.93 263.38 138.118 262.131 135.744L262.126 135.735L262.122 135.727C261.169 133.713 260.632 131.311 260.493 128.532C257.502 133.03 253.994 136.522 249.959 138.989C245.548 141.686 240.41 143.027 234.564 143.027C229.455 143.027 225.048 142.053 221.359 140.085C217.678 138.12 214.904 135.411 213.054 131.957C211.21 128.513 210.293 124.586 210.293 120.189C210.293 114.831 211.509 110.456 213.985 107.108C216.432 103.682 219.553 100.928 223.34 98.8506L223.345 98.8477C227.219 96.7887 231.275 95.0937 235.511 93.7617C239.836 92.3193 243.864 90.9965 247.59 89.7939C251.413 88.4792 254.499 86.9918 256.859 85.3389L256.868 85.333C259.282 83.7229 260.455 81.6304 260.455 79.0312V66.7568C260.455 62.4681 259.739 59.1262 258.35 56.6934L258.344 56.6816L258.338 56.6709C257.056 54.1053 255.263 52.321 252.965 51.2861L252.956 51.2822C250.746 50.2352 248.049 49.7022 244.851 49.7021C242.13 49.7021 239.223 50.1166 236.128 50.9502L236.119 50.9521L236.111 50.9541C233.319 51.5988 231.091 52.8803 229.402 54.7891C231.841 55.5894 233.866 57.0197 235.466 59.0771H235.465C237.341 61.2147 238.267 63.9067 238.268 67.1182C238.267 70.6023 237.08 73.3858 234.678 75.4092L234.677 75.4082C232.416 77.4139 229.539 78.4033 226.084 78.4033C222.259 78.4032 219.342 77.2258 217.428 74.8008L217.421 74.792C215.555 72.3035 214.623 69.4394 214.623 66.2168C214.623 62.8945 215.423 60.1409 217.062 57.9971L217.067 57.9902L217.072 57.9844C218.789 55.8994 220.988 53.9464 223.663 52.1221L223.667 52.1191C226.602 50.1617 230.316 48.5201 234.797 47.1875L234.8 47.1865C239.418 45.8493 244.514 45.1827 250.083 45.1826ZM260.455 87.7754C259.155 89.3178 257.453 90.6856 255.36 91.8818L255.354 91.8857L255.346 91.8896C252.817 93.2148 250.108 94.6008 247.219 96.0459C244.355 97.4786 241.609 99.1507 238.982 101.062L238.979 101.063C236.51 102.828 234.446 105.125 232.792 107.962C231.16 110.761 230.328 114.346 230.328 118.744C230.328 123.355 231.507 126.967 233.818 129.631C236.125 132.169 239.244 133.454 243.226 133.454C246.501 133.454 249.543 132.519 252.357 130.642L252.364 130.637C255.276 128.773 257.974 125.973 260.455 122.217V87.7754ZM125.06 96.8301H156.587L140.823 51.6211L125.06 96.8301Z" fill="white" stroke="#3858E9" stroke-width="0.908876"/>
+<rect x="1.26953" y="213.08" width="314" height="101.339" fill="url(#pattern9_2202_52477)"/>
+<rect x="1.26953" y="213.08" width="314" height="101.339" fill="url(#pattern10_2202_52477)"/>
+<path d="M0.5 215.104C0.5 210.163 4.5055 206.157 9.44654 206.157H312.784C317.725 206.157 321.731 210.163 321.731 215.104V414.134C321.731 419.075 317.725 423.08 312.784 423.08H9.44654C4.5055 423.08 0.5 419.075 0.5 414.134L0.5 215.104Z" stroke="#2A46CE"/>
+<g filter="url(#filter4_dddd_2202_52477)">
+<circle cx="20.2695" cy="226.08" r="5" fill="white"/>
+<circle cx="20.2695" cy="226.08" r="5" stroke="#2A46CE" stroke-width="0.923077"/>
+</g>
+<g filter="url(#filter5_dddd_2202_52477)">
+<circle cx="38.2695" cy="226.08" r="5" fill="white"/>
+<circle cx="38.2695" cy="226.08" r="5" stroke="#2A46CE" stroke-width="0.923077"/>
+</g>
+<g filter="url(#filter6_dddd_2202_52477)">
+<circle cx="56.2695" cy="226.08" r="5" fill="white"/>
+<circle cx="56.2695" cy="226.08" r="5" stroke="#2A46CE" stroke-width="0.923077"/>
+</g>
+<defs>
+<filter id="filter0_dddd_2202_52477" x="314.644" y="-5.8651e-05" width="15.8716" height="16.4913" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2.47484"/>
+<feGaussianBlur stdDeviation="1.23742"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.01 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1.85613"/>
+<feGaussianBlur stdDeviation="0.928066"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_2202_52477" result="effect2_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="0.618711"/>
+<feGaussianBlur stdDeviation="0.618711"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect2_dropShadow_2202_52477" result="effect3_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="0.618711"/>
+<feGaussianBlur stdDeviation="0.309355"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.03 0"/>
+<feBlend mode="normal" in2="effect3_dropShadow_2202_52477" result="effect4_dropShadow_2202_52477"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect4_dropShadow_2202_52477" result="shape"/>
+</filter>
+<filter id="filter1_dddd_2202_52477" x="54.6443" y="-5.8651e-05" width="15.8716" height="16.4913" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2.47484"/>
+<feGaussianBlur stdDeviation="1.23742"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.01 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1.85613"/>
+<feGaussianBlur stdDeviation="0.928066"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_2202_52477" result="effect2_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="0.618711"/>
+<feGaussianBlur stdDeviation="0.618711"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect2_dropShadow_2202_52477" result="effect3_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="0.618711"/>
+<feGaussianBlur stdDeviation="0.309355"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.03 0"/>
+<feBlend mode="normal" in2="effect3_dropShadow_2202_52477" result="effect4_dropShadow_2202_52477"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect4_dropShadow_2202_52477" result="shape"/>
+</filter>
+<filter id="filter2_dddd_2202_52477" x="314.644" y="159" width="15.8716" height="16.4913" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2.47484"/>
+<feGaussianBlur stdDeviation="1.23742"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.01 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1.85613"/>
+<feGaussianBlur stdDeviation="0.928066"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_2202_52477" result="effect2_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="0.618711"/>
+<feGaussianBlur stdDeviation="0.618711"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect2_dropShadow_2202_52477" result="effect3_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="0.618711"/>
+<feGaussianBlur stdDeviation="0.309355"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.03 0"/>
+<feBlend mode="normal" in2="effect3_dropShadow_2202_52477" result="effect4_dropShadow_2202_52477"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect4_dropShadow_2202_52477" result="shape"/>
+</filter>
+<filter id="filter3_dddd_2202_52477" x="54.6443" y="159" width="15.8716" height="16.4913" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2.47484"/>
+<feGaussianBlur stdDeviation="1.23742"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.01 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1.85613"/>
+<feGaussianBlur stdDeviation="0.928066"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_2202_52477" result="effect2_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="0.618711"/>
+<feGaussianBlur stdDeviation="0.618711"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect2_dropShadow_2202_52477" result="effect3_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="0.618711"/>
+<feGaussianBlur stdDeviation="0.309355"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.03 0"/>
+<feBlend mode="normal" in2="effect3_dropShadow_2202_52477" result="effect4_dropShadow_2202_52477"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect4_dropShadow_2202_52477" result="shape"/>
+</filter>
+<pattern id="pattern0_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00243466 0 0 0.00509065 -0.0144928 -0.028505)"/>
+</pattern>
+<pattern id="pattern1_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00243466 0 0 0.125994 -0.0144928 -23.2056)"/>
+</pattern>
+<pattern id="pattern2_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00243466 0 0 0.125994 -0.0144928 -23.2056)"/>
+</pattern>
+<pattern id="pattern3_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00243466 0 0 0.00509065 -0.0144928 -0.028505)"/>
+</pattern>
+<pattern id="pattern4_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00243466 0 0 0.125994 -0.0144928 -23.2056)"/>
+</pattern>
+<pattern id="pattern5_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00243466 0 0 0.125994 -0.0144928 -23.2056)"/>
+</pattern>
+<pattern id="pattern6_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00243466 0 0 0.00509065 -0.0144928 -0.028505)"/>
+</pattern>
+<pattern id="pattern7_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00243466 0 0 0.125994 -0.0144928 -23.2056)"/>
+</pattern>
+<pattern id="pattern8_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00243466 0 0 0.125994 -0.0144928 -23.2056)"/>
+</pattern>
+<pattern id="pattern9_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00160501 0 0 0.00497317 -0.00955415 -0.00477707)"/>
+</pattern>
+<pattern id="pattern10_2202_52477" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_2202_52477" transform="matrix(0.00160501 0 0 0.00497317 -0.00955415 -0.00477707)"/>
+</pattern>
+<filter id="filter4_dddd_2202_52477" x="10.8086" y="219.619" width="18.9219" height="19.9229" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.01 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_2202_52477" result="effect2_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect2_dropShadow_2202_52477" result="effect3_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.03 0"/>
+<feBlend mode="normal" in2="effect3_dropShadow_2202_52477" result="effect4_dropShadow_2202_52477"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect4_dropShadow_2202_52477" result="shape"/>
+</filter>
+<filter id="filter5_dddd_2202_52477" x="28.8086" y="219.619" width="18.9219" height="19.9229" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.01 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_2202_52477" result="effect2_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect2_dropShadow_2202_52477" result="effect3_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.03 0"/>
+<feBlend mode="normal" in2="effect3_dropShadow_2202_52477" result="effect4_dropShadow_2202_52477"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect4_dropShadow_2202_52477" result="shape"/>
+</filter>
+<filter id="filter6_dddd_2202_52477" x="46.8086" y="219.619" width="18.9219" height="19.9229" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.01 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_2202_52477" result="effect2_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.02 0"/>
+<feBlend mode="normal" in2="effect2_dropShadow_2202_52477" result="effect3_dropShadow_2202_52477"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.03 0"/>
+<feBlend mode="normal" in2="effect3_dropShadow_2202_52477" result="effect4_dropShadow_2202_52477"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect4_dropShadow_2202_52477" result="shape"/>
+</filter>
+<image id="image0_2202_52477" width="629" height="203" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAnUAAADLCAYAAAAIqGV4AAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAACdaADAAQAAAABAAAAywAAAABI7++7AAA2DElEQVR4Ae3daXdcxbU38BpOd2sebI0eMJMN2NgkFtZkQ0QIJE4gyU1uo8EkT17lc+Rz3FdZTy6WHa3cdUOS64TcBCdgyzJRwmBDGIIBYw0tWZZkW0P3qarnbImmJVh01z480ULOX2uBTp9T1Wf3r+vfu+U3JUT0c/jbU9X0m/Nz9OjbKfqPM6enxwXcOfT8G1VfnNf0eeojD47fRtbX9uRYhRBO/vPrczLO+7s6Z2PqW7XgSGzcmt3oTH3R1+wXvb6NylT8NfvPzxS9R/Hr4+UwzmcmMlUwpvcJmSIPJ+Ov2Y3NlKJCwwrb3907cX/hrSx9NFNX88RsfU1P6ZGFEUvN0wdma6uf5nyx60pf3kL1tfdO7Sk8U+mjOPXN1dUcpPpKP3thxOG+qW1UX1d6envhbOmj6D7fX2qZOFJ6ZGHE1dra9mt1tX2FM6WPOvvGb6f62vrHGkqPLoxIVKpjnX2T7YUzpY8i84dn66q/V3pkYURn38Qubn370heTpsL0dQ9MPVB4ptJH1+qqH79WW/310iMLIw6np/cElfppzhfPzZIpWhuFV1r6iDK1vC3zaOmRhRGUqWu1tf2FM6WP4mYqWam+u9ySYa/ZjcgUrdm4mSL30mqFEfk1y8k81bfyOXZskt0HuJnKNU7fRZmK0wc2ok9lWzOH4vYpbqaoD2xEpvJ9gNunkKnVXG2mTKnRX21bCIz6k1zU7xc+FkofSWdHRU5fKD2yMEIvireV0S+eOrV7uXC2+NHw0M4ZJfWfl5LmSvGR668GoboQ5Oxf158t/kjeVBeovuKj1l9dqmmY0s6drbtxbXr9leKPovuMShO+WnzU+qtS61eslcPrzxZ/VD93Y1xpN9w0e/N68ZHrr2qj/6wX9OvrzxZ/pMLsqAnFueKj1l/VC8FVqm90sPXq+iuf/eji0L4s1SdvyH989qhPX9FOjwbGvvzpK0XOLIsxen/PPNvo7bdZMrWQkFNFXvmnLlGmTJD7y6cuFDlBmbJOni0y5FOXPk+mhMn+/VNPWOyECkaUdazMl5UtTays2XtaZ4o99dpr+TXLzVQytC+70LE+x8RHa5abKeoD6rp+b23dpY6tC8/HzRS3D1B9N5LiUqma1l4nO6nd39aeK3Wc7wPc+uhzgpsp6gMbkSnqA3H7FDIVrZhbMFOlcoDrEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgMDHApI2cq7WW79hhPnbSye2X/74SomDrr7JbqvU8sjxxtESQz++fGhg8s7AiQPZ6qbfjP6HzH18ocgBbaRuKk2PE/L8yGDzZJGh6y519E8+5qzInD/Z/Mq6C0UeHE5P3RMqc+/IyZZfFhm27hLVZyvs17LSvDA6uM17/9eu3oknRCDeH36m5bV1T1jkQUd6fK8K9G3Dg02/LTJs3aWOY1drhA0fEyr4/cgzW+fXXSzyoLN/4slo38R/jAy1eu//2jEw1aacqBoebPxTkaded+lQOtOiAne4PLXwm9M/vWNp3cXPeNDT44KllslvOqXeGDne9PZnDPvU6c6+iQ5hZXDu581nPnXxM050D4ztMk4/uGV2/te+e0EiUwVMypRVZvfwyZZfF84WP/o8mZJCvHf2ZIv3ntS0ZoWxW0dONj9XvKrC1Xym2Gu2dfIoN1NdA+PtMtRlZ3/e9OdCBcWPjqTHbssF+hC7vihTRskLLx1vfrf4HQpXO3onOpWUavhEs/f+viub3jt1MFfb9CtOH7CV9lER6peGhxq89wGnPmWcuMnpA+29U3u0snu5fYr6gJXiLKtPDWS+6Yy7wqkvTqZozSoTPhqnTyFTQmymTKmVeErhkiJpClEtfeSEM9FG2Lb0yMIIaVRgrVgY/Q8RFs4WP5pNZZZphA6cKz5y/VVt5HI0h1WfUbnIQy6uf6bij67Xmmi/chcGKpUtPnL9VaPEgspq1hyVjLamdsbri0/+bgmntZC810RzrdM2+iLNslDSZG20LvL39v2tpLiRm6lK+I6ncVZo43LWex3RHClUlv4QoWPfHyNTUZ8TN3zHfzxuE2RKhVmvP6zyryluppyTrDVLmbJKLsfJVE7LhXy9Pr9pzUppWTkM7XKSMsVeszEyRfcxzPoWU4lcnExFAXGpnOFlKprD/cx0OhlKLW5y+8BKz4k+AX3e17VjAi2j7yX+P0rkdJw+RX2Amynl5E1un8oGYdQNeZmiPoBMfbQGkCn/MGAkBCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIPCxQPdA5ksrm1R/fKb0QcdAZvfKxsylh3484sjAbH3XsYn9H5/wOnCSNt3m1kebMkdzdnjd4qNBVF9HenwvZ05POlNF9fX86FIZZ16c+jr6J5tpM2fOffL1HT36doozjxza+scaOHO60tPbufXR5u2dvVMHe3pcwLkX1UfvF2tOtGbb0xN3cObErW8zZGoj1uxGZ6rt6alWzvt7KJ1pibNmKfNxMsVds5SpQwOTd3JeU9w1S5/N3PqoD8TNFOc1CeFknEzR52ycPsXtA1TfRvUB+lzm1pfvA3Eyj0wJsZkypahYa+2hIGtZH4bS2vukk/dzgrnsFrc5o1gfhl3pD+ulNQejfbe3cO4lld0vctndnDnWLN4ttW7nzLkehGXC2rabS8lGzjwtzYMizLG+dEYbqt9jtWnj3GdZqFqqL7O1juWnlHpQu8TtnHs5ae4LA8taE6Yi3OqkfXBx+0yF773og4neJyOXWH5KuDt1IB/wvc/KuJTYJpQ5WF7+jvadt1kylc2mmn1fE42jTClr7+LMoUwpLb/EmRM3U1LajkRobuPcS0t3PzdTNiVrKFNXG8urfO9Fa5YylbU5nl9g9mojWH7iozXLzRR9Nrtcrsn3NdE46gPcTIWpcCdlivOlmPpAnD6lpLnXObWH85pyIncnfb5w66M1wc0U9QFuplJW3sHNVL4PcPsUMvXRytlsmeIs3nw46F9WuP+6QnO5fynQnI2sL8694sxp+7FLiJ84Ra+P8xPnXrHN2fU5uaH1ceBWxjq54s6cF+c1xZmDTBXemDh+myJThZfoeRRvzXalL5d73uDjYXHM6V+obsVMxbGIM4fs4vTROPeKMweZ+jge4lbMVOHV4QgCEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQOCfLLC6cbuTnNvQ1lO0xyVrTrS1WMexqzWcOTSWu7E8zaEtPWgTYzr2/aFtVDaqvgM/mKjkbt8Vt76H0uOsfWnJixy42/9Qfdw1sbLNULRBte97lB/X/sMPt3K3WYtbH3eTc6rxVs0Ud6ucuGs2TuZpzcbJFH/N5t/f/Gr0+93zo2t1G5WpOGt2ozJF22LFqS/OmqD1wO0DG1kf5QmZWs1PvPcXmSK9tWtW0Qda4PT3Ovoz+/0+mlZHLS5XfMtW2W7OnKXm6QPChH2cD156o6m+9t4p1qbMNkh+cznhDnPqm6urOUj1ceYc7pvaRvXRb868iqz87tJSWSdnzrXaqi4Rmu9z5nT2jd+e1erfuIGRJtebmM20c+41W1/TYyvNE5w5nX0Tu8iPUx99UVDZ4Hsdb01/mXOva3XVj5tK08OZ09V/9Z6cXU5zGv9myVT3wNgujgVlSiSSD3PmrGSKuWbjZkqG4ZNLCxVtnPpozYbl7t85cyhTcdbs0tJyOk6mTLl9jFNffs1yMyWzie93vJm5n3OvmbqaJ7iZWm69ejdlKk4f6OifPMCpj/oUtw9kWzOH4tbHzZRTye9xMzVbW9MWpw/E6VPI1Opq20yZUmeebbwuhX0uuKkuccJiQ3nGOvEyZ45eFG/TvU7/9I4l33mjg9umac5S0lzxnUPjrAvPi1z2Jc4ceVNdoHtx5izVNEwpI/+YmGjIcOYZGf5ZmvBVzhynk3+V0jzPmZOrabninDpdPd46y5kX/Qva7/WSYtVnZTCsQ3uGc5/cTZcRSj5P77PvvFOndi9TfcEN8ZbvHBqnAjHihDzPmZO9kf2A6qOc+M7bLJm6oZW3Ob322JlirtnPlSmXfcP3fVp5TdGaTdjwD5w5183MGGVqdLD1qu+8/JrlZkqL1PnAmr/43ofG5dcsN1Nx+oAO3AtxMxWnDywG7h8ci8Cp4awzo5w5+T7ArY/6ADdT1Ae4fUotqNfi9IHYfQqZuiUzxckExkIAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQOBfXEDuS19M1gRbv29Cce78UIv3/q/dT2UetsKZcz9v9t7rs713ao9Udv+W2flfr+6FWFqfNkenTeJDZ1586cT2y6VnrI7oGMh80xl35fzJ5le856TH94pA3Tcy2PwL3zlHBmbrjVv6Rlbr06P/2TjuOy/amPr7Srm3hp9pec13Tmfv1EGhzPZzgy2/8p3Tlb68xQWpr8lw+X+Hh3bO+M6LU19H70Sn0GrLyPGm//G9z6G+KzuVDNrLUwu/8d1rsafHBYutme84q147f7LRe/9XWrNGu1T0/v7et744a3azZEo5/aczJxrHfC3iZkoFas/wYPN/+96HMhW67GM5LV/4Z2eK1qxUopGTqYfS4425QD+ib8pTvnsC59csN/Pd/ZNdToqa4ePNv/P16+6dvMso8aU4mdJWvHz2ZLP3/qqUqVDb4Pxgyx9964uTqXwf4PapjqfGH5FKLpw70TLiW1/HR30gTp/iZqqrf/K7xopL3D7FzVS+DyBTQtzqmVK00J2RU1rk5nwXPY0zgbwpE26eM0fbaI4Rc6dO3Z31nTebyiwLKWeULmPVJ4ydCaJX5nsfGmcTakk6671JN82pvja1EG0Vf61sXtygx74/yolxldXeDvS89OGkrJvwvQeNS4lU1lk3q5bLcpx55BB9KfbexJ6eWwtxg75Ic+4TGHtTWHF9xpRH0xk/0fsrAxXZ+/+4hL0WjZ70nxH52fAa1ceZQ2M3Q6ZCrVhrNm6mjJPsTNGa5WYq+myZMFleDqNN7Oe4mdJCL1J912ujdsz4oUyFxswypkQfSu66iV4XZ86yMnNxMkWfzVKqRc69qA9oJaY4c4LkisE8tw9YK69y+5QIgvnos/Ympz6dcDedcNe49VGf4mZKRp9H3D4lEjrHzVS+DyBT0UpApjhxwFgIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAINpOlBA6+yY6nE68MfLMVu+9XGnTYyfk4vmhlku+kG39Yw3aJW4/f2/DX8VPpNe+ibQR9lJTpsMlgtc49XUdm9gf7bU4f/b4tvd966ONukOtdwyfaPqb75yedKYq2jD2gYWUe/nVn7V47zHY0T95QEszx6mv7emp1lTObD17suUCp75l7Q7Uzc2Pnjq1e9l3Xnvf1IMpE77/wlCr976OhwYm71Q5WzYy1Pq6731oo25Xae+vnZ3/K6e+7t7xQ0qXv/Pi8Traz9Xrp7N37D5tE/bMUOObXhOiQR3HrtZoG+7j1rcZMsVds3EztazUNs6G5ZSpBS2+vJSwf+VmKnBq+syJxjHf9/dQ35WdCadrOZla2Vy+wu6Pkyltlt4dHto5411flKnA6eTwYMPffed8njUbqLK3OJmiPhCIwMTJ1Nl7mkZYfaBlso3bp7p7J+4PrbjJ7VNJF+wcvrfxFVZ9UZ/iZipOHziUzrRI5ZqRKSGoTyFThT5FmVJtT45VRB8WB4KsbfX90KBxMpB3RRs57+PMUUI2Rxto33d05J2E77zF7TMVQrm90mS3+M6hcdHmz3tMKO/kzMkmgtuscPdz5lwPwjIXOZTbRD1nnnLufmMUyzww7i4nxQHOfXJa1kTfnu/PbK1j+Wln99IXXM69tLW3iUDdx5ljKsKtxon9M1u2pHzn7UtfTFqp9+Vyiyw/qfVtNrCs+igX0ZpgrfPNkqnoDwTWmqBMiTDY5fs+0TjKlJY8P8qUFO4+bqaEEw8YYXZy6tNCsTMlKkQ1ZWq2qqzS9160ZilTQqdYfiq0u4QzsdYsN1NCqPtcLtfk+5poHPUBbqZENruDMsXuAzH6lFXijqjGuzmvib7QUR/g1kd9gJsp6gPcTKmE3M7NFPUBZGp1FSBTnDRgLAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCCQF2jrH2s4evRt7703aR5tGk3/5Z/D5zfdgzYj9hm7dgzV19PjgrXnSh13pS9voY23S41bez1efU5GmzI3CxHtysr4iVsfWTBuEw118nDf1DZufSvm0cbqnHuR35GBWdYeuG0/donV+jh3EiJOfQd+MFHJXbOfpz5kSoiNzBStiTiZ567ZjcwU7SPMre/zrNkeZubjZIrWROzMM/vARvYp6gO3Wp9Cplb70mbKlKIPwcDp781uqd7Daqs2fCzaaPoIZ85Mfd39Srtv9/zoUpnvvIfS441U30Lz9J2+c2icC1Jfs1W2mzNnrq7mINXHmXO4b7o12kj8O0fS46yNxIVKPhFtZt/Gude12qquhAue4Mzp7JvYFQr7REd/hrVRN5kvSfcA516zdbWPGLf0Dc6c1FzmNqqPPjx859Hm6FTfYkLe4zuHxlWE4qvKhI9y5qjrE3uoPs6XhU2TqcZJ1pqNmymtBWtNxM1U0upvmjJ7gPP+0poNbfY7nDn5TLX1j2/1nZdfs9xMJauCh3M2G2vNxsnUctLe4fuaaFx5KL/BzdR0XdXdlKk4fWB5++R9nPpE1KeUC7s4c/J9gFsf9YEFZqaoD8TpU9xM0ZqN06eQqdWVk+8DmyFT6syzjdelsM/VzVx/i7PwhQp+nxDJYc6c8px7Uxn9m9M/vWPJd94LQ61TVJ+pbbjkO4fGyXD5f1M5eYYzJxnK1wKhfs2Zc+ZE4xjV9+JQ62XOvNDK5xYS8iXOHL0QjGohn+PMOXei9b2EMb8dGWzKcOZZEZ5aSLmXOXPUTXkmDNXznDnJyab3yXx0cNu077yLQ/uyVF958sZF3zk0zqnEn7LSvMCZ0zB74x2hg/+hnPjO2zSZqm/+0Pc10bi4meKuWcoUrdlYmYqxZo0Rv+U4lE20fEj1xVmzcTJljXiRU1/leMubcTKllfldKrH4Nude1Ae0Sp3mzMlnKk4fyFY2/51zLxVmn08lkyOcOdQHKPNx6jPMTAmb/TW3T8mb6gI3U/k+gEwJQX0KmeIkAmMhAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCDwLy8gaaPp6qCx30lxduR4k/e+f139mW84Z5aiPeVO+yq2907t0dI8WDd3/RenTu1e9pnXcexqjTTme0KY07R/nc8cGtPZP/Gksm7i7MlW7/1VD/WP7wuEPDA82DLoex/a4DfhgidoLz7as9J3Xlf/RL+x8vXzJ5tf8Z3T2Tt10AmzZ+RkywnfOYfSmZZAucdpj8HhoZ0zvvOoPqHEheFnWl7zndP51ORhp0XLyGDzL3znHOq7slO74OGFpPvvV3/WctNnXtuPXSJ5ffLfjdWj5082eu9Z3N4/8VVtRcXwyRbv/X1X1qwybXWz1//Ld81ulkxJo34/PNRwxcecxsTNlLJyP2fNUqYCp49G+5f+gZspK+TFaP296vuauvsnu4x1uzj1daWntwtlHs3axC9Hh7bM+dwrv2a5merozxyJ9pauPzfY8iuf+9CY7t7Ju4wU3YsJ91/cTFmp/sLpAx29k49LIfW5k02nfOuLk6mVPmDNv3H7VHvf1LeiXZ/nz59o8t7zOd8HOJnP9yl+pjJPKWsucfsUN1PUB5R2jyFTQtzqmVIUROvEu2Eu4G34HpoPpJZXfYNM45x189KqD32bI825kZ1Yir7Qved00vsLCc0TVl+JNnD33oR9dUowY4W6vDLf839Nszeje5j3xIJg3ctZ/aa20utLTL4UGfkJJV/PP/b5bZfCeSftB2q5LOczPj/GWnFJOjuff+zzWzs1rZTz/pJFzxkYe1NIe2WLXjQ+96Axo9uEWakvUAu+c2hcItRXRCDe58zRdmnaOTe+uHi3d330/JshUzYpWWs2bqaiZvIux5wyFX2RuczNlJX6LRc61mtyoZziZiq7lL1GmcqVZUPf15Vfs1YkrvnOoXFBVJ9U4j3OHGez18iPmyln5AfCRZ8xnB9rP5SB/ZAzRaSWr1KmuH0gTqakCS9F/yjA6lNWr/YBbn3UB/iZku9w+5RSyTlupqgPIFOrqxSZYqUVgyEAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABIWRPjwuWWiaORHvkvcra8P3YxH6V1dkzQ41v+kJGmx7vkCa3/dy9zS+Jn0jrM+/o0bdT12qrurj1dfRPHnBWLXE2fO8eGNtlrWo5d6JlxKc2GnP421PVpiJsW0jIl3w3z6Z57b2TD9Der8NDTe/QY58f2qg72pu29tzJxr/6jKcx+frq524Mc/YypE2PQy3/MfqfjePe90pP3WOUqNyI+rqfyjxstHsz2rx90re+rmjN2qwzI0Ot3vvn0kbdzpgHts7Nnff12yyZKisre/n0T+tnff0oUyqUC6w1G2XKiETDyPHGUd/75NcsN1OdvVMHlc5dPXt8m/f+voc3cM3GzVRO2bLzJ5tf8fWLs2bpuTv7xnty0l0YHdw27XuvOJnqSl/eYnRq3/l7G8/8s/sA1WdCvczpA5+nT3EzFacPRO/T7U4FW5EpIZCp1aSuzZQqL39HSyG3KVHW6BvklXGh2JULzHbOnCBrK6UQd7WNCe0770pDdSCc2h5qVek756Nxu5WzrNfkpKqh+jj3samlhJB6V3koqzjztHJ7bULWcuZEu4dXSWXu4cwRFaJaCH17pq4y+u3/E9ndlsqZrf4zRPQ2hTVC8dZE9IU4uoe+fWbLlpTvvfalLyadsjuCUNX5zqFxzritKtC3seaEtkVJcSdnzmbJVG4prOC8rmjsbhk4dqaUM3s494mbKcqGs8EWzr3ojxCh3N2cOTYla+Ks2TiZCpWpF1Lt4NTnPlqz3ExRHygLE7zMh2oHN1NGlTVQprh9gOoTIsV6f50Vt0vlmjh+SuTqY/WpqA9wM0V9gJspqWU1N1MrfSBGn0KmVlfOrZgpTiYwFgIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhAQois9vf3o0be9994ks7b+sQbaOJrj1/OjS2WH+q7s5MyhsYf7prbRJumceYfSmRbaGJwzp+3JsQrazJkzJ9pRVB5Jj0X7ibpou0D/H3pNceqj1+V/FxrpJG0AHae+nnSGtZ8tjaeNhTn1tf3YJVbr48xaXbPc+o4MzNZz1yzlIm59yFT0OfEFzxStoYfS46z9bDcyU23pmVpat5x0fNEzRX2ge2BsF+c10VjqHdw+sJF9ivoAt75bsU8hU4WVTd+tNqJPrc2Uoi8WVptvzdVU7y6UUvoo6fRD0ua+UnpkYcRitmqfEsFRTrOjUIbCPrHcOHV74ZlKHwWBfcRWusOlRxZGJMr1l4UJv1k4U/qooz/TlNP6G519E6wPKSPc49Fm9m2l71AYkaiU7ToQXy+cKX10JD2+0wn1+OG+6dbSowsjVsy1O1A4U/poOeEOO514rPTIwgg9N30H1cdprLSAac0uJuQ9hWcqfZQT2S5hQ1Z9s1uq96z4Mf5A2CyZWmqZYP0BEztToWGZf55M2Qq7v/RKKIygNZsLNCvz+Uw9lJ5oKDxT8SNas3EylUzkOnNu+avFn3391eTNyXtjZypwd65/tuKPjF3u4WZqOVe+21j9dW4foN6RbZ68t3hF669Sn1LWdK8/W/zR0kJFW5w+RX2AmymtxTdi9SlmpmjNxu1TyJQQmylT6syzjdcDoX69XNv8ZvGlvv6q1cEfcjfsH9afLf6oPOfedMncL06d2r1cfGTh6ujgtmmqL1vf+H7hbOkjLct+Wzc793zpkYURZU6+QvUVzpQ+GhlsnqT6zp1oYdWXk+Gv6+duDJe+Q2GEXghGZbj8q8KZ0kcvDm37QEjxyzMnGsZLjy6MsEY+Wzc3P1o4U/pI3VBnpcn9vvTIwoiKyYZ3Q2n+64Wh1qnC2eJHp396xxLVt+Xa7IXiIz9xVeoXg5vquU+cLfqwbub6W1Qf5aTowDUXN0umcjUtV9aUXfIwdqZS2WdLPvmaAZQpWrNxMhVrzTIzFUy1jlF9cdZsnPpUmGV9jqWuNL8RJ1P0ObZldp7dB8Ib5tSat6/kYT5TcfoAt09plTqdvRH+uWRRawbk+0Cc+riZClTyl9w+pZfUq46ZqXwfQKaEoD6FTK1Z8DiEAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABEoJSNpUeba2+mll9Itnhhq99/3r6p/8brT/4eLw8ebflbpJ/npHenyv1Lq9fm5u0HdfvY5jV2uECfuksM+dO9H6Xv65Sv3u6J/8vhJqeniw8U+lxuavdw9kvmSs2z9yovln+XOlfh9KZ1qUdt+mfRPPnGgcKzU+f72rf6LfCnV5ZLDpxfy5Ur87+yY6pBB3DZ9oOV5qbP76ob4rO2lzatoLkvbRzZ8v9bujb/IH0abgb5w/0fiXUmPz1zueGn9EaLUl2rvTe//czr7x24WQjzmdODnyzNb5/HMV+70vfTFZpRt6hbGjI0Otrxcbu/Zae9/Ut5Q06txgi/f+ue29U3uiOV/J3bTPjP5q28La5/us482SKe6a3QyZkkK+d3aw2XtP5e6nMg87ZXdwMnUkPXYbbY6eUKmhF4/XXfusdbD2fH7NKiEvDJ9o+tvaa8WOKVNSy6o4a5abqWrdOOCMOc/JFPUBJ5yJU1/93PX/y+kDyuTS7D7VN/lvzorr537e/L/FnNdey/eBLXPzP+fUR32KmynqA0LoMU6f6hiYahPW7mX1qY/6QJz6kCkh8n1gM2RKfVCVddaJi2FSsTZ8jxbi36MPgA/WhqHUcSJRPq6cuegbFHq+G9mJJS3Fa9Fm9ldLPf/a61bYv5uQV5/Qdoy+yKx9nlLHC2JqRglxIWGc1xeS/PNJK14LtfxH/rHPb6XshNDiNZ+x+TH2prwa3etidRgs5c/5/KbmkzLh+z5j82OkEpeUcm/lH/v8XnlfrXw9rNyy6DOexlzctzek9ykMXMZ3zso4Y143wr3LmZNYFJSLV0d/1epd32bJlFgQ1zkWlCkpc+9x5lCmoj/+XuHMiZspE62jZa149QXRGmdmanFJTFOmTO66d6ZozVKmsjK8zLFwTr6nrLjEmUNrVkl5gZspG9UnkskPOfeyUl7kZqqiPKDcvsrtA7H6lNRvaKdY5mGQvUyfL9z6qA9wM0V9gJsprc1lbqaoD8TpU8jUahpuxUxxco6xEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQ+BcXkLTRdE2i4ZGsM6OcDd/beycf0IGzw8+0eO9F2nHs6g6Ry+4uz7S8cPq0DH3se9KZquWEOxzNe2l4aOeMzxwaQ/VFG3WHLw22XvSdQ5vLR5s/3zHy89bnfecc/vZUta2y3eqGOnvm2UbvvTS7e8cPSRvMnxlqfNP3XiubCjvbGG1OfcZ3zkp9le5w3ezc85y9DCOLHmvk++eHWrz3nezunbhfKFnN2VA971d3bf60f31Odj6VeVQ6/cbwUMMVX4uuYxP7rdPJkeONo95z0pe3OJk8WH99/gXf+jZLprRInffdkJ68KFNKmOy5k9u890deyZTUO0YGm170Nc+vCW6mOnonOoVWV0eON73tey9as07KmuETzWd95+Tr467ZjqcmemgvV26mjBBVIydbzvnW1xVjzQrhZEdv5jGddC+f/VmL957KcTL1UHq8MSfVA2WZptPcPhCnT3H7wKG+Kzu1De6JUx83Ux0DU23S5BY4mWpPT9whA7UdmYrWLDK18rGwNlPqthtJGW2UXFUWJrb6fmjQuGjz9iaZU/WcOUHWVkYfuls4c5bFsqH6Qq0qOfOkltsTQtUw51Rz67OppYSzro5+c+5llWwJE6KKM0cqW+a0aOHMyaZc5Gbrr9c3VnDmOam2usCx5oRCaiMla01kK7J11rj6+URd0re+fenXE5FDrRKO5WetqtUhefj/GJGoddI1+M8QYrNkKueWvc3p9VOmlNJ1HItoTnX0haGZMydupqLPpEYtBOv9pTUb1caqT1SIauHclpktW1K+r4vWLH22cDNlhU5KJ1nrPL9muZkSSlTLJc3Kr7GROTNTy0JWcTOV7wPJMGCtPx19XgZO1fq+TzQu0LqOPl84c6g+6gPsTDmzjZspnaS+wcsU9YE4fQqZWl0Ft2KmOOsbYyEAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAAB2qh7ak/bk2OsfT47+iebu38w0cTxo42waYNvzhwaG6c+2pS549hV1t6vcerr6XHBSn0/dqy9X8mBWx9t1E2vi+NH9XX3Tt7VFqM+8uDcK059tO5W14STnHvRHG59tGYPpTOsvXMLa4JXX5w1u9GZOnr0be+9S+m92chMfZHXLLltVH3tP/xw6+G+qW2cbGx0pr7IfYDsNrI+ZEqIOH0AmSok/PP2AUVNS0rbk6xK3lZ42tJHUrh2G4qO0iMLI8IqsSfaFvyxnh9dKiucLX7U1j/WQPUlKiXrC2Qg9RHlwq7iz77+qimzB6i+9WeLP7reOl63Ut/8xPbiIz95VfdIkz34ybPFHjsdHNAueLjYmE9ey7VMNxkpHi2bn2785LVij51Qj7tKe3+xMZ+6lkgeUjJo/9T5Iid0RWIH3autf3xrkWHrLtH6oTmmXOxed6HEAyXFl1TgDpcYtu6yrTa3070Of3vae1P1zZKpa7VVretebIkH8TOle0o89brLlClaswlmpqTQX13N8LqnK/4gWrPcTM3X1m2l+sT1ce9N3/NrlpspHSYeDKVlfY4la9RdcTNF67042Pqr1AdMKB9af7b4o1y5vZPqi9MHuH3KSNPmjPxy8YrWX833gTj1cTOlReLReH2Kl6l8H0CmhPiXyNSRgdl6IXj/EkGNi/tXifiJU/Qtfn2ESj+iL3YbUR/9axa9rtIVrR/xUHqc9YWJZtO/0nH96EOG+y+qdC/6a59+c37ivL896UwV54MwX0+c+siP/hUy/xw+v+k18etzMk59yNTqOxI3U3HM46zZ6POofCMzxV2zG5kpWrPc+uKY02d5nD6wuiY2pk+1pWe8v7DnP3s2qk/RZxi55+/r+xuZWpVCpnxXDMZBAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQj8fxTgbldFt17dIJ63ZQvNi3Mv/tZO+fsw64u2MdvY+kiE8RPVt+rOmBMNjfOa4syhLYa42wzRK4nz/saaE7O+OBZx5myOTPHWHm0NGGfNxtm6K4553Pri3CvOnLiZinOvOHPovY2T+Tj3ijMHmSrkFZlatbjVM7XyJWa2tvrpw+mpewpvf+mj5Hzmia6BzOOlRxZGdB2b2H+ttraf05BpD77FpYofdvaN3154ptJHM3U1T3Q+lXm09MjCiI63pr88U1vzVOFM6aND6UwL1deVnt5eenRhRGT+/a7+qa8UzpQ+6vz75KHk/GS69MjCiCPpsdui1/R/VvclLJwvdUTvU3fv+KFS49ZeX2idfHixNfOdtedKHdP7urRU/gPOXpD70heTS0uVfR3p8b2lnn/t9YWW6a8vtUx+c+25UseUi2u11T/k7LVIzWczZIq7ZlczNfm1UmZrr1OmgvlM39pzpY4pU0Glfppb30qm+ia7Sz3/2utdb04/xM1U98DYLsoUd81Spjp7pw6uvX+pY8pU3DXLrY/WLDdT1Afi1sftA3EylZjLPNnRn+Gt2YGpNuoD3Pri9oHOp3iZ6npr4kFupqgPIFOrabvVM6UWF+82zum/iWUxVuoDZu31UIlXrJDvrj1X6li7sg+dMedP//SOpVJj89erp+pvSqf+oheCq/lzPr+DUF2QTr/hMzY/JnS594Wxo/nHPr8XxNSMUGo0Jeycz/j8GGX0qBX27/nHPr+dTlyheT5j82OCyuUM1VcdBt7mNNdI85LS5e/kn8fnt1SJt8jdZ2x+DL2vTum/Du/bMZs/V+r3xaF9WantaCJRPl5q7NrrSoQXnVKsNUG5kEL95cyzDTfWPlex482SKbXs5ou9jk9eo/fWOMl6fylTgVHnP/lcxR7HzZQ17mUrxT+KPfcnr1ml/sHNVDK5PEmZmhfz3muC1ixlKtCJS5+sodjjZGjf0Ua/WWzMp659tGa5mRJanBfJ5Iefer4iJ6gPcDOVqAwmKVPcPhCnTxktXtbSvFXkJXzqUkIk3qU+wK2P1gQ3U7T2uJnKOvcuN1P5PsDtU8jUR8vjFszUpxY+TkAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACnyUgaXP0mkTDIyKnLwwPNVz5rIGfPN/eN/VgoFx49njTy5+89lmPafN2K4J9FRMNvzt9WoafNW7tedpI3VbZbuvEyyODzZNrrxU7jjZJPiwTbn74mZbXio1be609PXGH0Hrv+RONv1l7vtgx1RdWuYcSIjn84vG6a8XGrr0WWfRILa+y6uud2iOU2XF+sOWPa5+r2DHVZypNz0Ig/vjqz1puFhu79lrXwOTXo316Pzh3cpv3Xqldxyb2y5yqP/vzpj+vfa5ixw+lxxtzgeysn73+3KlTu5eLjS1cc7JrIPM47T08crzp7cL54kddfZkvO2GT5060jBQfWbja9vRUa8KYBzn1IVMFP8qUVHL3yMnm5wpnix/FzVTHU+OPCCcmR4ZaXy9+h8JVWrPOuK3nTrSeLpwtfpTPFGdNCLG6ZrmZ6h7IfCm0ovr8iaYXildVuBpnzX5cn7VvRhbvFZ6t+FGcTHWlp7e7IDxYNt58itsHskq9Ovqfjd57PlOf0tossz5nP+oD3D5FfUA4N8rqU3H6ADL10aJEpvLpXJspRSejL0xVMpEN8gN8fitrUzb6z2dsfox1QVKJaItlxo9NLYVUX6jVSq2+U6VWgQt1wnc8jXOBq1DSsO4TVisZBbk8J43h3EtKXRa9MMuZowOT0lZUcOYsVeZS0smg3CZY7lFzLJcq6Tj3MqGM9qd2rDWxFH2LpnvMJ+qSvvfal349QfVZ4VjmRkgtrGSt8/LlXCJ6l1hrgl7HZsiUS+S8/rDKvy+xMyWc93tL96JMKetS3EwprVNSOfaadUqzMhVW2grKVJw1y81UaJzjfmYml+XKeuXWF6Wp0hop8++3329XruTq/fzGC6FFVnMzle8DlEff+9C4wLoK+nzmzKE+IJ1hfU5QfXQfbqZsZMftUzopqhQzU9QHkKnVVYBMcdKAsRCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIAABCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgAAEIQAACEIBAXqC7d+J+2qQ6/9jn95H02G20cbTP2PwYusfh9NQ9+cd+v6NNe6NNt7n10UbiXenLW/zusTqK7tHeO7WHM+fo0bdTVF/Pjy6VcebRfdrSM7WcOfR64tR3qH98X9uPHWvPRLpPx7GrNZz6HkqPN3Lra3tyrKKrf/pe2lCccy+6D3dNRK9nR/fA2C7OfQprglffZsgUe81uYKY60uN72fXFyFT7Dz/cGmfNxs0Ud812/2CiqbNv/HbOmqVMkd9GZYpyxamvkCnOLCfjZIr6QJw+xV0TZB2nD3T3Tt61UX0KmVpdb7d6phQFLNrDuVukxDZOxEKtvpQw5kHOHFfl7jLaPExfhHzntfWPb402me4yFeFW3zk0Tgei08nkQc4cU2H2Kmm+wpmTqauspvqWlspaOPOUcl1ahwc4c5wODmjJM5+tqm9QTh0um59u5Nwrus9DIsxFjcH/J0yog9FO7Pv9Z0TvU0Vih3Xm4SMDc3W+82j9UH2mXOz2nUPjop2z9xmneWu23OyS0va0PTnuvSn4ZskUd83GzlS01jnvE2VKaHWEW5+Srjupc/s499Jh4kFuppJlyXrKlLg+7v1HWX7NhuWGVZ8z8stOqjbOa0pVqDvJL06mXLTeOfeSJndQ2LCDM8dWm9spU9w+EKdPKS32J61lfc7m+wC3vjh9wCp5JFafYmaK+gAytbpK/yUyRX/Zcf+qowXPWfQfcUruX6o0b3UO719K4ta3arFare//47ymOPX19LiAb5738301q+Pi1BdnDt0trh95cF7VRtaHTOXfGSeRqVULWn9f9DX7Ra9vo/pU/DX7z+9T9B7Fry+fS7/fcT4zqT6a53eHwqhbtQ9sdKb+H07JrCWQP+pmAAAAAElFTkSuQmCC"/>
+</defs>
+</svg>

--- a/client/my-sites/themes/hero-modern/index.tsx
+++ b/client/my-sites/themes/hero-modern/index.tsx
@@ -1,0 +1,43 @@
+import { useTranslate } from 'i18n-calypso';
+import FullWidthSection from 'calypso/components/full-width-section';
+import { SearchThemes } from 'calypso/components/search-themes';
+import { preventWidows } from 'calypso/lib/formatting';
+
+import './style.scss';
+
+interface HeroModernProps {
+	searchQuery: string;
+	onSearch: ( query: string ) => void;
+	onSearchTracksEvent: ( eventName: string, eventProperties?: object ) => void;
+}
+
+const HeroModern = ( { searchQuery, onSearch, onSearchTracksEvent }: HeroModernProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<FullWidthSection enabled className="hero-modern">
+			<div className="hero-modern__content">
+				<h1 className="hero-modern__title">
+					{ preventWidows( translate( 'Beautiful themes for every idea' ) ) }
+				</h1>
+				<p className="hero-modern__description">
+					{ preventWidows(
+						translate(
+							'Choose from thousands of free and premium themes to launch your blog, portfolio, store, or business — and customize every detail to make it your own.'
+						)
+					) }
+				</p>
+				<div className="hero-modern__search">
+					<SearchThemes
+						query={ searchQuery }
+						onSearch={ onSearch }
+						recordTracksEvent={ onSearchTracksEvent }
+					/>
+				</div>
+			</div>
+			<div className="hero-modern__illustration" aria-hidden="true" />
+		</FullWidthSection>
+	);
+};
+
+export default HeroModern;

--- a/client/my-sites/themes/hero-modern/index.tsx
+++ b/client/my-sites/themes/hero-modern/index.tsx
@@ -35,7 +35,6 @@ const HeroModern = ( { searchQuery, onSearch, onSearchTracksEvent }: HeroModernP
 					/>
 				</div>
 			</div>
-			<div className="hero-modern__illustration" aria-hidden="true" />
 		</FullWidthSection>
 	);
 };

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -2,15 +2,16 @@
 @import '@wordpress/base-styles/breakpoints';
 
 .hero-modern {
-	background: linear-gradient( 135deg, var( --studio-blue-50 ) 0%, var( --studio-blue-20 ) 100% );
-
+	padding: 0;
 	.full-width-section__content {
+		background: linear-gradient(150deg, var(--studio-white) 30%, var(--studio-blue-50) 90%);
 		display: flex;
 		flex-direction: column;
 		padding: 48px 24px;
 		gap: 24px;
 
 		@media ( min-width: $break-small ) {
+			background: url(./illustration.svg) no-repeat right bottom, linear-gradient(150deg, var(--studio-white) 30%, var(--studio-blue-50) 90%);
 			flex-direction: row;
 			align-items: center;
 			padding: 64px 40px;
@@ -20,18 +21,19 @@
 
 .hero-modern__content {
 	flex: 1;
+	max-width: 700px;
 }
 
 .hero-modern__title {
 	font-family: $brand-serif;
-	font-size: rem( 40px );
+	font-size: rem(60px);
 	font-weight: 400;
-	line-height: 1.1;
+	line-height: 1;
 	margin: 0 0 16px;
-	color: var( --studio-gray-100 );
+	color: var(--studio-gray-90);
 
 	@media ( min-width: $break-small ) {
-		font-size: rem( 50px );
+		font-size: rem(70px);
 	}
 }
 
@@ -39,16 +41,5 @@
 	font-size: $font-body-large;
 	line-height: 1.5;
 	margin-bottom: 24px;
-	color: var( --studio-gray-90 );
-	max-width: 500px;
-}
-
-.hero-modern__illustration {
-	display: none;
-
-	@media ( min-width: $break-small ) {
-		display: block;
-		flex: 0 0 40%;
-		min-height: 240px;
-	}
+	color: var(--studio-gray-90);
 }

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -1,0 +1,54 @@
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+
+.hero-modern {
+	background: linear-gradient( 135deg, var( --studio-blue-50 ) 0%, var( --studio-blue-20 ) 100% );
+
+	.full-width-section__content {
+		display: flex;
+		flex-direction: column;
+		padding: 48px 24px;
+		gap: 24px;
+
+		@media ( min-width: $break-small ) {
+			flex-direction: row;
+			align-items: center;
+			padding: 64px 40px;
+		}
+	}
+}
+
+.hero-modern__content {
+	flex: 1;
+}
+
+.hero-modern__title {
+	font-family: $brand-serif;
+	font-size: rem( 40px );
+	font-weight: 400;
+	line-height: 1.1;
+	margin: 0 0 16px;
+	color: var( --studio-gray-100 );
+
+	@media ( min-width: $break-small ) {
+		font-size: rem( 50px );
+	}
+}
+
+.hero-modern__description {
+	font-size: $font-body-large;
+	line-height: 1.5;
+	margin-bottom: 24px;
+	color: var( --studio-gray-90 );
+	max-width: 500px;
+}
+
+.hero-modern__illustration {
+	display: none;
+
+	@media ( min-width: $break-small ) {
+		display: block;
+		flex: 0 0 40%;
+		min-height: 240px;
+	}
+}

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -3,18 +3,26 @@
 
 .hero-modern {
 	padding: 0;
+	background: linear-gradient(135deg, var(--studio-white) 30%, var(--studio-blue-50) 90%);
+
 	.full-width-section__content {
-		background: linear-gradient(150deg, var(--studio-white) 30%, var(--studio-blue-50) 90%);
 		display: flex;
 		flex-direction: column;
-		padding: 48px 24px;
 		gap: 24px;
+		max-width: 1220px;
+		padding: 48px 24px;
 
-		@media ( min-width: $break-small ) {
-			background: url(./illustration.svg) no-repeat right bottom, linear-gradient(150deg, var(--studio-white) 30%, var(--studio-blue-50) 90%);
-			flex-direction: row;
-			align-items: center;
+		@media (min-width: $break-small) {
+			background: url(./illustration.svg) no-repeat right clamp(-500px, 70vw - 900px, 0px) bottom;
 			padding: 64px 40px;
+		}
+		@media (min-width: $break-xlarge) {
+			//background-position: right bottom;
+			padding: 64px 40px;
+		}
+
+		@media (min-width: $break-wide) {
+			background-position: right bottom;
 		}
 	}
 }
@@ -25,12 +33,12 @@
 }
 
 .hero-modern__title {
+	color: var(--studio-gray-90);
 	font-family: $brand-serif;
 	font-size: rem(60px);
 	font-weight: 400;
 	line-height: 1;
-	margin: 0 0 16px;
-	color: var(--studio-gray-90);
+	margin: 0 0 8px 0;
 
 	@media ( min-width: $break-small ) {
 		font-size: rem(70px);
@@ -38,8 +46,31 @@
 }
 
 .hero-modern__description {
+	color: var(--studio-gray-90);
 	font-size: $font-body-large;
 	line-height: 1.5;
-	margin-bottom: 24px;
-	color: var(--studio-gray-90);
+	margin: 0;
+}
+
+.hero-modern__search {
+	margin-top: 16px;
+
+	.search-themes-card {
+		max-width: 500px;
+	}
+
+	.components-input-base {
+		border-radius: 4px;
+		height: 55px;
+
+		.components-input-control__container {
+			input.components-input-control__input {
+				font-size: $font-body;
+			}
+			.components-input-control__backdrop {
+				border-color: var(--studio-gray-5);
+				border-radius: 4px;
+			}
+		}
+	}
 }

--- a/client/my-sites/themes/hero-modern/test/index.test.tsx
+++ b/client/my-sites/themes/hero-modern/test/index.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import HeroModern from '../index';
+
+jest.mock( 'calypso/components/search-themes', () => ( {
+	SearchThemes: ( { query }: { query: string } ) => (
+		<input placeholder="Search themes…" defaultValue={ query } />
+	),
+} ) );
+
+describe( 'HeroModern', () => {
+	const defaultProps = {
+		searchQuery: '',
+		onSearch: jest.fn(),
+		onSearchTracksEvent: jest.fn(),
+	};
+
+	test( 'renders title and description', () => {
+		render( <HeroModern { ...defaultProps } /> );
+		expect( screen.getByText( /Beautiful themes for every idea/i ) ).toBeVisible();
+		expect( screen.getByText( /Choose from thousands of free and premium/i ) ).toBeVisible();
+	} );
+
+	test( 'renders search input', () => {
+		render( <HeroModern { ...defaultProps } /> );
+		expect( screen.getByPlaceholderText( 'Search themes…' ) ).toBeVisible();
+	} );
+
+	test( 'renders inside a full-width section', () => {
+		const { container } = render( <HeroModern { ...defaultProps } /> );
+		expect( container.querySelector( '.full-width-section' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders illustration placeholder', () => {
+		const { container } = render( <HeroModern { ...defaultProps } /> );
+		expect( container.querySelector( '.hero-modern__illustration' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/themes/hero-modern/test/index.test.tsx
+++ b/client/my-sites/themes/hero-modern/test/index.test.tsx
@@ -32,9 +32,4 @@ describe( 'HeroModern', () => {
 		const { container } = render( <HeroModern { ...defaultProps } /> );
 		expect( container.querySelector( '.full-width-section' ) ).toBeInTheDocument();
 	} );
-
-	test( 'renders illustration placeholder', () => {
-		const { container } = render( <HeroModern { ...defaultProps } /> );
-		expect( container.querySelector( '.hero-modern__illustration' ) ).toBeInTheDocument();
-	} );
 } );


### PR DESCRIPTION
Fixes DOTTHEM-301

## Proposed Changes

<img width="1478" height="396" alt="Screenshot 2026-02-27 at 14 28 17" src="https://github.com/user-attachments/assets/d90fdd96-35eb-4e30-bc8e-e17c80078770" />

- Add a new `HeroModern` component for the redesigned logged-out Theme Showcase hero section.
- The component includes a hardcoded title and description, an integrated `SearchThemes` input, and an illustration (SVG).
- Styled with a gradient background and responsive layout.

## Why are these changes being made?

This is the foundation component for the updated Theme Showcase page design. The hero section is being modernized with a gradient background, serif typography, integrated search, and a typographic illustration. The component is self-contained and not yet wired into the page — integration will follow in a separate PR.

## Testing Instructions

The component is not wired into the page yet. To test it visually, apply the following patch to `client/my-sites/themes/theme-showcase.jsx`:

```diff
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -22,6 +22,7 @@
 import ThemeCollectionViewHeader from 'calypso/my-sites/themes/collections/theme-collection-view-header';
+import HeroModern from 'calypso/my-sites/themes/hero-modern';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -645,6 +646,7 @@
 		const showThemeErrors =
 			siteId && this.props.category === staticFilters.MYTHEMES.key && isJetpackSite;
+		const isShowcaseModernEnabled = config.isEnabled( 'themes/showcase-modern' ) && ! isLoggedIn;

@@ -662,6 +664,13 @@
 				/>
+				{ isShowcaseModernEnabled && (
+					<HeroModern
+						searchQuery={ featureStringFilter + search }
+						onSearch={ this.doSearch }
+						onSearchTracksEvent={ this.recordSearchThemesTracksEvent }
+					/>
+				) }
 				{ this.renderSiteAssemblerSelectorModal() }
@@ -692,13 +701,17 @@
-										<div className="theme__search-input">
-											<SearchThemes
-												query={ isLoggedIn ? filterString + search : featureStringFilter + search }
-												onSearch={ this.doSearch }
-												recordTracksEvent={ this.recordSearchThemesTracksEvent }
-											/>
-										</div>
+										{ ! isShowcaseModernEnabled && (
+											<div className="theme__search-input">
+												<SearchThemes
+													query={
+														isLoggedIn ? filterString + search : featureStringFilter + search
+													}
+													onSearch={ this.doSearch }
+													recordTracksEvent={ this.recordSearchThemesTracksEvent }
+												/>
+											</div>
+										) }
```

Then:
1. `yarn start`
2. Visit `http://calypso.localhost:3000/themes` in an incognito/logged-out window
3. The `themes/showcase-modern` feature flag is already enabled in the development config

Unit tests: `yarn test-client client/my-sites/themes/hero-modern/test/index.test.tsx`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?