### PR TITLE
A4A: Remove 'a4a-pressable-addons' feature flag

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -138,16 +138,6 @@ export default function useProductAndPlans( {
 			);
 		}
 
-		const pressableAddonProductIds = new Set(
-			filterProductsAndPlansByType( PRODUCT_TYPE_PRESSABLE_ADDON, filteredProductsAndBundles ).map(
-				( product ) => product.product_id
-			)
-		);
-
-		filteredProductsAndBundles = filteredProductsAndBundles.filter(
-			( product ) => ! pressableAddonProductIds.has( product.product_id )
-		);
-
 		// Filter products & plan that are already assigned to a site
 		if ( selectedSite && addedPlanAndProducts && filteredProductsAndBundles ) {
 			filteredProductsAndBundles = filteredProductsAndBundles.filter(

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { getQueryArg } from '@wordpress/url';
 import { useMemo } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
@@ -115,7 +114,6 @@ export default function useProductAndPlans( {
 	productSearchQuery,
 }: Props ) {
 	const { data, isLoading: isLoadingProducts } = useProductsQuery();
-	const isPressableAddonsEnabled = isEnabled( 'a4a-pressable-addons' );
 
 	const addedPlanAndProducts = useSelector( ( state ) =>
 		selectedSite ? getAssignedPlanAndProductIDsForSite( state, selectedSite.ID ) : null
@@ -140,19 +138,15 @@ export default function useProductAndPlans( {
 			);
 		}
 
-		// Hide Pressable add-ons behind feature flag across marketplace products UI.
-		if ( ! isPressableAddonsEnabled ) {
-			const pressableAddonProductIds = new Set(
-				filterProductsAndPlansByType(
-					PRODUCT_TYPE_PRESSABLE_ADDON,
-					filteredProductsAndBundles
-				).map( ( product ) => product.product_id )
-			);
+		const pressableAddonProductIds = new Set(
+			filterProductsAndPlansByType( PRODUCT_TYPE_PRESSABLE_ADDON, filteredProductsAndBundles ).map(
+				( product ) => product.product_id
+			)
+		);
 
-			filteredProductsAndBundles = filteredProductsAndBundles.filter(
-				( product ) => ! pressableAddonProductIds.has( product.product_id )
-			);
-		}
+		filteredProductsAndBundles = filteredProductsAndBundles.filter(
+			( product ) => ! pressableAddonProductIds.has( product.product_id )
+		);
 
 		// Filter products & plan that are already assigned to a site
 		if ( selectedSite && addedPlanAndProducts && filteredProductsAndBundles ) {
@@ -201,6 +195,5 @@ export default function useProductAndPlans( {
 		selectedSite,
 		addedPlanAndProducts,
 		isLoadingProducts,
-		isPressableAddonsEnabled,
 	] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	lock,
 	people,
@@ -52,7 +51,6 @@ import { isPressableAddonProduct } from '../../../lib/hosting';
 export default function useProductFilterOptions() {
 	const translate = useTranslate();
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
-	const isPressableAddonsEnabled = isEnabled( 'a4a-pressable-addons' );
 	const { data: productsAndPlans = [] } = useProductsQuery();
 	const { hasActiveAgencyPressablePlanLicense, hasActiveReferralPressablePlanLicense } =
 		usePressableAddonVisibility();
@@ -76,7 +74,7 @@ export default function useProductFilterOptions() {
 				label: translate( 'WooCommerce' ) as string,
 				image: <img width={ 80 } src={ WooLogoColor } alt="WooCommerce" />,
 			},
-			...( isPressableAddonsEnabled && hasPressableAddonsAvailable && canShowPressableAddonsByMode
+			...( hasPressableAddonsAvailable && canShowPressableAddonsByMode
 				? [
 						{
 							key: PRODUCT_CATEGORY_PRESSABLE_ADDON,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -49,7 +49,6 @@
 		"a4a-signup-v2-via-email": false,
 		"a4a-unified-onboarding-tour": true,
 		"a4a-bd-checkout": false,
-		"a4a-pressable-addons": true,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -42,7 +42,6 @@
 		"a4a-signup-v2-via-email": false,
 		"a4a-unified-onboarding-tour": true,
 		"a4a-bd-checkout": false,
-		"a4a-pressable-addons": true,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -42,7 +42,6 @@
 		"a4a-signup-v2-via-email": false,
 		"a4a-unified-onboarding-tour": true,
 		"a4a-bd-checkout": false,
-		"a4a-pressable-addons": true,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -44,7 +44,6 @@
 		"a4a-signup-v2-via-email": false,
 		"a4a-unified-onboarding-tour": true,
 		"a4a-bd-checkout": false,
-		"a4a-pressable-addons": true,
 		"a4a-vip-partner-opportunity-referrals": true,
 		"jetpack/crm-downloads": true,
 		"upgrades/redirect-payments": true,


### PR DESCRIPTION
Part of A4A-1554

## Proposed Changes

* Remove the `a4a-pressable-addons` feature flag checks from A4A marketplace product and filter hooks.
* Keep Pressable add-on visibility controlled by the existing mode and license availability logic.
* Delete the `a4a-pressable-addons` flag entry from the A4A development, horizon, stage, and production config files.

## Why are these changes being made?

* Pressable add-ons are already in production, so the extra feature-flag gate is no longer needed.
* Removing the flag simplifies the marketplace logic and avoids carrying rollout-only config and branching conditions forward.

## Testing Instructions

* Review the diff and confirm there are no remaining `isEnabled( 'a4a-pressable-addons' )` checks in the updated marketplace hooks.
* Verify `config/a8c-for-agencies-development.json`, `config/a8c-for-agencies-horizon.json`, `config/a8c-for-agencies-stage.json`, and `config/a8c-for-agencies-production.json` no longer include `a4a-pressable-addons`.
* Open the Automattic for Agencies live preview from the PR comments.
* Go to `/marketplace/products`.
* Confirm the Pressable add-on category still appears only when the current marketplace mode and available licenses allow it.
* Confirm Pressable add-on products still render in the marketplace list when they are allowed by those existing visibility rules.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
