### PR TITLE
Agents Manager: Fix stale suggestions after SPA navigation

### DIFF
--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -1,6 +1,6 @@
 import { type Suggestion } from '@automattic/agenttic-ui';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useState, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import type { LoadedProviders } from '../utils/load-external-providers';
 
@@ -67,31 +67,29 @@ export function useEmptyViewSuggestions( {
 		[ hasBigSkySuggestions ]
 	);
 
-	// Compute empty view suggestions once when store is ready
-	const [ emptyViewSuggestions, setEmptyViewSuggestions ] = useState< Suggestion[] | null >( null );
+	// Read current URL so suggestions re-evaluate after SPA navigation.
+	// The provider's getEmptyViewSuggestions() reads window.location at call
+	// time to return context-specific suggestions (e.g. onboarding vs dashboard).
+	// Including locationSearch in useMemo deps ensures we recompute when the
+	// component re-renders after navigation (e.g. user starts a new chat).
+	const locationSearch = window.location.search;
 
-	useEffect( () => {
-		if ( ! loadedProviders || ! isCoreStoreReady || emptyViewSuggestions !== null ) {
-			return;
+	const emptyViewSuggestions = useMemo( () => {
+		if ( ! loadedProviders || ! isCoreStoreReady ) {
+			return null;
 		}
 
 		if ( ! hasBigSkySuggestions ) {
-			// No Big Sky suggestions provider, use defaults immediately
-			setEmptyViewSuggestions( defaultSuggestions );
-		} else {
-			// Big Sky provides suggestions and store is ready - get filtered suggestions
-			const suggestions = loadedProviders.getEmptyViewSuggestions?.();
-			if ( suggestions && suggestions.length > 0 ) {
-				setEmptyViewSuggestions( suggestions );
-			}
+			return defaultSuggestions;
 		}
-	}, [
-		loadedProviders,
-		isCoreStoreReady,
-		hasBigSkySuggestions,
-		defaultSuggestions,
-		emptyViewSuggestions,
-	] );
+
+		const suggestions = loadedProviders.getEmptyViewSuggestions?.();
+		if ( suggestions && suggestions.length > 0 ) {
+			return suggestions;
+		}
+		return null;
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ loadedProviders, isCoreStoreReady, hasBigSkySuggestions, defaultSuggestions, locationSearch ] );
 
 	return emptyViewSuggestions;
 }

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -70,9 +70,9 @@ export function useEmptyViewSuggestions( {
 	// Read current URL so suggestions re-evaluate after SPA navigation.
 	// The provider's getEmptyViewSuggestions() reads window.location at call
 	// time to return context-specific suggestions (e.g. onboarding vs dashboard).
-	// Including locationSearch in useMemo deps ensures we recompute when the
+	// Including locationKey in useMemo deps ensures we recompute when the
 	// component re-renders after navigation (e.g. user starts a new chat).
-	const locationSearch = window.location.search;
+	const locationKey = window.location.pathname + window.location.search;
 
 	const emptyViewSuggestions = useMemo( () => {
 		if ( ! loadedProviders || ! isCoreStoreReady ) {
@@ -88,8 +88,10 @@ export function useEmptyViewSuggestions( {
 			return suggestions;
 		}
 		return null;
+		// locationKey is intentionally included as a recomputation trigger;
+		// getEmptyViewSuggestions() reads window.location internally.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ loadedProviders, isCoreStoreReady, hasBigSkySuggestions, defaultSuggestions, locationSearch ] );
+	}, [ loadedProviders, isCoreStoreReady, hasBigSkySuggestions, defaultSuggestions, locationKey ] );
 
 	return emptyViewSuggestions;
 }


### PR DESCRIPTION
## Summary
- Replace `useState` + `useEffect` with `useMemo` for computing empty view suggestions
- The previous approach cached suggestions on first computation and never re-evaluated, causing stale suggestions when navigating between pages in CIAB admin
- Adding `window.location.search` as a `useMemo` dependency ensures suggestions recompute after SPA navigation

## Context
The `calypso-agent-provider` in Big Sky returns context-aware suggestions (WooCommerce suggestions on dashboard, onboarding suggestions on onboarding page, design suggestions in block editor). But the `useEmptyViewSuggestions` hook was using `useState` with a `!== null` guard that prevented re-evaluation — whichever page the user opened the chat on first, those suggestions were cached forever.

## Related
- Big Sky PR: https://github.com/Automattic/big-sky-plugin/pull/5734

## Test plan
- [ ] Open CIAB admin dashboard, open chat → see WooCommerce suggestions
- [ ] Navigate to orders page, open new chat → see WooCommerce suggestions (not stale from previous page)
- [ ] Navigate to onboarding page, open new chat → see onboarding suggestions
- [ ] Open block editor, open chat → see design/theme suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)