### PR TITLE
A4A: Fix marketplace slider persistence and oscillation

### DIFF
--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -1,6 +1,6 @@
 import { useResizeObserver } from '@wordpress/compose';
 import clsx from 'clsx';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 import './style.scss';
 
@@ -67,9 +67,8 @@ export default function A4ASlider( {
 	const fillEndPosition = sliderSectionWidth * displayValue - valueOffset;
 	const fillAreaWidth = `${ Math.max( 0, fillEndPosition - disabledEndPosition + 1 ) }px`;
 
-	useEffect( () => {
-		onChange?.( options[ Math.max( value, normalizeMinimum ) ] );
-	}, [ normalizeMinimum, onChange, options, value ] );
+	// NOTE: Removed auto-select useEffect that was causing render loops
+	// The minimum is still enforced visually via displayValue and in onSliderChange
 
 	return (
 		<div className={ clsx( 'a4a-slider', className ) }>

--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -67,9 +67,6 @@ export default function A4ASlider( {
 	const fillEndPosition = sliderSectionWidth * displayValue - valueOffset;
 	const fillAreaWidth = `${ Math.max( 0, fillEndPosition - disabledEndPosition + 1 ) }px`;
 
-	// NOTE: Removed auto-select useEffect that was causing render loops
-	// The minimum is still enforced visually via displayValue and in onSliderChange
-
 	return (
 		<div className={ clsx( 'a4a-slider', className ) }>
 			{ label && (

--- a/client/a8c-for-agencies/sections/marketplace/hooks/test/use-keyed-persistence.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/test/use-keyed-persistence.test.ts
@@ -111,4 +111,34 @@ describe( 'useKeyedPersistence', () => {
 		expect( stored.tab1 ).toBe( '20' ); // serialized as doubled
 		expect( result.current[ 0 ] ).toBe( 10 ); // but state is correct
 	} );
+
+	it( 'provides synchronous getter for any key', () => {
+		// Pre-populate storage with values for multiple keys
+		sessionStorage.setItem(
+			STORAGE_KEY_PREFIX + 'test',
+			JSON.stringify( { tab1: 'value1', tab2: 'value2' } )
+		);
+
+		const { result } = renderHook( () =>
+			useKeyedPersistence( {
+				storageKey: 'test',
+				currentKey: 'tab1',
+				defaultValue: 'default',
+			} )
+		);
+
+		const getValueForKey = result.current[ 2 ];
+
+		// Can read current key's value synchronously
+		expect( getValueForKey( 'tab1' ) ).toBe( 'value1' );
+
+		// Can read other key's value synchronously without changing currentKey
+		expect( getValueForKey( 'tab2' ) ).toBe( 'value2' );
+
+		// Returns default for missing keys
+		expect( getValueForKey( 'tab3' ) ).toBe( 'default' );
+
+		// State value still reflects currentKey
+		expect( result.current[ 0 ] ).toBe( 'value1' );
+	} );
 } );

--- a/client/a8c-for-agencies/sections/marketplace/hooks/test/use-keyed-persistence.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/test/use-keyed-persistence.test.ts
@@ -27,7 +27,7 @@ describe( 'useKeyedPersistence', () => {
 	it( 'returns stored value for current key', () => {
 		sessionStorage.setItem(
 			STORAGE_KEY_PREFIX + 'test',
-			JSON.stringify( { tab1: 'stored-value' } )
+			JSON.stringify( { tab1: JSON.stringify( 'stored-value' ) } )
 		);
 
 		const { result } = renderHook( () =>
@@ -57,7 +57,7 @@ describe( 'useKeyedPersistence', () => {
 		expect( result.current[ 0 ] ).toBe( 'new-value' );
 
 		const stored = JSON.parse( sessionStorage.getItem( STORAGE_KEY_PREFIX + 'test' ) || '{}' );
-		expect( stored.tab1 ).toBe( 'new-value' );
+		expect( stored.tab1 ).toBe( JSON.stringify( 'new-value' ) );
 	} );
 
 	it( 'maintains separate values per key', () => {
@@ -92,31 +92,11 @@ describe( 'useKeyedPersistence', () => {
 		expect( result.current[ 0 ] ).toBe( 'tab1-value' );
 	} );
 
-	it( 'handles custom serialize/deserialize', () => {
-		const { result } = renderHook( () =>
-			useKeyedPersistence( {
-				storageKey: 'test',
-				currentKey: 'tab1',
-				defaultValue: 0,
-				serialize: ( v ) => String( v * 2 ),
-				deserialize: ( v ) => parseInt( v, 10 ) / 2,
-			} )
-		);
-
-		act( () => {
-			result.current[ 1 ]( 10 );
-		} );
-
-		const stored = JSON.parse( sessionStorage.getItem( STORAGE_KEY_PREFIX + 'test' ) || '{}' );
-		expect( stored.tab1 ).toBe( '20' ); // serialized as doubled
-		expect( result.current[ 0 ] ).toBe( 10 ); // but state is correct
-	} );
-
 	it( 'provides synchronous getter for any key', () => {
-		// Pre-populate storage with values for multiple keys
+		// Pre-populate storage with values for multiple keys (values are JSON-stringified)
 		sessionStorage.setItem(
 			STORAGE_KEY_PREFIX + 'test',
-			JSON.stringify( { tab1: 'value1', tab2: 'value2' } )
+			JSON.stringify( { tab1: JSON.stringify( 'value1' ), tab2: JSON.stringify( 'value2' ) } )
 		);
 
 		const { result } = renderHook( () =>

--- a/client/a8c-for-agencies/sections/marketplace/hooks/test/use-keyed-persistence.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/test/use-keyed-persistence.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import useKeyedPersistence from '../use-keyed-persistence';
+
+const STORAGE_KEY_PREFIX = 'a4a-marketplace-keyed-';
+
+describe( 'useKeyedPersistence', () => {
+	beforeEach( () => {
+		sessionStorage.clear();
+	} );
+
+	it( 'returns default value when no stored value exists', () => {
+		const { result } = renderHook( () =>
+			useKeyedPersistence( {
+				storageKey: 'test',
+				currentKey: 'tab1',
+				defaultValue: 'default',
+			} )
+		);
+
+		expect( result.current[ 0 ] ).toBe( 'default' );
+	} );
+
+	it( 'returns stored value for current key', () => {
+		sessionStorage.setItem(
+			STORAGE_KEY_PREFIX + 'test',
+			JSON.stringify( { tab1: 'stored-value' } )
+		);
+
+		const { result } = renderHook( () =>
+			useKeyedPersistence( {
+				storageKey: 'test',
+				currentKey: 'tab1',
+				defaultValue: 'default',
+			} )
+		);
+
+		expect( result.current[ 0 ] ).toBe( 'stored-value' );
+	} );
+
+	it( 'persists value when setter is called', () => {
+		const { result } = renderHook( () =>
+			useKeyedPersistence( {
+				storageKey: 'test',
+				currentKey: 'tab1',
+				defaultValue: 'default',
+			} )
+		);
+
+		act( () => {
+			result.current[ 1 ]( 'new-value' );
+		} );
+
+		expect( result.current[ 0 ] ).toBe( 'new-value' );
+
+		const stored = JSON.parse( sessionStorage.getItem( STORAGE_KEY_PREFIX + 'test' ) || '{}' );
+		expect( stored.tab1 ).toBe( 'new-value' );
+	} );
+
+	it( 'maintains separate values per key', () => {
+		const { result, rerender } = renderHook(
+			( { currentKey } ) =>
+				useKeyedPersistence( {
+					storageKey: 'test',
+					currentKey,
+					defaultValue: 'default',
+				} ),
+			{ initialProps: { currentKey: 'tab1' } }
+		);
+
+		// Set value for tab1
+		act( () => {
+			result.current[ 1 ]( 'tab1-value' );
+		} );
+		expect( result.current[ 0 ] ).toBe( 'tab1-value' );
+
+		// Switch to tab2
+		rerender( { currentKey: 'tab2' } );
+		expect( result.current[ 0 ] ).toBe( 'default' );
+
+		// Set value for tab2
+		act( () => {
+			result.current[ 1 ]( 'tab2-value' );
+		} );
+		expect( result.current[ 0 ] ).toBe( 'tab2-value' );
+
+		// Switch back to tab1 - should restore tab1's value
+		rerender( { currentKey: 'tab1' } );
+		expect( result.current[ 0 ] ).toBe( 'tab1-value' );
+	} );
+
+	it( 'handles custom serialize/deserialize', () => {
+		const { result } = renderHook( () =>
+			useKeyedPersistence( {
+				storageKey: 'test',
+				currentKey: 'tab1',
+				defaultValue: 0,
+				serialize: ( v ) => String( v * 2 ),
+				deserialize: ( v ) => parseInt( v, 10 ) / 2,
+			} )
+		);
+
+		act( () => {
+			result.current[ 1 ]( 10 );
+		} );
+
+		const stored = JSON.parse( sessionStorage.getItem( STORAGE_KEY_PREFIX + 'test' ) || '{}' );
+		expect( stored.tab1 ).toBe( '20' ); // serialized as doubled
+		expect( result.current[ 0 ] ).toBe( 10 ); // but state is correct
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/hooks/test/use-slider-persistence.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/test/use-slider-persistence.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import useSliderPersistence from '../use-slider-persistence';
+
+const STORAGE_KEY_PREFIX = 'a4a-marketplace-slider-';
+
+describe( 'useSliderPersistence', () => {
+	beforeEach( () => {
+		sessionStorage.clear();
+	} );
+
+	it( 'returns default value when no stored value exists', () => {
+		const { result } = renderHook( () => useSliderPersistence( { key: 'test', defaultValue: 5 } ) );
+
+		expect( result.current[ 0 ] ).toBe( 5 );
+	} );
+
+	it( 'returns stored value when available', () => {
+		sessionStorage.setItem( STORAGE_KEY_PREFIX + 'test', '10' );
+
+		const { result } = renderHook( () =>
+			useSliderPersistence( {
+				key: 'test',
+				defaultValue: 5,
+				deserialize: ( v ) => parseInt( v, 10 ),
+			} )
+		);
+
+		expect( result.current[ 0 ] ).toBe( 10 );
+	} );
+
+	it( 'updates both state and sessionStorage when setter is called', () => {
+		const { result } = renderHook( () => useSliderPersistence( { key: 'test', defaultValue: 1 } ) );
+
+		act( () => {
+			result.current[ 1 ]( 7 );
+		} );
+
+		expect( result.current[ 0 ] ).toBe( 7 );
+		expect( sessionStorage.getItem( STORAGE_KEY_PREFIX + 'test' ) ).toBe( '7' );
+	} );
+
+	it( 'handles string values correctly', () => {
+		const { result } = renderHook( () =>
+			useSliderPersistence( { key: 'plan', defaultValue: 'signature-1' } )
+		);
+
+		act( () => {
+			result.current[ 1 ]( 'enterprise-5' );
+		} );
+
+		expect( result.current[ 0 ] ).toBe( 'enterprise-5' );
+		expect( sessionStorage.getItem( STORAGE_KEY_PREFIX + 'plan' ) ).toBe( 'enterprise-5' );
+	} );
+
+	it( 'returns default value when deserialization fails', () => {
+		sessionStorage.setItem( STORAGE_KEY_PREFIX + 'test', 'invalid' );
+
+		const { result } = renderHook( () =>
+			useSliderPersistence( {
+				key: 'test',
+				defaultValue: 42,
+				deserialize: () => {
+					throw new Error( 'Parse error' );
+				},
+			} )
+		);
+
+		expect( result.current[ 0 ] ).toBe( 42 );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-keyed-persistence.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-keyed-persistence.ts
@@ -1,0 +1,92 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+const STORAGE_KEY_PREFIX = 'a4a-marketplace-keyed-';
+
+type KeyedPersistenceOptions< T > = {
+	storageKey: string;
+	currentKey: string;
+	defaultValue: T;
+	serialize?: ( value: T ) => string;
+	deserialize?: ( value: string ) => T;
+};
+
+/**
+ * Hook for persisting values per-key (e.g., per-tab) using sessionStorage.
+ * When the currentKey changes, the hook returns the stored value for that key.
+ * Values are cleared when the browser session ends.
+ */
+export default function useKeyedPersistence< T >( {
+	storageKey,
+	currentKey,
+	defaultValue,
+	serialize = ( v ) => String( v ),
+	deserialize = ( v ) => v as unknown as T,
+}: KeyedPersistenceOptions< T > ): [ T, ( value: T ) => void ] {
+	const fullStorageKey = STORAGE_KEY_PREFIX + storageKey;
+	const isInitialMount = useRef( true );
+
+	// Read the map from sessionStorage
+	const readMap = useCallback( (): Record< string, string > => {
+		try {
+			const stored = sessionStorage.getItem( fullStorageKey );
+			if ( stored ) {
+				return JSON.parse( stored );
+			}
+		} catch {
+			// sessionStorage might not be available or JSON parse failed
+		}
+		return {};
+	}, [ fullStorageKey ] );
+
+	// Write the map to sessionStorage
+	const writeMap = useCallback(
+		( map: Record< string, string > ) => {
+			try {
+				sessionStorage.setItem( fullStorageKey, JSON.stringify( map ) );
+			} catch {
+				// sessionStorage might not be available
+			}
+		},
+		[ fullStorageKey ]
+	);
+
+	// Get value for current key, or default
+	const getValueForKey = useCallback(
+		( key: string ): T => {
+			const map = readMap();
+			if ( key in map ) {
+				try {
+					return deserialize( map[ key ] );
+				} catch {
+					// deserialize failed
+				}
+			}
+			return defaultValue;
+		},
+		[ readMap, deserialize, defaultValue ]
+	);
+
+	const [ value, setValue ] = useState< T >( () => getValueForKey( currentKey ) );
+
+	// When currentKey changes, load the value for that key
+	useEffect( () => {
+		if ( isInitialMount.current ) {
+			isInitialMount.current = false;
+			return;
+		}
+		setValue( getValueForKey( currentKey ) );
+	}, [ currentKey, getValueForKey ] );
+
+	// Setter that persists to sessionStorage
+	const setPersistedValue = useCallback(
+		( newValue: T ) => {
+			const map = readMap();
+			map[ currentKey ] = serialize( newValue );
+			writeMap( map );
+			setValue( newValue );
+		},
+		[ currentKey, readMap, writeMap, serialize ]
+	);
+
+	return [ value, setPersistedValue ];
+}

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-keyed-persistence.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-keyed-persistence.ts
@@ -6,8 +6,6 @@ type KeyedPersistenceOptions< T > = {
 	storageKey: string;
 	currentKey: string;
 	defaultValue: T;
-	serialize?: ( value: T ) => string;
-	deserialize?: ( value: string ) => T;
 };
 
 /**
@@ -24,8 +22,6 @@ export default function useKeyedPersistence< T >( {
 	storageKey,
 	currentKey,
 	defaultValue,
-	serialize = ( v ) => String( v ),
-	deserialize = ( v ) => v as unknown as T,
 }: KeyedPersistenceOptions< T > ): [ T, ( value: T ) => void, ( key: string ) => T ] {
 	const fullStorageKey = STORAGE_KEY_PREFIX + storageKey;
 	const isInitialMount = useRef( true );
@@ -61,14 +57,14 @@ export default function useKeyedPersistence< T >( {
 			const map = readMap();
 			if ( key in map ) {
 				try {
-					return deserialize( map[ key ] );
+					return JSON.parse( map[ key ] ) as T;
 				} catch {
-					// deserialize failed
+					// JSON parse failed
 				}
 			}
 			return defaultValue;
 		},
-		[ readMap, deserialize, defaultValue ]
+		[ readMap, defaultValue ]
 	);
 
 	const [ value, setValue ] = useState< T >( () => getValueForKey( currentKey ) );
@@ -86,11 +82,11 @@ export default function useKeyedPersistence< T >( {
 	const setPersistedValue = useCallback(
 		( newValue: T ) => {
 			const map = readMap();
-			map[ currentKey ] = serialize( newValue );
+			map[ currentKey ] = JSON.stringify( newValue );
 			writeMap( map );
 			setValue( newValue );
 		},
-		[ currentKey, readMap, writeMap, serialize ]
+		[ currentKey, readMap, writeMap ]
 	);
 
 	return [ value, setPersistedValue, getValueForKey ];

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-keyed-persistence.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-keyed-persistence.ts
@@ -14,6 +14,11 @@ type KeyedPersistenceOptions< T > = {
  * Hook for persisting values per-key (e.g., per-tab) using sessionStorage.
  * When the currentKey changes, the hook returns the stored value for that key.
  * Values are cleared when the browser session ends.
+ *
+ * Returns: [value, setValue, getValueForKey]
+ * - value: The current value for currentKey
+ * - setValue: Setter that persists to sessionStorage
+ * - getValueForKey: Synchronous getter for any key (useful in effects)
  */
 export default function useKeyedPersistence< T >( {
 	storageKey,
@@ -21,7 +26,7 @@ export default function useKeyedPersistence< T >( {
 	defaultValue,
 	serialize = ( v ) => String( v ),
 	deserialize = ( v ) => v as unknown as T,
-}: KeyedPersistenceOptions< T > ): [ T, ( value: T ) => void ] {
+}: KeyedPersistenceOptions< T > ): [ T, ( value: T ) => void, ( key: string ) => T ] {
 	const fullStorageKey = STORAGE_KEY_PREFIX + storageKey;
 	const isInitialMount = useRef( true );
 
@@ -88,5 +93,5 @@ export default function useKeyedPersistence< T >( {
 		[ currentKey, readMap, writeMap, serialize ]
 	);
 
-	return [ value, setPersistedValue ];
+	return [ value, setPersistedValue, getValueForKey ];
 }

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-slider-persistence.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-slider-persistence.ts
@@ -1,0 +1,49 @@
+import { useState, useCallback } from 'react';
+
+const STORAGE_KEY_PREFIX = 'a4a-marketplace-slider-';
+
+type SliderPersistenceOptions< T > = {
+	key: string;
+	defaultValue: T;
+	serialize?: ( value: T ) => string;
+	deserialize?: ( value: string ) => T;
+};
+
+/**
+ * Hook for persisting slider values across tab switches using sessionStorage.
+ * Values are cleared when the browser session ends.
+ */
+export default function useSliderPersistence< T >( {
+	key,
+	defaultValue,
+	serialize = ( v ) => String( v ),
+	deserialize = ( v ) => v as unknown as T,
+}: SliderPersistenceOptions< T > ): [ T, ( value: T ) => void ] {
+	const storageKey = STORAGE_KEY_PREFIX + key;
+
+	const [ value, setValue ] = useState< T >( () => {
+		try {
+			const stored = sessionStorage.getItem( storageKey );
+			if ( stored !== null ) {
+				return deserialize( stored );
+			}
+		} catch {
+			// sessionStorage might not be available
+		}
+		return defaultValue;
+	} );
+
+	const setPersistedValue = useCallback(
+		( newValue: T ) => {
+			try {
+				sessionStorage.setItem( storageKey, serialize( newValue ) );
+			} catch {
+				// sessionStorage might not be available
+			}
+			setValue( newValue );
+		},
+		[ storageKey, serialize ]
+	);
+
+	return [ value, setPersistedValue ];
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -178,7 +178,9 @@ export default function PressablePlanSection( {
 			defaultSlug = 'pressable-build';
 		}
 
-		const defaultPlan = pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? null;
+		const defaultPlan = isReferralMode
+			? pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? null
+			: pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? pressablePlans[ 0 ];
 		setSelectedPlan( defaultPlan );
 	}, [
 		pressablePlans,

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -2,9 +2,11 @@ import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency, formatNumberCompact } from '@automattic/number-formatters';
 import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
+import useKeyedPersistence from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-keyed-persistence';
 import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
+import useSliderPersistence from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-slider-persistence';
 import {
 	PLAN_CATEGORY_SIGNATURE,
 	PLAN_CATEGORY_SIGNATURE_HIGH,
@@ -86,9 +88,18 @@ export default function PressablePlanSection( {
 
 	const existingPressablePlan = isReferralMode ? null : existingPlanInfo;
 
-	const [ selectedTab, setSelectedTab ] = useState(
-		getSelectedTab( existingPressablePlan, areSignaturePlans )
-	);
+	const [ selectedTab, setSelectedTab ] = useSliderPersistence( {
+		key: 'pressable-tab',
+		defaultValue: getSelectedTab( existingPressablePlan, areSignaturePlans ),
+	} );
+
+	// Persist the selected plan slug per-tab
+	const [ persistedPlanSlug, setPersistedPlanSlug ] = useKeyedPersistence< string | null >( {
+		storageKey: 'pressable-plan',
+		currentKey: selectedTab,
+		defaultValue: null,
+	} );
+
 	const [ selectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
 
 	const dispatch = useDispatch();
@@ -123,31 +134,86 @@ export default function PressablePlanSection( {
 		);
 	}, [ pressablePlans, areSignaturePlans ] );
 
-	useEffect( () => {
-		if ( pressablePlans?.length ) {
-			let defaultSlug = areSignaturePlans ? 'pressable-signature-1' : 'pressable-build';
+	// Track initialization to prevent effects from fighting each other
+	const isInitialized = useRef( false );
+	const skipNextTabChange = useRef( false );
 
-			if ( selectedTab === PLAN_CATEGORY_PREMIUM ) {
-				defaultSlug = 'pressable-premium-1';
+	// Restore plan for current tab when tab changes or on init
+	useEffect( () => {
+		if ( ! pressablePlans?.length ) {
+			return;
+		}
+
+		// Try to restore persisted plan for current tab
+		if ( persistedPlanSlug ) {
+			const persistedPlan = pressablePlans.find( ( p ) => p.slug === persistedPlanSlug );
+			if ( persistedPlan ) {
+				setSelectedPlan( persistedPlan );
+				return;
+			}
+		}
+
+		// Fall back to existing plan (for users with subscriptions)
+		if ( ! isReferralMode && existingPlan && ! isInitialized.current ) {
+			isInitialized.current = true;
+			const planInfo = getPressablePlan( existingPlan.slug );
+			// Only use existing plan if it matches current tab
+			if ( planInfo?.category === selectedTab ) {
+				setSelectedPlan( existingPlan );
+				setPersistedPlanSlug( existingPlan.slug );
+				return;
+			}
+		}
+
+		// Fall back to default plan for this tab
+		let defaultSlug = 'pressable-signature-1';
+		if (
+			selectedTab === PLAN_CATEGORY_SIGNATURE_HIGH ||
+			selectedTab === PLAN_CATEGORY_ENTERPRISE
+		) {
+			defaultSlug = areSignaturePlans ? 'pressable-signature-11' : 'pressable-enterprise-1';
+		} else if ( selectedTab === PLAN_CATEGORY_PREMIUM ) {
+			defaultSlug = 'pressable-premium-1';
+		} else if ( ! areSignaturePlans ) {
+			defaultSlug = 'pressable-build';
+		}
+
+		const defaultPlan = pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? null;
+		setSelectedPlan( defaultPlan );
+	}, [
+		pressablePlans,
+		selectedTab,
+		persistedPlanSlug,
+		setPersistedPlanSlug,
+		isReferralMode,
+		existingPlan,
+		areSignaturePlans,
+	] );
+
+	// Handle tab changes - just persist the tab, don't reset the plan
+	const handleTabChange = useCallback(
+		( tab: string ) => {
+			// Skip if this is from programmatic init (restoring persisted state)
+			if ( skipNextTabChange.current ) {
+				skipNextTabChange.current = false;
+				return;
 			}
 
-			setSelectedPlan(
-				isReferralMode
-					? pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? null
-					: pressablePlans.find( ( plan ) => plan.slug === defaultSlug ) ?? pressablePlans[ 0 ]
-			);
-		}
-	}, [ isReferralMode, pressablePlans, setSelectedPlan, areSignaturePlans, selectedTab ] );
+			setSelectedTab( tab );
+		},
+		[ setSelectedTab ]
+	);
 
-	useEffect( () => {
-		if ( ! isReferralMode && existingPlan ) {
-			setSelectedPlan( existingPlan );
-		}
-	}, [ existingPlan, isReferralMode ] );
-
-	useEffect( () => {
-		setSelectedTab( getSelectedTab( existingPressablePlan, areSignaturePlans ) );
-	}, [ areSignaturePlans, existingPressablePlan, setSelectedTab ] );
+	// Handle plan selection - update state and persist
+	const handlePlanSelect = useCallback(
+		( plan: APIProductFamilyProduct | null ) => {
+			setSelectedPlan( plan );
+			if ( plan ) {
+				setPersistedPlanSlug( plan.slug );
+			}
+		},
+		[ setPersistedPlanSlug ]
+	);
 
 	const onPlanAddToCart = useCallback( () => {
 		if ( selectedPlan ) {
@@ -170,13 +236,13 @@ export default function PressablePlanSection( {
 				<PlanSelectionFilter
 					selectedPlan={ selectedPlan }
 					plans={ filteredPressablePlans }
-					onSelectPlan={ setSelectedPlan }
+					onSelectPlan={ handlePlanSelect }
 					pressablePlan={ existingPressablePlan }
 					isLoading={ ! isFetching }
 					isReferralMode={ !! isReferralMode }
 					areSignaturePlans={ areSignaturePlans }
 					selectedTab={ selectedTab }
-					setSelectedTab={ setSelectedTab }
+					setSelectedTab={ handleTabChange }
 				/>
 			</HostingPlanSection.Banner>
 		);
@@ -189,6 +255,8 @@ export default function PressablePlanSection( {
 		isReferralMode,
 		areSignaturePlans,
 		selectedTab,
+		handleTabChange,
+		handlePlanSelect,
 	] );
 
 	const heading = useMemo( () => {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -94,7 +94,7 @@ export default function PressablePlanSection( {
 	} );
 
 	// Persist the selected plan slug per-tab
-	const [ persistedPlanSlug, setPersistedPlanSlug ] = useKeyedPersistence< string | null >( {
+	const [ , setPersistedPlanSlug, getPersistedPlanSlug ] = useKeyedPersistence< string | null >( {
 		storageKey: 'pressable-plan',
 		currentKey: selectedTab,
 		defaultValue: null,
@@ -136,7 +136,6 @@ export default function PressablePlanSection( {
 
 	// Track initialization to prevent effects from fighting each other
 	const isInitialized = useRef( false );
-	const skipNextTabChange = useRef( false );
 
 	// Restore plan for current tab when tab changes or on init
 	useEffect( () => {
@@ -144,9 +143,10 @@ export default function PressablePlanSection( {
 			return;
 		}
 
-		// Try to restore persisted plan for current tab
-		if ( persistedPlanSlug ) {
-			const persistedPlan = pressablePlans.find( ( p ) => p.slug === persistedPlanSlug );
+		// Read persisted plan synchronously to avoid race condition on tab switch
+		const persistedSlug = getPersistedPlanSlug( selectedTab );
+		if ( persistedSlug ) {
+			const persistedPlan = pressablePlans.find( ( p ) => p.slug === persistedSlug );
 			if ( persistedPlan ) {
 				setSelectedPlan( persistedPlan );
 				return;
@@ -183,7 +183,7 @@ export default function PressablePlanSection( {
 	}, [
 		pressablePlans,
 		selectedTab,
-		persistedPlanSlug,
+		getPersistedPlanSlug,
 		setPersistedPlanSlug,
 		isReferralMode,
 		existingPlan,
@@ -193,12 +193,6 @@ export default function PressablePlanSection( {
 	// Handle tab changes - just persist the tab, don't reset the plan
 	const handleTabChange = useCallback(
 		( tab: string ) => {
-			// Skip if this is from programmatic init (restoring persisted state)
-			if ( skipNextTabChange.current ) {
-				skipNextTabChange.current = false;
-				return;
-			}
-
 			setSelectedTab( tab );
 		},
 		[ setSelectedTab ]

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
@@ -12,6 +12,7 @@ import {
 	TermPricingContext,
 } from 'calypso/a8c-for-agencies/sections/marketplace/context';
 import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
+import useSliderPersistence from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-slider-persistence';
 import { getWPCOMCreatorPlan } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import { useDispatch, useSelector } from 'calypso/state';
 import { hasApprovedAgencyStatus } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -74,7 +75,11 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 		return count;
 	}, [ count, isReferralMode ] );
 
-	const [ quantity, setQuantity ] = useState( 1 );
+	const [ quantity, setQuantity ] = useSliderPersistence( {
+		key: 'wpcom-quantity',
+		defaultValue: 1,
+		deserialize: ( v ) => parseInt( v, 10 ) || 1,
+	} );
 
 	if ( ! plan ) {
 		return;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-selector/slider.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-selector/slider.tsx
@@ -96,9 +96,19 @@ export default function WPCOMPlanSlider( { quantity, ownedPlans, onChange, plan 
 		}
 	};
 
-	const value = isOverMaxValue
-		? MaxValue
-		: options.findIndex( ( option ) => option.value === ownedPlans + quantity );
+	const value = useMemo( () => {
+		if ( isOverMaxValue ) {
+			return options.length - 1;
+		}
+		const index = options.findIndex( ( option ) => option.value === ownedPlans + quantity );
+		// If persisted value doesn't match any option, default to first valid option
+		return index >= 0
+			? index
+			: Math.max(
+					0,
+					options.findIndex( ( o ) => o.value > ownedPlans )
+			  );
+	}, [ isOverMaxValue, options, ownedPlans, quantity ] );
 
 	return (
 		<A4ASlider

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
+import useSliderPersistence from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-slider-persistence';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -53,7 +54,10 @@ export default function PlanSelectionFilter( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
+	const [ filterType, setFilterType ] = useSliderPersistence< FilterType >( {
+		key: 'pressable-filter-type',
+		defaultValue: FILTER_TYPE_INSTALL,
+	} );
 	const [ disableStandardTab, setDisableStandardTab ] = useState( false );
 
 	const isMobile = useMobileBreakpoint();
@@ -161,7 +165,7 @@ export default function PlanSelectionFilter( {
 				recordTracksEvent( `calypso_a4a_marketplace_hosting_pressable_filter_by_${ value }_click` )
 			);
 		},
-		[ dispatch ]
+		[ dispatch, setFilterType ]
 	);
 
 	const onSelectTab = useCallback(
@@ -176,7 +180,7 @@ export default function PlanSelectionFilter( {
 				setFilterType( FILTER_TYPE_VISITS );
 			}
 		},
-		[ filterType, hasNewPremiumPlans, setSelectedTab ]
+		[ filterType, hasNewPremiumPlans, setSelectedTab, setFilterType ]
 	);
 
 	const additionalWrapperClass =


### PR DESCRIPTION
## Summary
- Fix slider oscillation/flashing when switching tabs on the A4A marketplace hosting page
- Persist slider positions when switching between hosting tabs (Pressable/WPCOM) and plan category tabs
- This issue was discussed in today's Product review call

## Changes
- Remove problematic `useEffect` in `A4ASlider` that fired `onChange` on every render, causing values to fight each other
- Add `useSliderPersistence` hook for simple sessionStorage-based state persistence
- Add `useKeyedPersistence` hook for per-tab plan persistence (each tab remembers its own selection)
- Persist WPCOM quantity slider across tab switches

## How persistence works
Values are stored in sessionStorage, meaning:
- Selections persist while the browser tab is open
- Selections reset when the browser tab is closed
- No server-side storage or cross-device sync

## Test plan
- [ ] Navigate to A4A marketplace hosting page
- [ ] Move the Pressable slider to select a different plan
- [ ] Switch to WPCOM hosting tab, then back to Pressable - slider should maintain position
- [ ] Switch between "Signature Plans 1-10" and "11-17" tabs - each tab should remember its selection
- [ ] Move the WPCOM quantity slider, switch to Pressable tab and back - should persist
- [ ] Close browser tab and reopen - selections should reset (expected behavior)

cc @jeffgolenski