### PR TITLE
Image Studio: Improve Agents experience

### DIFF
--- a/packages/image-studio/.agents/skills/ui-testing/SKILL.md
+++ b/packages/image-studio/.agents/skills/ui-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-studio-ui-tests
-description: Run comprehensive UI tests for the Image Studio feature
+description: Run comprehensive UI tests for the Image Studio feature. Covers Media Library entry points, Edit Mode, Generate Mode, Block Editor integration, navigation, and delete. Use when running the full UI smoke test or testing any Image Studio surface.
 ---
 
 # Image Studio UI Tests
@@ -55,81 +55,15 @@ Section 12 (Delete Permanently) ──► requires Edit Mode with Image Info sid
 
 ## CSS Selectors & Aria Labels Reference
 
-Use these selectors for automated testing with Playwright.
+Full selector tables for all elements (Modal, Sidebar, Generate Mode, Canvas, Block Editor): see [references/selectors.md](references/selectors.md).
 
-### Media Library Page
-
-| Element                | Selector                                                                       |
-| ---------------------- | ------------------------------------------------------------------------------ |
-| Generate Image button  | `.big-sky-image-studio-link` or `.page-title-action.big-sky-image-studio-link` |
-| List view toggle       | `.view-switch-list` or `button[id="view-switch-list"]`                         |
-| Row actions (on hover) | `.wp-list-table tbody tr td.title .row-actions`                                |
-| Image title link       | `.wp-list-table tbody tr td.title a`                                           |
-
-### Image Studio Modal (shared across modes)
-
-| Element                     | Selector / Aria Label                                                                               |
-| --------------------------- | --------------------------------------------------------------------------------------------------- |
-| Modal overlay               | `.components-modal__screen-overlay.image-studio-overlay`                                            |
-| Modal content               | `.image-studio-modal__content`                                                                      |
-| Header bar                  | `.image-studio-header`                                                                              |
-| Title text ("Image Editor") | `.image-studio-header__title`                                                                       |
-| Beta badge                  | `.image-studio-badge`                                                                               |
-| Nav prev button             | `aria-label="Previous image ⌘←"` / `.image-studio-header__nav-button`                               |
-| Nav next button             | `aria-label="Next image ⌘→"` / `.image-studio-header__nav-button`                                   |
-| Filename display            | `.image-studio-header__filename`                                                                    |
-| Media Library button        | `aria-label="Edit this image in the WordPress Media Library"` / `.image-studio-classic-editor-link` |
-| Select tool                 | `aria-label="Select an area of the image to edit"`                                                  |
-| Image Info toggle           | `aria-label="View or edit information about the image"` / `.image-studio-toolbar-alt-button`        |
-| Save button                 | `.image-studio-header button.is-primary` (text: "Save" or "Save & Apply")                           |
-| Close button                | `aria-label="Close image editor"`                                                                   |
-| Notices container           | `.image-studio-modal__notices`                                                                      |
-| Screen reader status        | `.image-studio-sr-only`                                                                             |
-
-### Sidebar (Image Info)
-
-| Element               | Selector                         |
-| --------------------- | -------------------------------- |
-| Sidebar container     | `.image-studio-sidebar`          |
-| Sidebar header        | `.image-studio-sidebar__header`  |
-| Sidebar content       | `.image-studio-sidebar__content` |
-| Modal sidebar wrapper | `.image-studio-modal__sidebar`   |
-
-### Generate Mode (Chat / AI Agent)
-
-| Element                    | Selector / Aria Label                                                             |
-| -------------------------- | --------------------------------------------------------------------------------- |
-| AI agent container         | `.image-studio-agent.agenttic`                                                    |
-| Chat input (textarea)      | `textarea` inside `.image-studio-modal__content`                                  |
-| Input toolbar              | `.image-studio-modal__input-toolbar`                                              |
-| Send button                | `aria-label="Send message"`                                                       |
-| Good response (thumbs up)  | `aria-label="Good response"`                                                      |
-| Bad response (thumbs down) | `aria-label="Bad response"`                                                       |
-| Style selector button      | `.AgentUIInputToolbar-module_button` (text shows current style, e.g. "None")      |
-| Aspect Ratio button        | `.AgentUIInputToolbar-module_button` (text shows "Aspect Ratio" or current ratio) |
-| Loading state              | `.image-studio-suggestions-loading` or `.image-studio-agent-loading`              |
-
-### Confirmation Dialog (Unsaved Changes)
-
-| Element        | Selector                                    |
-| -------------- | ------------------------------------------- |
-| Dialog content | `.image-studio-confirmation-dialog-content` |
-
-### Canvas
-
-| Element       | Selector                     |
-| ------------- | ---------------------------- |
-| Image display | `.image-studio-image`        |
-| Exit overlay  | `.image-studio-exit-overlay` |
-
-### Block Editor
-
-| Element                   | Selector                                                   |
-| ------------------------- | ---------------------------------------------------------- |
-| Editor content iframe     | `iframe[name="editor-canvas"]`                             |
-| Block Inserter button     | `aria-label="Block Inserter"`                              |
-| Image block placeholder   | `[data-type="core/image"]` (inside editor iframe)          |
-| Generate Image (in block) | `button:has-text("Generate Image")` (inside editor iframe) |
+Key selectors used across most sections:
+- Modal overlay: `.components-modal__screen-overlay.image-studio-overlay`
+- Modal content: `.image-studio-modal__content`
+- Close button: `aria-label="Close image editor"`
+- Save button: `.image-studio-header button.is-primary`
+- Image display: `.image-studio-image`
+- Generate Image button: `.big-sky-image-studio-link`
 
 ---
 
@@ -382,91 +316,7 @@ When running these tests with Playwright MCP (not playwright-test):
 
 ---
 
-## Troubleshooting
+## Troubleshooting & Output
 
-### Known Flaky Areas
-
-Use `⚠️ Partial` for these when behavior is intermittent and reproducible retries still fail.
-These flake notes apply to **sandbox test runs** (e.g., `*.sandbox.wordpress.com`) and should not be assumed for production without re-validation.
-
-- **Section 9 (Block Editor - Generate Entry Point):** The Image block may intermittently not expose **Generate Image** inside `iframe[name="editor-canvas"]`, even after valid setup.
-  - Retry once after re-selecting/re-inserting the Image block.
-  - If still missing, report as `⚠️ Partial (flaky Section 9)`.
-- **Section 10 (Block Editor - Edit Entry Point):** Depends on Section 9 setup and an inserted/selectable image block.
-  - If Section 9 is flaky/blocked, report Section 10 as `⚠️ Partial (blocked by Section 9)` instead of a hard fail.
-- **Section 6 (Prompt & AI Response):** Backend generation may intermittently time out with no explicit streaming error.
-  - Follow the existing retry-once rule, then report as `⚠️ Partial (backend flake)` if both attempts fail.
-
-| Issue                                        | Check                                                                                                                        |
-| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| **"Generate Image" button not visible**      | Confirm you're on Media Library page (`upload.php`), not a post edit screen                                                  |
-| **"Edit with AI" not in row actions**        | Confirm you're in List view, not Grid view. If still missing, use hash deep-link (Section 8) instead                         |
-| **AI generation hangs**                      | Check DevTools Console for API errors; wait up to 50 seconds, then retry once                                                |
-| **Streaming error during generation**        | May be a transient backend issue. Retry once. More common from block editor context than Media Library                       |
-| **Block Editor doesn't load**                | Try refreshing; check for JavaScript errors in console                                                                       |
-| **Hash deep-link not working**               | Verify ID is correct; check URL format is exactly `#ai-image-editor=123`; wait for full page load                            |
-| **Section 4 reopen inconsistent**            | Reopen by the captured attachment ID (hash or exact row selector), not by “first row” which may change order                 |
-| **Can't interact with block editor content** | Content is inside `iframe[name="editor-canvas"]` — use iframe-aware interaction methods                                      |
-| **Section 9/10 cannot find Image actions**   | Insert Image block via iframe inline **Add block** button first. `Edit with AI` appears only after a real image is selected. |
-| **Suggestion chip doesn't generate**         | Chips only populate the input; press Enter or click send button to start generation                                          |
-| **"AI Editor" sidebar opens site editor**    | This is expected — it links to the site editor (`site-editor.php`), not Image Studio edit mode                               |
-| **Modal intercepts clicks on background**    | Target elements inside `.image-studio-modal__content` specifically; use JS evaluate as fallback                              |
-
----
-
-## Test Output Template
-
-```
-## Image Studio UI Smoke Test Results
-
-**Date:** YYYY-MM-DD
-**Tester:** [Name]
-**Branch:** forno-194/image-studio-feature-parity
-**Site:** https://[site].wordpress.com
-
-### Results Summary
-- Total Sections: 12
-- Passed: [N]
-- Partial: [N]
-- Failed: [N]
-- Untestable: [N]
-
-### Section Results
-
-| Section | Status | Notes |
-|---------|--------|-------|
-| 1. Media Library Entry Points | ✅/⚠️/❌ | [Details if failed] |
-| 2. Edit Mode | ✅/⚠️/❌ | [Details if failed] |
-| 3. Sidebar & Metadata | ✅/⚠️/❌ | [Details if failed] |
-| 4. Unsaved Changes Dialog | ✅/⚠️/❌ | [Details if failed] |
-| 5. Generate Mode | ✅/⚠️/❌ | [Details if failed] |
-| 6. Prompt & AI Response | ✅/⚠️/❌ | [Details if failed] |
-| 7. Save Flow | ✅/⚠️/❌ | [Details if failed] |
-| 8. Hash Deep-Link | ✅/⚠️/❌ | [Details if failed] |
-| 9. Block Editor — Generate | ✅/⚠️/❌ | [Details if failed] |
-| 10. Block Editor — Edit | ✅/⚠️/❌ | [Details if failed] |
-| 11. Navigation Arrows | ✅/⚠️/❌ | [Details if failed] |
-| 12. Delete Permanently | ✅/⚠️/❌ | [Details if failed] |
-
-### Console Errors (if any)
-```
-
-[Paste relevant errors]
-
-```
-
-### Failed DOM Assertions (if any)
-- Step X.X: Expected `.selector` to be visible, got `offsetHeight: 0`
-- Step X.X: Expected `button` to be disabled, got `disabled: false`
-```
-
----
-
-## Reporting Issues
-
-For each failure, capture:
-
-1. **Exact step** that failed
-2. **DOM state** — what the selector returned vs. what was expected
-3. **Browser DevTools Console** errors (if any, via `playwright_console_logs`)
-4. **Entry point used** (row action, hash deep-link, block editor button, etc.)
+- **Known flaky areas and common issues**: see [references/troubleshooting.md](references/troubleshooting.md)
+- **Test results reporting template**: see [references/output-template.md](references/output-template.md)

--- a/packages/image-studio/.agents/skills/ui-testing/references/output-template.md
+++ b/packages/image-studio/.agents/skills/ui-testing/references/output-template.md
@@ -1,0 +1,54 @@
+# Test Output Template
+
+```
+## Image Studio UI Smoke Test Results
+
+**Date:** YYYY-MM-DD
+**Tester:** [Name]
+**Branch:** forno-194/image-studio-feature-parity
+**Site:** https://[site].wordpress.com
+
+### Results Summary
+- Total Sections: 12
+- Passed: [N]
+- Partial: [N]
+- Failed: [N]
+- Untestable: [N]
+
+### Section Results
+
+| Section | Status | Notes |
+|---------|--------|-------|
+| 1. Media Library Entry Points | ✅/⚠️/❌ | [Details if failed] |
+| 2. Edit Mode | ✅/⚠️/❌ | [Details if failed] |
+| 3. Sidebar & Metadata | ✅/⚠️/❌ | [Details if failed] |
+| 4. Unsaved Changes Dialog | ✅/⚠️/❌ | [Details if failed] |
+| 5. Generate Mode | ✅/⚠️/❌ | [Details if failed] |
+| 6. Prompt & AI Response | ✅/⚠️/❌ | [Details if failed] |
+| 7. Save Flow | ✅/⚠️/❌ | [Details if failed] |
+| 8. Hash Deep-Link | ✅/⚠️/❌ | [Details if failed] |
+| 9. Block Editor — Generate | ✅/⚠️/❌ | [Details if failed] |
+| 10. Block Editor — Edit | ✅/⚠️/❌ | [Details if failed] |
+| 11. Navigation Arrows | ✅/⚠️/❌ | [Details if failed] |
+| 12. Delete Permanently | ✅/⚠️/❌ | [Details if failed] |
+
+### Console Errors (if any)
+```
+
+[Paste relevant errors]
+
+```
+
+### Failed DOM Assertions (if any)
+- Step X.X: Expected `.selector` to be visible, got `offsetHeight: 0`
+- Step X.X: Expected `button` to be disabled, got `disabled: false`
+```
+
+## Reporting Issues
+
+For each failure, capture:
+
+1. **Exact step** that failed
+2. **DOM state** — what the selector returned vs. what was expected
+3. **Browser DevTools Console** errors (if any, via `playwright_console_logs`)
+4. **Entry point used** (row action, hash deep-link, block editor button, etc.)

--- a/packages/image-studio/.agents/skills/ui-testing/references/selectors.md
+++ b/packages/image-studio/.agents/skills/ui-testing/references/selectors.md
@@ -1,0 +1,77 @@
+# CSS Selectors & Aria Labels Reference
+
+Use these selectors for automated testing with Playwright.
+
+## Media Library Page
+
+| Element                | Selector                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| Generate Image button  | `.big-sky-image-studio-link` or `.page-title-action.big-sky-image-studio-link` |
+| List view toggle       | `.view-switch-list` or `button[id="view-switch-list"]`                         |
+| Row actions (on hover) | `.wp-list-table tbody tr td.title .row-actions`                                |
+| Image title link       | `.wp-list-table tbody tr td.title a`                                           |
+
+## Image Studio Modal (shared across modes)
+
+| Element                     | Selector / Aria Label                                                                               |
+| --------------------------- | --------------------------------------------------------------------------------------------------- |
+| Modal overlay               | `.components-modal__screen-overlay.image-studio-overlay`                                            |
+| Modal content               | `.image-studio-modal__content`                                                                      |
+| Header bar                  | `.image-studio-header`                                                                              |
+| Title text ("Image Editor") | `.image-studio-header__title`                                                                       |
+| Beta badge                  | `.image-studio-badge`                                                                               |
+| Nav prev button             | `aria-label="Previous image ⌘←"` / `.image-studio-header__nav-button`                               |
+| Nav next button             | `aria-label="Next image ⌘→"` / `.image-studio-header__nav-button`                                   |
+| Filename display            | `.image-studio-header__filename`                                                                    |
+| Media Library button        | `aria-label="Edit this image in the WordPress Media Library"` / `.image-studio-classic-editor-link` |
+| Select tool                 | `aria-label="Select an area of the image to edit"`                                                  |
+| Image Info toggle           | `aria-label="View or edit information about the image"` / `.image-studio-toolbar-alt-button`        |
+| Save button                 | `.image-studio-header button.is-primary` (text: "Save" or "Save & Apply")                           |
+| Close button                | `aria-label="Close image editor"`                                                                   |
+| Notices container           | `.image-studio-modal__notices`                                                                      |
+| Screen reader status        | `.image-studio-sr-only`                                                                             |
+
+## Sidebar (Image Info)
+
+| Element               | Selector                         |
+| --------------------- | -------------------------------- |
+| Sidebar container     | `.image-studio-sidebar`          |
+| Sidebar header        | `.image-studio-sidebar__header`  |
+| Sidebar content       | `.image-studio-sidebar__content` |
+| Modal sidebar wrapper | `.image-studio-modal__sidebar`   |
+
+## Generate Mode (Chat / AI Agent)
+
+| Element                    | Selector / Aria Label                                                             |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| AI agent container         | `.image-studio-agent.agenttic`                                                    |
+| Chat input (textarea)      | `textarea` inside `.image-studio-modal__content`                                  |
+| Input toolbar              | `.image-studio-modal__input-toolbar`                                              |
+| Send button                | `aria-label="Send message"`                                                       |
+| Good response (thumbs up)  | `aria-label="Good response"`                                                      |
+| Bad response (thumbs down) | `aria-label="Bad response"`                                                       |
+| Style selector button      | `.AgentUIInputToolbar-module_button` (text shows current style, e.g. "None")      |
+| Aspect Ratio button        | `.AgentUIInputToolbar-module_button` (text shows "Aspect Ratio" or current ratio) |
+| Loading state              | `.image-studio-suggestions-loading` or `.image-studio-agent-loading`              |
+
+## Confirmation Dialog (Unsaved Changes)
+
+| Element        | Selector                                    |
+| -------------- | ------------------------------------------- |
+| Dialog content | `.image-studio-confirmation-dialog-content` |
+
+## Canvas
+
+| Element       | Selector                     |
+| ------------- | ---------------------------- |
+| Image display | `.image-studio-image`        |
+| Exit overlay  | `.image-studio-exit-overlay` |
+
+## Block Editor
+
+| Element                   | Selector                                                   |
+| ------------------------- | ---------------------------------------------------------- |
+| Editor content iframe     | `iframe[name="editor-canvas"]`                             |
+| Block Inserter button     | `aria-label="Block Inserter"`                              |
+| Image block placeholder   | `[data-type="core/image"]` (inside editor iframe)          |
+| Generate Image (in block) | `button:has-text("Generate Image")` (inside editor iframe) |

--- a/packages/image-studio/.agents/skills/ui-testing/references/troubleshooting.md
+++ b/packages/image-studio/.agents/skills/ui-testing/references/troubleshooting.md
@@ -1,0 +1,31 @@
+# Troubleshooting
+
+## Known Flaky Areas
+
+Use `⚠️ Partial` for these when behavior is intermittent and reproducible retries still fail.
+These flake notes apply to **sandbox test runs** (e.g., `*.sandbox.wordpress.com`) and should not be assumed for production without re-validation.
+
+- **Section 9 (Block Editor - Generate Entry Point):** The Image block may intermittently not expose **Generate Image** inside `iframe[name="editor-canvas"]`, even after valid setup.
+  - Retry once after re-selecting/re-inserting the Image block.
+  - If still missing, report as `⚠️ Partial (flaky Section 9)`.
+- **Section 10 (Block Editor - Edit Entry Point):** Depends on Section 9 setup and an inserted/selectable image block.
+  - If Section 9 is flaky/blocked, report Section 10 as `⚠️ Partial (blocked by Section 9)` instead of a hard fail.
+- **Section 6 (Prompt & AI Response):** Backend generation may intermittently time out with no explicit streaming error.
+  - Follow the existing retry-once rule, then report as `⚠️ Partial (backend flake)` if both attempts fail.
+
+## Common Issues
+
+| Issue                                        | Check                                                                                                                        |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **"Generate Image" button not visible**      | Confirm you're on Media Library page (`upload.php`), not a post edit screen                                                  |
+| **"Edit with AI" not in row actions**        | Confirm you're in List view, not Grid view. If still missing, use hash deep-link (Section 8) instead                         |
+| **AI generation hangs**                      | Check DevTools Console for API errors; wait up to 50 seconds, then retry once                                                |
+| **Streaming error during generation**        | May be a transient backend issue. Retry once. More common from block editor context than Media Library                       |
+| **Block Editor doesn't load**                | Try refreshing; check for JavaScript errors in console                                                                       |
+| **Hash deep-link not working**               | Verify ID is correct; check URL format is exactly `#ai-image-editor=123`; wait for full page load                            |
+| **Section 4 reopen inconsistent**            | Reopen by the captured attachment ID (hash or exact row selector), not by "first row" which may change order                 |
+| **Can't interact with block editor content** | Content is inside `iframe[name="editor-canvas"]` — use iframe-aware interaction methods                                      |
+| **Section 9/10 cannot find Image actions**   | Insert Image block via iframe inline **Add block** button first. `Edit with AI` appears only after a real image is selected. |
+| **Suggestion chip doesn't generate**         | Chips only populate the input; press Enter or click send button to start generation                                          |
+| **"AI Editor" sidebar opens site editor**    | This is expected — it links to the site editor (`site-editor.php`), not Image Studio edit mode                               |
+| **Modal intercepts clicks on background**    | Target elements inside `.image-studio-modal__content` specifically; use JS evaluate as fallback                              |

--- a/packages/image-studio/AGENTS.md
+++ b/packages/image-studio/AGENTS.md
@@ -34,7 +34,9 @@ Run both before creating a PR. Test files go alongside source: `use-foo.ts` → 
 
 ## UI Testing
 
-Refer to comprehensive UI tests in [packages/image-studio/.agents/skills/ui-testing/SKILL.md](packages/image-studio/.agents/skills/ui-testing/SKILL.md)
+No local dev server. Visual testing requires a sandbox on `widgets.wp.com`. Without a sandbox, focus on unit tests and type checks.
+
+When sandbox is available and **user explicitly requests UI testing**, follow `.agents/skills/ui-testing/SKILL.md`. Use Playwright MCP (not playwright-test). Do not run UI tests automatically.
 
 ## PR Guidelines
 

--- a/packages/image-studio/AGENTS.md
+++ b/packages/image-studio/AGENTS.md
@@ -20,17 +20,18 @@ AI-powered image editing/generation for WordPress. Two modes: **Edit** and **Gen
 - **i18n**: All user-facing strings via `__()` or `_n()` from `@wordpress/i18n`.
 - **Types**: Shared types in `src/types/index.ts`. Use enums for fixed option sets.
 
-## Testing Commands
+## Build & Test
+
+All commands work from `packages/image-studio/`:
 
 ```bash
-# Unit tests (run from repo root)
-yarn jest packages/image-studio --config packages/image-studio/jest.config.js
-
-# Type check
-yarn workspace @automattic/image-studio tsc --build --dry
+yarn build       # TypeScript compile (ESM + CJS)
+yarn test        # Unit tests (~155 tests, ~2s)
+yarn lint        # ESLint
+yarn typecheck   # Type check (dry run)
 ```
 
-Run both before creating a PR. Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
+**Always run `yarn build && yarn test` after changes.** Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
 
 ## UI Testing
 

--- a/packages/image-studio/AGENTS.md
+++ b/packages/image-studio/AGENTS.md
@@ -2,22 +2,76 @@
 
 AI-powered image editing/generation for WordPress. Two modes: **Edit** and **Generate**.
 
+## File Guide (Read the Right File)
+
+| File | Purpose | When to read |
+|------|---------|--------------|
+| **AGENTS.md** (this file) | Critical patterns, pitfalls, conventions | Always read first for any code change |
+| [README.md](README.md) | Architecture, project structure, build/test/dev commands | When you need to understand how it works or run commands |
+| [.agents/skills/ui-testing/SKILL.md](.agents/skills/ui-testing/SKILL.md) | Comprehensive UI test cases | Only when running UI tests |
+
 ## Critical Patterns (Don't Break These)
 
 - **Single store**: All state in `src/store/index.ts`. Do NOT create separate store files.
 - **Non-serializable store values**: `onCloseCallback` and `annotationCanvasRef` are intentionally non-serializable in the Redux store for cross-bundle communication. Don't "fix" this.
 - **Checkpoint system**: `lastSavedAttachmentId` tracks the user's last explicit save. On exit, this determines which image to apply.
 - **Draft cleanup**: Temporary images tracked in `draftIds`. On exit, drafts are deleted except originals and saved images. Never delete the original attachment. See `use-draft-cleanup.ts`.
-- **Abilities API**: Changes to `update-canvas-image` affect the AI agent contract. Coordinate with backend team.
 - **Cross-bundle**: Image Studio runs in a separate bundle from the block editor. The store is the bridge. Don't assume direct component access.
+
+## Abilities API (`src/abilities/`)
+
+Changes to `update-canvas-image` affect the **AI agent contract** — this is how the backend tells Image Studio to refresh the canvas after saving an attachment. Coordinate with backend team before modifying.
+
+- **Contract**: Backend calls `image-studio/update-canvas-image` with `{ attachmentId, url, metadata }`.
+- **Registration**: Ability is registered once via `@wordpress/abilities`. The `isRegistered` guard prevents duplicates.
+- **Flow**: Receives attachment ID → preloads image → resolves attachment via `core-data` → updates store (canvas metadata, draft tracking, mode transition).
+- **0% test coverage** — changes here need manual sandbox testing at minimum.
+
+## Extensions (`src/extensions/`)
+
+Three HOCs that inject Image Studio into the block editor via `addFilter`. These run in the **block editor bundle**, not Image Studio's bundle.
+
+| File | What it does | Filter hook |
+|------|-------------|-------------|
+| `generate-button-extension.tsx` | "Generate Image" button in Image block placeholder | `editor.MediaPlaceholder` |
+| `image-toolbar-extension.tsx` | "Edit with AI" toolbar button on selected Image blocks | `editor.BlockEdit` |
+| `external-media-source-extension.tsx` | Image Studio as external media source | `editor.MediaPlaceholder` |
+
+- The `utils.ts` helper converts Image Studio's `ImageData` to the shape `onSelect` expects.
+- `any` types in these files are due to WordPress filter HOC signatures — no upstream types exist. If adding new extensions, follow the same pattern.
+
+## Tracking (`src/utils/tracking.ts`)
+
+576 lines, 28+ exported functions. **31% test coverage** — the biggest gap in the package.
+
+- **All events auto-prefixed**: `jetpack_big_sky_` (Jetpack) or `wpcom_big_sky_` (WP.com) based on `detectPlatform()`.
+- **Adding a new event**: Use `recordImageStudioEvent( name, properties )` — never call `recordTracksEvent` directly. The wrapper adds session ID, entry point, and platform prefix automatically.
+- **Session tracking**: Every event includes `session_id` from `src/utils/session.ts`.
+- **When adding features**: Check if a tracking function already exists before creating a new one. The file has granular helpers for most UI interactions (tool clicks, sidebar, generation, feedback, navigation, metadata).
+
+## Client Context (`src/utils/client-context.ts`)
+
+Builds the context object the AI agent receives. **0% test coverage.** This determines what the agent knows about the current state.
+
+- Reads from Image Studio store (current image, mode, metadata) and block editor store (page content, selected blocks).
+- `getPageContent()` walks the block tree to extract text content for contextual suggestions.
+- Changes here directly affect AI generation quality — test on sandbox with both Media Library and Block Editor entry points.
+
+## Type Guards (`src/types/guards.ts`)
+
+306 lines of runtime validation at WordPress API boundaries. **0% test coverage.**
+
+- Every `is*` function validates data from `@wordpress/core-data` or REST API responses before use.
+- If you modify the types in `src/types/index.ts`, update the corresponding guard. A guard that doesn't match its type will silently reject valid data.
 
 ## Conventions (Non-Obvious)
 
-- **Prefer hooks over components** for feature logic. Keep components as thin renderers. Simple prop transformations are fine in components.
-- **Tracking prefix**: All analytics events auto-prefixed with `jetpack_big_sky_`. Use `recordEvent()` from `src/utils/tracking.ts`.
+- **Prefer hooks over components** for feature logic. Keep components as thin renderers.
+- **Tracking**: See tracking section above. Use `recordImageStudioEvent()`, not the base function.
 - **Styling**: Use design tokens from `src/components/styles/_variables.scss`.
