### PR TITLE
My Sites: Guard against null selectedSite in onSelectedSiteAvailable

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -315,6 +315,11 @@ function isPathAllowedForDIFMInProgressSite( path, slug, domains, contextParams 
 function onSelectedSiteAvailable( context ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
+
+	if ( ! selectedSite ) {
+		return false;
+	}
+
 	// Use getSitePlanSlug() as it ignores expired plans.
 	const currentPlanSlug = getSitePlanSlug( state, selectedSite.ID );
 


### PR DESCRIPTION
## Proposed Changes

* Add a null guard for `selectedSite` at the top of `onSelectedSiteAvailable` in `client/my-sites/controller.js`

## Why are these changes being made?

`getSelectedSite` can return `null` when the Redux store has a selected site ID set but the full site object hasn't been loaded yet. Without this guard, the function immediately accesses `selectedSite.ID` on the next line, throwing an uncaught `TypeError: Cannot read properties of null (reading 'ID')` that surfaces as a promise rejection in production.

Returning `false` early is consistent with the existing behavior of the function — all other early exits also return `false`, which prevents the route middleware from calling `next()`.

## Testing Instructions

* Navigate to a my-sites route where the site data may not be immediately available
* Confirm no uncaught TypeError is thrown in the console
* Confirm normal site routing still works as expected

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?