### PR TITLE
Show custom thinking messages while processing

### DIFF
--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -36,6 +36,8 @@ interface Props {
 	emptyViewSuggestions?: Suggestion[];
 	/** Indicates if the chat is processing a request. */
 	isProcessing: boolean;
+	/** Custom thinking message to display while the agent is processing. */
+	thinkingMessage?: string | null;
 	/** Indicates if a conversation is being loaded. */
 	isLoadingConversation: boolean;
 	/** Indicates if the chat is docked in the sidebar. */
@@ -81,6 +83,7 @@ export default function AgentChat( {
 	chatHeaderOptions,
 	emptyViewSuggestions = [],
 	isProcessing,
+	thinkingMessage,
 	isLoadingConversation,
 	isDocked,
 	isOpen,
@@ -131,6 +134,7 @@ export default function AgentChat( {
 			className={ clsx( 'agenttic', { dark: isDocked } ) }
 			messages={ messages }
 			isProcessing={ isProcessing }
+			thinkingMessage={ thinkingMessage ?? undefined }
 			error={ error }
 			onSubmit={ onSubmit }
 			variant={ isDocked ? 'embedded' : 'floating' }

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -107,6 +107,7 @@ export default function OrchestratorChat( {
 		clearSuggestions,
 		registerSuggestions,
 		registerMessageActions,
+		progressMessage,
 	} = useAgentChat( agentConfig! );
 
 	// Notify parent when message count changes
@@ -295,6 +296,7 @@ export default function OrchestratorChat( {
 			suggestions={ suggestions }
 			emptyViewSuggestions={ displayedEmptyViewSuggestions }
 			isProcessing={ isProcessing || ( isThinking && ! isBuildingSite ) }
+			thinkingMessage={ progressMessage }
 			error={ error }
 			onSubmit={ onSubmitWithImages }
 			onAbort={ abortCurrentRequest }


### PR DESCRIPTION
Fixes DOTCOM-16172

## Proposed Changes

Wire up backend progress messages to the Agents Manager chat UI, so users see playful thinking messages (e.g. "Conjuring up some chromatic harmony...") while the agent processes their request.

## Why are these changes being made?

The backend ability classes (e.g. `Color_Palette_Ability`) already send playful progress messages via `TaskStatusUpdateEvent`, and `agenttic-client` already extracts them as `progressMessage` in the `useAgentChat` hook.

The `AgentUI.Container` component also already supports a `thinkingMessage` prop to display custom text in the thinking indicator. 

However, the Agents Manager never connected these two — so users always saw the default "Thinking…" text instead of the fun, contextual messages from the backend.

This change simply wires the existing `progressMessage` from `useAgentChat` through to `AgentUI.Container`'s `thinkingMessage` prop.

## Testing Instructions

* Sync the agents manager app with your sandbox using `yarn dev --sync`
* Make sure the Unified AI Chat experience is enabled
* Open the site editor and send the message `Show me color palettes for my site that are: playful`
* At some point, the `Thinking...` message should be replaced with a custom contextualized message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