-- **Prefer `@wordpress/components`** for standard UI (Button, Modal) over custom primitives, except for highly custom interactions (annotation canvas).
-- **Types**: Shared types in `src/types/index.ts`. Use enums for fixed option sets.
+- **Prefer `@wordpress/components`** for standard UI (Button, Modal) over custom primitives, except annotation canvas.
+- **Types**: Shared types in `src/types/index.ts`. Use enums for fixed option sets. Runtime validation in `src/types/guards.ts`.
+- **Tests must be TypeScript**: Use `.test.ts`/`.test.tsx`, not `.test.js`. (Two legacy `.test.js` files exist — don't add more.)
 
 ## Error Handling
 
@@ -37,20 +91,19 @@ Image Studio has multiple entry points defined in `ImageStudioEntryPoint` enum (
 
 ## Build & Test
 
-All commands work from `packages/image-studio/`:
+See [README.md](README.md) for all commands. Quick reference:
 
 ```bash
-yarn build       # TypeScript compile (ESM + CJS)
-yarn test        # Unit tests
-yarn lint        # ESLint
-yarn typecheck   # Type check (dry run)
+yarn build && yarn test && yarn lint && yarn typecheck  # Full validation (run before submitting)
 ```
 
-**Always run full validation** (`yarn build && yarn test && yarn lint && yarn typecheck`) before submitting. All must pass with zero errors. Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
+Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
 
-## UI Testing
-
-Refer to comprehensive UI tests in [packages/image-studio/.agents/skills/ui-testing/SKILL.md](packages/image-studio/.agents/skills/ui-testing/SKILL.md)
+**Coverage gaps to be aware of** (test manually if modifying):
+- `utils/tracking.ts` — 31% statements
+- `abilities/update-canvas-image.ts` — 0%
+- `utils/client-context.ts` — 0%
+- `types/guards.ts` — 0%
 
 ## PR Guidelines
 
@@ -58,16 +111,4 @@ Refer to comprehensive UI tests in [packages/image-studio/.agents/skills/ui-test
 - Before/after screenshots for UI changes
 - Test in both Edit and Generate modes for shared components
 
----
-
-## Self-Rating
-
-After completing any task in this package, evaluate this file:
-
-- If a section prevented a mistake, bump the rating up.
-- If you made a mistake this file should have caught, add the missing guidance above and bump the rating up.
-- If something here is wrong or stale, fix it and bump the rating down.
-
-**Rating: 7/10** | **Last updated**: 2026-03-01
-
-**7/10 justification**: Added error handling patterns, entry point behavior guidance, cross-bundle debugging tips, and contextual qualifiers to conventions. Trimmed over-specified styling/i18n details.
+**Last updated**: 2026-03-02

--- a/packages/image-studio/AGENTS.md
+++ b/packages/image-studio/AGENTS.md
@@ -13,12 +13,27 @@ AI-powered image editing/generation for WordPress. Two modes: **Edit** and **Gen
 
 ## Conventions (Non-Obvious)
 
-- **Hooks over components**: Feature logic goes in `src/hooks/`. Components should be thin renderers.
+- **Prefer hooks over components** for feature logic. Keep components as thin renderers. Simple prop transformations are fine in components.
 - **Tracking prefix**: All analytics events auto-prefixed with `jetpack_big_sky_`. Use `recordEvent()` from `src/utils/tracking.ts`.
-- **Styling**: Dark theme SCSS. Tokens in `src/components/styles/_variables.scss`. Background: `#1e1e1e`, foreground: `#fff`.
-- **Components**: Use `@wordpress/components` (Button, Modal, etc.) over custom primitives.
-- **i18n**: All user-facing strings via `__()` or `_n()` from `@wordpress/i18n`.
+- **Styling**: Use design tokens from `src/components/styles/_variables.scss`.
+- **Prefer `@wordpress/components`** for standard UI (Button, Modal) over custom primitives, except for highly custom interactions (annotation canvas).
 - **Types**: Shared types in `src/types/index.ts`. Use enums for fixed option sets.
+
+## Error Handling
+
+- **Notices**: Use store `setError()` action + `use-image-studio-message-display.ts` hook to display user-facing errors.
+- **Console logging**: Log errors to console for debugging. Store error state in `src/store/index.ts`.
+- **API failures**: Hooks should handle failed API calls gracefully and dispatch error actions to store.
+
+## Entry Points
+
+Image Studio has multiple entry points defined in `ImageStudioEntryPoint` enum (`src/types/index.ts`). Each affects modal behavior and feature availability. See `src/index.tsx:openImageStudioModal()` for initialization logic per entry point.
+
+## Debugging Cross-Bundle
+
+- **Store inspection**: Image Studio runs in a separate bundle. Inspect store state via browser console when debugging.
+- **Symptom**: Buttons render but modal doesn't open → check if store bridge is working.
+- **Symptom**: Save dispatches but editor doesn't update → verify extension filter registrations in `src/extensions/`.
 
 ## Build & Test
 
@@ -31,7 +46,7 @@ yarn lint        # ESLint
 yarn typecheck   # Type check (dry run)
 ```
 
-**Always run `yarn build && yarn test && yarn lint && yarn typecheck` after changes.** All tests must pass, lint must have zero errors, and typecheck must pass before submitting. Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
+**Always run full validation** (`yarn build && yarn test && yarn lint && yarn typecheck`) before submitting. All must pass with zero errors. Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
 
 ## UI Testing
 
@@ -53,4 +68,6 @@ After completing any task in this package, evaluate this file:
 - If you made a mistake this file should have caught, add the missing guidance above and bump the rating up.
 - If something here is wrong or stale, fix it and bump the rating down.
 
-**Rating: 6/10** | **Last updated**: 2026-02-23
+**Rating: 7/10** | **Last updated**: 2026-03-01
+
+**7/10 justification**: Added error handling patterns, entry point behavior guidance, cross-bundle debugging tips, and contextual qualifiers to conventions. Trimmed over-specified styling/i18n details.

--- a/packages/image-studio/AGENTS.md
+++ b/packages/image-studio/AGENTS.md
@@ -26,12 +26,12 @@ All commands work from `packages/image-studio/`:
 
 ```bash
 yarn build       # TypeScript compile (ESM + CJS)
-yarn test        # Unit tests (~155 tests, ~2s)
+yarn test        # Unit tests
 yarn lint        # ESLint
 yarn typecheck   # Type check (dry run)
 ```
 
-**Always run `yarn build && yarn test` after changes.** Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
+**Always run `yarn build && yarn test && yarn lint && yarn typecheck` after changes.** All tests must pass, lint must have zero errors, and typecheck must pass before submitting. Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
 
 ## UI Testing
 

--- a/packages/image-studio/AGENTS.md
+++ b/packages/image-studio/AGENTS.md
@@ -4,11 +4,11 @@ AI-powered image editing/generation for WordPress. Two modes: **Edit** and **Gen
 
 ## File Guide (Read the Right File)
 
-| File | Purpose | When to read |
-|------|---------|--------------|
-| **AGENTS.md** (this file) | Critical patterns, pitfalls, conventions | Always read first for any code change |
-| [README.md](README.md) | Architecture, project structure, build/test/dev commands | When you need to understand how it works or run commands |
-| [.agents/skills/ui-testing/SKILL.md](.agents/skills/ui-testing/SKILL.md) | Comprehensive UI test cases | Only when running UI tests |
+| File                                                                     | Purpose                                                  | When to read                                             |
+| ------------------------------------------------------------------------ | -------------------------------------------------------- | -------------------------------------------------------- |
+| **AGENTS.md** (this file)                                                | Critical patterns, pitfalls, conventions                 | Always read first for any code change                    |
+| [README.md](README.md)                                                   | Architecture, project structure, build/test/dev commands | When you need to understand how it works or run commands |
+| [.agents/skills/ui-testing/SKILL.md](.agents/skills/ui-testing/SKILL.md) | Comprehensive UI test cases                              | Only when running UI tests                               |
 
 ## Critical Patterns (Don't Break These)
 
@@ -31,11 +31,11 @@ Changes to `update-canvas-image` affect the **AI agent contract** — this is ho
 
 Three HOCs that inject Image Studio into the block editor via `addFilter`. These run in the **block editor bundle**, not Image Studio's bundle.
 
-| File | What it does | Filter hook |
-|------|-------------|-------------|
-| `generate-button-extension.tsx` | "Generate Image" button in Image block placeholder | `editor.MediaPlaceholder` |
-| `image-toolbar-extension.tsx` | "Edit with AI" toolbar button on selected Image blocks | `editor.BlockEdit` |
-| `external-media-source-extension.tsx` | Image Studio as external media source | `editor.MediaPlaceholder` |
+| File                                  | What it does                                           | Filter hook               |
+| ------------------------------------- | ------------------------------------------------------ | ------------------------- |
+| `generate-button-extension.tsx`       | "Generate Image" button in Image block placeholder     | `editor.MediaPlaceholder` |
+| `image-toolbar-extension.tsx`         | "Edit with AI" toolbar button on selected Image blocks | `editor.BlockEdit`        |
+| `external-media-source-extension.tsx` | Image Studio as external media source                  | `editor.MediaPlaceholder` |
 
 - The `utils.ts` helper converts Image Studio's `ImageData` to the shape `onSelect` expects.
 - `any` types in these files are due to WordPress filter HOC signatures — no upstream types exist. If adding new extensions, follow the same pattern.
@@ -100,6 +100,7 @@ yarn build && yarn test && yarn lint && yarn typecheck  # Full validation (run b
 Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
 
 **Coverage gaps to be aware of** (test manually if modifying):
+
 - `utils/tracking.ts` — 31% statements
 - `abilities/update-canvas-image.ts` — 0%
 - `utils/client-context.ts` — 0%

--- a/packages/image-studio/AGENTS.md
+++ b/packages/image-studio/AGENTS.md
@@ -34,9 +34,7 @@ Run both before creating a PR. Test files go alongside source: `use-foo.ts` → 
 
 ## UI Testing
 
-No local dev server. Visual testing requires a sandbox on `widgets.wp.com`. Without a sandbox, focus on unit tests and type checks.
-
-When sandbox is available and **user explicitly requests UI testing**, follow `.agents/skills/ui-testing/SKILL.md`. Use Playwright MCP (not playwright-test). Do not run UI tests automatically.
+Refer to comprehensive UI tests in [packages/image-studio/.agents/skills/ui-testing/SKILL.md](packages/image-studio/.agents/skills/ui-testing/SKILL.md)
 
 ## PR Guidelines
 

--- a/packages/image-studio/README.md
+++ b/packages/image-studio/README.md
@@ -114,7 +114,8 @@ Deployed as part of the `agents-manager` bundle to `widgets.wp.com`. PHP in `jet
 
 ## Related
 
-- [AGENTS.md](AGENTS.md) — Critical patterns, conventions, and pitfalls for AI agents
+- [AGENTS.md](AGENTS.md) — Critical patterns, conventions, and pitfalls for AI agents (read this first for any code change)
+- [UI Test Skill](.agents/skills/ui-testing/SKILL.md) — Comprehensive UI test cases for Playwright
 - [@automattic/agents-manager](../agents-manager/README.md) — Parent integration package
 
 ## License

--- a/packages/image-studio/README.md
+++ b/packages/image-studio/README.md
@@ -70,24 +70,23 @@ export {
 
 ### Commands
 
+All commands run from the package directory (`packages/image-studio/`):
+
 ```bash
-# Build the package (ESM + CJS)
-yarn build
+yarn build       # Build the package (ESM + CJS)
+yarn test        # Run unit tests (155 tests, ~2s)
+yarn lint        # ESLint
+yarn lint:fix    # ESLint with auto-fix
+yarn typecheck   # TypeScript type check (dry run)
+yarn watch       # Watch for changes
+yarn clean       # Clean build output
+```
 
-# Watch for changes
-yarn watch
+Or from the repo root:
 
-# Clean build output
-yarn clean
-
-# Lint
-yarn lint
-
-# Unit tests (from repo root)
-yarn jest packages/image-studio --config packages/image-studio/jest.config.js
-
-# Type check
-yarn workspace @automattic/image-studio tsc --build --dry
+```bash
+yarn workspace @automattic/image-studio build
+yarn test-packages packages/image-studio
 ```
 
 Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.

--- a/packages/image-studio/README.md
+++ b/packages/image-studio/README.md
@@ -1,160 +1,10 @@
 # @automattic/image-studio
 
-AI-powered image editing and generation for WordPress. Provides a full-screen editor experience for generating new images and editing existing ones using AI.
+AI-powered image editing and generation for WordPress. Two modes: **Edit** (modify existing images) and **Generate** (create new images via AI).
 
-## Installation
+Part of the `wp-calypso` monorepo. Bundled inside `@automattic/agents-manager` and served from `widgets.wp.com`.
 
-```bash
-yarn add @automattic/image-studio
-```
-
-## Usage
-
-### Basic Integration
-
-Initialize Image Studio on a WordPress admin page:
-
-```tsx
-import { initImageStudioIntegration, registerBlockEditorFilters } from '@automattic/image-studio';
-
-// Initialize when DOM is ready
-if ( document.readyState === 'loading' ) {
-	document.addEventListener( 'DOMContentLoaded', initImageStudioIntegration );
-} else {
-	initImageStudioIntegration();
-}
-
-// Register block editor integrations (toolbar buttons, etc.)
-registerBlockEditorFilters();
-```
-
-### Provider Integration (Agents Manager)
-
-For use with `@automattic/agents-manager`, import the provider exports:
-
-```tsx
-import { toolProvider, contextProvider } from '@automattic/image-studio/provider';
-
-// These can be registered with the agents manager
-```
-
-### Using the Store
-
-Image Studio exposes a WordPress data store for state management:
-
-```tsx
-import { useDispatch, useSelect } from '@wordpress/data';
-
-function MyComponent() {
-	const { setImageStudioOpen } = useDispatch( 'image-studio' );
-	const isOpen = useSelect( ( select ) => select( 'image-studio' ).getIsImageStudioOpen() );
-
-	return <button onClick={ () => setImageStudioOpen( true ) }>Open Image Studio</button>;
-}
-```
-
-## Testing
-
-### Unit Tests
-
-Run the unit tests with Jest:
-
-```bash
-# From wp-calypso root
-yarn jest packages/image-studio --config packages/image-studio/jest.config.js
-```
-
-Test files are located alongside their source files with `.test.ts` or `.test.tsx` extensions.
-
-### Type Check
-
-```bash
-yarn workspace @automattic/image-studio tsc --build --dry
-```
-
-### Manual Testing
-
-**Step 1 — Build and sync to sandbox:**
-
-```bash
-cd apps/agents-manager && yarn dev --sync
-```
-
-**Step 2 — Test on a sandboxed WordPress site:**
-
-- Navigate to Media Library: `/wp-admin/upload.php`
-- Click on any image → "Edit with AI" to open Image Studio in Edit mode
-- Or click "Generate Image" to create new images
-
-**Step 3 — Test in Block Editor:**
-
-- Open the post/page editor
-- Add an Image block → click "Generate" in the placeholder
-- Or select an existing image → click "Edit with AI" in the toolbar
-
-## Deployment
-
-### Development Build
-
-```bash
-# Build the package
-yarn workspace @automattic/image-studio build
-
-# Watch for changes during development
-yarn workspace @automattic/image-studio watch
-```
-
-### Production Deployment
-
-Image Studio is deployed as part of the `agents-manager` bundle to `widgets.wp.com`:
-
-**Build agents-manager app:**
-
-```bash
-yarn workspace @automattic/agents-manager build
-```
-
-**The bundle is deployed to:**
-
-- `https://widgets.wp.com/agents-manager/image-studio.min.js`
-- `https://widgets.wp.com/agents-manager/image-studio.css`
-
-**PHP enqueues the scripts** in `jetpack-mu-wpcom` when on an Image Studio screen:
-
-- Media Library (`upload.php`)
-- Block Editor (when editing images)
-- External Media modal
-
-### Feature Flags
-
-| Flag                   | Description                                                |
-| ---------------------- | ---------------------------------------------------------- |
-| `image-studio-calypso` | Enables Image Studio from Calypso (without Big Sky plugin) |
-
-Use via URL: `?flags=image-studio-calypso`
-
-## Development
-
-### Commands
-
-```bash
-# Build the package (ESM + CJS)
-yarn build
-
-# Watch for changes
-yarn watch
-
-# Clean build output
-yarn clean
-
-# Lint
-yarn lint
-
-# Type check
-yarn workspace @automattic/image-studio tsc --build --dry
-```
-
-### Project Structure
+## Project Structure
 
 ```
 src/
@@ -182,6 +32,22 @@ src/
 └── utils/                 # Utility functions
 ```
 
+## How It Works
+
+Image Studio does not run standalone. The loading chain:
+
+1. **Jetpack plugin** (PHP) — enqueues the `agents-manager` script on relevant WordPress admin screens (Media Library, Block Editor, External Media modal)
+2. **`agents-manager`** (JS bundle on `widgets.wp.com`) — imports and initializes Image Studio, calls `initImageStudioIntegration()` and `registerBlockEditorFilters()`
+3. **Image Studio** — injects UI entry points ("Edit with AI" buttons, "Generate Image" link) and renders the full-screen modal when triggered
+
+Image Studio and the block editor run in **separate bundles**. They communicate through a shared WordPress data store (`src/store/index.ts`) — no direct component access between bundles.
+
+### Key Integration Points
+
+- **Abilities API** (`src/abilities/`) — `image-studio/update-canvas-image` for AI agent integration
+- **Block Editor filters** (`src/extensions/`) — toolbar buttons, generate placeholder, external media
+- **Provider exports** (`src/provider/`) — `toolProvider` and `contextProvider` for `agents-manager`
+
 ### Key Exports
 
 ```tsx
@@ -200,34 +66,57 @@ export {
 } from '@automattic/image-studio/provider';
 ```
 
-## Architecture
+## Development
 
-### Store
+### Commands
 
-The `image-studio` store manages:
+```bash
+# Build the package (ESM + CJS)
+yarn build
 
-- Current image state (URL, attachment ID, metadata)
-- UI state (open/closed, mode, dialogs)
-- Draft management (temporary images during editing)
-- Undo/redo history
+# Watch for changes
+yarn watch
 
-### Abilities
+# Clean build output
+yarn clean
 
-Image Studio registers WordPress Abilities for AI agent integration:
+# Lint
+yarn lint
 
-- `image-studio/update-canvas-image` - Update the displayed image
+# Unit tests (from repo root)
+yarn jest packages/image-studio --config packages/image-studio/jest.config.js
 
-### Block Editor Integration
+# Type check
+yarn workspace @automattic/image-studio tsc --build --dry
+```
 
-Filters registered for Gutenberg:
+Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
 
-- Image block toolbar button
-- Generate button in image placeholder
-- External media integration
+### Manual Testing
 
-## Related Documentation
+No local dev server. Image Studio requires a sandbox on `widgets.wp.com`:
 
-- [@automattic/agents-manager](../agents-manager/README.md) - Parent integration package
+```bash
+# 1. Add `widgets.wp.com` to your etc/hosts pointing to sandbox IP
+# 2. Build and sync (from repo root)
+cd apps/agents-manager && yarn dev --sync
+```
+
+Then on the sandboxed site:
+
+- **Media Library** (`/wp-admin/upload.php`): Click any image → "Edit with AI", or click "Generate Image"
+- **Block Editor**: Add an Image block → "Generate" in placeholder, or select an existing image → "Edit with AI" in toolbar
+
+For comprehensive UI test cases, see [.agents/skills/ui-testing/SKILL.md](.agents/skills/ui-testing/SKILL.md).
+
+### Deployment
+
+Deployed as part of the `agents-manager` bundle to `widgets.wp.com`. PHP in `jetpack-plugin` enqueues scripts on Media Library, Block Editor, and External Media screens.
+
+## Related
+
+- [AGENTS.md](AGENTS.md) — Critical patterns, conventions, and pitfalls for AI agents
+- [@automattic/agents-manager](../agents-manager/README.md) — Parent integration package
 
 ## License
 

--- a/packages/image-studio/README.md
+++ b/packages/image-studio/README.md
@@ -1,10 +1,160 @@
 # @automattic/image-studio
 
-AI-powered image editing and generation for WordPress. Two modes: **Edit** (modify existing images) and **Generate** (create new images via AI).
+AI-powered image editing and generation for WordPress. Provides a full-screen editor experience for generating new images and editing existing ones using AI.
 
-Part of the `wp-calypso` monorepo. Bundled inside `@automattic/agents-manager` and served from `widgets.wp.com`.
+## Installation
 
-## Project Structure
+```bash
+yarn add @automattic/image-studio
+```
+
+## Usage
+
+### Basic Integration
+
+Initialize Image Studio on a WordPress admin page:
+
+```tsx
+import { initImageStudioIntegration, registerBlockEditorFilters } from '@automattic/image-studio';
+
+// Initialize when DOM is ready
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', initImageStudioIntegration );
+} else {
+	initImageStudioIntegration();
+}
+
+// Register block editor integrations (toolbar buttons, etc.)
+registerBlockEditorFilters();
+```
+
+### Provider Integration (Agents Manager)
+
+For use with `@automattic/agents-manager`, import the provider exports:
+
+```tsx
+import { toolProvider, contextProvider } from '@automattic/image-studio/provider';
+
+// These can be registered with the agents manager
+```
+
+### Using the Store
+
+Image Studio exposes a WordPress data store for state management:
+
+```tsx
+import { useDispatch, useSelect } from '@wordpress/data';
+
+function MyComponent() {
+	const { setImageStudioOpen } = useDispatch( 'image-studio' );
+	const isOpen = useSelect( ( select ) => select( 'image-studio' ).getIsImageStudioOpen() );
+
+	return <button onClick={ () => setImageStudioOpen( true ) }>Open Image Studio</button>;
+}
+```
+
+## Testing
+
+### Unit Tests
+
+Run the unit tests with Jest:
+
+```bash
+# From wp-calypso root
+yarn jest packages/image-studio --config packages/image-studio/jest.config.js
+```
+
+Test files are located alongside their source files with `.test.ts` or `.test.tsx` extensions.
+
+### Type Check
+
+```bash
+yarn workspace @automattic/image-studio tsc --build --dry
+```
+
+### Manual Testing
+
+**Step 1 — Build and sync to sandbox:**
+
+```bash
+cd apps/agents-manager && yarn dev --sync
+```
+
+**Step 2 — Test on a sandboxed WordPress site:**
+
+- Navigate to Media Library: `/wp-admin/upload.php`
+- Click on any image → "Edit with AI" to open Image Studio in Edit mode
+- Or click "Generate Image" to create new images
+
+**Step 3 — Test in Block Editor:**
+
+- Open the post/page editor
+- Add an Image block → click "Generate" in the placeholder
+- Or select an existing image → click "Edit with AI" in the toolbar
+
+## Deployment
+
+### Development Build
+
+```bash
+# Build the package
+yarn workspace @automattic/image-studio build
+
+# Watch for changes during development
+yarn workspace @automattic/image-studio watch
+```
+
+### Production Deployment
+
+Image Studio is deployed as part of the `agents-manager` bundle to `widgets.wp.com`:
+
+**Build agents-manager app:**
+
+```bash
+yarn workspace @automattic/agents-manager build
+```
+
+**The bundle is deployed to:**
+
+- `https://widgets.wp.com/agents-manager/image-studio.min.js`
+- `https://widgets.wp.com/agents-manager/image-studio.css`
+
+**PHP enqueues the scripts** in `jetpack-mu-wpcom` when on an Image Studio screen:
+
+- Media Library (`upload.php`)
+- Block Editor (when editing images)
+- External Media modal
+
+### Feature Flags
+
+| Flag                   | Description                                                |
+| ---------------------- | ---------------------------------------------------------- |
+| `image-studio-calypso` | Enables Image Studio from Calypso (without Big Sky plugin) |
+
+Use via URL: `?flags=image-studio-calypso`
+
+## Development
+
+### Commands
+
+```bash
+# Build the package (ESM + CJS)
+yarn build
+
+# Watch for changes
+yarn watch
+
+# Clean build output
+yarn clean
+
+# Lint
+yarn lint
+
+# Type check
+yarn workspace @automattic/image-studio tsc --build --dry
+```
+
+### Project Structure
 
 ```
 src/
@@ -32,22 +182,6 @@ src/
 └── utils/                 # Utility functions
 ```
 
-## How It Works
-
-Image Studio does not run standalone. The loading chain:
-
-1. **Jetpack plugin** (PHP) — enqueues the `agents-manager` script on relevant WordPress admin screens (Media Library, Block Editor, External Media modal)
-2. **`agents-manager`** (JS bundle on `widgets.wp.com`) — imports and initializes Image Studio, calls `initImageStudioIntegration()` and `registerBlockEditorFilters()`
-3. **Image Studio** — injects UI entry points ("Edit with AI" buttons, "Generate Image" link) and renders the full-screen modal when triggered
-
-Image Studio and the block editor run in **separate bundles**. They communicate through a shared WordPress data store (`src/store/index.ts`) — no direct component access between bundles.
-
-### Key Integration Points
-
-- **Abilities API** (`src/abilities/`) — `image-studio/update-canvas-image` for AI agent integration
-- **Block Editor filters** (`src/extensions/`) — toolbar buttons, generate placeholder, external media
-- **Provider exports** (`src/provider/`) — `toolProvider` and `contextProvider` for `agents-manager`
-
 ### Key Exports
 
 ```tsx
@@ -66,57 +200,34 @@ export {
 } from '@automattic/image-studio/provider';
 ```
 
-## Development
+## Architecture
 
-### Commands
+### Store
 
-```bash
-# Build the package (ESM + CJS)
-yarn build
+The `image-studio` store manages:
 
-# Watch for changes
-yarn watch
+- Current image state (URL, attachment ID, metadata)
+- UI state (open/closed, mode, dialogs)
+- Draft management (temporary images during editing)
+- Undo/redo history
 
-# Clean build output
-yarn clean
+### Abilities
 
-# Lint
-yarn lint
+Image Studio registers WordPress Abilities for AI agent integration:
 
-# Unit tests (from repo root)
-yarn jest packages/image-studio --config packages/image-studio/jest.config.js
+- `image-studio/update-canvas-image` - Update the displayed image
 
-# Type check
-yarn workspace @automattic/image-studio tsc --build --dry
-```
+### Block Editor Integration
 
-Test files go alongside source: `use-foo.ts` → `use-foo.test.ts`.
+Filters registered for Gutenberg:
 
-### Manual Testing
+- Image block toolbar button
+- Generate button in image placeholder
+- External media integration
 
-No local dev server. Image Studio requires a sandbox on `widgets.wp.com`:
+## Related Documentation
 
-```bash
-# 1. Add `widgets.wp.com` to your etc/hosts pointing to sandbox IP
-# 2. Build and sync (from repo root)
-cd apps/agents-manager && yarn dev --sync
-```
-
-Then on the sandboxed site:
-
-- **Media Library** (`/wp-admin/upload.php`): Click any image → "Edit with AI", or click "Generate Image"
-- **Block Editor**: Add an Image block → "Generate" in placeholder, or select an existing image → "Edit with AI" in toolbar
-
-For comprehensive UI test cases, see [.agents/skills/ui-testing/SKILL.md](.agents/skills/ui-testing/SKILL.md).
-
-### Deployment
-
-Deployed as part of the `agents-manager` bundle to `widgets.wp.com`. PHP in `jetpack-plugin` enqueues scripts on Media Library, Block Editor, and External Media screens.
-
-## Related
-
-- [AGENTS.md](AGENTS.md) — Critical patterns, conventions, and pitfalls for AI agents
-- [@automattic/agents-manager](../agents-manager/README.md) — Parent integration package
+- [@automattic/agents-manager](../agents-manager/README.md) - Parent integration package
 
 ## License
 

--- a/packages/image-studio/jest.config.js
+++ b/packages/image-studio/jest.config.js
@@ -4,4 +4,11 @@ module.exports = {
 	testMatch: [ '<rootDir>/src/**/*.test.{js,ts,tsx}' ],
 	modulePathIgnorePatterns: [ '<rootDir>/dist' ],
 	testEnvironment: 'jsdom',
+	moduleNameMapper: {
+		'^@wordpress/data$': '<rootDir>/src/__mocks__/@wordpress/data.ts',
+		'^@wordpress/core-data$': '<rootDir>/src/__mocks__/@wordpress/core-data.ts',
+		'^@wordpress/block-editor$': '<rootDir>/src/__mocks__/@wordpress/block-editor.ts',
+		'^@wordpress/media-utils$': '<rootDir>/src/__mocks__/@wordpress/media-utils.ts',
+		'\\.(webp|png|jpe?g|gif|svg)$': '<rootDir>/src/__mocks__/fileMock.ts',
+	},
 };

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -43,7 +43,11 @@
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
-		"watch": "tsc --build ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch",
+		"test": "cd ../.. && yarn test-packages packages/image-studio",
+		"lint": "run -T eslint src/",
+		"lint:fix": "run -T eslint src/ --fix",
+		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",

--- a/packages/image-studio/src/__mocks__/@automattic/agenttic-ui.tsx
+++ b/packages/image-studio/src/__mocks__/@automattic/agenttic-ui.tsx
@@ -1,0 +1,26 @@
+export const cn = ( ...classes: any[] ) => classes.filter( Boolean ).join( ' ' );
+
+export const AgentUI = {
+	InputToolbar: ( {
+		label,
+		icon,
+		children,
+		disabled,
+	}: {
+		label: string;
+		icon: React.ReactNode;
+		children: React.ReactNode;
+		disabled?: boolean;
+		className?: string;
+	} ) => (
+		<div data-testid="input-toolbar">
+			<button disabled={ disabled } data-testid="toolbar-button">
+				{ icon }
+				{ label }
+			</button>
+			<div data-testid="toolbar-content">{ children }</div>
+		</div>
+	),
+};
+
+export const RegenerateIcon = () => <span>Regenerate Icon</span>;

--- a/packages/image-studio/src/__mocks__/@wordpress/block-editor.ts
+++ b/packages/image-studio/src/__mocks__/@wordpress/block-editor.ts
@@ -1,0 +1,9 @@
+/**
+ * Mock for @wordpress/block-editor package
+ */
+
+export const store = {
+	name: 'core/block-editor',
+};
+
+export const useBlockProps = jest.fn( () => ( {} ) );

--- a/packages/image-studio/src/__mocks__/@wordpress/core-data.ts
+++ b/packages/image-studio/src/__mocks__/@wordpress/core-data.ts
@@ -1,0 +1,19 @@
+/**
+ * Mock for @wordpress/core-data package
+ */
+
+export const store = {
+	name: 'core',
+};
+
+export const useEntityRecord = jest.fn( () => ( {
+	record: null,
+	isResolving: false,
+	hasResolved: false,
+} ) );
+
+export const useEntityRecords = jest.fn( () => ( {
+	records: [],
+	isResolving: false,
+	hasResolved: false,
+} ) );

--- a/packages/image-studio/src/__mocks__/@wordpress/data.ts
+++ b/packages/image-studio/src/__mocks__/@wordpress/data.ts
@@ -1,0 +1,20 @@
+/**
+ * Mock for @wordpress/data package
+ * Prevents module-level store initialization errors in tests
+ */
+
+// Mutable mocks that tests can override
+// Default implementations return empty objects so tests can use mockImplementation
+export const dispatch = jest.fn( () => ( {} ) );
+export const select = jest.fn( () => ( {} ) );
+export const resolveSelect = jest.fn( () => ( {} ) );
+
+// Function mocks
+export const createReduxStore = jest.fn( () => ( {} ) );
+export const createSelector = jest.fn( ( fn ) => fn );
+export const register = jest.fn();
+export const useDispatch = jest.fn( () => ( {} ) );
+export const useSelect = jest.fn( () => ( {} ) );
+export const combineReducers = jest.fn( ( reducers ) => reducers );
+export const createRegistrySelector = jest.fn( ( fn ) => fn );
+export const createRegistryControl = jest.fn( ( fn ) => fn );

--- a/packages/image-studio/src/__mocks__/@wordpress/media-utils.ts
+++ b/packages/image-studio/src/__mocks__/@wordpress/media-utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Mock for @wordpress/media-utils package
+ */
+
+const transformAttachment = jest.fn( ( attachment ) => ( {
+	...attachment,
+	transformed: true,
+} ) );
+
+export { transformAttachment };

--- a/packages/image-studio/src/__mocks__/fileMock.ts
+++ b/packages/image-studio/src/__mocks__/fileMock.ts
@@ -1,0 +1,5 @@
+/**
+ * Mock for binary file imports (images, fonts, etc.)
+ * Returns the filename as a string, mimicking webpack's file-loader behavior.
+ */
+export default 'test-file-stub';

--- a/packages/image-studio/src/abilities/update-canvas-image.ts
+++ b/packages/image-studio/src/abilities/update-canvas-image.ts
@@ -12,6 +12,7 @@ import { store as imageStudioStore } from '../store';
 import { ImageStudioMode } from '../types';
 import { trackImageStudioError, trackImageStudioImageGenerated } from '../utils/tracking';
 import type { CanvasMetadata, ImageStudioActions } from '../store';
+import type { CurriedImageStudioSelectors, CoreDataDispatch } from '../types/wordpress.d';
 
 function preloadImage( url: string ): Promise< void > {
 	if ( ! url || typeof window === 'undefined' ) {
@@ -129,7 +130,7 @@ export async function registerUpdateCanvasImageAbility(): Promise< void > {
 				const canvasMetadata = select( imageStudioStore ).getCanvasMetadata() || {};
 
 				// Get current state from store
-				const storeSelectors = select( imageStudioStore ) as any;
+				const storeSelectors = select( imageStudioStore ) as CurriedImageStudioSelectors;
 				const currentDraftIds = storeSelectors.getDraftIds() || [];
 				const originalAttachmentId = storeSelectors.getOriginalAttachmentId();
 
@@ -208,7 +209,7 @@ export async function registerUpdateCanvasImageAbility(): Promise< void > {
 
 					// Invalidate the cached attachment data in the core store
 					// Then trigger a fresh fetch so the attachment is available for subsequent context reads
-					const coreDispatch = dispatch( coreStore ) as any;
+					const coreDispatch = dispatch( coreStore ) as unknown as CoreDataDispatch;
 					if ( coreDispatch?.invalidateResolution ) {
 						coreDispatch.invalidateResolution( 'getEntityRecord', [
 							'postType',

--- a/packages/image-studio/src/components/canvas-controls/revision-navigator.tsx
+++ b/packages/image-studio/src/components/canvas-controls/revision-navigator.tsx
@@ -56,11 +56,9 @@ export const RevisionNavigator = () => {
 						return null;
 					}
 
-					const attachment = select( coreStore ).getEntityRecord(
-						'postType',
-						'attachment',
-						id
-					) as any;
+					const attachment = select( coreStore ).getEntityRecord( 'postType', 'attachment', id ) as
+						| import('../../types/wordpress').AttachmentRecord
+						| undefined;
 
 					if ( ! attachment ) {
 						return null;

--- a/packages/image-studio/src/components/header/index.test.tsx
+++ b/packages/image-studio/src/components/header/index.test.tsx
@@ -1,0 +1,706 @@
+/* eslint-disable import/order */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Mock dependencies - MUST be before imports that use them
+jest.mock( '@automattic/agenttic-ui', () => ( {
+	cn: ( ...args: any[] ) => {
+		return args
+			.map( ( arg ) => {
+				if ( typeof arg === 'string' ) {
+					return arg;
+				}
+				if ( typeof arg === 'object' && arg !== null ) {
+					return Object.keys( arg )
+						.filter( ( key ) => arg[ key ] )
+						.join( ' ' );
+				}
+				return '';
+			} )
+			.filter( Boolean )
+			.join( ' ' );
+	},
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( {
+		children,
+		text,
+		icon,
+		label,
+		variant,
+		isBusy,
+		isPressed,
+		showTooltip,
+		accessibleWhenDisabled,
+		...props
+	}: any ) => (
+		<button { ...props } aria-label={ label } aria-pressed={ isPressed }>
+			{ children || text }
+		</button>
+	),
+	Icon: ( { icon }: any ) => <span>{ icon }</span>,
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+	sprintf: ( format: string, ...args: any[] ) => {
+		let result = format;
+		args.forEach( ( arg ) => {
+			result = result.replace( /%s|%d|%\d\$s|%\d\$d/, String( arg ) );
+		} );
+		return result;
+	},
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	useKeyboardShortcut: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/keycodes', () => ( {
+	isAppleOS: jest.fn( () => true ),
+} ) );
+
+jest.mock( '../../utils/tracking', () => ( {
+	trackImageStudioToolClick: jest.fn(),
+} ) );
+
+jest.mock( '../../store', () => ( {
+	store: 'image-studio',
+	ImageStudioEntryPoint: {
+		MediaLibrary: 'media_library',
+		EditorBlock: 'editor_block',
+		EditorSidebar: 'editor_sidebar',
+		JetpackExternalMediaBlock: 'jetpack_external_media_block',
+		JetpackExternalMediaFeaturedImage: 'jetpack_external_media_featured_image',
+	},
+} ) );
+
+// Import after mocks
+import { useDispatch, useSelect } from '@wordpress/data';
+import { ImageStudioEntryPoint } from '../../store';
+import { ImageStudioMode, ToolbarOption } from '../../types';
+import { trackImageStudioToolClick } from '../../utils/tracking';
+import { Header } from './index';
+
+const mockUseDispatch = useDispatch as jest.MockedFunction< typeof useDispatch >;
+const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
+const mockTrackImageStudioToolClick = trackImageStudioToolClick as jest.MockedFunction<
+	typeof trackImageStudioToolClick
+>;
+
+describe( 'Header', () => {
+	const defaultProps = {
+		mode: ImageStudioMode.Edit,
+		onClose: jest.fn(),
+		setActiveToolbarOption: jest.fn(),
+		activeToolbarOption: null,
+		config: {
+			imageData: {
+				filename: 'test-image.jpg',
+			},
+		},
+	};
+
+	const mockSetAnnotationMode = jest.fn();
+	const mockAddNotice = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUseDispatch.mockReturnValue( {
+			setAnnotationMode: mockSetAnnotationMode,
+			addNotice: mockAddNotice,
+		} as any );
+
+		mockUseSelect.mockImplementation( ( selector: any ) => {
+			const result = selector( () => ( {
+				getImageStudioAiProcessing: () => false,
+				getHasUpdatedMetadata: () => false,
+				getIsAnnotationMode: () => false,
+				getDraftIds: () => [],
+				getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+			} ) );
+			return result;
+		} );
+	} );
+
+	describe( 'Rendering', () => {
+		it( 'renders header with title in Generate mode', () => {
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Generate } /> );
+
+			expect( screen.getByText( 'Image Editor' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Beta' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders navigation pill in Edit mode with filename', () => {
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+
+			expect( screen.getByText( 'test-image.jpg' ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not render navigation pill when filename is missing', () => {
+			const propsWithoutFilename = {
+				...defaultProps,
+				config: {},
+			};
+
+			render( <Header { ...propsWithoutFilename } mode={ ImageStudioMode.Edit } /> );
+
+			expect( screen.queryByText( 'test-image.jpg' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'renders toolbar in Edit mode', () => {
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+
+			expect( screen.getByLabelText( 'Select an area of the image to edit' ) ).toBeInTheDocument();
+			expect(
+				screen.getByLabelText( 'View or edit information about the image' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'does not render toolbar in Generate mode', () => {
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Generate } /> );
+
+			expect(
+				screen.queryByLabelText( 'Select an area of the image to edit' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'renders close button', () => {
+			render( <Header { ...defaultProps } /> );
+
+			expect( screen.getByLabelText( 'Close image editor' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders custom left content when provided', () => {
+			const customContent = <div>Custom Content</div>;
+			render( <Header { ...defaultProps } leftContent={ customContent } /> );
+
+			expect( screen.getByText( 'Custom Content' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Save Button', () => {
+		it( 'renders save button with default text for Media Library entry point', () => {
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+
+			expect( screen.getByRole( 'button', { name: /Save/i } ) ).toHaveTextContent( 'Save' );
+		} );
+
+		it( 'renders save button with "Save & Apply" text for Editor entry points', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => false,
+					getHasUpdatedMetadata: () => false,
+					getIsAnnotationMode: () => false,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.EditorBlock,
+				} ) );
+				return result;
+			} );
+
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+
+			expect( screen.getByRole( 'button', { name: /Save and apply/i } ) ).toHaveTextContent(
+				'Save & Apply'
+			);
+		} );
+
+		it( 'shows "Saving…" text when isSaving is true', () => {
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } isSaving /> );
+
+			expect( screen.getByRole( 'button', { name: /Save/i } ) ).toHaveTextContent( 'Saving…' );
+		} );
+
+		it( 'disables save button when not saveable', () => {
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } isSaveable={ false } /> );
+
+			expect( screen.getByRole( 'button', { name: /Save/i } ) ).toBeDisabled();
+		} );
+
+		it( 'disables save button when saving', () => {
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } isSaving /> );
+
+			expect( screen.getByRole( 'button', { name: /Save/i } ) ).toBeDisabled();
+		} );
+
+		it( 'calls onSave when save button is clicked', async () => {
+			const onSave = jest.fn();
+			const user = userEvent.setup();
+
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } onSave={ onSave } /> );
+
+			await user.click( screen.getByRole( 'button', { name: /Save displayed/i } ) );
+
+			expect( onSave ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'Toolbar Interactions', () => {
+		it( 'toggles Annotate toolbar option when Select button is clicked', async () => {
+			const setActiveToolbarOption = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				<Header
+					{ ...defaultProps }
+					mode={ ImageStudioMode.Edit }
+					setActiveToolbarOption={ setActiveToolbarOption }
+				/>
+			);
+
+			await user.click( screen.getByLabelText( 'Select an area of the image to edit' ) );
+
+			expect( setActiveToolbarOption ).toHaveBeenCalledWith( ToolbarOption.Annotate );
+			expect( mockSetAnnotationMode ).toHaveBeenCalledWith( true );
+			expect( mockTrackImageStudioToolClick ).toHaveBeenCalledWith( 'annotate' );
+		} );
+
+		it( 'deactivates Annotate when clicked again', async () => {
+			const setActiveToolbarOption = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				<Header
+					{ ...defaultProps }
+					mode={ ImageStudioMode.Edit }
+					activeToolbarOption={ ToolbarOption.Annotate }
+					setActiveToolbarOption={ setActiveToolbarOption }
+				/>
+			);
+
+			await user.click( screen.getByLabelText( 'Select an area of the image to edit' ) );
+
+			expect( setActiveToolbarOption ).toHaveBeenCalledWith( null );
+			expect( mockSetAnnotationMode ).toHaveBeenCalledWith( false );
+		} );
+
+		it( 'toggles AltText toolbar option when Image Info button is clicked', async () => {
+			const setActiveToolbarOption = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				<Header
+					{ ...defaultProps }
+					mode={ ImageStudioMode.Edit }
+					setActiveToolbarOption={ setActiveToolbarOption }
+				/>
+			);
+
+			await user.click( screen.getByLabelText( 'View or edit information about the image' ) );
+
+			expect( setActiveToolbarOption ).toHaveBeenCalledWith( ToolbarOption.AltText );
+			expect( mockSetAnnotationMode ).toHaveBeenCalledWith( false );
+			expect( mockTrackImageStudioToolClick ).toHaveBeenCalledWith( 'alt_text', 'open' );
+		} );
+
+		it( 'tracks close event when AltText is toggled off', async () => {
+			const setActiveToolbarOption = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				<Header
+					{ ...defaultProps }
+					mode={ ImageStudioMode.Edit }
+					activeToolbarOption={ ToolbarOption.AltText }
+					setActiveToolbarOption={ setActiveToolbarOption }
+				/>
+			);
+
+			await user.click( screen.getByLabelText( 'View or edit information about the image' ) );
+
+			expect( mockTrackImageStudioToolClick ).toHaveBeenCalledWith( 'alt_text', 'close' );
+		} );
+
+		it( 'disables toolbar buttons when AI is processing', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => true,
+					getHasUpdatedMetadata: () => false,
+					getIsAnnotationMode: () => false,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+				} ) );
+				return result;
+			} );
+
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+
+			expect( screen.getByLabelText( 'Select an area of the image to edit' ) ).toBeDisabled();
+			expect( screen.getByLabelText( 'View or edit information about the image' ) ).toBeDisabled();
+		} );
+
+		it( 'shows pressed state for active toolbar option', () => {
+			render(
+				<Header
+					{ ...defaultProps }
+					mode={ ImageStudioMode.Edit }
+					activeToolbarOption={ ToolbarOption.Annotate }
+				/>
+			);
+
+			const annotateButton = screen.getByLabelText( 'Select an area of the image to edit' );
+			expect( annotateButton ).toHaveAttribute( 'aria-pressed', 'true' );
+		} );
+	} );
+
+	describe( 'Annotation Mode', () => {
+		it( 'renders undo/redo buttons in annotation mode', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => false,
+					getHasUpdatedMetadata: () => false,
+					getIsAnnotationMode: () => true,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+				} ) );
+				return result;
+			} );
+
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+
+			expect( screen.getByLabelText( /Undo/ ) ).toBeInTheDocument();
+			expect( screen.getByLabelText( /Redo/ ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not render undo/redo buttons when not in annotation mode', () => {
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+
+			expect( screen.queryByLabelText( /Undo/ ) ).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( /Redo/ ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'calls onAnnotationUndo when undo button is clicked', async () => {
+			const onAnnotationUndo = jest.fn();
+			const user = userEvent.setup();
+
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => false,
+					getHasUpdatedMetadata: () => false,
+					getIsAnnotationMode: () => true,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+				} ) );
+				return result;
+			} );
+
+			render(
+				<Header
+					{ ...defaultProps }
+					mode={ ImageStudioMode.Edit }
+					onAnnotationUndo={ onAnnotationUndo }
+					hasPendingAnnotations
+				/>
+			);
+
+			await user.click( screen.getByLabelText( /Undo/ ) );
+
+			expect( onAnnotationUndo ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'disables undo button when no pending annotations', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => false,
+					getHasUpdatedMetadata: () => false,
+					getIsAnnotationMode: () => true,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+				} ) );
+				return result;
+			} );
+
+			render(
+				<Header { ...defaultProps } mode={ ImageStudioMode.Edit } hasPendingAnnotations={ false } />
+			);
+
+			expect( screen.getByLabelText( /Undo/ ) ).toBeDisabled();
+		} );
+
+		it( 'calls onAnnotationRedo when redo button is clicked', async () => {
+			const onAnnotationRedo = jest.fn();
+			const user = userEvent.setup();
+
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => false,
+					getHasUpdatedMetadata: () => false,
+					getIsAnnotationMode: () => true,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+				} ) );
+				return result;
+			} );
+
+			render(
+				<Header
+					{ ...defaultProps }
+					mode={ ImageStudioMode.Edit }
+					onAnnotationRedo={ onAnnotationRedo }
+					hasUndoneAnnotations
+				/>
+			);
+
+			await user.click( screen.getByLabelText( /Redo/ ) );
+
+			expect( onAnnotationRedo ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'disables redo button when no undone annotations', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => false,
+					getHasUpdatedMetadata: () => false,
+					getIsAnnotationMode: () => true,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+				} ) );
+				return result;
+			} );
+
+			render(
+				<Header { ...defaultProps } mode={ ImageStudioMode.Edit } hasUndoneAnnotations={ false } />
+			);
+
+			expect( screen.getByLabelText( /Redo/ ) ).toBeDisabled();
+		} );
+	} );
+
+	describe( 'Navigation', () => {
+		it( 'calls onNavigatePrevious when previous button is clicked', async () => {
+			const onNavigatePrevious = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				<Header
+					{ ...defaultProps }
+					mode={ ImageStudioMode.Edit }
+					onNavigatePrevious={ onNavigatePrevious }
+					hasPreviousImage
+				/>
+			);
+
+			await user.click( screen.getByLabelText( /Previous image/ ) );
+
+			expect( onNavigatePrevious ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'calls onNavigateNext when next button is clicked', async () => {
+			const onNavigateNext = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				<Header
+					{ ...defaultProps }
+					mode={ ImageStudioMode.Edit }
+					onNavigateNext={ onNavigateNext }
+					hasNextImage
+				/>
+			);
+
+			await user.click( screen.getByLabelText( /Next image/ ) );
+
+			expect( onNavigateNext ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'disables previous button when no previous image', () => {
+			render(
+				<Header { ...defaultProps } mode={ ImageStudioMode.Edit } hasPreviousImage={ false } />
+			);
+
+			expect( screen.getByLabelText( /Previous image/ ) ).toBeDisabled();
+		} );
+
+		it( 'disables next button when no next image', () => {
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } hasNextImage={ false } /> );
+
+			expect( screen.getByLabelText( /Next image/ ) ).toBeDisabled();
+		} );
+
+		it( 'disables navigation when saving', () => {
+			render(
+				<Header
+					{ ...defaultProps }
+					mode={ ImageStudioMode.Edit }
+					isSaving
+					hasPreviousImage
+					hasNextImage
+				/>
+			);
+
+			expect( screen.getByLabelText( /Previous image/ ) ).toBeDisabled();
+			expect( screen.getByLabelText( /Next image/ ) ).toBeDisabled();
+		} );
+
+		it( 'disables navigation when there are drafts', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => false,
+					getHasUpdatedMetadata: () => false,
+					getIsAnnotationMode: () => false,
+					getDraftIds: () => [ '123' ],
+					getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+				} ) );
+				return result;
+			} );
+
+			render(
+				<Header { ...defaultProps } mode={ ImageStudioMode.Edit } hasPreviousImage hasNextImage />
+			);
+
+			// When there are drafts, the nav button labels change to a tooltip message
+			const navButtons = screen.getAllByLabelText( /Save or discard your changes/ );
+			expect( navButtons ).toHaveLength( 2 );
+			navButtons.forEach( ( button ) => {
+				expect( button ).toBeDisabled();
+			} );
+		} );
+
+		it( 'disables navigation when AI is processing', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => true,
+					getHasUpdatedMetadata: () => false,
+					getIsAnnotationMode: () => false,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+				} ) );
+				return result;
+			} );
+
+			render(
+				<Header { ...defaultProps } mode={ ImageStudioMode.Edit } hasPreviousImage hasNextImage />
+			);
+
+			expect( screen.getByLabelText( /Previous image/ ) ).toBeDisabled();
+			expect( screen.getByLabelText( /Next image/ ) ).toBeDisabled();
+		} );
+	} );
+
+	describe( 'Classic Media Editor', () => {
+		it( 'renders Media Library button when classic editor URL is provided', () => {
+			const propsWithAttachmentId = {
+				...defaultProps,
+				config: {
+					...defaultProps.config,
+					attachmentId: 123,
+				},
+				onClassicMediaEditorNavigation: jest.fn(),
+			};
+
+			render( <Header { ...propsWithAttachmentId } mode={ ImageStudioMode.Edit } /> );
+
+			expect(
+				screen.getByLabelText( 'Edit this image in the WordPress Media Library' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'does not render Media Library button without attachment ID', () => {
+			const propsWithoutAttachmentId = {
+				...defaultProps,
+				onClassicMediaEditorNavigation: jest.fn(),
+			};
+
+			render( <Header { ...propsWithoutAttachmentId } mode={ ImageStudioMode.Edit } /> );
+
+			expect(
+				screen.queryByLabelText( 'Edit this image in the WordPress Media Library' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'calls onClassicMediaEditorNavigation when Media Library button is clicked', async () => {
+			const onClassicMediaEditorNavigation = jest.fn().mockResolvedValue( undefined );
+			const user = userEvent.setup();
+
+			const propsWithAttachmentId = {
+				...defaultProps,
+				config: {
+					...defaultProps.config,
+					attachmentId: 123,
+				},
+				onClassicMediaEditorNavigation,
+			};
+
+			render( <Header { ...propsWithAttachmentId } mode={ ImageStudioMode.Edit } /> );
+
+			await user.click( screen.getByLabelText( 'Edit this image in the WordPress Media Library' ) );
+
+			expect( onClassicMediaEditorNavigation ).toHaveBeenCalledWith(
+				'post.php?post=123&action=edit'
+			);
+			expect( mockTrackImageStudioToolClick ).toHaveBeenCalledWith( 'media_library' );
+		} );
+
+		it( 'shows error notice when navigation fails', async () => {
+			const error = new Error( 'Navigation failed' );
+			const onClassicMediaEditorNavigation = jest.fn().mockRejectedValue( error );
+			const user = userEvent.setup();
+
+			const propsWithAttachmentId = {
+				...defaultProps,
+				config: {
+					...defaultProps.config,
+					attachmentId: 123,
+				},
+				onClassicMediaEditorNavigation,
+			};
+
+			render( <Header { ...propsWithAttachmentId } mode={ ImageStudioMode.Edit } /> );
+
+			await user.click( screen.getByLabelText( 'Edit this image in the WordPress Media Library' ) );
+
+			await waitFor( () => {
+				expect( mockAddNotice ).toHaveBeenCalledWith(
+					'Failed to save changes. Please try again or use the Save button.',
+					'error'
+				);
+			} );
+		} );
+	} );
+
+	describe( 'Close Button', () => {
+		it( 'calls onClose when close button is clicked', async () => {
+			const onClose = jest.fn();
+			const user = userEvent.setup();
+
+			render( <Header { ...defaultProps } onClose={ onClose } /> );
+
+			await user.click( screen.getByLabelText( 'Close image editor' ) );
+
+			expect( onClose ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'disables close button when saving', () => {
+			render( <Header { ...defaultProps } isSaving /> );
+
+			expect( screen.getByLabelText( 'Close image editor' ) ).toBeDisabled();
+		} );
+	} );
+
+	describe( 'Metadata Updates', () => {
+		it( 'shows special styling for AltText button when metadata is updated', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAiProcessing: () => false,
+					getHasUpdatedMetadata: () => true,
+					getIsAnnotationMode: () => false,
+					getDraftIds: () => [],
+					getEntryPoint: () => ImageStudioEntryPoint.MediaLibrary,
+				} ) );
+				return result;
+			} );
+
+			render( <Header { ...defaultProps } mode={ ImageStudioMode.Edit } /> );
+
+			const altTextButton = screen.getByLabelText( 'View or edit information about the image' );
+			expect( altTextButton ).toHaveClass( 'image-studio-toolbar-alt-button' );
+		} );
+	} );
+} );

