### PR TITLE
Newsletter: Show guidance when Substack images fail to import

### DIFF
--- a/client/my-sites/importer/newsletter/content/conversion-summary.tsx
+++ b/client/my-sites/importer/newsletter/content/conversion-summary.tsx
@@ -1,6 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { video, verse, page, file, Icon, audio, gallery, post, code, help } from '@wordpress/icons';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useResetMutation } from 'calypso/data/paid-newsletter/use-reset-mutation';
@@ -30,6 +30,7 @@ interface ConversionSummaryProps {
 			attachmentsNumber?: number;
 			unsupportedFileTypes?: UnsupportedFilesType;
 			postErrors?: PostErrorsType;
+			failedImagesCount?: number;
 		};
 	};
 }
@@ -81,6 +82,72 @@ const UnsupportedFilesMessage = ( {
 					}
 				) }
 			</p>
+		</div>
+	);
+};
+
+const FailedImagesMessage = ( { count }: { count: number } ) => {
+	if ( count <= 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="conversion-summary__failed-images">
+			<p>
+				{ sprintf(
+					/* translators: %d is the number of images that could not be imported */
+					_n(
+						'%d image could not be imported because Substack did not include it in the export. To add it to your post:',
+						'%d images could not be imported because Substack did not include them in the export. To add them to your posts:',
+						count
+					),
+					count
+				) }
+			</p>
+			<ol>
+				<li>
+					{ __( 'Open the original post on Substack.' ) }
+				</li>
+				<li>
+					{ __( 'Right-click each missing image and save it to your computer.' ) }
+				</li>
+				<li>
+					{ createInterpolateElement(
+						__(
+							'Upload the saved images to your <supportLink>Media Library</supportLink>.'
+						),
+						{
+							supportLink: (
+								<InlineSupportLink
+									supportLink={ localizeUrl(
+										'https://wordpress.com/support/media/'
+									) }
+									showIcon={ false }
+									supportPostId={ 853 }
+								/>
+							),
+						}
+					) }
+				</li>
+				<li>
+					{ createInterpolateElement(
+						__(
+							'Insert them into the affected posts using the <supportLink>Image block</supportLink>.'
+						),
+						{
+							supportLink: (
+								<InlineSupportLink
+									supportLink={ localizeUrl(
+										'https://wordpress.com/support/wordpress-editor/blocks/image-block/'
+									) }
+									showIcon={ false }
+									supportPostId={ 148672 }
+								/>
+							),
+						}
+					) }
+				</li>
+			</ol>
 		</div>
 	);
 };
@@ -232,11 +299,13 @@ const ConversionSummary = ( {
 	const attachments = importerStatus?.customData?.attachmentsNumber || 0;
 	const unsupportedFiles = importerStatus?.customData?.unsupportedFileTypes || {};
 	const postErrors = importerStatus?.customData?.postErrors || {};
+	const failedImagesCount = importerStatus?.customData?.failedImagesCount || 0;
 
 	const hasUnsupportedFiles = Object.keys( unsupportedFiles ).length > 0;
 	const hasPostErrors = Object.keys( postErrors ).length > 0;
+	const hasFailedImages = failedImagesCount > 0;
 
-	const hasIssues = hasUnsupportedFiles || hasPostErrors;
+	const hasIssues = hasUnsupportedFiles || hasPostErrors || hasFailedImages;
 
 	return (
 		<div className="importer__conversion-summary-pane">
@@ -265,6 +334,9 @@ const ConversionSummary = ( {
 					<hr />
 					<div className="conversion-summary__issues">
 						<h2>{ __( 'Items that need your attention' ) }</h2>
+						{ hasFailedImages && (
+							<FailedImagesMessage count={ failedImagesCount } />
+						) }
 						{ hasUnsupportedFiles && (
 							<UnsupportedFilesMessage unsupportedFileTypes={ unsupportedFiles } />
 						) }

--- a/client/my-sites/importer/newsletter/content/style.scss
+++ b/client/my-sites/importer/newsletter/content/style.scss
@@ -207,7 +207,8 @@
 	}
 
 	.conversion-summary__post-errors,
-	.conversion-summary__unsupported-files {
+	.conversion-summary__unsupported-files,
+	.conversion-summary__failed-images {
 		p {
 			margin-bottom: 0.825em;
 
@@ -231,6 +232,15 @@
 			.post-errors__item-icon {
 				flex-shrink: 0;
 			}
+		}
+	}
+
+	.conversion-summary__failed-images ol {
+		margin-top: 0.5em;
+		padding-inline-start: 1.5em;
+
+		li {
+			margin-bottom: 0.25em;
 		}
 	}
 


### PR DESCRIPTION
Part of NL-482

## Proposed Changes

- Add `FailedImagesMessage` component to the Substack import conversion summary screen
- Shows when backend reports `failedImagesCount > 0` in the import data
- Explains that Substack did not include images in the export
- Provides numbered steps to manually save and re-upload images, with links to Media Library and Image block support docs
- Uses `_n` for proper singular/plural handling
- Adds SCSS for the ordered list, using logical CSS properties (`padding-inline-start`)

## Why are these changes being made?

When importing from Substack, ~33% of images fail because Substack hosts them in protected storage that denies external access. The importer already surfaces unsupported file types and unconverted content, but silently drops images that fail with HTTP errors. Users see broken images with no explanation or guidance on how to fix them.

This PR adds actionable guidance so users know why images are missing and exactly how to fix them.

**Note:** This PR is safely inert until a corresponding backend change ships to populate `failedImagesCount` in the API response. Until then, the field defaults to 0 and the component does not render.

## Testing Instructions

1. Import a Substack export at `/import/{site}/newsletter/substack`
2. Verify the conversion summary looks identical to before (no `failedImagesCount` from backend yet)
3. To test the new component, use browser DevTools to inject mock data into the React component props:
   - Set `failedImagesCount = 5` → verify message appears with "5 images could not be imported..."
   - Set `failedImagesCount = 1` → verify singular "1 image could not be imported..."
   - Set `failedImagesCount = 0` → verify no message appears
4. Verify "Media Library" and "Image block" links point to correct support docs
5. Verify existing unsupported file types and unconverted content messages still render

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?