### PR TITLE
Checkout: Fix post-checkout redirect for logged-in unified checkout

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -201,6 +201,7 @@ function useRedirectOnTransactionSuccess( {
 	const isRenewal = firstPurchase?.isRenewal ?? false;
 	const productName = firstPurchase?.productName ?? '';
 	const willAutoRenew = firstPurchase?.willAutoRenew ?? false;
+	const blogId = firstPurchase?.blogId;
 	const saasRedirectUrl = getSaaSProductRedirectUrl( receipt );
 
 	const { searchParams } = getUrlParts( redirectTo || '/' );
@@ -249,13 +250,21 @@ function useRedirectOnTransactionSuccess( {
 			return;
 		}
 
+		// For siteless purchases where the pre-transaction redirect URL defaults to '/'
+		// (because the new site's ID was unknown before the transaction), use the
+		// receipt's blogId to redirect to the new site's thank-you page instead.
+		const effectiveRedirectTo =
+			( ! redirectTo || redirectTo === '/' ) && blogId && finalReceiptId
+				? `/checkout/thank-you/${ blogId }/${ finalReceiptId }`
+				: redirectTo;
+
 		const redirectInstructions = getRedirectFromPendingPage( {
 			isLoadingOrder,
 			error,
 			transaction,
 			orderId,
 			receiptId,
-			redirectTo,
+			redirectTo: effectiveRedirectTo,
 			siteSlug,
 			saasRedirectUrl,
 			fromSiteSlug,
@@ -288,6 +297,7 @@ function useRedirectOnTransactionSuccess( {
 		finalReceiptId,
 		isReceiptLoaded,
 		isRenewal,
+		blogId,
 		orderId,
 		productName,
 		receiptId,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1716/post-checkout-destination-for-logged-in-unified-checkout-is-not-the

## Proposed Changes

This PR modifies the checkout pending page to add a case for when a site ID is in the response but we have no other redirect URL; if so we redirect to `/checkout/thank-you/${siteId}/${receiptId}` instead of falling through to the root `/`.

## Why are these changes being made?

When a logged-in user with existing sites visits `/checkout/unified/personal` and completes checkout, a new site is created and the plan is assigned to it. However, the post-checkout redirect was landing on the user's **primary site's** home page (`/home/primarysite.wordpress.com`) rather than a page related to the new purchase.

Two bugs combined to cause this:

1. `getThankYouPageUrl`'s `unified` block had no fallback for the common case where the user skipped the onboarding flow (no cookie) and isn't buying an ecommerce plan. The function fell through to `getFallbackDestination` with `siteSlug = undefined` (intentionally unset for unified checkout), which returns `/`, and Calypso's root route then redirects to the primary site's home.

2. The `siteId` passed to `getThankYouPageUrl` is coming from `getSelectedSiteId` (the Redux-selected primary site), not from the newly created site. The new site's ID is available in `transactionResult.purchases` after the transaction completes.

## Testing Instructions

* Use a logged-in WordPress.com user that has at least one existing site.
* Visit `/checkout/unified/personal` and complete checkout.
* **Before**: redirected to `/home/<primary-site>`.
* **After**: redirected to `/checkout/thank-you/<new-site-id>/<receipt-id>`.
