### PR TITLE
Revert "A4A: Update Pressable incentives banners. (#108670)"

### DIFF
--- a/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -27,8 +26,6 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 
 	const pressableOwnership = usePressableOwnershipType();
 
-	const { showSupportGuide } = useHelpCenter();
-
 	// Make sure we only show the offer if the agency is a Billing Dragon agency and does not have a Pressable license through A4A, unless we are in referral mode
 	const shouldShowOffer =
 		agency?.billing_system === 'billingdragon' &&
@@ -50,42 +47,9 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 		);
 	}, [ dispatch ] );
 
-	const onSeeFullTermClick = useCallback(
-		( e: React.MouseEvent< HTMLButtonElement > ) => {
-			e.stopPropagation();
-			dispatch(
-				recordTracksEvent( 'calypso_a4a_pressable_promo_offer_2026_see_full_terms_click' )
-			);
-		},
-		[ dispatch ]
-	);
-
-	const onSeeMigrationBonusTermsClick = useCallback(
-		( e: React.MouseEvent< HTMLButtonElement > ) => {
-			e.stopPropagation();
-			dispatch(
-				recordTracksEvent(
-					'calypso_a4a_pressable_promo_offer_2026_see_migration_bonus_terms_click'
-				)
-			);
-		},
-		[ dispatch ]
-	);
-
-	const onSeeMigrationIncentivesTrackingGuideClick = useCallback(
-		( e: React.MouseEvent< HTMLButtonElement > ) => {
-			e.stopPropagation();
-			dispatch(
-				recordTracksEvent(
-					'calypso_a4a_pressable_promo_offer_2026_see_migration_incentives_tracking_guide_click'
-				)
-			);
-			showSupportGuide(
-				'https://agencieshelp.automattic.com/knowledge-base/migration-incentive-tracking/'
-			);
-		},
-		[ dispatch, showSupportGuide ]
-	);
+	const onSeeFullTermClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_pressable_promo_offer_2026_see_full_terms_click' ) );
+	}, [ dispatch ] );
 
 	if ( ! shouldShowOffer ) {
 		return null;
@@ -107,7 +71,12 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 				<h3 className="a4a-pressable-offer__title">
 					<span>
 						{ translate(
-							'Your Exclusive Automattic for Agencies Limited-Time Pressable Offer Just Got Better 🎉'
+							'{{b}}Limited time offer:{{/b}} Get up to 6 months of free Pressable hosting on new plans!',
+							{
+								components: {
+									b: <b />,
+								},
+							}
 						) }
 					</span>
 
@@ -121,7 +90,7 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 						<SimpleList
 							items={ [
 								translate(
-									'{{b}}6 months of free hosting on annual Premium or Signature plans:{{/b}} Purchase a 12-month plan and receive a 50% discount on your first year.',
+									'{{b}}6 Months Free on Annual Plans:{{/b}} Purchase a 12-month plan and receive a 50% discount on the upfront cost.',
 									{
 										components: {
 											b: <b />,
@@ -129,7 +98,7 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 									}
 								),
 								translate(
-									'{{b}}3 months of free hosting on monthly plans:{{/b}} Choose a monthly billing cycle and receive savings equal to 3 free months (applied as a discount evenly across the first 12 invoices).',
+									'{{b}}3 Months Free on Monthly Plans:{{/b}} Choose a monthly billing cycle and receive savings equal to 3 free months (applied as a discount evenly across the first 12 invoices).',
 									{
 										components: {
 											b: <b />,
@@ -137,15 +106,10 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 									}
 								),
 								translate(
-									'PLUS earn up to $200 for each Signature site and up to $1,000 for each Premium site successfully migrated and {{a}}tagged{{/a}} by the deadline.',
+									'{{b}}Automattic for Agencies Exclusive:{{/b}} As a partner, you can unlock these savings on Pressable’s full Signature Plan suite in addition to Premium plans.',
 									{
 										components: {
-											a: (
-												<Button
-													variant="link"
-													onClick={ onSeeMigrationIncentivesTrackingGuideClick }
-												/>
-											),
+											b: <b />,
 										},
 									}
 								),
@@ -166,30 +130,18 @@ const PressableOffer = ( { isReferMode }: Props ) => {
 								</Button>
 							) }
 
+							<Button
+								variant="secondary"
+								href="https://pressable.com/legal/hosting-promotion-terms/"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ onSeeFullTermClick }
+							>
+								{ translate( 'See full terms ↗' ) }
+							</Button>
+
 							<span className="a4a-pressable-offer__body-actions-footnote">
-								{ translate(
-									'See terms of Hosting Promotion {{TermLink}}here{{/TermLink}} and the Migration Bonus {{MigrationBonusLink}}here{{/MigrationBonusLink}}',
-									{
-										components: {
-											TermLink: (
-												<Button
-													variant="link"
-													onClick={ onSeeFullTermClick }
-													href="https://pressable.com/legal/hosting-promotion-terms/"
-													target="_blank"
-												/>
-											),
-											MigrationBonusLink: (
-												<Button
-													variant="link"
-													onClick={ onSeeMigrationBonusTermsClick }
-													href="https://pressable.com/legal/migration-bonus-2026/"
-													target="_blank"
-												/>
-											),
-										},
-									}
-								) }
+								{ translate( '*Offer valid January 27 - April 30, 2026' ) }
 							</span>
 						</div>
 					</div>

--- a/client/a8c-for-agencies/components/upcoming-event/index.tsx
+++ b/client/a8c-for-agencies/components/upcoming-event/index.tsx
@@ -62,7 +62,9 @@ const UpcomingEvent = ( {
 		<div className="a4a-event">
 			<div className="a4a-event__content">
 				<div className="a4a-event__header">
-					<div className="a4a-event__logo">{ logoElement ?? <img src={ logoUrl } alt="" /> }</div>
+					<div className="a4a-event__logo">
+						{ logoElement ?? <img src={ logoUrl } alt={ title } /> }
+					</div>
 					<div className="a4a-event__date-and-title">
 						<div className={ clsx( 'a4a-event__date', dateClassName ) }>
 							<time dateTime={ dateTimeString }>{ displayDate }</time>
@@ -95,7 +97,7 @@ const UpcomingEvent = ( {
 						);
 					} ) }
 
-					<div className="a4a-event__extra-content">{ extraContent }</div>
+					{ extraContent }
 				</div>
 			</div>
 			<div

--- a/client/a8c-for-agencies/components/upcoming-event/style.scss
+++ b/client/a8c-for-agencies/components/upcoming-event/style.scss
@@ -119,10 +119,6 @@
 		width: 100%;
 	}
 
-	.a4a-event__extra-content {
-		@include body-small;
-	}
-
 	@include break-large {
 		flex-direction: row;
 		justify-content: flex-start;

--- a/client/a8c-for-agencies/components/upcoming-event/types.ts
+++ b/client/a8c-for-agencies/components/upcoming-event/types.ts
@@ -5,7 +5,7 @@ export type UpcomingEventProps = {
 	id: string;
 	date: { from: Moment; to: Moment };
 	displayDate?: string;
-	title: TranslateResult;
+	title: string;
 	subtitle: string;
 	descriptions: TranslateResult[];
 	logoUrl?: string;

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useMemo } from 'react';

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -1,18 +1,15 @@
-import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { UpcomingEventProps } from 'calypso/a8c-for-agencies/components/upcoming-event/types';
-import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/events/pressable-logo.svg';
 import WordCampAsia2026Image from 'calypso/assets/images/a8c-for-agencies/events/wordcamp-asia2026-compliment-image.svg';
 import WordCampAsia2026Logo from 'calypso/assets/images/a8c-for-agencies/events/wordcamp-asia2026-image.svg';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export const useUpcomingEvents = () => {
 	const translate = useTranslate();
@@ -24,40 +21,6 @@ export const useUpcomingEvents = () => {
 
 	const shouldShowPressablePromoOffer =
 		agency?.billing_system === 'billingdragon' && pressableOwnership !== 'agency';
-
-	const dispatch = useDispatch();
-	const { showSupportGuide } = useHelpCenter();
-
-	const onSeeMigrationIncentivesTrackingGuideClick = useCallback(
-		( e: React.MouseEvent< HTMLButtonElement > ) => {
-			e.stopPropagation();
-			dispatch(
-				recordTracksEvent(
-					'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_see_migration_incentives_tracking_guide_click'
-				)
-			);
-			showSupportGuide(
-				'https://agencieshelp.automattic.com/knowledge-base/migration-incentive-tracking/'
-			);
-		},
-		[ dispatch, showSupportGuide ]
-	);
-
-	const onSeeFullTermClick = useCallback( () => {
-		dispatch(
-			recordTracksEvent(
-				'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_see_full_terms_click'
-			)
-		);
-	}, [ dispatch ] );
-
-	const onSeeMigrationBonusTermsClick = useCallback( () => {
-		dispatch(
-			recordTracksEvent(
-				'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_see_migration_bonus_terms_click'
-			)
-		);
-	}, [ dispatch ] );
 
 	return useMemo( () => {
 		const eventsData: UpcomingEventProps[] = [
@@ -111,36 +74,17 @@ export const useUpcomingEvents = () => {
 						{
 							id: 'a4a-pressable-promo-offer-2026-01-29',
 							date: {
-								from: moment( '2026-02-12' ),
+								from: moment( '2026-01-27' ),
 								to: moment( '2026-04-30' ),
 							},
-							displayDate: ' ', // Empty string to hide the date
+							displayDate: translate( 'Jan 27—April 30, 2026' ),
 							title: translate(
-								'Your Exclusive Automattic for Agencies Limited-Time Pressable Offer Just{{nbsp/}}Got{{nbsp/}}Better 🎉',
-								{
-									components: {
-										nbsp: <>&nbsp;</>,
-									},
-								}
+								'Limited time offer: Get up to 6 months of free Pressable hosting on new plans!'
 							),
 							subtitle: translate( 'Automattic for Agencies & Pressable' ),
 							descriptions: [
 								translate(
 									'Enjoy up to 6 months free on Pressable Signature and Premium Plans with Automattic for Agencies. Choose annual billing for 6 months free or monthly billing for 3 months free, while still earning revenue share and reseller incentives.'
-								),
-
-								translate(
-									'PLUS earn up to $200 for each Signature site and up to $1,000 for each Premium site successfully migrated and {{a}}tagged{{/a}} by the deadline.',
-									{
-										components: {
-											a: (
-												<Button
-													variant="link"
-													onClick={ onSeeMigrationIncentivesTrackingGuideClick }
-												/>
-											),
-										},
-									}
 								),
 							],
 							ctas: [
@@ -151,34 +95,15 @@ export const useUpcomingEvents = () => {
 									trackEventName:
 										'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_view_click',
 								},
+								{
+									variant: 'secondary',
+									label: translate( 'See full terms' ),
+									url: 'https://pressable.com/legal/hosting-promotion-terms',
+									isExternal: true,
+									trackEventName:
+										'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_view_terms_click',
+								},
 							],
-							extraContent: (
-								<>
-									{ translate(
-										'See terms of Hosting Promotion {{TermLink}}here{{/TermLink}} and the Migration Bonus {{MigrationBonusLink}}here{{/MigrationBonusLink}}',
-										{
-											components: {
-												TermLink: (
-													<Button
-														variant="link"
-														onClick={ onSeeFullTermClick }
-														href="https://pressable.com/legal/hosting-promotion-terms/"
-														target="_blank"
-													/>
-												),
-												MigrationBonusLink: (
-													<Button
-														variant="link"
-														onClick={ onSeeMigrationBonusTermsClick }
-														href="https://pressable.com/legal/migration-bonus-2026/"
-														target="_blank"
-													/>
-												),
-											},
-										}
-									) }
-								</>
-							),
 							logoUrl: PressableLogo,
 							dateClassName: 'a4a-event__date--pressable',
 						},
@@ -191,12 +116,5 @@ export const useUpcomingEvents = () => {
 			const today = localizedMoment().startOf( 'day' );
 			return eventDate.isSameOrAfter( today );
 		} );
-	}, [
-		localizedMoment,
-		onSeeFullTermClick,
-		onSeeMigrationBonusTermsClick,
-		onSeeMigrationIncentivesTrackingGuideClick,
-		shouldShowPressablePromoOffer,
-		translate,
-	] );
+	}, [ localizedMoment, shouldShowPressablePromoOffer, translate ] );
 };


### PR DESCRIPTION
This reverts commit f8fbe88bc578bbda9abd1fd6a426ffba664d0b00.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
