### PR TITLE
Bump agenttic package to v0.1.49

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.46",
+		"@automattic/agenttic-ui": "^0.1.48",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.48",
+		"@automattic/agenttic-ui": "^0.1.49",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
 		"whybundled:server": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons CONCATENATE_MODULES=false yarn run build-server && whybundled client/stats-server.json"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.48",
+		"@automattic/agenttic-ui": "^0.1.49",
 		"@automattic/calypso-babel-config": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
 		"whybundled:server": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons CONCATENATE_MODULES=false yarn run build-server && whybundled client/stats-server.json"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.46",
+		"@automattic/agenttic-ui": "^0.1.48",
 		"@automattic/calypso-babel-config": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.48",
-		"@automattic/agenttic-ui": "^0.1.48",
+		"@automattic/agenttic-client": "^0.1.49",
+		"@automattic/agenttic-ui": "^0.1.49",
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.46",
-		"@automattic/agenttic-ui": "^0.1.46",
+		"@automattic/agenttic-client": "^0.1.48",
+		"@automattic/agenttic-ui": "^0.1.48",
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -46,9 +46,9 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.46",
-		"@automattic/agenttic-ui": "^0.1.46",
 		"@automattic/agents-manager": "workspace:^",
+		"@automattic/agenttic-client": "^0.1.48",
+		"@automattic/agenttic-ui": "^0.1.48",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -47,8 +47,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.48",
-		"@automattic/agenttic-ui": "^0.1.48",
+		"@automattic/agenttic-client": "^0.1.49",
+		"@automattic/agenttic-ui": "^0.1.49",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.46",
+		"@automattic/agenttic-ui": "^0.1.48",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.48",
+		"@automattic/agenttic-ui": "^0.1.49",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,8 +326,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.48"
-    "@automattic/agenttic-ui": "npm:^0.1.48"
+    "@automattic/agenttic-client": "npm:^0.1.49"
+    "@automattic/agenttic-ui": "npm:^0.1.49"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -376,7 +376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-client@npm:^0.1.48":
+"@automattic/agenttic-client@npm:^0.1.49":
   version: 0.1.49
   resolution: "@automattic/agenttic-client@npm:0.1.49"
   dependencies:
@@ -396,7 +396,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.48":
+"@automattic/agenttic-ui@npm:^0.1.49":
   version: 0.1.49
   resolution: "@automattic/agenttic-ui@npm:0.1.49"
   dependencies:
@@ -1622,8 +1622,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.48"
-    "@automattic/agenttic-ui": "npm:^0.1.48"
+    "@automattic/agenttic-client": "npm:^0.1.49"
+    "@automattic/agenttic-ui": "npm:^0.1.49"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1956,7 +1956,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.48"
+    "@automattic/agenttic-ui": "npm:^0.1.49"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -14872,7 +14872,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.48"
+    "@automattic/agenttic-ui": "npm:^0.1.49"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"
@@ -37845,7 +37845,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wp-calypso@workspace:."
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.48"
+    "@automattic/agenttic-ui": "npm:^0.1.49"
     "@automattic/calypso-babel-config": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,8 +326,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.46"
-    "@automattic/agenttic-ui": "npm:^0.1.46"
+    "@automattic/agenttic-client": "npm:^0.1.48"
+    "@automattic/agenttic-ui": "npm:^0.1.48"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -356,7 +356,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.44, @automattic/agenttic-client@npm:^0.1.46":
+"@automattic/agenttic-client@npm:^0.1.44":
   version: 0.1.46
   resolution: "@automattic/agenttic-client@npm:0.1.46"
   dependencies:
@@ -376,9 +376,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.46":
-  version: 0.1.46
-  resolution: "@automattic/agenttic-ui@npm:0.1.46"
+"@automattic/agenttic-client@npm:^0.1.48":
+  version: 0.1.49
+  resolution: "@automattic/agenttic-client@npm:0.1.49"
+  dependencies:
+    "@types/react": "npm:^18.0.0"
+    marked: "npm:^16.2.1"
+    react: "npm:^18.0.0"
+  peerDependencies:
+    "@wordpress/api-fetch": ^6.0.0 || ^7.0.0
+    react: ^18.0.0
+  dependenciesMeta:
+    marked:
+      optional: true
+  peerDependenciesMeta:
+    "@wordpress/api-fetch":
+      optional: true
+  checksum: 5c23307b250453fe781bfe493497d9a0f94eea02ea640b42e7fa55cb1327352dad92c49030553c6fb1276aee7a009c971035c246eb710e488e87a709e57abacf
+  languageName: node
+  linkType: hard
+
+"@automattic/agenttic-ui@npm:^0.1.48":
+  version: 0.1.49
+  resolution: "@automattic/agenttic-ui@npm:0.1.49"
   dependencies:
     "@automattic/charts": "npm:>=0.14.0 <1.0.0"
     "@floating-ui/react-dom": "npm:^2.1.6"
@@ -404,7 +424,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: 87b975cf03a4f02e9327f791c204d8dd8588fb147cf9ebe8b10ec61f1d45a3a22cc4a9b5b5670964f0188e59d2affabe7deee47427523a6b8740dc407774f773
+  checksum: cd05efcab8f9daf2e5b1fe144091be516ea31bbcbaff3dc0e511112e8922780653da0c33a5d0a2d177a114c80ec8a815ca0775c8eda0d81adef3bd0b7d8ea748
   languageName: node
   linkType: hard
 
@@ -1602,8 +1622,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.46"
-    "@automattic/agenttic-ui": "npm:^0.1.46"
+    "@automattic/agenttic-client": "npm:^0.1.48"
+    "@automattic/agenttic-ui": "npm:^0.1.48"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1936,7 +1956,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.46"
+    "@automattic/agenttic-ui": "npm:^0.1.48"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -14852,7 +14872,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.46"
+    "@automattic/agenttic-ui": "npm:^0.1.48"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"
@@ -37825,7 +37845,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wp-calypso@workspace:."
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.46"
+    "@automattic/agenttic-ui": "npm:^0.1.48"
     "@automattic/calypso-babel-config": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,27 +356,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.44":
-  version: 0.1.46
-  resolution: "@automattic/agenttic-client@npm:0.1.46"
-  dependencies:
-    "@types/react": "npm:^18.0.0"
-    marked: "npm:^16.2.1"
-    react: "npm:^18.0.0"
-  peerDependencies:
-    "@wordpress/api-fetch": ^6.0.0 || ^7.0.0
-    react: ^18.0.0
-  dependenciesMeta:
-    marked:
-      optional: true
-  peerDependenciesMeta:
-    "@wordpress/api-fetch":
-      optional: true
-  checksum: 8276da7e546e51e83651b161e688b7d19f9fa4a1d9171ad8093899ae480e095991134a255509defaea83571ffb1769838dd661929462980dbd3419881fa3e718
-  languageName: node
-  linkType: hard
-
-"@automattic/agenttic-client@npm:^0.1.49":
+"@automattic/agenttic-client@npm:^0.1.44, @automattic/agenttic-client@npm:^0.1.49":
   version: 0.1.49
   resolution: "@automattic/agenttic-client@npm:0.1.49"
   dependencies:


### PR DESCRIPTION
## Proposed Changes

* Bump agenttic package to v0.1.49

## Why are these changes being made?

* To benefit from the latest changes on the agenttic package

## Testing Instructions

* Run `yarn && yarn start`
* Enable "Unified Experience - https://wordpress.com/wp-admin/profile.php
* Check the AI Chat - it should look and work as before

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?