### PR TITLE
Theme Showcase: Integrate HeroModern into ThemeShowcaseHeader

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -149,6 +149,9 @@ const LayoutLoggedOut = ( {
 				currentRoute?.startsWith( '/start/do-it-for-me/' ) ) &&
 			userAllowedToHelpCenter );
 
+	const isThemeShowcaseModern =
+		sectionName === 'themes' && isEnabled( 'themes/showcase-modern' ) && ! isLoggedIn;
+
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
 		[ 'is-section-' + sectionName ]: sectionName,
@@ -176,6 +179,7 @@ const LayoutLoggedOut = ( {
 		woo: isWoo,
 		'feature-flag-woocommerce-core-profiler-passwordless-auth': true,
 		'jetpack-cloud': isJetpackCloud,
+		'is-theme-showcase-modern': isThemeShowcaseModern,
 	};
 
 	let masterbar = null;
@@ -241,6 +245,7 @@ const LayoutLoggedOut = ( {
 					! nonMonochromeSections.includes( sectionName ) && {
 						logoColor: 'white',
 					} ) }
+				{ ...( isThemeShowcaseModern && { logoColor: 'var(--studio-black)' } ) }
 				{ ...( sectionName === 'subscriptions' && { variant: 'minimal' } ) }
 				{ ...( sectionName === 'patterns' && {
 					startUrl: getPatternLibraryOnboardingUrl( locale, isLoggedIn ),

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -1,26 +1,38 @@
 @import '@automattic/typography/styles/variables';
 @import '@wordpress/base-styles/breakpoints';
 
+$hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
+
+.is-section-themes.is-theme-showcase-modern.has-no-sidebar {
+	.masterbar-menu .masterbar {
+		background: transparent;
+		border-bottom-color: transparent;
+		height: 56px;
+		position: relative;
+	}
+
+	.cta-btn-nav {
+		color: var(--studio-gray-100) !important;
+		background: inherit !important;
+		border: 1px solid var(--studio-gray-100);
+	}
+}
+
+
 .hero-modern {
-	padding: 0;
-	background: linear-gradient(135deg, var(--studio-white) 30%, var(--studio-blue-50) 90%);
+	margin-top: -$hero-modern-navbar-height;
+	padding: $hero-modern-navbar-height 0 0;
+	background: linear-gradient(150deg, var(--studio-white) 30%, var(--studio-blue-50) 90%);
 
 	.full-width-section__content {
-		display: flex;
-		flex-direction: column;
-		gap: 24px;
 		max-width: 1220px;
 		padding: 48px 24px;
 
 		@media (min-width: $break-small) {
 			background: url(./illustration.svg) no-repeat right clamp(-500px, 70vw - 900px, 0px) bottom;
-			padding: 64px 40px;
+			padding-top: 100px;
+			padding-bottom: 64px;
 		}
-		@media (min-width: $break-xlarge) {
-			//background-position: right bottom;
-			padding: 64px 40px;
-		}
-
 		@media (min-width: $break-wide) {
 			background-position: right bottom;
 		}

--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -40,7 +40,7 @@ export default function ThemeShowcaseHeader( {
 	const title = useThemeShowcaseTitle( { filter, tier, vertical } );
 	const skipTitleFormatting = shouldSkipTitleFormatting( { filter, tier } );
 	const loggedOutSeoContent = useThemeShowcaseLoggedOutSeoContent( filter, tier );
-	const isModern = useIsThemeShowcaseModernEnabled();
+	const isThemeShowcaseModern = useIsThemeShowcaseModernEnabled();
 	const dashboardOptIn = useSelector( ( state ) => hasDashboardOptIn( state ) );
 	const shouldUseLoggedInHeader =
 		isEnabled( 'themes/universal-header' ) && dashboardOptIn ? selectedSiteId : isLoggedIn;
@@ -122,7 +122,7 @@ export default function ThemeShowcaseHeader( {
 			);
 		}
 
-		if ( isModern ) {
+		if ( isThemeShowcaseModern ) {
 			return (
 				<HeroModern
 					searchQuery={ search || '' }

--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -8,6 +8,8 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import HeroModern from './hero-modern';
+import { useIsThemeShowcaseModernEnabled } from './hooks/use-is-theme-showcase-modern-enabled';
 import InstallThemeButton from './install-theme-button';
 import useThemeShowcaseDescription from './use-theme-showcase-description';
 import useThemeShowcaseLoggedOutSeoContent from './use-theme-showcase-logged-out-seo-content';
@@ -22,6 +24,9 @@ export default function ThemeShowcaseHeader( {
 	filter,
 	tier,
 	vertical,
+	search,
+	onSearch,
+	onSearchTracksEvent,
 	isCollectionView = false,
 	noIndex = false,
 	isSiteECommerceFreeTrial = false,
@@ -35,6 +40,7 @@ export default function ThemeShowcaseHeader( {
 	const title = useThemeShowcaseTitle( { filter, tier, vertical } );
 	const skipTitleFormatting = shouldSkipTitleFormatting( { filter, tier } );
 	const loggedOutSeoContent = useThemeShowcaseLoggedOutSeoContent( filter, tier );
+	const isModern = useIsThemeShowcaseModernEnabled();
 	const dashboardOptIn = useSelector( ( state ) => hasDashboardOptIn( state ) );
 	const shouldUseLoggedInHeader =
 		isEnabled( 'themes/universal-header' ) && dashboardOptIn ? selectedSiteId : isLoggedIn;
@@ -92,14 +98,9 @@ export default function ThemeShowcaseHeader( {
 		);
 	}
 
-	return (
-		<>
-			<DocumentHead
-				title={ documentHeadTitle }
-				meta={ metas }
-				skipTitleFormatting={ skipTitleFormatting }
-			/>
-			{ shouldUseLoggedInHeader ? (
+	const renderHeader = () => {
+		if ( shouldUseLoggedInHeader ) {
+			return (
 				<div className="themes__header-navigation-container">
 					<NavigationHeader
 						compactBreadcrumb={ false }
@@ -118,14 +119,37 @@ export default function ThemeShowcaseHeader( {
 						{ showInstallThemeButton && <InstallThemeButton /> }
 					</NavigationHeader>
 				</div>
-			) : (
-				<div className="themes__header-logged-out">
-					<div className="themes__page-heading">
-						<h1>{ preventWidows( themesHeaderTitle ) }</h1>
-						<p className="page-sub-header">{ preventWidows( themesHeaderDescription ) }</p>
-					</div>
+			);
+		}
+
+		if ( isModern ) {
+			return (
+				<HeroModern
+					searchQuery={ search || '' }
+					onSearch={ onSearch }
+					onSearchTracksEvent={ onSearchTracksEvent }
+				/>
+			);
+		}
+
+		return (
+			<div className="themes__header-logged-out">
+				<div className="themes__page-heading">
+					<h1>{ preventWidows( themesHeaderTitle ) }</h1>
+					<p className="page-sub-header">{ preventWidows( themesHeaderDescription ) }</p>
 				</div>
-			) }
+			</div>
+		);
+	};
+
+	return (
+		<>
+			<DocumentHead
+				title={ documentHeadTitle }
+				meta={ metas }
+				skipTitleFormatting={ skipTitleFormatting }
+			/>
+			{ renderHeader() }
 		</>
 	);
 }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -602,7 +602,7 @@ class ThemeShowcase extends Component {
 		} = this.props;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
-		const isModernShowcase = config.isEnabled( 'themes/showcase-modern' ) && ! isLoggedIn;
+		const isThemeShowcaseModern = config.isEnabled( 'themes/showcase-modern' ) && ! isLoggedIn;
 		const staticFilters = this.getStaticFilters();
 
 		// Update the filters to accommodate updates/translations from the API.
@@ -696,7 +696,7 @@ class ThemeShowcase extends Component {
 							>
 								<div className="theme__search-container">
 									<div className="theme__search">
-										{ ! isModernShowcase && (
+										{ ! isThemeShowcaseModern && (
 											<div className="theme__search-input">
 												<SearchThemes
 													query={

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -602,6 +602,7 @@ class ThemeShowcase extends Component {
 		} = this.props;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
+		const isModernShowcase = config.isEnabled( 'themes/showcase-modern' ) && ! isLoggedIn;
 		const staticFilters = this.getStaticFilters();
 
 		// Update the filters to accommodate updates/translations from the API.
@@ -658,6 +659,9 @@ class ThemeShowcase extends Component {
 					filter={ this.props.filter }
 					tier={ this.props.tier }
 					vertical={ this.props.vertical }
+					search={ search }
+					onSearch={ this.doSearch }
+					onSearchTracksEvent={ this.recordSearchThemesTracksEvent }
 					isCollectionView={ isCollectionView }
 					noIndex={ isCollectionView }
 					isSiteECommerceFreeTrial={ isSiteECommerceFreeTrial }
@@ -692,13 +696,17 @@ class ThemeShowcase extends Component {
 							>
 								<div className="theme__search-container">
 									<div className="theme__search">
-										<div className="theme__search-input">
-											<SearchThemes
-												query={ isLoggedIn ? filterString + search : featureStringFilter + search }
-												onSearch={ this.doSearch }
-												recordTracksEvent={ this.recordSearchThemesTracksEvent }
-											/>
-										</div>
+										{ ! isModernShowcase && (
+											<div className="theme__search-input">
+												<SearchThemes
+													query={
+														isLoggedIn ? filterString + search : featureStringFilter + search
+													}
+													onSearch={ this.doSearch }
+													recordTracksEvent={ this.recordSearchThemesTracksEvent }
+												/>
+											</div>
+										) }
 										{ tabFilters && premiumThemesEnabled && ! isMultisite && (
 											<CustomSelectWrapper
 												className="theme__tier-select"


### PR DESCRIPTION
Fixes DOTTHEM-302

## Proposed Changes

<img width="1491" height="694" alt="Screenshot 2026-02-27 at 18 08 32" src="https://github.com/user-attachments/assets/98f6c45b-78f2-4cda-a0ad-7011d3ad48c1" />

* Conditionally render `HeroModern` in `ThemeShowcaseHeader` when the `themes/showcase-modern` feature flag is enabled and the user is logged out.
* Pass search props (`search`, `onSearch`, `onSearchTracksEvent`) from `ThemeShowcase` through `ThemeShowcaseHeader` to `HeroModern`.
* Hide the duplicate `SearchThemes` in the controls section when the modern showcase is active.
* Style the universal navbar to be transparent with black logo and nav elements when the hero is present, so the hero gradient extends to the top of the page.

Note: ignore the unstyled filter components: they will be addressed separately.

## Why are these changes being made?

This integrates the new `HeroModern` component (added in #108976) into the logged-out theme showcase page, replacing the classic header with a modern hero section that includes a gradient background, illustration, and integrated search.

## Testing Instructions

* Enable the `themes/showcase-modern` feature flag.
* Visit `/themes` while logged out.
* Verify the modern hero is displayed with gradient background extending behind the transparent navbar.
* Verify the navbar logo and "Get Started" button are styled in black.
* Verify the search in the hero works (typing a query filters themes).
* Verify there is no duplicate search bar below the hero.
* Disable the flag and verify the classic logged-out header is shown unchanged.
* Verify logged-in users always see the standard `NavigationHeader`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?