### PR TITLE
Analytics: Enable Quora tracking pixel (#108921)

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -51,7 +51,7 @@ export const TRACKING_IDS = {
 	outbrainAdvId: '00f0f5287433c2851cc0cb917c7ff0465e',
 	pinterestInit: '2613194105266',
 	quantcast: 'p-3Ma3jHaQMB_bS',
-	quoraPixelId: '420845cb70e444938cf0728887a74ca1',
+	quoraPixelId: '683a7cd9d4c24c33a4645f1cc9ffe3df',
 	twitterPixelId: 'nvzbs',
 	wpcomFloodlightGtag: 'DC-6355556',
 	wpcomGoogleAdsGtag: 'AW-946162814',

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -31,7 +31,7 @@ import './setup';
 
 declare global {
 	interface Window {
-		qp: ( ...args: string[] ) => void;
+		qp: ( ...args: any[] ) => void;
 		twq: ( ...args: any[] ) => void;
 		fbq: ( ...args: any[] ) => void;
 		gtag: ( ...args: any[] ) => void;

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -123,13 +123,6 @@ export async function retarget( urlPath ) {
 			debug( 'retarget: [Yahoo Gemini] [rate limited]', params );
 			new window.Image().src = params;
 		}
-
-		// Quora
-		if ( mayWeTrackByTracker( 'quora' ) ) {
-			const params = [ 'track', 'ViewContent' ];
-			debug( 'retarget: [Quora] [rate limited]', params );
-			window.qp( ...params );
-		}
 	}
 
 	// uses JSON.stringify for consistency with recordOrder()

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -65,6 +65,7 @@ export const AdTrackersBuckets: { [ key in AdTracker ]: Bucket | null } = {
 	reddit: Bucket.ADVERTISING,
 	linkedin: Bucket.ADVERTISING,
 	tiktok: Bucket.ADVERTISING,
+	quora: Bucket.ADVERTISING,
 
 	// Disabled trackers:
 	quantcast: null,
@@ -73,7 +74,6 @@ export const AdTrackersBuckets: { [ key in AdTracker ]: Bucket | null } = {
 	iconMedia: null,
 	criteo: null,
 	pandora: null,
-	quora: null,
 	adroll: null,
 	clarity: null,
 	outbrain: null,

--- a/client/lib/analytics/utils/get-exceptions.ts
+++ b/client/lib/analytics/utils/get-exceptions.ts
@@ -13,6 +13,7 @@ const getExceptions = (): Partial< Record< AdTracker, boolean > > => {
 	return {
 		facebook: region === 'california' && countryCode === 'us',
 		tiktok: region === 'california' && countryCode === 'us',
+		quora: region === 'california' && countryCode === 'us',
 	};
 };
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -553,6 +553,7 @@ function setUpCSP( req, res, next ) {
 			'https://snap.licdn.com', // LinkedIn analytics
 			'www.redditstatic.com', // Reddit tracking pixel
 			'https://analytics.tiktok.com', // TikTok tracking pixel
+			'https://a.quora.com', // Quora tracking pixel.
 			'www.googletagmanager.com',
 			'https://accounts.google.com',
 			'https://bat.bing.com', // Bing Ads JS
@@ -622,6 +623,7 @@ function setUpCSP( req, res, next ) {
 			'https://woocommerce.com', // WooCommerce marketplace
 			'localhost:8888',
 			'p.typekit.net',
+			'https://q.quora.com', //Quora tracking pixel image.
 		],
 		'frame-src': [
 			"'self'",
@@ -669,6 +671,7 @@ function setUpCSP( req, res, next ) {
 			'*.sentry.io',
 			'*.reddit.com',
 			'https://analytics.tiktok.com', // TikTok tracking pixel
+			'https://a.quora.com', //Quora tracking pixel
 			// Payment provider APIs (for tokenization and payment processing)
 			'*.stripe.com', // Stripe API calls
 			'api.stripe.com', // Stripe API endpoint


### PR DESCRIPTION
[The initial PR](https://github.com/Automattic/wp-calypso/pull/108921) was reverted because of Quora warnings. 
This PR adds the tracking code without triggering a `ViewContent` event.

## Proposed Changes

Update the pixel ID, the previous pixel was inactive.
Respect the California exception, similar to what we're doing for Meta.
Update CSP to be able to load content from https://q.quora.com/.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support upcoming Quora ad campaigns.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/setup/onboarding/domains` and make sure you clear the sensitive_pixel_options cookie if set.
- Visit `/setup/onboarding/domains?flags=ad-tracking,cookie-banner`, confirm there are no console errors and no script containing tiktok is loaded.
- Click on Customize, accept Analytics but not Advertising and click Accept selection. Confirm there are no console errors and no script containing tiktok is loaded.
- Clear the sensitive_pixel_options cookie and refresh the page.
- Accept Advertising and confirm there are no console errors and the Quora pixel was loaded successfully.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
