### PR TITLE
MCP Settings: Use static toggle labels matching codebase conventions

### DIFF
--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -275,13 +275,7 @@ function McpComponent( { path } ) {
 									__nextHasNoMarginBottom
 									checked={ anyToolsEnabled }
 									onChange={ handleMasterToggle }
-									label={
-										<Text weight="bold">
-											{ anyToolsEnabled
-												? translate( 'Disable MCP Tool Access' )
-												: translate( 'Enable MCP Tool Access' ) }
-										</Text>
-									}
+									label={ <Text weight="bold">{ translate( 'Enable MCP Tool Access' ) }</Text> }
 								/>
 								{ anyToolsEnabled && (
 									<Button variant="secondary" href="/me/mcp-setup">
@@ -324,11 +318,7 @@ function McpComponent( { path } ) {
 										disabled={ mutation.isPending }
 										onChange={ ( enabled ) => handleSiteToggle( selectedSiteId, enabled ) }
 										label={
-											<Text weight="bold">
-												{ getSiteAccountToolsEnabled( userSettings || {}, selectedSiteId )
-													? translate( 'Disable MCP access for this site' )
-													: translate( 'Enable MCP access for this site' ) }
-											</Text>
+											<Text weight="bold">{ translate( 'Enable MCP access for this site' ) }</Text>
 										}
 									/>
 								) }


### PR DESCRIPTION
## Proposed Changes

* Changed MCP toggle labels from dynamic ("Enable"/"Disable" flipping based on state) to static labels that describe the ON state
* Applies to both the master toggle ("Enable MCP Tool Access") and the site-specific toggle ("Enable MCP access for this site")

## Why are these changes being made?

The previous implementation flipped toggle labels between "Enable" and "Disable" based on the current state, which was confusing — when the toggle was ON, the text said "Disable", contradicting the visual state. This doesn't match the convention used throughout Calypso settings pages, where toggles use static labels (e.g., "Allow people to post comments", "Enable the in-page translator") and the visual toggle state communicates whether it's on or off.

## Screenshots

### Master Toggle
| Before | After |
|--------|-------|
| Toggle ON shows "Disable MCP Tool Access" | Toggle ON shows "Enable MCP Tool Access" |
| <img width="1069" height="171" alt="Screenshot 2026-02-27 at 4 32 40 PM" src="https://github.com/user-attachments/assets/c2ee5ce8-f83d-4364-9efb-56e1384c90fa" /> | <img width="1066" height="170" alt="Screenshot 2026-02-27 at 4 32 53 PM" src="https://github.com/user-attachments/assets/3bac8487-ca7b-4f91-bafb-d39fd6010b26" /> |


### Site-specific Toggle
| Before | After |
|--------|-------|
| Toggle ON shows "Disable MCP access for this site" | Toggle ON shows "Enable MCP access for this site" |
| <img width="1063" height="250" alt="Screenshot 2026-02-27 at 4 33 23 PM" src="https://github.com/user-attachments/assets/386334a5-0497-4640-b700-a090917eca2f" /> | <img width="1062" height="248" alt="Screenshot 2026-02-27 at 4 33 33 PM" src="https://github.com/user-attachments/assets/58c1a0d7-c71a-480f-b54b-4fed87766cda" /> |

## Testing Instructions

* Navigate to `/me/mcp` (MCP Account Settings)
* Verify the master toggle label always reads "Enable MCP Tool Access" regardless of toggle state
* Toggle on, select a site, and verify the site-specific toggle label always reads "Enable MCP access for this site"
* Compare with other settings pages (e.g., `/me/privacy`, Discussion settings) to confirm consistent toggle label behavior

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)