### PR TITLE
Config: enable ciab/custom-branding in stage

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -30,7 +30,7 @@
 		"catch-js-errors": true,
 		"checkout/checkout-version": true,
 		"ciab/allow-domain-features": true,
-		"ciab/custom-branding": false,
+		"ciab/custom-branding": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/razorpay": true,


### PR DESCRIPTION
Part of ARC-1486

## Proposed Changes

* Enable the `ciab/custom-branding` feature flag in `config/stage.json`.
* Keep all other environments unchanged (strictly stage-only enablement).

## Why are these changes being made?

* We need to validate partner branding behavior (for example `/log-in?from=woo`) in a production-like environment without enabling the feature in production.

## Testing Instructions

* Deploy to stage environment.
* Open `/log-in?from=woo` on stage and verify partner branding is rendered.
* Open `/log-in` (without `from`) and verify default WordPress.com branding is still rendered.
* Confirm no behavior change in production where the flag remains disabled.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector, Using memoizing selectors, and Our Approach to Data.
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?