### PR TITLE
A4A: Add preview referral email modal

### DIFF
--- a/client/a8c-for-agencies/AGENTS.md
+++ b/client/a8c-for-agencies/AGENTS.md
@@ -12,6 +12,11 @@
 - When creating new components or building a new feature that uses `LayoutBody`, put the body content in a separate component in the same directory rather than inlining it.
 - For logic (data fetching, derived state, side effects), use an existing library when it fits; if none exists, extract it into a new custom hook. Keep components readable by avoiding inlined non-trivial logic.
 
+### Analytics and tracking
+
+- When adding new user-facing actions or key flows (e.g. form submissions, modal open/close, option toggles, file uploads), add Tracks events via `recordTracksEvent` from `calypso/state/analytics/actions`.
+- Use the `calypso_a4a_*` event name prefix for A4A-specific events. Include relevant properties where they help analysis.
+
 ### Style Conventions
 
 - Prefer `@wordpress/components` for UI primitives (e.g., `Button`, input controls, modals) and the existing design system primitives over writing new custom components or custom CSS wherever possible.

--- a/client/a8c-for-agencies/components/logo-file-upload/index.tsx
+++ b/client/a8c-for-agencies/components/logo-file-upload/index.tsx
@@ -19,6 +19,8 @@ import {
 	validateLogoDimensions,
 	validateLogoFile,
 } from 'calypso/a8c-for-agencies/lib/logo-file-validation';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
 
@@ -35,6 +37,7 @@ export interface LogoFileUploadProps {
  */
 function LogoFileUpload( { displayUrl, onFileSelect }: LogoFileUploadProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const [ error, setError ] = useState< LogoFileValidationError | 'dimensions' | null >( null );
 	const maxLogoSizeMb = Math.floor( A4A_LOGO_MAX_FILE_SIZE_BYTES / ( 1024 * 1024 ) );
 
@@ -65,9 +68,10 @@ function LogoFileUpload( { displayUrl, onFileSelect }: LogoFileUploadProps ) {
 				return;
 			}
 
+			dispatch( recordTracksEvent( 'calypso_a4a_client_referral_logo_file_select' ) );
 			onFileSelect( file );
 		},
-		[ onFileSelect ]
+		[ dispatch, onFileSelect ]
 	);
 
 	let errorMessage: React.ReactNode | null = null;

--- a/client/a8c-for-agencies/lib/logo-url-utils.ts
+++ b/client/a8c-for-agencies/lib/logo-url-utils.ts
@@ -47,3 +47,26 @@ export const getLogoUrlForPreview = async (
 	// Use the logo URL directly (profile logo or agency referrals logo)
 	return referralLogo.option === 'profile' ? profileLogoUrl : referralLogo.logoUrl;
 };
+
+/**
+ * Derives a small, deterministic cache key for a logo URL.
+ * For regular URLs we use the URL directly; for data URLs we use a short hash
+ * instead of the full string to keep React Query keys compact.
+ */
+export const getLogoCacheKey = ( logoUrl?: string | null ): string | null => {
+	if ( ! logoUrl ) {
+		return null;
+	}
+
+	if ( ! logoUrl.startsWith( 'data:' ) ) {
+		return logoUrl;
+	}
+
+	// Simple 32-bit hash to fingerprint the data URL.
+	let hash = 5381;
+	for ( let index = 0; index < logoUrl.length; index++ ) {
+		hash = ( hash * 33 ) ^ logoUrl.charCodeAt( index );
+	}
+
+	return `inline-${ ( hash >>> 0 ).toString( 16 ) }`;
+};

--- a/client/a8c-for-agencies/lib/logo-url-utils.ts
+++ b/client/a8c-for-agencies/lib/logo-url-utils.ts
@@ -1,0 +1,49 @@
+import type { ReferralLogoChoice } from '../sections/marketplace/checkout/referral-logo';
+
+/**
+ * Converts a blob URL to a base64 data URL for use in email previews.
+ * Blob URLs are browser-only and cannot be accessed by the backend.
+ *
+ * @param file - The File object to convert
+ * @returns Promise that resolves to a data URL string
+ */
+export const convertBlobToDataUrl = ( file: File ): Promise< string > => {
+	return new Promise( ( resolve, reject ) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			if ( typeof reader.result === 'string' ) {
+				resolve( reader.result );
+			} else {
+				reject( new Error( 'Failed to read file as data URL' ) );
+			}
+		};
+		reader.onerror = () => reject( new Error( 'FileReader error' ) );
+		reader.readAsDataURL( file );
+	} );
+};
+
+/**
+ * Gets the appropriate logo URL for email preview.
+ * Converts blob URLs to data URLs, falls back to profile logo or agency referrals logo.
+ *
+ * @param referralLogo - The referral logo choice object
+ * @param profileLogoUrl - The agency's profile logo URL
+ * @returns Promise that resolves to the logo URL string or null
+ */
+export const getLogoUrlForPreview = async (
+	referralLogo: ReferralLogoChoice,
+	profileLogoUrl: string | null
+): Promise< string | null > => {
+	// Convert blob URL to data URL if a file is selected
+	if ( referralLogo.file && referralLogo.logoUrl?.startsWith( 'blob:' ) ) {
+		try {
+			const dataUrl = await convertBlobToDataUrl( referralLogo.file );
+			return dataUrl;
+		} catch ( error ) {
+			// Fallback to profile logo or null
+			return referralLogo.option === 'profile' ? profileLogoUrl : null;
+		}
+	}
+	// Use the logo URL directly (profile logo or agency referrals logo)
+	return referralLogo.option === 'profile' ? profileLogoUrl : referralLogo.logoUrl;
+};

