### PR TITLE
Image Studio: handle low credits warning notice from backend

### DIFF
--- a/packages/image-studio/src/abilities/update-canvas-image.ts
+++ b/packages/image-studio/src/abilities/update-canvas-image.ts
@@ -8,6 +8,7 @@
 import { registerAbility, registerAbilityCategory } from '@wordpress/abilities';
 import { store as coreStore } from '@wordpress/core-data';
 import { dispatch, resolveSelect, select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { store as imageStudioStore } from '../store';
 import { ImageStudioMode } from '../types';
 import { trackImageStudioError, trackImageStudioImageGenerated } from '../utils/tracking';
@@ -34,6 +35,13 @@ const ABILITY_NAME = 'image-studio/update-canvas-image';
 // Track if ability has been registered to avoid duplicate registration
 let isRegistered = false;
 
+interface LowCreditsNotice {
+	type: 'low_credits_warning';
+	message: string;
+	requests_remaining?: number;
+	upgrade_url?: string | null;
+}
+
 interface UpdateCanvasImageAbilityInput {
 	attachmentId?: string | number | null;
 	url?: string | null;
@@ -43,6 +51,7 @@ interface UpdateCanvasImageAbilityInput {
 		description?: string | null;
 		alt_text?: string | null;
 	};
+	notice?: LowCreditsNotice | null;
 }
 
 /**
@@ -124,8 +133,13 @@ export async function registerUpdateCanvasImageAbility(): Promise< void > {
 
 				const url = input?.url || '';
 
-				const { updateImageStudioCanvas, setDraftIds, setHasUpdatedMetadata, setCanvasMetadata } =
-					dispatch( imageStudioStore ) as ImageStudioActions;
+				const {
+					updateImageStudioCanvas,
+					setDraftIds,
+					setHasUpdatedMetadata,
+					setCanvasMetadata,
+					addNotice,
+				} = dispatch( imageStudioStore ) as ImageStudioActions;
 
 				const canvasMetadata = select( imageStudioStore ).getCanvasMetadata() || {};
 
@@ -240,6 +254,25 @@ export async function registerUpdateCanvasImageAbility(): Promise< void > {
 						attachmentId,
 						isAnnotated: false,
 					} );
+
+					// Show low credits warning if present in input
+					if ( input?.notice?.type === 'low_credits_warning' ) {
+						const notice = input.notice;
+						addNotice(
+							notice.message,
+							'warning',
+							notice.upgrade_url
+								? [
+										{
+											label: __( 'Upgrade', __i18n_text_domain__ ),
+											url: notice.upgrade_url,
+											openInNewTab: true,
+										},
+								  ]
+								: undefined,
+							true // dismissible
+						);
+					}
 				} catch ( error ) {
 					// Track the error
 					trackImageStudioError( {

--- a/packages/image-studio/src/abilities/update-canvas-image.ts
+++ b/packages/image-studio/src/abilities/update-canvas-image.ts
@@ -38,7 +38,6 @@ let isRegistered = false;
 interface LowCreditsNotice {
 	type: 'low_credits_warning';
 	message: string;
-	requests_remaining?: number;
 	upgrade_url?: string | null;
 }
 
@@ -139,6 +138,25 @@ export async function registerUpdateCanvasImageAbility(): Promise< void > {
 								description: 'The alt text for the image.',
 							},
 						},
+					},
+					notice: {
+						type: 'object',
+						description: 'Optional notice from the backend, e.g. a low-credits warning.',
+						properties: {
+							type: {
+								type: 'string',
+								description: 'The notice type identifier.',
+							},
+							message: {
+								type: 'string',
+								description: 'The user-facing message to display.',
+							},
+							upgrade_url: {
+								type: 'string',
+								description: 'Optional URL to an upgrade page.',
+							},
+						},
+						required: [ 'type', 'message' ],
 					},
 				},
 				required: [ 'attachmentId' ],

--- a/packages/image-studio/src/abilities/update-canvas-image.ts
+++ b/packages/image-studio/src/abilities/update-canvas-image.ts
@@ -42,6 +42,31 @@ interface LowCreditsNotice {
 	upgrade_url?: string | null;
 }
 
+/**
+ * Validate that a backend notice payload has the required shape.
+ * Guards against malformed or unexpected data from the API.
+ */
+function isValidNoticePayload( notice: unknown ): notice is LowCreditsNotice {
+	if ( typeof notice !== 'object' || notice === null ) {
+		return false;
+	}
+	const candidate = notice as Record< string, unknown >;
+	if ( candidate.type !== 'low_credits_warning' ) {
+		return false;
+	}
+	if ( typeof candidate.message !== 'string' || candidate.message.trim() === '' ) {
+		return false;
+	}
+	if (
+		candidate.upgrade_url !== undefined &&
+		candidate.upgrade_url !== null &&
+		typeof candidate.upgrade_url !== 'string'
+	) {
+		return false;
+	}
+	return true;
+}
+
 interface UpdateCanvasImageAbilityInput {
 	attachmentId?: string | number | null;
 	url?: string | null;
@@ -255,8 +280,8 @@ export async function registerUpdateCanvasImageAbility(): Promise< void > {
 						isAnnotated: false,
 					} );
 
-					// Show low credits warning if present in input
-					if ( input?.notice?.type === 'low_credits_warning' ) {
+					// Show notice from backend if present and well-formed
+					if ( input?.notice != null && isValidNoticePayload( input.notice ) ) {
 						const notice = input.notice;
 						addNotice(
 							notice.message,

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -141,7 +141,10 @@ function ImageStudioAgentChat( {
 
 	const isProcessing = agentChatProps.isProcessing || isAnnotationSaving;
 
-	const isFinalizingPhase = agentChatProps.progressPhase === 'uploading';
+	// progressPhase may not be present in all versions of agenttic-client
+	const isFinalizingPhase =
+		'progressPhase' in agentChatProps &&
+		( agentChatProps as unknown as Record< string, unknown > ).progressPhase === 'uploading';
 
 	// Disable input during upload phase or annotation saving to prevent orphan images
 	const isStopDisabled = isFinalizingPhase || isAnnotationSaving;

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -141,10 +141,8 @@ function ImageStudioAgentChat( {
 
 	const isProcessing = agentChatProps.isProcessing || isAnnotationSaving;
 
-	// progressPhase may not be present in all versions of agenttic-client
 	const isFinalizingPhase =
-		'progressPhase' in agentChatProps &&
-		( agentChatProps as unknown as Record< string, unknown > ).progressPhase === 'uploading';
+		( agentChatProps as unknown as { progressPhase?: string } ).progressPhase === 'uploading';
 
 	// Disable input during upload phase or annotation saving to prevent orphan images
 	const isStopDisabled = isFinalizingPhase || isAnnotationSaving;

--- a/packages/image-studio/src/components/notice/index.tsx
+++ b/packages/image-studio/src/components/notice/index.tsx
@@ -6,13 +6,13 @@ import './style.scss';
 
 /**
  * Renders a single warning notice using the core Notice component.
+ * Dismissibility is controlled by the notice's `dismissible` flag (set by the store).
  * Opens links in new tab to preserve Image Studio modal context.
  * @param root0           - Component props.
  * @param root0.notice    - The notice object to render.
  * @param root0.onDismiss - Callback when notice is dismissed.
  */
 function WarningNotice( { notice, onDismiss }: { notice: NoticeType; onDismiss?: () => void } ) {
-	// Low credits warnings are dismissible; quota exceeded warnings are not
 	const isDismissible = notice.dismissible ?? false;
 
 	return (

--- a/packages/image-studio/src/components/notice/index.tsx
+++ b/packages/image-studio/src/components/notice/index.tsx
@@ -7,15 +7,19 @@ import './style.scss';
 /**
  * Renders a single warning notice using the core Notice component.
  * Opens links in new tab to preserve Image Studio modal context.
- * @param root0        - Component props.
- * @param root0.notice - The notice object to render.
+ * @param root0           - Component props.
+ * @param root0.notice    - The notice object to render.
+ * @param root0.onDismiss - Callback when notice is dismissed.
  */
-function WarningNotice( { notice }: { notice: NoticeType } ) {
+function WarningNotice( { notice, onDismiss }: { notice: NoticeType; onDismiss?: () => void } ) {
+	// Low credits warnings are dismissible; quota exceeded warnings are not
+	const isDismissible = notice.dismissible ?? false;
+
 	return (
 		<Notice
 			status="warning"
-			// Intentionally non-dismissible: upgrade prompts should persist until user takes action
-			isDismissible={ false }
+			isDismissible={ isDismissible }
+			onDismiss={ isDismissible ? onDismiss : undefined }
 			actions={
 				notice.actions?.map( ( action ) => ( {
 					label: action.label,
@@ -47,7 +51,11 @@ export function ImageStudioNotice() {
 	return (
 		<>
 			{ warningNotices.map( ( notice ) => (
-				<WarningNotice key={ notice.id } notice={ notice } />
+				<WarningNotice
+					key={ notice.id }
+					notice={ notice }
+					onDismiss={ () => removeNotice( notice.id ) }
+				/>
 			) ) }
 			{ snackbarNotices.length > 0 && (
 				<SnackbarList

--- a/packages/image-studio/src/store/index.test.ts
+++ b/packages/image-studio/src/store/index.test.ts
@@ -1,7 +1,7 @@
-/* eslint-disable import/order */
 /**
- * Tests for Image Studio Store
+ * @jest-environment jsdom
  */
+/* eslint-disable import/order */
 import type { ImageStudioState, ImageStudioEntryPoint, AnnotationCanvasRef } from './index';
 // Mock localStorage
 const localStorageMock = ( () => {
@@ -242,6 +242,31 @@ describe( 'Image Studio Store', () => {
 				const action2 = actions.addNotice( 'Message 2', 'success' );
 
 				expect( action1.payload.id ).not.toBe( action2.payload.id );
+			} );
+
+			it( 'defaults warning notices to non-dismissible', () => {
+				const action = actions.addNotice( 'Quota exceeded', 'warning' );
+				expect( action.payload.dismissible ).toBe( false );
+			} );
+
+			it( 'defaults error notices to dismissible', () => {
+				const action = actions.addNotice( 'Something failed', 'error' );
+				expect( action.payload.dismissible ).toBe( true );
+			} );
+
+			it( 'defaults success notices to dismissible', () => {
+				const action = actions.addNotice( 'Saved', 'success' );
+				expect( action.payload.dismissible ).toBe( true );
+			} );
+
+			it( 'allows overriding dismissible to true for warnings', () => {
+				const action = actions.addNotice( 'Low credits', 'warning', undefined, true );
+				expect( action.payload.dismissible ).toBe( true );
+			} );
+
+			it( 'allows overriding dismissible to false for non-warnings', () => {
+				const action = actions.addNotice( 'Critical error', 'error', undefined, false );
+				expect( action.payload.dismissible ).toBe( false );
 			} );
 		} );
 	} );

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -38,6 +38,7 @@ export interface Notice {
 	content: string;
 	type: NoticeType;
 	actions?: NoticeAction[];
+	dismissible?: boolean;
 }
 
 export enum ImageStudioEntryPoint {
@@ -663,7 +664,8 @@ export interface ImageStudioActions {
 	addNotice: (
 		content: string,
 		type: NoticeType,
-		noticeActions?: NoticeAction[]
+		noticeActions?: NoticeAction[],
+		dismissible?: boolean
 	) => Promise< AddNoticeAction >;
 	removeNotice: ( noticeId: string ) => Promise< RemoveNoticeAction >;
 	setNavigableAttachmentIds: (
@@ -811,7 +813,12 @@ const actions = {
 		};
 	},
 
-	addNotice( content: string, type: NoticeType, noticeActions?: NoticeAction[] ): AddNoticeAction {
+	addNotice(
+		content: string,
+		type: NoticeType,
+		noticeActions?: NoticeAction[],
+		dismissible?: boolean
+	): AddNoticeAction {
 		return {
 			type: 'ADD_NOTICE',
 			payload: {
@@ -819,6 +826,8 @@ const actions = {
 				id: `${ Math.random().toString( 36 ).substring( 2, 9 ) }`,
 				content,
 				type,
+				// Warnings are non-dismissible by default (quota exceeded), unless explicitly set
+				dismissible: dismissible ?? type !== 'warning',
 				...( noticeActions?.length && {
 					actions: noticeActions,
 				} ),

--- a/packages/image-studio/src/store/index.ts
+++ b/packages/image-studio/src/store/index.ts
@@ -285,6 +285,20 @@ type ImageStudioAction =
 	| ResetCanvasHistoryAction;
 
 /**
+ * Resolve the dismissible flag for a notice.
+ *
+ * When the caller provides an explicit value it is used as-is.
+ * Otherwise, warning notices default to non-dismissible (e.g. hard
+ * quota errors), while all other notice types default to dismissible.
+ */
+function resolveNoticeDismissible( type: NoticeType, explicit?: boolean ): boolean {
+	if ( explicit !== undefined ) {
+		return explicit;
+	}
+	return type !== 'warning';
+}
+
+/**
  * Key for localStorage persistence
  */
 const SIDEBAR_IS_OPEN_STORAGE_KEY = 'big-sky-image-studio-sidebar-open';
@@ -826,8 +840,7 @@ const actions = {
 				id: `${ Math.random().toString( 36 ).substring( 2, 9 ) }`,
 				content,
 				type,
-				// Warnings are non-dismissible by default (quota exceeded), unless explicitly set
-				dismissible: dismissible ?? type !== 'warning',
+				dismissible: resolveNoticeDismissible( type, dismissible ),
 				...( noticeActions?.length && {
 					actions: noticeActions,
 				} ),


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

This PR adds the frontend support for displaying a dismissible "low credits" warning notice in Image Studio when the backend indicates the user is approaching their usage limit.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

  Currently, users only see a notice when they've completely exhausted their free credits. This creates a jarring experience when generation suddenly stops working.
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Follow the instructions from wpcom 205745

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