--- a/packages/image-studio/src/components/header/index.tsx
+++ b/packages/image-studio/src/components/header/index.tsx
@@ -60,7 +60,9 @@ export const Header = ( {
 }: HeaderProps ) => {
 	const { isAiProcessing, hasUpdatedMetadata, isAnnotationMode, hasDrafts } = useSelect(
 		( select ) => {
-			const selectors = select( imageStudioStore ) as any;
+			const selectors = select(
+				imageStudioStore
+			) as unknown as import('../../types/wordpress').CurriedImageStudioSelectors;
 			return {
 				isAiProcessing: selectors.getImageStudioAiProcessing(),
 				hasUpdatedMetadata: selectors.getHasUpdatedMetadata(),

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -25,7 +25,7 @@ import { useRevertToOriginal } from '../hooks/use-revert-to-original';
 import { useSaveShortcut } from '../hooks/use-save-shortcut';
 import { useUnsavedChangesConfirmation } from '../hooks/use-unsaved-changes-confirmation';
 import { type ImageStudioActions, store as imageStudioStore } from '../store';
-import { ImageStudioMode, type ImageStudioProps, ToolbarOption, type AgentMessage } from '../types';
+import { ImageStudioMode, type ImageStudioProps, ToolbarOption } from '../types';
 import { defaultAgentConfigFactory } from '../utils/agent-config';
 import { trackImageStudioError, trackImageStudioPromptSent } from '../utils/tracking';
 import AnnotationCanvas from './annotation-canvas';
@@ -160,7 +160,6 @@ function ImageStudioAgentChat( {
 	return (
 		<AgentUI.Container
 			{ ...agentUiProps }
-			// AgentMessage uses structural typing - allows additional properties from agenttic-ui
 			messages={ displayMessages as any }
 			variant="embedded"
 			placeholder={ placeholder }

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -1,4 +1,4 @@
-import { getAgentManager, useAgentChat } from '@automattic/agenttic-client';
+import { getAgentManager, useAgentChat, UseAgentChatConfig } from '@automattic/agenttic-client';
 import { AgentUI, cn, ThinkingMessage } from '@automattic/agenttic-ui';
 import {
 	__unstableAnimatePresence as AnimatePresence,
@@ -25,7 +25,7 @@ import { useRevertToOriginal } from '../hooks/use-revert-to-original';
 import { useSaveShortcut } from '../hooks/use-save-shortcut';
 import { useUnsavedChangesConfirmation } from '../hooks/use-unsaved-changes-confirmation';
 import { type ImageStudioActions, store as imageStudioStore } from '../store';
-import { ImageStudioMode, type ImageStudioProps, ToolbarOption } from '../types';
+import { ImageStudioMode, type ImageStudioProps, ToolbarOption, type AgentMessage } from '../types';
 import { defaultAgentConfigFactory } from '../utils/agent-config';
 import { trackImageStudioError, trackImageStudioPromptSent } from '../utils/tracking';
 import AnnotationCanvas from './annotation-canvas';
@@ -48,7 +48,7 @@ function ImageStudioAgentChat( {
 	mode,
 	onChatSubmit,
 }: {
-	agentConfig: any;
+	agentConfig: UseAgentChatConfig;
 	attachmentId?: number;
 	mode: ImageStudioMode;
 	onChatSubmit?: () => Promise< void > | void;
@@ -160,6 +160,7 @@ function ImageStudioAgentChat( {
 	return (
 		<AgentUI.Container
 			{ ...agentUiProps }
+			// AgentMessage uses structural typing - allows additional properties from agenttic-ui
 			messages={ displayMessages as any }
 			variant="embedded"
 			placeholder={ placeholder }
@@ -195,7 +196,7 @@ const ImageStudioAgentUIComponent = ( {
 	onChatSubmit,
 	mode,
 }: {
-	agentConfig: any;
+	agentConfig: UseAgentChatConfig;
 	attachmentId?: number;
 	modalOpenKey?: number;
 	onChatSubmit?: () => void;

--- a/packages/image-studio/src/components/sidebar/index.test.tsx
+++ b/packages/image-studio/src/components/sidebar/index.test.tsx
@@ -1,0 +1,502 @@
+/* eslint-disable import/order */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Mock dependencies - MUST be before imports that use them
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+jest.mock( '../../utils/tracking', () => ( {
+	trackImageStudioSidebarClose: jest.fn(),
+	trackImageStudioMetadataUpdated: jest.fn(),
+} ) );
+
+jest.mock( './editable-field', () => {
+	const { useState } = require( '@wordpress/element' );
+	return {
+		EditableField: ( {
+			label,
+			value,
+			onSave,
+		}: {
+			label: string;
+			value: string;
+			onSave: ( value: string ) => void;
+		} ) => {
+			const [ localValue, setLocalValue ] = useState( value );
+			return (
+				<div data-testid={ `editable-field-${ label.toLowerCase() }` }>
+					<label>{ label }</label>
+					<input
+						value={ localValue }
+						onChange={ ( e ) => setLocalValue( e.target.value ) }
+						onBlur={ () => onSave( localValue ) }
+						data-testid={ `input-${ label.toLowerCase() }` }
+					/>
+				</div>
+			);
+		},
+	};
+} );
+
+jest.mock( './file-details', () => ( {
+	FileDetails: ( { attachmentId }: { attachmentId: number } ) => (
+		<div data-testid="file-details">File Details: { attachmentId }</div>
+	),
+} ) );
+
+jest.mock( '../confirmation-dialog', () => ( {
+	ConfirmationDialog: ( { isOpen, title, children, actions }: any ) =>
+		isOpen ? (
+			<div role="dialog">
+				<h2>{ title }</h2>
+				<div>{ children }</div>
+				{ actions.map( ( action: any, index: number ) => (
+					<button key={ index } onClick={ action.onClick }>
+						{ action.text }
+					</button>
+				) ) }
+			</div>
+		) : null,
+} ) );
+
+jest.mock( '../../store', () => ( {
+	store: 'image-studio',
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( {
+		children,
+		text,
+		icon,
+		label,
+		variant,
+		isDestructive,
+		showTooltip,
+		accessibleWhenDisabled,
+		...props
+	}: any ) => (
+		<button { ...props } aria-label={ label }>
+			{ children || text }
+		</button>
+	),
+	Icon: ( { icon }: any ) => <span>{ icon }</span>,
+} ) );
+
+// Import after mocks
+import { useDispatch, useSelect } from '@wordpress/data';
+import { MetadataField } from '../../types';
+import {
+	trackImageStudioMetadataUpdated,
+	trackImageStudioSidebarClose,
+} from '../../utils/tracking';
+import { ImageStudioAltTextSidebar, ImageStudioSidebar } from './index';
+
+const mockUseDispatch = useDispatch as jest.MockedFunction< typeof useDispatch >;
+const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
+const mockTrackSidebarClose = trackImageStudioSidebarClose as jest.MockedFunction<
+	typeof trackImageStudioSidebarClose
+>;
+const mockTrackMetadataUpdated = trackImageStudioMetadataUpdated as jest.MockedFunction<
+	typeof trackImageStudioMetadataUpdated
+>;
+
+describe( 'ImageStudioSidebar', () => {
+	const defaultProps = {
+		onClose: jest.fn(),
+		title: 'Test Sidebar',
+		children: <div>Test Content</div>,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Rendering', () => {
+		it( 'renders sidebar with title and children', () => {
+			render( <ImageStudioSidebar { ...defaultProps } /> );
+
+			expect( screen.getByText( 'Test Sidebar' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Test Content' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders close button', () => {
+			render( <ImageStudioSidebar { ...defaultProps } /> );
+
+			expect( screen.getByLabelText( 'Close sidebar' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Interactions', () => {
+		it( 'calls onClose and tracks event when close button is clicked', async () => {
+			const onClose = jest.fn();
+			const user = userEvent.setup();
+
+			render( <ImageStudioSidebar { ...defaultProps } onClose={ onClose } /> );
+
+			await user.click( screen.getByLabelText( 'Close sidebar' ) );
+
+			expect( onClose ).toHaveBeenCalledTimes( 1 );
+			expect( mockTrackSidebarClose ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );
+
+describe( 'ImageStudioAltTextSidebar', () => {
+	const defaultProps = {
+		onClose: jest.fn(),
+	};
+
+	const mockSetHasUpdatedMetadata = jest.fn();
+	const mockSetCanvasMetadata = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUseDispatch.mockReturnValue( {
+			setHasUpdatedMetadata: mockSetHasUpdatedMetadata,
+			setCanvasMetadata: mockSetCanvasMetadata,
+		} as any );
+
+		mockUseSelect.mockImplementation( ( selector: any ) => {
+			const result = selector( () => ( {
+				getImageStudioAttachmentId: () => 123,
+				getCanvasMetadata: () => ( {
+					title: 'Test Title',
+					caption: 'Test Caption',
+					description: 'Test Description',
+					alt_text: 'Test Alt Text',
+				} ),
+			} ) );
+			return result;
+		} );
+	} );
+
+	describe( 'Rendering', () => {
+		it( 'renders alt text sidebar with title', () => {
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			expect( screen.getByText( 'Image Info' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders all metadata fields', () => {
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			expect( screen.getByTestId( 'editable-field-title' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'editable-field-caption' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'editable-field-description' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'editable-field-alt text' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders help text for alt text', () => {
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			expect( screen.getByText( /Alt text describes the image's purpose/ ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Learn more' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders file details when attachmentId is present', () => {
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			expect( screen.getByTestId( 'file-details' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'File Details: 123' ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not render file details when attachmentId is null', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAttachmentId: () => null,
+					getCanvasMetadata: () => ( {} ),
+				} ) );
+				return result;
+			} );
+
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			expect( screen.queryByTestId( 'file-details' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'renders delete button when onDeletePermanently is provided', () => {
+			const onDeletePermanently = jest.fn();
+
+			render(
+				<ImageStudioAltTextSidebar
+					{ ...defaultProps }
+					onDeletePermanently={ onDeletePermanently }
+					canDeletePermanently
+				/>
+			);
+
+			expect( screen.getByRole( 'button', { name: 'Delete permanently' } ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not render delete button when onDeletePermanently is not provided', () => {
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			expect(
+				screen.queryByRole( 'button', { name: 'Delete permanently' } )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Metadata Updates', () => {
+		it( 'updates canvas metadata when field is saved', async () => {
+			const user = userEvent.setup();
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			const titleInput = screen.getByTestId( 'input-title' );
+
+			// Simulate changing the title
+			await user.clear( titleInput );
+			await user.type( titleInput, 'New Title' );
+			await user.tab(); // Trigger blur by moving focus
+
+			await waitFor( () => {
+				expect( mockSetCanvasMetadata ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						title: 'New Title',
+					} )
+				);
+			} );
+		} );
+
+		it( 'sets hasUpdatedMetadata flag when field is saved', async () => {
+			const user = userEvent.setup();
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			const titleInput = screen.getByTestId( 'input-title' );
+
+			// Simulate changing the title
+			await user.clear( titleInput );
+			await user.type( titleInput, 'New Title' );
+			await user.tab(); // Trigger blur by moving focus
+
+			await waitFor( () => {
+				expect( mockSetHasUpdatedMetadata ).toHaveBeenCalledWith( true );
+			} );
+		} );
+
+		it( 'tracks metadata update with correct field and attachment ID', async () => {
+			const user = userEvent.setup();
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			const titleInput = screen.getByTestId( 'input-title' );
+
+			// Simulate changing the title
+			await user.clear( titleInput );
+			await user.type( titleInput, 'New Title' );
+			await user.tab(); // Trigger blur by moving focus
+
+			await waitFor( () => {
+				expect( mockTrackMetadataUpdated ).toHaveBeenCalledWith( {
+					attachmentId: 123,
+					field: MetadataField.Title,
+				} );
+			} );
+		} );
+
+		it( 'preserves existing metadata when updating a single field', async () => {
+			const user = userEvent.setup();
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			const titleInput = screen.getByTestId( 'input-title' );
+
+			// Simulate changing the title
+			await user.clear( titleInput );
+			await user.type( titleInput, 'New Title' );
+			await user.tab(); // Trigger blur by moving focus
+
+			await waitFor( () => {
+				expect( mockSetCanvasMetadata ).toHaveBeenCalledWith( {
+					title: 'New Title',
+					caption: 'Test Caption',
+					description: 'Test Description',
+					alt_text: 'Test Alt Text',
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'Delete Functionality', () => {
+		it( 'disables delete button when canDeletePermanently is false', () => {
+			const onDeletePermanently = jest.fn();
+
+			render(
+				<ImageStudioAltTextSidebar
+					{ ...defaultProps }
+					onDeletePermanently={ onDeletePermanently }
+					canDeletePermanently={ false }
+				/>
+			);
+
+			// When disabled, the button shows the tooltip as the label
+			expect( screen.getByLabelText( 'Save or discard your changes' ) ).toBeDisabled();
+		} );
+
+		it( 'shows confirmation dialog when delete button is clicked', async () => {
+			const onDeletePermanently = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				<ImageStudioAltTextSidebar
+					{ ...defaultProps }
+					onDeletePermanently={ onDeletePermanently }
+					canDeletePermanently
+				/>
+			);
+
+			await user.click( screen.getByRole( 'button', { name: 'Delete permanently' } ) );
+
+			expect( screen.getByText( 'Delete this item' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					/You are about to permanently delete this item from your site. This action cannot be undone./
+				)
+			).toBeInTheDocument();
+		} );
+
+		it( 'closes confirmation dialog when Cancel is clicked', async () => {
+			const onDeletePermanently = jest.fn();
+			const user = userEvent.setup();
+
+			render(
+				<ImageStudioAltTextSidebar
+					{ ...defaultProps }
+					onDeletePermanently={ onDeletePermanently }
+					canDeletePermanently
+				/>
+			);
+
+			// Open dialog
+			await user.click( screen.getByRole( 'button', { name: 'Delete permanently' } ) );
+
+			expect( screen.getByText( 'Delete this item' ) ).toBeInTheDocument();
+
+			// Click cancel
+			await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+			// Dialog should be closed
+			await waitFor( () => {
+				expect( screen.queryByText( 'Delete this item' ) ).not.toBeInTheDocument();
+			} );
+
+			expect( onDeletePermanently ).not.toHaveBeenCalled();
+		} );
+
+		it( 'calls onDeletePermanently when confirmed', async () => {
+			const onDeletePermanently = jest.fn().mockResolvedValue( undefined );
+			const user = userEvent.setup();
+
+			render(
+				<ImageStudioAltTextSidebar
+					{ ...defaultProps }
+					onDeletePermanently={ onDeletePermanently }
+					canDeletePermanently
+				/>
+			);
+
+			// Open dialog
+			await user.click( screen.getByRole( 'button', { name: /Delete permanently/ } ) );
+
+			// Confirm deletion - find the button within the dialog
+			const confirmButtons = screen.getAllByRole( 'button', { name: 'Delete permanently' } );
+			const confirmButton = confirmButtons.find( ( button ) => {
+				// The confirm button should be the one inside the dialog (has isDestructive variant)
+				return button.closest( '[role="dialog"]' ) !== null;
+			} );
+
+			if ( confirmButton ) {
+				await user.click( confirmButton );
+			}
+
+			await waitFor( () => {
+				expect( onDeletePermanently ).toHaveBeenCalledTimes( 1 );
+			} );
+		} );
+
+		it( 'closes dialog before calling onDeletePermanently', async () => {
+			const deletePromise = new Promise< void >( ( resolve ) => {
+				// resolve stored but not used — promise stays pending to test intermediate state
+				void resolve;
+			} );
+
+			const onDeletePermanently = jest.fn().mockReturnValue( deletePromise );
+			const user = userEvent.setup();
+
+			render(
+				<ImageStudioAltTextSidebar
+					{ ...defaultProps }
+					onDeletePermanently={ onDeletePermanently }
+					canDeletePermanently
+				/>
+			);
+
+			// Open dialog
+			await user.click( screen.getByRole( 'button', { name: /Delete permanently/ } ) );
+
+			// Confirm deletion
+			const confirmButtons = screen.getAllByRole( 'button', { name: 'Delete permanently' } );
+			const confirmButton = confirmButtons.find( ( button ) => {
+				return button.closest( '[role="dialog"]' ) !== null;
+			} );
+
+			if ( confirmButton ) {
+				await user.click( confirmButton );
+			}
+
+			// Dialog should close immediately
+			await waitFor( () => {
+				expect( screen.queryByText( 'Delete this item' ) ).not.toBeInTheDocument();
+			} );
+
+			// And deletion should be in progress
+			expect( onDeletePermanently ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Edge Cases', () => {
+		it( 'handles missing canvas metadata gracefully', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAttachmentId: () => 123,
+					getCanvasMetadata: () => null,
+				} ) );
+				return result;
+			} );
+
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			// Should render with empty values
+			expect( screen.getByTestId( 'editable-field-title' ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not save metadata when attachmentId is null', async () => {
+			const user = userEvent.setup();
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getImageStudioAttachmentId: () => null,
+					getCanvasMetadata: () => ( {} ),
+				} ) );
+				return result;
+			} );
+
+			render( <ImageStudioAltTextSidebar { ...defaultProps } /> );
+
+			const titleInput = screen.getByTestId( 'input-title' );
+
+			// Simulate changing the title
+			await user.clear( titleInput );
+			await user.type( titleInput, 'New Title' );
+			await user.tab(); // Trigger blur by moving focus
+
+			// Should not update metadata without attachmentId
+			expect( mockSetCanvasMetadata ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/packages/image-studio/src/components/style-picker/index.test.tsx
+++ b/packages/image-studio/src/components/style-picker/index.test.tsx
@@ -1,0 +1,598 @@
+/* eslint-disable import/order */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Mock dependencies - MUST be before imports that use them
+jest.mock( '@automattic/agenttic-ui', () => {
+	const React = require( 'react' );
+	const { useState } = React;
+
+	return {
+		AgentUI: {
+			InputToolbar: ( { label, icon, className, disabled, children }: any ) => {
+				const [ isOpen, setIsOpen ] = useState( false );
+
+				return (
+					<div className={ className }>
+						<button
+							type="button"
+							disabled={ disabled }
+							data-testid="toolbar-button"
+							onClick={ () => setIsOpen( ! isOpen ) }
+						>
+							{ icon }
+							{ label }
+						</button>
+						{ isOpen && <div data-testid="dropdown-content">{ children }</div> }
+					</div>
+				);
+			},
+		},
+		cn: ( ...args: any[] ) => {
+			return args
+				.map( ( arg ) => {
+					if ( typeof arg === 'string' ) {
+						return arg;
+					}
+					if ( typeof arg === 'object' && arg !== null ) {
+						return Object.keys( arg )
+							.filter( ( key ) => arg[ key ] )
+							.join( ' ' );
+					}
+					return '';
+				} )
+				.filter( Boolean )
+				.join( ' ' );
+		},
+	};
+} );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+jest.mock( '../../utils/tracking', () => ( {
+	trackImageStudioStyleSelected: jest.fn(),
+} ) );
+
+jest.mock( '../../store', () => ( {
+	store: 'image-studio',
+} ) );
+
+jest.mock( '../icons/BrushIcon', () => ( {
+	BrushIcon: ( { size }: { size: number } ) => <div data-testid="brush-icon">Brush { size }</div>,
+} ) );
+
+// Import after mocks
+import { useDispatch, useSelect } from '@wordpress/data';
+import { ImageStudioMode } from '../../types';
+import { trackImageStudioStyleSelected } from '../../utils/tracking';
+import { STYLE_OPTIONS, StylePicker } from './index';
+
+const mockUseDispatch = useDispatch as jest.MockedFunction< typeof useDispatch >;
+const mockUseSelect = useSelect as jest.MockedFunction< typeof useSelect >;
+const mockTrackStyleSelected = trackImageStudioStyleSelected as jest.MockedFunction<
+	typeof trackImageStudioStyleSelected
+>;
+
+describe( 'StylePicker', () => {
+	const mockSetSelectedStyle = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUseDispatch.mockReturnValue( {
+			setSelectedStyle: mockSetSelectedStyle,
+		} as any );
+
+		mockUseSelect.mockImplementation( ( selector: any ) => {
+			const result = selector( () => ( {
+				getSelectedStyle: () => '',
+			} ) );
+			return result;
+		} );
+
+		// Mock requestAnimationFrame
+		global.requestAnimationFrame = jest.fn( ( cb ) => {
+			cb( 0 );
+			return 0;
+		} );
+
+		// Mock document.body.dispatchEvent
+		document.body.dispatchEvent = jest.fn();
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	describe( 'Rendering', () => {
+		it( 'renders style picker with default label', () => {
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// When selectedStyle is '', it shows 'None' (the label for value: '')
+			expect( screen.getByTestId( 'toolbar-button' ) ).toHaveTextContent( 'None' );
+		} );
+
+		it( 'renders style picker with selected style label', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getSelectedStyle: () => 'vivid',
+				} ) );
+				return result;
+			} );
+
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			expect( screen.getByTestId( 'toolbar-button' ) ).toHaveTextContent( 'Vivid' );
+		} );
+
+		it( 'renders brush icon', () => {
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			expect( screen.getByTestId( 'brush-icon' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Brush 16' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders all style options with previews', async () => {
+			const user = userEvent.setup();
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			// Filter out the first option which has no preview
+			const optionsWithPreviews = STYLE_OPTIONS.filter( ( opt ) => opt.preview );
+
+			const styleButtons = screen.getAllByRole( 'button' ).filter( ( button ) => {
+				return button.querySelector( 'img' ) !== null;
+			} );
+
+			expect( styleButtons ).toHaveLength( optionsWithPreviews.length );
+		} );
+
+		it( 'renders style option labels', async () => {
+			const user = userEvent.setup();
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			// Now check for labels within the dropdown
+			const dropdown = screen.getByTestId( 'dropdown-content' );
+			expect( dropdown ).toHaveTextContent( 'None' );
+			expect( dropdown ).toHaveTextContent( 'Vivid' );
+			expect( dropdown ).toHaveTextContent( 'Anime' );
+			expect( dropdown ).toHaveTextContent( 'Photographic' );
+		} );
+
+		it( 'renders style option images with empty alt text', async () => {
+			const user = userEvent.setup();
+			const { container } = render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			// Images with alt="" are presentational, so use DOM query instead of getByRole('img')
+			const images = container.querySelectorAll( 'img' );
+			expect( images.length ).toBeGreaterThan( 0 );
+
+			images.forEach( ( img ) => {
+				expect( img ).toHaveAttribute( 'alt', '' );
+			} );
+		} );
+
+		it( 'applies is-selected class to selected style', async () => {
+			const user = userEvent.setup();
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getSelectedStyle: () => 'vivid',
+				} ) );
+				return result;
+			} );
+
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			// Find the vivid button in the dropdown
+			const vividButton = screen
+				.getAllByRole( 'button' )
+				.find(
+					( button ) =>
+						button.textContent?.includes( 'Vivid' ) &&
+						button.getAttribute( 'data-testid' ) !== 'toolbar-button'
+				);
+
+			expect( vividButton ).toHaveClass( 'is-selected' );
+		} );
+
+		it( 'disables style picker when disabled prop is true', () => {
+			render( <StylePicker mode={ ImageStudioMode.Generate } disabled /> );
+
+			const toolbarButton = screen.getByTestId( 'toolbar-button' );
+			expect( toolbarButton ).toBeDisabled();
+		} );
+
+		it( 'enables style picker by default', () => {
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			const toolbarButton = screen.getByTestId( 'toolbar-button' );
+			expect( toolbarButton ).not.toBeDisabled();
+		} );
+	} );
+
+	describe( 'Style Selection', () => {
+		it( 'calls setSelectedStyle when a style is clicked', async () => {
+			const user = userEvent.setup();
+
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			const vividButton = screen
+				.getAllByRole( 'button' )
+				.find(
+					( button ) =>
+						button.textContent?.includes( 'Vivid' ) &&
+						button.getAttribute( 'data-testid' ) !== 'toolbar-button'
+				);
+
+			if ( vividButton ) {
+				await user.click( vividButton );
+			}
+
+			expect( mockSetSelectedStyle ).toHaveBeenCalledWith( 'vivid' );
+		} );
+
+		it( 'tracks style selection with correct parameters', async () => {
+			const user = userEvent.setup();
+
+			render( <StylePicker mode={ ImageStudioMode.Edit } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			const animeButton = screen
+				.getAllByRole( 'button' )
+				.find(
+					( button ) =>
+						button.textContent?.includes( 'Anime' ) &&
+						button.getAttribute( 'data-testid' ) !== 'toolbar-button'
+				);
+
+			if ( animeButton ) {
+				await user.click( animeButton );
+			}
+
+			expect( mockTrackStyleSelected ).toHaveBeenCalledWith( {
+				style: 'anime',
+				mode: ImageStudioMode.Edit,
+			} );
+		} );
+
+		it( 'closes dropdown after style selection', async () => {
+			const user = userEvent.setup();
+
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			const vividButton = screen
+				.getAllByRole( 'button' )
+				.find(
+					( button ) =>
+						button.textContent?.includes( 'Vivid' ) &&
+						button.getAttribute( 'data-testid' ) !== 'toolbar-button'
+				);
+
+			if ( vividButton ) {
+				await user.click( vividButton );
+			}
+
+			await waitFor( () => {
+				expect( requestAnimationFrame ).toHaveBeenCalled();
+			} );
+
+			await waitFor( () => {
+				expect( document.body.dispatchEvent ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						type: 'mousedown',
+						bubbles: true,
+						cancelable: true,
+					} )
+				);
+			} );
+		} );
+
+		it( 'updates selected style in different modes', async () => {
+			const user = userEvent.setup();
+
+			// Test Generate mode
+			const { rerender } = render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			const photographicButton = screen
+				.getAllByRole( 'button' )
+				.find(
+					( button ) =>
+						button.textContent?.includes( 'Photographic' ) &&
+						button.getAttribute( 'data-testid' ) !== 'toolbar-button'
+				);
+
+			if ( photographicButton ) {
+				await user.click( photographicButton );
+			}
+
+			expect( mockTrackStyleSelected ).toHaveBeenCalledWith( {
+				style: 'photographic',
+				mode: ImageStudioMode.Generate,
+			} );
+
+			// Close dropdown before rerender (mock dropdown doesn't auto-close)
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			// Test Edit mode
+			rerender( <StylePicker mode={ ImageStudioMode.Edit } /> );
+
+			// Open dropdown after rerender
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			const digitalArtButton = screen
+				.getAllByRole( 'button' )
+				.find(
+					( button ) =>
+						button.textContent?.includes( 'Digital Art' ) &&
+						button.getAttribute( 'data-testid' ) !== 'toolbar-button'
+				);
+
+			if ( digitalArtButton ) {
+				await user.click( digitalArtButton );
+			}
+
+			expect( mockTrackStyleSelected ).toHaveBeenCalledWith( {
+				style: 'digital-art',
+				mode: ImageStudioMode.Edit,
+			} );
+		} );
+	} );
+
+	describe( 'Style Options', () => {
+		it( 'renders all expected style options', async () => {
+			const user = userEvent.setup();
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			const expectedStyles = [
+				'None',
+				'Vivid',
+				'Anime',
+				'Photographic',
+				'Digital Art',
+				'Comicbook',
+				'Fantasy Art',
+				'Analog Film',
+				'Neonpunk',
+				'Isometric',
+				'Lowpoly',
+				'Origami',
+				'Line Art',
+				'Craft Clay',
+				'Cinematic',
+				'3D Model',
+				'Pixel Art',
+				'Texture',
+			];
+
+			const dropdown = screen.getByTestId( 'dropdown-content' );
+			expectedStyles.forEach( ( style ) => {
+				expect( dropdown ).toHaveTextContent( style );
+			} );
+		} );
+
+		it( 'maps style values correctly', async () => {
+			const user = userEvent.setup();
+
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Test a few key mappings
+			const testCases = [
+				{ label: 'None', value: '' },
+				{ label: 'Vivid', value: 'vivid' },
+				{ label: '3D Model', value: '3d-model' },
+				{ label: 'Pixel Art', value: 'pixel-art' },
+			];
+
+			for ( const testCase of testCases ) {
+				// Open dropdown for each test
+				await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+				const button = screen
+					.getAllByRole( 'button' )
+					.find(
+						( btn ) =>
+							btn.textContent?.includes( testCase.label ) &&
+							btn.getAttribute( 'data-testid' ) !== 'toolbar-button'
+					);
+
+				if ( button ) {
+					await user.click( button );
+					// eslint-disable-next-line jest/no-conditional-expect
+					expect( mockSetSelectedStyle ).toHaveBeenCalledWith( testCase.value );
+				}
+
+				// Reset for next iteration
+				jest.clearAllMocks();
+			}
+		} );
+	} );
+
+	describe( 'State Synchronization', () => {
+		it( 'updates label when selected style changes', () => {
+			const { rerender } = render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// When selectedStyle is '', it matches the 'None' option
+			expect( screen.getByTestId( 'toolbar-button' ) ).toHaveTextContent( 'None' );
+
+			// Update selected style
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getSelectedStyle: () => 'cinematic',
+				} ) );
+				return result;
+			} );
+
+			rerender( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			expect( screen.getByTestId( 'toolbar-button' ) ).toHaveTextContent( 'Cinematic' );
+		} );
+
+		it( 'handles unknown selected style gracefully', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getSelectedStyle: () => 'non-existent-style',
+				} ) );
+				return result;
+			} );
+
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Should fall back to 'Styles' when value doesn't match any option
+			const toolbarButton = screen.getByTestId( 'toolbar-button' );
+			expect( toolbarButton ).toHaveTextContent( 'Styles' );
+		} );
+
+		it( 'reflects selection state across multiple instances', async () => {
+			const user = userEvent.setup();
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getSelectedStyle: () => 'anime',
+				} ) );
+				return result;
+			} );
+
+			const { container: container1 } = render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+			const { container: container2 } = render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdowns to render style option buttons
+			const toolbarButtons = screen.getAllByTestId( 'toolbar-button' );
+			await user.click( toolbarButtons[ 0 ] );
+			await user.click( toolbarButtons[ 1 ] );
+
+			// Both instances should show the same selected state
+			const selectedButtons1 = container1.querySelectorAll( '.is-selected' );
+			const selectedButtons2 = container2.querySelectorAll( '.is-selected' );
+
+			expect( selectedButtons1.length ).toBeGreaterThan( 0 );
+			expect( selectedButtons2.length ).toBeGreaterThan( 0 );
+		} );
+	} );
+
+	describe( 'Accessibility', () => {
+		it( 'uses button elements for style options', async () => {
+			const user = userEvent.setup();
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			const styleButtons = screen.getAllByRole( 'button' ).filter( ( button ) => {
+				return button.querySelector( 'img' ) !== null;
+			} );
+
+			styleButtons.forEach( ( button ) => {
+				expect( button ).toHaveAttribute( 'type', 'button' );
+			} );
+		} );
+
+		it( 'provides empty alt text for decorative images', async () => {
+			const user = userEvent.setup();
+			const { container } = render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			// Images with alt="" are presentational, so use DOM query instead of getByRole('img')
+			const images = container.querySelectorAll( 'img' );
+			expect( images.length ).toBeGreaterThan( 0 );
+
+			images.forEach( ( img ) => {
+				expect( img ).toHaveAttribute( 'alt', '' );
+			} );
+		} );
+	} );
+
+	describe( 'Edge Cases', () => {
+		it( 'handles rapid style selection', async () => {
+			const user = userEvent.setup();
+
+			render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			// Open dropdown and click Vivid
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			const vividButton = screen
+				.getAllByRole( 'button' )
+				.find(
+					( button ) =>
+						button.textContent?.includes( 'Vivid' ) &&
+						button.getAttribute( 'data-testid' ) !== 'toolbar-button'
+				);
+
+			expect( vividButton ).toBeDefined();
+			await user.click( vividButton! );
+
+			// The mock InputToolbar toggles on button click. After clicking a style,
+			// the dropdown may still be open (mock doesn't handle the requestAnimationFrame close).
+			// Close and reopen to ensure a fresh dropdown.
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+			await user.click( screen.getByTestId( 'toolbar-button' ) );
+
+			const animeButton = screen
+				.getAllByRole( 'button' )
+				.find(
+					( button ) =>
+						button.textContent?.includes( 'Anime' ) &&
+						button.getAttribute( 'data-testid' ) !== 'toolbar-button'
+				);
+
+			expect( animeButton ).toBeDefined();
+			await user.click( animeButton! );
+
+			expect( mockSetSelectedStyle ).toHaveBeenCalledTimes( 2 );
+			expect( mockSetSelectedStyle ).toHaveBeenNthCalledWith( 1, 'vivid' );
+			expect( mockSetSelectedStyle ).toHaveBeenNthCalledWith( 2, 'anime' );
+		} );
+
+		it( 'maintains state when mode changes', () => {
+			mockUseSelect.mockImplementation( ( selector: any ) => {
+				const result = selector( () => ( {
+					getSelectedStyle: () => 'vivid',
+				} ) );
+				return result;
+			} );
+
+			const { rerender } = render( <StylePicker mode={ ImageStudioMode.Generate } /> );
+
+			expect( screen.getByTestId( 'toolbar-button' ) ).toHaveTextContent( 'Vivid' );
+
+			// Change mode
+			rerender( <StylePicker mode={ ImageStudioMode.Edit } /> );
+
+			// Selected style should remain
+			expect( screen.getByTestId( 'toolbar-button' ) ).toHaveTextContent( 'Vivid' );
+		} );
+	} );
+} );

--- a/packages/image-studio/src/extensions/image-toolbar-extension.tsx
+++ b/packages/image-studio/src/extensions/image-toolbar-extension.tsx
@@ -6,7 +6,12 @@ import { dispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ImageStudioEntryPoint, store as imageStudioStore } from '../store/index';
-import { IMAGE_STUDIO_SUPPORTED_MIME_TYPES, ImageStudioMode } from '../types';
+import {
+	type BlockEditProps,
+	IMAGE_STUDIO_SUPPORTED_MIME_TYPES,
+	type MediaAttachment,
+	ImageStudioMode,
+} from '../types';
 import { type ImageData } from '../utils/get-image-data';
 import { trackImageStudioOpened } from '../utils/tracking';
 
@@ -14,8 +19,8 @@ import { trackImageStudioOpened } from '../utils/tracking';
  * Add Image Studio button to image blocks toolbar
  */
 export const withImageStudioToolbarButton = createHigherOrderComponent(
-	( BlockEdit: React.ComponentType< any > ) => {
-		const ImageStudioToolbarButton = ( props: any ) => {
+	( BlockEdit: React.ComponentType< BlockEditProps > ) => {
+		const ImageStudioToolbarButton = ( props: BlockEditProps ) => {
 			const { openImageStudio } = dispatch( imageStudioStore );
 			const { attributes, setAttributes } = props;
 
@@ -29,11 +34,11 @@ export const withImageStudioToolbarButton = createHigherOrderComponent(
 						return { media: null, hasResolved: true };
 					}
 					return {
-						media: select( coreStore ).getEntityRecord( 'postType', 'attachment', attributes.id ),
+						media: select( coreStore ).getEntityRecord( 'postType', 'attachment', attributes.id as number ),
 						hasResolved: ( select( coreStore ) as any ).hasFinishedResolution( 'getEntityRecord', [
 							'postType',
 							'attachment',
-							attributes.id,
+							attributes.id as number,
 						] ),
 					};
 				},
@@ -65,14 +70,16 @@ export const withImageStudioToolbarButton = createHigherOrderComponent(
 				[ setAttributes ]
 			);
 
+			const attachmentId = attributes.id as number | undefined;
+
 			const handleEditClick = useCallback( () => {
 				trackImageStudioOpened( {
 					mode: ImageStudioMode.Edit,
-					attachmentId: attributes.id,
+					attachmentId,
 					entryPoint: ImageStudioEntryPoint.EditorBlock,
 				} );
-				openImageStudio( attributes.id, handleClose, ImageStudioEntryPoint.EditorBlock );
-			}, [ attributes, handleClose, openImageStudio ] );
+				openImageStudio( attachmentId, handleClose, ImageStudioEntryPoint.EditorBlock );
+			}, [ attachmentId, handleClose, openImageStudio ] );
 
 			if ( props.name !== 'core/image' || ! attributes?.id ) {
 				return <BlockEdit { ...props } />;

--- a/packages/image-studio/src/extensions/image-toolbar-extension.tsx
+++ b/packages/image-studio/src/extensions/image-toolbar-extension.tsx
@@ -111,7 +111,7 @@ export const withImageStudioToolbarButton = createHigherOrderComponent(
 					}
 				}
 			}
-			const attributeUrl = attributes?.url ? stripParams( attributes.url ) : null;
+			const attributeUrl = attributes?.url ? stripParams( attributes.url as string ) : null;
 			if ( hasResolved && attributeUrl && ( ! attachment || ! knownUrls.has( attributeUrl ) ) ) {
 				return <BlockEdit { ...props } />;
 			}

--- a/packages/image-studio/src/extensions/image-toolbar-extension.tsx
+++ b/packages/image-studio/src/extensions/image-toolbar-extension.tsx
@@ -6,12 +6,7 @@ import { dispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ImageStudioEntryPoint, store as imageStudioStore } from '../store/index';
-import {
-	type BlockEditProps,
-	IMAGE_STUDIO_SUPPORTED_MIME_TYPES,
-	type MediaAttachment,
-	ImageStudioMode,
-} from '../types';
+import { type BlockEditProps, IMAGE_STUDIO_SUPPORTED_MIME_TYPES, ImageStudioMode } from '../types';
 import { type ImageData } from '../utils/get-image-data';
 import { trackImageStudioOpened } from '../utils/tracking';
 
@@ -34,7 +29,11 @@ export const withImageStudioToolbarButton = createHigherOrderComponent(
 						return { media: null, hasResolved: true };
 					}
 					return {
-						media: select( coreStore ).getEntityRecord( 'postType', 'attachment', attributes.id as number ),
+						media: select( coreStore ).getEntityRecord(
+							'postType',
+							'attachment',
+							attributes.id as number
+						),
 						hasResolved: ( select( coreStore ) as any ).hasFinishedResolution( 'getEntityRecord', [
 							'postType',
 							'attachment',

--- a/packages/image-studio/src/extensions/index.test.ts
+++ b/packages/image-studio/src/extensions/index.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for extension registration system
+ */
+
+// Mock @wordpress/hooks
+const mockAddFilter = jest.fn();
+jest.mock( '@wordpress/hooks', () => ( {
+	addFilter: mockAddFilter,
+} ) );
+
+// Mock extension modules
+const mockAddImageStudioMediaSource = jest.fn();
+const mockWithImageStudioGenerateButton = jest.fn();
+const mockWithImageStudioToolbarButton = jest.fn();
+
+jest.mock( './external-media-source-extension', () => ( {
+	addImageStudioMediaSource: mockAddImageStudioMediaSource,
+} ) );
+
+jest.mock( './generate-button-extension', () => ( {
+	withImageStudioGenerateButton: mockWithImageStudioGenerateButton,
+} ) );
+
+jest.mock( './image-toolbar-extension', () => ( {
+	withImageStudioToolbarButton: mockWithImageStudioToolbarButton,
+} ) );
+
+describe( 'Extension Registration', () => {
+	beforeEach( () => {
+		mockAddFilter.mockClear();
+		mockAddImageStudioMediaSource.mockClear();
+		mockWithImageStudioGenerateButton.mockClear();
+		mockWithImageStudioToolbarButton.mockClear();
+		// Reset module to clear filtersRegistered flag
+		jest.resetModules();
+	} );
+
+	describe( 'registerBlockEditorFilters', () => {
+		it( 'should register all three filters when called', () => {
+			const { registerBlockEditorFilters } = require( './index' );
+
+			registerBlockEditorFilters();
+
+			expect( mockAddFilter ).toHaveBeenCalledTimes( 3 );
+
+			// Verify toolbar button filter
+			expect( mockAddFilter ).toHaveBeenCalledWith(
+				'editor.BlockEdit',
+				'big-sky/image-studio',
+				mockWithImageStudioToolbarButton
+			);
+
+			// Verify external media source filter
+			expect( mockAddFilter ).toHaveBeenCalledWith(
+				'jetpack.externalMedia.extraMediaSources',
+				'big-sky/image-studio',
+				mockAddImageStudioMediaSource
+			);
+
+			// Verify generate button filter
+			expect( mockAddFilter ).toHaveBeenCalledWith(
+				'editor.MediaUpload',
+				'big-sky/generate-button',
+				mockWithImageStudioGenerateButton
+			);
+		} );
+
+		it( 'should only register filters once (idempotency)', () => {
+			const { registerBlockEditorFilters } = require( './index' );
+
+			registerBlockEditorFilters();
+			registerBlockEditorFilters();
+			registerBlockEditorFilters();
+
+			// Should only call addFilter 3 times total (not 9)
+			expect( mockAddFilter ).toHaveBeenCalledTimes( 3 );
+		} );
+
+		it( 'should use correct namespace for filters', () => {
+			const { registerBlockEditorFilters } = require( './index' );
+			registerBlockEditorFilters();
+
+			const calls = mockAddFilter.mock.calls;
+
+			// Check that big-sky/image-studio namespace is used for BlockEdit and externalMedia
+			expect( calls[ 0 ][ 1 ] ).toBe( 'big-sky/image-studio' );
+			expect( calls[ 1 ][ 1 ] ).toBe( 'big-sky/image-studio' );
+
+			// Check that big-sky/generate-button namespace is used for MediaUpload
+			expect( calls[ 2 ][ 1 ] ).toBe( 'big-sky/generate-button' );
+		} );
+	} );
+} );

--- a/packages/image-studio/src/extensions/utils.test.ts
+++ b/packages/image-studio/src/extensions/utils.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for extension utilities
+ */
+import { dispatch, select } from '@wordpress/data';
+import { transformAttachment } from '@wordpress/media-utils';
+import { ImageStudioMode } from '../types';
+import { handleImageSelection, openImageStudioForBlock } from './utils';
+import type { ImageData } from '../utils/get-image-data';
+
+// Mock store
+const mockImageStudioStore = {
+	openImageStudio: jest.fn(),
+};
+
+const mockBlockEditorStore = {
+	updateBlockAttributes: jest.fn(),
+};
+
+const mockCoreStore = {
+	getEntityRecord: jest.fn(),
+};
+
+// Mock console.error to capture error logs
+const consoleErrorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+describe( 'Extension Utils', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		( dispatch as unknown as jest.Mock ).mockImplementation( ( storeName ) => {
+			if ( storeName?.name === 'core/block-editor' ) {
+				return mockBlockEditorStore;
+			}
+			return mockImageStudioStore;
+		} );
+
+		( select as unknown as jest.Mock ).mockImplementation( ( storeName ) => {
+			if ( storeName?.name === 'core' ) {
+				return mockCoreStore;
+			}
+			return {};
+		} );
+	} );
+
+	afterAll( () => {
+		consoleErrorSpy.mockRestore();
+	} );
+
+	describe( 'handleImageSelection', () => {
+		const mockOnSelect = jest.fn();
+
+		it( 'should return early when image is null (deletion case)', () => {
+			handleImageSelection( {
+				image: null,
+				onSelect: mockOnSelect,
+				multiple: false,
+			} );
+
+			expect( mockOnSelect ).not.toHaveBeenCalled();
+			expect( mockCoreStore.getEntityRecord ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should log error and return early when image has no id', () => {
+			const imageWithoutId = {
+				url: 'https://example.com/image.jpg',
+			} as ImageData;
+
+			handleImageSelection( {
+				image: imageWithoutId,
+				onSelect: mockOnSelect,
+				multiple: false,
+			} );
+
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'[Image Studio] Image data is missing an ID.'
+			);
+			expect( mockOnSelect ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should fetch attachment and call onSelect with transformed attachment (single)', () => {
+			const mockAttachment = {
+				id: 123,
+				source_url: 'https://example.com/image.jpg',
+				alt_text: 'Test image',
+			};
+
+			mockCoreStore.getEntityRecord.mockReturnValue( mockAttachment );
+
+			const image: ImageData = {
+				id: 123,
+				url: 'https://example.com/image.jpg',
+				alt: 'Test',
+				title: '',
+				caption: '',
+				description: '',
+				width: 100,
+				height: 100,
+				filename: 'image.jpg',
+			};
+
+			handleImageSelection( {
+				image,
+				onSelect: mockOnSelect,
+				multiple: false,
+			} );
+
+			expect( mockCoreStore.getEntityRecord ).toHaveBeenCalledWith( 'postType', 'attachment', 123 );
+			expect( transformAttachment ).toHaveBeenCalledWith( mockAttachment );
+			expect( mockOnSelect ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					...mockAttachment,
+					transformed: true,
+				} )
+			);
+		} );
+
+		it( 'should call onSelect with array when multiple is true', () => {
+			const mockAttachment = {
+				id: 123,
+				source_url: 'https://example.com/image.jpg',
+			};
+
+			mockCoreStore.getEntityRecord.mockReturnValue( mockAttachment );
+
+			const image: ImageData = {
+				id: 123,
+				url: 'https://example.com/image.jpg',
+				alt: '',
+				title: '',
+				caption: '',
+				description: '',
+				width: 100,
+				height: 100,
+				filename: 'image.jpg',
+			};
+
+			handleImageSelection( {
+				image,
+				onSelect: mockOnSelect,
+				multiple: true,
+			} );
+
+			expect( mockOnSelect ).toHaveBeenCalledWith( [
+				expect.objectContaining( {
+					...mockAttachment,
+					transformed: true,
+				} ),
+			] );
+		} );
+
+		it( 'should not call onSelect when attachment is not found', () => {
+			mockCoreStore.getEntityRecord.mockReturnValue( undefined );
+
+			const image: ImageData = {
+				id: 999,
+				url: 'https://example.com/missing.jpg',
+				alt: '',
+				title: '',
+				caption: '',
+				description: '',
+				width: 100,
+				height: 100,
+				filename: 'missing.jpg',
+			};
+
+			handleImageSelection( {
+				image,
+				onSelect: mockOnSelect,
+				multiple: false,
+			} );
+
+			expect( mockOnSelect ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'openImageStudioForBlock', () => {
+		it( 'should return false when imageBlock has no clientId', () => {
+			const result = openImageStudioForBlock( {
+				name: 'core/image',
+			} );
+
+			expect( result ).toBe( false );
+			expect( mockImageStudioStore.openImageStudio ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should open Image Studio in edit mode with attachment ID', () => {
+			const imageBlock = {
+				name: 'core/image',
+				clientId: 'block-123',
+				attributes: {
+					id: 456,
+					url: 'https://example.com/image.jpg',
+				},
+			};
+
+			const result = openImageStudioForBlock( imageBlock, ImageStudioMode.Edit );
+
+			expect( result ).toBe( true );
+			expect( mockImageStudioStore.openImageStudio ).toHaveBeenCalledWith(
+				456,
+				expect.any( Function ),
+				'editor_block'
+			);
+		} );
+
+		it( 'should open Image Studio in generate mode without attachment ID', () => {
+			const imageBlock = {
+				name: 'core/image',
+				clientId: 'block-123',
+				attributes: {},
+			};
+
+			const result = openImageStudioForBlock( imageBlock, ImageStudioMode.Generate );
+
+			expect( result ).toBe( true );
+			expect( mockImageStudioStore.openImageStudio ).toHaveBeenCalledWith(
+				undefined,
+				expect.any( Function ),
+				'editor_block'
+			);
+		} );
+
+		it( 'should clear block attributes when handleClose receives null (deletion)', () => {
+			const imageBlock = {
+				name: 'core/image',
+				clientId: 'block-123',
+				attributes: {
+					id: 456,
+				},
+			};
+
+			openImageStudioForBlock( imageBlock );
+
+			// Get the handleClose callback that was passed to openImageStudio
+			const handleClose = mockImageStudioStore.openImageStudio.mock.calls[ 0 ][ 1 ];
+
+			// Call it with null (image deleted)
+			handleClose( null );
+
+			expect( mockBlockEditorStore.updateBlockAttributes ).toHaveBeenCalledWith( 'block-123', {
+				url: undefined,
+				id: undefined,
+				alt: '',
+				title: '',
+				caption: '',
+			} );
+		} );
+
+		it( 'should update block attributes when handleClose receives image data', () => {
+			const imageBlock = {
+				name: 'core/image',
+				clientId: 'block-123',
+				attributes: {},
+			};
+
+			openImageStudioForBlock( imageBlock );
+
+			const handleClose = mockImageStudioStore.openImageStudio.mock.calls[ 0 ][ 1 ];
+
+			const newImage: ImageData = {
+				id: 789,
+				url: 'https://example.com/new-image.jpg',
+				alt: 'New image',
+				title: 'New title',
+				caption: 'New caption',
+				description: 'New description',
+				width: 200,
+				height: 200,
+				filename: 'new-image.jpg',
+			};
+
+			handleClose( newImage );
+
+			expect( mockBlockEditorStore.updateBlockAttributes ).toHaveBeenCalledWith( 'block-123', {
+				url: 'https://example.com/new-image.jpg',
+				id: 789,
+				alt: 'New image',
+			} );
+		} );
+
+		it( 'should not update attributes when handleClose receives image without id', () => {
+			const imageBlock = {
+				name: 'core/image',
+				clientId: 'block-123',
+				attributes: {},
+			};
+
+			openImageStudioForBlock( imageBlock );
+
+			const handleClose = mockImageStudioStore.openImageStudio.mock.calls[ 0 ][ 1 ];
+
+			const imageWithoutId = {
+				url: 'https://example.com/image.jpg',
+			} as ImageData;
+
+			handleClose( imageWithoutId );
+
+			expect( mockBlockEditorStore.updateBlockAttributes ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/packages/image-studio/src/extensions/utils.ts
+++ b/packages/image-studio/src/extensions/utils.ts
@@ -3,19 +3,24 @@ import { store as coreStore } from '@wordpress/core-data';
 import { dispatch, select } from '@wordpress/data';
 import { transformAttachment } from '@wordpress/media-utils';
 import { ImageStudioEntryPoint, store as imageStudioStore } from '../store';
-import { ImageStudioMode } from '../types';
+import {
+	type BlockEditorDispatch,
+	ImageStudioMode,
+	type MediaAttachment,
+	type MediaSelectCallback,
+} from '../types';
 import { type ImageData } from '../utils/get-image-data';
 
 interface HandleImageSelectionOptions {
 	image: ImageData | null;
-	onSelect: ( image: any ) => void;
+	onSelect: MediaSelectCallback;
 	multiple: boolean;
 }
 
 interface BlockContext {
 	name: string;
 	clientId?: string;
-	attributes?: Record< string, any >;
+	attributes?: Record< string, unknown >;
 	innerBlocks?: BlockContext[];
 }
 
@@ -45,13 +50,18 @@ export function handleImageSelection( {
 
 	// Fetch the full attachment record. ImageData lacks some fields like 'link' and 'sizes' that the image block uses.
 	const attachment = select( coreStore ).getEntityRecord( 'postType', 'attachment', image.id ) as
-		| Record< string, any >
+		| MediaAttachment
 		| undefined;
 
 	// Transform the attachment from the REST API format to block editor format.
 	// Maps REST API fields (alt_text, source_url, caption.raw, title.raw) to block editor fields (alt, caption, title, url).
 	if ( attachment ) {
-		const transformedAttachment = transformAttachment( attachment as any );
+		// transformAttachment expects RestAttachment which extends WP_REST_API_Attachment.
+		// MediaAttachment is a compatible subset, but the nominal types don't overlap,
+		// so we use a targeted cast through unknown.
+		const transformedAttachment = transformAttachment(
+			attachment as unknown as Parameters< typeof transformAttachment >[ 0 ]
+		);
 
 		onSelect( multiple ? [ transformedAttachment ] : transformedAttachment );
 	}
@@ -74,12 +84,14 @@ export function openImageStudioForBlock(
 	}
 
 	const { clientId } = imageBlock;
-	const attachmentId = imageBlock.attributes?.id;
+	const attachmentId = imageBlock.attributes?.id as number | undefined;
+
+	const blockEditorDispatch = dispatch( blockEditorStore ) as unknown as BlockEditorDispatch;
 
 	const handleClose = ( image: ImageData | null ) => {
 		if ( image === null ) {
 			// Image was deleted - clear the block's image reference
-			( dispatch( blockEditorStore ) as any ).updateBlockAttributes( clientId, {
+			blockEditorDispatch.updateBlockAttributes( clientId, {
 				url: undefined,
 				id: undefined,
 				alt: '',
@@ -90,7 +102,7 @@ export function openImageStudioForBlock(
 		}
 
 		if ( image?.id ) {
-			( dispatch( blockEditorStore ) as any ).updateBlockAttributes( clientId, {
+			blockEditorDispatch.updateBlockAttributes( clientId, {
 				url: image.url,
 				id: image.id,
 				alt: image.alt,

--- a/packages/image-studio/src/hooks/use-agent-config.ts
+++ b/packages/image-studio/src/hooks/use-agent-config.ts
@@ -1,4 +1,4 @@
-import { getAgentManager } from '@automattic/agenttic-client';
+import { getAgentManager, UseAgentChatConfig } from '@automattic/agenttic-client';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { getSessionId } from '../utils/session';
 
@@ -16,11 +16,11 @@ import { getSessionId } from '../utils/session';
  */
 export function useAgentConfig(
 	agentConfigFactory: {
-		createAgentConfig: ( sessionId: string ) => Promise< any >;
+		createAgentConfig: ( sessionId: string ) => Promise< UseAgentChatConfig >;
 	},
 	modalOpenKey?: number
-) {
-	const [ agentConfigState, setAgentConfigState ] = useState< any >( null );
+): UseAgentChatConfig | null {
+	const [ agentConfigState, setAgentConfigState ] = useState< UseAgentChatConfig | null >( null );
 
 	const sessionId = getSessionId();
 	const sessionKey = useMemo( () => sessionId || 'image-studio-default', [ sessionId ] );

--- a/packages/image-studio/src/hooks/use-annotation.ts
+++ b/packages/image-studio/src/hooks/use-annotation.ts
@@ -13,7 +13,8 @@ import {
 } from '../utils/tracking';
 import { uploadAnnotation } from '../utils/upload-annotation';
 import type { ImageStudioActions } from '../store';
-import type { ImageStudioConfig } from '../types';
+import type { ImageStudioConfig, UploadedMedia } from '../types';
+import type { CurriedImageStudioSelectors } from '../types/wordpress';
 
 interface UseAnnotationOptions {
 	originalImageUrl: string | null;
@@ -31,7 +32,7 @@ export function useAnnotation( { originalImageUrl, config }: UseAnnotationOption
 	} = useDispatch( imageStudioStore ) as ImageStudioActions;
 
 	const { annotationCanvas, hasAnnotations, hasUndoneAnnotations } = useSelect( ( select ) => {
-		const selectors = select( imageStudioStore ) as any;
+		const selectors = select( imageStudioStore ) as CurriedImageStudioSelectors;
 		const canvasRef = selectors.getAnnotationCanvasRef();
 		return {
 			annotationCanvas: canvasRef,
@@ -42,7 +43,10 @@ export function useAnnotation( { originalImageUrl, config }: UseAnnotationOption
 
 	// Helper function to get the latest attachment ID from the store
 	const getCurrentAttachmentId = useCallback( () => {
-		const state = ( window as any ).wp.data.select( 'image-studio' );
+		// Access image-studio store directly via window.wp.data (bypasses React context for sync access)
+		const state = window.wp?.data?.select( 'image-studio' ) as
+			| CurriedImageStudioSelectors
+			| undefined;
 		const attachmentId = state?.getImageStudioAttachmentId?.();
 		if ( typeof attachmentId === 'number' ) {
 			return attachmentId;
@@ -164,15 +168,32 @@ export function useAnnotation( { originalImageUrl, config }: UseAnnotationOption
 		await uploadAnnotation( {
 			blob,
 			originalFilename,
-			onSuccess: async ( media: any ) => {
+			onSuccess: async ( media: UploadedMedia ) => {
 				// Get the actual uploaded URL (not blob URL)
 				// WordPress REST API returns different property names:
 				// - media.source_url (full size)
 				// - media.url (might be undefined or blob URL)
-				// - media.guid.rendered (always available)
-				const uploadedUrl = media.source_url || media.url || media.guid?.rendered;
+				// - media.guid.rendered (always available as fallback)
+				// TODO: remove cast when @wordpress/media-utils exports guid type
+				const uploadedUrl =
+					media.source_url ??
+					media.url ??
+					( media as { guid?: { rendered: string } } ).guid?.rendered;
 
-				const parsedAttachmentId = parseInt( media.id, 10 );
+				if ( ! uploadedUrl || typeof uploadedUrl !== 'string' ) {
+					// eslint-disable-next-line no-console
+					console.error(
+						'[Image Studio] Upload succeeded but no URL found in media response',
+						media
+					);
+					// Revoke the blob URL
+					URL.revokeObjectURL( blobUrl );
+					setIsAnnotationSaving( false );
+					return;
+				}
+
+				const parsedAttachmentId =
+					typeof media.id === 'number' ? media.id : parseInt( String( media.id ), 10 );
 				const resolvedAttachmentId =
 					typeof parsedAttachmentId === 'number' && ! Number.isNaN( parsedAttachmentId )
 						? parsedAttachmentId

--- a/packages/image-studio/src/hooks/use-delete-permanently.ts
+++ b/packages/image-studio/src/hooks/use-delete-permanently.ts
@@ -39,7 +39,6 @@ export interface UseDeletePermanentlyReturn {
  * - Resets canvas history to bypass unsaved-changes exit dialog
  * - Calls onExit to close Image Studio after deletion
  * - Shows error notifications on failure
- *
  * @param props              - Hook props
  * @param props.onExit       - Function to close Image Studio after deletion
  * @param props.setIsExiting - Setter for shared isExiting state (shows exit overlay)
@@ -58,7 +57,9 @@ export function useDeletePermanently( {
 		imageStudioStore
 	) as ImageStudioActions;
 
-	const { deleteEntityRecord } = useDispatch( coreStore ) as any;
+	const { deleteEntityRecord } = useDispatch(
+		coreStore
+	) as unknown as import('../types/wordpress').CoreDataDispatch;
 
 	// Get draft cleanup utilities for cleaning up temporary images before exit
 	const { deleteDraftsExcept } = useDraftCleanup();

--- a/packages/image-studio/src/hooks/use-draft-cleanup.ts
+++ b/packages/image-studio/src/hooks/use-draft-cleanup.ts
@@ -78,7 +78,9 @@ export const useDraftCleanup = () => {
 	 */
 	const deleteDraftsExcept = useCallback(
 		async ( idsToKeep: number[] ) => {
-			const selectors = select( imageStudioStore ) as any;
+			const selectors = select(
+				imageStudioStore
+			) as unknown as import('../types/wordpress').CurriedImageStudioSelectors;
 			const currentDraftIds: number[] = selectors.getDraftIds() || [];
 			const annotatedAttachmentIds: number[] = selectors.getAnnotatedAttachmentIds() || [];
 
@@ -162,7 +164,9 @@ export const useDraftCleanup = () => {
 	const cleanupOnExit = useCallback( async () => {
 		// Always read the latest identifiers from the store to avoid using
 		// stale values when Save & Exit is triggered immediately after a save.
-		const selectors = select( imageStudioStore ) as any;
+		const selectors = select(
+			imageStudioStore
+		) as unknown as import('../types/wordpress').CurriedImageStudioSelectors;
 
 		// Guard against store not being available
 		if ( ! selectors ) {

--- a/packages/image-studio/src/hooks/use-image-studio-suggestions.ts
+++ b/packages/image-studio/src/hooks/use-image-studio-suggestions.ts
@@ -13,6 +13,7 @@ import { getSuggestions, type SuggestionState } from './suggestions-data';
 import { useAsyncSuggestionsLoader } from './use-async-suggestions-loader';
 import useCurrentScreen from './use-current-screen';
 import type { AgentMessage } from '../types/agenttic';
+import type { CurriedImageStudioSelectors } from '../types/wordpress';
 
 /**
  * Async suggestions configuration for different contexts.
@@ -48,7 +49,7 @@ function getAsyncSuggestionsConfig(
  * @param selectors - The store selectors.
  * @returns The current suggestion state.
  */
-function getSuggestionState( selectors: Record< string, any > ): SuggestionState {
+function getSuggestionState( selectors: CurriedImageStudioSelectors ): SuggestionState {
 	const annotationCanvasRef = selectors.getAnnotationCanvasRef();
 	const currentAttachmentId = selectors.getImageStudioAttachmentId();
 	const annotatedAttachmentIds = selectors.getAnnotatedAttachmentIds() || [];

--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -59,7 +59,9 @@ function ImageStudioIntegration(): JSX.Element | null {
 		addSavedAttachmentId,
 		setHasUpdatedMetadata,
 	} = useDispatch( imageStudioStore ) as ImageStudioActions;
-	const { invalidateResolution, saveEntityRecord } = useDispatch( coreStore ) as any;
+	const { invalidateResolution, saveEntityRecord } = useDispatch(
+		coreStore
+	) as unknown as import('./types/wordpress').CoreDataDispatch;
 	const { isOpen, attachmentId, canvasMetadata, originalAttachmentId, onCloseCallback } = useSelect(
 		( selectStore ) => ( {
 			isOpen: selectStore( imageStudioStore ).getIsImageStudioOpen(),
@@ -72,7 +74,7 @@ function ImageStudioIntegration(): JSX.Element | null {
 	);
 
 	// Navigation is only available when opened from media library
-	const isMediaLibraryContext = ( window as any ).pagenow === 'upload';
+	const isMediaLibraryContext = window.pagenow === 'upload';
 
 	const [ image, setImage ] = useState< ImageData | null >( null );
 
@@ -148,7 +150,7 @@ function ImageStudioIntegration(): JSX.Element | null {
 				}
 
 				// Check if this is a supported image by querying WordPress media library
-				const wpMedia = ( window as any ).wp?.media;
+				const wpMedia = window.wp?.media;
 				if ( wpMedia?.attachment ) {
 					const attachmentModel = wpMedia.attachment( parseInt( id, 10 ) );
 					const mimeType = attachmentModel?.get( 'mime' );
@@ -241,7 +243,7 @@ function ImageStudioIntegration(): JSX.Element | null {
 
 	// If `?ai-assistant` is present, open the Image Studio directly on the upload.php page.
 	useEffect( () => {
-		if ( ( window as any ).pagenow !== 'upload' ) {
+		if ( window.pagenow !== 'upload' ) {
 			return;
 		}
 
@@ -285,7 +287,7 @@ function ImageStudioIntegration(): JSX.Element | null {
 	// Sync URL with open state
 	useEffect( () => {
 		// Only sync URL on the upload.php page
-		if ( ( window as any ).pagenow !== 'upload' ) {
+		if ( window.pagenow !== 'upload' ) {
 			return;
 		}
 
@@ -384,7 +386,9 @@ function ImageStudioIntegration(): JSX.Element | null {
 
 			// Read value from store to avoid stale value when called immediately after save
 			const lastSavedAttachmentId = (
-				select( imageStudioStore ) as any
+				select(
+					imageStudioStore
+				) as unknown as import('./types/wordpress').CurriedImageStudioSelectors
 			 ).getLastSavedAttachmentId();
 
 			// Apply saved image to block/chat context (if not discarded)

--- a/packages/image-studio/src/store/index.test.ts
+++ b/packages/image-studio/src/store/index.test.ts
@@ -1,0 +1,1187 @@
+/* eslint-disable import/order */
+/**
+ * Tests for Image Studio Store
+ */
+import type { ImageStudioState, ImageStudioEntryPoint, AnnotationCanvasRef } from './index';
+// Mock localStorage
+const localStorageMock = ( () => {
+	let store: Record< string, string > = {};
+	return {
+		getItem: jest.fn( ( key: string ) => store[ key ] || null ),
+		setItem: jest.fn( ( key: string, value: string ) => {
+			store[ key ] = value;
+		} ),
+		removeItem: jest.fn( ( key: string ) => {
+			delete store[ key ];
+		} ),
+		clear: jest.fn( () => {
+			store = {};
+		} ),
+	};
+} )();
+
+Object.defineProperty( window, 'localStorage', {
+	value: localStorageMock,
+	writable: true,
+} );
+
+// Mock console.warn to avoid noise in tests
+const consoleWarnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+// Mock @wordpress/data
+jest.mock( '@wordpress/data', () => ( {
+	createReduxStore: jest.fn( ( storeName: string, config: Record< string, unknown > ) => ( {
+		name: storeName,
+		...config,
+	} ) ),
+	register: jest.fn(),
+	select: jest.fn( () => null ),
+} ) );
+
+// Import store module after mocks are set up — must come after jest.mock
+import { store as imageStudioStore } from './index';
+
+describe( 'Image Studio Store', () => {
+	const { reducer, actions, selectors } = imageStudioStore as any;
+
+	// Helper to get initial state - this will re-invoke the reducer's initialization logic
+	const getInitialState = (): ImageStudioState => {
+		// Clear and reset localStorage before getting initial state for each test
+		localStorageMock.clear();
+		return reducer( undefined, { type: '@@INIT' } as any );
+	};
+
+	beforeEach( () => {
+		localStorageMock.clear();
+		jest.clearAllMocks();
+	} );
+
+	afterAll( () => {
+		consoleWarnSpy.mockRestore();
+	} );
+
+	describe( 'Initial State', () => {
+		it( 'has correct default values', () => {
+			const state = getInitialState();
+
+			expect( state ).toMatchObject( {
+				isImageStudioOpen: false,
+				imageStudioAttachmentId: null,
+				imageStudioOriginalImageUrl: null,
+				imageStudioCurrentImageUrl: null,
+				imageStudioAiProcessing: false,
+				isAnnotationMode: false,
+				imageStudioTransitioning: false,
+				annotationCanvasRef: null,
+				isAnnotationSaving: false,
+				annotatedAttachmentIds: [],
+				imageStudioAiProcessingSources: {},
+				originalAttachmentId: null,
+				draftIds: [],
+				savedAttachmentIds: [],
+				hasUpdatedMetadata: false,
+				canvasMetadata: null,
+				lastSavedAttachmentId: null,
+				isExitConfirmed: false,
+				entryPoint: null,
+				onCloseCallback: null,
+				notices: [],
+				navigableAttachmentIds: [],
+				currentNavigationIndex: -1,
+				navigationCurrentPage: 1,
+				navigationHasMorePages: true,
+				isSidebarOpen: false,
+				selectedStyle: '',
+				selectedAspectRatio: null,
+				lastAgentMessageId: null,
+			} );
+		} );
+
+		it( 'initializes with localStorage value at module load time', () => {
+			// Note: This test reflects that localStorage is read once at module load time
+			// The OPEN_IMAGE_STUDIO action re-reads localStorage each time
+			const state = getInitialState();
+			// Since we clear localStorage in beforeEach, initial state should be false
+			expect( state.isSidebarOpen ).toBe( false );
+		} );
+
+		it( 'defaults to closed sidebar when localStorage has invalid value', () => {
+			localStorageMock.setItem( 'big-sky-image-studio-sidebar-open', 'invalid' );
+			const state = getInitialState();
+			expect( state.isSidebarOpen ).toBe( false );
+		} );
+
+		it( 'handles localStorage errors gracefully', () => {
+			localStorageMock.getItem.mockImplementationOnce( () => {
+				throw new Error( 'localStorage error' );
+			} );
+			const state = getInitialState();
+			expect( state.isSidebarOpen ).toBe( false );
+		} );
+	} );
+
+	describe( 'Actions', () => {
+		describe( 'openImageStudio', () => {
+			it( 'creates action with all parameters', () => {
+				const callback = jest.fn();
+				const action = actions.openImageStudio(
+					123,
+					callback,
+					'media_library' as ImageStudioEntryPoint
+				);
+
+				expect( action ).toEqual( {
+					type: 'OPEN_IMAGE_STUDIO',
+					payload: {
+						attachmentId: 123,
+						entryPoint: 'media_library',
+						onCloseCallback: callback,
+					},
+				} );
+			} );
+
+			it( 'handles undefined parameters', () => {
+				const action = actions.openImageStudio();
+
+				expect( action ).toEqual( {
+					type: 'OPEN_IMAGE_STUDIO',
+					payload: {
+						attachmentId: null,
+						entryPoint: null,
+						onCloseCallback: null,
+					},
+				} );
+			} );
+		} );
+
+		describe( 'closeImageStudio', () => {
+			it( 'creates close action', () => {
+				const action = actions.closeImageStudio();
+
+				expect( action ).toEqual( {
+					type: 'CLOSE_IMAGE_STUDIO',
+				} );
+			} );
+		} );
+
+		describe( 'updateImageStudioCanvas', () => {
+			it( 'creates action with all parameters', () => {
+				const action = actions.updateImageStudioCanvas(
+					'https://example.com/image.jpg',
+					456,
+					true
+				);
+
+				expect( action ).toEqual( {
+					type: 'UPDATE_IMAGE_STUDIO_CANVAS',
+					payload: {
+						url: 'https://example.com/image.jpg',
+						attachmentId: 456,
+						isAiProcessing: true,
+					},
+				} );
+			} );
+
+			it( 'defaults isAiProcessing to false', () => {
+				const action = actions.updateImageStudioCanvas( 'https://example.com/image.jpg', 456 );
+
+				expect( action.payload.isAiProcessing ).toBe( false );
+			} );
+		} );
+
+		describe( 'setImageStudioAiProcessing', () => {
+			it( 'handles boolean input', () => {
+				const action = actions.setImageStudioAiProcessing( true );
+
+				expect( action ).toEqual( {
+					type: 'SET_IMAGE_STUDIO_AI_PROCESSING',
+					payload: {
+						source: 'default',
+						value: true,
+					},
+				} );
+			} );
+
+			it( 'handles object input with source', () => {
+				const action = actions.setImageStudioAiProcessing( {
+					source: 'annotation',
+					value: false,
+				} );
+
+				expect( action ).toEqual( {
+					type: 'SET_IMAGE_STUDIO_AI_PROCESSING',
+					payload: {
+						source: 'annotation',
+						value: false,
+					},
+				} );
+			} );
+
+			it( 'defaults source to "default" when not provided in object', () => {
+				const action = actions.setImageStudioAiProcessing( {
+					value: true,
+				} as any );
+
+				expect( action.payload.source ).toBe( 'default' );
+			} );
+		} );
+
+		describe( 'addNotice', () => {
+			it( 'creates notice with generated ID', () => {
+				const action = actions.addNotice( 'Test message', 'error' );
+
+				expect( action.type ).toBe( 'ADD_NOTICE' );
+				expect( action.payload.content ).toBe( 'Test message' );
+				expect( action.payload.type ).toBe( 'error' );
+				expect( typeof action.payload.id ).toBe( 'string' );
+				expect( action.payload.id.length ).toBeGreaterThan( 0 );
+			} );
+
+			it( 'generates unique IDs for different notices', () => {
+				const action1 = actions.addNotice( 'Message 1', 'error' );
+				const action2 = actions.addNotice( 'Message 2', 'success' );
+
+				expect( action1.payload.id ).not.toBe( action2.payload.id );
+			} );
+		} );
+	} );
+
+	describe( 'Reducer', () => {
+		describe( 'OPEN_IMAGE_STUDIO', () => {
+			it( 'resets state and opens studio', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					isImageStudioOpen: false,
+					notices: [ { id: '1', content: 'old notice', type: 'error' } ],
+					draftIds: [ 99 ],
+				};
+
+				const state = reducer(
+					previousState,
+					actions.openImageStudio( 123, null, 'media_library' as ImageStudioEntryPoint )
+				);
+
+				expect( state.isImageStudioOpen ).toBe( true );
+				expect( state.imageStudioAttachmentId ).toBe( 123 );
+				expect( state.originalAttachmentId ).toBe( 123 );
+				expect( state.entryPoint ).toBe( 'media_library' );
+				expect( state.notices ).toEqual( [] );
+				expect( state.draftIds ).toEqual( [] );
+				expect( state.savedAttachmentIds ).toEqual( [] );
+			} );
+
+			it( 'sets originalAttachmentId to null when opening without attachment', () => {
+				const state = reducer( getInitialState(), actions.openImageStudio() );
+
+				expect( state.originalAttachmentId ).toBeNull();
+				expect( state.imageStudioAttachmentId ).toBeNull();
+			} );
+
+			it( 're-reads sidebar state from localStorage on open', () => {
+				// Don't use getInitialState() as it clears localStorage
+				const initialState = reducer( undefined, { type: '@@INIT' } as any );
+
+				// Now set localStorage value
+				localStorageMock.setItem( 'big-sky-image-studio-sidebar-open', 'true' );
+
+				const state = reducer( initialState, actions.openImageStudio( 123 ) );
+
+				expect( state.isSidebarOpen ).toBe( true );
+			} );
+		} );
+
+		describe( 'CLOSE_IMAGE_STUDIO', () => {
+			it( 'resets to initial state', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					isImageStudioOpen: true,
+					imageStudioAttachmentId: 123,
+					draftIds: [ 1, 2 ],
+					notices: [ { id: '1', content: 'notice', type: 'error' } ],
+				};
+
+				const state = reducer( previousState, actions.closeImageStudio() );
+
+				expect( state ).toEqual( getInitialState() );
+			} );
+		} );
+
+		describe( 'UPDATE_IMAGE_STUDIO_CANVAS', () => {
+			it( 'updates URL and attachment ID', () => {
+				const state = reducer(
+					getInitialState(),
+					actions.updateImageStudioCanvas( 'https://example.com/new.jpg', 789 )
+				);
+
+				expect( state.imageStudioCurrentImageUrl ).toBe( 'https://example.com/new.jpg' );
+				expect( state.imageStudioAttachmentId ).toBe( 789 );
+			} );
+
+			it( 'manages AI processing sources when isAiProcessing is true', () => {
+				const state = reducer(
+					getInitialState(),
+					actions.updateImageStudioCanvas( 'https://example.com/new.jpg', 789, true )
+				);
+
+				expect( state.imageStudioAiProcessing ).toBe( true );
+				expect( state.imageStudioAiProcessingSources ).toEqual( { default: true } );
+			} );
+
+			it( 'removes source when isAiProcessing is false', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					imageStudioAiProcessing: true,
+					imageStudioAiProcessingSources: { default: true, annotation: true },
+				};
+
+				const state = reducer(
+					previousState,
+					actions.updateImageStudioCanvas( 'https://example.com/new.jpg', 789, false )
+				);
+
+				expect( state.imageStudioAiProcessingSources ).toEqual( { annotation: true } );
+				expect( state.imageStudioAiProcessing ).toBe( true ); // Still true because annotation source is active
+			} );
+
+			it( 'sets imageStudioAiProcessing to false when all sources are removed', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					imageStudioAiProcessing: true,
+					imageStudioAiProcessingSources: { default: true },
+				};
+
+				const state = reducer(
+					previousState,
+					actions.updateImageStudioCanvas( 'https://example.com/new.jpg', 789, false )
+				);
+
+				expect( state.imageStudioAiProcessing ).toBe( false );
+				expect( state.imageStudioAiProcessingSources ).toEqual( {} );
+			} );
+		} );
+
+		describe( 'SET_IMAGE_STUDIO_AI_PROCESSING', () => {
+			it( 'adds processing source when value is true', () => {
+				const state = reducer(
+					getInitialState(),
+					actions.setImageStudioAiProcessing( { source: 'annotation', value: true } )
+				);
+
+				expect( state.imageStudioAiProcessing ).toBe( true );
+				expect( state.imageStudioAiProcessingSources ).toEqual( { annotation: true } );
+			} );
+
+			it( 'removes processing source when value is false', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					imageStudioAiProcessing: true,
+					imageStudioAiProcessingSources: { annotation: true, default: true },
+				};
+
+				const state = reducer(
+					previousState,
+					actions.setImageStudioAiProcessing( { source: 'annotation', value: false } )
+				);
+
+				expect( state.imageStudioAiProcessingSources ).toEqual( { default: true } );
+				expect( state.imageStudioAiProcessing ).toBe( true );
+			} );
+
+			it( 'manages multiple sources independently', () => {
+				let state = getInitialState();
+
+				state = reducer(
+					state,
+					actions.setImageStudioAiProcessing( { source: 'source1', value: true } )
+				);
+				expect( state.imageStudioAiProcessing ).toBe( true );
+
+				state = reducer(
+					state,
+					actions.setImageStudioAiProcessing( { source: 'source2', value: true } )
+				);
+				expect( state.imageStudioAiProcessingSources ).toEqual( { source1: true, source2: true } );
+
+				state = reducer(
+					state,
+					actions.setImageStudioAiProcessing( { source: 'source1', value: false } )
+				);
+				expect( state.imageStudioAiProcessing ).toBe( true );
+				expect( state.imageStudioAiProcessingSources ).toEqual( { source2: true } );
+
+				state = reducer(
+					state,
+					actions.setImageStudioAiProcessing( { source: 'source2', value: false } )
+				);
+				expect( state.imageStudioAiProcessing ).toBe( false );
+				expect( state.imageStudioAiProcessingSources ).toEqual( {} );
+			} );
+		} );
+
+		describe( 'ADD_SAVED_ATTACHMENT_ID', () => {
+			it( 'adds attachment ID to saved list', () => {
+				const state = reducer( getInitialState(), actions.addSavedAttachmentId( 123 ) );
+
+				expect( state.savedAttachmentIds ).toEqual( [ 123 ] );
+			} );
+
+			it( 'prevents duplicate saved IDs', () => {
+				let state = reducer( getInitialState(), actions.addSavedAttachmentId( 123 ) );
+				state = reducer( state, actions.addSavedAttachmentId( 123 ) );
+
+				expect( state.savedAttachmentIds ).toEqual( [ 123 ] );
+			} );
+
+			it( 'removes ID from draftIds when saving', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					draftIds: [ 123, 456, 789 ],
+				};
+
+				const state = reducer( previousState, actions.addSavedAttachmentId( 456 ) );
+
+				expect( state.savedAttachmentIds ).toEqual( [ 456 ] );
+				expect( state.draftIds ).toEqual( [ 123, 789 ] );
+			} );
+
+			it( 'preserves other saved IDs', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					savedAttachmentIds: [ 100, 200 ],
+					draftIds: [ 300 ],
+				};
+
+				const state = reducer( previousState, actions.addSavedAttachmentId( 300 ) );
+
+				expect( state.savedAttachmentIds ).toEqual( [ 100, 200, 300 ] );
+			} );
+		} );
+
+		describe( 'ADD_ANNOTATED_ATTACHMENT_ID', () => {
+			it( 'adds attachment ID to annotated list', () => {
+				const state = reducer( getInitialState(), actions.addAnnotatedAttachmentId( 456 ) );
+
+				expect( state.annotatedAttachmentIds ).toEqual( [ 456 ] );
+			} );
+
+			it( 'allows duplicate annotated IDs', () => {
+				let state = reducer( getInitialState(), actions.addAnnotatedAttachmentId( 456 ) );
+				state = reducer( state, actions.addAnnotatedAttachmentId( 456 ) );
+
+				expect( state.annotatedAttachmentIds ).toEqual( [ 456, 456 ] );
+			} );
+		} );
+
+		describe( 'ADD_NOTICE and REMOVE_NOTICE', () => {
+			it( 'adds notice to list', () => {
+				const state = reducer( getInitialState(), actions.addNotice( 'Error message', 'error' ) );
+
+				expect( state.notices ).toHaveLength( 1 );
+				expect( state.notices[ 0 ] ).toMatchObject( {
+					content: 'Error message',
+					type: 'error',
+				} );
+			} );
+
+			it( 'removes notice by ID', () => {
+				let state = reducer( getInitialState(), actions.addNotice( 'Message 1', 'error' ) );
+				const noticeId = state.notices[ 0 ].id;
+				state = reducer( state, actions.addNotice( 'Message 2', 'success' ) );
+
+				expect( state.notices ).toHaveLength( 2 );
+
+				state = reducer( state, actions.removeNotice( noticeId ) );
+
+				expect( state.notices ).toHaveLength( 1 );
+				expect( state.notices[ 0 ].content ).toBe( 'Message 2' );
+			} );
+
+			it( 'handles removing non-existent notice', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					notices: [ { id: 'existing', content: 'Existing', type: 'error' } ],
+				};
+
+				const state = reducer( previousState, actions.removeNotice( 'non-existent' ) );
+
+				expect( state.notices ).toEqual( previousState.notices );
+			} );
+		} );
+
+		describe( 'SET_NAVIGABLE_ATTACHMENT_IDS', () => {
+			it( 'sets navigable list and calculates current index', () => {
+				const state = reducer(
+					getInitialState(),
+					actions.setNavigableAttachmentIds( [ 10, 20, 30, 40 ], 30 )
+				);
+
+				expect( state.navigableAttachmentIds ).toEqual( [ 10, 20, 30, 40 ] );
+				expect( state.currentNavigationIndex ).toBe( 2 );
+			} );
+
+			it( 'sets index to -1 when current ID is not in list', () => {
+				const state = reducer(
+					getInitialState(),
+					actions.setNavigableAttachmentIds( [ 10, 20, 30 ], 99 )
+				);
+
+				expect( state.currentNavigationIndex ).toBe( -1 );
+			} );
+
+			it( 'sets index to -1 when currentAttachmentId is null', () => {
+				const state = reducer(
+					getInitialState(),
+					actions.setNavigableAttachmentIds( [ 10, 20, 30 ], null )
+				);
+
+				expect( state.currentNavigationIndex ).toBe( -1 );
+			} );
+		} );
+
+		describe( 'NAVIGATE_TO_ATTACHMENT', () => {
+			it( 'navigates to attachment in the list', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					navigableAttachmentIds: [ 10, 20, 30 ],
+					currentNavigationIndex: 0,
+					imageStudioAttachmentId: 10,
+					originalAttachmentId: 10,
+				};
+
+				const state = reducer( previousState, actions.navigateToAttachment( 30 ) );
+
+				expect( state.currentNavigationIndex ).toBe( 2 );
+				expect( state.imageStudioAttachmentId ).toBe( 30 );
+				expect( state.originalAttachmentId ).toBe( 30 );
+			} );
+
+			it( 'resets working session state when navigating', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					navigableAttachmentIds: [ 10, 20, 30 ],
+					currentNavigationIndex: 0,
+					imageStudioAttachmentId: 10,
+					draftIds: [ 99 ],
+					savedAttachmentIds: [ 88 ],
+					hasUpdatedMetadata: true,
+					annotatedAttachmentIds: [ 77 ],
+					isAnnotationMode: true,
+					notices: [ { id: '1', content: 'Notice', type: 'error' } ],
+				};
+
+				const state = reducer( previousState, actions.navigateToAttachment( 20 ) );
+
+				expect( state.draftIds ).toEqual( [] );
+				expect( state.savedAttachmentIds ).toEqual( [] );
+				expect( state.hasUpdatedMetadata ).toBe( false );
+				expect( state.annotatedAttachmentIds ).toEqual( [] );
+				expect( state.isAnnotationMode ).toBe( false );
+				expect( state.notices ).toEqual( [] );
+			} );
+
+			it( 'preserves navigation and user preferences when navigating', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					navigableAttachmentIds: [ 10, 20, 30 ],
+					currentNavigationIndex: 0,
+					navigationCurrentPage: 3,
+					navigationHasMorePages: true,
+					isSidebarOpen: true,
+					selectedStyle: 'watercolor',
+					selectedAspectRatio: '16:9',
+				};
+
+				const state = reducer( previousState, actions.navigateToAttachment( 20 ) );
+
+				expect( state.navigationCurrentPage ).toBe( 3 );
+				expect( state.navigationHasMorePages ).toBe( true );
+				expect( state.isSidebarOpen ).toBe( true );
+				expect( state.selectedStyle ).toBe( 'watercolor' );
+				expect( state.selectedAspectRatio ).toBe( '16:9' );
+			} );
+
+			it( 'warns and returns unchanged state for attachment not in list', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					navigableAttachmentIds: [ 10, 20, 30 ],
+					currentNavigationIndex: 1,
+				};
+
+				const state = reducer( previousState, actions.navigateToAttachment( 999 ) );
+
+				expect( state ).toBe( previousState );
+				expect( consoleWarnSpy ).toHaveBeenCalledWith(
+					expect.stringContaining( 'Attempted to navigate to attachment 999' )
+				);
+			} );
+		} );
+
+		describe( 'SET_NAVIGATION_PAGINATION', () => {
+			it( 'updates pagination state', () => {
+				const state = reducer( getInitialState(), actions.setNavigationPagination( 5, false ) );
+
+				expect( state.navigationCurrentPage ).toBe( 5 );
+				expect( state.navigationHasMorePages ).toBe( false );
+			} );
+		} );
+
+		describe( 'SET_IS_SIDEBAR_OPEN', () => {
+			it( 'updates sidebar state', () => {
+				const state = reducer( getInitialState(), actions.setIsSidebarOpen( true ) );
+
+				expect( state.isSidebarOpen ).toBe( true );
+			} );
+
+			it( 'persists to localStorage', () => {
+				reducer( getInitialState(), actions.setIsSidebarOpen( true ) );
+
+				expect( localStorageMock.setItem ).toHaveBeenCalledWith(
+					'big-sky-image-studio-sidebar-open',
+					'true'
+				);
+			} );
+
+			it( 'handles localStorage errors gracefully', () => {
+				localStorageMock.setItem.mockImplementationOnce( () => {
+					throw new Error( 'localStorage error' );
+				} );
+
+				const state = reducer( getInitialState(), actions.setIsSidebarOpen( true ) );
+
+				expect( state.isSidebarOpen ).toBe( true );
+			} );
+		} );
+
+		describe( 'RESET_CANVAS_HISTORY', () => {
+			it( 'resets canvas editing history', () => {
+				const previousState: ImageStudioState = {
+					...getInitialState(),
+					hasUpdatedMetadata: true,
+					isAnnotationMode: true,
+					lastSavedAttachmentId: 123,
+					canvasMetadata: { title: 'Test' },
+					draftIds: [ 1, 2 ],
+					savedAttachmentIds: [ 3, 4 ],
+					annotatedAttachmentIds: [ 5, 6 ],
+					originalAttachmentId: 999,
+					entryPoint: 'media_library' as ImageStudioEntryPoint,
+				};
+
+				const state = reducer( previousState, actions.resetCanvasHistory() );
+
+				expect( state.hasUpdatedMetadata ).toBe( false );
+				expect( state.isAnnotationMode ).toBe( false );
+				expect( state.lastSavedAttachmentId ).toBeNull();
+				expect( state.canvasMetadata ).toBeNull();
+				expect( state.draftIds ).toEqual( [] );
+				expect( state.savedAttachmentIds ).toEqual( [] );
+				expect( state.annotatedAttachmentIds ).toEqual( [] );
+				// Should preserve session context
+				expect( state.originalAttachmentId ).toBe( 999 );
+				expect( state.entryPoint ).toBe( 'media_library' );
+			} );
+		} );
+
+		describe( 'Simple state setters', () => {
+			it( 'SET_IMAGE_STUDIO_ORIGINAL_IMAGE_URL', () => {
+				const state = reducer(
+					getInitialState(),
+					actions.setImageStudioOriginalImageUrl( 'https://example.com/original.jpg' )
+				);
+
+				expect( state.imageStudioOriginalImageUrl ).toBe( 'https://example.com/original.jpg' );
+			} );
+
+			it( 'SET_ANNOTATION_MODE', () => {
+				const state = reducer( getInitialState(), actions.setAnnotationMode( true ) );
+
+				expect( state.isAnnotationMode ).toBe( true );
+			} );
+
+			it( 'SET_ANNOTATION_CANVAS_REF', () => {
+				const mockRef: AnnotationCanvasRef = {
+					clear: jest.fn(),
+					undo: jest.fn(),
+					redo: jest.fn(),
+					getBlob: jest.fn(),
+					hasAnnotations: jest.fn(),
+					hasUndoneAnnotations: jest.fn(),
+				};
+
+				const state = reducer( getInitialState(), actions.setAnnotationCanvasRef( mockRef ) );
+
+				expect( state.annotationCanvasRef ).toBe( mockRef );
+			} );
+
+			it( 'SET_DRAFT_IDS', () => {
+				const state = reducer( getInitialState(), actions.setDraftIds( [ 1, 2, 3 ] ) );
+
+				expect( state.draftIds ).toEqual( [ 1, 2, 3 ] );
+			} );
+
+			it( 'SET_HAS_UPDATED_METADATA', () => {
+				const state = reducer( getInitialState(), actions.setHasUpdatedMetadata( true ) );
+
+				expect( state.hasUpdatedMetadata ).toBe( true );
+			} );
+
+			it( 'SET_CANVAS_METADATA', () => {
+				const metadata = { title: 'Test Title', alt_text: 'Test Alt' };
+				const state = reducer( getInitialState(), actions.setCanvasMetadata( metadata ) );
+
+				expect( state.canvasMetadata ).toEqual( metadata );
+			} );
+
+			it( 'SET_IS_ANNOTATION_SAVING', () => {
+				const state = reducer( getInitialState(), actions.setIsAnnotationSaving( true ) );
+
+				expect( state.isAnnotationSaving ).toBe( true );
+			} );
+
+			it( 'SET_LAST_SAVED_ATTACHMENT_ID', () => {
+				const state = reducer( getInitialState(), actions.setLastSavedAttachmentId( 789 ) );
+
+				expect( state.lastSavedAttachmentId ).toBe( 789 );
+			} );
+
+			it( 'SET_IS_EXIT_CONFIRMED', () => {
+				const state = reducer( getInitialState(), actions.setIsExitConfirmed( true ) );
+
+				expect( state.isExitConfirmed ).toBe( true );
+			} );
+
+			it( 'SET_SELECTED_STYLE', () => {
+				const state = reducer( getInitialState(), actions.setSelectedStyle( 'watercolor' ) );
+
+				expect( state.selectedStyle ).toBe( 'watercolor' );
+			} );
+
+			it( 'SET_SELECTED_ASPECT_RATIO', () => {
+				const state = reducer( getInitialState(), actions.setSelectedAspectRatio( '16:9' ) );
+
+				expect( state.selectedAspectRatio ).toBe( '16:9' );
+			} );
+
+			it( 'SET_LAST_AGENT_MESSAGE_ID', () => {
+				const state = reducer( getInitialState(), actions.setLastAgentMessageId( 'msg-123' ) );
+
+				expect( state.lastAgentMessageId ).toBe( 'msg-123' );
+			} );
+		} );
+	} );
+
+	describe( 'Selectors', () => {
+		it( 'getIsImageStudioOpen', () => {
+			const state: ImageStudioState = { ...getInitialState(), isImageStudioOpen: true };
+			expect( selectors.getIsImageStudioOpen( state ) ).toBe( true );
+		} );
+
+		it( 'getImageStudioAttachmentId', () => {
+			const state: ImageStudioState = { ...getInitialState(), imageStudioAttachmentId: 123 };
+			expect( selectors.getImageStudioAttachmentId( state ) ).toBe( 123 );
+		} );
+
+		it( 'getImageStudioOriginalImageUrl', () => {
+			const state: ImageStudioState = {
+				...getInitialState(),
+				imageStudioOriginalImageUrl: 'https://example.com/original.jpg',
+			};
+			expect( selectors.getImageStudioOriginalImageUrl( state ) ).toBe(
+				'https://example.com/original.jpg'
+			);
+		} );
+
+		it( 'getImageStudioCurrentImageUrl', () => {
+			const state: ImageStudioState = {
+				...getInitialState(),
+				imageStudioCurrentImageUrl: 'https://example.com/current.jpg',
+			};
+			expect( selectors.getImageStudioCurrentImageUrl( state ) ).toBe(
+				'https://example.com/current.jpg'
+			);
+		} );
+
+		it( 'getImageStudioAiProcessing', () => {
+			const state: ImageStudioState = { ...getInitialState(), imageStudioAiProcessing: true };
+			expect( selectors.getImageStudioAiProcessing( state ) ).toBe( true );
+		} );
+
+		it( 'getIsAnnotationMode', () => {
+			const state: ImageStudioState = { ...getInitialState(), isAnnotationMode: true };
+			expect( selectors.getIsAnnotationMode( state ) ).toBe( true );
+		} );
+
+		it( 'getImageStudioTransitioning', () => {
+			const state: ImageStudioState = { ...getInitialState(), imageStudioTransitioning: true };
+			expect( selectors.getImageStudioTransitioning( state ) ).toBe( true );
+		} );
+
+		it( 'getAnnotationCanvasRef', () => {
+			const mockRef: AnnotationCanvasRef = {
+				clear: jest.fn(),
+				undo: jest.fn(),
+				redo: jest.fn(),
+				getBlob: jest.fn(),
+				hasAnnotations: jest.fn(),
+				hasUndoneAnnotations: jest.fn(),
+			};
+			const state: ImageStudioState = { ...getInitialState(), annotationCanvasRef: mockRef };
+			expect( selectors.getAnnotationCanvasRef( state ) ).toBe( mockRef );
+		} );
+
+		it( 'getOriginalAttachmentId', () => {
+			const state: ImageStudioState = { ...getInitialState(), originalAttachmentId: 456 };
+			expect( selectors.getOriginalAttachmentId( state ) ).toBe( 456 );
+		} );
+
+		it( 'getDraftIds', () => {
+			const state: ImageStudioState = { ...getInitialState(), draftIds: [ 1, 2, 3 ] };
+			expect( selectors.getDraftIds( state ) ).toEqual( [ 1, 2, 3 ] );
+		} );
+
+		it( 'getHasUpdatedMetadata', () => {
+			const state: ImageStudioState = { ...getInitialState(), hasUpdatedMetadata: true };
+			expect( selectors.getHasUpdatedMetadata( state ) ).toBe( true );
+		} );
+
+		it( 'getCanvasMetadata', () => {
+			const metadata = { title: 'Test' };
+			const state: ImageStudioState = { ...getInitialState(), canvasMetadata: metadata };
+			expect( selectors.getCanvasMetadata( state ) ).toEqual( metadata );
+		} );
+
+		it( 'getIsAnnotationSaving', () => {
+			const state: ImageStudioState = { ...getInitialState(), isAnnotationSaving: true };
+			expect( selectors.getIsAnnotationSaving( state ) ).toBe( true );
+		} );
+
+		it( 'getAnnotatedAttachmentIds', () => {
+			const state: ImageStudioState = { ...getInitialState(), annotatedAttachmentIds: [ 7, 8, 9 ] };
+			expect( selectors.getAnnotatedAttachmentIds( state ) ).toEqual( [ 7, 8, 9 ] );
+		} );
+
+		it( 'getLastSavedAttachmentId', () => {
+			const state: ImageStudioState = { ...getInitialState(), lastSavedAttachmentId: 789 };
+			expect( selectors.getLastSavedAttachmentId( state ) ).toBe( 789 );
+		} );
+
+		it( 'getSavedAttachmentIds', () => {
+			const state: ImageStudioState = { ...getInitialState(), savedAttachmentIds: [ 10, 11, 12 ] };
+			expect( selectors.getSavedAttachmentIds( state ) ).toEqual( [ 10, 11, 12 ] );
+		} );
+
+		it( 'getIsExitConfirmed', () => {
+			const state: ImageStudioState = { ...getInitialState(), isExitConfirmed: true };
+			expect( selectors.getIsExitConfirmed( state ) ).toBe( true );
+		} );
+
+		it( 'getEntryPoint', () => {
+			const state: ImageStudioState = {
+				...getInitialState(),
+				entryPoint: 'media_library' as ImageStudioEntryPoint,
+			};
+			expect( selectors.getEntryPoint( state ) ).toBe( 'media_library' );
+		} );
+
+		it( 'getNotices', () => {
+			const notices = [ { id: '1', content: 'Test', type: 'error' as const } ];
+			const state: ImageStudioState = { ...getInitialState(), notices };
+			expect( selectors.getNotices( state ) ).toEqual( notices );
+		} );
+
+		it( 'getOnCloseCallback', () => {
+			const callback = jest.fn();
+			const state: ImageStudioState = { ...getInitialState(), onCloseCallback: callback };
+			expect( selectors.getOnCloseCallback( state ) ).toBe( callback );
+		} );
+
+		it( 'getNavigableAttachmentIds', () => {
+			const state: ImageStudioState = { ...getInitialState(), navigableAttachmentIds: [ 1, 2, 3 ] };
+			expect( selectors.getNavigableAttachmentIds( state ) ).toEqual( [ 1, 2, 3 ] );
+		} );
+
+		it( 'getCurrentNavigationIndex', () => {
+			const state: ImageStudioState = { ...getInitialState(), currentNavigationIndex: 2 };
+			expect( selectors.getCurrentNavigationIndex( state ) ).toBe( 2 );
+		} );
+
+		it( 'getIsSidebarOpen', () => {
+			const state: ImageStudioState = { ...getInitialState(), isSidebarOpen: true };
+			expect( selectors.getIsSidebarOpen( state ) ).toBe( true );
+		} );
+
+		it( 'getNavigationCurrentPage', () => {
+			const state: ImageStudioState = { ...getInitialState(), navigationCurrentPage: 5 };
+			expect( selectors.getNavigationCurrentPage( state ) ).toBe( 5 );
+		} );
+
+		it( 'getNavigationHasMorePages', () => {
+			const state: ImageStudioState = { ...getInitialState(), navigationHasMorePages: false };
+			expect( selectors.getNavigationHasMorePages( state ) ).toBe( false );
+		} );
+
+		it( 'getSelectedStyle', () => {
+			const state: ImageStudioState = { ...getInitialState(), selectedStyle: 'watercolor' };
+			expect( selectors.getSelectedStyle( state ) ).toBe( 'watercolor' );
+		} );
+
+		it( 'getSelectedAspectRatio', () => {
+			const state: ImageStudioState = { ...getInitialState(), selectedAspectRatio: '16:9' };
+			expect( selectors.getSelectedAspectRatio( state ) ).toBe( '16:9' );
+		} );
+
+		it( 'getLastAgentMessageId', () => {
+			const state: ImageStudioState = { ...getInitialState(), lastAgentMessageId: 'msg-123' };
+			expect( selectors.getLastAgentMessageId( state ) ).toBe( 'msg-123' );
+		} );
+
+		describe( 'getHasUnsavedChanges', () => {
+			it( 'returns true when metadata has been updated', () => {
+				const state: ImageStudioState = {
+					...getInitialState(),
+					hasUpdatedMetadata: true,
+					imageStudioAttachmentId: 123,
+					originalAttachmentId: 123,
+				};
+
+				expect( selectors.getHasUnsavedChanges( state ) ).toBe( true );
+			} );
+
+			it( 'returns false when no image is loaded', () => {
+				const state: ImageStudioState = {
+					...getInitialState(),
+					imageStudioAttachmentId: null,
+				};
+
+				expect( selectors.getHasUnsavedChanges( state ) ).toBe( false );
+			} );
+
+			it( 'returns false when current image is the original', () => {
+				const state: ImageStudioState = {
+					...getInitialState(),
+					imageStudioAttachmentId: 100,
+					originalAttachmentId: 100,
+					hasUpdatedMetadata: false,
+				};
+
+				expect( selectors.getHasUnsavedChanges( state ) ).toBe( false );
+			} );
+
+			it( 'returns false when current image has been saved', () => {
+				const state: ImageStudioState = {
+					...getInitialState(),
+					imageStudioAttachmentId: 200,
+					originalAttachmentId: 100,
+					savedAttachmentIds: [ 150, 200, 250 ],
+					hasUpdatedMetadata: false,
+				};
+
+				expect( selectors.getHasUnsavedChanges( state ) ).toBe( false );
+			} );
+
+			it( 'returns true for unsaved draft', () => {
+				const state: ImageStudioState = {
+					...getInitialState(),
+					imageStudioAttachmentId: 300,
+					originalAttachmentId: 100,
+					savedAttachmentIds: [ 200 ],
+					draftIds: [ 300 ],
+					hasUpdatedMetadata: false,
+				};
+
+				expect( selectors.getHasUnsavedChanges( state ) ).toBe( true );
+			} );
+
+			it( 'returns true for newly generated image not yet saved', () => {
+				const state: ImageStudioState = {
+					...getInitialState(),
+					imageStudioAttachmentId: 400,
+					originalAttachmentId: 100,
+					savedAttachmentIds: [],
+					hasUpdatedMetadata: false,
+				};
+
+				expect( selectors.getHasUnsavedChanges( state ) ).toBe( true );
+			} );
+		} );
+
+		describe( 'Navigation selectors', () => {
+			const navigationState: ImageStudioState = {
+				...getInitialState(),
+				navigableAttachmentIds: [ 10, 20, 30, 40, 50 ],
+				currentNavigationIndex: 2,
+			};
+
+			describe( 'getHasNextImage', () => {
+				it( 'returns true when not at end of list', () => {
+					expect( selectors.getHasNextImage( navigationState ) ).toBe( true );
+				} );
+
+				it( 'returns false when at end of list', () => {
+					const state = { ...navigationState, currentNavigationIndex: 4 };
+					expect( selectors.getHasNextImage( state ) ).toBe( false );
+				} );
+
+				it( 'returns false when index is -1', () => {
+					const state = { ...navigationState, currentNavigationIndex: -1 };
+					expect( selectors.getHasNextImage( state ) ).toBe( false );
+				} );
+			} );
+
+			describe( 'getHasPreviousImage', () => {
+				it( 'returns true when not at start of list', () => {
+					expect( selectors.getHasPreviousImage( navigationState ) ).toBe( true );
+				} );
+
+				it( 'returns false when at start of list', () => {
+					const state = { ...navigationState, currentNavigationIndex: 0 };
+					expect( selectors.getHasPreviousImage( state ) ).toBe( false );
+				} );
+
+				it( 'returns false when index is -1', () => {
+					const state = { ...navigationState, currentNavigationIndex: -1 };
+					expect( selectors.getHasPreviousImage( state ) ).toBe( false );
+				} );
+			} );
+
+			describe( 'getNextAttachmentId', () => {
+				it( 'returns next attachment ID when available', () => {
+					expect( selectors.getNextAttachmentId( navigationState ) ).toBe( 40 );
+				} );
+
+				it( 'returns null when at end of list', () => {
+					const state = { ...navigationState, currentNavigationIndex: 4 };
+					expect( selectors.getNextAttachmentId( state ) ).toBeNull();
+				} );
+
+				it( 'returns null when index is -1', () => {
+					const state = { ...navigationState, currentNavigationIndex: -1 };
+					expect( selectors.getNextAttachmentId( state ) ).toBeNull();
+				} );
+			} );
+
+			describe( 'getPreviousAttachmentId', () => {
+				it( 'returns previous attachment ID when available', () => {
+					expect( selectors.getPreviousAttachmentId( navigationState ) ).toBe( 20 );
+				} );
+
+				it( 'returns null when at start of list', () => {
+					const state = { ...navigationState, currentNavigationIndex: 0 };
+					expect( selectors.getPreviousAttachmentId( state ) ).toBeNull();
+				} );
+
+				it( 'returns null when index is -1', () => {
+					const state = { ...navigationState, currentNavigationIndex: -1 };
+					expect( selectors.getPreviousAttachmentId( state ) ).toBeNull();
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'Store configuration', () => {
+		it( 'exports store with correct structure', () => {
+			expect( imageStudioStore ).toBeDefined();
+			expect( imageStudioStore.name ).toBe( 'image-studio' );
+			expect( typeof imageStudioStore.reducer ).toBe( 'function' );
+			expect( typeof imageStudioStore.actions ).toBe( 'object' );
+			expect( typeof imageStudioStore.selectors ).toBe( 'object' );
+		} );
+	} );
+
+	describe( 'Complex scenarios', () => {
+		describe( 'AI Processing with multiple sources', () => {
+			it( 'tracks multiple concurrent AI operations', () => {
+				let state = getInitialState();
+
+				// Start annotation processing
+				state = reducer(
+					state,
+					actions.setImageStudioAiProcessing( { source: 'annotation', value: true } )
+				);
+				expect( state.imageStudioAiProcessing ).toBe( true );
+
+				// Start generation processing
+				state = reducer(
+					state,
+					actions.setImageStudioAiProcessing( { source: 'generation', value: true } )
+				);
+				expect( state.imageStudioAiProcessing ).toBe( true );
+				expect( state.imageStudioAiProcessingSources ).toEqual( {
+					annotation: true,
+					generation: true,
+				} );
+
+				// Complete annotation
+				state = reducer(
+					state,
+					actions.setImageStudioAiProcessing( { source: 'annotation', value: false } )
+				);
+				expect( state.imageStudioAiProcessing ).toBe( true ); // Still processing generation
+				expect( state.imageStudioAiProcessingSources ).toEqual( { generation: true } );
+
+				// Complete generation
+				state = reducer(
+					state,
+					actions.setImageStudioAiProcessing( { source: 'generation', value: false } )
+				);
+				expect( state.imageStudioAiProcessing ).toBe( false );
+				expect( state.imageStudioAiProcessingSources ).toEqual( {} );
+			} );
+		} );
+
+		describe( 'Session lifecycle', () => {
+			it( 'manages complete workflow from open to close', () => {
+				let state = getInitialState();
+
+				// Open studio with attachment
+				state = reducer( state, actions.openImageStudio( 100 ) );
+				expect( state.isImageStudioOpen ).toBe( true );
+				expect( state.originalAttachmentId ).toBe( 100 );
+
+				// Generate new image
+				state = reducer( state, actions.updateImageStudioCanvas( 'https://new.jpg', 101, true ) );
+				expect( state.imageStudioAttachmentId ).toBe( 101 );
+
+				// Add to drafts
+				state = reducer( state, actions.setDraftIds( [ 101 ] ) );
+
+				// Save the draft
+				state = reducer( state, actions.addSavedAttachmentId( 101 ) );
+				expect( state.savedAttachmentIds ).toEqual( [ 101 ] );
+				expect( state.draftIds ).toEqual( [] ); // Removed from drafts
+
+				// Close studio
+				state = reducer( state, actions.closeImageStudio() );
+				expect( state.isImageStudioOpen ).toBe( false );
+				expect( state.savedAttachmentIds ).toEqual( [] );
+			} );
+		} );
+
+		describe( 'Navigation workflow', () => {
+			it( 'manages navigation through media library', () => {
+				let state = getInitialState();
+
+				// Setup navigable list
+				state = reducer( state, actions.setNavigableAttachmentIds( [ 10, 20, 30, 40 ], 20 ) );
+				expect( state.currentNavigationIndex ).toBe( 1 );
+
+				// Navigate forward
+				expect( selectors.getHasNextImage( state ) ).toBe( true );
+				const nextId = selectors.getNextAttachmentId( state );
+				expect( nextId ).toBe( 30 );
+
+				state = reducer( state, actions.navigateToAttachment( nextId! ) );
+				expect( state.currentNavigationIndex ).toBe( 2 );
+				expect( state.imageStudioAttachmentId ).toBe( 30 );
+
+				// Navigate backward
+				expect( selectors.getHasPreviousImage( state ) ).toBe( true );
+				const prevId = selectors.getPreviousAttachmentId( state );
+				expect( prevId ).toBe( 20 );
+
+				state = reducer( state, actions.navigateToAttachment( prevId! ) );
+				expect( state.currentNavigationIndex ).toBe( 1 );
+			} );
+		} );
+	} );
+} );

--- a/packages/image-studio/src/types/agenttic.ts
+++ b/packages/image-studio/src/types/agenttic.ts
@@ -1,8 +1,10 @@
 /**
  * Minimal Agenttic message type used within Image Studio.
+ * Defines only the properties that Image Studio directly accesses.
+ * Additional properties from the Agenttic UI library are allowed via
+ * structural typing (duck typing) - we don't enforce their types here.
  */
-export type AgentMessage = {
+export interface AgentMessage {
 	id?: string;
 	role?: string;
-	[ key: string ]: any;
-};
+}

--- a/packages/image-studio/src/types/guards.test.ts
+++ b/packages/image-studio/src/types/guards.test.ts
@@ -27,12 +27,6 @@ import {
 
 const NON_OBJECTS = [ null, undefined, 0, '', false, 42, 'string', true, Symbol(), [] ];
 
-function expectRejectsNonObjects( guard: ( obj: unknown ) => boolean ) {
-	for ( const value of NON_OBJECTS ) {
-		expect( guard( value ) ).toBe( false );
-	}
-}
-
 // ── Fixtures ────────────────────────────────────────────────────────
 
 const validMediaAttachment = {
@@ -101,8 +95,8 @@ const validJobState = {
 // ── isMediaAttachment ───────────────────────────────────────────────
 
 describe( 'isMediaAttachment', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isMediaAttachment );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isMediaAttachment( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid attachment', () => {
@@ -149,8 +143,8 @@ describe( 'isMediaAttachment', () => {
 // ── isAttachmentRecord ──────────────────────────────────────────────
 
 describe( 'isAttachmentRecord', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isAttachmentRecord );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isAttachmentRecord( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid record', () => {
@@ -180,8 +174,8 @@ describe( 'isAttachmentRecord', () => {
 // ── isWPBlock ───────────────────────────────────────────────────────
 
 describe( 'isWPBlock', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isWPBlock );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isWPBlock( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid block', () => {
@@ -210,8 +204,8 @@ describe( 'isWPBlock', () => {
 // ── isBlockEditProps ────────────────────────────────────────────────
 
 describe( 'isBlockEditProps', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isBlockEditProps );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isBlockEditProps( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid props', () => {
@@ -247,8 +241,8 @@ describe( 'isBlockEditProps', () => {
 // ── isCoreDataDispatch ──────────────────────────────────────────────
 
 describe( 'isCoreDataDispatch', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isCoreDataDispatch );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isCoreDataDispatch( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid dispatch', () => {
@@ -302,8 +296,8 @@ describe( 'isCoreDataDispatch', () => {
 // ── isBlockEditorDispatch ───────────────────────────────────────────
 
 describe( 'isBlockEditorDispatch', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isBlockEditorDispatch );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isBlockEditorDispatch( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid dispatch', () => {
@@ -376,8 +370,8 @@ describe( 'isFile', () => {
 // ── isErrorPayload ──────────────────────────────────────────────────
 
 describe( 'isErrorPayload', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isErrorPayload );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isErrorPayload( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid error payload', () => {
@@ -413,8 +407,8 @@ describe( 'isErrorPayload', () => {
 // ── isGenerationSuccess ─────────────────────────────────────────────
 
 describe( 'isGenerationSuccess', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isGenerationSuccess );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isGenerationSuccess( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid success', () => {
@@ -454,8 +448,8 @@ describe( 'isGenerationSuccess', () => {
 // ── isGenerationError ───────────────────────────────────────────────
 
 describe( 'isGenerationError', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isGenerationError );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isGenerationError( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid error', () => {
@@ -495,8 +489,8 @@ describe( 'isGenerationResult', () => {
 // ── isImageGenerationRequest ────────────────────────────────────────
 
 describe( 'isImageGenerationRequest', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isImageGenerationRequest );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isImageGenerationRequest( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid request', () => {
@@ -533,8 +527,8 @@ describe( 'isImageGenerationRequest', () => {
 // ── isImageEditRequest ──────────────────────────────────────────────
 
 describe( 'isImageEditRequest', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isImageEditRequest );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isImageEditRequest( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid request', () => {
@@ -570,16 +564,16 @@ describe( 'isGenerationRequest', () => {
 		expect( isGenerationRequest( { type: 'unknown', sessionId: 'x', prompt: 'y' } ) ).toBe( false );
 	} );
 
-	it( 'rejects non-objects', () => {
-		expect( isGenerationRequest( null ) ).toBe( false );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isGenerationRequest( value ) ).toBe( false );
 	} );
 } );
 
 // ── isJobState ──────────────────────────────────────────────────────
 
 describe( 'isJobState', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isJobState );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isJobState( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid job state', () => {
@@ -621,8 +615,8 @@ describe( 'isJobState', () => {
 // ── OperationState guards ───────────────────────────────────────────
 
 describe( 'isIdleOperationState', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isIdleOperationState );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isIdleOperationState( value ) ).toBe( false );
 	} );
 
 	it( 'accepts idle', () => {
@@ -637,8 +631,8 @@ describe( 'isIdleOperationState', () => {
 } );
 
 describe( 'isProcessingOperationState', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isProcessingOperationState );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isProcessingOperationState( value ) ).toBe( false );
 	} );
 
 	it( 'accepts processing', () => {
@@ -657,8 +651,8 @@ describe( 'isProcessingOperationState', () => {
 } );
 
 describe( 'isSuccessOperationState', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isSuccessOperationState );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isSuccessOperationState( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid success state', () => {
@@ -705,8 +699,8 @@ describe( 'isSuccessOperationState', () => {
 } );
 
 describe( 'isErrorOperationState', () => {
-	it( 'rejects non-objects', () => {
-		expectRejectsNonObjects( isErrorOperationState );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isErrorOperationState( value ) ).toBe( false );
 	} );
 
 	it( 'accepts valid error state', () => {
@@ -742,8 +736,7 @@ describe( 'isOperationState', () => {
 		expect( isOperationState( { status: 'cancelled' } ) ).toBe( false );
 	} );
 
-	it( 'rejects non-objects', () => {
-		expect( isOperationState( null ) ).toBe( false );
-		expect( isOperationState( 'idle' ) ).toBe( false );
+	it.each( NON_OBJECTS )( 'rejects non-object: %p', ( value ) => {
+		expect( isOperationState( value ) ).toBe( false );
 	} );
 } );

--- a/packages/image-studio/src/types/guards.test.ts
+++ b/packages/image-studio/src/types/guards.test.ts
@@ -1,0 +1,749 @@
+import {
+	isMediaAttachment,
+	isAttachmentRecord,
+	isWPBlock,
+	isBlockEditProps,
+	isCoreDataDispatch,
+	isBlockEditorDispatch,
+	isSupportedImageFile,
+	isBlob,
+	isFile,
+	isErrorPayload,
+	isGenerationSuccess,
+	isGenerationError,
+	isGenerationResult,
+	isImageGenerationRequest,
+	isImageEditRequest,
+	isGenerationRequest,
+	isJobState,
+	isIdleOperationState,
+	isProcessingOperationState,
+	isSuccessOperationState,
+	isErrorOperationState,
+	isOperationState,
+} from './guards';
+
+// ── Shared null/primitive rejection cases ───────────────────────────
+
+const NON_OBJECTS = [ null, undefined, 0, '', false, 42, 'string', true, Symbol(), [] ];
+
+function expectRejectsNonObjects( guard: ( obj: unknown ) => boolean ) {
+	for ( const value of NON_OBJECTS ) {
+		expect( guard( value ) ).toBe( false );
+	}
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+const validMediaAttachment = {
+	id: 123,
+	source_url: 'https://example.com/image.jpg',
+	link: 'https://example.com/?attachment_id=123',
+	mime_type: 'image/jpeg',
+};
+
+const validAttachmentRecord = {
+	id: 456,
+	source_url: 'https://example.com/photo.png',
+	date: '2026-01-15T12:00:00',
+};
+
+const validWPBlock = {
+	name: 'core/image',
+	clientId: 'abc-123',
+};
+
+const validBlockEditProps = {
+	name: 'core/image',
+	clientId: 'abc-123',
+	isSelected: true,
+	attributes: { id: 1 },
+	setAttributes: jest.fn(),
+};
+
+const validErrorPayload = {
+	category: 'network',
+	message: 'Request failed',
+	timestamp: Date.now(),
+};
+
+const validGenerationSuccess = {
+	status: 'success' as const,
+	attachmentId: 789,
+	imageUrl: 'https://example.com/generated.jpg',
+};
+
+const validGenerationError = {
+	status: 'error' as const,
+	error: { ...validErrorPayload },
+};
+
+const validImageGenerationRequest = {
+	type: 'generate' as const,
+	sessionId: 'sess-001',
+	prompt: 'sunset over ocean',
+};
+
+const validImageEditRequest = {
+	type: 'edit' as const,
+	sessionId: 'sess-002',
+	prompt: 'remove background',
+	attachmentId: 100,
+};
+
+const validJobState = {
+	jobId: 'job-001',
+	status: 'processing',
+	createdAt: Date.now(),
+	updatedAt: Date.now(),
+};
+
+// ── isMediaAttachment ───────────────────────────────────────────────
+
+describe( 'isMediaAttachment', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isMediaAttachment );
+	} );
+
+	it( 'accepts valid attachment', () => {
+		expect( isMediaAttachment( validMediaAttachment ) ).toBe( true );
+	} );
+
+	it( 'accepts with optional fields', () => {
+		expect(
+			isMediaAttachment( {
+				...validMediaAttachment,
+				alt_text: 'A photo',
+				title: { rendered: 'Photo', raw: 'Photo' },
+				media_details: { width: 800, height: 600 },
+			} )
+		).toBe( true );
+	} );
+
+	it( 'rejects missing id', () => {
+		const { id, ...rest } = validMediaAttachment;
+		expect( isMediaAttachment( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing source_url', () => {
+		const { source_url, ...rest } = validMediaAttachment;
+		expect( isMediaAttachment( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing link', () => {
+		const { link, ...rest } = validMediaAttachment;
+		expect( isMediaAttachment( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing mime_type', () => {
+		const { mime_type, ...rest } = validMediaAttachment;
+		expect( isMediaAttachment( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects wrong types', () => {
+		expect( isMediaAttachment( { ...validMediaAttachment, id: '123' } ) ).toBe( false );
+		expect( isMediaAttachment( { ...validMediaAttachment, source_url: 42 } ) ).toBe( false );
+	} );
+} );
+
+// ── isAttachmentRecord ──────────────────────────────────────────────
+
+describe( 'isAttachmentRecord', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isAttachmentRecord );
+	} );
+
+	it( 'accepts valid record', () => {
+		expect( isAttachmentRecord( validAttachmentRecord ) ).toBe( true );
+	} );
+
+	it( 'rejects missing id', () => {
+		const { id, ...rest } = validAttachmentRecord;
+		expect( isAttachmentRecord( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing source_url', () => {
+		const { source_url, ...rest } = validAttachmentRecord;
+		expect( isAttachmentRecord( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing date', () => {
+		const { date, ...rest } = validAttachmentRecord;
+		expect( isAttachmentRecord( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects wrong id type', () => {
+		expect( isAttachmentRecord( { ...validAttachmentRecord, id: '456' } ) ).toBe( false );
+	} );
+} );
+
+// ── isWPBlock ───────────────────────────────────────────────────────
+
+describe( 'isWPBlock', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isWPBlock );
+	} );
+
+	it( 'accepts valid block', () => {
+		expect( isWPBlock( validWPBlock ) ).toBe( true );
+	} );
+
+	it( 'accepts block with extra properties', () => {
+		expect( isWPBlock( { ...validWPBlock, attributes: { url: 'test' }, innerBlocks: [] } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'rejects missing name', () => {
+		expect( isWPBlock( { clientId: 'abc' } ) ).toBe( false );
+	} );
+
+	it( 'rejects missing clientId', () => {
+		expect( isWPBlock( { name: 'core/image' } ) ).toBe( false );
+	} );
+
+	it( 'rejects wrong types', () => {
+		expect( isWPBlock( { name: 123, clientId: 'abc' } ) ).toBe( false );
+	} );
+} );
+
+// ── isBlockEditProps ────────────────────────────────────────────────
+
+describe( 'isBlockEditProps', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isBlockEditProps );
+	} );
+
+	it( 'accepts valid props', () => {
+		expect( isBlockEditProps( validBlockEditProps ) ).toBe( true );
+	} );
+
+	it( 'rejects missing isSelected', () => {
+		const { isSelected, ...rest } = validBlockEditProps;
+		expect( isBlockEditProps( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing attributes', () => {
+		const { attributes, ...rest } = validBlockEditProps;
+		expect( isBlockEditProps( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing setAttributes', () => {
+		const { setAttributes, ...rest } = validBlockEditProps;
+		expect( isBlockEditProps( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects non-function setAttributes', () => {
+		expect( isBlockEditProps( { ...validBlockEditProps, setAttributes: 'not-a-fn' } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'rejects non-boolean isSelected', () => {
+		expect( isBlockEditProps( { ...validBlockEditProps, isSelected: 1 } ) ).toBe( false );
+	} );
+} );
+
+// ── isCoreDataDispatch ──────────────────────────────────────────────
+
+describe( 'isCoreDataDispatch', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isCoreDataDispatch );
+	} );
+
+	it( 'accepts valid dispatch', () => {
+		expect(
+			isCoreDataDispatch( {
+				saveEntityRecord: jest.fn(),
+				deleteEntityRecord: jest.fn(),
+				invalidateResolution: jest.fn(),
+			} )
+		).toBe( true );
+	} );
+
+	it( 'rejects missing saveEntityRecord', () => {
+		expect(
+			isCoreDataDispatch( {
+				deleteEntityRecord: jest.fn(),
+				invalidateResolution: jest.fn(),
+			} )
+		).toBe( false );
+	} );
+
+	it( 'rejects missing deleteEntityRecord', () => {
+		expect(
+			isCoreDataDispatch( {
+				saveEntityRecord: jest.fn(),
+				invalidateResolution: jest.fn(),
+			} )
+		).toBe( false );
+	} );
+
+	it( 'rejects missing invalidateResolution', () => {
+		expect(
+			isCoreDataDispatch( {
+				saveEntityRecord: jest.fn(),
+				deleteEntityRecord: jest.fn(),
+			} )
+		).toBe( false );
+	} );
+
+	it( 'rejects non-function values', () => {
+		expect(
+			isCoreDataDispatch( {
+				saveEntityRecord: 'not-fn',
+				deleteEntityRecord: jest.fn(),
+				invalidateResolution: jest.fn(),
+			} )
+		).toBe( false );
+	} );
+} );
+
+// ── isBlockEditorDispatch ───────────────────────────────────────────
+
+describe( 'isBlockEditorDispatch', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isBlockEditorDispatch );
+	} );
+
+	it( 'accepts valid dispatch', () => {
+		expect( isBlockEditorDispatch( { updateBlockAttributes: jest.fn() } ) ).toBe( true );
+	} );
+
+	it( 'rejects missing method', () => {
+		expect( isBlockEditorDispatch( {} ) ).toBe( false );
+	} );
+
+	it( 'rejects non-function value', () => {
+		expect( isBlockEditorDispatch( { updateBlockAttributes: 'nope' } ) ).toBe( false );
+	} );
+} );
+
+// ── isSupportedImageFile ────────────────────────────────────────────
+
+describe( 'isSupportedImageFile', () => {
+	const supported = [ 'image/jpeg', 'image/png', 'image/webp' ];
+
+	it( 'accepts supported MIME type', () => {
+		const file = new File( [ '' ], 'test.jpg', { type: 'image/jpeg' } );
+		expect( isSupportedImageFile( file, supported ) ).toBe( true );
+	} );
+
+	it( 'rejects unsupported MIME type', () => {
+		const file = new File( [ '' ], 'test.gif', { type: 'image/gif' } );
+		expect( isSupportedImageFile( file, supported ) ).toBe( false );
+	} );
+
+	it( 'rejects empty MIME type', () => {
+		const file = new File( [ '' ], 'test', { type: '' } );
+		expect( isSupportedImageFile( file, supported ) ).toBe( false );
+	} );
+} );
+
+// ── isBlob / isFile ─────────────────────────────────────────────────
+
+describe( 'isBlob', () => {
+	it( 'accepts Blob', () => {
+		expect( isBlob( new Blob( [ 'data' ] ) ) ).toBe( true );
+	} );
+
+	it( 'accepts File (subclass of Blob)', () => {
+		expect( isBlob( new File( [ 'data' ], 'test.txt' ) ) ).toBe( true );
+	} );
+
+	it( 'rejects non-Blob', () => {
+		expect( isBlob( 'not a blob' ) ).toBe( false );
+		expect( isBlob( null ) ).toBe( false );
+		expect( isBlob( {} ) ).toBe( false );
+	} );
+} );
+
+describe( 'isFile', () => {
+	it( 'accepts File', () => {
+		expect( isFile( new File( [ 'data' ], 'test.txt' ) ) ).toBe( true );
+	} );
+
+	it( 'rejects plain Blob', () => {
+		expect( isFile( new Blob( [ 'data' ] ) ) ).toBe( false );
+	} );
+
+	it( 'rejects non-File', () => {
+		expect( isFile( 'not a file' ) ).toBe( false );
+		expect( isFile( null ) ).toBe( false );
+	} );
+} );
+
+// ── isErrorPayload ──────────────────────────────────────────────────
+
+describe( 'isErrorPayload', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isErrorPayload );
+	} );
+
+	it( 'accepts valid error payload', () => {
+		expect( isErrorPayload( validErrorPayload ) ).toBe( true );
+	} );
+
+	it( 'accepts with optional fields', () => {
+		expect( isErrorPayload( { ...validErrorPayload, code: 'ERR_NET', statusCode: 500 } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'rejects missing category', () => {
+		const { category, ...rest } = validErrorPayload;
+		expect( isErrorPayload( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing message', () => {
+		const { message, ...rest } = validErrorPayload;
+		expect( isErrorPayload( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing timestamp', () => {
+		const { timestamp, ...rest } = validErrorPayload;
+		expect( isErrorPayload( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects wrong types', () => {
+		expect( isErrorPayload( { ...validErrorPayload, timestamp: 'not-a-number' } ) ).toBe( false );
+	} );
+} );
+
+// ── isGenerationSuccess ─────────────────────────────────────────────
+
+describe( 'isGenerationSuccess', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isGenerationSuccess );
+	} );
+
+	it( 'accepts valid success', () => {
+		expect( isGenerationSuccess( validGenerationSuccess ) ).toBe( true );
+	} );
+
+	it( 'accepts with optional metadata', () => {
+		expect(
+			isGenerationSuccess( {
+				...validGenerationSuccess,
+				metadata: { width: 1024, height: 768 },
+			} )
+		).toBe( true );
+	} );
+
+	it( 'rejects wrong status', () => {
+		expect( isGenerationSuccess( { ...validGenerationSuccess, status: 'error' } ) ).toBe( false );
+	} );
+
+	it( 'rejects missing attachmentId', () => {
+		const { attachmentId, ...rest } = validGenerationSuccess;
+		expect( isGenerationSuccess( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing imageUrl', () => {
+		const { imageUrl, ...rest } = validGenerationSuccess;
+		expect( isGenerationSuccess( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects string attachmentId', () => {
+		expect( isGenerationSuccess( { ...validGenerationSuccess, attachmentId: '789' } ) ).toBe(
+			false
+		);
+	} );
+} );
+
+// ── isGenerationError ───────────────────────────────────────────────
+
+describe( 'isGenerationError', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isGenerationError );
+	} );
+
+	it( 'accepts valid error', () => {
+		expect( isGenerationError( validGenerationError ) ).toBe( true );
+	} );
+
+	it( 'rejects wrong status', () => {
+		expect( isGenerationError( { ...validGenerationError, status: 'success' } ) ).toBe( false );
+	} );
+
+	it( 'rejects invalid error payload', () => {
+		expect( isGenerationError( { status: 'error', error: { message: 'oops' } } ) ).toBe( false );
+	} );
+
+	it( 'rejects missing error', () => {
+		expect( isGenerationError( { status: 'error' } ) ).toBe( false );
+	} );
+} );
+
+// ── isGenerationResult ──────────────────────────────────────────────
+
+describe( 'isGenerationResult', () => {
+	it( 'accepts success', () => {
+		expect( isGenerationResult( validGenerationSuccess ) ).toBe( true );
+	} );
+
+	it( 'accepts error', () => {
+		expect( isGenerationResult( validGenerationError ) ).toBe( true );
+	} );
+
+	it( 'rejects invalid', () => {
+		expect( isGenerationResult( { status: 'pending' } ) ).toBe( false );
+		expect( isGenerationResult( null ) ).toBe( false );
+	} );
+} );
+
+// ── isImageGenerationRequest ────────────────────────────────────────
+
+describe( 'isImageGenerationRequest', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isImageGenerationRequest );
+	} );
+
+	it( 'accepts valid request', () => {
+		expect( isImageGenerationRequest( validImageGenerationRequest ) ).toBe( true );
+	} );
+
+	it( 'accepts with optional fields', () => {
+		expect(
+			isImageGenerationRequest( {
+				...validImageGenerationRequest,
+				style: 'photographic',
+				aspectRatio: '16:9',
+			} )
+		).toBe( true );
+	} );
+
+	it( 'rejects wrong type', () => {
+		expect( isImageGenerationRequest( { ...validImageGenerationRequest, type: 'edit' } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'rejects missing sessionId', () => {
+		const { sessionId, ...rest } = validImageGenerationRequest;
+		expect( isImageGenerationRequest( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing prompt', () => {
+		const { prompt, ...rest } = validImageGenerationRequest;
+		expect( isImageGenerationRequest( rest ) ).toBe( false );
+	} );
+} );
+
+// ── isImageEditRequest ──────────────────────────────────────────────
+
+describe( 'isImageEditRequest', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isImageEditRequest );
+	} );
+
+	it( 'accepts valid request', () => {
+		expect( isImageEditRequest( validImageEditRequest ) ).toBe( true );
+	} );
+
+	it( 'rejects wrong type', () => {
+		expect( isImageEditRequest( { ...validImageEditRequest, type: 'generate' } ) ).toBe( false );
+	} );
+
+	it( 'rejects missing attachmentId', () => {
+		const { attachmentId, ...rest } = validImageEditRequest;
+		expect( isImageEditRequest( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects string attachmentId', () => {
+		expect( isImageEditRequest( { ...validImageEditRequest, attachmentId: '100' } ) ).toBe( false );
+	} );
+} );
+
+// ── isGenerationRequest ─────────────────────────────────────────────
+
+describe( 'isGenerationRequest', () => {
+	it( 'accepts generate request', () => {
+		expect( isGenerationRequest( validImageGenerationRequest ) ).toBe( true );
+	} );
+
+	it( 'accepts edit request', () => {
+		expect( isGenerationRequest( validImageEditRequest ) ).toBe( true );
+	} );
+
+	it( 'rejects invalid type', () => {
+		expect( isGenerationRequest( { type: 'unknown', sessionId: 'x', prompt: 'y' } ) ).toBe( false );
+	} );
+
+	it( 'rejects non-objects', () => {
+		expect( isGenerationRequest( null ) ).toBe( false );
+	} );
+} );
+
+// ── isJobState ──────────────────────────────────────────────────────
+
+describe( 'isJobState', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isJobState );
+	} );
+
+	it( 'accepts valid job state', () => {
+		expect( isJobState( validJobState ) ).toBe( true );
+	} );
+
+	it( 'accepts with optional fields', () => {
+		expect( isJobState( { ...validJobState, result: { url: 'test' }, progress: 50 } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'rejects missing jobId', () => {
+		const { jobId, ...rest } = validJobState;
+		expect( isJobState( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing status', () => {
+		const { status, ...rest } = validJobState;
+		expect( isJobState( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing createdAt', () => {
+		const { createdAt, ...rest } = validJobState;
+		expect( isJobState( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects missing updatedAt', () => {
+		const { updatedAt, ...rest } = validJobState;
+		expect( isJobState( rest ) ).toBe( false );
+	} );
+
+	it( 'rejects wrong types', () => {
+		expect( isJobState( { ...validJobState, jobId: 123 } ) ).toBe( false );
+		expect( isJobState( { ...validJobState, createdAt: 'now' } ) ).toBe( false );
+	} );
+} );
+
+// ── OperationState guards ───────────────────────────────────────────
+
+describe( 'isIdleOperationState', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isIdleOperationState );
+	} );
+
+	it( 'accepts idle', () => {
+		expect( isIdleOperationState( { status: 'idle' } ) ).toBe( true );
+	} );
+
+	it( 'rejects other statuses', () => {
+		expect( isIdleOperationState( { status: 'processing' } ) ).toBe( false );
+		expect( isIdleOperationState( { status: 'success' } ) ).toBe( false );
+		expect( isIdleOperationState( { status: 'error' } ) ).toBe( false );
+	} );
+} );
+
+describe( 'isProcessingOperationState', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isProcessingOperationState );
+	} );
+
+	it( 'accepts processing', () => {
+		expect( isProcessingOperationState( { status: 'processing' } ) ).toBe( true );
+	} );
+
+	it( 'accepts with optional fields', () => {
+		expect(
+			isProcessingOperationState( { status: 'processing', source: 'gen', progress: 42 } )
+		).toBe( true );
+	} );
+
+	it( 'rejects other statuses', () => {
+		expect( isProcessingOperationState( { status: 'idle' } ) ).toBe( false );
+	} );
+} );
+
+describe( 'isSuccessOperationState', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isSuccessOperationState );
+	} );
+
+	it( 'accepts valid success state', () => {
+		expect(
+			isSuccessOperationState( {
+				status: 'success',
+				data: { result: 'ok' },
+				completedAt: Date.now(),
+			} )
+		).toBe( true );
+	} );
+
+	it( 'rejects missing data', () => {
+		expect( isSuccessOperationState( { status: 'success', completedAt: Date.now() } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'rejects missing completedAt', () => {
+		expect( isSuccessOperationState( { status: 'success', data: 'ok' } ) ).toBe( false );
+	} );
+
+	it( 'rejects wrong status', () => {
+		expect(
+			isSuccessOperationState( {
+				status: 'error',
+				data: 'ok',
+				completedAt: Date.now(),
+			} )
+		).toBe( false );
+	} );
+
+	it( 'accepts data as any truthy value', () => {
+		expect(
+			isSuccessOperationState( { status: 'success', data: 0, completedAt: Date.now() } )
+		).toBe( true );
+		expect(
+			isSuccessOperationState( { status: 'success', data: '', completedAt: Date.now() } )
+		).toBe( true );
+		expect(
+			isSuccessOperationState( { status: 'success', data: false, completedAt: Date.now() } )
+		).toBe( true );
+	} );
+} );
+
+describe( 'isErrorOperationState', () => {
+	it( 'rejects non-objects', () => {
+		expectRejectsNonObjects( isErrorOperationState );
+	} );
+
+	it( 'accepts valid error state', () => {
+		expect( isErrorOperationState( { status: 'error', error: validErrorPayload } ) ).toBe( true );
+	} );
+
+	it( 'rejects invalid error payload', () => {
+		expect( isErrorOperationState( { status: 'error', error: { message: 'bad' } } ) ).toBe( false );
+	} );
+
+	it( 'rejects missing error', () => {
+		expect( isErrorOperationState( { status: 'error' } ) ).toBe( false );
+	} );
+
+	it( 'rejects wrong status', () => {
+		expect( isErrorOperationState( { status: 'idle', error: validErrorPayload } ) ).toBe( false );
+	} );
+} );
+
+// ── isOperationState (union) ────────────────────────────────────────
+
+describe( 'isOperationState', () => {
+	it( 'accepts all four valid states', () => {
+		expect( isOperationState( { status: 'idle' } ) ).toBe( true );
+		expect( isOperationState( { status: 'processing' } ) ).toBe( true );
+		expect( isOperationState( { status: 'success', data: 'ok', completedAt: Date.now() } ) ).toBe(
+			true
+		);
+		expect( isOperationState( { status: 'error', error: validErrorPayload } ) ).toBe( true );
+	} );
+
+	it( 'rejects unknown status', () => {
+		expect( isOperationState( { status: 'cancelled' } ) ).toBe( false );
+	} );
+
+	it( 'rejects non-objects', () => {
+		expect( isOperationState( null ) ).toBe( false );
+		expect( isOperationState( 'idle' ) ).toBe( false );
+	} );
+} );

--- a/packages/image-studio/src/types/guards.ts
+++ b/packages/image-studio/src/types/guards.ts
@@ -1,0 +1,342 @@
+/**
+ * Runtime type guards for Image Studio shared types.
+ * Provides type narrowing and validation at WordPress API boundaries.
+ */
+
+import type {
+	MediaAttachment,
+	BlockEditProps,
+	BlockEditorDispatch,
+	GenerationRequest,
+	ImageGenerationRequest,
+	ImageEditRequest,
+	GenerationResult,
+	GenerationSuccess,
+	GenerationError,
+	JobState,
+	ErrorPayload,
+	OperationState,
+	IdleOperationState,
+	ProcessingOperationState,
+	SuccessOperationState,
+	ErrorOperationState,
+} from './index';
+import type { AttachmentRecord, WPBlock, CoreDataDispatch } from './wordpress';
+
+/**
+ * Type guard for MediaAttachment interface.
+ * Validates that an object matches the WordPress REST API attachment shape.
+ */
+export function isMediaAttachment( obj: unknown ): obj is MediaAttachment {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return (
+		typeof candidate.id === 'number' &&
+		typeof candidate.source_url === 'string' &&
+		typeof candidate.link === 'string' &&
+		typeof candidate.mime_type === 'string'
+	);
+}
+
+/**
+ * Type guard for AttachmentRecord interface.
+ * Validates minimal attachment record shape from core-data store.
+ */
+export function isAttachmentRecord( obj: unknown ): obj is AttachmentRecord {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return (
+		typeof candidate.id === 'number' &&
+		typeof candidate.source_url === 'string' &&
+		typeof candidate.date === 'string'
+	);
+}
+
+/**
+ * Type guard for WPBlock interface.
+ * Validates that an object is a WordPress block editor block.
+ */
+export function isWPBlock( obj: unknown ): obj is WPBlock {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return typeof candidate.name === 'string' && typeof candidate.clientId === 'string';
+}
+
+/**
+ * Type guard for BlockEditProps interface.
+ * Validates block editor component props.
+ */
+export function isBlockEditProps( obj: unknown ): obj is BlockEditProps {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return (
+		typeof candidate.name === 'string' &&
+		typeof candidate.clientId === 'string' &&
+		typeof candidate.isSelected === 'boolean' &&
+		typeof candidate.attributes === 'object' &&
+		typeof candidate.setAttributes === 'function'
+	);
+}
+
+/**
+ * Type guard to check if a dispatch object has core-data methods.
+ * Useful for validating useDispatch returns at runtime.
+ */
+export function isCoreDataDispatch( obj: unknown ): obj is CoreDataDispatch {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return (
+		typeof candidate.saveEntityRecord === 'function' &&
+		typeof candidate.deleteEntityRecord === 'function' &&
+		typeof candidate.invalidateResolution === 'function'
+	);
+}
+
+/**
+ * Type guard to check if a dispatch object has block-editor methods.
+ */
+export function isBlockEditorDispatch( obj: unknown ): obj is BlockEditorDispatch {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return typeof candidate.updateBlockAttributes === 'function';
+}
+
+/**
+ * Type guard for validating file is an image with supported MIME type.
+ */
+export function isSupportedImageFile( file: File, supportedTypes: readonly string[] ): boolean {
+	return supportedTypes.includes( file.type );
+}
+
+/**
+ * Type guard for checking if a value is a valid Blob.
+ */
+export function isBlob( obj: unknown ): obj is Blob {
+	return obj instanceof Blob;
+}
+
+/**
+ * Type guard for checking if a value is a File (subclass of Blob).
+ */
+export function isFile( obj: unknown ): obj is File {
+	return obj instanceof File;
+}
+
+/**
+ * Type guard for ErrorPayload interface.
+ * Validates structured error payload shape.
+ */
+export function isErrorPayload( obj: unknown ): obj is ErrorPayload {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return (
+		typeof candidate.category === 'string' &&
+		typeof candidate.message === 'string' &&
+		typeof candidate.timestamp === 'number'
+	);
+}
+
+/**
+ * Type guard for GenerationSuccess interface.
+ * Validates successful generation result shape.
+ */
+export function isGenerationSuccess( obj: unknown ): obj is GenerationSuccess {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return (
+		candidate.status === 'success' &&
+		typeof candidate.attachmentId === 'number' &&
+		typeof candidate.imageUrl === 'string'
+	);
+}
+
+/**
+ * Type guard for GenerationError interface.
+ * Validates failed generation result shape.
+ */
+export function isGenerationError( obj: unknown ): obj is GenerationError {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return candidate.status === 'error' && isErrorPayload( candidate.error );
+}
+
+/**
+ * Type guard for GenerationResult discriminated union.
+ * Narrows to either GenerationSuccess or GenerationError.
+ */
+export function isGenerationResult( obj: unknown ): obj is GenerationResult {
+	return isGenerationSuccess( obj ) || isGenerationError( obj );
+}
+
+/**
+ * Type guard for ImageGenerationRequest interface.
+ * Validates image generation request shape.
+ */
+export function isImageGenerationRequest( obj: unknown ): obj is ImageGenerationRequest {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return (
+		candidate.type === 'generate' &&
+		typeof candidate.sessionId === 'string' &&
+		typeof candidate.prompt === 'string'
+	);
+}
+
+/**
+ * Type guard for ImageEditRequest interface.
+ * Validates image edit request shape.
+ */
+export function isImageEditRequest( obj: unknown ): obj is ImageEditRequest {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return (
+		candidate.type === 'edit' &&
+		typeof candidate.sessionId === 'string' &&
+		typeof candidate.prompt === 'string' &&
+		typeof candidate.attachmentId === 'number'
+	);
+}
+
+/**
+ * Type guard for GenerationRequest discriminated union.
+ * Narrows to either ImageGenerationRequest or ImageEditRequest.
+ */
+export function isGenerationRequest( obj: unknown ): obj is GenerationRequest {
+	return isImageGenerationRequest( obj ) || isImageEditRequest( obj );
+}
+
+/**
+ * Type guard for JobState interface.
+ * Validates job state structure with generic result type.
+ */
+export function isJobState< TResult = unknown >( obj: unknown ): obj is JobState< TResult > {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return (
+		typeof candidate.jobId === 'string' &&
+		typeof candidate.status === 'string' &&
+		typeof candidate.createdAt === 'number' &&
+		typeof candidate.updatedAt === 'number'
+	);
+}
+
+/**
+ * Type guard for IdleOperationState interface.
+ */
+export function isIdleOperationState( obj: unknown ): obj is IdleOperationState {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return candidate.status === 'idle';
+}
+
+/**
+ * Type guard for ProcessingOperationState interface.
+ */
+export function isProcessingOperationState( obj: unknown ): obj is ProcessingOperationState {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return candidate.status === 'processing';
+}
+
+/**
+ * Type guard for SuccessOperationState interface.
+ */
+export function isSuccessOperationState< TData = unknown >(
+	obj: unknown
+): obj is SuccessOperationState< TData > {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return (
+		candidate.status === 'success' &&
+		candidate.data !== undefined &&
+		typeof candidate.completedAt === 'number'
+	);
+}
+
+/**
+ * Type guard for ErrorOperationState interface.
+ */
+export function isErrorOperationState( obj: unknown ): obj is ErrorOperationState {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return false;
+	}
+
+	const candidate = obj as Record< string, unknown >;
+
+	return candidate.status === 'error' && isErrorPayload( candidate.error );
+}
+
+/**
+ * Type guard for OperationState discriminated union.
+ * Narrows to one of the four operation state types.
+ */
+export function isOperationState< TData = unknown >(
+	obj: unknown
+): obj is OperationState< TData > {
+	return (
+		isIdleOperationState( obj ) ||
+		isProcessingOperationState( obj ) ||
+		isSuccessOperationState( obj ) ||
+		isErrorOperationState( obj )
+	);
+}

--- a/packages/image-studio/src/types/index.ts
+++ b/packages/image-studio/src/types/index.ts
@@ -69,3 +69,334 @@ export const IMAGE_STUDIO_SUPPORTED_MIME_TYPES = [
 	'image/bmp',
 	'image/tiff',
 ] as const;
+
+/**
+ * Props passed to a BlockEdit component by the block editor.
+ */
+export interface BlockEditProps {
+	name: string;
+	clientId: string;
+	isSelected: boolean;
+	attributes: Record< string, unknown >;
+	setAttributes: ( attrs: Record< string, unknown > ) => void;
+}
+
+/**
+ * A WordPress media attachment record as returned by getEntityRecord for 'attachment' post type.
+ * This is the REST API shape before transformation.
+ */
+export interface MediaAttachment {
+	id: number;
+	source_url: string;
+	link: string;
+	mime_type: string;
+	alt_text?: string;
+	title?: {
+		rendered: string;
+		raw: string;
+	};
+	caption?: {
+		rendered: string;
+		raw: string;
+	};
+	description?: {
+		rendered: string;
+		raw: string;
+	};
+	media_details?: {
+		width: number;
+		height: number;
+		sizes?: Record<
+			string,
+			{
+				source_url: string;
+				width: number;
+				height: number;
+				mime_type: string;
+			}
+		>;
+	};
+}
+
+/**
+ * Callback for media selection in block editor contexts.
+ * Uses a generic record type since the transformed attachment shape
+ * varies depending on the WordPress media-utils version.
+ */
+export type MediaSelectCallback = (
+	media: Record< string, unknown > | Record< string, unknown >[]
+) => void;
+
+/**
+ * Block editor store dispatch with updateBlockAttributes action.
+ * The @wordpress/block-editor package doesn't export store action types,
+ * so we define just the action we need.
+ */
+export interface BlockEditorDispatch {
+	updateBlockAttributes: ( clientId: string, attributes: Record< string, unknown > ) => void;
+}
+
+// Re-export annotation types
+export type { AnnotationPoint, AnnotationPath, AnnotationTool } from './annotation';
+
+// Re-export agenttic types
+export type { AgentMessage } from './agenttic';
+
+// Re-export upload types
+export type {
+	UploadedMedia,
+	UploadSuccessCallback,
+	UploadErrorCallback,
+	UploadAnnotationOptions,
+	FileValidationResult,
+	FileToBlobOptions,
+	UploadProgress,
+	UploadState,
+} from './upload';
+
+/**
+ * Generation request types for Image Studio AI operations.
+ */
+
+/**
+ * Base request parameters shared across all generation types.
+ */
+export interface GenerationRequestBase {
+	/** Session ID for tracking the generation request */
+	sessionId: string;
+	/** User prompt or instruction for the AI */
+	prompt: string;
+	/** Optional metadata to attach to generated image */
+	metadata?: {
+		title?: string;
+		alt_text?: string;
+		caption?: string;
+		description?: string;
+	};
+}
+
+/**
+ * Request to generate a new image from scratch.
+ */
+export interface ImageGenerationRequest extends GenerationRequestBase {
+	type: 'generate';
+	/** Selected style preset identifier */
+	style?: string | null;
+	/** Selected aspect ratio (e.g., '1:1', '16:9') */
+	aspectRatio?: string | null;
+}
+
+/**
+ * Request to edit an existing image.
+ */
+export interface ImageEditRequest extends GenerationRequestBase {
+	type: 'edit';
+	/** ID of the attachment being edited */
+	attachmentId: number;
+	/** Annotation data if using annotation mode */
+	annotation?: Blob;
+}
+
+/**
+ * Discriminated union of all generation request types.
+ */
+export type GenerationRequest = ImageGenerationRequest | ImageEditRequest;
+
+/**
+ * Job status types for tracking asynchronous generation operations.
+ */
+
+/**
+ * Processing states for generation jobs.
+ */
+export enum JobStatus {
+	/** Job is queued but not yet started */
+	Pending = 'pending',
+	/** Job is actively processing */
+	Processing = 'processing',
+	/** Job completed successfully */
+	Success = 'success',
+	/** Job failed with an error */
+	Error = 'error',
+	/** Job was cancelled by user */
+	Cancelled = 'cancelled',
+}
+
+/**
+ * Generic job state for tracking long-running operations.
+ */
+export interface JobState< TResult = unknown > {
+	/** Unique identifier for the job */
+	jobId: string;
+	/** Current status of the job */
+	status: JobStatus;
+	/** Result data if status is Success */
+	result?: TResult;
+	/** Error information if status is Error */
+	error?: ErrorPayload;
+	/** Optional progress indicator (0-100) */
+	progress?: number;
+	/** Timestamp when the job was created */
+	createdAt: number;
+	/** Timestamp when the job last updated */
+	updatedAt: number;
+}
+
+/**
+ * Generation result types for AI operation outcomes.
+ */
+
+/**
+ * Successful generation result.
+ */
+export interface GenerationSuccess {
+	status: 'success';
+	/** ID of the generated/modified attachment */
+	attachmentId: number;
+	/** URL of the generated/modified image */
+	imageUrl: string;
+	/** Optional metadata returned by the backend */
+	metadata?: {
+		width?: number;
+		height?: number;
+		mimeType?: string;
+		fileSize?: number;
+	};
+}
+
+/**
+ * Failed generation result.
+ */
+export interface GenerationError {
+	status: 'error';
+	/** Structured error payload */
+	error: ErrorPayload;
+}
+
+/**
+ * Discriminated union of generation result types.
+ */
+export type GenerationResult = GenerationSuccess | GenerationError;
+
+/**
+ * Error payload types for structured error handling.
+ */
+
+/**
+ * Error categories for different failure modes.
+ */
+export enum ErrorCategory {
+	/** Network or connectivity errors */
+	Network = 'network',
+	/** Authentication or authorization errors */
+	Auth = 'auth',
+	/** Validation errors (invalid input) */
+	Validation = 'validation',
+	/** Rate limiting or quota errors */
+	RateLimit = 'rate_limit',
+	/** Server-side processing errors */
+	Server = 'server',
+	/** Client-side errors */
+	Client = 'client',
+	/** Unknown or uncategorized errors */
+	Unknown = 'unknown',
+}
+
+/**
+ * Structured error payload for consistent error handling.
+ */
+export interface ErrorPayload {
+	/** Error category for routing to appropriate handler */
+	category: ErrorCategory;
+	/** Human-readable error message */
+	message: string;
+	/** Optional error code for specific error types */
+	code?: string;
+	/** Optional HTTP status code if from network request */
+	statusCode?: number;
+	/** Optional additional details for debugging */
+	details?: Record< string, unknown >;
+	/** Timestamp when the error occurred */
+	timestamp: number;
+}
+
+/**
+ * Store state union types for different operational modes.
+ */
+
+/**
+ * Idle state - no active operations.
+ */
+export interface IdleOperationState {
+	status: 'idle';
+}
+
+/**
+ * Processing state - operation in progress.
+ */
+export interface ProcessingOperationState {
+	status: 'processing';
+	/** Optional source identifier for tracking multiple concurrent operations */
+	source?: string;
+	/** Optional progress indicator (0-100) */
+	progress?: number;
+}
+
+/**
+ * Success state - operation completed successfully.
+ */
+export interface SuccessOperationState< TData = unknown > {
+	status: 'success';
+	/** Result data from the operation */
+	data: TData;
+	/** Timestamp when operation completed */
+	completedAt: number;
+}
+
+/**
+ * Error state - operation failed.
+ */
+export interface ErrorOperationState {
+	status: 'error';
+	/** Structured error information */
+	error: ErrorPayload;
+}
+
+/**
+ * Discriminated union for operation state tracking.
+ * Generic type parameter allows specifying the success data type.
+ */
+export type OperationState< TData = unknown > =
+	| IdleOperationState
+	| ProcessingOperationState
+	| SuccessOperationState< TData >
+	| ErrorOperationState;
+
+// Re-export runtime type guards
+export {
+	isMediaAttachment,
+	isAttachmentRecord,
+	isWPBlock,
+	isBlockEditProps,
+	isCoreDataDispatch,
+	isBlockEditorDispatch,
+	isSupportedImageFile,
+	isBlob,
+	isFile,
+	isErrorPayload,
+	isGenerationSuccess,
+	isGenerationError,
+	isGenerationResult,
+	isImageGenerationRequest,
+	isImageEditRequest,
+	isGenerationRequest,
+	isJobState,
+	isIdleOperationState,
+	isProcessingOperationState,
+	isSuccessOperationState,
+	isErrorOperationState,
+	isOperationState,
+} from './guards';
+
+// Re-export WordPress type declarations (these are ambient, so we don't re-export them)
+// They're available globally through wordpress.d.ts module augmentation

--- a/packages/image-studio/src/types/upload.ts
+++ b/packages/image-studio/src/types/upload.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared types for file upload and media handling in Image Studio.
+ * These types provide a contract for upload utilities and media transformations.
+ */
+
+import type { Attachment } from '@wordpress/media-utils';
+
+/**
+ * Partial media upload result from WordPress media-utils.
+ * Represents an uploaded media item with optional fields.
+ */
+export type UploadedMedia = Partial< Attachment >;
+
+/**
+ * Generic upload callback signature for successful uploads.
+ */
+export type UploadSuccessCallback< T = UploadedMedia > = ( media: T ) => void | Promise< void >;
+
+/**
+ * Generic upload callback signature for upload errors.
+ */
+export type UploadErrorCallback = ( error: Error ) => void;
+
+/**
+ * Options for uploading an annotated image.
+ */
+export interface UploadAnnotationOptions {
+	/** The image blob to upload */
+	blob: Blob;
+	/** Original filename for generating the new filename */
+	originalFilename?: string;
+	/** Optional metadata to attach to the uploaded image */
+	metadata?: {
+		title?: string;
+		alt_text?: string;
+		caption?: string;
+		description?: string;
+	};
+	/** Callback invoked when upload succeeds */
+	onSuccess: UploadSuccessCallback;
+	/** Optional callback invoked when upload fails */
+	onError?: UploadErrorCallback;
+}
+
+/**
+ * Generic file validation result.
+ */
+export interface FileValidationResult {
+	/** Whether the file is valid */
+	valid: boolean;
+	/** Error message if invalid */
+	error?: string;
+	/** Validated file if valid */
+	file?: File;
+}
+
+/**
+ * Options for file-to-blob conversion.
+ */
+export interface FileToBlobOptions {
+	/** MIME type for the output blob */
+	type?: string;
+	/** Quality for lossy formats (0-1) */
+	quality?: number;
+}
+
+/**
+ * Generic upload progress info.
+ */
+export interface UploadProgress {
+	/** Bytes loaded so far */
+	loaded: number;
+	/** Total bytes to upload */
+	total: number;
+	/** Percentage complete (0-100) */
+	percentage: number;
+}
+
+/**
+ * Upload state discriminated union.
+ */
+export type UploadState =
+	| { status: 'idle' }
+	| { status: 'uploading'; progress: UploadProgress }
+	| { status: 'success'; media: UploadedMedia }
+	| { status: 'error'; error: Error };

--- a/packages/image-studio/src/types/wordpress.d.ts
+++ b/packages/image-studio/src/types/wordpress.d.ts
@@ -16,7 +16,7 @@ export interface CoreDataDispatch {
 		record: Record< string, unknown >,
 		options?: {
 			isAutosave?: boolean;
-			__unstableFetch?: Function;
+			__unstableFetch?: ( ...args: unknown[] ) => Promise< unknown >;
 			throwOnError?: boolean;
 		}
 	) => Promise< unknown >;
@@ -27,7 +27,7 @@ export interface CoreDataDispatch {
 		recordId: number | string,
 		query?: Record< string, unknown > | null,
 		options?: {
-			__unstableFetch?: Function;
+			__unstableFetch?: ( ...args: unknown[] ) => Promise< unknown >;
 			throwOnError?: boolean;
 			force?: boolean;
 		}

--- a/packages/image-studio/src/types/wordpress.d.ts
+++ b/packages/image-studio/src/types/wordpress.d.ts
@@ -1,0 +1,181 @@
+/**
+ * WordPress type declarations for Image Studio
+ *
+ * Provides typed interfaces for @wordpress/data and @wordpress/core-data
+ * interactions, eliminating `as any` casts at WordPress API boundaries.
+ */
+
+/**
+ * Typed interface for core-data dispatch actions used by Image Studio.
+ * The full core-data store has many more actions, but we only type the ones we use.
+ */
+export interface CoreDataDispatch {
+	saveEntityRecord: (
+		kind: string,
+		name: string,
+		record: Record< string, unknown >,
+		options?: {
+			isAutosave?: boolean;
+			__unstableFetch?: Function;
+			throwOnError?: boolean;
+		}
+	) => Promise< unknown >;
+
+	deleteEntityRecord: (
+		kind: string,
+		name: string,
+		recordId: number | string,
+		query?: Record< string, unknown > | null,
+		options?: {
+			__unstableFetch?: Function;
+			throwOnError?: boolean;
+			force?: boolean;
+		}
+	) => Promise< boolean | undefined >;
+
+	/**
+	 * Invalidate the resolution cache for a specific selector.
+	 * This is a metadata action automatically added by @wordpress/data to all stores.
+	 */
+	invalidateResolution: ( selectorName: string, args?: unknown[] ) => void;
+}
+
+/**
+ * Typed interface for Image Studio store selectors as returned by
+ * `select( imageStudioStore )` (state parameter already curried away).
+ */
+export interface CurriedImageStudioSelectors {
+	getIsImageStudioOpen: () => boolean;
+	getImageStudioAttachmentId: () => number | null;
+	getImageStudioOriginalImageUrl: () => string | null;
+	getImageStudioCurrentImageUrl: () => string | null;
+	getImageStudioAiProcessing: () => boolean;
+	getIsAnnotationMode: () => boolean;
+	getImageStudioTransitioning: () => boolean;
+	getAnnotationCanvasRef: () => import('../store').AnnotationCanvasRef | null;
+	getOriginalAttachmentId: () => number | null;
+	getDraftIds: () => number[];
+	getHasUpdatedMetadata: () => boolean;
+	getCanvasMetadata: () => import('../store').CanvasMetadata | null;
+	getIsAnnotationSaving: () => boolean;
+	getAnnotatedAttachmentIds: () => number[];
+	getLastSavedAttachmentId: () => number | null;
+	getSavedAttachmentIds: () => number[];
+	getHasUnsavedChanges: () => boolean;
+	getIsExitConfirmed: () => boolean;
+	getEntryPoint: () => import('../store').ImageStudioEntryPoint | null;
+	getOnCloseCallback: () =>
+		| ( ( image: import('../utils/get-image-data').ImageData | null ) => Promise< void > | void )
+		| null;
+	getNotices: () => import('../store').Notice[];
+	getNavigableAttachmentIds: () => number[];
+	getCurrentNavigationIndex: () => number;
+	getHasNextImage: () => boolean;
+	getHasPreviousImage: () => boolean;
+	getNextAttachmentId: () => number | null;
+	getPreviousAttachmentId: () => number | null;
+	getIsSidebarOpen: () => boolean;
+	getNavigationCurrentPage: () => number;
+	getNavigationHasMorePages: () => boolean;
+	getSelectedStyle: () => string | null;
+	getSelectedAspectRatio: () => string | null;
+	getLastAgentMessageId: () => string | null;
+}
+
+/**
+ * Typed interface for block-editor selectors used by Image Studio.
+ * The @wordpress/block-editor package doesn't export typed selectors,
+ * so we define the subset we depend on.
+ *
+ * TODO: remove when @wordpress/block-editor exports store types
+ */
+export interface BlockEditorSelectors {
+	getBlocks: ( rootClientId?: string ) => WPBlock[];
+	getBlocksByName: ( blockName: string ) => string[];
+	getBlock: ( clientId: string ) => WPBlock | null;
+}
+
+/**
+ * Typed interface for core-data selectors used by Image Studio.
+ * The @wordpress/core-data package doesn't export typed selectors,
+ * so we define the subset we depend on.
+ *
+ * TODO: remove when @wordpress/core-data exports store types
+ */
+export interface CoreDataSelectors {
+	getEntityRecord: (
+		kind: string,
+		name: string,
+		key: number | string
+	) => AttachmentRecord | undefined;
+}
+
+/**
+ * A WordPress block from the block editor store.
+ * Simplified interface covering the fields used by client-context.
+ */
+export interface WPBlock {
+	name: string;
+	clientId: string;
+	attributes?: Record< string, unknown >;
+	innerBlocks?: WPBlock[];
+}
+
+/**
+ * Minimal attachment record shape for fields Image Studio reads.
+ * The full WordPress Attachment entity has many more fields.
+ */
+export interface AttachmentRecord {
+	id: number;
+	source_url: string;
+	date: string;
+	title?: { rendered: string } | string;
+	caption?: { rendered: string } | string;
+	description?: { rendered: string } | string;
+	alt_text?: string;
+	mime_type?: string;
+	media_details?: {
+		width: number;
+		height: number;
+	};
+}
+
+/**
+ * WordPress Media backbone model interface (window.wp.media).
+ * Used in legacy media library grid view overrides.
+ */
+export interface WpMedia {
+	attachment: ( id: number ) => WpMediaAttachmentModel | undefined;
+}
+
+export interface WpMediaAttachmentModel {
+	get: ( key: string ) => string | undefined;
+}
+
+/**
+ * Global Window extensions used by Image Studio.
+ */
+declare global {
+	interface Window {
+		/**
+		 * WordPress admin page identifier. Set by WordPress on admin pages.
+		 * Value is 'upload' on the Media Library page (upload.php).
+		 */
+		pagenow?: string;
+
+		/**
+		 * WordPress global namespace containing media library utilities.
+		 */
+		wp?: {
+			media?: WpMedia;
+			/**
+			 * WordPress data module for store access outside React context.
+			 * Provides select/dispatch for any registered store.
+			 */
+			data?: {
+				select: ( storeName: string ) => unknown;
+				dispatch: ( storeName: string ) => unknown;
+			};
+		};
+	}
+}

--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -6,6 +6,7 @@
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { select } from '@wordpress/data';
 import { store as imageStudioStore } from '../store';
+import type { BlockEditorSelectors, CoreDataSelectors, WPBlock } from '../types/wordpress.d';
 
 export interface ImageStudioMetadata {
 	id?: number;
@@ -46,15 +47,29 @@ export interface ImageStudioClientContext extends Record< string, unknown > {
 const TEMPLATE_PART_SLUGS = [ 'header', 'header-hero', 'footer' ];
 
 /**
+ * Extract rendered text from a WordPress entity field that may be
+ * either a plain string or a `{ rendered: string }` object.
+ */
+function getRenderedText( field: string | { rendered: string } | undefined ): string | undefined {
+	if ( ! field ) {
+		return undefined;
+	}
+	if ( typeof field === 'string' ) {
+		return field;
+	}
+	return field.rendered;
+}
+
+/**
  * Recursively process blocks to resolve template part inner blocks.
  * Template part blocks don't include their innerBlocks by default;
  * they must be fetched separately from the block editor store.
  */
 function processTemplatePartBlocks(
-	blocks: any[],
-	getBlocks: ( clientId?: string ) => any[]
-): any[] {
-	return blocks.map( ( block: any ) => {
+	blocks: WPBlock[],
+	getBlocks: ( clientId?: string ) => WPBlock[]
+): WPBlock[] {
+	return blocks.map( ( block: WPBlock ) => {
 		const processed = { ...block };
 
 		if ( block.name === 'core/template-part' || block.name === 'core/post-content' ) {
@@ -78,7 +93,8 @@ function processTemplatePartBlocks(
  */
 function getCurrentPageContent(): PageContentBlock[] | null {
 	try {
-		const blockEditorSelect = select( blockEditorStore ) as any;
+		// TODO: remove cast when @wordpress/block-editor exports store types
+		const blockEditorSelect = select( blockEditorStore ) as unknown as BlockEditorSelectors;
 		if ( ! blockEditorSelect ) {
 			return null;
 		}
@@ -109,8 +125,9 @@ function getCurrentPageContent(): PageContentBlock[] | null {
 
 		// Filter content blocks (exclude known template parts)
 		const contentBlocks = rootBlocks.filter(
-			( b: any ) =>
-				b.name !== 'core/template-part' || ! TEMPLATE_PART_SLUGS.includes( b.attributes?.slug )
+			( b: WPBlock ) =>
+				b.name !== 'core/template-part' ||
+				! TEMPLATE_PART_SLUGS.includes( b.attributes?.slug as string )
 		);
 
 		// Get inner blocks of header and footer
@@ -167,7 +184,7 @@ function getCurrentPageContent(): PageContentBlock[] | null {
  */
 function detectImageEntity(): ImageStudioData | null {
 	try {
-		const storeSelect = select( imageStudioStore ) as any;
+		const storeSelect = select( imageStudioStore );
 		if ( ! storeSelect ) {
 			return null;
 		}
@@ -192,7 +209,8 @@ function detectImageEntity(): ImageStudioData | null {
 		}
 
 		// Try to get attachment metadata from core store
-		const coreSelect = select( 'core' ) as any;
+		// TODO: remove cast when @wordpress/core-data exports store types
+		const coreSelect = select( 'core' ) as unknown as CoreDataSelectors;
 		const attachment = attachmentId
 			? coreSelect.getEntityRecord?.( 'postType', 'attachment', attachmentId )
 			: null;
@@ -200,11 +218,11 @@ function detectImageEntity(): ImageStudioData | null {
 		if ( attachment ) {
 			imageStudio.metadata = {
 				id: attachment.id,
-				title: attachment.title?.rendered || attachment.title,
+				title: getRenderedText( attachment.title ),
 				alt: attachment.alt_text,
 				width: attachment.media_details?.width,
 				height: attachment.media_details?.height,
-				description: attachment.description?.rendered || attachment.description,
+				description: getRenderedText( attachment.description ),
 			};
 		}
 

--- a/packages/image-studio/src/utils/extract-filename.test.ts
+++ b/packages/image-studio/src/utils/extract-filename.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for extractFilenameFromUrl utility
+ */
+import { extractFilenameFromUrl } from './extract-filename';
+
+// Mock window.location for URL parsing
+Object.defineProperty( window, 'location', {
+	value: {
+		origin: 'https://example.com',
+	},
+	writable: true,
+} );
+
+describe( 'extractFilenameFromUrl', () => {
+	describe( 'null/undefined handling', () => {
+		it( 'should return default fallback for null URL', () => {
+			expect( extractFilenameFromUrl( null ) ).toBe( 'Untitled' );
+		} );
+
+		it( 'should return default fallback for undefined URL', () => {
+			expect( extractFilenameFromUrl( undefined ) ).toBe( 'Untitled' );
+		} );
+
+		it( 'should return custom fallback when provided', () => {
+			expect( extractFilenameFromUrl( null, 'Custom Fallback' ) ).toBe( 'Custom Fallback' );
+		} );
+	} );
+
+	describe( 'basic URL parsing', () => {
+		it( 'should extract filename from simple URL', () => {
+			const url = 'https://example.com/path/to/image.jpg';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'image.jpg' );
+		} );
+
+		it( 'should extract filename with query parameters', () => {
+			const url = 'https://example.com/path/image.jpg?size=large&v=123';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'image.jpg' );
+		} );
+
+		it( 'should extract filename with hash fragment', () => {
+			const url = 'https://example.com/path/image.jpg#section';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'image.jpg' );
+		} );
+
+		it( 'should extract filename from root path', () => {
+			const url = 'https://example.com/image.png';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'image.png' );
+		} );
+	} );
+
+	describe( 'URL encoding handling', () => {
+		it( 'should decode URL-encoded filename', () => {
+			const url = 'https://example.com/path/my%20image%20file.jpg';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'my image file.jpg' );
+		} );
+
+		it( 'should decode special characters', () => {
+			const url = 'https://example.com/path/img%2Btest%26photo.jpg';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'img+test&photo.jpg' );
+		} );
+
+		it( 'should handle Unicode characters', () => {
+			const url = 'https://example.com/path/%E2%9C%93%20check.jpg';
+			expect( extractFilenameFromUrl( url ) ).toBe( '✓ check.jpg' );
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'should handle URL with trailing slash', () => {
+			const url = 'https://example.com/path/image.jpg/';
+			// Empty filename triggers fallback
+			expect( extractFilenameFromUrl( url ) ).toBe( 'Untitled' );
+		} );
+
+		it( 'should return fallback for empty path', () => {
+			const url = 'https://example.com/';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'Untitled' );
+		} );
+
+		it( 'should handle relative URL', () => {
+			const url = '/path/to/image.jpg';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'image.jpg' );
+		} );
+
+		it( 'should handle data URL gracefully', () => {
+			const url = 'data:image/png;base64,iVBORw0KGg';
+			// Data URLs extract the path component
+			expect( extractFilenameFromUrl( url ) ).toBe( 'png;base64,iVBORw0KGg' );
+		} );
+
+		it( 'should handle blob URL', () => {
+			const url = 'blob:https://example.com/550e8400-e29b-41d4-a716-446655440000';
+			// Blob URLs have UUID as filename
+			expect( extractFilenameFromUrl( url ) ).toBe( '550e8400-e29b-41d4-a716-446655440000' );
+		} );
+	} );
+
+	describe( 'malformed URL handling', () => {
+		it( 'should handle URL with invalid characters using fallback parser', () => {
+			const url = 'not a valid URL with spaces';
+			// Fallback to split-based extraction
+			expect( extractFilenameFromUrl( url ) ).toBe( 'not a valid URL with spaces' );
+		} );
+
+		it( 'should return fallback when decoding fails', () => {
+			// Create a URL that will fail decoding
+			const url = 'https://example.com/%E0%A4%A';
+			// This should trigger the fallback path
+			const result = extractFilenameFromUrl( url );
+			// Should either decode correctly or return fallback
+			expect( result ).toBeTruthy();
+		} );
+
+		it( 'should handle empty string', () => {
+			expect( extractFilenameFromUrl( '' ) ).toBe( 'Untitled' );
+		} );
+	} );
+
+	describe( 'complex filenames', () => {
+		it( 'should handle filename with multiple dots', () => {
+			const url = 'https://example.com/my.image.file.tar.gz';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'my.image.file.tar.gz' );
+		} );
+
+		it( 'should handle filename with dashes and underscores', () => {
+			const url = 'https://example.com/my-image_file-2024.jpg';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'my-image_file-2024.jpg' );
+		} );
+
+		it( 'should handle very long filename', () => {
+			const longName = 'a'.repeat( 200 ) + '.jpg';
+			const url = `https://example.com/${ longName }`;
+			expect( extractFilenameFromUrl( url ) ).toBe( longName );
+		} );
+	} );
+
+	describe( 'WordPress media library URLs', () => {
+		it( 'should extract filename from WordPress uploads URL', () => {
+			const url = 'https://example.com/wp-content/uploads/2024/03/my-image-scaled.jpg';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'my-image-scaled.jpg' );
+		} );
+
+		it( 'should extract filename from WordPress uploads URL with dimensions', () => {
+			const url = 'https://example.com/wp-content/uploads/2024/03/my-image-150x150.jpg';
+			expect( extractFilenameFromUrl( url ) ).toBe( 'my-image-150x150.jpg' );
+		} );
+	} );
+} );

--- a/packages/image-studio/src/utils/extract-json.ts
+++ b/packages/image-studio/src/utils/extract-json.ts
@@ -9,7 +9,7 @@
  * @param responseText - The raw text response from the AI model.
  * @returns The parsed JSON value, or null if no valid JSON could be extracted.
  */
-export function extractJsonFromModelResponse( responseText: string ): any | null {
+export function extractJsonFromModelResponse( responseText: string ): unknown {
 	// Try direct parse first
 	try {
 		return JSON.parse( responseText );

--- a/packages/image-studio/src/utils/get-image-data.test.ts
+++ b/packages/image-studio/src/utils/get-image-data.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for getImageData utility
+ */
+import { resolveSelect } from '@wordpress/data';
+import { getImageData } from './get-image-data';
+
+// Mock WordPress data
+jest.mock( '@wordpress/data', () => ( {
+	resolveSelect: jest.fn(),
+} ) );
+
+// Mock i18n
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+// Mock extract-filename
+jest.mock( './extract-filename', () => ( {
+	extractFilenameFromUrl: jest.fn( ( url, fallback ) => {
+		if ( ! url ) {
+			return fallback;
+		}
+		const parts = url.split( '/' );
+		return parts[ parts.length - 1 ] || fallback;
+	} ),
+} ) );
+
+const mockCoreStore = {
+	getEntityRecord: jest.fn(),
+};
+
+const consoleErrorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+describe( 'getImageData', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( resolveSelect as unknown as jest.Mock ).mockReturnValue( mockCoreStore );
+	} );
+
+	afterAll( () => {
+		consoleErrorSpy.mockRestore();
+	} );
+
+	describe( 'successful data retrieval', () => {
+		it( 'should fetch and transform complete media entity', async () => {
+			const mockMedia = {
+				id: 123,
+				source_url: 'https://example.com/wp-content/uploads/image.jpg',
+				alt_text: 'Test image',
+				title: {
+					raw: 'Test Title',
+					rendered: '<h1>Test Title</h1>',
+				},
+				caption: {
+					raw: 'Test caption',
+					rendered: '<p>Test caption</p>',
+				},
+				description: {
+					raw: 'Test description',
+					rendered: '<p>Test description</p>',
+				},
+				media_details: {
+					width: 1920,
+					height: 1080,
+				},
+			};
+
+			mockCoreStore.getEntityRecord.mockResolvedValue( mockMedia );
+
+			const result = await getImageData( 123 );
+
+			expect( mockCoreStore.getEntityRecord ).toHaveBeenCalledWith( 'postType', 'attachment', 123 );
+
+			expect( result ).toEqual( {
+				id: 123,
+				url: 'https://example.com/wp-content/uploads/image.jpg',
+				alt: 'Test image',
+				title: 'Test Title',
+				caption: 'Test caption',
+				description: 'Test description',
+				width: 1920,
+				height: 1080,
+				filename: 'image.jpg',
+			} );
+		} );
+
+		it( 'should handle media entity with missing optional fields', async () => {
+			const mockMedia = {
+				id: 456,
+				source_url: 'https://example.com/minimal-image.png',
+			};
+
+			mockCoreStore.getEntityRecord.mockResolvedValue( mockMedia );
+
+			const result = await getImageData( 456 );
+
+			expect( result ).toEqual( {
+				id: 456,
+				url: 'https://example.com/minimal-image.png',
+				alt: '',
+				title: '',
+				caption: '',
+				description: '',
+				width: 0,
+				height: 0,
+				filename: 'minimal-image.png',
+			} );
+		} );
+
+		it( 'should handle media entity with partial metadata', async () => {
+			const mockMedia = {
+				id: 789,
+				source_url: 'https://example.com/partial.jpg',
+				alt_text: 'Alt text only',
+				media_details: {
+					width: 800,
+					// height missing
+				},
+			};
+
+			mockCoreStore.getEntityRecord.mockResolvedValue( mockMedia );
+
+			const result = await getImageData( 789 );
+
+			expect( result ).toEqual( {
+				id: 789,
+				url: 'https://example.com/partial.jpg',
+				alt: 'Alt text only',
+				title: '',
+				caption: '',
+				description: '',
+				width: 800,
+				height: 0,
+				filename: 'partial.jpg',
+			} );
+		} );
+	} );
+
+	describe( 'error handling', () => {
+		it( 'should return null when media is not found', async () => {
+			mockCoreStore.getEntityRecord.mockResolvedValue( null );
+
+			const result = await getImageData( 999 );
+
+			expect( result ).toBeNull();
+			expect( consoleErrorSpy ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should return null and log error when getEntityRecord throws', async () => {
+			const error = new Error( 'Network error' );
+			mockCoreStore.getEntityRecord.mockRejectedValue( error );
+
+			const result = await getImageData( 123 );
+
+			expect( result ).toBeNull();
+			expect( consoleErrorSpy ).toHaveBeenCalledWith( 'Error fetching image data:', error );
+		} );
+
+		it( 'should return null when getEntityRecord throws non-Error', async () => {
+			mockCoreStore.getEntityRecord.mockRejectedValue( 'String error' );
+
+			const result = await getImageData( 123 );
+
+			expect( result ).toBeNull();
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Error fetching image data:',
+				'String error'
+			);
+		} );
+	} );
+
+	describe( 'filename extraction', () => {
+		it( 'should extract filename from source_url', async () => {
+			const { extractFilenameFromUrl } = require( './extract-filename' );
+
+			const mockMedia = {
+				id: 123,
+				source_url: 'https://example.com/uploads/test-image.jpg',
+			};
+
+			mockCoreStore.getEntityRecord.mockResolvedValue( mockMedia );
+
+			await getImageData( 123 );
+
+			expect( extractFilenameFromUrl ).toHaveBeenCalledWith(
+				'https://example.com/uploads/test-image.jpg',
+				'Untitled'
+			);
+		} );
+	} );
+
+	describe( 'data transformation', () => {
+		it( 'should extract raw values from title object', async () => {
+			const mockMedia = {
+				id: 123,
+				source_url: 'https://example.com/image.jpg',
+				title: {
+					raw: 'Raw Title',
+					rendered: '<h1>Rendered Title</h1>',
+				},
+			};
+
+			mockCoreStore.getEntityRecord.mockResolvedValue( mockMedia );
+
+			const result = await getImageData( 123 );
+
+			expect( result?.title ).toBe( 'Raw Title' );
+		} );
+
+		it( 'should extract raw values from caption object', async () => {
+			const mockMedia = {
+				id: 123,
+				source_url: 'https://example.com/image.jpg',
+				caption: {
+					raw: 'Raw Caption',
+					rendered: '<p>Rendered Caption</p>',
+				},
+			};
+
+			mockCoreStore.getEntityRecord.mockResolvedValue( mockMedia );
+
+			const result = await getImageData( 123 );
+
+			expect( result?.caption ).toBe( 'Raw Caption' );
+		} );
+
+		it( 'should extract raw values from description object', async () => {
+			const mockMedia = {
+				id: 123,
+				source_url: 'https://example.com/image.jpg',
+				description: {
+					raw: 'Raw Description',
+					rendered: '<p>Rendered Description</p>',
+				},
+			};
+
+			mockCoreStore.getEntityRecord.mockResolvedValue( mockMedia );
+
+			const result = await getImageData( 123 );
+
+			expect( result?.description ).toBe( 'Raw Description' );
+		} );
+
+		it( 'should extract dimensions from media_details', async () => {
+			const mockMedia = {
+				id: 123,
+				source_url: 'https://example.com/image.jpg',
+				media_details: {
+					width: 2560,
+					height: 1440,
+					file: 'image.jpg',
+					sizes: {},
+				},
+			};
+
+			mockCoreStore.getEntityRecord.mockResolvedValue( mockMedia );
+
+			const result = await getImageData( 123 );
+
+			expect( result?.width ).toBe( 2560 );
+			expect( result?.height ).toBe( 1440 );
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'should handle attachment ID of 0', async () => {
+			mockCoreStore.getEntityRecord.mockResolvedValue( null );
+
+			const result = await getImageData( 0 );
+
+			expect( result ).toBeNull();
+			expect( mockCoreStore.getEntityRecord ).toHaveBeenCalledWith( 'postType', 'attachment', 0 );
+		} );
+
+		it( 'should handle negative attachment ID', async () => {
+			mockCoreStore.getEntityRecord.mockResolvedValue( null );
+
+			const result = await getImageData( -1 );
+
+			expect( result ).toBeNull();
+		} );
+
+		it( 'should handle very large attachment ID', async () => {
+			const largeId = 999999999;
+			mockCoreStore.getEntityRecord.mockResolvedValue( null );
+
+			const result = await getImageData( largeId );
+
+			expect( result ).toBeNull();
+			expect( mockCoreStore.getEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'attachment',
+				largeId
+			);
+		} );
+	} );
+} );

--- a/packages/image-studio/src/utils/session.test.ts
+++ b/packages/image-studio/src/utils/session.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for session utilities
+ */
+import { getSessionId } from './session';
+
+// Mock localStorage
+const localStorageMock = ( () => {
+	let store: Record< string, string > = {};
+	return {
+		getItem: jest.fn( ( key: string ) => store[ key ] || null ),
+		setItem: jest.fn( ( key: string, value: string ) => {
+			store[ key ] = value;
+		} ),
+		removeItem: jest.fn( ( key: string ) => {
+			delete store[ key ];
+		} ),
+		clear: jest.fn( () => {
+			store = {};
+		} ),
+	};
+} )();
+
+Object.defineProperty( window, 'localStorage', {
+	value: localStorageMock,
+	writable: true,
+} );
+
+// Helper to reset all mocks and storage
+function resetMocks() {
+	localStorageMock.clear();
+	jest.clearAllMocks();
+	delete ( window as any ).agentsManager;
+}
+
+describe( 'Session Utilities', () => {
+	beforeEach( () => {
+		resetMocks();
+	} );
+
+	describe( 'getSessionId', () => {
+		describe( 'agents-manager priority', () => {
+			it( 'should use agents-manager session ID when available', () => {
+				const mockSessionId = 'agents-manager-session-123';
+				( window as any ).agentsManager = {
+					getSessionId: () => mockSessionId,
+				};
+
+				const sessionId = getSessionId();
+
+				expect( sessionId ).toBe( mockSessionId );
+				expect( localStorageMock.getItem ).not.toHaveBeenCalled();
+			} );
+
+			it( 'should fall back to localStorage when agents-manager returns empty string', () => {
+				( window as any ).agentsManager = {
+					getSessionId: () => '',
+				};
+
+				const sessionId = getSessionId();
+
+				expect( sessionId ).toBeTruthy();
+				expect( sessionId ).not.toBe( '' );
+				// Should have tried to read from localStorage
+				expect( localStorageMock.getItem ).toHaveBeenCalled();
+			} );
+
+			it( 'should fall back to localStorage when agents-manager is undefined', () => {
+				// No agentsManager on window
+				const sessionId = getSessionId();
+
+				expect( sessionId ).toBeTruthy();
+				expect( localStorageMock.getItem ).toHaveBeenCalled();
+			} );
+		} );
+
+		describe( 'localStorage session management', () => {
+			it( 'should generate new session ID when localStorage is empty', () => {
+				const sessionId = getSessionId();
+
+				expect( sessionId ).toBeTruthy();
+				expect( sessionId ).toMatch(
+					/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+				);
+				expect( localStorageMock.setItem ).toHaveBeenCalledWith(
+					'image-studio-session-id',
+					expect.stringContaining( sessionId )
+				);
+			} );
+
+			it( 'should reuse valid session from localStorage', () => {
+				const existingSessionId = 'existing-session-uuid';
+				const sessionData = JSON.stringify( {
+					sessionId: existingSessionId,
+					timestamp: Date.now(),
+				} );
+
+				localStorageMock.getItem.mockReturnValue( sessionData );
+
+				const sessionId = getSessionId();
+
+				expect( sessionId ).toBe( existingSessionId );
+			} );
+
+			it( 'should generate new session when stored session is expired', () => {
+				const expiredSessionId = 'expired-session-uuid';
+				const expiredTimestamp = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
+				const sessionData = JSON.stringify( {
+					sessionId: expiredSessionId,
+					timestamp: expiredTimestamp,
+				} );
+
+				localStorageMock.getItem.mockReturnValue( sessionData );
+
+				const sessionId = getSessionId();
+
+				expect( sessionId ).not.toBe( expiredSessionId );
+				expect( localStorageMock.removeItem ).toHaveBeenCalledWith( 'image-studio-session-id' );
+			} );
+
+			it( 'should persist new session to localStorage', () => {
+				getSessionId();
+
+				expect( localStorageMock.setItem ).toHaveBeenCalledWith(
+					'image-studio-session-id',
+					expect.any( String )
+				);
+
+				const setItemCall = localStorageMock.setItem.mock.calls[ 0 ];
+				const storedData = JSON.parse( setItemCall[ 1 ] );
+
+				expect( storedData ).toHaveProperty( 'sessionId' );
+				expect( storedData ).toHaveProperty( 'timestamp' );
+				expect( typeof storedData.sessionId ).toBe( 'string' );
+				expect( typeof storedData.timestamp ).toBe( 'number' );
+			} );
+		} );
+
+		describe( 'error handling', () => {
+			it( 'should handle localStorage.getItem throwing error', () => {
+				localStorageMock.getItem.mockImplementation( () => {
+					throw new Error( 'localStorage disabled' );
+				} );
+
+				const sessionId = getSessionId();
+
+				// Should still generate a valid session ID
+				expect( sessionId ).toBeTruthy();
+				expect( sessionId ).toMatch( /^[0-9a-f-]+$/ );
+			} );
+
+			it( 'should handle localStorage.setItem throwing error', () => {
+				localStorageMock.setItem.mockImplementation( () => {
+					throw new Error( 'localStorage full' );
+				} );
+
+				const sessionId = getSessionId();
+
+				// Should still return a valid session ID even if storage fails
+				expect( sessionId ).toBeTruthy();
+			} );
+
+			it( 'should handle corrupted JSON in localStorage', () => {
+				localStorageMock.getItem.mockReturnValue( 'invalid-json{' );
+
+				const sessionId = getSessionId();
+
+				// Should generate new session ID
+				expect( sessionId ).toBeTruthy();
+			} );
+
+			it( 'should handle malformed session data structure', () => {
+				const malformedData = JSON.stringify( {
+					wrongKey: 'value',
+				} );
+
+				localStorageMock.getItem.mockReturnValue( malformedData );
+
+				const sessionId = getSessionId();
+
+				// Should generate new session ID
+				expect( sessionId ).toBeTruthy();
+			} );
+		} );
+
+		describe( 'UUID generation', () => {
+			it( 'should generate valid UUID v4 format', () => {
+				const sessionId = getSessionId();
+
+				// UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+				// where y is one of [8, 9, a, b]
+				const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+				expect( sessionId ).toMatch( uuidRegex );
+			} );
+
+			it( 'should generate unique session IDs', () => {
+				resetMocks();
+
+				const sessionIds = new Set< string >();
+				for ( let i = 0; i < 10; i++ ) {
+					resetMocks();
+					sessionIds.add( getSessionId() );
+				}
+
+				// All 10 should be unique
+				expect( sessionIds.size ).toBe( 10 );
+			} );
+		} );
+
+		describe( 'session expiry', () => {
+			it( 'should consider session valid when within 24 hours', () => {
+				const recentSessionId = 'recent-session-uuid';
+				const recentTimestamp = Date.now() - 23 * 60 * 60 * 1000; // 23 hours ago
+				const sessionData = JSON.stringify( {
+					sessionId: recentSessionId,
+					timestamp: recentTimestamp,
+				} );
+
+				localStorageMock.getItem.mockReturnValue( sessionData );
+
+				const sessionId = getSessionId();
+
+				expect( sessionId ).toBe( recentSessionId );
+			} );
+
+			it( 'should consider session expired after 24 hours', () => {
+				const oldSessionId = 'old-session-uuid';
+				const oldTimestamp = Date.now() - 24 * 60 * 60 * 1000 - 1000; // Just over 24 hours
+				const sessionData = JSON.stringify( {
+					sessionId: oldSessionId,
+					timestamp: oldTimestamp,
+				} );
+
+				localStorageMock.getItem.mockReturnValue( sessionData );
+
+				const sessionId = getSessionId();
+
+				expect( sessionId ).not.toBe( oldSessionId );
+			} );
+		} );
+	} );
+} );

--- a/packages/image-studio/src/utils/tool-provider.test.ts
+++ b/packages/image-studio/src/utils/tool-provider.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for tool provider utilities
+ */
+import { getAbilities, executeAbility } from '@wordpress/abilities';
+import { registerUpdateCanvasImageAbility } from '../abilities';
+import {
+	ALLOWED_ABILITIES,
+	initializeAbilities,
+	getFilteredAbilities,
+	executeFilteredAbility,
+	createToolProvider,
+} from './tool-provider';
+
+// Mock WordPress abilities
+jest.mock( '@wordpress/abilities', () => ( {
+	getAbilities: jest.fn().mockResolvedValue( [] ),
+	executeAbility: jest.fn().mockResolvedValue( {} ),
+} ) );
+
+// Mock abilities registration
+jest.mock( '../abilities', () => ( {
+	registerUpdateCanvasImageAbility: jest.fn(),
+} ) );
+
+// Mock console methods
+const consoleLogSpy = jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+
+describe( 'Tool Provider', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		// Don't reset modules for getFilteredAbilities/executeFilteredAbility tests
+		// as they need the mocked @wordpress/abilities to work properly
+	} );
+
+	afterAll( () => {
+		consoleLogSpy.mockRestore();
+	} );
+
+	describe( 'ALLOWED_ABILITIES', () => {
+		it( 'should define allowed abilities list', () => {
+			expect( ALLOWED_ABILITIES ).toEqual( [
+				'image-studio/update-canvas-image',
+				'image-studio/render-images',
+			] );
+		} );
+	} );
+
+	describe( 'initializeAbilities', () => {
+		it( 'should register abilities on first call and not on subsequent calls (idempotency)', async () => {
+			await initializeAbilities();
+
+			expect( registerUpdateCanvasImageAbility ).toHaveBeenCalledTimes( 1 );
+			expect( consoleLogSpy ).toHaveBeenCalledWith( '[Image Studio] Abilities registered' );
+
+			// Call again - should not register again
+			await initializeAbilities();
+			await initializeAbilities();
+
+			expect( registerUpdateCanvasImageAbility ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'getFilteredAbilities', () => {
+		it( 'should return only allowed abilities', async () => {
+			const mockAbilities = [
+				{ name: 'image-studio/update-canvas-image', description: 'Update canvas' },
+				{ name: 'image-studio/render-images', description: 'Render images' },
+				{ name: 'other/ability', description: 'Not allowed' },
+				{ name: 'another/ability', description: 'Also not allowed' },
+			];
+
+			( getAbilities as jest.Mock ).mockResolvedValue( mockAbilities );
+
+			const filtered = await getFilteredAbilities();
+
+			expect( filtered ).toHaveLength( 2 );
+			expect( filtered ).toEqual( [
+				{ name: 'image-studio/update-canvas-image', description: 'Update canvas' },
+				{ name: 'image-studio/render-images', description: 'Render images' },
+			] );
+		} );
+
+		it( 'should handle abilities with missing names', async () => {
+			const mockAbilities = [
+				{ name: 'image-studio/update-canvas-image', description: 'Update canvas' },
+				{ description: 'No name' }, // Missing name
+				null, // Null ability
+				{ name: '', description: 'Empty name' }, // Empty name
+			];
+
+			( getAbilities as jest.Mock ).mockResolvedValue( mockAbilities );
+
+			const filtered = await getFilteredAbilities();
+
+			expect( filtered ).toHaveLength( 1 );
+			expect( filtered[ 0 ].name ).toBe( 'image-studio/update-canvas-image' );
+		} );
+
+		it( 'should log available abilities', async () => {
+			const mockAbilities = [
+				{ name: 'image-studio/update-canvas-image', description: 'Update canvas' },
+				{ name: 'image-studio/render-images', description: 'Render images' },
+			];
+
+			( getAbilities as jest.Mock ).mockResolvedValue( mockAbilities );
+
+			await getFilteredAbilities();
+
+			expect( consoleLogSpy ).toHaveBeenCalledWith( '[Image Studio] Available abilities:', [
+				'image-studio/update-canvas-image',
+				'image-studio/render-images',
+			] );
+		} );
+
+		it( 'should call getAbilities from WordPress abilities API', async () => {
+			const mockAbilities = [
+				{ name: 'image-studio/update-canvas-image', description: 'Update canvas' },
+			];
+
+			( getAbilities as jest.Mock ).mockResolvedValue( mockAbilities );
+
+			await getFilteredAbilities();
+
+			expect( getAbilities ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'executeFilteredAbility', () => {
+		it( 'should execute allowed ability', async () => {
+			const abilityName = 'image-studio/update-canvas-image';
+			const abilityArgs = { imageUrl: 'https://example.com/image.jpg' };
+			const mockResult = { success: true };
+
+			( executeAbility as jest.Mock ).mockResolvedValue( mockResult );
+
+			const result = await executeFilteredAbility( abilityName, abilityArgs );
+
+			expect( executeAbility ).toHaveBeenCalledWith( abilityName, abilityArgs );
+			expect( result ).toEqual( mockResult );
+			expect( consoleLogSpy ).toHaveBeenCalledWith(
+				'[Image Studio] Executing ability: image-studio/update-canvas-image',
+				abilityArgs
+			);
+		} );
+
+		it( 'should throw error for disallowed ability', async () => {
+			const abilityName = 'malicious/ability';
+			const abilityArgs = { data: 'test' };
+
+			await expect( executeFilteredAbility( abilityName, abilityArgs ) ).rejects.toThrow(
+				"Ability 'malicious/ability' is not allowed for Image Studio"
+			);
+
+			expect( executeAbility ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should call executeAbility from WordPress abilities API', async () => {
+			const abilityName = 'image-studio/render-images';
+			const abilityArgs = {};
+
+			( executeAbility as jest.Mock ).mockResolvedValue( {} );
+
+			await executeFilteredAbility( abilityName, abilityArgs );
+
+			expect( executeAbility ).toHaveBeenCalledWith( abilityName, abilityArgs );
+		} );
+
+		it( 'should pass through execution errors', async () => {
+			const abilityName = 'image-studio/update-canvas-image';
+			const executionError = new Error( 'Execution failed' );
+
+			( executeAbility as jest.Mock ).mockRejectedValue( executionError );
+
+			await expect( executeFilteredAbility( abilityName, {} ) ).rejects.toThrow(
+				'Execution failed'
+			);
+		} );
+	} );
+
+	describe( 'createToolProvider', () => {
+		it( 'should return tool provider with correct interface', () => {
+			const toolProvider = createToolProvider();
+
+			expect( toolProvider ).toHaveProperty( 'getAbilities' );
+			expect( toolProvider ).toHaveProperty( 'executeAbility' );
+			expect( typeof toolProvider.getAbilities ).toBe( 'function' );
+			expect( typeof toolProvider.executeAbility ).toBe( 'function' );
+		} );
+
+		it( 'should use getFilteredAbilities for getAbilities method', async () => {
+			const mockAbilities = [
+				{ name: 'image-studio/update-canvas-image', description: 'Update canvas' },
+			];
+
+			( getAbilities as jest.Mock ).mockResolvedValue( mockAbilities );
+
+			const toolProvider = createToolProvider();
+
+			const abilities = await toolProvider.getAbilities();
+
+			expect( abilities ).toEqual( mockAbilities );
+		} );
+
+		it( 'should use executeFilteredAbility for executeAbility method', async () => {
+			const abilityName = 'image-studio/update-canvas-image';
+			const abilityArgs = { test: 'data' };
+			const mockResult = { success: true };
+
+			( executeAbility as jest.Mock ).mockResolvedValue( mockResult );
+
+			const toolProvider = createToolProvider();
+
+			const result = await toolProvider.executeAbility( abilityName, abilityArgs );
+
+			expect( executeAbility ).toHaveBeenCalledWith( abilityName, abilityArgs );
+			expect( result ).toEqual( mockResult );
+		} );
+	} );
+} );

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -521,7 +521,6 @@ interface TrackImageStudioStyleSelectedOptions {
 
 /**
  * Tracks when a user selects a style in Image Studio
- *
  * @param {Object} options       - Tracking options
  * @param {string} options.style - The selected style value
  * @param {string} options.mode  - 'edit' or 'generate'
@@ -543,7 +542,6 @@ interface TrackImageStudioAspectRatioSelectedOptions {
 
 /**
  * Tracks when a user selects an aspect ratio in Image Studio
- *
  * @param {Object} options             - Tracking options
  * @param {string} options.aspectRatio - The selected aspect ratio value
  * @param {string} options.mode        - 'edit' or 'generate'
@@ -560,7 +558,6 @@ export function trackImageStudioAspectRatioSelected( {
 
 /**
  * Tracks when an image is permanently deleted from Image Studio
- *
  * @param {Object} options                - Tracking options
  * @param {number} [options.attachmentId] - Attachment ID of the deleted image
  * @param {string} options.mode           - 'edit' or 'generate'

--- a/packages/image-studio/src/utils/upload-annotation.test.ts
+++ b/packages/image-studio/src/utils/upload-annotation.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for uploadAnnotation utility
+ */
+import { uploadMedia } from '@wordpress/media-utils';
+import { uploadAnnotation } from './upload-annotation';
+
+// Mock uploadMedia
+jest.mock( '@wordpress/media-utils', () => ( {
+	uploadMedia: jest.fn(),
+} ) );
+
+// Mock Date.now() for deterministic timestamps
+const mockNow = 1234567890000;
+jest.spyOn( Date, 'now' ).mockReturnValue( mockNow );
+
+describe( 'uploadAnnotation', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'filename generation', () => {
+		it( 'should generate default filename with timestamp when no original filename', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				onFileChange( [ { id: 123, url: 'https://example.com/uploaded.jpg' } ] );
+			} );
+
+			await uploadAnnotation( {
+				blob: mockBlob,
+				onSuccess: mockOnSuccess,
+			} );
+
+			const uploadCall = ( uploadMedia as jest.Mock ).mock.calls[ 0 ][ 0 ];
+			const uploadedFile = uploadCall.filesList[ 0 ];
+
+			expect( uploadedFile.name ).toBe( `annotated-image-${ mockNow }.png` );
+		} );
+
+		it( 'should preserve original extension when provided', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				onFileChange( [ { id: 123, url: 'https://example.com/uploaded.jpg' } ] );
+			} );
+
+			await uploadAnnotation( {
+				blob: mockBlob,
+				originalFilename: 'original-image.jpg',
+				onSuccess: mockOnSuccess,
+			} );
+
+			const uploadCall = ( uploadMedia as jest.Mock ).mock.calls[ 0 ][ 0 ];
+			const uploadedFile = uploadCall.filesList[ 0 ];
+
+			expect( uploadedFile.name ).toBe( `original-image-annotated-${ mockNow }.jpg` );
+		} );
+
+		it( 'should handle filename with multiple dots', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				onFileChange( [ { id: 123, url: 'https://example.com/uploaded.jpg' } ] );
+			} );
+
+			await uploadAnnotation( {
+				blob: mockBlob,
+				originalFilename: 'my.image.file.png',
+				onSuccess: mockOnSuccess,
+			} );
+
+			const uploadCall = ( uploadMedia as jest.Mock ).mock.calls[ 0 ][ 0 ];
+			const uploadedFile = uploadCall.filesList[ 0 ];
+
+			expect( uploadedFile.name ).toBe( `my.image.file-annotated-${ mockNow }.png` );
+		} );
+
+		it( 'should handle filename without extension', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				onFileChange( [ { id: 123, url: 'https://example.com/uploaded.jpg' } ] );
+			} );
+
+			await uploadAnnotation( {
+				blob: mockBlob,
+				originalFilename: 'noextension',
+				onSuccess: mockOnSuccess,
+			} );
+
+			const uploadCall = ( uploadMedia as jest.Mock ).mock.calls[ 0 ][ 0 ];
+			const uploadedFile = uploadCall.filesList[ 0 ];
+
+			// When no dots exist, the entire filename becomes the "extension"
+			// and baseName is empty, resulting in: -annotated-timestamp.noextension
+			expect( uploadedFile.name ).toBe( `-annotated-${ mockNow }.noextension` );
+		} );
+	} );
+
+	describe( 'file creation', () => {
+		it( 'should create File from Blob with correct type', async () => {
+			const mockBlob = new Blob( [ 'test-data' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				onFileChange( [ { id: 123, url: 'https://example.com/uploaded.jpg' } ] );
+			} );
+
+			await uploadAnnotation( {
+				blob: mockBlob,
+				onSuccess: mockOnSuccess,
+			} );
+
+			const uploadCall = ( uploadMedia as jest.Mock ).mock.calls[ 0 ][ 0 ];
+			const uploadedFile = uploadCall.filesList[ 0 ];
+
+			expect( uploadedFile ).toBeInstanceOf( File );
+			expect( uploadedFile.type ).toBe( 'image/png' );
+		} );
+
+		it( 'should pass file to uploadMedia', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				onFileChange( [ { id: 123, url: 'https://example.com/uploaded.jpg' } ] );
+			} );
+
+			await uploadAnnotation( {
+				blob: mockBlob,
+				onSuccess: mockOnSuccess,
+			} );
+
+			expect( uploadMedia ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					filesList: expect.arrayContaining( [ expect.any( File ) ] ),
+					allowedTypes: [ 'image' ],
+					onFileChange: expect.any( Function ),
+					onError: expect.any( Function ),
+				} )
+			);
+		} );
+	} );
+
+	describe( 'upload success', () => {
+		it( 'should call onSuccess and resolve when upload completes', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+			const mockUploadedMedia = {
+				id: 123,
+				url: 'https://example.com/uploaded.jpg',
+				title: 'Uploaded image',
+			};
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				onFileChange( [ mockUploadedMedia ] );
+			} );
+
+			const result = await uploadAnnotation( {
+				blob: mockBlob,
+				onSuccess: mockOnSuccess,
+			} );
+
+			expect( mockOnSuccess ).toHaveBeenCalledWith( mockUploadedMedia );
+			expect( result ).toEqual( mockUploadedMedia );
+		} );
+
+		it( 'should handle async onSuccess callback', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn().mockResolvedValue( undefined );
+			const mockUploadedMedia = { id: 123, url: 'https://example.com/uploaded.jpg' };
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				onFileChange( [ mockUploadedMedia ] );
+			} );
+
+			const result = await uploadAnnotation( {
+				blob: mockBlob,
+				onSuccess: mockOnSuccess,
+			} );
+
+			expect( mockOnSuccess ).toHaveBeenCalledWith( mockUploadedMedia );
+			expect( result ).toEqual( mockUploadedMedia );
+		} );
+
+		it( 'should ignore intermediate blob URLs (only process final media)', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				// First call with blob URL (intermediate)
+				onFileChange( [ { url: 'blob:http://localhost/temp-id' } ] );
+				// Second call with actual media
+				onFileChange( [ { id: 123, url: 'https://example.com/uploaded.jpg' } ] );
+			} );
+
+			await uploadAnnotation( {
+				blob: mockBlob,
+				onSuccess: mockOnSuccess,
+			} );
+
+			// onSuccess should only be called once with the final media
+			expect( mockOnSuccess ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnSuccess ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 123,
+					url: 'https://example.com/uploaded.jpg',
+				} )
+			);
+		} );
+	} );
+
+	describe( 'upload errors', () => {
+		it( 'should call onError callback when upload fails', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+			const mockOnError = jest.fn();
+			const uploadError = new Error( 'Upload failed' );
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onError } ) => {
+				onError( uploadError );
+			} );
+
+			await expect(
+				uploadAnnotation( {
+					blob: mockBlob,
+					onSuccess: mockOnSuccess,
+					onError: mockOnError,
+				} )
+			).rejects.toThrow( 'Upload failed' );
+
+			expect( mockOnError ).toHaveBeenCalledWith( uploadError );
+			expect( mockOnSuccess ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should reject promise when upload fails even without onError callback', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+			const uploadError = new Error( 'Network error' );
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onError } ) => {
+				onError( uploadError );
+			} );
+
+			await expect(
+				uploadAnnotation( {
+					blob: mockBlob,
+					onSuccess: mockOnSuccess,
+				} )
+			).rejects.toThrow( 'Network error' );
+
+			expect( mockOnSuccess ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should reject if onSuccess throws error', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const successError = new Error( 'onSuccess error' );
+			const mockOnSuccess = jest.fn().mockRejectedValue( successError );
+			const mockUploadedMedia = { id: 123, url: 'https://example.com/uploaded.jpg' };
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				onFileChange( [ mockUploadedMedia ] );
+			} );
+
+			await expect(
+				uploadAnnotation( {
+					blob: mockBlob,
+					onSuccess: mockOnSuccess,
+				} )
+			).rejects.toThrow( 'onSuccess error' );
+		} );
+	} );
+
+	describe( 'metadata handling', () => {
+		it( 'should accept metadata parameter (for future use)', async () => {
+			const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
+			const mockOnSuccess = jest.fn();
+			const metadata = {
+				title: 'Test Title',
+				alt_text: 'Test alt',
+				caption: 'Test caption',
+				description: 'Test description',
+			};
+
+			( uploadMedia as jest.Mock ).mockImplementation( ( { onFileChange } ) => {
+				onFileChange( [ { id: 123, url: 'https://example.com/uploaded.jpg' } ] );
+			} );
+
+			// Should not throw even though metadata is currently unused
+			await expect(
+				uploadAnnotation( {
+					blob: mockBlob,
+					metadata,
+					onSuccess: mockOnSuccess,
+				} )
+			).resolves.toBeDefined();
+		} );
+	} );
+} );

--- a/packages/image-studio/src/utils/upload-annotation.ts
+++ b/packages/image-studio/src/utils/upload-annotation.ts
@@ -1,4 +1,7 @@
 import { uploadMedia } from '@wordpress/media-utils';
+import type { Attachment } from '@wordpress/media-utils';
+
+type UploadedMedia = Partial< Attachment >;
 
 interface UploadAnnotationOptions {
 	blob: Blob;
@@ -9,7 +12,7 @@ interface UploadAnnotationOptions {
 		caption?: string;
 		description?: string;
 	};
-	onSuccess: ( media: any ) => void | Promise< void >;
+	onSuccess: ( media: UploadedMedia ) => void | Promise< void >;
 	onError?: ( error: Error ) => void;
 }
 
@@ -27,7 +30,7 @@ export function uploadAnnotation( {
 	originalFilename,
 	onSuccess,
 	onError,
-}: UploadAnnotationOptions ): Promise< any > {
+}: UploadAnnotationOptions ): Promise< UploadedMedia > {
 	// Generate filename based on original filename if provided
 	// Add timestamp to ensure unique filename for each annotation
 	const timestamp = Date.now();
@@ -46,10 +49,10 @@ export function uploadAnnotation( {
 	} );
 
 	// Upload to WordPress
-	return new Promise< any >( ( resolve, reject ) => {
+	return new Promise< UploadedMedia >( ( resolve, reject ) => {
 		uploadMedia( {
 			filesList: [ file ],
-			onFileChange: async ( [ media ]: any[] ) => {
+			onFileChange: async ( [ media ]: UploadedMedia[] ) => {
 				// Only process once when media is fully uploaded (not blob URL)
 				if ( media && media.id ) {
 					try {

--- a/packages/image-studio/tsconfig.json
+++ b/packages/image-studio/tsconfig.json
@@ -8,5 +8,5 @@
 		"rootDir": "src"
 	},
 	"include": [ "src", "src/*.json", "types" ],
-	"exclude": [ "**/test/*", "**/*.test.ts", "**/*.test.tsx", "**/*.test.js" ]
+	"exclude": [ "**/test/*", "**/*.test.ts", "**/*.test.tsx", "**/*.test.js", "**/__mocks__/**" ]
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #
## Proposed Changes

 - Fix broken skill path in AGENTS.md (resolved to nonexistent double-nested directory)
 - Extract CSS selectors, troubleshooting, and output template from UI testing SKILL.md into references/ for progressive disclosure
 - Expand AGENTS.md coverage to document abilities API, extensions, tracking, client-context, and type guards — previously undocumented areas
 covering ~60% of the codebase
 - Add unit tests for src/types/guards.ts (0% → 100% coverage, +112 tests)
 - Fix markdown table pipe alignment lint errors
 - Remove self-rating section (never triggered by agents across 11 commits)
 - Add file navigation guide to AGENTS.md so agents load the right file first

## Why are these changes being made?

AGENTS.md only covered ~40% of the codebase surface area. An agent working on tracking, abilities, extensions, or type guards had no guardrails and those are among the lowest-coverage, highest-risk files. The broken skill path meant the UI testing skill was undiscoverable. The type guards file (306 lines of runtime validation at API boundaries) had zero tests, and broken guards fail silently by rejecting valid data.

## Testing Instructions

Run lint, typecheck, and tests
 ```bash
   cd packages/image-studio
   yarn build && yarn test && yarn lint && yarn typecheck
 ```

Expected:
 - All 767 tests pass (was 493)
 - Package coverage: 83.7% → 89.7% statements, 66.3% → 80.7% branches
 - types/guards.ts: 0% → 100% across all metrics
 - npx eslint packages/image-studio/AGENTS.md — 0 errors, 0 warnings

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### E2E Test

* Sandbox `widgets.wp.com`
* Install this PR to your sandbox
```
install-plugin.sh am forno-218/improve-agents-experience
```
* Enable filter
```
echo "<?php add_filter( 'jetpack_image_studio_enabled', '__return_true' );" > ~/public_html/wp-content/mu-plugins/enable-image-studio.php
```
* Test Image Studio in Media Library and Block Editor
* Or just ask AI to run Image Studio comprehensive browser tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
