### PR TITLE
Domain-Only Thank You Page: Add Tracks events

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/index.tsx
@@ -1,3 +1,5 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { getTld } from '@automattic/domain-search';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Step } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
@@ -23,6 +25,13 @@ import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 import './style.scss';
 
+type NextStep =
+	| 'start_new_site'
+	| 'add_mailbox'
+	| 'attach_existing_site'
+	| 'use_domain_only'
+	| 'migrate_existing_site';
+
 export default function DomainOnly( {
 	domainPurchase,
 	currency,
@@ -42,6 +51,15 @@ export default function DomainOnly( {
 			domain: domainPurchase.meta,
 		},
 	} );
+
+	const getOnClickEventHandler = ( nextStep: NextStep ) => {
+		return () => {
+			recordTracksEvent( 'calypso_checkout_thank_you_domain_next_step_click', {
+				next_step: nextStep,
+				domain_tld: getTld( domainPurchase.meta ),
+			} );
+		};
+	};
 
 	return (
 		<div className="checkout-thank-you__domain-only-container">
@@ -78,6 +96,7 @@ export default function DomainOnly( {
 							: undefined
 					}
 					href={ createSiteFromDomainOnly( domainPurchase.meta, domainPurchase.blogId ) }
+					onSelect={ getOnClickEventHandler( 'start_new_site' ) }
 				/>
 				<OptionContent
 					illustration={ <img src={ addMailbox } alt="" aria-hidden /> }
@@ -88,6 +107,7 @@ export default function DomainOnly( {
 							? dashboardLink( `/emails/choose-email-solution/${ domainPurchase.meta }` )
 							: domainAddEmailUpsell( domainPurchase.meta, domainPurchase.meta )
 					}
+					onSelect={ getOnClickEventHandler( 'add_mailbox' ) }
 				/>
 				{ hasConnectableSites && (
 					<OptionContent
@@ -99,6 +119,7 @@ export default function DomainOnly( {
 								? dashboardLink( `/domains/${ domainPurchase.meta }/transfer/other-site` )
 								: domainManagementTransferToOtherSite( domainPurchase.meta, domainPurchase.meta )
 						}
+						onSelect={ getOnClickEventHandler( 'attach_existing_site' ) }
 					/>
 				) }
 				<OptionContent
@@ -112,6 +133,7 @@ export default function DomainOnly( {
 							? dashboardLink( `/domains/${ domainPurchase.meta }` )
 							: domainManagementList( domainPurchase.meta, domainPurchase.meta )
 					}
+					onSelect={ getOnClickEventHandler( 'use_domain_only' ) }
 				/>
 				<Step.LinkButton
 					className="domain-only__migrate-link"
@@ -119,6 +141,7 @@ export default function DomainOnly( {
 						dashboard: getDashboardFromQuery(),
 						siteSlug: domainPurchase.meta,
 					} ) }
+					onClick={ getOnClickEventHandler( 'migrate_existing_site' ) }
 				>
 					{ translate( 'Migrate an existing site' ) }
 				</Step.LinkButton>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/test/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/test/index.tsx
@@ -71,24 +71,23 @@ function renderComponent( { currency = 'USD' }: { currency?: string } = {} ) {
 }
 
 describe( 'DomainOnly', () => {
-	beforeAll( () => {
+	beforeEach( () => {
 		// Suppress the console for navigation errors, which are not implemented by JSDom
 		const consoleError = console.error;
+
 		jest.spyOn( console, 'error' ).mockImplementation( ( message ) => {
 			if ( ! message.toString().includes( 'Not implemented: navigation' ) ) {
 				consoleError( message );
 			}
 		} );
-	} );
 
-	afterAll( () => {
-		jest.spyOn( console, 'error' ).mockRestore();
-	} );
-
-	beforeEach( () => {
 		jest.mocked( hasDashboardOptIn ).mockReturnValue( false );
 		jest.mocked( canAnySiteConnectDomains ).mockReturnValue( false );
 		jest.mocked( useDomainToPlanCreditsApplicable ).mockReturnValue( null );
+	} );
+
+	afterEach( () => {
+		jest.spyOn( console, 'error' ).mockRestore();
 	} );
 
 	describe( 'Start a new site', () => {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/test/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/test/index.tsx
@@ -144,21 +144,6 @@ describe( 'DomainOnly', () => {
 				screen.queryByText( /in upgrade credits will be applied to new paid plan purchases/ )
 			).not.toBeInTheDocument();
 		} );
-
-		it( 'records a tracks event when the user clicks the "Add a mailbox" link', async () => {
-			const user = userEvent.setup();
-			renderComponent();
-
-			await user.click( screen.getByRole( 'link', { name: /Add a mailbox/ } ) );
-
-			expect( recordTracksEvent ).toHaveBeenCalledWith(
-				'calypso_checkout_thank_you_domain_next_step_click',
-				{
-					next_step: 'add_mailbox',
-					domain_tld: 'com',
-				}
-			);
-		} );
 	} );
 
 	describe( 'Add a mailbox', () => {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/test/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only/test/index.tsx
@@ -2,7 +2,9 @@
  * @jest-environment jsdom
  */
 
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { getDashboardFromQuery } from 'calypso/dashboard/app/routing';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import {
@@ -17,6 +19,8 @@ import { canAnySiteConnectDomains } from 'calypso/state/selectors/can-any-site-c
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import DomainOnly from '../index';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
+
+jest.mock( '@automattic/calypso-analytics' );
 
 jest.mock( 'calypso/state/dashboard/selectors', () => ( {
 	hasDashboardOptIn: jest.fn(),
@@ -67,6 +71,20 @@ function renderComponent( { currency = 'USD' }: { currency?: string } = {} ) {
 }
 
 describe( 'DomainOnly', () => {
+	beforeAll( () => {
+		// Suppress the console for navigation errors, which are not implemented by JSDom
+		const consoleError = console.error;
+		jest.spyOn( console, 'error' ).mockImplementation( ( message ) => {
+			if ( ! message.toString().includes( 'Not implemented: navigation' ) ) {
+				consoleError( message );
+			}
+		} );
+	} );
+
+	afterAll( () => {
+		jest.spyOn( console, 'error' ).mockRestore();
+	} );
+
 	beforeEach( () => {
 		jest.mocked( hasDashboardOptIn ).mockReturnValue( false );
 		jest.mocked( canAnySiteConnectDomains ).mockReturnValue( false );
@@ -80,6 +98,21 @@ describe( 'DomainOnly', () => {
 			expect( screen.getByRole( 'link', { name: /Start a new site/ } ) ).toHaveAttribute(
 				'href',
 				createSiteFromDomainOnly( mockDomainPurchase.meta, mockDomainPurchase.blogId )
+			);
+		} );
+
+		it( 'records a tracks event when the user clicks the "Start a new site" link', async () => {
+			const user = userEvent.setup();
+			renderComponent();
+
+			await user.click( screen.getByRole( 'link', { name: /Start a new site/ } ) );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_checkout_thank_you_domain_next_step_click',
+				{
+					next_step: 'start_new_site',
+					domain_tld: 'com',
+				}
 			);
 		} );
 	} );
@@ -111,6 +144,21 @@ describe( 'DomainOnly', () => {
 				screen.queryByText( /in upgrade credits will be applied to new paid plan purchases/ )
 			).not.toBeInTheDocument();
 		} );
+
+		it( 'records a tracks event when the user clicks the "Add a mailbox" link', async () => {
+			const user = userEvent.setup();
+			renderComponent();
+
+			await user.click( screen.getByRole( 'link', { name: /Add a mailbox/ } ) );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_checkout_thank_you_domain_next_step_click',
+				{
+					next_step: 'add_mailbox',
+					domain_tld: 'com',
+				}
+			);
+		} );
 	} );
 
 	describe( 'Add a mailbox', () => {
@@ -140,6 +188,21 @@ describe( 'DomainOnly', () => {
 			expect(
 				screen.getByText( `Create a professional email address on ${ mockDomainPurchase.meta }.` )
 			).toBeVisible();
+		} );
+
+		it( 'records a tracks event when the user clicks the "Add a mailbox" link', async () => {
+			const user = userEvent.setup();
+			renderComponent();
+
+			await user.click( screen.getByRole( 'link', { name: /Add a mailbox/ } ) );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_checkout_thank_you_domain_next_step_click',
+				{
+					next_step: 'add_mailbox',
+					domain_tld: 'com',
+				}
+			);
 		} );
 	} );
 
@@ -181,6 +244,23 @@ describe( 'DomainOnly', () => {
 				dashboardLink( `/domains/${ mockDomainPurchase.meta }/transfer/other-site` )
 			);
 		} );
+
+		it( 'records a tracks event when the user clicks the "Attach to an existing site" link', async () => {
+			jest.mocked( canAnySiteConnectDomains ).mockReturnValue( true );
+
+			const user = userEvent.setup();
+			renderComponent();
+
+			await user.click( screen.getByRole( 'link', { name: /Attach to an existing site/ } ) );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_checkout_thank_you_domain_next_step_click',
+				{
+					next_step: 'attach_existing_site',
+					domain_tld: 'com',
+				}
+			);
+		} );
 	} );
 
 	describe( 'Use the domain name only', () => {
@@ -203,6 +283,21 @@ describe( 'DomainOnly', () => {
 				dashboardLink( `/domains/${ mockDomainPurchase.meta }` )
 			);
 		} );
+
+		it( 'records a tracks event when the user clicks the "Use the domain name only" link', async () => {
+			const user = userEvent.setup();
+			renderComponent();
+
+			await user.click( screen.getByRole( 'link', { name: /Use the domain name only/ } ) );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_checkout_thank_you_domain_next_step_click',
+				{
+					next_step: 'use_domain_only',
+					domain_tld: 'com',
+				}
+			);
+		} );
 	} );
 
 	describe( 'Migrate an existing site', () => {
@@ -222,6 +317,21 @@ describe( 'DomainOnly', () => {
 			expect( screen.getByRole( 'link', { name: /Migrate an existing site/ } ) ).toHaveAttribute(
 				'href',
 				`/setup/site-migration?dashboard=ciab&siteSlug=${ mockDomainPurchase.meta }`
+			);
+		} );
+
+		it( 'records a tracks event when the user clicks the "Migrate an existing site" link', async () => {
+			const user = userEvent.setup();
+			renderComponent();
+
+			await user.click( screen.getByRole( 'link', { name: /Migrate an existing site/ } ) );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_checkout_thank_you_domain_next_step_click',
+				{
+					next_step: 'migrate_existing_site',
+					domain_tld: 'com',
+				}
 			);
 		} );
 	} );


### PR DESCRIPTION
Fixes p1772024230484729/1770164256.252079-slack-C04H4NY6STW.

## Proposed Changes

Allow us to track the link clicks within the redesigned domain-only thank-you page.

## Testing Instructions

Run `localStorage.setItem('debug', 'calypso:analytics');` in the dev tools, refresh the page, then click the links. Verify you see the events being dispatched in the devtools console according to the reference document.

The reference document also lists the "Need help?" link at the top-right corner but we already have an event for that link: `calypso_thank_you_inlinehelp_show` with props `location: 'thank-you-help-center'`.