--- a/client/a8c-for-agencies/sections/marketplace/checkout/hooks/use-referral-email-preview.ts
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/hooks/use-referral-email-preview.ts
@@ -1,4 +1,5 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { getLogoCacheKey } from 'calypso/a8c-for-agencies/lib/logo-url-utils';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -25,12 +26,15 @@ export default function useReferralEmailPreview( {
 }: UseReferralEmailPreviewParams ): UseQueryResult< ReferralEmailPreviewResponse, Error > {
 	const agencyId = useSelector( getActiveAgencyId );
 
+	const logoKey = getLogoCacheKey( logoUrl );
+
 	return useQuery< ReferralEmailPreviewResponse, Error >( {
 		queryKey: [
 			'referral-email-preview',
 			agencyId,
 			productIds,
 			greetingLine,
+			logoKey,
 			logoUrl,
 			termPricing,
 		],

--- a/client/a8c-for-agencies/sections/marketplace/checkout/hooks/use-referral-email-preview.ts
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/hooks/use-referral-email-preview.ts
@@ -1,0 +1,54 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { TermPricingType } from '../../types';
+
+interface ReferralEmailPreviewResponse {
+	html: string;
+}
+
+interface UseReferralEmailPreviewParams {
+	productIds: number[];
+	greetingLine?: string;
+	logoUrl?: string | null;
+	termPricing: TermPricingType;
+	enabled?: boolean;
+}
+
+export default function useReferralEmailPreview( {
+	productIds,
+	greetingLine,
+	logoUrl,
+	termPricing,
+	enabled = true,
+}: UseReferralEmailPreviewParams ): UseQueryResult< ReferralEmailPreviewResponse, Error > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery< ReferralEmailPreviewResponse, Error >( {
+		queryKey: [
+			'referral-email-preview',
+			agencyId,
+			productIds,
+			greetingLine,
+			logoUrl,
+			termPricing,
+		],
+		queryFn: async () => {
+			if ( ! agencyId ) {
+				throw new Error( 'Agency ID is required' );
+			}
+			return wpcom.req.post( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/referral-email-preview`,
+				body: {
+					product_ids: productIds,
+					greeting_line: greetingLine || '',
+					logo_url: logoUrl || undefined,
+					term_pricing: termPricing,
+				},
+			} );
+		},
+		enabled: enabled && productIds.length > 0 && !! agencyId,
+	} );
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.tsx
@@ -45,16 +45,26 @@ const PREVIEW_IFRAME_CSS = `
 		pointer-events: none;
 		cursor: default;
 	}
+
+	/* Scale so 600px email fits: scale = viewport width / 600px (capped at 1). */
+	@media (max-width: 600px) {
+		html {
+			transform: scale(calc(100vw / 600px));
+			transform-origin: 0 0;
+		}
+	}
 `;
+
+const VIEWPORT_META = '<meta name="viewport" content="width=device-width, initial-scale=1">';
 
 function injectPreviewStyles( html: string ): string {
 	const styleTag = `<style>${ PREVIEW_IFRAME_CSS }</style>`;
 
 	if ( html.includes( '</head>' ) ) {
-		return html.replace( '</head>', `${ styleTag }</head>` );
+		return html.replace( '</head>', `${ VIEWPORT_META }${ styleTag }</head>` );
 	}
 
-	return `${ styleTag }${ html }`;
+	return `${ VIEWPORT_META }${ styleTag }${ html }`;
 }
 
 export default function ReferralEmailPreviewModal( {
@@ -91,18 +101,24 @@ export default function ReferralEmailPreviewModal( {
 	const updateIframeHeight = useCallback( () => {
 		const iframe = iframeRef.current;
 		const doc = iframe?.contentDocument;
+		const win = iframe?.contentWindow;
 
-		if ( ! doc ) {
+		if ( ! doc || ! win ) {
 			return;
 		}
 
 		const { body, documentElement } = doc;
-		// Use only scrollHeight so iframe matches content height (avoids extra space from offsetHeight/clientHeight)
-		const nextHeight = body?.scrollHeight ?? documentElement?.scrollHeight ?? 0;
-
-		if ( nextHeight > 0 ) {
-			setIframeHeight( nextHeight );
+		const scrollHeight = body?.scrollHeight ?? documentElement?.scrollHeight ?? 0;
+		if ( scrollHeight <= 0 ) {
+			return;
 		}
+
+		// When content is scaled (viewport ≤ 600px), visual height = scrollHeight * scale.
+		const viewportWidth = win.innerWidth;
+		const scale = viewportWidth <= 600 ? viewportWidth / 600 : 1;
+		const nextHeight = Math.ceil( scrollHeight * scale );
+
+		setIframeHeight( nextHeight );
 	}, [] );
 
 	useEffect( () => {
@@ -147,7 +163,8 @@ export default function ReferralEmailPreviewModal( {
 			<VStack spacing={ 0 } className="referral-email-preview">
 				<div
 					style={ {
-						width: '600px',
+						width: '100%',
+						maxWidth: '600px',
 						marginInline: 'auto',
 						background: 'var(--color-surface)',
 						borderRadius: '8px',

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.tsx
@@ -1,4 +1,8 @@
-import { Modal, __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	Modal,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useReferralEmailPreview from './hooks/use-referral-email-preview';
@@ -35,6 +39,11 @@ const PREVIEW_IFRAME_CSS = `
 
 	td.container {
 		margin: 0 !important;
+	}
+
+	a {
+		pointer-events: none;
+		cursor: default;
 	}
 `;
 
@@ -146,14 +155,17 @@ export default function ReferralEmailPreviewModal( {
 					} }
 				>
 					{ isLoading && (
-						<div style={ { padding: '40px', textAlign: 'center' } }>
+						<Text as="div" style={ { padding: '40px', textAlign: 'center' } }>
 							{ translate( 'Loading preview' ) }
-						</div>
+						</Text>
 					) }
 					{ error && (
-						<div style={ { padding: '40px', textAlign: 'center', color: 'var(--color-error)' } }>
+						<Text
+							as="div"
+							style={ { padding: '40px', textAlign: 'center', color: 'var(--color-error)' } }
+						>
 							{ translate( 'Failed to load email preview. Please try again.' ) }
-						</div>
+						</Text>
 					) }
 					{ previewSrcDoc && (
 						<iframe

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-email-preview-modal.tsx
@@ -1,0 +1,179 @@
+import { Modal, __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useReferralEmailPreview from './hooks/use-referral-email-preview';
+import type { ShoppingCartItem, TermPricingType } from '../types';
+
+type Props = {
+	isOpen: boolean;
+	onClose: () => void;
+	clientMessage: string;
+	checkoutItems: ShoppingCartItem[];
+	termPricing: TermPricingType;
+	logoUrl: string | null;
+};
+
+// This is to remove the margin from the table cells.
+// We need to do this because removing the style from the table cells
+// will affect the email being rendered on the client's email client.
+// We need to use !important to override the style as the style is being applied as inline style.
+const PREVIEW_IFRAME_CSS = `
+	:root {
+		color-scheme: light !important;
+	}
+
+	html,
+	body {
+		background: #ffffff !important;
+		color: #101517 !important;
+	}
+
+	table {
+		margin: 0;
+		background: none !important;
+	}
+
+	td.container {
+		margin: 0 !important;
+	}
+`;
+
+function injectPreviewStyles( html: string ): string {
+	const styleTag = `<style>${ PREVIEW_IFRAME_CSS }</style>`;
+
+	if ( html.includes( '</head>' ) ) {
+		return html.replace( '</head>', `${ styleTag }</head>` );
+	}
+
+	return `${ styleTag }${ html }`;
+}
+
+export default function ReferralEmailPreviewModal( {
+	isOpen,
+	onClose,
+	clientMessage,
+	checkoutItems,
+	termPricing,
+	logoUrl,
+}: Props ) {
+	const translate = useTranslate();
+	const [ iframeHeight, setIframeHeight ] = useState( 900 );
+	const iframeRef = useRef< HTMLIFrameElement >( null );
+	const resizeObserverRef = useRef< ResizeObserver | null >( null );
+
+	const productIds = useMemo(
+		() => checkoutItems.map( ( item ) => item.product_id ),
+		[ checkoutItems ]
+	);
+
+	const { data, isLoading, error } = useReferralEmailPreview( {
+		productIds,
+		greetingLine: clientMessage.trim(),
+		logoUrl,
+		termPricing,
+		enabled: isOpen,
+	} );
+
+	const previewSrcDoc = useMemo(
+		() => ( data?.html ? injectPreviewStyles( data.html ) : '' ),
+		[ data?.html ]
+	);
+
+	const updateIframeHeight = useCallback( () => {
+		const iframe = iframeRef.current;
+		const doc = iframe?.contentDocument;
+
+		if ( ! doc ) {
+			return;
+		}
+
+		const { body, documentElement } = doc;
+		// Use only scrollHeight so iframe matches content height (avoids extra space from offsetHeight/clientHeight)
+		const nextHeight = body?.scrollHeight ?? documentElement?.scrollHeight ?? 0;
+
+		if ( nextHeight > 0 ) {
+			setIframeHeight( nextHeight );
+		}
+	}, [] );
+
+	useEffect( () => {
+		if ( ! previewSrcDoc ) {
+			return;
+		}
+
+		setIframeHeight( 900 );
+
+		return () => {
+			resizeObserverRef.current?.disconnect();
+			resizeObserverRef.current = null;
+		};
+	}, [ previewSrcDoc ] );
+
+	const handleIframeLoad = useCallback( () => {
+		updateIframeHeight();
+
+		const iframe = iframeRef.current;
+		const body = iframe?.contentDocument?.body;
+		if ( ! body || typeof ResizeObserver === 'undefined' ) {
+			return;
+		}
+
+		resizeObserverRef.current?.disconnect();
+		resizeObserverRef.current = new ResizeObserver( updateIframeHeight );
+		resizeObserverRef.current.observe( body );
+	}, [ updateIframeHeight ] );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ translate( 'Preview referral email' ) }
+			onRequestClose={ onClose }
+			className="referral-email-preview-modal"
+			bodyOpenClassName="referral-email-preview-modal-body"
+			isFullScreen
+		>
+			<VStack spacing={ 0 } className="referral-email-preview">
+				<div
+					style={ {
+						width: '600px',
+						marginInline: 'auto',
+						background: 'var(--color-surface)',
+						borderRadius: '8px',
+						overflow: 'hidden',
+					} }
+				>
+					{ isLoading && (
+						<div style={ { padding: '40px', textAlign: 'center' } }>
+							{ translate( 'Loading preview' ) }
+						</div>
+					) }
+					{ error && (
+						<div style={ { padding: '40px', textAlign: 'center', color: 'var(--color-error)' } }>
+							{ translate( 'Failed to load email preview. Please try again.' ) }
+						</div>
+					) }
+					{ previewSrcDoc && (
+						<iframe
+							ref={ iframeRef }
+							title={ translate( 'Referral email preview' ) }
+							srcDoc={ previewSrcDoc }
+							sandbox="allow-popups allow-top-navigation-by-user-activation allow-same-origin"
+							scrolling="no"
+							onLoad={ handleIframeLoad }
+							style={ {
+								width: '100%',
+								height: `${ iframeHeight }px`,
+								border: '0',
+								overflow: 'hidden',
+								display: 'block',
+							} }
+						/>
+					) }
+				</div>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/referral-logo.tsx
@@ -8,8 +8,9 @@ import {
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import LogoFileUpload from 'calypso/a8c-for-agencies/components/logo-file-upload';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export type ReferralLogoChoice = {
 	option: 'profile' | 'different' | 'none' | null;
@@ -23,6 +24,7 @@ interface Props {
 
 export default function ReferralLogo( { onChange }: Props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const agency = useSelector( getActiveAgency );
 	const profileLogoUrl = agency?.profile?.company_details?.logo_url || null;
 	const agencyReferralsLogoUrl = agency?.referrals_logo || null;
@@ -98,7 +100,15 @@ export default function ReferralLogo( { onChange }: Props ) {
 						},
 					] }
 					onChange={ ( value ) => {
-						setLogoOption( ( value as 'profile' | 'different' | 'none' ) || null );
+						const option = ( value as 'profile' | 'different' | 'none' ) || null;
+						if ( option ) {
+							dispatch(
+								recordTracksEvent( 'calypso_a4a_client_referral_logo_option_click', {
+									option,
+								} )
+							);
+						}
+						setLogoOption( option );
 					} }
 				/>
 				{ logoOption === 'profile' && profileLogoUrl && (

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -92,8 +92,6 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 
 	const isCobrandedCheckoutEnabled = isEnabled( 'a4a-referral-cobranded-checkout' );
 
-	const isCobrandedCheckoutEnabled = isEnabled( 'a4a-referral-cobranded-checkout' );
-
 	const ctaButtonRef = useRef< HTMLButtonElement >( null );
 
 	const [ showVerifyAccountToolip, setShowVerifyAccountToolip ] = useState( false );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -279,6 +279,9 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						: 'calypso_a4a_marketplace_referral_checkout_request_payment_copy_click',
 					{
 						term_pricing: termPricing,
+						...( isCobrandedCheckoutEnabled && referralLogo.option
+							? { logo_type: referralLogo.option }
+							: {} ),
 					}
 				)
 			);
@@ -467,6 +470,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 					<Button
 						variant="link"
 						onClick={ async () => {
+							dispatch( recordTracksEvent( 'calypso_a4a_client_referral_email_preview_click' ) );
 							const logoUrlForPreview = await getLogoUrlForPreview( referralLogo, profileLogoUrl );
 							setPreviewLogoUrl( logoUrlForPreview );
 							setIsPreviewOpen( true );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -8,7 +8,7 @@ import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, useCallback, useMemo, useRef, useState } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import {
@@ -76,19 +76,12 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const [ isPreviewOpen, setIsPreviewOpen ] = useState( false );
 	const [ isUploadingLogo, setIsUploadingLogo ] = useState( false );
 	const [ previewLogoUrl, setPreviewLogoUrl ] = useState< string | null >( null );
-	const [ pendingPreviewOpen, setPendingPreviewOpen ] = useState( false );
 	const [ referralLogo, setReferralLogo ] = useState< ReferralLogoChoice >( {
 		option: 'different',
 		logoUrl: null,
 		file: null,
 	} );
-	// Open preview modal once logo URL is ready
-	useEffect( () => {
-		if ( pendingPreviewOpen ) {
-			setIsPreviewOpen( true );
-			setPendingPreviewOpen( false );
-		}
-	}, [ pendingPreviewOpen, previewLogoUrl ] );
+
 	// Track the last uploaded file to avoid re-uploading the same file
 	const [ lastUploadedFile, setLastUploadedFile ] = useState< {
 		name: string;
@@ -478,7 +471,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						onClick={ async () => {
 							const logoUrlForPreview = await getLogoUrlForPreview( referralLogo, profileLogoUrl );
 							setPreviewLogoUrl( logoUrlForPreview );
-							setPendingPreviewOpen( true );
+							setIsPreviewOpen( true );
 						} }
 					>
 						{ translate( 'Preview referral email' ) }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -83,6 +83,8 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 
 	const isCobrandedCheckoutEnabled = isEnabled( 'a4a-referral-cobranded-checkout' );
 
+	const isCobrandedCheckoutEnabled = isEnabled( 'a4a-referral-cobranded-checkout' );
+
 	const ctaButtonRef = useRef< HTMLButtonElement >( null );
 
 	const [ showVerifyAccountToolip, setShowVerifyAccountToolip ] = useState( false );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -361,6 +361,8 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 			hasPressableAddonsInCheckout,
 			dispatch,
 			termPricing,
+			isCobrandedCheckoutEnabled,
+			referralLogo.option,
 			buildLogoPayload,
 			requestPayment,
 			message,

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -8,7 +8,7 @@ import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useCallback, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import {
@@ -20,6 +20,7 @@ import {
 	NEW_REFERRAL_ORDER_CHECKOUT_URL_QUERY_PARAM_KEY,
 	NEW_REFERRAL_ORDER_FLOW_TYPE_QUERY_PARAM_KEY,
 } from 'calypso/a8c-for-agencies/constants';
+import { getLogoUrlForPreview } from 'calypso/a8c-for-agencies/lib/logo-url-utils';
 import { useUploadLogo } from 'calypso/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-upload-logo';
 import { ReferralOrderFlowType } from 'calypso/a8c-for-agencies/sections/referrals/types';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -27,7 +28,10 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { useDispatch, useSelector } from 'calypso/state';
 import { updateAgencyReferralsLogo } from 'calypso/state/a8c-for-agencies/agency/actions';
-import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import {
+	getActiveAgency,
+	getActiveAgencyId,
+} from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -42,6 +46,7 @@ import useShoppingCart from '../hooks/use-shopping-cart';
 import { isPressableAddonProduct } from '../lib/hosting';
 import hasActiveReferralPressablePlanForClient from './lib/has-active-referral-pressable-plan';
 import NoticeSummary from './notice-summary';
+import ReferralEmailPreviewModal from './referral-email-preview-modal';
 import ReferralLogo from './referral-logo';
 import type { ReferralLogoChoice } from './referral-logo';
 import type { ShoppingCartItem, TermPricingType } from '../types';
@@ -60,19 +65,30 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const isMobile = useBreakpoint( '<660px' );
 
 	const user = useSelector( getCurrentUser );
+	const agency = useSelector( getActiveAgency );
+	const profileLogoUrl = agency?.profile?.company_details?.logo_url || null;
 
 	const isUserUnverified = ! user?.email_verified;
 
 	const [ email, setEmail ] = useState( '' );
 	const [ message, setMessage ] = useState( '' );
 	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
+	const [ isPreviewOpen, setIsPreviewOpen ] = useState( false );
 	const [ isUploadingLogo, setIsUploadingLogo ] = useState( false );
+	const [ previewLogoUrl, setPreviewLogoUrl ] = useState< string | null >( null );
+	const [ pendingPreviewOpen, setPendingPreviewOpen ] = useState( false );
 	const [ referralLogo, setReferralLogo ] = useState< ReferralLogoChoice >( {
 		option: 'different',
 		logoUrl: null,
 		file: null,
 	} );
-
+	// Open preview modal once logo URL is ready
+	useEffect( () => {
+		if ( pendingPreviewOpen ) {
+			setIsPreviewOpen( true );
+			setPendingPreviewOpen( false );
+		}
+	}, [ pendingPreviewOpen, previewLogoUrl ] );
 	// Track the last uploaded file to avoid re-uploading the same file
 	const [ lastUploadedFile, setLastUploadedFile ] = useState< {
 		name: string;
@@ -456,7 +472,31 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						) }
 					</Tooltip>
 				</div>
+				{ isCobrandedCheckoutEnabled && (
+					<Button
+						variant="link"
+						onClick={ async () => {
+							const logoUrlForPreview = await getLogoUrlForPreview( referralLogo, profileLogoUrl );
+							setPreviewLogoUrl( logoUrlForPreview );
+							setPendingPreviewOpen( true );
+						} }
+					>
+						{ translate( 'Preview referral email' ) }
+					</Button>
+				) }
 			</VStack>
+
+			<ReferralEmailPreviewModal
+				isOpen={ isPreviewOpen }
+				onClose={ () => {
+					setIsPreviewOpen( false );
+					setPreviewLogoUrl( null );
+				} }
+				clientMessage={ message }
+				checkoutItems={ checkoutItems }
+				termPricing={ termPricing }
+				logoUrl={ previewLogoUrl }
+			/>
 		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
@@ -3,443 +3,469 @@
 @import '@wordpress/base-styles/variables';
 
 @mixin loading-effect {
-	animation: loading-fade 1.6s ease-in-out infinite;
-	background: var( --color-sidebar-menu-selected-background );
+    animation: loading-fade 1.6s ease-in-out infinite;
+    background: var( --color-sidebar-menu-selected-background );
 }
 
 .checkout.hosting-dashboard-layout {
-	display: flex;
-	flex-direction: column;
-	height: calc(100vh - 32px);
-	overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 32px);
+    overflow: hidden;
 
-	@include break-large {
-		display: block;
-	}
+    @include break-large {
+        display: block;
+    }
 }
 
 .checkout .hosting-dashboard-layout__body,
 .checkout .hosting-dashboard-layout__body-wrapper {
-	border-radius: 8px;
+    border-radius: 8px;
 }
 
 .checkout .hosting-dashboard-layout__container {
-	height: auto;
-	flex: 1;
-	min-height: 0;
+    height: auto;
+    flex: 1;
+    min-height: 0;
 }
 
 .checkout .hosting-dashboard-layout__body {
-	padding: 0;
-	flex-grow: 1;
+    padding: 0;
+    flex-grow: 1;
 
-	@include break-large {
-		background: linear-gradient(
-			to right,
-			var( --color-surface ) 0%,
-			var( --color-surface ) 70%,
-			var( --color-neutral-0 ) 70%,
-			var( --color-neutral-0 ) 100%
-		);
-	}
+    @include break-large {
+        background: linear-gradient(
+            to right,
+            var( --color-surface ) 0%,
+            var( --color-surface ) 70%,
+            var( --color-neutral-0 ) 70%,
+            var( --color-neutral-0 ) 100%
+        );
+    }
 }
 
 .checkout .hosting-dashboard-layout__body-wrapper {
-	height: 100%;
+    height: 100%;
 }
 
 .checkout__client-referral-form-footer-error {
-	margin-block-start: 0.25rem;
-	color: var( --color-scary-40 );
-	font-style: italic;
-	@include body-medium;
+    margin-block-start: 0.25rem;
+    color: var( --color-scary-40 );
+    font-style: italic;
+    @include body-medium;
 
-	&.hidden {
-		display: none;
-	}
+    &.hidden {
+        display: none;
+    }
 }
 
 .checkout__container {
-	display: flex;
-	flex-direction: column;
-	align-items: stretch;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
 
-	@include break-large {
-		flex-direction: row;
-		min-height: 100%;
-	}
+    @include break-large {
+        flex-direction: row;
+        min-height: 100%;
+    }
 }
 
 .checkout__main {
-	flex-grow: 1;
+    flex-grow: 1;
 
-	@include break-large {
-		padding: 64px 64px 0 0;
-	}
+    @include break-large {
+        padding: 64px 64px 0 0;
+    }
 }
 
 .checkout__main-title {
-	margin-block-end: 64px;
-	margin-block-start: 32px;
-	@include heading-x-large;
+    margin-block-end: 64px;
+    margin-block-start: 32px;
+    @include heading-x-large;
 
-	@include breakpoint-deprecated( '>960px' ) {
-		margin-block-start: 0;
-	}
+    @include breakpoint-deprecated( '>960px' ) {
+        margin-block-start: 0;
+    }
 }
 
 .checkout__main-list {
-	display: flex;
-	flex-direction: column;
-	gap: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
 }
 
 .checkout__aside {
-	padding: 32px 0;
+    padding: 32px 0;
 
-	@include break-large {
-		max-width: 443px;
-		padding: 128px 48px 48px;
-		background: var( --color-neutral-0 );
-	}
+    @include break-large {
+        max-width: 443px;
+        padding: 128px 48px 48px;
+        background: var( --color-neutral-0 );
+    }
 
-	&.checkout__aside--referral,
-	&.checkout__aside--client {
-		padding-block-start: 64px;
-	}
+    &.checkout__aside--referral,
+    &.checkout__aside--client {
+        padding-block-start: 64px;
+    }
 }
 
 .checkout__summary {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
 
-	hr {
-		width: 100%;
-		margin: 0;
-		padding: 0;
-		border: none;
-	}
+    hr {
+        width: 100%;
+        margin: 0;
+        padding: 0;
+        border: none;
+    }
 }
 
 .checkout__tipalti-action-required-notice {
-	padding-top: 24px;
+    padding-top: 24px;
 }
 
 .checkout__summary-pricing {
-	background-color: var( --color-surface );
-	border-radius: 8px;
-	border: 1px solid var( --color-link );
-	padding: 1rem;
+    background-color: var( --color-surface );
+    border-radius: 8px;
+    border: 1px solid var( --color-link );
+    padding: 1rem;
 
-	@media only screen and ( min-width: 782px ) {
-		margin-block-start: 32px;
-	}
+    @media only screen and ( min-width: 782px ) {
+        margin-block-start: 32px;
+    }
 
-	@include break-xlarge {
-		margin-block-start: 24px;
-	}
+    @include break-xlarge {
+        margin-block-start: 24px;
+    }
 
-	.checkout__summary-pricing-discounted {
-		@include heading-large;
-		color: var( --color-neutral-80 );
+    .checkout__summary-pricing-discounted {
+        @include heading-large;
+        color: var( --color-neutral-80 );
 
-		@include break-xlarge {
-			@include heading-x-large;
-			color: var( --color-black );
-		}
-	}
+        @include break-xlarge {
+            @include heading-x-large;
+            color: var( --color-black );
+        }
+    }
 
-	.checkout__summary-pricing-original {
-		@include body-large;
-		text-decoration: line-through;
-		margin-inline-start: 8px;
-	}
+    .checkout__summary-pricing-original {
+        @include body-large;
+        text-decoration: line-through;
+        margin-inline-start: 8px;
+    }
 
-	.checkout__summary-pricing-interval {
-		@include body-small;
-		color: var( --color-neutral-60 );
-		line-height: 2;
-	}
+    .checkout__summary-pricing-interval {
+        @include body-small;
+        color: var( --color-neutral-60 );
+        line-height: 2;
+    }
 }
 
 .checkout__summary-items {
-	margin: 0;
+    margin: 0;
 }
 
 .checkout__summary-total {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	@include heading-medium;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    @include heading-medium;
 }
 
 .checkout__summary-notice {
-	@include body-small;
-	margin-block-end: 16px;
-	color: var( --color-neutral-50 );
+    @include body-small;
+    margin-block-end: 16px;
+    color: var( --color-neutral-50 );
 
-	a {
-		text-decoration: underline;
-		color: var( --color-text-black );
-	}
+    a {
+        text-decoration: underline;
+        color: var( --color-text-black );
+    }
 
-	&.margin-top {
-		margin-block-start: 16px;
-	}
+    &.margin-top {
+        margin-block-start: 16px;
+    }
 
-	h3 {
-		margin-block: 24px;
-		@include heading-large;
-		color: var( --color-neutral-70 );
-	}
+    h3 {
+        margin-block: 24px;
+        @include heading-large;
+        color: var( --color-neutral-70 );
+    }
 }
 
 .checkout__summary-notice-item {
-	@include body-small;
-	color: var( --color-neutral-50 );
-	margin-block-end: 0.5rem;
+    @include body-small;
+    color: var( --color-neutral-50 );
+    margin-block-end: 0.5rem;
 }
 
 .checkout__aside-actions {
-	display: flex;
-	flex-direction: column;
-	align-items: stretch;
-	gap: 16px;
-	text-align: center;
-	margin-block-end: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+    text-align: center;
+    margin-block-end: 8px;
 
-	> .button {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		border-radius: 4px;
-		min-height: 40px;
-	}
+    > .button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 4px;
+        min-height: 40px;
+    }
 
-	> .button.is-link {
-		color: var( --color-black );
-		text-decoration: underline;
-	}
+    > .button.is-link {
+        color: var( --color-black );
+        text-decoration: underline;
+    }
 }
 
 .product-info {
-	display: flex;
-	gap: 14px;
+    display: flex;
+    gap: 14px;
 
-	.product-info__icon {
-		display: none;
-		box-sizing: border-box;
-		width: 48px;
-		height: 48px;
-		background: linear-gradient( 159.87deg, #f6f6f4 7.24%, #f7f4ea 64.73%, #ddedd5 116.53% );
-		border-radius: 4px;
+    .product-info__icon {
+        display: none;
+        box-sizing: border-box;
+        width: 48px;
+        height: 48px;
+        background: linear-gradient( 159.87deg, #f6f6f4 7.24%, #f7f4ea 64.73%, #ddedd5 116.53% );
+        border-radius: 4px;
 
-		@media only screen and ( min-width: 821px ) {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-		}
-	}
+        @media only screen and ( min-width: 821px ) {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+    }
 
-	.product-info__icon > img {
-		width: 22px;
-		height: auto;
-	}
+    .product-info__icon > img {
+        width: 22px;
+        height: auto;
+    }
 
-	.product-info__text-content {
-		width: 100%;
-	}
+    .product-info__text-content {
+        width: 100%;
+    }
 
-	.product-info__header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-	}
+    .product-info__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
 
-	.product-info__label {
-		@include heading-medium;
+    .product-info__label {
+        @include heading-medium;
 
-		a {
-			text-decoration: underline;
-			color: var( --color-text );
-		}
-	}
+        a {
+            text-decoration: underline;
+            color: var( --color-text );
+        }
+    }
 
-	.product-info__count {
-		background-color: var( --color-neutral-0 );
-		padding: 5px 15px;
-		border-radius: 4px;
-		font-weight: 500;
-	}
+    .product-info__count {
+        background-color: var( --color-neutral-0 );
+        padding: 5px 15px;
+        border-radius: 4px;
+        font-weight: 500;
+    }
 
-	.product-info__description {
-		@include body-large;
-		margin-block: 4px 0;
-		color: var( --color-neutral-70 );
-	}
+    .product-info__description {
+        @include body-large;
+        margin-block: 4px 0;
+        color: var( --color-neutral-70 );
+    }
 
-	.product-info__site-url {
-		@include body-medium;
-		margin-block: 4px 0;
-		color: var( --color-neutral-40 );
-	}
+    .product-info__site-url {
+        @include body-medium;
+        margin-block: 4px 0;
+        color: var( --color-neutral-40 );
+    }
 }
 
 .product-info__placeholder {
-	@include loading-effect();
+    @include loading-effect();
 
-	width: 100%;
-	height: 48px;
-	background-color: var( --color-neutral-0 );
-	border-radius: 4px;
+    width: 100%;
+    height: 48px;
+    background-color: var( --color-neutral-0 );
+    border-radius: 4px;
 }
 
 .checkout__client-referral-form {
-	padding-block-start: 48px;
+    padding-block-start: 48px;
 
-	input[type='text'].form-text-input:disabled,
-	.form-textarea:disabled {
-		border-color: var( --color-neutral-10 );
-	}
+    input[type='text'].form-text-input:disabled,
+    .form-textarea:disabled {
+        border-color: var( --color-neutral-10 );
+    }
 }
 
 .checkout__aside--client {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	padding-block-end: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding-block-end: 0;
 
-	@include breakpoint-deprecated( '>960px' ) {
-		width: 400px;
-	}
+    @include breakpoint-deprecated( '>960px' ) {
+        width: 400px;
+    }
 
-	.checkout__aside-actions {
-		margin-block-start: 16px;
-	}
-	.checkout__summary-client-payment-notice {
-		margin-block-start: 48px;
-		color: var( --color-neutral-70 );
-		@include heading-large;
-	}
+    .checkout__aside-actions {
+        margin-block-start: 16px;
+    }
+    .checkout__summary-client-payment-notice {
+        margin-block-start: 48px;
+        color: var( --color-neutral-70 );
+        @include heading-large;
+    }
 
-	.checkout__summary-notice {
-		margin-block-start: 48px;
+    .checkout__summary-notice {
+        margin-block-start: 48px;
 
-		div {
-			margin-block-start: 8px;
-		}
-	}
+        div {
+            margin-block-start: 8px;
+        }
+    }
 
-	.checkout__aside-footer {
-		margin-block-start: 32px;
-		padding-block-end: 16px;
+    .checkout__aside-footer {
+        margin-block-start: 32px;
+        padding-block-end: 16px;
 
-		@include breakpoint-deprecated( '>960px' ) {
-			margin-block-start: auto;
-		}
+        @include breakpoint-deprecated( '>960px' ) {
+            margin-block-start: auto;
+        }
 
-		.checkout__aside-powered-by {
-			div {
-				color: var( --color-neutral-70 );
-				@include body-small;
-			}
+        .checkout__aside-powered-by {
+            div {
+                color: var( --color-neutral-70 );
+                @include body-small;
+            }
 
-			img {
-				margin-block-start: 8px;
-				width: 150px;
-			}
-		}
-	}
+            img {
+                margin-block-start: 8px;
+                width: 150px;
+            }
+        }
+    }
 }
 
 .checkout__aside-actions-wrapper {
-	display: grid;
+    display: grid;
 }
 
 .checkout__button-popover {
-	.components-popover__content {
-		width: 300px;
+    .components-popover__content {
+        width: 300px;
 
-		@include break-large {
-			width: 350px;
-		}
-	}
+        @include break-large {
+            width: 350px;
+        }
+    }
 
-	.a4a-popover__content {
-		width: 100%;
+    .a4a-popover__content {
+        width: 100%;
 
-		.a4a-popover__title {
-			@include heading-medium;
-			color: var( --studio-gray-80 );
-		}
+        .a4a-popover__title {
+            @include heading-medium;
+            color: var( --studio-gray-80 );
+        }
 
-		.checkout__button-popover-description {
-			@include body-medium;
-		}
-	}
+        .checkout__button-popover-description {
+            @include body-medium;
+        }
+    }
 }
 
 .checkout__verify-account-tooltip {
-	a {
-		color: var( --color-text-inverted );
-		text-decoration: underline;
-	}
+    a {
+        color: var( --color-text-inverted );
+        text-decoration: underline;
+    }
 }
 
 .product-info__pressable-limit-warning {
-	margin-block-start: 8px;
-	@include body-small;
+    margin-block-start: 8px;
+    @include body-small;
 }
 
 .checkout__aside-actions.is-row {
-	flex-direction: row;
-	gap: 16px;
-	align-items: center;
-	justify-content: center;
+    flex-direction: row;
+    gap: 16px;
+    align-items: center;
+    justify-content: center;
 
-	> .button {
-		flex-grow: 1;
-		display: flex;
-		flex-direction: row;
-		gap: 8px;
-		align-items: center;
-		justify-content: center;
-	}
+    > .button {
+        flex-grow: 1;
+        display: flex;
+        flex-direction: row;
+        gap: 8px;
+        align-items: center;
+        justify-content: center;
+    }
 }
 
 .checkout__logo-section {
-	.checkout__profile-logo-preview {
-		width: 250px;
-		height: 100px;
-		border: 1px solid var( --color-neutral-20 );
-		border-radius: 4px;
-		background: var( --color-neutral-0 );
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		overflow: hidden;
-	}
+    .checkout__profile-logo-preview {
+        width: 250px;
+        height: 100px;
+        border: 1px solid var( --color-neutral-20 );
+        border-radius: 4px;
+        background: var( --color-neutral-0 );
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+    }
 
-	.checkout__profile-logo-preview img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-	}
+    .checkout__profile-logo-preview img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
 
-	.logo-file-upload-placeholder {
-		width: 250px;
-		height: 100px;
-		padding: 0;
-	}
+    .logo-file-upload-placeholder {
+        width: 250px;
+        height: 100px;
+        padding: 0;
+    }
 
-	.logo-file-upload-preview {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-	}
+    .logo-file-upload-preview {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
 
-	.components-radio-control__input[type='radio']:checked {
-		background-color: var( --color-primary-50 );
-	}
+    .components-radio-control__input[type='radio']:checked {
+        background-color: var( --color-primary-50 );
+    }
+}
+
+.referral-email-preview-modal {
+    .components-modal__content {
+        background-color: var( --a4a-brand-blue-80 );
+    }
+
+    .shopping-cart__menu-list-item-price-interval {
+        display: block;
+    }
+}
+
+.referral-email-preview-modal-body {
+    overflow-y: auto;
+}
+
+.referral-email-preview {
+    padding: 24px;
+
+    @include break-medium {
+        padding: 56px;
+    }
+
+    .product-info__text-content {
+        display: flex;
+    }
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
@@ -447,6 +447,12 @@
 .referral-email-preview-modal {
 	.components-modal__content {
 		background-color: var( --a4a-brand-blue-80 );
+		padding: 4px;
+
+		@include break-small {
+			padding: 4px 24px 24px;
+		}
+
 	}
 
 	.shopping-cart__menu-list-item-price-interval {
@@ -459,9 +465,9 @@
 }
 
 .referral-email-preview {
-	padding: 24px;
+	padding: 0 0 4px 0;
 
-	@include break-medium {
+	@include break-small {
 		padding: 56px;
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
@@ -3,445 +3,445 @@
 @import '@wordpress/base-styles/variables';
 
 @mixin loading-effect {
-    animation: loading-fade 1.6s ease-in-out infinite;
-    background: var( --color-sidebar-menu-selected-background );
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background: var( --color-sidebar-menu-selected-background );
 }
 
 .checkout.hosting-dashboard-layout {
-    display: flex;
-    flex-direction: column;
-    height: calc(100vh - 32px);
-    overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	height: calc(100vh - 32px);
+	overflow: hidden;
 
-    @include break-large {
-        display: block;
-    }
+	@include break-large {
+		display: block;
+	}
 }
 
 .checkout .hosting-dashboard-layout__body,
 .checkout .hosting-dashboard-layout__body-wrapper {
-    border-radius: 8px;
+	border-radius: 8px;
 }
 
 .checkout .hosting-dashboard-layout__container {
-    height: auto;
-    flex: 1;
-    min-height: 0;
+	height: auto;
+	flex: 1;
+	min-height: 0;
 }
 
 .checkout .hosting-dashboard-layout__body {
-    padding: 0;
-    flex-grow: 1;
+	padding: 0;
+	flex-grow: 1;
 
-    @include break-large {
-        background: linear-gradient(
-            to right,
-            var( --color-surface ) 0%,
-            var( --color-surface ) 70%,
-            var( --color-neutral-0 ) 70%,
-            var( --color-neutral-0 ) 100%
-        );
-    }
+	@include break-large {
+		background: linear-gradient(
+			to right,
+			var( --color-surface ) 0%,
+			var( --color-surface ) 70%,
+			var( --color-neutral-0 ) 70%,
+			var( --color-neutral-0 ) 100%
+		);
+	}
 }
 
 .checkout .hosting-dashboard-layout__body-wrapper {
-    height: 100%;
+	height: 100%;
 }
 
 .checkout__client-referral-form-footer-error {
-    margin-block-start: 0.25rem;
-    color: var( --color-scary-40 );
-    font-style: italic;
-    @include body-medium;
+	margin-block-start: 0.25rem;
+	color: var( --color-scary-40 );
+	font-style: italic;
+	@include body-medium;
 
-    &.hidden {
-        display: none;
-    }
+	&.hidden {
+		display: none;
+	}
 }
 
 .checkout__container {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
 
-    @include break-large {
-        flex-direction: row;
-        min-height: 100%;
-    }
+	@include break-large {
+		flex-direction: row;
+		min-height: 100%;
+	}
 }
 
 .checkout__main {
-    flex-grow: 1;
+	flex-grow: 1;
 
-    @include break-large {
-        padding: 64px 64px 0 0;
-    }
+	@include break-large {
+		padding: 64px 64px 0 0;
+	}
 }
 
 .checkout__main-title {
-    margin-block-end: 64px;
-    margin-block-start: 32px;
-    @include heading-x-large;
+	margin-block-end: 64px;
+	margin-block-start: 32px;
+	@include heading-x-large;
 
-    @include breakpoint-deprecated( '>960px' ) {
-        margin-block-start: 0;
-    }
+	@include breakpoint-deprecated( '>960px' ) {
+		margin-block-start: 0;
+	}
 }
 
 .checkout__main-list {
-    display: flex;
-    flex-direction: column;
-    gap: 32px;
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
 }
 
 .checkout__aside {
-    padding: 32px 0;
+	padding: 32px 0;
 
-    @include break-large {
-        max-width: 443px;
-        padding: 128px 48px 48px;
-        background: var( --color-neutral-0 );
-    }
+	@include break-large {
+		max-width: 443px;
+		padding: 128px 48px 48px;
+		background: var( --color-neutral-0 );
+	}
 
-    &.checkout__aside--referral,
-    &.checkout__aside--client {
-        padding-block-start: 64px;
-    }
+	&.checkout__aside--referral,
+	&.checkout__aside--client {
+		padding-block-start: 64px;
+	}
 }
 
 .checkout__summary {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
 
-    hr {
-        width: 100%;
-        margin: 0;
-        padding: 0;
-        border: none;
-    }
+	hr {
+		width: 100%;
+		margin: 0;
+		padding: 0;
+		border: none;
+	}
 }
 
 .checkout__tipalti-action-required-notice {
-    padding-top: 24px;
+	padding-top: 24px;
 }
 
 .checkout__summary-pricing {
-    background-color: var( --color-surface );
-    border-radius: 8px;
-    border: 1px solid var( --color-link );
-    padding: 1rem;
+	background-color: var( --color-surface );
+	border-radius: 8px;
+	border: 1px solid var( --color-link );
+	padding: 1rem;
 
-    @media only screen and ( min-width: 782px ) {
-        margin-block-start: 32px;
-    }
+	@media only screen and ( min-width: 782px ) {
+		margin-block-start: 32px;
+	}
 
-    @include break-xlarge {
-        margin-block-start: 24px;
-    }
+	@include break-xlarge {
+		margin-block-start: 24px;
+	}
 
-    .checkout__summary-pricing-discounted {
-        @include heading-large;
-        color: var( --color-neutral-80 );
+	.checkout__summary-pricing-discounted {
+		@include heading-large;
+		color: var( --color-neutral-80 );
 
-        @include break-xlarge {
-            @include heading-x-large;
-            color: var( --color-black );
-        }
-    }
+		@include break-xlarge {
+			@include heading-x-large;
+			color: var( --color-black );
+		}
+	}
 
-    .checkout__summary-pricing-original {
-        @include body-large;
-        text-decoration: line-through;
-        margin-inline-start: 8px;
-    }
+	.checkout__summary-pricing-original {
+		@include body-large;
+		text-decoration: line-through;
+		margin-inline-start: 8px;
+	}
 
-    .checkout__summary-pricing-interval {
-        @include body-small;
-        color: var( --color-neutral-60 );
-        line-height: 2;
-    }
+	.checkout__summary-pricing-interval {
+		@include body-small;
+		color: var( --color-neutral-60 );
+		line-height: 2;
+	}
 }
 
 .checkout__summary-items {
-    margin: 0;
+	margin: 0;
 }
 
 .checkout__summary-total {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    @include heading-medium;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	@include heading-medium;
 }
 
 .checkout__summary-notice {
-    @include body-small;
-    margin-block-end: 16px;
-    color: var( --color-neutral-50 );
+	@include body-small;
+	margin-block-end: 16px;
+	color: var( --color-neutral-50 );
 
-    a {
-        text-decoration: underline;
-        color: var( --color-text-black );
-    }
+	a {
+		text-decoration: underline;
+		color: var( --color-text-black );
+	}
 
-    &.margin-top {
-        margin-block-start: 16px;
-    }
+	&.margin-top {
+		margin-block-start: 16px;
+	}
 
-    h3 {
-        margin-block: 24px;
-        @include heading-large;
-        color: var( --color-neutral-70 );
-    }
+	h3 {
+		margin-block: 24px;
+		@include heading-large;
+		color: var( --color-neutral-70 );
+	}
 }
 
 .checkout__summary-notice-item {
-    @include body-small;
-    color: var( --color-neutral-50 );
-    margin-block-end: 0.5rem;
+	@include body-small;
+	color: var( --color-neutral-50 );
+	margin-block-end: 0.5rem;
 }
 
 .checkout__aside-actions {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 16px;
-    text-align: center;
-    margin-block-end: 8px;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 16px;
+	text-align: center;
+	margin-block-end: 8px;
 
-    > .button {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border-radius: 4px;
-        min-height: 40px;
-    }
+	> .button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 4px;
+		min-height: 40px;
+	}
 
-    > .button.is-link {
-        color: var( --color-black );
-        text-decoration: underline;
-    }
+	> .button.is-link {
+		color: var( --color-black );
+		text-decoration: underline;
+	}
 }
 
 .product-info {
-    display: flex;
-    gap: 14px;
+	display: flex;
+	gap: 14px;
 
-    .product-info__icon {
-        display: none;
-        box-sizing: border-box;
-        width: 48px;
-        height: 48px;
-        background: linear-gradient( 159.87deg, #f6f6f4 7.24%, #f7f4ea 64.73%, #ddedd5 116.53% );
-        border-radius: 4px;
+	.product-info__icon {
+		display: none;
+		box-sizing: border-box;
+		width: 48px;
+		height: 48px;
+		background: linear-gradient( 159.87deg, #f6f6f4 7.24%, #f7f4ea 64.73%, #ddedd5 116.53% );
+		border-radius: 4px;
 
-        @media only screen and ( min-width: 821px ) {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-    }
+		@media only screen and ( min-width: 821px ) {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+	}
 
-    .product-info__icon > img {
-        width: 22px;
-        height: auto;
-    }
+	.product-info__icon > img {
+		width: 22px;
+		height: auto;
+	}
 
-    .product-info__text-content {
-        width: 100%;
-    }
+	.product-info__text-content {
+		width: 100%;
+	}
 
-    .product-info__header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-    }
+	.product-info__header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
 
-    .product-info__label {
-        @include heading-medium;
+	.product-info__label {
+		@include heading-medium;
 
-        a {
-            text-decoration: underline;
-            color: var( --color-text );
-        }
-    }
+		a {
+			text-decoration: underline;
+			color: var( --color-text );
+		}
+	}
 
-    .product-info__count {
-        background-color: var( --color-neutral-0 );
-        padding: 5px 15px;
-        border-radius: 4px;
-        font-weight: 500;
-    }
+	.product-info__count {
+		background-color: var( --color-neutral-0 );
+		padding: 5px 15px;
+		border-radius: 4px;
+		font-weight: 500;
+	}
 
-    .product-info__description {
-        @include body-large;
-        margin-block: 4px 0;
-        color: var( --color-neutral-70 );
-    }
+	.product-info__description {
+		@include body-large;
+		margin-block: 4px 0;
+		color: var( --color-neutral-70 );
+	}
 
-    .product-info__site-url {
-        @include body-medium;
-        margin-block: 4px 0;
-        color: var( --color-neutral-40 );
-    }
+	.product-info__site-url {
+		@include body-medium;
+		margin-block: 4px 0;
+		color: var( --color-neutral-40 );
+	}
 }
 
 .product-info__placeholder {
-    @include loading-effect();
+	@include loading-effect();
 
-    width: 100%;
-    height: 48px;
-    background-color: var( --color-neutral-0 );
-    border-radius: 4px;
+	width: 100%;
+	height: 48px;
+	background-color: var( --color-neutral-0 );
+	border-radius: 4px;
 }
 
 .checkout__client-referral-form {
-    padding-block-start: 48px;
+	padding-block-start: 48px;
 
-    input[type='text'].form-text-input:disabled,
-    .form-textarea:disabled {
-        border-color: var( --color-neutral-10 );
-    }
+	input[type='text'].form-text-input:disabled,
+	.form-textarea:disabled {
+		border-color: var( --color-neutral-10 );
+	}
 }
 
 .checkout__aside--client {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    padding-block-end: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	padding-block-end: 0;
 
-    @include breakpoint-deprecated( '>960px' ) {
-        width: 400px;
-    }
+	@include breakpoint-deprecated( '>960px' ) {
+		width: 400px;
+	}
 
-    .checkout__aside-actions {
-        margin-block-start: 16px;
-    }
-    .checkout__summary-client-payment-notice {
-        margin-block-start: 48px;
-        color: var( --color-neutral-70 );
-        @include heading-large;
-    }
+	.checkout__aside-actions {
+		margin-block-start: 16px;
+	}
+	.checkout__summary-client-payment-notice {
+		margin-block-start: 48px;
+		color: var( --color-neutral-70 );
+		@include heading-large;
+	}
 
-    .checkout__summary-notice {
-        margin-block-start: 48px;
+	.checkout__summary-notice {
+		margin-block-start: 48px;
 
-        div {
-            margin-block-start: 8px;
-        }
-    }
+		div {
+			margin-block-start: 8px;
+		}
+	}
 
-    .checkout__aside-footer {
-        margin-block-start: 32px;
-        padding-block-end: 16px;
+	.checkout__aside-footer {
+		margin-block-start: 32px;
+		padding-block-end: 16px;
 
-        @include breakpoint-deprecated( '>960px' ) {
-            margin-block-start: auto;
-        }
+		@include breakpoint-deprecated( '>960px' ) {
+			margin-block-start: auto;
+		}
 
-        .checkout__aside-powered-by {
-            div {
-                color: var( --color-neutral-70 );
-                @include body-small;
-            }
+		.checkout__aside-powered-by {
+			div {
+				color: var( --color-neutral-70 );
+				@include body-small;
+			}
 
-            img {
-                margin-block-start: 8px;
-                width: 150px;
-            }
-        }
-    }
+			img {
+				margin-block-start: 8px;
+				width: 150px;
+			}
+		}
+	}
 }
 
 .checkout__aside-actions-wrapper {
-    display: grid;
+	display: grid;
 }
 
 .checkout__button-popover {
-    .components-popover__content {
-        width: 300px;
+	.components-popover__content {
+		width: 300px;
 
-        @include break-large {
-            width: 350px;
-        }
-    }
+		@include break-large {
+			width: 350px;
+		}
+	}
 
-    .a4a-popover__content {
-        width: 100%;
+	.a4a-popover__content {
+		width: 100%;
 
-        .a4a-popover__title {
-            @include heading-medium;
-            color: var( --studio-gray-80 );
-        }
+		.a4a-popover__title {
+			@include heading-medium;
+			color: var( --studio-gray-80 );
+		}
 
-        .checkout__button-popover-description {
-            @include body-medium;
-        }
-    }
+		.checkout__button-popover-description {
+			@include body-medium;
+		}
+	}
 }
 
 .checkout__verify-account-tooltip {
-    a {
-        color: var( --color-text-inverted );
-        text-decoration: underline;
-    }
+	a {
+		color: var( --color-text-inverted );
+		text-decoration: underline;
+	}
 }
 
 .product-info__pressable-limit-warning {
-    margin-block-start: 8px;
-    @include body-small;
+	margin-block-start: 8px;
+	@include body-small;
 }
 
 .checkout__aside-actions.is-row {
-    flex-direction: row;
-    gap: 16px;
-    align-items: center;
-    justify-content: center;
+	flex-direction: row;
+	gap: 16px;
+	align-items: center;
+	justify-content: center;
 
-    > .button {
-        flex-grow: 1;
-        display: flex;
-        flex-direction: row;
-        gap: 8px;
-        align-items: center;
-        justify-content: center;
-    }
+	> .button {
+		flex-grow: 1;
+		display: flex;
+		flex-direction: row;
+		gap: 8px;
+		align-items: center;
+		justify-content: center;
+	}
 }
 
 .checkout__logo-section {
-    .checkout__profile-logo-preview {
-        width: 250px;
-        height: 100px;
-        border: 1px solid var( --color-neutral-20 );
-        border-radius: 4px;
-        background: var( --color-neutral-0 );
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        overflow: hidden;
-    }
+	.checkout__profile-logo-preview {
+		width: 250px;
+		height: 100px;
+		border: 1px solid var( --color-neutral-20 );
+		border-radius: 4px;
+		background: var( --color-neutral-0 );
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+	}
 
-    .checkout__profile-logo-preview img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
+	.checkout__profile-logo-preview img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
 
-    .logo-file-upload-placeholder {
-        width: 250px;
-        height: 100px;
-        padding: 0;
-    }
+	.logo-file-upload-placeholder {
+		width: 250px;
+		height: 100px;
+		padding: 0;
+	}
 
-    .logo-file-upload-preview {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
+	.logo-file-upload-preview {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
 
-    .components-radio-control__input[type='radio']:checked {
-        background-color: var( --color-primary-50 );
-    }
+	.components-radio-control__input[type='radio']:checked {
+		background-color: var( --color-primary-50 );
+	}
 }
 
 .referral-email-preview-modal {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
@@ -445,27 +445,27 @@
 }
 
 .referral-email-preview-modal {
-    .components-modal__content {
-        background-color: var( --a4a-brand-blue-80 );
-    }
+	.components-modal__content {
+		background-color: var( --a4a-brand-blue-80 );
+	}
 
-    .shopping-cart__menu-list-item-price-interval {
-        display: block;
-    }
+	.shopping-cart__menu-list-item-price-interval {
+		display: block;
+	}
 }
 
 .referral-email-preview-modal-body {
-    overflow-y: auto;
+	overflow-y: auto;
 }
 
 .referral-email-preview {
-    padding: 24px;
+	padding: 24px;
 
-    @include break-medium {
-        padding: 56px;
-    }
+	@include break-medium {
+		padding: 56px;
+	}
 
-    .product-info__text-content {
-        display: flex;
-    }
+	.product-info__text-content {
+		display: flex;
+	}
 }


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/108738

Fixes https://linear.app/a8c/issue/A4A-2122/implement-preview-referral-email
Fixes https://linear.app/a8c/issue/A4A-2094/data-and-reporting-referral-tracking

## Proposed Changes

* Add a **Preview referral email** button on the request-client-payment checkout that opens a modal showing how the referral email will look with the current message, products, term pricing, and selected logo.
* **ReferralEmailPreviewModal** – Renders the preview HTML (from the backend preview endpoint) in an iframe with injected styles so it matches the email client appearance; supports optional logo, client message, and product list.
* **Referral email preview (mobile)** – Preview is responsive on narrow viewports: wrapper uses 100% width with max 600px; viewport meta and formula-based scale (`100vw / 600px`) so the 600px email fits; iframe height is scaled to match visible content and avoid extra scrollbar.
* **useReferralEmailPreview** – TanStack Query hook that fetches preview HTML from the agency referral preview API (product IDs, greeting line, logo URL, term pricing).
* **logo-url-utils** – `getLogoUrlForPreview()` and `convertBlobToDataUrl()` so the preview can show the selected logo (including blob URLs from a newly chosen file) without uploading first.
* Checkout styles updated for the preview modal and any layout tweaks.
* **Event tracking** – Tracks events in the referral checkout flow: "Preview referral email" click; logo option change (profile / different / none); successful logo file select in upload.
* **AGENTS.md** – Add an "Analytics and tracking" section with instructions to add Tracks events for new user-facing actions using `recordTracksEvent` and the `calypso_a4a_*` prefix.

## Why are these changes being made?

* Agencies need to see how the referral email will look (logo, message, products) before sending or copying the link, so they can correct the copy or logo without sending multiple emails.
* The preview is backed by the same API that generates the real email, so layout and content stay in sync; the modal is a thin client that displays the returned HTML.

## Testing Instructions

* Patch 204479-ghe-Automattic/wpcom
* Sandbox wordpress.com
* Open A4A > Marketplace > enable referral mode > add products > go to checkout.
* Confirm a **Preview referral email** link is shown as displayed below

<img width="1920" height="960" alt="Screenshot 2026-03-02 at 4 22 49 PM" src="https://github.com/user-attachments/assets/6fc73859-46c1-4ec4-beb2-86db534daf38" />

* Click it: a modal opens with the current client message, products, term pricing, and the currently selected logo (profile, custom, or none).
* Change the logo option or upload a different logo, then preview again – the modal should show the updated logo (blob URLs are converted to data URLs for preview).
* Change the client message and/or cart, then preview again – content in the modal should match.
* Close the modal and send or copy the referral link; behavior should match PR #108738 (no regression).
* On mobile or narrow viewport (e.g. 320px–600px), the email preview should scale to fit with no clipped content and no extra scrollbar.

<img width="1066" height="1496" alt="Screenshot 2026-03-03 at 5 11 24 PM" src="https://github.com/user-attachments/assets/c3b78940-8945-43d8-8ef1-27d4a32ba767" />

Mobile view:

<img width="533" height="898" alt="Screenshot 2026-03-04 at 11 14 57 AM" src="https://github.com/user-attachments/assets/efc562e6-f666-43d8-99f8-71810617a736" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Using memoizing selectors and Our Approach to Data
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
  - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
