### PR TITLE
Woo AI: Save checkpoint ID's

### DIFF
--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -109,6 +109,15 @@ export default function OrchestratorChat( {
 		registerMessageActions,
 	} = useAgentChat( agentConfig! );
 
+	// Save agenttic checkpoint ID cookie when the last message is from the user.
+	useEffect( () => {
+		const lastMessage = messages[ messages.length - 1 ];
+		if ( lastMessage?.role === 'user' ) {
+			const checkpoint = `chat-${ String( performance.now() ).replace( '.', '' ) }`;
+			document.cookie = `agenttic_checkpoint_id=${ checkpoint }; path=/`;
+		}
+	}, [ messages ] );
+
 	// Notify parent when message count changes
 	useEffect( () => {
 		onMessagesCountChange( messages.length );


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/WOOAI-360

## Proposed Changes
* Save new checkpoint ID in the cookies for every user message sent to the AI assistant

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See 3459-ghe-Automattic/ciab-admin for details.

## Testing Instructions

TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
