### PR TITLE
Add Jetpack logo to Jetpack page headers

### DIFF
--- a/client/components/jetpack-title/index.tsx
+++ b/client/components/jetpack-title/index.tsx
@@ -1,0 +1,16 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+
+type JetpackTitleProps = {
+	title: string;
+};
+
+const JetpackTitle = ( { title }: JetpackTitleProps ) => (
+	<HStack alignment="center" spacing={ 2 }>
+		{ ! isJetpackCloud() && <JetpackLogo size={ 20 } /> }
+		<span>{ title }</span>
+	</HStack>
+);
+
+export default JetpackTitle;

--- a/client/components/jetpack-title/index.tsx
+++ b/client/components/jetpack-title/index.tsx
@@ -7,7 +7,7 @@ type JetpackTitleProps = {
 };
 
 const JetpackTitle = ( { title }: JetpackTitleProps ) => (
-	<HStack alignment="center" spacing={ 2 }>
+	<HStack alignment="center" justify="start" spacing={ 2 }>
 		{ ! isJetpackCloud() && <JetpackLogo size={ 20 } /> }
 		<span>{ title }</span>
 	</HStack>

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -22,6 +22,7 @@ import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings'; // For site time offset
 import EmptyContent from 'calypso/components/empty-content';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -489,7 +490,7 @@ class ActivityLog extends Component {
 
 				<NavigationHeader
 					navigationItems={ [] }
-					title={ translate( 'Activity' ) }
+					title={ <JetpackTitle title={ translate( 'Activity Log' ) } /> }
 					subtitle={ translate(
 						"Keep tabs on all your site's activity — plugin and theme updates, user logins, setting modifications, and more."
 					) }

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -1,6 +1,5 @@
 import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { ExternalLink } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -16,9 +15,9 @@ import QuerySiteCredentials from 'calypso/components/data/query-site-credentials
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import BackupActionsToolbar from 'calypso/components/jetpack/backup-actions-toolbar';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -50,7 +49,6 @@ const BackupPage = ( { queryDate } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSettingsUrl = useSelector( ( state ) => getSettingsUrl( state, siteId, 'general' ) );
-	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 
 	const moment = useLocalizedMoment();
 	const parsedQueryDate = queryDate ? moment( queryDate, INDEX_FORMAT ) : moment();
@@ -65,14 +63,6 @@ const BackupPage = ( { queryDate } ) => {
 	const selectedDate = useDateWithOffset( parsedQueryDate, {
 		keepLocalTime: !! queryDate,
 	} );
-
-	const supportLink = isAtomic ? (
-		<InlineSupportLink supportContext="backups" showIcon={ false } />
-	) : (
-		<ExternalLink href="https://jetpack.com/support/backup/">
-			{ translate( 'Learn more' ) }
-		</ExternalLink>
-	);
 
 	return (
 		<div
@@ -91,15 +81,8 @@ const BackupPage = ( { queryDate } ) => {
 				{ ! ( isJetpackCloud() || isA8CForAgencies() ) && (
 					<NavigationHeader
 						navigationItems={ [] }
-						title={ translate( 'Jetpack VaultPress Backup' ) }
-						subtitle={ translate(
-							'Restore or download a backup of your site from a specific moment in time. {{learnMoreLink/}}',
-							{
-								components: {
-									learnMoreLink: supportLink,
-								},
-							}
-						) }
+						title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
+						subtitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
 					>
 						<BackupActionsToolbar siteId={ siteId } />
 					</NavigationHeader>

--- a/client/my-sites/backup/wpcom-backup-upsell-placeholder.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell-placeholder.tsx
@@ -1,12 +1,17 @@
 import { useTranslate } from 'i18n-calypso';
 import WpcomUpsellPlaceholder from 'calypso/components/jetpack/wpcom-upsell-placeholder';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import NavigationHeader from 'calypso/components/navigation-header';
 
 export default function WpcomBackupUpsellPlaceholder() {
 	const translate = useTranslate();
 	return (
 		<>
-			<NavigationHeader navigationItems={ [] } title={ translate( 'Jetpack VaultPress Backup' ) } />
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
+				subtitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
+			/>
 			<WpcomUpsellPlaceholder />
 		</>
 	);

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -12,6 +12,7 @@ import VaultPressLogo from 'calypso/assets/images/jetpack/vaultpress-logo.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackDisconnectedWPCOM from 'calypso/components/jetpack/jetpack-disconnected-wpcom';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
@@ -281,7 +282,11 @@ export default function WPCOMUpsellPage( { reason }: { reason: string } ) {
 		<Main wideLayout className="backup__main backup__wpcom-upsell">
 			<DocumentHead title="Jetpack VaultPress Backup" />
 			<PageViewTracker path="/backup/:site" title="VaultPress Backup" />
-			<NavigationHeader navigationItems={ [] } title={ translate( 'Jetpack VaultPress Backup' ) } />
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
+				subtitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
+			/>
 
 			{ body }
 		</Main>

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -8,6 +8,7 @@ import { useTranslate } from 'i18n-calypso';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
@@ -53,7 +54,11 @@ export default function WPCOMUpsellPage() {
 			<DocumentHead title="Jetpack VaultPress Backup" />
 			<PageViewTracker path="/backup/:site" title="VaultPress Backup" />
 
-			<NavigationHeader navigationItems={ [] } title={ translate( 'Jetpack VaultPress Backup' ) } />
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ <JetpackTitle title={ translate( 'Backup' ) } /> }
+				subtitle={ translate( 'Save changes and restore quickly with one-click recovery.' ) }
+			/>
 
 			<PromoCard
 				title={ preventWidows(

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { capitalize, find } from 'lodash';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SectionNav from 'calypso/components/section-nav';
@@ -253,7 +254,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				<>
 					<NavigationHeader
 						navigationItems={ [] }
-						title={ translate( 'Monetize' ) }
+						title={ <JetpackTitle title={ translate( 'Monetize' ) } /> }
 						subtitle={ translate(
 							'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 							{

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import ThreatHistoryList from 'calypso/components/jetpack/threat-history-list';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
@@ -32,7 +33,11 @@ export default function ScanHistoryPage( { filter }: Props ) {
 			{ isJetpackPlatform && <SidebarNavigation /> }
 			<PageViewTracker path="/scan/history/:site" title="Scan History" />
 			{ ! ( isJetpackPlatform || isA8CForAgencies() ) && (
-				<NavigationHeader navigationItems={ [] } title={ translate( 'Jetpack Scan' ) } />
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
+					subtitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+				/>
 			) }
 
 			<ScanNavigation section="history" />

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -11,6 +11,7 @@ import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import ScanPlaceholder from 'calypso/components/jetpack/scan-placeholder';
 import ScanThreats from 'calypso/components/jetpack/scan-threats';
 import SecurityIcon from 'calypso/components/jetpack/security-icon';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -347,7 +348,11 @@ class ScanPage extends Component< Props > {
 				<PageViewTracker path="/scan/:site" title="Scanner" />
 				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
 				{ ! ( isJetpackPlatform || isA8CForAgencies() ) && (
-					<NavigationHeader navigationItems={ [] } title={ translate( 'Jetpack Scan' ) } />
+					<NavigationHeader
+						navigationItems={ [] }
+						title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
+						subtitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+					/>
 				) }
 
 				<QueryJetpackScan siteId={ siteId } />

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -11,6 +11,7 @@ import VaultPressLogo from 'calypso/assets/images/jetpack/vaultpress-logo.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackDisconnectedWPCOM from 'calypso/components/jetpack/jetpack-disconnected-wpcom';
 import SecurityIcon from 'calypso/components/jetpack/security-icon';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
@@ -196,7 +197,11 @@ export default function WPCOMScanUpsellPage( { reason }: { reason?: string } ) {
 			<DocumentHead title="Scanner" />
 			<PageViewTracker path="/scan/:site" title="Scanner" />
 
-			<NavigationHeader navigationItems={ [] } title={ translate( 'Jetpack Scan' ) } />
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
+				subtitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+			/>
 
 			{ body }
 		</Main>

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import JetpackScanSVG from 'calypso/assets/images/illustrations/jetpack-scan.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PromoCard from 'calypso/components/promo-section/promo-card';
@@ -26,7 +27,11 @@ export default function WPCOMScanUpsellPage() {
 			<DocumentHead title="Scanner" />
 			<PageViewTracker path="/scan/:site" title="Scanner" />
 
-			<NavigationHeader navigationItems={ [] } title={ translate( 'Jetpack Scan' ) } />
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ <JetpackTitle title={ translate( 'Scan' ) } /> }
+				subtitle={ translate( 'Automated malware scanning and firewall protection.' ) }
+			/>
 
 			<PromoCard
 				title={ translate( 'We guard your site. You run your business.' ) }

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -18,6 +18,7 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
@@ -434,7 +435,7 @@ const PodcastingDetails = () => {
 			<DocumentHead title={ translate( 'Podcasting' ) } />
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ translate( 'Podcasting' ) }
+				title={ <JetpackTitle title={ translate( 'Podcasting' ) } /> }
 				subtitle={ translate(
 					'Publish a podcast feed to Apple Podcasts and other podcasting services. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from 'react';
 import SubscriptionsModuleBanner from 'calypso/blocks/subscriptions-module-banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
@@ -401,10 +402,10 @@ const NewsletterSettings = () => {
 
 	return (
 		<Main wideLayout className="site-settings">
-			<DocumentHead title={ translate( 'Newsletter Settings' ) } />
+			<DocumentHead title="Jetpack Newsletter" />
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ translate( 'Newsletter Settings' ) }
+				title={ <JetpackTitle title={ translate( 'Newsletter' ) } /> }
 				subtitle={ translate(
 					'Transform your blog posts into newsletters to easily reach your subscribers.'
 				) }

--- a/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
@@ -7,6 +7,8 @@ import { plus } from '@wordpress/icons';
 import { translate, fixMe } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
+import DocumentHead from 'calypso/components/data/document-head';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import NavigationHeader from 'calypso/components/navigation-header';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSelector } from 'calypso/state';
@@ -112,9 +114,10 @@ export const SubscribersHeader = ( {
 
 	return (
 		<>
+			<DocumentHead title="Subscribers" />
 			<NavigationHeader
 				className="subscribers__header"
-				title={ translate( 'Subscribers' ) }
+				title={ <JetpackTitle title={ translate( 'Subscribers' ) } /> }
 				subtitle={
 					hideSubtitle
 						? null

--- a/client/sites/marketing/traffic/traffic.js
+++ b/client/sites/marketing/traffic/traffic.js
@@ -9,6 +9,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import JetpackTitle from 'calypso/components/jetpack-title';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -58,7 +59,7 @@ const SiteSettingsTraffic = ( {
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ translate( 'Traffic' ) }
+				title={ <JetpackTitle title={ translate( 'Traffic' ) } /> }
 				subtitle={ translate(
 					'Manage settings and tools related to the traffic your website receives. {{learnMoreLink/}}',
 					{


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of JETPACK-1364
Part of JETPACK-1358
Part of JETPACK-1365
Part of JETPACK-1383
Part of JETPACK-1362
Part of JETPACK-1349
Part of JETPACK-1390

## Proposed Changes

Adds Jetpack logo to Calypso page headers under Jetpack menu.

Simple logo addition first, before a more complex header swap:
- https://github.com/Automattic/wp-calypso/pull/108876
- https://github.com/Automattic/wp-calypso/pull/108878
- etc

We'll need this component in those headers components next up.

### Before

<img width="1563" height="799" alt="image" src="https://github.com/user-attachments/assets/f531cb8e-6daa-4666-915c-1c80ed796bd3" />
<img width="1571" height="673" alt="image" src="https://github.com/user-attachments/assets/16f9bf65-2e4e-493f-b196-61f4b95a7983" />
<img width="1577" height="696" alt="image" src="https://github.com/user-attachments/assets/a4afe337-9567-4946-a18a-41bd0daed0e1" />
<img width="1586" height="732" alt="image" src="https://github.com/user-attachments/assets/59b71f63-718b-4312-a49e-b10cb5ac8ced" />
<img width="1595" height="658" alt="image" src="https://github.com/user-attachments/assets/31a8d169-6bb8-4584-84d3-e4fb71c00537" />
<img width="1590" height="659" alt="image" src="https://github.com/user-attachments/assets/036f28a5-9d47-4055-8ac2-30cd0b06711b" />


### After

<img width="1547" height="698" alt="image" src="https://github.com/user-attachments/assets/d7b2a486-e01e-4769-8362-a34d0efe5607" />
<img width="1548" height="661" alt="image" src="https://github.com/user-attachments/assets/0f719697-315a-41a7-b0a8-dfcd24b7f32d" />
<img width="1544" height="664" alt="image" src="https://github.com/user-attachments/assets/3d643e2b-a50c-4737-a4c7-fe7b458b2033" />
<img width="1545" height="659" alt="image" src="https://github.com/user-attachments/assets/70fe9dad-0ae1-4acd-8066-1abcbdac67bc" />
<img width="1541" height="661" alt="image" src="https://github.com/user-attachments/assets/456a5976-0ee8-430f-985f-b397642cdede" />
<img width="1539" height="650" alt="image" src="https://github.com/user-attachments/assets/3bb9f12c-9ff2-4522-ac42-f05de17d2dcc" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
