### PR TITLE
Reader: Disable AddSitesForm submit button if input is invalid

### DIFF
--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -21,11 +21,6 @@ export type AddSitesFormProps = {
 	onChangeSubscribe?: ( subscribed: boolean ) => void;
 };
 
-type SubscriptionError = {
-	error?: string;
-	message?: string;
-};
-
 const AddSitesForm = ( {
 	placeholder,
 	buttonText,
@@ -99,7 +94,7 @@ const AddSitesForm = ( {
 							onSubscribeToggle( true );
 						}
 					},
-					onError: ( error: SubscriptionError ) => {
+					onError: ( error ) => {
 						showErrorNotice( inputValue, error );
 						onChangeSubscribe?.( false );
 					},

--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -144,7 +144,7 @@ const AddSitesForm = ( {
 				<Button
 					variant="primary"
 					className="button subscriptions-add-sites__save-button"
-					disabled={ ! inputValue || !! inputFieldError || subscribing }
+					disabled={ ! inputValue || ! isValidInput || subscribing }
 					isBusy={ isSubmitting }
 					type="submit"
 					__next40pxDefaultSize

--- a/client/landing/subscriptions/components/add-sites-form/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-form/styles.scss
@@ -48,6 +48,12 @@
 		}
 	}
 
+	.subscriptions-add-sites__save-button {
+		&[disabled] {
+			cursor: not-allowed;
+		}
+	}
+
 	.components-base-control {
 		position: relative;
 	}

--- a/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
@@ -93,4 +93,43 @@ describe( 'AddSitesForm', () => {
 
 		expect( addButton ).toBeDisabled();
 	} );
+
+	test( 'disables the Add site button immediately when typing invalid URL', () => {
+		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
+		const input = screen.getByRole( 'textbox' );
+		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
+
+		fireEvent.change( input, { target: { value: 'not-a-valid-url' } } );
+
+		expect( addButton ).toBeDisabled();
+	} );
+
+	test( 'enables the Add site button immediately when typing valid URL', () => {
+		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
+		const input = screen.getByRole( 'textbox' );
+		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
+
+		fireEvent.change( input, { target: { value: 'https://example.com' } } );
+
+		expect( addButton ).toBeEnabled();
+	} );
+
+	test( 'disables the Add site button when input is empty', () => {
+		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
+		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
+
+		expect( addButton ).toBeDisabled();
+	} );
+
+	test( 'disables button when transitioning from valid to invalid URL', () => {
+		renderWithContextProvider( <AddSitesForm { ...mockProps } /> );
+		const input = screen.getByRole( 'textbox' );
+		const addButton = screen.getByRole( 'button', { name: 'Add site' } );
+
+		fireEvent.change( input, { target: { value: 'https://example.com' } } );
+		expect( addButton ).toBeEnabled();
+
+		fireEvent.change( input, { target: { value: 'invalid' } } );
+		expect( addButton ).toBeDisabled();
+	} );
 } );

--- a/client/landing/subscriptions/hooks/use-add-sites-modal-notices.ts
+++ b/client/landing/subscriptions/hooks/use-add-sites-modal-notices.ts
@@ -33,7 +33,7 @@ const useAddSitesModalNotices = () => {
 					translate( 'There was an error when trying to subscribe to %s.', {
 						args: [ url ],
 						comment: 'URL of the site that the user tried to subscribe to.',
-					} )
+					} ) + ( error instanceof Error && error.cause ? ` (${ error.cause })` : '' )
 				)
 			);
 		},

--- a/client/landing/subscriptions/hooks/use-add-sites-modal-notices.ts
+++ b/client/landing/subscriptions/hooks/use-add-sites-modal-notices.ts
@@ -9,7 +9,7 @@ const useAddSitesModalNotices = () => {
 	const translate = useTranslate();
 
 	const showErrorNotice = useCallback(
-		( url: string, error?: { error?: string } ) => {
+		( url: string, error?: Error & { error?: string } ) => {
 			if ( error?.error === 'email_unverified' ) {
 				dispatch(
 					errorNotice(
@@ -33,7 +33,7 @@ const useAddSitesModalNotices = () => {
 					translate( 'There was an error when trying to subscribe to %s.', {
 						args: [ url ],
 						comment: 'URL of the site that the user tried to subscribe to.',
-					} ) + ( error instanceof Error && error.cause ? ` (${ error.cause })` : '' )
+					} ) + ( error?.cause ? ` (${ error.cause })` : '' )
 				)
 			);
 		},

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -68,7 +68,8 @@ const useSiteSubscribeMutation = () => {
 			if ( ! response.subscribed ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
-					'Something went wrong while subscribing.'
+					'Something went wrong while subscribing.',
+					{ cause: response.info }
 				);
 			}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: [READ-347](https://linear.app/a8c/issue/READ-347)

## Proposed Changes

- Disable `AddSitesForm` submit button when input is not a valid URL.
- Update error message to include cause of the error if available on backend.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Improve UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/reader/new?flags=reader/discover-v3`
- Enter invalid URL in input field.
- Verify the submit button is disabled.
- Enter a valid URL that doesn't have the feed. (e.g. example.com).
- Verify that the error message now include reason.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
