### PR TITLE
Agents Manager: Handle inline suggestion click events from Big Sky

### DIFF
--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -209,6 +209,32 @@ export default function OrchestratorChat( {
 		agentId,
 	} );
 
+	// Listen for inline suggestion clicks dispatched by Big Sky's InlineSuggestions component.
+	useEffect( () => {
+		const handleInlineSuggestionClick = ( event: Event ) => {
+			const { value } = ( event as CustomEvent ).detail;
+			if ( value ) {
+				const inputValue = value.endsWith( ' ' ) ? value : `${ value } `;
+				setInputValue( inputValue );
+
+				// Focus the textarea and set cursor position to end
+				const textarea = document.querySelector< HTMLTextAreaElement >(
+					'.agenttic .Textarea-module_textarea'
+				);
+				if ( textarea ) {
+					textarea.value = inputValue;
+					textarea.focus();
+					textarea.setSelectionRange( inputValue.length, inputValue.length );
+				}
+			}
+		};
+
+		window.addEventListener( 'big-sky-inline-suggestion-click', handleInlineSuggestionClick );
+		return () => {
+			window.removeEventListener( 'big-sky-inline-suggestion-click', handleInlineSuggestionClick );
+		};
+	}, [] );
+
 	// Invoke abilities setup hook to register hook-based abilities that utilize React context.
 	// Provides custom action handlers for agent and chat interaction within Big Sky's AI store.
 	// The hook is stable as `OrchestratorChat` only renders after external providers have been loaded.

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -222,7 +222,6 @@ export default function OrchestratorChat( {
 					'.agenttic .Textarea-module_textarea'
 				);
 				if ( textarea ) {
-					textarea.value = inputValue;
 					textarea.focus();
 					textarea.setSelectionRange( inputValue.length, inputValue.length );
 				}


### PR DESCRIPTION

Fixes BSKY-1657

## Proposed Changes

When BigSky completes a site build, it dispatches a "Your site is ready!" message with inline suggestion buttons (e.g., "Customize colors", "Change page layout"). Clicking one of these buttons fires a `big-sky-inline-suggestion-click` custom event on the window, which BigSky's Dock component listens for to populate the chat input.

Agents Manager was missing a listener for this event, so clicking the inline suggestions after a site build had no effect.

## Why are these changes being made?

This adds a `useEffect` in `OrchestratorChat` that listens for the `big-sky-inline-suggestion-click` event, sets the suggestion prompt as the input value, and focuses the textarea with the cursor at the end — matching BigSky's existing behavior.

## Testing Instructions

* Sync the agents manager app with `yarn dev --sync`
* Disable the Unified AI experience - https://wordpress.com/wp-admin/profile.php
* Start a new site build, but before adding the inputs, add `&flags=unified-big-sky` to the URL and refresh
* Go through the site creation flow
* Once it is done, some suggestions will be presented
* Clicking one of the suggestions should populate the chat input field

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
