### PR TITLE
MSD: update CIAB visibility card copy

### DIFF
--- a/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
@@ -34,7 +34,7 @@ export default function VisibilityCardCiab( { site }: { site: Site } ) {
 			link={ link }
 			icon={ published }
 			heading={ __( 'Live' ) }
-			description={ __( 'Your site is visible to everyone.' ) }
+			description={ __( 'Your store is visible to everyone.' ) }
 			intent="success"
 		/>
 	);

--- a/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
+++ b/client/dashboard/sites/overview-visibility-card-ciab/index.tsx
@@ -1,10 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import { published } from '@wordpress/icons';
+import { launch } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import type { Site } from '@automattic/api-core';
 
 const CARD_PROPS = {
-	title: __( 'Visibility' ),
+	title: __( 'Store Visibility' ),
 	tracksId: 'site-overview-visibility-ciab',
 };
 
@@ -13,13 +14,27 @@ export default function VisibilityCardCiab( { site }: { site: Site } ) {
 		? `${ site.options.admin_url }admin.php?page=next-admin&p=%2Fwoocommerce%2Fsettings%2Fgeneral`
 		: undefined;
 
+	if ( site.is_coming_soon ) {
+		return (
+			<OverviewCard
+				{ ...CARD_PROPS }
+				link={ link }
+				icon={ launch }
+				heading={ __( 'Coming Soon' ) }
+				description={ __(
+					'Your site is hidden from visitors behind a “Coming Soon” notice until it is ready for viewing.'
+				) }
+			/>
+		);
+	}
+
 	return (
 		<OverviewCard
 			{ ...CARD_PROPS }
 			link={ link }
 			icon={ published }
-			heading={ __( 'Public' ) }
-			description={ __( 'Anyone can view your site.' ) }
+			heading={ __( 'Live' ) }
+			description={ __( 'Your site is visible to everyone.' ) }
 			intent="success"
 		/>
 	);


### PR DESCRIPTION
Related to #108930

## Proposed Changes

* Update CIAB visibility card title from "Visibility" to "Store Visibility"
* Show "Coming Soon" variant when `site.is_coming_soon` is true
* Show "Live" variant (default) with updated copy matching ciab-admin terminology

<img width="2400" height="1122" alt="CleanShot 2026-03-02 at 16 37 45@2x" src="https://github.com/user-attachments/assets/92bb2ce7-8801-4c7e-8fc6-9e101d1d9b28" />


## Why are these changes being made?

Feedback on #108930 requested the card copy match ciab-admin terminology, with two variants based on site visibility state.

## Testing Instructions

* View the CIAB site overview — card should show "Live" heading with success intent
* Coming Soon variant not yet testable for CIAB sites (`site.is_coming_soon` not synced yet)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?