### PR TITLE
FORNO-224: Image Studio: Hide toolbar button when image block has a mismatched attachment

### DIFF
--- a/packages/image-studio/src/extensions/image-toolbar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/image-toolbar-extension.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+// eslint-disable-next-line import/order
+import React from 'react';
+
+// Webpack global injected at build time, used at render time by __().
+( globalThis as Record< string, unknown > ).__i18n_text_domain__ = 'default';
+
+const BASE_URL = 'https://example.com/wp-content/uploads/2024/01/photo.jpg';
+
+// Mock media records
+const makeAttachment = ( overrides = {} ) => ( {
+	source_url: BASE_URL,
+	mime_type: 'image/jpeg',
+	media_details: {
+		sizes: {
+			thumbnail: { source_url: BASE_URL.replace( '.jpg', '-150x150.jpg' ) },
+			medium: { source_url: BASE_URL.replace( '.jpg', '-300x200.jpg' ) },
+			large: { source_url: BASE_URL.replace( '.jpg', '-1024x768.jpg' ) },
+			custom: { source_url: BASE_URL.replace( '.jpg', '-500x500.jpg?ver=123' ) },
+		},
+	},
+	...overrides,
+} );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn( () => ( { openImageStudio: jest.fn() } ) ),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	BlockControls: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="block-controls">{ children }</div>
+	),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	ToolbarButton: ( { children, label }: { children: React.ReactNode; label: string } ) => (
+		<button data-testid="toolbar-button" aria-label={ label }>
+			{ children }
+		</button>
+	),
+	ToolbarGroup: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	createHigherOrderComponent: ( fn: ( component: React.ComponentType ) => React.ComponentType ) =>
+		fn,
+} ) );
+
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+jest.mock( '../store/index', () => ( {
+	store: 'image-studio',
+	ImageStudioEntryPoint: { EditorBlock: 'editor-block' },
+} ) );
+
+jest.mock( '../types', () => ( {
+	IMAGE_STUDIO_SUPPORTED_MIME_TYPES: [ 'image/jpeg', 'image/png', 'image/webp' ],
+	ImageStudioMode: { Edit: 'edit' },
+} ) );
+
+jest.mock( '../utils/tracking', () => ( {
+	trackImageStudioOpened: jest.fn(),
+} ) );
+
+jest.mock( '../utils/get-image-data', () => ( {} ) );
+
+// Must import after jest.mock() calls to receive the mocked dependencies.
+import { withImageStudioToolbarButton } from './image-toolbar-extension';
+
+const BlockEdit = () => <div data-testid="block-edit" />;
+
+function renderToolbar( {
+	attachment = makeAttachment(),
+	hasResolved = true,
+	attributes = { id: 1, url: BASE_URL },
+	name = 'core/image',
+}: {
+	attachment?: ReturnType< typeof makeAttachment > | null;
+	hasResolved?: boolean;
+	attributes?: { id?: number; url?: string };
+	name?: string;
+} = {} ) {
+	( useSelect as jest.Mock ).mockImplementation(
+		( callback: ( select: () => Record< string, jest.Mock > ) => unknown ) =>
+			callback( () => ( {
+				getEntityRecord: jest.fn( () => attachment ),
+				hasFinishedResolution: jest.fn( () => hasResolved ),
+			} ) )
+	);
+
+	const Component = withImageStudioToolbarButton( BlockEdit );
+	return render(
+		<Component name={ name } attributes={ attributes } setAttributes={ jest.fn() } />
+	);
+}
+
+describe( 'withImageStudioToolbarButton', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should always render BlockEdit regardless of button visibility', () => {
+		renderToolbar( { name: 'core/paragraph' } );
+		expect( screen.getByTestId( 'block-edit' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'toolbar-button' ) ).not.toBeInTheDocument();
+	} );
+
+	describe( 'URL matching', () => {
+		it( 'should show button for a matching full-size URL', () => {
+			renderToolbar();
+			expect( screen.getByTestId( 'toolbar-button' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should show button for an intermediate size URL', () => {
+			renderToolbar( {
+				attributes: { id: 1, url: BASE_URL.replace( '.jpg', '-1024x768.jpg' ) },
+			} );
+			expect( screen.getByTestId( 'toolbar-button' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should show button when attributes URL has query params', () => {
+			renderToolbar( {
+				attributes: { id: 1, url: BASE_URL + '?w=300&quality=80' },
+			} );
+			expect( screen.getByTestId( 'toolbar-button' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should show button when source_url has query params', () => {
+			renderToolbar( {
+				attachment: makeAttachment( { source_url: BASE_URL + '?ver=123' } ),
+			} );
+			expect( screen.getByTestId( 'toolbar-button' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should show button when size URL has query params', () => {
+			// The custom size has a unique base path (-500x500) with query params.
+			// This only matches if params are stripped from the size URL.
+			renderToolbar( {
+				attributes: { id: 1, url: BASE_URL.replace( '.jpg', '-500x500.jpg' ) },
+			} );
+			expect( screen.getByTestId( 'toolbar-button' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should hide button when URL does not match any known size', () => {
+			renderToolbar( {
+				attributes: { id: 1, url: 'https://other-site.com/different-image.jpg' },
+			} );
+			expect( screen.getByTestId( 'block-edit' ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( 'toolbar-button' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should hide button for a stale attachment ID', () => {
+			renderToolbar( {
+				attachment: makeAttachment( {
+					source_url: 'https://example.com/wp-content/uploads/2024/01/other.jpg',
+					media_details: {
+						sizes: {
+							thumbnail: {
+								source_url: 'https://example.com/wp-content/uploads/2024/01/other-150x150.jpg',
+							},
+						},
+					},
+				} ),
+				attributes: { id: 1, url: BASE_URL },
+			} );
+			expect( screen.getByTestId( 'block-edit' ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( 'toolbar-button' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should show button when attachment has no media_details', () => {
+			renderToolbar( {
+				attachment: makeAttachment( { media_details: undefined } ),
+				attributes: { id: 1, url: BASE_URL },
+			} );
+			expect( screen.getByTestId( 'toolbar-button' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'resolution state', () => {
+		it( 'should show button while resolution is pending', () => {
+			renderToolbar( {
+				hasResolved: false,
+				attachment: null,
+				attributes: { id: 1, url: BASE_URL },
+			} );
+			expect( screen.getByTestId( 'toolbar-button' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should hide button when attachment is null after resolution', () => {
+			renderToolbar( { attachment: null, attributes: { id: 1, url: BASE_URL } } );
+			expect( screen.getByTestId( 'block-edit' ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( 'toolbar-button' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'guard conditions', () => {
+		it( 'should hide button for non-image blocks', () => {
+			renderToolbar( { name: 'core/paragraph' } );
+			expect( screen.getByTestId( 'block-edit' ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( 'toolbar-button' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should hide button when there is no attachment ID', () => {
+			renderToolbar( { attributes: { id: undefined, url: BASE_URL } } );
+			expect( screen.getByTestId( 'block-edit' ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( 'toolbar-button' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should show button when attributes URL is undefined', () => {
+			// No URL means no mismatch can be detected, so the button shows.
+			renderToolbar( { attributes: { id: 1, url: undefined } } );
+			expect( screen.getByTestId( 'toolbar-button' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should hide button for unsupported MIME types', () => {
+			renderToolbar( {
+				attachment: makeAttachment( { mime_type: 'image/svg+xml' } ),
+			} );
+			expect( screen.getByTestId( 'block-edit' ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( 'toolbar-button' ) ).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/packages/image-studio/src/extensions/image-toolbar-extension.tsx
+++ b/packages/image-studio/src/extensions/image-toolbar-extension.tsx
@@ -22,13 +22,20 @@ export const withImageStudioToolbarButton = createHigherOrderComponent(
 			// Get supported MIME types
 			const supportedMimeTypes: readonly string[] = IMAGE_STUDIO_SUPPORTED_MIME_TYPES;
 
-			// Fetch the attachment MIME type from the media store
-			const media = useSelect(
+			// Fetch the attachment from the media store
+			const { media, hasResolved } = useSelect(
 				( select ) => {
 					if ( ! attributes?.id ) {
-						return null;
+						return { media: null, hasResolved: true };
 					}
-					return select( coreStore ).getEntityRecord( 'postType', 'attachment', attributes.id );
+					return {
+						media: select( coreStore ).getEntityRecord( 'postType', 'attachment', attributes.id ),
+						hasResolved: ( select( coreStore ) as any ).hasFinishedResolution( 'getEntityRecord', [
+							'postType',
+							'attachment',
+							attributes.id,
+						] ),
+					};
 				},
 				[ attributes?.id ]
 			);
@@ -74,6 +81,12 @@ export const withImageStudioToolbarButton = createHigherOrderComponent(
 			// Check if image MIME type is supported
 			const imageMimeType = media?.mime_type;
 			if ( imageMimeType && ! supportedMimeTypes.includes( imageMimeType ) ) {
+				return <BlockEdit { ...props } />;
+			}
+
+			// Don't show button if the attachment doesn't match the displayed image
+			// (e.g., image block pasted from another site with a stale ID)
+			if ( hasResolved && attributes?.url && ( ! media || media?.source_url !== attributes.url ) ) {
 				return <BlockEdit { ...props } />;
 			}
 

--- a/packages/image-studio/src/extensions/image-toolbar-extension.tsx
+++ b/packages/image-studio/src/extensions/image-toolbar-extension.tsx
@@ -78,15 +78,35 @@ export const withImageStudioToolbarButton = createHigherOrderComponent(
 				return <BlockEdit { ...props } />;
 			}
 
+			const attachment = media as {
+				source_url?: string;
+				mime_type?: string;
+				media_details?: { sizes?: Record< string, { source_url?: string } > };
+			} | null;
+
 			// Check if image MIME type is supported
-			const imageMimeType = media?.mime_type;
-			if ( imageMimeType && ! supportedMimeTypes.includes( imageMimeType ) ) {
+			if ( attachment?.mime_type && ! supportedMimeTypes.includes( attachment.mime_type ) ) {
 				return <BlockEdit { ...props } />;
 			}
 
 			// Don't show button if the attachment doesn't match the displayed image
-			// (e.g., image block pasted from another site with a stale ID)
-			if ( hasResolved && attributes?.url && ( ! media || media?.source_url !== attributes.url ) ) {
+			// (e.g., image block pasted from another site with a stale ID).
+			// Collect all known URLs for this attachment (full size + all
+			// intermediate sizes) and check if the block URL matches any of them.
+			const stripParams = ( url: string ) => url.split( '?' )[ 0 ];
+			const knownUrls = new Set< string >();
+			if ( attachment?.source_url ) {
+				knownUrls.add( stripParams( attachment.source_url ) );
+			}
+			if ( attachment?.media_details?.sizes ) {
+				for ( const size of Object.values( attachment.media_details.sizes ) ) {
+					if ( size.source_url ) {
+						knownUrls.add( stripParams( size.source_url ) );
+					}
+				}
+			}
+			const attributeUrl = attributes?.url ? stripParams( attributes.url ) : null;
+			if ( hasResolved && attributeUrl && ( ! attachment || ! knownUrls.has( attributeUrl ) ) ) {
 				return <BlockEdit { ...props } />;
 			}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Ensures the attachment ID in the block attributes corresponds to the displayed image URL. If not, we do not show the `Edit with AI` button in the block toolbar. This follows a similar pattern we use when validating supported mime types, and where an attachment ID is not present in the block attributes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If users copy / paste a block from another site, the image may display from the origin site, but the ID in block attributes may correspond to a different image on the target site. This can cause image studio to open with a seemingly random image.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `install-plugin.sh am fix-ai-image-block-mismatch` on your sandbox
* Sandbox `widgets.wp.com` and your test site
* Open a post in the editor (add an image block if one is not present and save the post)
* Verify the `Edit with AI` block toolbar button is displayed
* Switch to `Code Editor` and update the `id` block attribute to a different number (also update the ID in the `img` class `wp-image-xxxx`)
* Switch back to visual editor and verify the `Edit with AI` button is not displayed in the toolbar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
